### PR TITLE
'defined' cannot be used as a macro name in #define or #undef.

### DIFF
--- a/Test/baseResults/preprocessor.defined.vert.err
+++ b/Test/baseResults/preprocessor.defined.vert.err
@@ -1,0 +1,4 @@
+ERROR: 0:2: '#define' : "defined" can't be (un)defined: defined
+ERROR: 1 compilation errors.  No code generated.
+
+

--- a/Test/preprocessor.defined.vert
+++ b/Test/preprocessor.defined.vert
@@ -1,0 +1,2 @@
+#define defined_not_really
+#define defined // ERROR: "defined" can't be (un)defined:

--- a/Test/test-preprocessor-list
+++ b/Test/test-preprocessor-list
@@ -11,3 +11,4 @@ preprocessor.line.frag
 preprocessor.pragma.vert
 preprocessor.simple.vert
 preprocessor.success_if_parse_would_fail.vert
+preprocessor.defined.vert

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -2063,6 +2063,8 @@ void TParseContext::reservedPpErrorCheck(const TSourceLoc& loc, const char* iden
     // however, before that, ES tests required an error.
     if (strncmp(identifier, "GL_", 3) == 0)
         ppError(loc, "names beginning with \"GL_\" can't be (un)defined:", op,  identifier);
+    else if (strncmp(identifier, "defined", 8) == 0)
+        ppError(loc, "\"defined\" can't be (un)defined:", op,  identifier);
     else if (strstr(identifier, "__") != 0) {
         if (profile == EEsProfile && version >= 300 &&
             (strcmp(identifier, "__LINE__") == 0 ||


### PR DESCRIPTION
Should resolve #59