### PR TITLE
linkValidate: Round up structure sizes to vec4 in std140

### DIFF
--- a/glslang/MachineIndependent/linkValidate.cpp
+++ b/glslang/MachineIndependent/linkValidate.cpp
@@ -959,6 +959,11 @@ int TIntermediate::getBaseAlignment(const TType& type, int& size, int& stride, b
             size += memberSize;
         }
 
+        // The structure may have padding at the end; the base offset of
+        // the member following the sub-structure is rounded up to the next
+        // multiple of the base alignment of the structure.
+        RoundToPow2(size, maxAlignment);
+
         return maxAlignment;
     }
 

--- a/glslang/MachineIndependent/linkValidate.cpp
+++ b/glslang/MachineIndependent/linkValidate.cpp
@@ -987,7 +987,7 @@ int TIntermediate::getBaseAlignment(const TType& type, int& size, int& stride, b
     // rules 5 and 7
     if (type.isMatrix()) {
         // rule 5: deref to row, not to column, meaning the size of vector is num columns instead of num rows
-        TType derefType(type, 0, type.getQualifier().layoutMatrix == ElmRowMajor);
+        TType derefType(type, 0, rowMajor);
             
         alignment = getBaseAlignment(derefType, size, dummyStride, std140, rowMajor);
         if (std140)


### PR DESCRIPTION
This fixes a bug with structs of structs where it wasn't properly applying the last sentence of clause 9 of the std140 UBO packing rules.