### PR TITLE
Fix for most Xcode/clang warnings on OSX

### DIFF
--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -1175,7 +1175,7 @@ Id Builder::createTextureCall(Decoration precision, Id resultType, bool proj, co
 Id Builder::createTextureQueryCall(Op opCode, const TextureParameters& parameters)
 {
     // Figure out the result type
-    Id resultType;
+    Id resultType = NoType;
     switch (opCode) {
     case OpTextureQuerySize:
     case OpTextureQuerySizeLod:

--- a/SPIRV/doc.h
+++ b/SPIRV/doc.h
@@ -213,10 +213,10 @@ public:
 class InstructionParameters {
 public:
     InstructionParameters() :
-        typePresent(true),         // most normal, only exceptions have to be spelled out
-        resultPresent(true),       // most normal, only exceptions have to be spelled out
         opDesc(0),
-        opClass(OpClassMisc)
+        opClass(OpClassMisc),
+        typePresent(true),         // most normal, only exceptions have to be spelled out
+        resultPresent(true)        // most normal, only exceptions have to be spelled out
     { }
 
     void setResultAndType(bool r, bool t)

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -1054,7 +1054,7 @@ void TBuiltIns::initialize(int version, EProfile profile)
     //
     //============================================================================
     bool esBarrier = (profile == EEsProfile && version >= 310);
-    if (profile != EEsProfile && version >= 150 || esBarrier)
+    if ((profile != EEsProfile && version >= 150) || esBarrier)
         stageBuiltins[EShLangTessControl].append(
             "void barrier();"
             );

--- a/glslang/MachineIndependent/Scan.cpp
+++ b/glslang/MachineIndependent/Scan.cpp
@@ -685,7 +685,7 @@ int TScanContext::tokenizeIdentifier()
         return keyword;
 
     case ATOMIC_UINT:
-        if (parseContext.profile == EEsProfile && parseContext.version >= 310 ||
+        if ((parseContext.profile == EEsProfile && parseContext.version >= 310) ||
             parseContext.extensionsTurnedOn(1, &E_GL_ARB_shader_atomic_counters))
             return keyword;
         return es30ReservedFromGLSL(420);

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -457,6 +457,8 @@ bool TParseContext::extensionsTurnedOn(int numExtensions, const char* const exte
         case EBhRequire:
         case EBhWarn:
             return true;
+        default:
+            break;
         }
     }
 

--- a/glslang/MachineIndependent/preprocessor/PpContext.h
+++ b/glslang/MachineIndependent/preprocessor/PpContext.h
@@ -86,7 +86,7 @@ namespace glslang {
 
 class TPpToken {
 public:
-    TPpToken() : token(0), ival(0), space(false), dval(0.0), atom(0)
+    TPpToken() : token(0), space(false), ival(0), dval(0.0), atom(0)
     {
         loc.init(); 
         name[0] = 0;


### PR DESCRIPTION
This PR fixes the following warnings when compiled with latest clang in Xcode7 on OSX 10.11, there are 2 warnings remaining which I need advice on how to fix (see below).

The tests are running successfully.

```
In file included from /Users/floh/projects/glslang/SPIRV/SPVRemapper.cpp:37:
/Users/floh/projects/glslang/SPIRV/doc.h:217:9: warning: field 'resultPresent' will be initialized after field 'opDesc' [-Wreorder]
        resultPresent(true),       // most normal, only exceptions have to be spelled out

/Users/floh/projects/glslang/SPIRV/SpvBuilder.cpp:1217:5: warning: variable 'resultType' is used uninitialized whenever switch default is taken [-Wsometimes-uninitialized]
    default:
    ^~~~~~~
/Users/floh/projects/glslang/SPIRV/SpvBuilder.cpp:1221:57: note: uninitialized use occurs here
    Instruction* query = new Instruction(getUniqueId(), resultType, opCode);
                                                        ^~~~~~~~~~
/Users/floh/projects/glslang/SPIRV/SpvBuilder.cpp:1178:18: note: initialize the variable 'resultType' to silence this warning
    Id resultType;
                 ^
                  = 0

In file included from /Users/floh/projects/glslang/SPIRV/disassemble.cpp:53:
/Users/floh/projects/glslang/SPIRV/doc.h:217:9: warning: field 'resultPresent' will be initialized after field 'opDesc' [-Wreorder]
        resultPresent(true),       // most normal, only exceptions have to be spelled out

/Users/floh/projects/glslang/glslang/MachineIndependent/Initialize.cpp:1057:31: warning: '&&' within '||' [-Wlogical-op-parentheses]
    if (profile != EEsProfile && version >= 150 || esBarrier)
        ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~ ~~
/Users/floh/projects/glslang/glslang/MachineIndependent/Initialize.cpp:1057:31: note: place parentheses around the '&&' expression to silence this warning
    if (profile != EEsProfile && version >= 150 || esBarrier)
                              ^
        (                                      )


In file included from /Users/floh/projects/glslang/glslang/MachineIndependent/ParseHelper.cpp:44:
/Users/floh/projects/glslang/glslang/MachineIndependent/preprocessor/PpContext.h:89:28: warning: field 'ival' will be initialized after field 'space' [-Wreorder]
    TPpToken() : token(0), ival(0), space(false), dval(0.0), atom(0)

/Users/floh/projects/glslang/glslang/MachineIndependent/Scan.cpp:688:48: warning: '&&' within '||' [-Wlogical-op-parentheses]
        if (parseContext.profile == EEsProfile && parseContext.version >= 310 ||
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~
/Users/floh/projects/glslang/glslang/MachineIndependent/Scan.cpp:688:48: note: place parentheses around the '&&' expression to silence this warning
        if (parseContext.profile == EEsProfile && parseContext.version >= 310 ||
                                               ^
            (                                                                )

/Users/floh/projects/glslang/glslang/MachineIndependent/Versions.cpp:455:17: warning: enumeration values 'EBhMissing', 'EBhDisable', and 'EBhDisablePartial' not handled in switch [-Wswitch]
        switch (getExtensionBehavior(extensions[i])) {
                ^
```
There are 2 warnings remaining, these happen because a constant 0xFFFFFFFF is compared against an enum which doesn't contain such a value. To fix this I would need advice what your preferred fix would be, for instance, adding an 'Invalid' entry to the enum which has value 0xFFFFFFFF, or performing a cast of the enum to unsigned int inside the if()...?

```
/Users/floh/projects/glslang/SPIRV/GlslangToSpv.cpp:2446:13: warning: comparison of constant 4294967295 with expression of type 'spv::Decoration' is always true [-Wtautological-constant-out-of-range-compare]
    if (dec != spv::BadValue)
        ~~~ ^  ~~~~~~~~~~~~~
/Users/floh/projects/glslang/SPIRV/GlslangToSpv.cpp:2452:13: warning: comparison of constant 4294967295 with expression of type 'spv::Decoration' is always true [-Wtautological-constant-out-of-range-compare]
    if (dec != spv::BadValue)
        ~~~ ^  ~~~~~~~~~~~~~
```
