### PR TITLE
Remove unused members from TPpContext

### DIFF
--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
+++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
@@ -551,8 +551,7 @@ int TPpContext::CPPif(TPpToken* ppToken)
 {
     int token = scanToken(ppToken);
     elsetracker++;
-    if (! ifdepth++)
-        ifloc = ppToken->loc;
+    ifdepth++;
     if (ifdepth > maxIfNesting) {
         parseContext.ppError(ppToken->loc, "maximum nesting depth exceeded", "#if", "");
         return 0;

--- a/glslang/MachineIndependent/preprocessor/PpContext.h
+++ b/glslang/MachineIndependent/preprocessor/PpContext.h
@@ -237,7 +237,6 @@ protected:
     int ifdepth;                  // current #if-#else-#endif nesting in the cpp.c file (pre-processor)    
     bool elseSeen[maxIfNesting];  // Keep a track of whether an else has been seen at a particular depth
     int elsetracker;              // #if-#else and #endif constructs...Counter.
-    const char* ErrMsg;
 
     class tMacroInput : public tInput {
     public:
@@ -286,7 +285,7 @@ protected:
     //
     // from Pp.cpp
     //
-    TSourceLoc ifloc; /* outermost #if */
+
     // Used to obtain #include content.
     const TShader::Includer& includer;
 


### PR DESCRIPTION
The `ErrMsg` and `ifloc` members were unused or had no effect.