### PR TITLE
Fixed VS2015 build

### DIFF
--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -37,7 +37,7 @@
 #ifndef _COMMON_INCLUDED_
 #define _COMMON_INCLUDED_
 
-#if defined _MSC_VER || defined MINGW_HAS_SECURE_API
+#if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/) || defined MINGW_HAS_SECURE_API
     #include <basetsd.h>
     #define snprintf sprintf_s
     #define safe_vsprintf(buf,max,format,args) vsnprintf_s((buf), (max), (max), (format), (args))

--- a/glslang/MachineIndependent/preprocessor/PpTokens.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpTokens.cpp
@@ -80,7 +80,7 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // For recording and playing back the stream of tokens in a macro definition.
 //
 
-#ifdef _WIN32
+#if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/)
 #define _CRT_SECURE_NO_WARNINGS
 #define snprintf sprintf_s
 #endif


### PR DESCRIPTION
Check _MSC_VER, defining snprintf triggers a #error in the VS2015 headers. It's already defined and there to use now.