### PR TITLE
cmake: Don't override CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-set(CMAKE_INSTALL_PREFIX "install" CACHE STRING "prefix" FORCE)
+set(CMAKE_INSTALL_PREFIX "install" CACHE STRING "prefix")
 
 project(glslang)
 


### PR DESCRIPTION
Stop forcing CMAKE_INSTALL_PREFIX="install". If the user manually set
CMAKE_INSTALL_PREFIX, then trust that he knows what he's doing.

This patch does NOT change the project's default value ("install") of
CMAKE_INSTALL_PREFIX.

Change-Id: I81b46dd1986427b498fe6316bed03f01689987d4