### PR TITLE
Only output explicit extension directives in preprocessing.

### DIFF
--- a/Test/baseResults/preprocessor.extensions.vert.out
+++ b/Test/baseResults/preprocessor.extensions.vert.out
@@ -1,6 +1,6 @@
 #version 310 es
 
-#extension GL_OES_texture_3D : enable
+#extension GL_EXT_geometry_shader : enable
 #extension GL_EXT_frag_depth : disable
 #extension GL_EXT_gpu_shader5 : require
 #extension GL_EXT_shader_texture_image_samples : warn

--- a/Test/preprocessor.extensions.vert
+++ b/Test/preprocessor.extensions.vert
@@ -1,6 +1,6 @@
 #version 310 es
 
-#extension GL_OES_texture_3D: enable
+#extension GL_EXT_geometry_shader: enable
 #extension GL_EXT_frag_depth: disable
 #extension GL_EXT_gpu_shader5: require
 #extension GL_EXT_shader_texture_image_samples: warn

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -5333,4 +5333,11 @@ void TParseContext::notifyLineDirective(int curLineNo, int newLineNo, bool hasSo
     }
 }
 
+void TParseContext::notifyExtensionDirective(int line, const char* extension, const char* behavior)
+{
+    if (extensionCallback) {
+        extensionCallback(line, extension, behavior);
+    }
+}
+
 } // end namespace glslang

--- a/glslang/MachineIndependent/ParseHelper.h
+++ b/glslang/MachineIndependent/ParseHelper.h
@@ -222,6 +222,7 @@ public:
     void notifyVersion(int line, int version, const char* type_string);
     void notifyErrorDirective(int line, const char* error_message);
     void notifyLineDirective(int curLineNo, int newLineNo, bool hasSource, int sourceNum);
+    void notifyExtensionDirective(int line, const char* extension, const char* behavior);
 
     // The following are implemented in Versions.cpp to localize version/profile/stage/extensions control
     void initializeExtensionBehavior();

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -475,9 +475,6 @@ bool TParseContext::extensionsTurnedOn(int numExtensions, const char* const exte
 //
 void TParseContext::updateExtensionBehavior(int line, const char* extension, const char* behaviorString)
 {
-    if (extensionCallback)
-        extensionCallback(line, extension, behaviorString);
-
     // Translate from text string of extension's behavior to an enum.
     TExtensionBehavior behavior = EBhDisable;
     if (! strcmp("require", behaviorString))

--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
+++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
@@ -773,6 +773,7 @@ int TPpContext::CPPextension(TPpToken* ppToken)
     }
 
     parseContext.updateExtensionBehavior(line, extensionName, ppToken->name);
+    parseContext.notifyExtensionDirective(line, extensionName, ppToken->name);
 
     token = scanToken(ppToken);
     if (token == '\n')


### PR DESCRIPTION
Preprocessing output shouldn't contain extensions enabled as
dependencies.