### PR TITLE
Fix missing const qualifier on TUnorderedMap template type

### DIFF
--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -156,7 +156,7 @@ class TMap : public std::map<K, D, CMP, pool_allocator<std::pair<K, D> > > {
 };
 
 template <class K, class D, class HASH = std::hash<K>, class PRED = std::equal_to<K> >
-class TUnorderedMap : public std::unordered_map<K, D, HASH, PRED, pool_allocator<std::pair<K, D> > > {
+class TUnorderedMap : public std::unordered_map<K, D, HASH, PRED, pool_allocator<std::pair<K const, D> > > {
 };
 
 //


### PR DESCRIPTION
Broke in https://github.com/KhronosGroup/glslang/commit/2f273369e4f78af8c5b1bc558eb7809e1cb69e02 with this error (I think this is a XCode bug):
```c++
In file included from /Users/fkaaman/Dev/glslang/glslang/MachineIndependent/ParseHelper.cpp:37:
In file included from /Users/fkaaman/Dev/glslang/glslang/MachineIndependent/ParseHelper.h:40:
In file included from /Users/fkaaman/Dev/glslang/glslang/MachineIndependent/../Include/ShHandle.h:49:
In file included from /Users/fkaaman/Dev/glslang/glslang/MachineIndependent/../Include/InfoSink.h:38:
In file included from /Users/fkaaman/Dev/glslang/glslang/MachineIndependent/../Include/../Include/Common.h:65:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/unordered_map:724:5: error: static_assert failed "Invalid allocator::value_type"
    static_assert((is_same<value_type, typename allocator_type::value_type>::value),
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/fkaaman/Dev/glslang/glslang/MachineIndependent/../Include/../Include/Common.h:159:30: note: in instantiation of template class 'std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, glslang::pool_allocator<char> >, int, std::__1::hash<glslang::TString>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, glslang::pool_allocator<char> > >, glslang::pool_allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, glslang::pool_allocator<char> >, int> > >' requested here
class TUnorderedMap : public std::unordered_map<K, D, HASH, PRED, pool_allocator<std::pair<K, D> > > {
                             ^
/Users/fkaaman/Dev/glslang/glslang/MachineIndependent/preprocessor/PpContext.h:441:14: note: in instantiation of template class 'glslang::TUnorderedMap<std::__1::basic_string<char, std::__1::char_traits<char>, glslang::pool_allocator<char> >, int, std::__1::hash<glslang::TString>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, glslang::pool_allocator<char> > > >' requested here
    TAtomMap atomMap;
             ^
1 error generated.
```
Unsure if this fix is compatible with other toolchains.