### PR TITLE
Add mechanism for specifying names for source strings.

### DIFF
--- a/glslang/MachineIndependent/Scan.h
+++ b/glslang/MachineIndependent/Scan.h
@@ -51,7 +51,7 @@ const int EndOfInput = -1;
 //
 class TInputScanner {
 public:
-    TInputScanner(int n, const char* const s[], size_t L[], int b = 0, int f = 0) : 
+    TInputScanner(int n, const char* const s[], size_t L[], const char* const* names = nullptr, int b = 0, int f = 0) :
         numSources(n),
         sources(reinterpret_cast<const unsigned char* const *>(s)), // up to this point, common usage is "char*", but now we need positive 8-bit characters
         lengths(L), currentSource(0), currentChar(0), stringBias(b), finale(f)
@@ -59,6 +59,10 @@ public:
         loc = new TSourceLoc[numSources];
         for (int i = 0; i < numSources; ++i) {
             loc[i].init();
+        }
+        if (names != nullptr) {
+            for (int i = 0; i < numSources; ++i)
+                loc[i].name = names[i];
         }
         loc[currentSource].string = -stringBias;
         loc[currentSource].line = 1;

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -285,6 +285,8 @@ public:
     virtual ~TShader();
     void setStrings(const char* const* s, int n);
     void setStringsWithLengths(const char* const* s, const int* l, int n);
+    void setStringsWithLengthsAndNames(
+        const char* const* s, const int* l, const char* const* names, int n);
     void setPreamble(const char* s) { preamble = s; }
     bool parse(const TBuiltInResource*, int defaultVersion, EProfile defaultProfile, bool forceDefaultVersionAndProfile, bool forwardCompatible, EShMessages);
     // Equivalent to parse() without a default profile and without forcing defaults.
@@ -312,8 +314,12 @@ protected:
     //         integers containing the length of the associated strings.
     //         if lengths is null or lengths[n] < 0  the associated strings[n] is
     //         assumed to be null-terminated.
+    // stringNames is the optional names for all the strings. If stringNames
+    // is null, then none of the strings has name. If a certain element in
+    // stringNames is null, then the corresponding string does not have name.
     const char* const* strings;
     const int* lengths;
+    const char* const* stringNames;
     const char* preamble;
     int numStrings;
 


### PR DESCRIPTION
Expose a new method `setStringsWithLengthsAndNames()` in the interface
which allows the caller to set descriptive names for source strings.
The names can then be used in error messages.

This new API will provide a way to set filenames. This is the last commit
for the second step listed in Issue #37. The next pull request will be the
implementation for the `#include` directive.