### PR TITLE
Display the filename if we have output, even if validating  a single file

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -827,7 +827,7 @@ int C_DECL main(int argc, char* argv[])
         // Print out all the resulting infologs
         for (int w = 0; w < NumWorkItems; ++w) {
             if (Work[w]) {
-                if (printShaderNames)
+                if (printShaderNames || Work[w]->results.size() > 0)
                     PutsIfNonEmpty(Work[w]->name.c_str());
                 PutsIfNonEmpty(Work[w]->results.c_str());
                 delete Work[w];


### PR DESCRIPTION
I'm running glslangValidator as part of a cmake build. With its current output choices, I either can validate all the shaders in one call (which then outputs every filename even if they succeed), or I do them one at a time (but if one fails, I have no idea which one failed, since cmake/ninja groups them all into a single massive shell call). This pull request outputs the filename even if only validating a single file: as long as compiler output is available (e.g. validation failed, info log, etc).