### PR TITLE
Simplify function calls for extensionsTurnedOn().

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -1841,7 +1841,7 @@ bool TParseContext::lineContinuationCheck(TSourceLoc loc, bool endOfComment)
     const char* message = "line continuation";
 
     bool lineContinuationAllowed = (profile == EEsProfile && version >= 300) ||
-                                   (profile != EEsProfile && (version >= 420 || extensionsTurnedOn(1, &E_GL_ARB_shading_language_420pack)));
+                                   (profile != EEsProfile && (version >= 420 || extensionTurnedOn(E_GL_ARB_shading_language_420pack)));
 
     if (endOfComment) {
         if (lineContinuationAllowed)
@@ -2228,7 +2228,7 @@ void TParseContext::mergeQualifiers(TSourceLoc loc, TQualifier& dst, const TQual
     // Ordering
     if (! force && ((profile != EEsProfile && version < 420) || 
                     (profile == EEsProfile && version < 310))
-                && ! extensionsTurnedOn(1, &E_GL_ARB_shading_language_420pack)) {
+                && ! extensionTurnedOn(E_GL_ARB_shading_language_420pack)) {
         // non-function parameters
         if (src.invariant && (dst.isInterpolation() || dst.isAuxiliary() || dst.storage != EvqTemporary || dst.precision != EpqNone))
             error(loc, "invariant qualifier must appear first", "", "");
@@ -2691,7 +2691,7 @@ TSymbol* TParseContext::redeclareBuiltinVariable(TSourceLoc loc, const TString& 
 
     // Special case when using GL_ARB_separate_shader_objects
     bool ssoPre150 = false;  // means the only reason this variable is redeclared is due to this combination
-    if (profile != EEsProfile && version <= 140 && extensionsTurnedOn(1, &E_GL_ARB_separate_shader_objects)) {
+    if (profile != EEsProfile && version <= 140 && extensionTurnedOn(E_GL_ARB_separate_shader_objects)) {
         if (identifier == "gl_Position"     ||
             identifier == "gl_PointSize"    ||
             identifier == "gl_ClipVertex"   ||

--- a/glslang/MachineIndependent/ParseHelper.h
+++ b/glslang/MachineIndependent/ParseHelper.h
@@ -227,6 +227,7 @@ public:
     void requireNotRemoved(TSourceLoc, int queryProfiles, int removedVersion, const char* featureDesc);
     void requireExtensions(TSourceLoc, int numExtensions, const char* const extensions[], const char* featureDesc);
     TExtensionBehavior getExtensionBehavior(const char*);
+    bool extensionTurnedOn(const char* const extension);
     bool extensionsTurnedOn(int numExtensions, const char* const extensions[]);
     void updateExtensionBehavior(int line, const char* const extension, const char* behavior);
     void fullIntegerCheck(TSourceLoc, const char* op);

--- a/glslang/MachineIndependent/Scan.cpp
+++ b/glslang/MachineIndependent/Scan.cpp
@@ -686,7 +686,7 @@ int TScanContext::tokenizeIdentifier()
 
     case ATOMIC_UINT:
         if ((parseContext.profile == EEsProfile && parseContext.version >= 310) ||
-            parseContext.extensionsTurnedOn(1, &E_GL_ARB_shader_atomic_counters))
+            parseContext.extensionTurnedOn(E_GL_ARB_shader_atomic_counters))
             return keyword;
         return es30ReservedFromGLSL(420);
 
@@ -696,12 +696,12 @@ int TScanContext::tokenizeIdentifier()
     case WRITEONLY:
         if (parseContext.profile == EEsProfile && parseContext.version >= 310)
             return keyword;
-        return es30ReservedFromGLSL(parseContext.extensionsTurnedOn(1, &E_GL_ARB_shader_image_load_store) ? 130 : 420);
+        return es30ReservedFromGLSL(parseContext.extensionTurnedOn(E_GL_ARB_shader_image_load_store) ? 130 : 420);
 
     case VOLATILE:
         if (parseContext.profile == EEsProfile && parseContext.version >= 310)
             return keyword;
-        if (! parseContext.symbolTable.atBuiltInLevel() && (parseContext.profile == EEsProfile || (parseContext.version < 420 && ! parseContext.extensionsTurnedOn(1, &E_GL_ARB_shader_image_load_store))))
+        if (! parseContext.symbolTable.atBuiltInLevel() && (parseContext.profile == EEsProfile || (parseContext.version < 420 && ! parseContext.extensionTurnedOn(E_GL_ARB_shader_image_load_store))))
             reservedWord();
         return keyword;
 
@@ -725,7 +725,7 @@ int TScanContext::tokenizeIdentifier()
     case PATCH:
         if (parseContext.symbolTable.atBuiltInLevel() ||
             (parseContext.profile == EEsProfile && parseContext.extensionsTurnedOn(Num_AEP_tessellation_shader, AEP_tessellation_shader)) ||
-            (parseContext.profile != EEsProfile && parseContext.extensionsTurnedOn(1, &E_GL_ARB_tessellation_shader)))
+            (parseContext.profile != EEsProfile && parseContext.extensionTurnedOn(E_GL_ARB_tessellation_shader)))
             return keyword;
 
         return es30ReservedFromGLSL(400);
@@ -818,7 +818,7 @@ int TScanContext::tokenizeIdentifier()
     case ISAMPLERCUBEARRAY:
     case USAMPLERCUBEARRAY:
         afterType = true;
-        if (parseContext.profile == EEsProfile || (parseContext.version < 400 && ! parseContext.extensionsTurnedOn(1, &E_GL_ARB_texture_cube_map_array)))
+        if (parseContext.profile == EEsProfile || (parseContext.version < 400 && ! parseContext.extensionTurnedOn(E_GL_ARB_texture_cube_map_array)))
             reservedWord();
         return keyword;
 
@@ -880,7 +880,7 @@ int TScanContext::tokenizeIdentifier()
     case SAMPLER3D:
         afterType = true;
         if (parseContext.profile == EEsProfile && parseContext.version < 300) {
-            if (! parseContext.extensionsTurnedOn(1, &E_GL_OES_texture_3D))
+            if (! parseContext.extensionTurnedOn(E_GL_OES_texture_3D))
                 reservedWord();
         }
         return keyword;
@@ -896,7 +896,7 @@ int TScanContext::tokenizeIdentifier()
         afterType = true;
         if (parseContext.profile == EEsProfile)
             reservedWord();
-        else if (parseContext.version < 140 && ! parseContext.symbolTable.atBuiltInLevel() && ! parseContext.extensionsTurnedOn(1, &E_GL_ARB_texture_rectangle)) {
+        else if (parseContext.version < 140 && ! parseContext.symbolTable.atBuiltInLevel() && ! parseContext.extensionTurnedOn(E_GL_ARB_texture_rectangle)) {
             if (parseContext.relaxedErrors())
                 parseContext.requireExtensions(loc, 1, &E_GL_ARB_texture_rectangle, "texture-rectangle sampler keyword");
             else
@@ -915,7 +915,7 @@ int TScanContext::tokenizeIdentifier()
 
     case SAMPLEREXTERNALOES:
         afterType = true;
-        if (parseContext.symbolTable.atBuiltInLevel() || parseContext.extensionsTurnedOn(1, &E_GL_OES_EGL_image_external))
+        if (parseContext.symbolTable.atBuiltInLevel() || parseContext.extensionTurnedOn(E_GL_OES_EGL_image_external))
             return keyword;
         return identifierOrType();
 
@@ -1107,7 +1107,7 @@ int TScanContext::firstGenerationImage(bool inEs310)
     afterType = true;
 
     if (parseContext.symbolTable.atBuiltInLevel() || 
-        (parseContext.profile != EEsProfile && (parseContext.version >= 420 || parseContext.extensionsTurnedOn(1, &E_GL_ARB_shader_image_load_store))) ||                                                     
+        (parseContext.profile != EEsProfile && (parseContext.version >= 420 || parseContext.extensionTurnedOn(E_GL_ARB_shader_image_load_store))) ||
         (inEs310 && parseContext.profile == EEsProfile && parseContext.version >= 310))
         return keyword;
 
@@ -1135,7 +1135,7 @@ int TScanContext::secondGenerationImage()
 
     if (parseContext.symbolTable.atBuiltInLevel() || 
         (parseContext.profile != EEsProfile && 
-         (parseContext.version >= 420 || parseContext.extensionsTurnedOn(1, &E_GL_ARB_shader_image_load_store))))
+         (parseContext.version >= 420 || parseContext.extensionTurnedOn(E_GL_ARB_shader_image_load_store))))
         return keyword;
 
     if (parseContext.forwardCompatible)

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -448,20 +448,25 @@ TExtensionBehavior TParseContext::getExtensionBehavior(const char* extension)
         return iter->second;
 }
 
+// Returns true if the given extension is set to enable, require, or warn.
+bool TParseContext::extensionTurnedOn(const char* const extension)
+{
+      switch (getExtensionBehavior(extension)) {
+      case EBhEnable:
+      case EBhRequire:
+      case EBhWarn:
+          return true;
+      default:
+          break;
+      }
+      return false;
+}
 // See if any of the extensions are set to enable, require, or warn.
 bool TParseContext::extensionsTurnedOn(int numExtensions, const char* const extensions[])
 {
     for (int i = 0; i < numExtensions; ++i) {
-        switch (getExtensionBehavior(extensions[i])) {
-        case EBhEnable:
-        case EBhRequire:
-        case EBhWarn:
-            return true;
-        default:
-            break;
-        }
+        if (extensionTurnedOn(extensions[i])) return true;
     }
-
     return false;
 }
 


### PR DESCRIPTION
Lots of places in the code use `extensionsTurnedOn(1, ...)`. This
patch introduces a new method, `extensionTurnedOn()`, for testing
if a single extension is turned on.