### PR TITLE
Fix include directive depending on root folder name

### DIFF
--- a/SPIRV/SPVRemapper.h
+++ b/SPIRV/SPVRemapper.h
@@ -101,8 +101,8 @@ public:
 #include <set>
 #include <cassert>
 
-#include "../../glslang/SPIRV/spirv.h"
-#include "../../glslang/SPIRV/spvIR.h"
+#include "spirv.h"
+#include "spvIR.h"
 
 namespace spv {
 


### PR DESCRIPTION
Compilation fails if the root folder is anything other than `glslang`.