### PR TITLE
SPIRV: Add support for texelFetch

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -1666,8 +1666,6 @@ spv::Id TGlslangToSpvTraverser::createImageTextureFunctionCall(glslang::TIntermO
 
     // This is no longer a query....
 
-    if (cracked.fetch)
-        spv::MissingFunctionality("texel fetch");
     if (cracked.gather)
         spv::MissingFunctionality("texture gather");
 
@@ -1723,7 +1721,7 @@ spv::Id TGlslangToSpvTraverser::createImageTextureFunctionCall(glslang::TIntermO
         ++extraArgs;
     }
 
-    return builder.createTextureCall(precision, convertGlslangToSpvType(node->getType()), cracked.proj, params);
+    return builder.createTextureCall(precision, convertGlslangToSpvType(node->getType()), cracked.fetch, cracked.proj, params);
 }
 
 spv::Id TGlslangToSpvTraverser::handleUserFunctionCall(const glslang::TIntermAggregate* node)

--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -1137,7 +1137,7 @@ Id Builder::createBuiltinCall(Decoration /*precision*/, Id resultType, Id builti
 
 // Accept all parameters needed to create a texture instruction.
 // Create the correct instruction based on the inputs, and make the call.
-Id Builder::createTextureCall(Decoration precision, Id resultType, bool proj, const TextureParameters& parameters)
+Id Builder::createTextureCall(Decoration precision, Id resultType, bool fetch, bool proj, const TextureParameters& parameters)
 {
     static const int maxTextureArgs = 10;
     Id texArgs[maxTextureArgs] = {};
@@ -1196,7 +1196,9 @@ Id Builder::createTextureCall(Decoration precision, Id resultType, bool proj, co
     //
     Op opCode;
     opCode = OpImageSampleImplicitLod;
-    if (xplicit) {
+    if (fetch) {
+        opCode = OpImageFetch;
+    } else if (xplicit) {
         if (parameters.Dref) {
             if (proj)
                 opCode = OpImageSampleProjDrefExplicitLod;

--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -298,7 +298,7 @@ public:
     };
 
     // Select the correct texture operation based on all inputs, and emit the correct instruction
-    Id createTextureCall(Decoration precision, Id resultType, bool proj, const TextureParameters&);
+    Id createTextureCall(Decoration precision, Id resultType, bool fetch, bool proj, const TextureParameters&);
 
     // Emit the OpTextureQuery* instruction that was passed in.
     // Figure out the right return value and type, and return it.


### PR DESCRIPTION
There's nothing really special about texelFetch other than the opcode and
some restrictions so adding it is pretty trivial.

This resolves issue #67 