### PR TITLE
Fix warnings compiling on x64 with size_t to int casts

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -1099,9 +1099,9 @@ bool TGlslangToSpvTraverser::visitSwitch(glslang::TVisit /* visit */, glslang::T
     for (glslang::TIntermSequence::iterator c = sequence.begin(); c != sequence.end(); ++c) {
         TIntermNode* child = *c;
         if (child->getAsBranchNode() && child->getAsBranchNode()->getFlowOp() == glslang::EOpDefault)
-            defaultSegment = codeSegments.size();
+            defaultSegment = (int)codeSegments.size();
         else if (child->getAsBranchNode() && child->getAsBranchNode()->getFlowOp() == glslang::EOpCase) {
-            valueIndexToSegment[caseValues.size()] = codeSegments.size();
+            valueIndexToSegment[caseValues.size()] = (int)codeSegments.size();
             caseValues.push_back(child->getAsBranchNode()->getExpression()->getAsConstantUnion()->getConstArray()[0].getIConst());
         } else
             codeSegments.push_back(child);
@@ -1115,7 +1115,7 @@ bool TGlslangToSpvTraverser::visitSwitch(glslang::TVisit /* visit */, glslang::T
 
     // make the switch statement
     std::vector<spv::Block*> segmentBlocks; // returned, as the blocks allocated in the call
-    builder.makeSwitch(selector, codeSegments.size(), caseValues, valueIndexToSegment, defaultSegment, segmentBlocks);
+    builder.makeSwitch(selector, (int)codeSegments.size(), caseValues, valueIndexToSegment, defaultSegment, segmentBlocks);
 
     // emit all the code in the segments
     breakForLoop.push(false);

--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -704,7 +704,7 @@ void Builder::closeMain()
 Function* Builder::makeFunctionEntry(Id returnType, const char* name, std::vector<Id>& paramTypes, Block **entry)
 {
     Id typeId = makeFunctionType(returnType, paramTypes);
-    Id firstParamId = paramTypes.size() == 0 ? 0 : getUniqueIds(paramTypes.size());
+    Id firstParamId = paramTypes.size() == 0 ? 0 : getUniqueIds((int)paramTypes.size());
     Function* function = new Function(getUniqueId(), returnType, typeId, firstParamId, module);
 
     if (entry) {
@@ -1943,7 +1943,7 @@ Id Builder::accessChainLoad(Decoration /*precision*/)
         // static swizzle
         Id resultType = componentType;
         if (accessChain.swizzle.size() > 1)
-            resultType = makeVectorType(componentType, accessChain.swizzle.size());
+            resultType = makeVectorType(componentType, (int)accessChain.swizzle.size());
         id = createRvalueSwizzle(resultType, id, accessChain.swizzle);
     }
 

--- a/glslang/MachineIndependent/Scan.h
+++ b/glslang/MachineIndependent/Scan.h
@@ -106,7 +106,7 @@ public:
                 }
                 --ch;
               }
-              loc[currentSource].column = currentChar - ch;
+              loc[currentSource].column = (int)(currentChar - ch);
             }
         } else {
             do {


### PR DESCRIPTION
There were already many explicit (int) casts, so it looks like this is maybe just new code that slipped through.