### PR TITLE
include by relative path, so root doesn't need to be in the search path

### DIFF
--- a/OGLCompilersDLL/InitializeDll.cpp
+++ b/OGLCompilersDLL/InitializeDll.cpp
@@ -37,9 +37,9 @@
 #include <assert.h>
 
 #include "InitializeDll.h"
-#include "Include/InitializeGlobals.h"
+#include "../glslang/Include/InitializeGlobals.h"
 
-#include "Public/ShaderLang.h"
+#include "../glslang/Public/ShaderLang.h"
 
 namespace glslang {
 

--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -45,8 +45,8 @@
 #include "GLSL450Lib.h"
 
 // Glslang includes
-#include "glslang/MachineIndependent/localintermediate.h"
-#include "glslang/MachineIndependent/SymbolTable.h"
+#include "../glslang/MachineIndependent/localintermediate.h"
+#include "../glslang/MachineIndependent/SymbolTable.h"
 
 #include <string>
 #include <map>

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -49,7 +49,7 @@
 #include "ScanContext.h"
 
 #include "../Include/ShHandle.h"
-#include "InitializeDll.h"
+#include "../../OGLCompilersDLL/InitializeDll.h"
 
 #include "preprocessor/PpContext.h"
 

--- a/glslang/MachineIndependent/preprocessor/PpScanner.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpScanner.cpp
@@ -88,7 +88,7 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "PpContext.h"
 #include "PpTokens.h"
-#include "Scan.h"
+#include "../Scan.h"
 
 namespace glslang {
 

--- a/glslang/OSDependent/Linux/ossource.cpp
+++ b/glslang/OSDependent/Linux/ossource.cpp
@@ -36,7 +36,7 @@
 // This file contains the Linux-specific functions
 //
 #include "osinclude.h"
-#include "InitializeDll.h"
+#include "../../../OGLCompilersDLL/InitializeDll.h"
 
 namespace glslang {
 


### PR DESCRIPTION
I'm not sure if this is desired, but I've made some changes so that glslang doesn't depend any directories being in the include search path (which is default for building the project, but isn't so desirable when including glslang in a larger project).

---

On a related but separate note - the same include path requirement is true for osinclude.h. The include search path needs to be set up to point to either glslang/OSDependent/Linux or glslang/OSDependent/Windows on their respective platforms. I've [changed this locally](https://github.com/baldurk/glslang/commit/c0384798d86774f6ae7c7227ef8a3e25aa9fd4ef) so that osinclude.h is included relatively like so:

```cpp
#include "../glslang/OSDependent/osinclude.h"
```

and that file just contains a simple redirect based on platform macros:

```cpp
#if defined(WIN32)
#include "Windows/osinclude.h"
#elif defined(__linux__)
#include "Linux/osinclude.h"
#else
#error "Unknown platform"
#endif
```

If that's desirable to have upstream then let me know and I can make a pull request, but otherwise I'll just keep the change locally.