### PR TITLE
Fixes for compiling glslang on Android.

### DIFF
--- a/SPIRV/SPVRemapper.cpp
+++ b/SPIRV/SPVRemapper.cpp
@@ -42,6 +42,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include "../glslang/Include/Common.h"
 
 namespace spv {
 

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -24,7 +24,9 @@ set(LIBRARIES
 if(WIN32)
     set(LIBRARIES ${LIBRARIES} psapi)
 elseif(UNIX)
-    set(LIBRARIES ${LIBRARIES} pthread)
+    if(NOT ANDROID)
+        set(LIBRARIES ${LIBRARIES} pthread)
+    endif()
 endif(WIN32)
 
 target_link_libraries(glslangValidator ${LIBRARIES})

--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -51,6 +51,17 @@
     #define UINT_PTR uintptr_t
 #endif
 
+#ifdef __ANDROID__
+#include <sstream>
+namespace std {
+template<typename T>
+std::string to_string(const T& val) {
+  std::ostringstream os;
+  os << val;
+  return os.str();
+}
+}
+#endif
 /* windows only pragma */
 #ifdef _MSC_VER
     #pragma warning(disable : 4786) // Don't warn about too long identifiers

--- a/glslang/MachineIndependent/intermOut.cpp
+++ b/glslang/MachineIndependent/intermOut.cpp
@@ -48,6 +48,8 @@ namespace {
 bool is_positive_infinity(double x) {
 #ifdef _MSC_VER
   return _fpclass(x) == _FPCLASS_PINF;
+#elif defined __ANDROID__
+  return std::isinf(x) && (x >= 0);
 #else
   return isinf(x) && (x >= 0);
 #endif

--- a/glslang/OSDependent/Linux/ossource.cpp
+++ b/glslang/OSDependent/Linux/ossource.cpp
@@ -62,6 +62,9 @@ void DetachThreadLinux(void *)
 // 
 void OS_CleanupThreadData(void)
 {
+#ifdef __ANDROID__
+  DetachThread();
+#else
 	int old_cancel_state, old_cancel_type;
 	void *cleanupArg = NULL;
 
@@ -85,6 +88,7 @@ void OS_CleanupThreadData(void)
 	// Restore the thread's previous cancellation mode.
 	//
 	pthread_setcanceltype(old_cancel_state, NULL);
+#endif
 }
 
 


### PR DESCRIPTION
Primarily fix is due to Android not supporting std::to_string().