### PR TITLE
Fix ordered pointer comparison build warning/error

### DIFF
--- a/glslang/MachineIndependent/SymbolTable.cpp
+++ b/glslang/MachineIndependent/SymbolTable.cpp
@@ -269,7 +269,7 @@ TFunction::TFunction(const TFunction& copyOf) : TSymbol(copyOf)
 
     numExtensions = 0;
     extensions = 0;
-    if (copyOf.extensions > 0)
+    if (copyOf.extensions != 0)
         setExtensions(copyOf.numExtensions, copyOf.extensions);
     returnType.deepCopy(copyOf.returnType);
     mangledName = copyOf.mangledName;


### PR DESCRIPTION
Encountered with GCC-4.7.3 in a build environment using -Werror=extra