### PR TITLE
Compile fixes for gcc -Wall

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -1371,7 +1371,7 @@ spv::Id TGlslangToSpvTraverser::convertGlslangToSpvType(const glslang::TType& ty
 
                     // built-in variable decorations
                     int builtIn = TranslateBuiltInDecoration(glslangType.getQualifier().builtIn);
-                    if (builtIn != spv::BadValue)
+                    if ((unsigned int)builtIn != spv::BadValue)
                         builder.addMemberDecoration(spvType, member, spv::DecorationBuiltIn, builtIn);
                 }
             }
@@ -2519,7 +2519,7 @@ spv::Id TGlslangToSpvTraverser::getSymbolId(const glslang::TIntermSymbol* symbol
 
     // built-in variable decorations
     int builtIn = TranslateBuiltInDecoration(symbol->getQualifier().builtIn);
-    if (builtIn != spv::BadValue)
+    if ((unsigned int)builtIn != spv::BadValue)
         builder.addDecoration(id, spv::DecorationBuiltIn, builtIn);
 
     if (linkageOnly)

--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -1032,7 +1032,7 @@ Id Builder::createRvalueSwizzle(Id typeId, Id source, std::vector<unsigned>& cha
 // Comments in header
 Id Builder::createLvalueSwizzle(Id typeId, Id target, Id source, std::vector<unsigned>& channels)
 {
-    assert(getNumComponents(source) == channels.size());
+    assert((size_t)getNumComponents(source) == channels.size());
     if (channels.size() == 1 && getNumComponents(source) == 1)
         return createCompositeInsert(source, target, typeId, channels.front());
 
@@ -1471,7 +1471,7 @@ Id Builder::createCompare(Decoration precision, Id value1, Id value2, bool equal
 // OpCompositeConstruct
 Id Builder::createCompositeConstruct(Id typeId, std::vector<Id>& constituents)
 {
-    assert(isAggregateType(typeId) || getNumTypeComponents(typeId) > 1 && getNumTypeComponents(typeId) == constituents.size());
+    assert((isAggregateType(typeId) || getNumTypeComponents(typeId) > 1) && (size_t)getNumTypeComponents(typeId) == constituents.size());
 
     Instruction* op = new Instruction(getUniqueId(), typeId, OpCompositeConstruct);
     for (int c = 0; c < (int)constituents.size(); ++c)

--- a/glslang/MachineIndependent/Constant.cpp
+++ b/glslang/MachineIndependent/Constant.cpp
@@ -172,7 +172,7 @@ TIntermTyped* TIntermConstantUnion::fold(TOperator op, const TIntermTyped* const
             case EbtInt:
                 if (rightUnionArray[i] == 0)
                     newConstArray[i].setIConst(0x7FFFFFFF);
-                else if (rightUnionArray[i].getIConst() == -1 && unionArray[i].getIConst() == 0x80000000)
+                else if (rightUnionArray[i].getIConst() == -1 && (unsigned int)unionArray[i].getIConst() == 0x80000000)
                     newConstArray[i].setIConst(0x80000000);
                 else
                     newConstArray[i].setIConst(unionArray[i].getIConst() / rightUnionArray[i].getIConst());

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -3530,13 +3530,13 @@ void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publi
             // the implementation-dependent constant gl_MaxTransformFeedbackBuffers."
             if (value >= resources.maxTransformFeedbackBuffers)
                 error(loc, "buffer is too large:", id.c_str(), "gl_MaxTransformFeedbackBuffers is %d", resources.maxTransformFeedbackBuffers);                
-            if (value >= TQualifier::layoutXfbBufferEnd)
+            if (value >= (int)TQualifier::layoutXfbBufferEnd)
                 error(loc, "buffer is too large:", id.c_str(), "internal max is %d", TQualifier::layoutXfbBufferEnd-1);
             else
                 publicType.qualifier.layoutXfbBuffer = value;
             return;
         } else if (id == "xfb_offset") {
-            if (value >= TQualifier::layoutXfbOffsetEnd)
+            if (value >= (int)TQualifier::layoutXfbOffsetEnd)
                 error(loc, "offset is too large:", id.c_str(), "internal max is %d", TQualifier::layoutXfbOffsetEnd-1);
             else
                 publicType.qualifier.layoutXfbOffset = value;
@@ -3546,9 +3546,9 @@ void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publi
             // implementation-dependent constant gl_MaxTransformFeedbackInterleavedComponents."
             if (value > 4 * resources.maxTransformFeedbackInterleavedComponents)
                 error(loc, "1/4 stride is too large:", id.c_str(), "gl_MaxTransformFeedbackInterleavedComponents is %d", resources.maxTransformFeedbackInterleavedComponents);
-            else if (value >= TQualifier::layoutXfbStrideEnd)
+            else if (value >= (int)TQualifier::layoutXfbStrideEnd)
                 error(loc, "stride is too large:", id.c_str(), "internal max is %d", TQualifier::layoutXfbStrideEnd-1);
-            if (value < TQualifier::layoutXfbStrideEnd)
+            if (value < (int)TQualifier::layoutXfbStrideEnd)
                 publicType.qualifier.layoutXfbStride = value;
             return;
         }
@@ -4927,7 +4927,7 @@ void TParseContext::fixBlockLocations(const TSourceLoc& loc, TQualifier& qualifi
                 TQualifier& memberQualifier = typeList[member].type->getQualifier();
                 const TSourceLoc& memberLoc = typeList[member].loc;
                 if (! memberQualifier.hasLocation()) {
-                    if (nextLocation >= TQualifier::layoutLocationEnd)
+                    if (nextLocation >= (int)TQualifier::layoutLocationEnd)
                         error(memberLoc, "location is too large", "location", "");
                     memberQualifier.layoutLocation = nextLocation;
                     memberQualifier.layoutComponent = 0;

--- a/glslang/MachineIndependent/Scan.h
+++ b/glslang/MachineIndependent/Scan.h
@@ -172,7 +172,7 @@ protected:
     void advance()
     {
         ++currentChar;
-        if (currentChar >= static_cast<int>(lengths[currentSource])) {
+        if (currentChar >= static_cast<size_t>(lengths[currentSource])) {
             ++currentSource;
             if (currentSource < numSources) {
                 loc[currentSource].string = loc[currentSource - 1].string + 1;

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1288,7 +1288,7 @@ public:
 };
 
 TShader::TShader(EShLanguage s) 
-    : pool(0), stage(s), preamble(""), lengths(nullptr), stringNames(nullptr)
+    : pool(0), stage(s), lengths(nullptr), stringNames(nullptr), preamble("")
 {
     infoSink = new TInfoSink;
     compiler = new TDeferredCompiler(stage, *infoSink);

--- a/glslang/MachineIndependent/glslang.y
+++ b/glslang/MachineIndependent/glslang.y
@@ -96,10 +96,13 @@ using namespace glslang;
 }
 
 %{
-    
-#pragma warning(disable : 4065)
-#pragma warning(disable : 4127)
-#pragma warning(disable : 4244)
+
+/* windows only pragma */
+#ifdef _MSC_VER
+    #pragma warning(disable : 4065)
+    #pragma warning(disable : 4127)
+    #pragma warning(disable : 4244)
+#endif
 
 #define parseContext (*pParseContext)
 #define yyerror(context, msg) context->parserError(msg)

--- a/glslang/MachineIndependent/linkValidate.cpp
+++ b/glslang/MachineIndependent/linkValidate.cpp
@@ -540,7 +540,6 @@ void TIntermediate::checkCallGraphCycles(TInfoSink& infoSink)
 void TIntermediate::inOutLocationCheck(TInfoSink& infoSink)
 {
     // ES 3.0 requires all outputs to have location qualifiers if there is more than one output
-    bool fragOutHasLocation = false;
     bool fragOutWithNoLocation = false;
     int numFragOut = 0;
 
@@ -553,9 +552,7 @@ void TIntermediate::inOutLocationCheck(TInfoSink& infoSink)
         if (language == EShLangFragment) {
             if (qualifier.storage == EvqVaryingOut) {
                 ++numFragOut;
-                if (qualifier.hasAnyLocation())
-                    fragOutHasLocation = true;
-                else
+                if (!qualifier.hasAnyLocation())
                     fragOutWithNoLocation = true;
             }
         }

--- a/glslang/MachineIndependent/preprocessor/PpAtom.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpAtom.cpp
@@ -183,7 +183,7 @@ void TPpContext::InitAtomTable()
     }
 
     // Add multiple character scanner tokens :
-    for (int ii = 0; ii < sizeof(tokens)/sizeof(tokens[0]); ii++)
+    for (size_t ii = 0; ii < sizeof(tokens)/sizeof(tokens[0]); ii++)
         AddAtomFixed(tokens[ii].str, tokens[ii].val);
 
     nextAtom = PpAtomLast;

--- a/glslang/MachineIndependent/preprocessor/PpContext.h
+++ b/glslang/MachineIndependent/preprocessor/PpContext.h
@@ -82,7 +82,10 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "../ParseHelper.h"
 
-#pragma warning(disable : 4127)
+/* windows only pragma */
+#ifdef _MSC_VER
+    #pragma warning(disable : 4127)
+#endif
 
 namespace glslang {
 

--- a/glslang/MachineIndependent/preprocessor/PpScanner.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpScanner.cpp
@@ -440,7 +440,7 @@ int TPpContext::tStringInput::scan(TPpToken* ppToken)
                 const unsigned remainderMaxInt = 0xFFFFFFFFu - 10 * oneTenthMaxInt;
                 for (int i = 0; i < numericLen; i++) {
                     ch = ppToken->name[i] - '0';
-                    if ((ival > oneTenthMaxInt) || (ival == oneTenthMaxInt && ch > remainderMaxInt)) {
+                    if ((ival > oneTenthMaxInt) || (ival == oneTenthMaxInt && (unsigned)ch > remainderMaxInt)) {
                         pp->parseContext.ppError(ppToken->loc, "numeric literal too big", "", "");
                         ival = 0xFFFFFFFFu;
                         break;

--- a/glslang/MachineIndependent/preprocessor/PpSymbols.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpSymbols.cpp
@@ -100,7 +100,7 @@ TPpContext::Symbol* TPpContext::NewSymbol(int atom)
 {
     Symbol* lSymb;
     char* pch;
-    int ii;
+    size_t ii;
 
     lSymb = (Symbol *) mem_Alloc(pool, sizeof(Symbol));
     lSymb->atom = atom;


### PR DESCRIPTION
Some of these fixes are safe & sensible like #ifdef'ing out windows only #pragmas, re-ordering constructor arguments.

The casts between unsigned and signed ints are less clear-cut, so this pull request isn't necessarily to take as-is if you don't want to bandage over things, but to raise these as issues. If there's a refactor that would be better let me know and I can look into doing it, or I can drop them from this PR if you'd rather take just the other fixes.

I also removed an unused variable (fragOutHasLocation) but that's maybe a warning you'd want to ignore.