### PR TITLE
Fix compile warning/error due to assignment in while() loop

### DIFF
--- a/glslang/MachineIndependent/Scan.cpp
+++ b/glslang/MachineIndependent/Scan.cpp
@@ -309,7 +309,7 @@ struct str_hash
         unsigned long hash = 5381;
         int c;
 
-        while (c = *str++)
+        while ((c = *str++))
             hash = ((hash << 5) + hash) + c;
 
         return hash;


### PR DESCRIPTION
This causes build failures with -Werror=parentheses