### PR TITLE
Fix incompatibility with <GL/glext.h>

### DIFF
--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -2856,7 +2856,7 @@ void IdentifyBuiltIns(int version, EProfile profile, EShLanguage language, TSymb
         BuiltInVariable("gl_TessCoord",       EbvTessCoord,      symbolTable);
 
         if (version < 410)
-            symbolTable.setVariableExtensions("gl_ViewportIndex", 1, &GL_ARB_viewport_array);
+            symbolTable.setVariableExtensions("gl_ViewportIndex", 1, &_GL_ARB_viewport_array);
 
         // Compatibility variables
 
@@ -2932,76 +2932,76 @@ void IdentifyBuiltIns(int version, EProfile profile, EShLanguage language, TSymb
         // built-in functions
 
         if (version == 100) {
-            symbolTable.setFunctionExtensions("dFdx",   1, &GL_OES_standard_derivatives);
-            symbolTable.setFunctionExtensions("dFdy",   1, &GL_OES_standard_derivatives);
-            symbolTable.setFunctionExtensions("fwidth", 1, &GL_OES_standard_derivatives);
+            symbolTable.setFunctionExtensions("dFdx",   1, &_GL_OES_standard_derivatives);
+            symbolTable.setFunctionExtensions("dFdy",   1, &_GL_OES_standard_derivatives);
+            symbolTable.setFunctionExtensions("fwidth", 1, &_GL_OES_standard_derivatives);
         }
         if (profile == EEsProfile) {
-            symbolTable.setFunctionExtensions("texture2DLodEXT",     1, &GL_EXT_shader_texture_lod);
-            symbolTable.setFunctionExtensions("texture2DProjLodEXT", 1, &GL_EXT_shader_texture_lod);
-            symbolTable.setFunctionExtensions("textureCubeLodEXT",   1, &GL_EXT_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture2DLodEXT",     1, &_GL_EXT_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture2DProjLodEXT", 1, &_GL_EXT_shader_texture_lod);
+            symbolTable.setFunctionExtensions("textureCubeLodEXT",   1, &_GL_EXT_shader_texture_lod);
         } else if (version < 130) {
-            symbolTable.setFunctionExtensions("texture1DLod",        1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("texture2DLod",        1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("texture3DLod",        1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("textureCubeLod",      1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("texture1DProjLod",    1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("texture2DProjLod",    1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("texture3DProjLod",    1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("shadow1DLod",         1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("shadow2DLod",         1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("shadow1DProjLod",     1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("shadow2DProjLod",     1, &GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture1DLod",        1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture2DLod",        1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture3DLod",        1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("textureCubeLod",      1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture1DProjLod",    1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture2DProjLod",    1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture3DProjLod",    1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("shadow1DLod",         1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("shadow2DLod",         1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("shadow1DProjLod",     1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("shadow2DProjLod",     1, &_GL_ARB_shader_texture_lod);
         }
 
-        // GL_ARB_shader_texture_lod functions usable only with the extension enabled
+        // _GL_ARB_shader_texture_lod functions usable only with the extension enabled
         if (profile != EEsProfile) {
-            symbolTable.setFunctionExtensions("texture1DGradARB",         1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("texture1DProjGradARB",     1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("texture2DGradARB",         1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("texture2DProjGradARB",     1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("texture3DGradARB",         1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("texture3DProjGradARB",     1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("textureCubeGradARB",       1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("shadow1DGradARB",          1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("shadow1DProjGradARB",      1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("shadow2DGradARB",          1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("shadow2DProjGradARB",      1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("texture2DRectGradARB",     1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("texture2DRectProjGradARB", 1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("shadow2DRectGradARB",      1, &GL_ARB_shader_texture_lod);
-            symbolTable.setFunctionExtensions("shadow2DRectProjGradARB",  1, &GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture1DGradARB",         1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture1DProjGradARB",     1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture2DGradARB",         1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture2DProjGradARB",     1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture3DGradARB",         1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture3DProjGradARB",     1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("textureCubeGradARB",       1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("shadow1DGradARB",          1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("shadow1DProjGradARB",      1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("shadow2DGradARB",          1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("shadow2DProjGradARB",      1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture2DRectGradARB",     1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture2DRectProjGradARB", 1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("shadow2DRectGradARB",      1, &_GL_ARB_shader_texture_lod);
+            symbolTable.setFunctionExtensions("shadow2DRectProjGradARB",  1, &_GL_ARB_shader_texture_lod);
         }
 
         if (profile == EEsProfile) {
-            symbolTable.setFunctionExtensions("texture2DGradEXT",     1, &GL_EXT_shader_texture_lod);
-            symbolTable.setFunctionExtensions("texture2DProjGradEXT", 1, &GL_EXT_shader_texture_lod);
-            symbolTable.setFunctionExtensions("textureCubeGradEXT",   1, &GL_EXT_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture2DGradEXT",     1, &_GL_EXT_shader_texture_lod);
+            symbolTable.setFunctionExtensions("texture2DProjGradEXT", 1, &_GL_EXT_shader_texture_lod);
+            symbolTable.setFunctionExtensions("textureCubeGradEXT",   1, &_GL_EXT_shader_texture_lod);
         }
 
-        // GL_ARB_shader_image_load_store
+        // _GL_ARB_shader_image_load_store
         if (profile != EEsProfile && version < 420)
-            symbolTable.setFunctionExtensions("memoryBarrier", 1, &GL_ARB_shader_image_load_store);
+            symbolTable.setFunctionExtensions("memoryBarrier", 1, &_GL_ARB_shader_image_load_store);
         // All the image access functions are protected by checks on the type of the first argument.
 
-        // GL_ARB_shader_atomic_counters
+        // _GL_ARB_shader_atomic_counters
         if (profile != EEsProfile && version < 420) {
-            symbolTable.setFunctionExtensions("atomicCounterIncrement", 1, &GL_ARB_shader_atomic_counters);
-            symbolTable.setFunctionExtensions("atomicCounterDecrement", 1, &GL_ARB_shader_atomic_counters);
-            symbolTable.setFunctionExtensions("atomicCounter"         , 1, &GL_ARB_shader_atomic_counters);
+            symbolTable.setFunctionExtensions("atomicCounterIncrement", 1, &_GL_ARB_shader_atomic_counters);
+            symbolTable.setFunctionExtensions("atomicCounterDecrement", 1, &_GL_ARB_shader_atomic_counters);
+            symbolTable.setFunctionExtensions("atomicCounter"         , 1, &_GL_ARB_shader_atomic_counters);
         }
 
-        // GL_ARB_derivative_control
+        // _GL_ARB_derivative_control
         if (profile != EEsProfile && version < 450) {
-            symbolTable.setFunctionExtensions("dFdxFine",     1, &GL_ARB_derivative_control);
-            symbolTable.setFunctionExtensions("dFdyFine",     1, &GL_ARB_derivative_control);
-            symbolTable.setFunctionExtensions("fwidthFine",   1, &GL_ARB_derivative_control);
-            symbolTable.setFunctionExtensions("dFdxCoarse",   1, &GL_ARB_derivative_control);
-            symbolTable.setFunctionExtensions("dFdyCoarse",   1, &GL_ARB_derivative_control);
-            symbolTable.setFunctionExtensions("fwidthCoarse", 1, &GL_ARB_derivative_control);
+            symbolTable.setFunctionExtensions("dFdxFine",     1, &_GL_ARB_derivative_control);
+            symbolTable.setFunctionExtensions("dFdyFine",     1, &_GL_ARB_derivative_control);
+            symbolTable.setFunctionExtensions("fwidthFine",   1, &_GL_ARB_derivative_control);
+            symbolTable.setFunctionExtensions("dFdxCoarse",   1, &_GL_ARB_derivative_control);
+            symbolTable.setFunctionExtensions("dFdyCoarse",   1, &_GL_ARB_derivative_control);
+            symbolTable.setFunctionExtensions("fwidthCoarse", 1, &_GL_ARB_derivative_control);
         }
 
-        symbolTable.setVariableExtensions("gl_FragDepthEXT", 1, &GL_EXT_frag_depth);
+        symbolTable.setVariableExtensions("gl_FragDepthEXT", 1, &_GL_EXT_frag_depth);
         symbolTable.setVariableExtensions("gl_PrimitiveID",  Num_AEP_geometry_shader, AEP_geometry_shader);
         symbolTable.setVariableExtensions("gl_Layer",        Num_AEP_geometry_shader, AEP_geometry_shader);
         break;
@@ -3233,15 +3233,15 @@ void IdentifyBuiltIns(int version, EProfile profile, EShLanguage language, TSymb
 void IdentifyBuiltIns(int version, EProfile profile, EShLanguage language, TSymbolTable& symbolTable, const TBuiltInResource &resources)
 {
     if (profile != EEsProfile && version >= 430 && version < 440) {
-        symbolTable.setVariableExtensions("gl_MaxTransformFeedbackBuffers", 1, &GL_ARB_enhanced_layouts);
-        symbolTable.setVariableExtensions("gl_MaxTransformFeedbackInterleavedComponents", 1, &GL_ARB_enhanced_layouts);
+        symbolTable.setVariableExtensions("gl_MaxTransformFeedbackBuffers", 1, &_GL_ARB_enhanced_layouts);
+        symbolTable.setVariableExtensions("gl_MaxTransformFeedbackInterleavedComponents", 1, &_GL_ARB_enhanced_layouts);
     }
     if (profile != EEsProfile && version >= 130 && version < 420) {
-        symbolTable.setVariableExtensions("gl_MinProgramTexelOffset", 1, &GL_ARB_shading_language_420pack);
-        symbolTable.setVariableExtensions("gl_MaxProgramTexelOffset", 1, &GL_ARB_shading_language_420pack);
+        symbolTable.setVariableExtensions("gl_MinProgramTexelOffset", 1, &_GL_ARB_shading_language_420pack);
+        symbolTable.setVariableExtensions("gl_MaxProgramTexelOffset", 1, &_GL_ARB_shading_language_420pack);
     }
     if (profile != EEsProfile && version >= 150 && version < 410)
-        symbolTable.setVariableExtensions("gl_MaxViewports", 1, &GL_ARB_viewport_array);
+        symbolTable.setVariableExtensions("gl_MaxViewports", 1, &_GL_ARB_viewport_array);
 
     switch(language) {
     case EShLangFragment:

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -730,12 +730,12 @@ TIntermTyped* TParseContext::handleDotDereference(TSourceLoc loc, TIntermTyped* 
     //
     if (field == "length") {
         if (base->isArray()) {
-            profileRequires(loc, ENoProfile, 120, GL_3DL_array_objects, ".length");
+            profileRequires(loc, ENoProfile, 120, _GL_3DL_array_objects, ".length");
             profileRequires(loc, EEsProfile, 300, nullptr, ".length");
         } else if (base->isVector() || base->isMatrix()) {
             const char* feature = ".length() on vectors and matrices";
             requireProfile(loc, ~EEsProfile, feature);
-            profileRequires(loc, ~EEsProfile, 420, GL_ARB_shading_language_420pack, feature);
+            profileRequires(loc, ~EEsProfile, 420, _GL_ARB_shading_language_420pack, feature);
         } else {
             error(loc, "does not operate on this type:", field.c_str(), base->getType().getCompleteString().c_str());
 
@@ -761,7 +761,7 @@ TIntermTyped* TParseContext::handleDotDereference(TSourceLoc loc, TIntermTyped* 
         if (base->isScalar()) {
             const char* dotFeature = "scalar swizzle";
             requireProfile(loc, ~EEsProfile, dotFeature);
-            profileRequires(loc, ~EEsProfile, 420, GL_ARB_shading_language_420pack, dotFeature);
+            profileRequires(loc, ~EEsProfile, 420, _GL_ARB_shading_language_420pack, dotFeature);
         }
 
         TVectorFields fields;
@@ -1310,13 +1310,13 @@ void TParseContext::nonOpBuiltInCheck(TSourceLoc loc, const TFunction& fnCandida
             if (fnCandidate.getName().compare("textureGatherOffset") == 0) {
                 // GL_ARB_texture_gather is good enough for 2D non-shadow textures with no component argument
                 if (fnCandidate[0].type->getSampler().dim == Esd2D && ! fnCandidate[0].type->getSampler().shadow && fnCandidate.getParamCount() == 3)
-                    profileRequires(loc, ~EEsProfile, 400, GL_ARB_texture_gather, feature);
+                    profileRequires(loc, ~EEsProfile, 400, _GL_ARB_texture_gather, feature);
                 else
-                    profileRequires(loc, ~EEsProfile, 400, GL_ARB_gpu_shader5, feature);
+                    profileRequires(loc, ~EEsProfile, 400, _GL_ARB_gpu_shader5, feature);
                 if (! fnCandidate[0].type->getSampler().shadow)
                     compArg = 3;
             } else if (fnCandidate.getName().compare("textureGatherOffsets") == 0) {
-                profileRequires(loc, ~EEsProfile, 400, GL_ARB_gpu_shader5, feature);
+                profileRequires(loc, ~EEsProfile, 400, _GL_ARB_gpu_shader5, feature);
                 if (! fnCandidate[0].type->getSampler().shadow)
                     compArg = 3;
                 // check for constant offsets
@@ -1327,11 +1327,11 @@ void TParseContext::nonOpBuiltInCheck(TSourceLoc loc, const TFunction& fnCandida
                 // More than two arguments needs gpu_shader5, and rectangular or shadow needs gpu_shader5,
                 // otherwise, need GL_ARB_texture_gather.
                 if (fnCandidate.getParamCount() > 2 || fnCandidate[0].type->getSampler().dim == EsdRect || fnCandidate[0].type->getSampler().shadow) {
-                    profileRequires(loc, ~EEsProfile, 400, GL_ARB_gpu_shader5, feature);
+                    profileRequires(loc, ~EEsProfile, 400, _GL_ARB_gpu_shader5, feature);
                     if (! fnCandidate[0].type->getSampler().shadow)
                         compArg = 2;
                 } else
-                    profileRequires(loc, ~EEsProfile, 400, GL_ARB_texture_gather, feature);
+                    profileRequires(loc, ~EEsProfile, 400, _GL_ARB_texture_gather, feature);
             }
 
             if (compArg > 0 && compArg < fnCandidate.getParamCount()) {
@@ -1381,7 +1381,7 @@ void TParseContext::nonOpBuiltInCheck(TSourceLoc loc, const TFunction& fnCandida
 
     // GL_ARB_shader_texture_image_samples
     if (fnCandidate.getName().compare(0, 14, "textureSamples") == 0 || fnCandidate.getName().compare(0, 12, "imageSamples") == 0)
-        profileRequires(loc, ~EEsProfile, 450, GL_ARB_shader_texture_image_samples, "textureSamples and imageSamples");
+        profileRequires(loc, ~EEsProfile, 450, _GL_ARB_shader_texture_image_samples, "textureSamples and imageSamples");
 
     if (fnCandidate.getName().compare(0, 11, "imageAtomic") == 0) {
         const TType& imageType = callNode.getSequence()[0]->getAsTyped()->getType();
@@ -1402,7 +1402,7 @@ TFunction* TParseContext::handleConstructorCall(TSourceLoc loc, const TPublicTyp
     type.getQualifier().precision = EpqNone;
 
     if (type.isArray()) {
-        profileRequires(loc, ENoProfile, 120, GL_3DL_array_objects, "arrayed constructor");
+        profileRequires(loc, ENoProfile, 120, _GL_3DL_array_objects, "arrayed constructor");
         profileRequires(loc, EEsProfile, 300, nullptr, "arrayed constructor");
     }
 
@@ -1841,7 +1841,7 @@ bool TParseContext::lineContinuationCheck(TSourceLoc loc, bool endOfComment)
     const char* message = "line continuation";
 
     bool lineContinuationAllowed = (profile == EEsProfile && version >= 300) ||
-                                   (profile != EEsProfile && (version >= 420 || extensionsTurnedOn(1, &GL_ARB_shading_language_420pack)));
+                                   (profile != EEsProfile && (version >= 420 || extensionsTurnedOn(1, &_GL_ARB_shading_language_420pack)));
 
     if (endOfComment) {
         if (lineContinuationAllowed)
@@ -1858,7 +1858,7 @@ bool TParseContext::lineContinuationCheck(TSourceLoc loc, bool endOfComment)
         return true;
     } else {
         profileRequires(loc, EEsProfile, 300, nullptr, message);
-        profileRequires(loc, ~EEsProfile, 420, GL_ARB_shading_language_420pack, message);
+        profileRequires(loc, ~EEsProfile, 420, _GL_ARB_shading_language_420pack, message);
     }
 
     return lineContinuationAllowed;
@@ -2228,7 +2228,7 @@ void TParseContext::mergeQualifiers(TSourceLoc loc, TQualifier& dst, const TQual
     // Ordering
     if (! force && ((profile != EEsProfile && version < 420) || 
                     (profile == EEsProfile && version < 310))
-                && ! extensionsTurnedOn(1, &GL_ARB_shading_language_420pack)) {
+                && ! extensionsTurnedOn(1, &_GL_ARB_shading_language_420pack)) {
         // non-function parameters
         if (src.invariant && (dst.isInterpolation() || dst.isAuxiliary() || dst.storage != EvqTemporary || dst.precision != EpqNone))
             error(loc, "invariant qualifier must appear first", "", "");
@@ -2411,7 +2411,7 @@ void TParseContext::arraySizeCheck(TSourceLoc loc, TIntermTyped* expr, int& size
 bool TParseContext::arrayQualifierError(TSourceLoc loc, const TQualifier& qualifier)
 {
     if (qualifier.storage == EvqConst) {
-        profileRequires(loc, ENoProfile, 120, GL_3DL_array_objects, "const array");
+        profileRequires(loc, ENoProfile, 120, _GL_3DL_array_objects, "const array");
         profileRequires(loc, EEsProfile, 300, nullptr, "const array");
     }
 
@@ -2683,7 +2683,7 @@ TSymbol* TParseContext::redeclareBuiltinVariable(TSourceLoc loc, const TString& 
 
     // Special case when using GL_ARB_separate_shader_objects
     bool ssoPre150 = false;  // means the only reason this variable is redeclared is due to this combination
-    if (profile != EEsProfile && version <= 140 && extensionsTurnedOn(1, &GL_ARB_separate_shader_objects)) {
+    if (profile != EEsProfile && version <= 140 && extensionsTurnedOn(1, &_GL_ARB_separate_shader_objects)) {
         if (identifier == "gl_Position"     ||
             identifier == "gl_PointSize"    ||
             identifier == "gl_ClipVertex"   ||
@@ -2800,7 +2800,7 @@ void TParseContext::redeclareBuiltinBlock(TSourceLoc loc, TTypeList& newTypeList
 {
     const char* feature = "built-in block redeclaration";
     profileRequires(loc, EEsProfile, 0, Num_AEP_shader_io_blocks, AEP_shader_io_blocks, feature);
-    profileRequires(loc, ~EEsProfile, 410, GL_ARB_separate_shader_objects, feature);
+    profileRequires(loc, ~EEsProfile, 410, _GL_ARB_separate_shader_objects, feature);
 
     if (blockName != "gl_PerVertex" && blockName != "gl_PerFragment") {
         error(loc, "cannot redeclare block: ", "block declaration", blockName.c_str());
@@ -2998,7 +2998,7 @@ void TParseContext::arrayObjectCheck(TSourceLoc loc, const TType& type, const ch
 {
     // Some versions don't allow comparing arrays or structures containing arrays
     if (type.containsArray()) {
-        profileRequires(loc, ENoProfile, 120, GL_3DL_array_objects, op);
+        profileRequires(loc, ENoProfile, 120, _GL_3DL_array_objects, op);
         profileRequires(loc, EEsProfile, 300, nullptr, op);
     }
 }
@@ -3194,11 +3194,11 @@ void TParseContext::finalErrorCheck()
         if (profile == EEsProfile && version == 310)
             requireExtensions(getCurrentLoc(), Num_AEP_tessellation_shader, AEP_tessellation_shader, "tessellation shaders");
         else if (profile != EEsProfile && version < 400)
-            requireExtensions(getCurrentLoc(), 1, &GL_ARB_tessellation_shader, "tessellation shaders");
+            requireExtensions(getCurrentLoc(), 1, &_GL_ARB_tessellation_shader, "tessellation shaders");
         break;
     case EShLangCompute:
         if (profile != EEsProfile && version < 430)
-            requireExtensions(getCurrentLoc(), 1, &GL_ARB_compute_shader, "tessellation shaders");
+            requireExtensions(getCurrentLoc(), 1, &_GL_ARB_compute_shader, "tessellation shaders");
         break;
     default:
         break;
@@ -3248,8 +3248,8 @@ void TParseContext::setLayoutQualifier(TSourceLoc loc, TPublicType& publicType, 
                 (format > ElfEsIntGuard && format < ElfIntGuard) ||
                 (format > ElfEsUintGuard && format < ElfCount))
                 requireProfile(loc, ENoProfile | ECoreProfile | ECompatibilityProfile, "image load-store format");
-            profileRequires(loc, ENoProfile | ECoreProfile | ECompatibilityProfile, 420, GL_ARB_shader_image_load_store, "image load store");
-            profileRequires(loc, EEsProfile, 310, GL_ARB_shader_image_load_store, "image load store");
+            profileRequires(loc, ENoProfile | ECoreProfile | ECompatibilityProfile, 420, _GL_ARB_shader_image_load_store, "image load store");
+            profileRequires(loc, EEsProfile, 310, _GL_ARB_shader_image_load_store, "image load store");
             publicType.qualifier.layoutFormat = format;
             return;
         }
@@ -3344,7 +3344,7 @@ void TParseContext::setLayoutQualifier(TSourceLoc loc, TPublicType& publicType, 
             return;
         }
         if (id == "early_fragment_tests") {
-            profileRequires(loc, ENoProfile | ECoreProfile | ECompatibilityProfile, 420, GL_ARB_shader_image_load_store, "early_fragment_tests");
+            profileRequires(loc, ENoProfile | ECoreProfile | ECompatibilityProfile, 420, _GL_ARB_shader_image_load_store, "early_fragment_tests");
             profileRequires(loc, EEsProfile, 310, nullptr, "early_fragment_tests");
             publicType.shaderQualifiers.earlyFragmentTests = true;
             return;
@@ -3375,7 +3375,7 @@ void TParseContext::setLayoutQualifier(TSourceLoc loc, TPublicType& publicType, 
         value = constUnion->getConstArray()[0].getIConst();
         if (! constUnion->isLiteral()) {
             requireProfile(loc, ECoreProfile | ECompatibilityProfile, nonLiteralFeature);
-            profileRequires(loc, ECoreProfile | ECompatibilityProfile, 440, GL_ARB_enhanced_layouts, nonLiteralFeature);
+            profileRequires(loc, ECoreProfile | ECompatibilityProfile, 440, _GL_ARB_enhanced_layouts, nonLiteralFeature);
         }
     } else {
         // grammar should have give out the error message
@@ -3392,7 +3392,7 @@ void TParseContext::setLayoutQualifier(TSourceLoc loc, TPublicType& publicType, 
     if (id == "offset") {
         const char* feature = "uniform offset";
         requireProfile(loc, EEsProfile | ECoreProfile | ECompatibilityProfile, feature);
-        const char* exts[2] = { GL_ARB_enhanced_layouts, GL_ARB_shader_atomic_counters };
+        const char* exts[2] = { _GL_ARB_enhanced_layouts, _GL_ARB_shader_atomic_counters };
         profileRequires(loc, ECoreProfile | ECompatibilityProfile, 420, 2, exts, feature);
         profileRequires(loc, EEsProfile, 310, nullptr, feature);
         publicType.qualifier.layoutOffset = value;
@@ -3400,7 +3400,7 @@ void TParseContext::setLayoutQualifier(TSourceLoc loc, TPublicType& publicType, 
     } else if (id == "align") {
         const char* feature = "uniform buffer-member align";
         requireProfile(loc, ECoreProfile | ECompatibilityProfile, feature);
-        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 440, GL_ARB_enhanced_layouts, feature);
+        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 440, _GL_ARB_enhanced_layouts, feature);
         // "The specified alignment must be a power of 2, or a compile-time error results."
         if (! IsPow2(value))
             error(loc, "must be a power of 2", "align", "");
@@ -3409,7 +3409,7 @@ void TParseContext::setLayoutQualifier(TSourceLoc loc, TPublicType& publicType, 
         return;
     } else if (id == "location") {
         profileRequires(loc, EEsProfile, 300, nullptr, "location");
-        const char* exts[2] = { GL_ARB_separate_shader_objects, GL_ARB_explicit_attrib_location };
+        const char* exts[2] = { _GL_ARB_separate_shader_objects, _GL_ARB_explicit_attrib_location };
         profileRequires(loc, ~EEsProfile, 330, 2, exts, "location");
         if ((unsigned int)value >= TQualifier::layoutLocationEnd)
             error(loc, "location is too large", id.c_str(), "");
@@ -3423,7 +3423,7 @@ void TParseContext::setLayoutQualifier(TSourceLoc loc, TPublicType& publicType, 
             publicType.qualifier.layoutSet = value;
         return;
     } else if (id == "binding") {
-        profileRequires(loc, ~EEsProfile, 420, GL_ARB_shading_language_420pack, "binding");
+        profileRequires(loc, ~EEsProfile, 420, _GL_ARB_shading_language_420pack, "binding");
         profileRequires(loc, EEsProfile, 310, nullptr, "binding");
         if ((unsigned int)value >= TQualifier::layoutBindingEnd)
             error(loc, "binding is too large", id.c_str(), "");
@@ -3432,7 +3432,7 @@ void TParseContext::setLayoutQualifier(TSourceLoc loc, TPublicType& publicType, 
         return;
     } else if (id == "component") {
         requireProfile(loc, ECoreProfile | ECompatibilityProfile, "component");
-        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 440, GL_ARB_enhanced_layouts, "component");
+        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 440, _GL_ARB_enhanced_layouts, "component");
         if ((unsigned)value >= TQualifier::layoutComponentEnd)
             error(loc, "component is too large", id.c_str(), "");
         else
@@ -3447,7 +3447,7 @@ void TParseContext::setLayoutQualifier(TSourceLoc loc, TPublicType& publicType, 
         const char* feature = "transform feedback qualifier";
         requireStage(loc, (EShLanguageMask)(EShLangVertexMask | EShLangGeometryMask | EShLangTessControlMask | EShLangTessEvaluationMask), feature);
         requireProfile(loc, ECoreProfile | ECompatibilityProfile, feature);
-        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 440, GL_ARB_enhanced_layouts, feature);
+        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 440, _GL_ARB_enhanced_layouts, feature);
         if (id == "xfb_buffer") {
             // "It is a compile-time error to specify an *xfb_buffer* that is greater than
             // the implementation-dependent constant gl_MaxTransformFeedbackBuffers."
@@ -3513,7 +3513,7 @@ void TParseContext::setLayoutQualifier(TSourceLoc loc, TPublicType& publicType, 
     case EShLangFragment:
         if (id == "index") {
             requireProfile(loc, ECompatibilityProfile | ECoreProfile, "index layout qualifier on fragment output");
-            const char* exts[2] = { GL_ARB_separate_shader_objects, GL_ARB_explicit_attrib_location };
+            const char* exts[2] = { _GL_ARB_separate_shader_objects, _GL_ARB_explicit_attrib_location };
             profileRequires(loc, ECompatibilityProfile | ECoreProfile, 330, 2, exts, "index layout qualifier on fragment output");
             publicType.qualifier.layoutIndex = value;
             return;
@@ -3678,7 +3678,7 @@ void TParseContext::layoutTypeCheck(TSourceLoc loc, const TType& type)
         case EvqVaryingIn:
         case EvqVaryingOut:
             if (type.getBasicType() == EbtBlock)
-                profileRequires(loc, ECoreProfile | ECompatibilityProfile, 440, GL_ARB_enhanced_layouts, "location qualifier on in/out block");
+                profileRequires(loc, ECoreProfile | ECompatibilityProfile, 440, _GL_ARB_enhanced_layouts, "location qualifier on in/out block");
             break;
         case EvqUniform:
         case EvqBuffer:
@@ -3806,11 +3806,11 @@ void TParseContext::layoutQualifierCheck(TSourceLoc loc, const TQualifier& quali
             else
                 requireStage(loc, (EShLanguageMask)~EShLangComputeMask, feature);
             if (language == EShLangVertex) {
-                const char* exts[2] = { GL_ARB_separate_shader_objects, GL_ARB_explicit_attrib_location };
+                const char* exts[2] = { _GL_ARB_separate_shader_objects, _GL_ARB_explicit_attrib_location };
                 profileRequires(loc, ~EEsProfile, 330, 2, exts, feature);
                 profileRequires(loc, EEsProfile, 300, nullptr, feature);
             } else {
-                profileRequires(loc, ~EEsProfile, 410, GL_ARB_separate_shader_objects, feature);
+                profileRequires(loc, ~EEsProfile, 410, _GL_ARB_separate_shader_objects, feature);
                 profileRequires(loc, EEsProfile, 310, nullptr, feature);
             }
             break;
@@ -3823,11 +3823,11 @@ void TParseContext::layoutQualifierCheck(TSourceLoc loc, const TQualifier& quali
             else
                 requireStage(loc, (EShLanguageMask)~EShLangComputeMask, feature);
             if (language == EShLangFragment) {
-                const char* exts[2] = { GL_ARB_separate_shader_objects, GL_ARB_explicit_attrib_location };
+                const char* exts[2] = { _GL_ARB_separate_shader_objects, _GL_ARB_explicit_attrib_location };
                 profileRequires(loc, ~EEsProfile, 330, 2, exts, feature);
                 profileRequires(loc, EEsProfile, 300, nullptr, feature);
             } else {
-                profileRequires(loc, ~EEsProfile, 410, GL_ARB_separate_shader_objects, feature);
+                profileRequires(loc, ~EEsProfile, 410, _GL_ARB_separate_shader_objects, feature);
                 profileRequires(loc, EEsProfile, 310, nullptr, feature);
             }
             break;
@@ -4107,7 +4107,7 @@ TIntermNode* TParseContext::declareVariable(TSourceLoc loc, TString& identifier,
             declareArray(loc, identifier, type, symbol, newDeclaration);
 
         if (initializer) {
-            profileRequires(loc, ENoProfile, 120, GL_3DL_array_objects, "initializer");
+            profileRequires(loc, ENoProfile, 120, _GL_3DL_array_objects, "initializer");
             profileRequires(loc, EEsProfile, 300, nullptr, "initializer");
         }
     } else {
@@ -4246,7 +4246,7 @@ TIntermNode* TParseContext::executeInitializer(TSourceLoc loc, TIntermTyped* ini
         if (initializer->getType().getQualifier().storage != EvqConst) {
             const char* initFeature = "non-constant initializer";
             requireProfile(loc, ~EEsProfile, initFeature);
-            profileRequires(loc, ~EEsProfile, 420, GL_ARB_shading_language_420pack, initFeature);
+            profileRequires(loc, ~EEsProfile, 420, _GL_ARB_shading_language_420pack, initFeature);
             variable->getWritableType().getQualifier().storage = EvqConstReadOnly;
             qualifier = EvqConstReadOnly;
         }
@@ -4580,7 +4580,7 @@ void TParseContext::declareBlock(TSourceLoc loc, TTypeList& typeList, const TStr
             requireProfile(memberLoc, ~EEsProfile, "implicitly-sized array in a block");
         if (memberQualifier.hasOffset()) {
             requireProfile(memberLoc, ~EEsProfile, "offset on block member");
-            profileRequires(memberLoc, ~EEsProfile, 440, GL_ARB_enhanced_layouts, "offset on block member");
+            profileRequires(memberLoc, ~EEsProfile, 440, _GL_ARB_enhanced_layouts, "offset on block member");
         }
 
         TBasicType basicType = memberType.getBasicType();
@@ -4653,7 +4653,7 @@ void TParseContext::declareBlock(TSourceLoc loc, TTypeList& typeList, const TStr
             case EvqVaryingIn:
             case EvqVaryingOut:
                 requireProfile(memberLoc, ECoreProfile | ECompatibilityProfile | EEsProfile, feature);
-                profileRequires(memberLoc, ECoreProfile | ECompatibilityProfile, 440, GL_ARB_enhanced_layouts, feature);
+                profileRequires(memberLoc, ECoreProfile | ECompatibilityProfile, 440, _GL_ARB_enhanced_layouts, feature);
                 profileRequires(memberLoc, EEsProfile, 0, Num_AEP_shader_io_blocks, AEP_shader_io_blocks, feature);
                 memberWithLocation = true;
                 break;
@@ -4767,7 +4767,7 @@ void TParseContext::blockStageIoCheck(TSourceLoc loc, const TQualifier& qualifie
         profileRequires(loc, EEsProfile, 310, nullptr, "buffer block");
         break;
     case EvqVaryingIn:
-        profileRequires(loc, ~EEsProfile, 150, GL_ARB_separate_shader_objects, "input block");
+        profileRequires(loc, ~EEsProfile, 150, _GL_ARB_separate_shader_objects, "input block");
         // It is a compile-time error to have an input block in a vertex shader or an output block in a fragment shader
         // "Compute shaders do not permit user-defined input variables..."
         requireStage(loc, (EShLanguageMask)(EShLangTessControlMask|EShLangTessEvaluationMask|EShLangGeometryMask|EShLangFragmentMask), "input block");
@@ -4775,7 +4775,7 @@ void TParseContext::blockStageIoCheck(TSourceLoc loc, const TQualifier& qualifie
             profileRequires(loc, EEsProfile, 0, Num_AEP_shader_io_blocks, AEP_shader_io_blocks, "fragment input block");
         break;
     case EvqVaryingOut:
-        profileRequires(loc, ~EEsProfile, 150, GL_ARB_separate_shader_objects, "output block");
+        profileRequires(loc, ~EEsProfile, 150, _GL_ARB_separate_shader_objects, "output block");
         requireStage(loc, (EShLanguageMask)(EShLangVertexMask|EShLangTessControlMask|EShLangTessEvaluationMask|EShLangGeometryMask), "output block");
         // ES 310 can have a block before shader_io is turned on, so skip this test for built-ins
         if (language == EShLangVertex && ! parsingBuiltins)

--- a/glslang/MachineIndependent/Scan.cpp
+++ b/glslang/MachineIndependent/Scan.cpp
@@ -686,7 +686,7 @@ int TScanContext::tokenizeIdentifier()
 
     case ATOMIC_UINT:
         if (parseContext.profile == EEsProfile && parseContext.version >= 310 ||
-            parseContext.extensionsTurnedOn(1, &GL_ARB_shader_atomic_counters))
+            parseContext.extensionsTurnedOn(1, &_GL_ARB_shader_atomic_counters))
             return keyword;
         return es30ReservedFromGLSL(420);
 
@@ -696,20 +696,20 @@ int TScanContext::tokenizeIdentifier()
     case WRITEONLY:
         if (parseContext.profile == EEsProfile && parseContext.version >= 310)
             return keyword;
-        return es30ReservedFromGLSL(parseContext.extensionsTurnedOn(1, &GL_ARB_shader_image_load_store) ? 130 : 420);
+        return es30ReservedFromGLSL(parseContext.extensionsTurnedOn(1, &_GL_ARB_shader_image_load_store) ? 130 : 420);
 
     case VOLATILE:
         if (parseContext.profile == EEsProfile && parseContext.version >= 310)
             return keyword;
-        if (! parseContext.symbolTable.atBuiltInLevel() && (parseContext.profile == EEsProfile || (parseContext.version < 420 && ! parseContext.extensionsTurnedOn(1, &GL_ARB_shader_image_load_store))))
+        if (! parseContext.symbolTable.atBuiltInLevel() && (parseContext.profile == EEsProfile || (parseContext.version < 420 && ! parseContext.extensionsTurnedOn(1, &_GL_ARB_shader_image_load_store))))
             reservedWord();
         return keyword;
 
     case LAYOUT:
     {
         const int numLayoutExts = 2;
-        const char* layoutExts[numLayoutExts] = { GL_ARB_shading_language_420pack,
-                                                  GL_ARB_explicit_attrib_location };
+        const char* layoutExts[numLayoutExts] = { _GL_ARB_shading_language_420pack,
+                                                  _GL_ARB_explicit_attrib_location };
         if ((parseContext.profile == EEsProfile && parseContext.version < 300) ||
             (parseContext.profile != EEsProfile && parseContext.version < 140 &&
             ! parseContext.extensionsTurnedOn(numLayoutExts, layoutExts)))
@@ -725,7 +725,7 @@ int TScanContext::tokenizeIdentifier()
     case PATCH:
         if (parseContext.symbolTable.atBuiltInLevel() ||
             (parseContext.profile == EEsProfile && parseContext.extensionsTurnedOn(Num_AEP_tessellation_shader, AEP_tessellation_shader)) ||
-            (parseContext.profile != EEsProfile && parseContext.extensionsTurnedOn(1, &GL_ARB_tessellation_shader)))
+            (parseContext.profile != EEsProfile && parseContext.extensionsTurnedOn(1, &_GL_ARB_tessellation_shader)))
             return keyword;
 
         return es30ReservedFromGLSL(400);
@@ -818,7 +818,7 @@ int TScanContext::tokenizeIdentifier()
     case ISAMPLERCUBEARRAY:
     case USAMPLERCUBEARRAY:
         afterType = true;
-        if (parseContext.profile == EEsProfile || (parseContext.version < 400 && ! parseContext.extensionsTurnedOn(1, &GL_ARB_texture_cube_map_array)))
+        if (parseContext.profile == EEsProfile || (parseContext.version < 400 && ! parseContext.extensionsTurnedOn(1, &_GL_ARB_texture_cube_map_array)))
             reservedWord();
         return keyword;
 
@@ -880,7 +880,7 @@ int TScanContext::tokenizeIdentifier()
     case SAMPLER3D:
         afterType = true;
         if (parseContext.profile == EEsProfile && parseContext.version < 300) {
-            if (! parseContext.extensionsTurnedOn(1, &GL_OES_texture_3D))
+            if (! parseContext.extensionsTurnedOn(1, &_GL_OES_texture_3D))
                 reservedWord();
         }
         return keyword;
@@ -896,9 +896,9 @@ int TScanContext::tokenizeIdentifier()
         afterType = true;
         if (parseContext.profile == EEsProfile)
             reservedWord();
-        else if (parseContext.version < 140 && ! parseContext.symbolTable.atBuiltInLevel() && ! parseContext.extensionsTurnedOn(1, &GL_ARB_texture_rectangle)) {
+        else if (parseContext.version < 140 && ! parseContext.symbolTable.atBuiltInLevel() && ! parseContext.extensionsTurnedOn(1, &_GL_ARB_texture_rectangle)) {
             if (parseContext.messages & EShMsgRelaxedErrors)
-                parseContext.requireExtensions(loc, 1, &GL_ARB_texture_rectangle, "texture-rectangle sampler keyword");
+                parseContext.requireExtensions(loc, 1, &_GL_ARB_texture_rectangle, "texture-rectangle sampler keyword");
             else
                 reservedWord();
         }
@@ -915,7 +915,7 @@ int TScanContext::tokenizeIdentifier()
 
     case SAMPLEREXTERNALOES:
         afterType = true;
-        if (parseContext.symbolTable.atBuiltInLevel() || parseContext.extensionsTurnedOn(1, &GL_OES_EGL_image_external))
+        if (parseContext.symbolTable.atBuiltInLevel() || parseContext.extensionsTurnedOn(1, &_GL_OES_EGL_image_external))
             return keyword;
         return identifierOrType();
 
@@ -1107,7 +1107,7 @@ int TScanContext::firstGenerationImage(bool inEs310)
     afterType = true;
 
     if (parseContext.symbolTable.atBuiltInLevel() || 
-        (parseContext.profile != EEsProfile && (parseContext.version >= 420 || parseContext.extensionsTurnedOn(1, &GL_ARB_shader_image_load_store))) ||                                                     
+        (parseContext.profile != EEsProfile && (parseContext.version >= 420 || parseContext.extensionsTurnedOn(1, &_GL_ARB_shader_image_load_store))) ||                                                     
         (inEs310 && parseContext.profile == EEsProfile && parseContext.version >= 310))
         return keyword;
 
@@ -1135,7 +1135,7 @@ int TScanContext::secondGenerationImage()
 
     if (parseContext.symbolTable.atBuiltInLevel() || 
         (parseContext.profile != EEsProfile && 
-         (parseContext.version >= 420 || parseContext.extensionsTurnedOn(1, &GL_ARB_shader_image_load_store))))
+         (parseContext.version >= 420 || parseContext.extensionsTurnedOn(1, &_GL_ARB_shader_image_load_store))))
         return keyword;
 
     if (parseContext.forwardCompatible)

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -149,58 +149,58 @@ namespace glslang {
 //
 void TParseContext::initializeExtensionBehavior()
 {
-    extensionBehavior[GL_OES_texture_3D]                   = EBhDisable;
-    extensionBehavior[GL_OES_standard_derivatives]         = EBhDisable;
-    extensionBehavior[GL_EXT_frag_depth]                   = EBhDisable;
-    extensionBehavior[GL_OES_EGL_image_external]           = EBhDisable;
-    extensionBehavior[GL_EXT_shader_texture_lod]           = EBhDisable;
+    extensionBehavior[_GL_OES_texture_3D]                   = EBhDisable;
+    extensionBehavior[_GL_OES_standard_derivatives]         = EBhDisable;
+    extensionBehavior[_GL_EXT_frag_depth]                   = EBhDisable;
+    extensionBehavior[_GL_OES_EGL_image_external]           = EBhDisable;
+    extensionBehavior[_GL_EXT_shader_texture_lod]           = EBhDisable;
                                                           
-    extensionBehavior[GL_ARB_texture_rectangle]            = EBhDisable;
-    extensionBehavior[GL_3DL_array_objects]                = EBhDisable;
-    extensionBehavior[GL_ARB_shading_language_420pack]     = EBhDisable;
-    extensionBehavior[GL_ARB_texture_gather]               = EBhDisable;
-    extensionBehavior[GL_ARB_gpu_shader5]                  = EBhDisablePartial;
-    extensionBehavior[GL_ARB_separate_shader_objects]      = EBhDisable;
-    extensionBehavior[GL_ARB_compute_shader]               = EBhDisablePartial;
-    extensionBehavior[GL_ARB_tessellation_shader]          = EBhDisable;
-    extensionBehavior[GL_ARB_enhanced_layouts]             = EBhDisable;
-    extensionBehavior[GL_ARB_texture_cube_map_array]       = EBhDisable;
-    extensionBehavior[GL_ARB_shader_texture_lod]           = EBhDisable;
-    extensionBehavior[GL_ARB_explicit_attrib_location]     = EBhDisable;
-    extensionBehavior[GL_ARB_shader_image_load_store]      = EBhDisable;
-    extensionBehavior[GL_ARB_shader_atomic_counters]       = EBhDisable;
-    extensionBehavior[GL_ARB_derivative_control]           = EBhDisable;
-    extensionBehavior[GL_ARB_shader_texture_image_samples] = EBhDisable;
-    extensionBehavior[GL_ARB_viewport_array]               = EBhDisable;
-//    extensionBehavior[GL_ARB_cull_distance]                = EBhDisable;    // present for 4.5, but need extension control over block members
+    extensionBehavior[_GL_ARB_texture_rectangle]            = EBhDisable;
+    extensionBehavior[_GL_3DL_array_objects]                = EBhDisable;
+    extensionBehavior[_GL_ARB_shading_language_420pack]     = EBhDisable;
+    extensionBehavior[_GL_ARB_texture_gather]               = EBhDisable;
+    extensionBehavior[_GL_ARB_gpu_shader5]                  = EBhDisablePartial;
+    extensionBehavior[_GL_ARB_separate_shader_objects]      = EBhDisable;
+    extensionBehavior[_GL_ARB_compute_shader]               = EBhDisablePartial;
+    extensionBehavior[_GL_ARB_tessellation_shader]          = EBhDisable;
+    extensionBehavior[_GL_ARB_enhanced_layouts]             = EBhDisable;
+    extensionBehavior[_GL_ARB_texture_cube_map_array]       = EBhDisable;
+    extensionBehavior[_GL_ARB_shader_texture_lod]           = EBhDisable;
+    extensionBehavior[_GL_ARB_explicit_attrib_location]     = EBhDisable;
+    extensionBehavior[_GL_ARB_shader_image_load_store]      = EBhDisable;
+    extensionBehavior[_GL_ARB_shader_atomic_counters]       = EBhDisable;
+    extensionBehavior[_GL_ARB_derivative_control]           = EBhDisable;
+    extensionBehavior[_GL_ARB_shader_texture_image_samples] = EBhDisable;
+    extensionBehavior[_GL_ARB_viewport_array]               = EBhDisable;
+//    extensionBehavior[_GL_ARB_cull_distance]                = EBhDisable;    // present for 4.5, but need extension control over block members
 
     // AEP
-    extensionBehavior[GL_ANDROID_extension_pack_es31a]             = EBhDisablePartial;
-    extensionBehavior[GL_KHR_blend_equation_advanced]              = EBhDisablePartial;
-    extensionBehavior[GL_OES_sample_variables]                     = EBhDisablePartial;
-    extensionBehavior[GL_OES_shader_image_atomic]                  = EBhDisablePartial;
-    extensionBehavior[GL_OES_shader_multisample_interpolation]     = EBhDisablePartial;
-    extensionBehavior[GL_OES_texture_storage_multisample_2d_array] = EBhDisablePartial;
-    extensionBehavior[GL_EXT_geometry_shader]                      = EBhDisable;
-    extensionBehavior[GL_EXT_geometry_point_size]                  = EBhDisable;
-    extensionBehavior[GL_EXT_gpu_shader5]                          = EBhDisablePartial;
-    extensionBehavior[GL_EXT_primitive_bounding_box]               = EBhDisablePartial;
-    extensionBehavior[GL_EXT_shader_io_blocks]                     = EBhDisable;
-    extensionBehavior[GL_EXT_tessellation_shader]                  = EBhDisable;
-    extensionBehavior[GL_EXT_tessellation_point_size]              = EBhDisable;
-    extensionBehavior[GL_EXT_texture_buffer]                       = EBhDisablePartial;
-    extensionBehavior[GL_EXT_texture_cube_map_array]               = EBhDisablePartial;
+    extensionBehavior[_GL_ANDROID_extension_pack_es31a]             = EBhDisablePartial;
+    extensionBehavior[_GL_KHR_blend_equation_advanced]              = EBhDisablePartial;
+    extensionBehavior[_GL_OES_sample_variables]                     = EBhDisablePartial;
+    extensionBehavior[_GL_OES_shader_image_atomic]                  = EBhDisablePartial;
+    extensionBehavior[_GL_OES_shader_multisample_interpolation]     = EBhDisablePartial;
+    extensionBehavior[_GL_OES_texture_storage_multisample_2d_array] = EBhDisablePartial;
+    extensionBehavior[_GL_EXT_geometry_shader]                      = EBhDisable;
+    extensionBehavior[_GL_EXT_geometry_point_size]                  = EBhDisable;
+    extensionBehavior[_GL_EXT_gpu_shader5]                          = EBhDisablePartial;
+    extensionBehavior[_GL_EXT_primitive_bounding_box]               = EBhDisablePartial;
+    extensionBehavior[_GL_EXT_shader_io_blocks]                     = EBhDisable;
+    extensionBehavior[_GL_EXT_tessellation_shader]                  = EBhDisable;
+    extensionBehavior[_GL_EXT_tessellation_point_size]              = EBhDisable;
+    extensionBehavior[_GL_EXT_texture_buffer]                       = EBhDisablePartial;
+    extensionBehavior[_GL_EXT_texture_cube_map_array]               = EBhDisablePartial;
 
     // OES matching AEP
-    extensionBehavior[GL_OES_geometry_shader]          = EBhDisable;
-    extensionBehavior[GL_OES_geometry_point_size]      = EBhDisable;
-    extensionBehavior[GL_OES_gpu_shader5]              = EBhDisablePartial;
-    extensionBehavior[GL_OES_primitive_bounding_box]   = EBhDisablePartial;
-    extensionBehavior[GL_OES_shader_io_blocks]         = EBhDisable;
-    extensionBehavior[GL_OES_tessellation_shader]      = EBhDisable;
-    extensionBehavior[GL_OES_tessellation_point_size]  = EBhDisable;
-    extensionBehavior[GL_OES_texture_buffer]           = EBhDisablePartial;
-    extensionBehavior[GL_OES_texture_cube_map_array]   = EBhDisablePartial;
+    extensionBehavior[_GL_OES_geometry_shader]          = EBhDisable;
+    extensionBehavior[_GL_OES_geometry_point_size]      = EBhDisable;
+    extensionBehavior[_GL_OES_gpu_shader5]              = EBhDisablePartial;
+    extensionBehavior[_GL_OES_primitive_bounding_box]   = EBhDisablePartial;
+    extensionBehavior[_GL_OES_shader_io_blocks]         = EBhDisable;
+    extensionBehavior[_GL_OES_tessellation_shader]      = EBhDisable;
+    extensionBehavior[_GL_OES_tessellation_point_size]  = EBhDisable;
+    extensionBehavior[_GL_OES_texture_buffer]           = EBhDisablePartial;
+    extensionBehavior[_GL_OES_texture_cube_map_array]   = EBhDisablePartial;
 }
 
 // Get code that is not part of a shared symbol table, is specific to this shader,

--- a/glslang/MachineIndependent/Versions.h
+++ b/glslang/MachineIndependent/Versions.h
@@ -87,86 +87,86 @@ typedef enum {
 // Symbolic names for extensions.  Strings may be directly used when calling the
 // functions, but better to have the compiler do spelling checks.
 //
-const char* const GL_OES_texture_3D                   = "GL_OES_texture_3D";
-const char* const GL_OES_standard_derivatives         = "GL_OES_standard_derivatives";
-const char* const GL_EXT_frag_depth                   = "GL_EXT_frag_depth";
-const char* const GL_OES_EGL_image_external           = "GL_OES_EGL_image_external";
-const char* const GL_EXT_shader_texture_lod           = "GL_EXT_shader_texture_lod";
+const char* const _GL_OES_texture_3D                   = "GL_OES_texture_3D";
+const char* const _GL_OES_standard_derivatives         = "GL_OES_standard_derivatives";
+const char* const _GL_EXT_frag_depth                   = "GL_EXT_frag_depth";
+const char* const _GL_OES_EGL_image_external           = "GL_OES_EGL_image_external";
+const char* const _GL_EXT_shader_texture_lod           = "GL_EXT_shader_texture_lod";
 
-const char* const GL_ARB_texture_rectangle            = "GL_ARB_texture_rectangle";
-const char* const GL_3DL_array_objects                = "GL_3DL_array_objects";
-const char* const GL_ARB_shading_language_420pack     = "GL_ARB_shading_language_420pack";
-const char* const GL_ARB_texture_gather               = "GL_ARB_texture_gather";
-const char* const GL_ARB_gpu_shader5                  = "GL_ARB_gpu_shader5";
-const char* const GL_ARB_separate_shader_objects      = "GL_ARB_separate_shader_objects";
-const char* const GL_ARB_compute_shader               = "GL_ARB_compute_shader";
-const char* const GL_ARB_tessellation_shader          = "GL_ARB_tessellation_shader";
-const char* const GL_ARB_enhanced_layouts             = "GL_ARB_enhanced_layouts";
-const char* const GL_ARB_texture_cube_map_array       = "GL_ARB_texture_cube_map_array";
-const char* const GL_ARB_shader_texture_lod           = "GL_ARB_shader_texture_lod";
-const char* const GL_ARB_explicit_attrib_location     = "GL_ARB_explicit_attrib_location";
-const char* const GL_ARB_shader_image_load_store      = "GL_ARB_shader_image_load_store";
-const char* const GL_ARB_shader_atomic_counters       = "GL_ARB_shader_atomic_counters";
-const char* const GL_ARB_derivative_control           = "GL_ARB_derivative_control";
-const char* const GL_ARB_shader_texture_image_samples = "GL_ARB_shader_texture_image_samples";
-const char* const GL_ARB_viewport_array               = "GL_ARB_viewport_array";
-//const char* const GL_ARB_cull_distance            = "GL_ARB_cull_distance";  // present for 4.5, but need extension control over block members
+const char* const _GL_ARB_texture_rectangle            = "GL_ARB_texture_rectangle";
+const char* const _GL_3DL_array_objects                = "GL_3DL_array_objects";
+const char* const _GL_ARB_shading_language_420pack     = "GL_ARB_shading_language_420pack";
+const char* const _GL_ARB_texture_gather               = "GL_ARB_texture_gather";
+const char* const _GL_ARB_gpu_shader5                  = "GL_ARB_gpu_shader5";
+const char* const _GL_ARB_separate_shader_objects      = "GL_ARB_separate_shader_objects";
+const char* const _GL_ARB_compute_shader               = "GL_ARB_compute_shader";
+const char* const _GL_ARB_tessellation_shader          = "GL_ARB_tessellation_shader";
+const char* const _GL_ARB_enhanced_layouts             = "GL_ARB_enhanced_layouts";
+const char* const _GL_ARB_texture_cube_map_array       = "GL_ARB_texture_cube_map_array";
+const char* const _GL_ARB_shader_texture_lod           = "GL_ARB_shader_texture_lod";
+const char* const _GL_ARB_explicit_attrib_location     = "GL_ARB_explicit_attrib_location";
+const char* const _GL_ARB_shader_image_load_store      = "GL_ARB_shader_image_load_store";
+const char* const _GL_ARB_shader_atomic_counters       = "GL_ARB_shader_atomic_counters";
+const char* const _GL_ARB_derivative_control           = "GL_ARB_derivative_control";
+const char* const _GL_ARB_shader_texture_image_samples = "GL_ARB_shader_texture_image_samples";
+const char* const _GL_ARB_viewport_array               = "GL_ARB_viewport_array";
+//const char* const _GL_ARB_cull_distance            = "GL_ARB_cull_distance";  // present for 4.5, but need extension control over block members
 
 // AEP
-const char* const GL_ANDROID_extension_pack_es31a             = "GL_ANDROID_extension_pack_es31a";
-const char* const GL_KHR_blend_equation_advanced              = "GL_KHR_blend_equation_advanced";
-const char* const GL_OES_sample_variables                     = "GL_OES_sample_variables";
-const char* const GL_OES_shader_image_atomic                  = "GL_OES_shader_image_atomic";
-const char* const GL_OES_shader_multisample_interpolation     = "GL_OES_shader_multisample_interpolation";
-const char* const GL_OES_texture_storage_multisample_2d_array = "GL_OES_texture_storage_multisample_2d_array";
-const char* const GL_EXT_geometry_shader                      = "GL_EXT_geometry_shader";
-const char* const GL_EXT_geometry_point_size                  = "GL_EXT_geometry_point_size";
-const char* const GL_EXT_gpu_shader5                          = "GL_EXT_gpu_shader5";
-const char* const GL_EXT_primitive_bounding_box               = "GL_EXT_primitive_bounding_box";
-const char* const GL_EXT_shader_io_blocks                     = "GL_EXT_shader_io_blocks";
-const char* const GL_EXT_tessellation_shader                  = "GL_EXT_tessellation_shader";
-const char* const GL_EXT_tessellation_point_size              = "GL_EXT_tessellation_point_size";
-const char* const GL_EXT_texture_buffer                       = "GL_EXT_texture_buffer";
-const char* const GL_EXT_texture_cube_map_array               = "GL_EXT_texture_cube_map_array";
+const char* const _GL_ANDROID_extension_pack_es31a             = "GL_ANDROID_extension_pack_es31a";
+const char* const _GL_KHR_blend_equation_advanced              = "GL_KHR_blend_equation_advanced";
+const char* const _GL_OES_sample_variables                     = "GL_OES_sample_variables";
+const char* const _GL_OES_shader_image_atomic                  = "GL_OES_shader_image_atomic";
+const char* const _GL_OES_shader_multisample_interpolation     = "GL_OES_shader_multisample_interpolation";
+const char* const _GL_OES_texture_storage_multisample_2d_array = "GL_OES_texture_storage_multisample_2d_array";
+const char* const _GL_EXT_geometry_shader                      = "GL_EXT_geometry_shader";
+const char* const _GL_EXT_geometry_point_size                  = "GL_EXT_geometry_point_size";
+const char* const _GL_EXT_gpu_shader5                          = "GL_EXT_gpu_shader5";
+const char* const _GL_EXT_primitive_bounding_box               = "GL_EXT_primitive_bounding_box";
+const char* const _GL_EXT_shader_io_blocks                     = "GL_EXT_shader_io_blocks";
+const char* const _GL_EXT_tessellation_shader                  = "GL_EXT_tessellation_shader";
+const char* const _GL_EXT_tessellation_point_size              = "GL_EXT_tessellation_point_size";
+const char* const _GL_EXT_texture_buffer                       = "GL_EXT_texture_buffer";
+const char* const _GL_EXT_texture_cube_map_array               = "GL_EXT_texture_cube_map_array";
 
 // OES matching AEP
-const char* const GL_OES_geometry_shader                      = "GL_OES_geometry_shader";
-const char* const GL_OES_geometry_point_size                  = "GL_OES_geometry_point_size";
-const char* const GL_OES_gpu_shader5                          = "GL_OES_gpu_shader5";
-const char* const GL_OES_primitive_bounding_box               = "GL_OES_primitive_bounding_box";
-const char* const GL_OES_shader_io_blocks                     = "GL_OES_shader_io_blocks";
-const char* const GL_OES_tessellation_shader                  = "GL_OES_tessellation_shader";
-const char* const GL_OES_tessellation_point_size              = "GL_OES_tessellation_point_size";
-const char* const GL_OES_texture_buffer                       = "GL_OES_texture_buffer";
-const char* const GL_OES_texture_cube_map_array               = "GL_OES_texture_cube_map_array";
+const char* const _GL_OES_geometry_shader                      = "GL_OES_geometry_shader";
+const char* const _GL_OES_geometry_point_size                  = "GL_OES_geometry_point_size";
+const char* const _GL_OES_gpu_shader5                          = "GL_OES_gpu_shader5";
+const char* const _GL_OES_primitive_bounding_box               = "GL_OES_primitive_bounding_box";
+const char* const _GL_OES_shader_io_blocks                     = "GL_OES_shader_io_blocks";
+const char* const _GL_OES_tessellation_shader                  = "GL_OES_tessellation_shader";
+const char* const _GL_OES_tessellation_point_size              = "GL_OES_tessellation_point_size";
+const char* const _GL_OES_texture_buffer                       = "GL_OES_texture_buffer";
+const char* const _GL_OES_texture_cube_map_array               = "GL_OES_texture_cube_map_array";
 
 // Arrays of extensions for the above AEP duplications
 
-const char* const AEP_geometry_shader[] = { GL_EXT_geometry_shader, GL_OES_geometry_shader };
+const char* const AEP_geometry_shader[] = { _GL_EXT_geometry_shader, _GL_OES_geometry_shader };
 const int Num_AEP_geometry_shader = sizeof(AEP_geometry_shader)/sizeof(AEP_geometry_shader[0]);
 
-const char* const AEP_geometry_point_size[] = { GL_EXT_geometry_point_size, GL_OES_geometry_point_size };
+const char* const AEP_geometry_point_size[] = { _GL_EXT_geometry_point_size, _GL_OES_geometry_point_size };
 const int Num_AEP_geometry_point_size = sizeof(AEP_geometry_point_size)/sizeof(AEP_geometry_point_size[0]);
 
-const char* const AEP_gpu_shader5[] = { GL_EXT_gpu_shader5, GL_OES_gpu_shader5 };
+const char* const AEP_gpu_shader5[] = { _GL_EXT_gpu_shader5, _GL_OES_gpu_shader5 };
 const int Num_AEP_gpu_shader5 = sizeof(AEP_gpu_shader5)/sizeof(AEP_gpu_shader5[0]);
 
-const char* const AEP_primitive_bounding_box[] = { GL_EXT_primitive_bounding_box, GL_OES_primitive_bounding_box };
+const char* const AEP_primitive_bounding_box[] = { _GL_EXT_primitive_bounding_box, _GL_OES_primitive_bounding_box };
 const int Num_AEP_primitive_bounding_box = sizeof(AEP_primitive_bounding_box)/sizeof(AEP_primitive_bounding_box[0]);
 
-const char* const AEP_shader_io_blocks[] = { GL_EXT_shader_io_blocks, GL_OES_shader_io_blocks };
+const char* const AEP_shader_io_blocks[] = { _GL_EXT_shader_io_blocks, _GL_OES_shader_io_blocks };
 const int Num_AEP_shader_io_blocks = sizeof(AEP_shader_io_blocks)/sizeof(AEP_shader_io_blocks[0]);
 
-const char* const AEP_tessellation_shader[] = { GL_EXT_tessellation_shader, GL_OES_tessellation_shader };
+const char* const AEP_tessellation_shader[] = { _GL_EXT_tessellation_shader, _GL_OES_tessellation_shader };
 const int Num_AEP_tessellation_shader = sizeof(AEP_tessellation_shader)/sizeof(AEP_tessellation_shader[0]);
 
-const char* const AEP_tessellation_point_size[] = { GL_EXT_tessellation_point_size, GL_OES_tessellation_point_size };
+const char* const AEP_tessellation_point_size[] = { _GL_EXT_tessellation_point_size, _GL_OES_tessellation_point_size };
 const int Num_AEP_tessellation_point_size = sizeof(AEP_tessellation_point_size)/sizeof(AEP_tessellation_point_size[0]);
 
-const char* const AEP_texture_buffer[] = { GL_EXT_texture_buffer, GL_OES_texture_buffer };
+const char* const AEP_texture_buffer[] = { _GL_EXT_texture_buffer, _GL_OES_texture_buffer };
 const int Num_AEP_texture_buffer = sizeof(AEP_texture_buffer)/sizeof(AEP_texture_buffer[0]);
 
-const char* const AEP_texture_cube_map_array[] = { GL_EXT_texture_cube_map_array, GL_OES_texture_cube_map_array };
+const char* const AEP_texture_cube_map_array[] = { _GL_EXT_texture_cube_map_array, _GL_OES_texture_cube_map_array };
 const int Num_AEP_texture_cube_map_array = sizeof(AEP_texture_cube_map_array)/sizeof(AEP_texture_cube_map_array[0]);
 
 } // end namespace glslang

--- a/glslang/MachineIndependent/glslang.y
+++ b/glslang/MachineIndependent/glslang.y
@@ -809,7 +809,7 @@ parameter_declarator
     // Type + name
     : type_specifier IDENTIFIER {
         if ($1.arraySizes) {
-            parseContext.profileRequires($1.loc, ENoProfile, 120, GL_3DL_array_objects, "arrayed type");
+            parseContext.profileRequires($1.loc, ENoProfile, 120, _GL_3DL_array_objects, "arrayed type");
             parseContext.profileRequires($1.loc, EEsProfile, 300, 0, "arrayed type");
             parseContext.arraySizeRequiredCheck($1.loc, $1.arraySizes->getSize());
         }
@@ -824,7 +824,7 @@ parameter_declarator
     }
     | type_specifier IDENTIFIER array_specifier {
         if ($1.arraySizes) {
-            parseContext.profileRequires($1.loc, ENoProfile, 120, GL_3DL_array_objects, "arrayed type");
+            parseContext.profileRequires($1.loc, ENoProfile, 120, _GL_3DL_array_objects, "arrayed type");
             parseContext.profileRequires($1.loc, EEsProfile, 300, 0, "arrayed type");
             parseContext.arraySizeRequiredCheck($1.loc, $1.arraySizes->getSize());
         }
@@ -953,7 +953,7 @@ fully_specified_type
 
         parseContext.globalQualifierTypeCheck($1.loc, $1.qualifier, $$);
         if ($1.arraySizes) {
-            parseContext.profileRequires($1.loc, ENoProfile, 120, GL_3DL_array_objects, "arrayed type");
+            parseContext.profileRequires($1.loc, ENoProfile, 120, _GL_3DL_array_objects, "arrayed type");
             parseContext.profileRequires($1.loc, EEsProfile, 300, 0, "arrayed type");
         }
 
@@ -964,7 +964,7 @@ fully_specified_type
         parseContext.globalQualifierTypeCheck($1.loc, $1.qualifier, $2);
 
         if ($2.arraySizes) {
-            parseContext.profileRequires($2.loc, ENoProfile, 120, GL_3DL_array_objects, "arrayed type");
+            parseContext.profileRequires($2.loc, ENoProfile, 120, _GL_3DL_array_objects, "arrayed type");
             parseContext.profileRequires($2.loc, EEsProfile, 300, 0, "arrayed type");
         }
 
@@ -1956,7 +1956,7 @@ struct_declaration_list
 struct_declaration
     : type_specifier struct_declarator_list SEMICOLON {
         if ($1.arraySizes) {
-            parseContext.profileRequires($1.loc, ENoProfile, 120, GL_3DL_array_objects, "arrayed type");
+            parseContext.profileRequires($1.loc, ENoProfile, 120, _GL_3DL_array_objects, "arrayed type");
             parseContext.profileRequires($1.loc, EEsProfile, 300, 0, "arrayed type");
             if (parseContext.profile == EEsProfile)
                 parseContext.arraySizeRequiredCheck($1.loc, $1.arraySizes->getSize());
@@ -1975,7 +1975,7 @@ struct_declaration
     | type_qualifier type_specifier struct_declarator_list SEMICOLON {
         parseContext.globalQualifierFixCheck($1.loc, $1.qualifier);
         if ($2.arraySizes) {
-            parseContext.profileRequires($2.loc, ENoProfile, 120, GL_3DL_array_objects, "arrayed type");
+            parseContext.profileRequires($2.loc, ENoProfile, 120, _GL_3DL_array_objects, "arrayed type");
             parseContext.profileRequires($2.loc, EEsProfile, 300, 0, "arrayed type");
             if (parseContext.profile == EEsProfile)
                 parseContext.arraySizeRequiredCheck($2.loc, $2.arraySizes->getSize());
@@ -2028,13 +2028,13 @@ initializer
     | LEFT_BRACE initializer_list RIGHT_BRACE {
         const char* initFeature = "{ } style initializers";
         parseContext.requireProfile($1.loc, ~EEsProfile, initFeature);
-        parseContext.profileRequires($1.loc, ~EEsProfile, 420, GL_ARB_shading_language_420pack, initFeature);
+        parseContext.profileRequires($1.loc, ~EEsProfile, 420, _GL_ARB_shading_language_420pack, initFeature);
         $$ = $2;
     }
     | LEFT_BRACE initializer_list COMMA RIGHT_BRACE {
         const char* initFeature = "{ } style initializers";
         parseContext.requireProfile($1.loc, ~EEsProfile, initFeature);
-        parseContext.profileRequires($1.loc, ~EEsProfile, 420, GL_ARB_shading_language_420pack, initFeature);
+        parseContext.profileRequires($1.loc, ~EEsProfile, 420, _GL_ARB_shading_language_420pack, initFeature);
         $$ = $2;
     }
     ;


### PR DESCRIPTION
New extensions in glext.h follow the pattern:

    #ifndef GL_ARB_texture_rectangle
    #define GL_ARB_texture_rectangle 1
    #define GL_TEXTURE_RECTANGLE_ARB          0x84F5
    #define GL_TEXTURE_BINDING_RECTANGLE_ARB  0x84F6
    #define GL_PROXY_TEXTURE_RECTANGLE_ARB    0x84F7
    #define GL_MAX_RECTANGLE_TEXTURE_SIZE_ARB 0x84F8
    #endif /* GL_ARB_texture_rectangle */

Versions.h tries to declare:

    const char* const GL_ARB_texture_rectangle = "GL_ARB_texture_rectangle";

Which means, if you've included glext.h before Versions.h, that the
compiler will see "const char* const 1 = ...", and rightly refuse to
continue.

The ham-fisted approach taken here is to rename the variables in
Versions.h with a leading underscore.  This does sort of undermine the
comment about "better to have the compiler do spelling checks", but.

Signed-off-by: Adam Jackson <ajax@redhat.com>