### PR TITLE
Remove obsolete unistd.h file

### DIFF
--- a/glslang.vcxproj
+++ b/glslang.vcxproj
@@ -643,7 +643,6 @@ xcopy /y $(IntDir)$(TargetName)$(TargetExt) Test</Command>
     <ClInclude Include="glslang\MachineIndependent\SymbolTable.h" />
     <ClInclude Include="glslang\Include\Types.h" />
     <ClInclude Include="glslang\Include\intermediate.h" />
-    <ClInclude Include="glslang\MachineIndependent\unistd.h" />
     <ClInclude Include="glslang\Public\ShaderLang.h" />
     <ClInclude Include="glslang\OSDependent\Windows\osinclude.h" />
     <ClInclude Include="glslang\OSDependent\Linux\osinclude.h" />

--- a/glslang.vcxproj.filters
+++ b/glslang.vcxproj.filters
@@ -165,9 +165,6 @@
     <ClInclude Include="glslang\Include\intermediate.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="glslang\MachineIndependent\unistd.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="glslang\Public\ShaderLang.h">
       <Filter>Public</Filter>
     </ClInclude>

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -63,7 +63,6 @@ set(HEADERS
     MachineIndependent/Scan.h
     MachineIndependent/ScanContext.h
     MachineIndependent/SymbolTable.h
-    MachineIndependent/unistd.h
     MachineIndependent/Versions.h
     MachineIndependent/preprocessor/PpContext.h
     MachineIndependent/preprocessor/PpTokens.h)

--- a/glslang/MachineIndependent/unistd.h
+++ b/glslang/MachineIndependent/unistd.h
@@ -1,1 +1,0 @@
-// This is a NULL file and is meant to be empty

--- a/glslang_vs2010.vcxproj
+++ b/glslang_vs2010.vcxproj
@@ -366,7 +366,6 @@ xcopy /y $(IntDir)$(TargetName)$(TargetExt) Test</Command>
     <ClInclude Include="glslang\MachineIndependent\SymbolTable.h" />
     <ClInclude Include="glslang\Include\Types.h" />
     <ClInclude Include="glslang\Include\intermediate.h" />
-    <ClInclude Include="glslang\MachineIndependent\unistd.h" />
     <ClInclude Include="glslang\Public\ShaderLang.h" />
     <ClInclude Include="glslang\OSDependent\Windows\osinclude.h" />
     <ClInclude Include="glslang\OSDependent\Linux\osinclude.h" />

--- a/glslang_vs2013.vcxproj
+++ b/glslang_vs2013.vcxproj
@@ -366,7 +366,6 @@ xcopy /y $(IntDir)$(TargetName)$(TargetExt) Test</Command>
     <ClInclude Include="glslang\MachineIndependent\SymbolTable.h" />
     <ClInclude Include="glslang\Include\Types.h" />
     <ClInclude Include="glslang\Include\intermediate.h" />
-    <ClInclude Include="glslang\MachineIndependent\unistd.h" />
     <ClInclude Include="glslang\Public\ShaderLang.h" />
     <ClInclude Include="glslang\OSDependent\Windows\osinclude.h" />
     <ClInclude Include="glslang\OSDependent\Linux\osinclude.h" />


### PR DESCRIPTION
The presence of this file can cause build issues when integrating glslang
into other projects.

Note that the VS build projects were hand edited due to tool availability. However, given they've been deprecated, that shouldn't be an issue.