### PR TITLE
Protect location setting methods from writing to non-existing strings.

### DIFF
--- a/glslang/MachineIndependent/Scan.h
+++ b/glslang/MachineIndependent/Scan.h
@@ -123,10 +123,12 @@ public:
     }
 
     // for #line override
-    void setLine(int newLine) { loc[currentSource].line = newLine; }
-    void setString(int newString) { loc[currentSource].string = newString; }
+    void setLine(int newLine) { loc[getLastValidSourceIndex()].line = newLine; }
+    void setString(int newString) { loc[getLastValidSourceIndex()].string = newString; }
 
     const TSourceLoc& getSourceLoc() const { return loc[std::max(0, std::min(currentSource, numSources - finale - 1))]; }
+    // Returns the index (starting from 0) of the most recent valid source string we are reading from.
+    int getLastValidSourceIndex() const { return std::min(currentSource, numSources - 1); }
 
     void consumeWhiteSpace(bool& foundNonSpaceTab);
     bool consumeComment();


### PR DESCRIPTION
`TInputScanner` advances its internal indices to the next character at
the end of `get()`, which means, after reading in the last character
in the user-provided shader string, internal index (`currentSource`)
will point to the next shader string (`currentSource == numSources`),
which doesn't exist. Then if a location setting method is called,
we will write to some out-of-bound memory.

A test case for this is `#line 10000\n`. The `eval()` method in `CPPline()`
will evaluate `10000`, but at the same time it reads in the next
token, `\n`, and the `currentSource` will be `numSources` in `TInputScanner`.
Then a `parseContext.setCurrentLine()` is called, we are writing to
out-of-bound memory. Another test case will be `#line 10000 0\n`.