### PR TITLE
Addresses some of the memory leaks in glslang.

### DIFF
--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -77,7 +77,7 @@ Id Builder::import(const char* name)
     Instruction* import = new Instruction(getUniqueId(), NoType, OpExtInstImport);
     import->addStringOperand(name);
     
-    imports.push_back(import);
+    imports.push_back(std::unique_ptr<Instruction>(import));
     return import->getResultId();
 }
 
@@ -88,7 +88,7 @@ Id Builder::makeVoidType()
     if (groupedTypes[OpTypeVoid].size() == 0) {
         type = new Instruction(getUniqueId(), NoType, OpTypeVoid);
         groupedTypes[OpTypeVoid].push_back(type);
-        constantsTypesGlobals.push_back(type);
+        constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
         module.mapInstruction(type);
     } else
         type = groupedTypes[OpTypeVoid].back();
@@ -102,7 +102,7 @@ Id Builder::makeBoolType()
     if (groupedTypes[OpTypeBool].size() == 0) {
         type = new Instruction(getUniqueId(), NoType, OpTypeBool);
         groupedTypes[OpTypeBool].push_back(type);
-        constantsTypesGlobals.push_back(type);
+        constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
         module.mapInstruction(type);
     } else
         type = groupedTypes[OpTypeBool].back();
@@ -116,7 +116,7 @@ Id Builder::makeSamplerType()
     if (groupedTypes[OpTypeSampler].size() == 0) {
         type = new Instruction(getUniqueId(), NoType, OpTypeSampler);
         groupedTypes[OpTypeSampler].push_back(type);
-        constantsTypesGlobals.push_back(type);
+        constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
         module.mapInstruction(type);
     } else
         type = groupedTypes[OpTypeSampler].back();
@@ -140,7 +140,7 @@ Id Builder::makePointer(StorageClass storageClass, Id pointee)
     type->addImmediateOperand(storageClass);
     type->addIdOperand(pointee);
     groupedTypes[OpTypePointer].push_back(type);
-    constantsTypesGlobals.push_back(type);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
     module.mapInstruction(type);
 
     return type->getResultId();
@@ -162,7 +162,7 @@ Id Builder::makeIntegerType(int width, bool hasSign)
     type->addImmediateOperand(width);
     type->addImmediateOperand(hasSign ? 1 : 0);
     groupedTypes[OpTypeInt].push_back(type);
-    constantsTypesGlobals.push_back(type);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
     module.mapInstruction(type);
 
     return type->getResultId();
@@ -182,7 +182,7 @@ Id Builder::makeFloatType(int width)
     type = new Instruction(getUniqueId(), NoType, OpTypeFloat);
     type->addImmediateOperand(width);
     groupedTypes[OpTypeFloat].push_back(type);
-    constantsTypesGlobals.push_back(type);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
     module.mapInstruction(type);
 
     return type->getResultId();
@@ -202,7 +202,7 @@ Id Builder::makeStructType(std::vector<Id>& members, const char* name)
     for (int op = 0; op < (int)members.size(); ++op)
         type->addIdOperand(members[op]);
     groupedTypes[OpTypeStruct].push_back(type);
-    constantsTypesGlobals.push_back(type);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
     module.mapInstruction(type);
     addName(type->getResultId(), name);
 
@@ -249,7 +249,7 @@ Id Builder::makeVectorType(Id component, int size)
     type->addIdOperand(component);
     type->addImmediateOperand(size);
     groupedTypes[OpTypeVector].push_back(type);
-    constantsTypesGlobals.push_back(type);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
     module.mapInstruction(type);
 
     return type->getResultId();
@@ -275,7 +275,7 @@ Id Builder::makeMatrixType(Id component, int cols, int rows)
     type->addIdOperand(column);
     type->addImmediateOperand(cols);
     groupedTypes[OpTypeMatrix].push_back(type);
-    constantsTypesGlobals.push_back(type);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
     module.mapInstruction(type);
 
     return type->getResultId();
@@ -305,7 +305,7 @@ Id Builder::makeArrayType(Id element, unsigned size, int stride)
     type->addIdOperand(element);
     type->addIdOperand(sizeId);
     groupedTypes[OpTypeArray].push_back(type);
-    constantsTypesGlobals.push_back(type);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
     module.mapInstruction(type);
 
     return type->getResultId();
@@ -315,7 +315,7 @@ Id Builder::makeRuntimeArray(Id element)
 {
     Instruction* type = new Instruction(getUniqueId(), NoType, OpTypeRuntimeArray);
     type->addIdOperand(element);
-    constantsTypesGlobals.push_back(type);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
     module.mapInstruction(type);
 
     return type->getResultId();
@@ -346,7 +346,7 @@ Id Builder::makeFunctionType(Id returnType, std::vector<Id>& paramTypes)
     for (int p = 0; p < (int)paramTypes.size(); ++p)
         type->addIdOperand(paramTypes[p]);
     groupedTypes[OpTypeFunction].push_back(type);
-    constantsTypesGlobals.push_back(type);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
     module.mapInstruction(type);
 
     return type->getResultId();
@@ -379,7 +379,7 @@ Id Builder::makeImageType(Id sampledType, Dim dim, bool depth, bool arrayed, boo
     type->addImmediateOperand((unsigned int)format);
 
     groupedTypes[OpTypeImage].push_back(type);
-    constantsTypesGlobals.push_back(type);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
     module.mapInstruction(type);
 
     return type->getResultId();
@@ -400,7 +400,7 @@ Id Builder::makeSampledImageType(Id imageType)
     type->addIdOperand(imageType);
 
     groupedTypes[OpTypeSampledImage].push_back(type);
-    constantsTypesGlobals.push_back(type);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(type));
     module.mapInstruction(type);
 
     return type->getResultId();
@@ -594,7 +594,7 @@ Id Builder::makeBoolConstant(bool b, bool specConstant)
 
     // Make it
     Instruction* c = new Instruction(getUniqueId(), typeId, opcode);
-    constantsTypesGlobals.push_back(c);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(c));
     groupedConstants[OpTypeBool].push_back(c);
     module.mapInstruction(c);
 
@@ -610,7 +610,7 @@ Id Builder::makeIntConstant(Id typeId, unsigned value, bool specConstant)
 
     Instruction* c = new Instruction(getUniqueId(), typeId, opcode);
     c->addImmediateOperand(value);
-    constantsTypesGlobals.push_back(c);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(c));
     groupedConstants[OpTypeInt].push_back(c);
     module.mapInstruction(c);
 
@@ -628,7 +628,7 @@ Id Builder::makeFloatConstant(float f, bool specConstant)
 
     Instruction* c = new Instruction(getUniqueId(), typeId, opcode);
     c->addImmediateOperand(value);
-    constantsTypesGlobals.push_back(c);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(c));
     groupedConstants[OpTypeFloat].push_back(c);
     module.mapInstruction(c);
 
@@ -649,7 +649,7 @@ Id Builder::makeDoubleConstant(double d, bool specConstant)
     Instruction* c = new Instruction(getUniqueId(), typeId, opcode);
     c->addImmediateOperand(op1);
     c->addImmediateOperand(op2);
-    constantsTypesGlobals.push_back(c);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(c));
     groupedConstants[OpTypeFloat].push_back(c);
     module.mapInstruction(c);
 
@@ -708,7 +708,7 @@ Id Builder::makeCompositeConstant(Id typeId, std::vector<Id>& members)
     Instruction* c = new Instruction(getUniqueId(), typeId, OpConstantComposite);
     for (int op = 0; op < (int)members.size(); ++op)
         c->addIdOperand(members[op]);
-    constantsTypesGlobals.push_back(c);
+    constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(c));
     groupedConstants[typeClass].push_back(c);
     module.mapInstruction(c);
 
@@ -722,7 +722,7 @@ Instruction* Builder::addEntryPoint(ExecutionModel model, Function* function, co
     entryPoint->addIdOperand(function->getId());
     entryPoint->addStringOperand(name);
 
-    entryPoints.push_back(entryPoint);
+    entryPoints.push_back(std::unique_ptr<Instruction>(entryPoint));
 
     return entryPoint;
 }
@@ -740,7 +740,7 @@ void Builder::addExecutionMode(Function* entryPoint, ExecutionMode mode, int val
     if (value3 >= 0)
         instr->addImmediateOperand(value3);
 
-    executionModes.push_back(instr);
+    executionModes.push_back(std::unique_ptr<Instruction>(instr));
 }
 
 void Builder::addName(Id id, const char* string)
@@ -749,7 +749,7 @@ void Builder::addName(Id id, const char* string)
     name->addIdOperand(id);
     name->addStringOperand(string);
 
-    names.push_back(name);
+    names.push_back(std::unique_ptr<Instruction>(name));
 }
 
 void Builder::addMemberName(Id id, int memberNumber, const char* string)
@@ -759,7 +759,7 @@ void Builder::addMemberName(Id id, int memberNumber, const char* string)
     name->addImmediateOperand(memberNumber);
     name->addStringOperand(string);
 
-    names.push_back(name);
+    names.push_back(std::unique_ptr<Instruction>(name));
 }
 
 void Builder::addLine(Id target, Id fileName, int lineNum, int column)
@@ -770,7 +770,7 @@ void Builder::addLine(Id target, Id fileName, int lineNum, int column)
     line->addImmediateOperand(lineNum);
     line->addImmediateOperand(column);
 
-    lines.push_back(line);
+    lines.push_back(std::unique_ptr<Instruction>(line));
 }
 
 void Builder::addDecoration(Id id, Decoration decoration, int num)
@@ -783,7 +783,7 @@ void Builder::addDecoration(Id id, Decoration decoration, int num)
     if (num >= 0)
         dec->addImmediateOperand(num);
 
-    decorations.push_back(dec);
+    decorations.push_back(std::unique_ptr<Instruction>(dec));
 }
 
 void Builder::addMemberDecoration(Id id, unsigned int member, Decoration decoration, int num)
@@ -795,7 +795,7 @@ void Builder::addMemberDecoration(Id id, unsigned int member, Decoration decorat
     if (num >= 0)
         dec->addImmediateOperand(num);
 
-    decorations.push_back(dec);
+    decorations.push_back(std::unique_ptr<Instruction>(dec));
 }
 
 // Comments in header
@@ -826,6 +826,8 @@ Function* Builder::makeFunctionEntry(Id returnType, const char* name, std::vecto
 
     if (name)
         addName(function->getId(), name);
+
+    functions.push_back(std::unique_ptr<Function>(function));
 
     return function;
 }
@@ -896,7 +898,7 @@ Id Builder::createVariable(StorageClass storageClass, Id type, const char* name)
         break;
 
     default:
-        constantsTypesGlobals.push_back(inst);
+        constantsTypesGlobals.push_back(std::unique_ptr<Instruction>(inst));
         module.mapInstruction(inst);
         break;
     }
@@ -2235,7 +2237,7 @@ void Builder::createConditionalBranch(Id condition, Block* thenBlock, Block* els
     elseBlock->addPredecessor(buildPoint);
 }
 
-void Builder::dumpInstructions(std::vector<unsigned int>& out, const std::vector<Instruction*>& instructions) const
+void Builder::dumpInstructions(std::vector<unsigned int>& out, const std::vector<std::unique_ptr<Instruction> >& instructions) const
 {
     for (int i = 0; i < (int)instructions.size(); ++i) {
         instructions[i]->dump(out);

--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -838,9 +838,9 @@ void Builder::makeReturn(bool implicit, Id retVal)
     if (retVal) {
         Instruction* inst = new Instruction(NoResult, NoType, OpReturnValue);
         inst->addIdOperand(retVal);
-        buildPoint->addInstruction(inst);
+        buildPoint->addInstruction(std::unique_ptr<Instruction>(inst));
     } else
-        buildPoint->addInstruction(new Instruction(NoResult, NoType, OpReturn));
+        buildPoint->addInstruction(std::unique_ptr<Instruction>(new Instruction(NoResult, NoType, OpReturn)));
 
     if (! implicit)
         createAndSetNoPredecessorBlock("post-return");
@@ -880,7 +880,7 @@ void Builder::leaveFunction()
 // Comments in header
 void Builder::makeDiscard()
 {
-    buildPoint->addInstruction(new Instruction(OpKill));
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(new Instruction(OpKill)));
     createAndSetNoPredecessorBlock("post-discard");
 }
 
@@ -894,7 +894,7 @@ Id Builder::createVariable(StorageClass storageClass, Id type, const char* name)
     switch (storageClass) {
     case StorageClassFunction:
         // Validation rules require the declaration in the entry block
-        buildPoint->getParent().addLocalVariable(inst);
+        buildPoint->getParent().addLocalVariable(std::unique_ptr<Instruction>(inst));
         break;
 
     default:
@@ -913,7 +913,7 @@ Id Builder::createVariable(StorageClass storageClass, Id type, const char* name)
 Id Builder::createUndefined(Id type)
 {
   Instruction* inst = new Instruction(getUniqueId(), type, OpUndef);
-  buildPoint->addInstruction(inst);
+  buildPoint->addInstruction(std::unique_ptr<Instruction>(inst));
   return inst->getResultId();
 }
 
@@ -923,7 +923,7 @@ void Builder::createStore(Id rValue, Id lValue)
     Instruction* store = new Instruction(OpStore);
     store->addIdOperand(lValue);
     store->addIdOperand(rValue);
-    buildPoint->addInstruction(store);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(store));
 }
 
 // Comments in header
@@ -931,7 +931,7 @@ Id Builder::createLoad(Id lValue)
 {
     Instruction* load = new Instruction(getUniqueId(), getDerefTypeId(lValue), OpLoad);
     load->addIdOperand(lValue);
-    buildPoint->addInstruction(load);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(load));
 
     return load->getResultId();
 }
@@ -957,7 +957,7 @@ Id Builder::createAccessChain(StorageClass storageClass, Id base, std::vector<Id
     chain->addIdOperand(base);
     for (int i = 0; i < (int)offsets.size(); ++i)
         chain->addIdOperand(offsets[i]);
-    buildPoint->addInstruction(chain);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(chain));
 
     return chain->getResultId();
 }
@@ -967,7 +967,7 @@ Id Builder::createArrayLength(Id base, unsigned int member)
     Instruction* length = new Instruction(getUniqueId(), makeIntType(32), OpArrayLength);
     length->addIdOperand(base);
     length->addImmediateOperand(member);
-    buildPoint->addInstruction(length);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(length));
 
     return length->getResultId();
 }
@@ -977,7 +977,7 @@ Id Builder::createCompositeExtract(Id composite, Id typeId, unsigned index)
     Instruction* extract = new Instruction(getUniqueId(), typeId, OpCompositeExtract);
     extract->addIdOperand(composite);
     extract->addImmediateOperand(index);
-    buildPoint->addInstruction(extract);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(extract));
 
     return extract->getResultId();
 }
@@ -988,7 +988,7 @@ Id Builder::createCompositeExtract(Id composite, Id typeId, std::vector<unsigned
     extract->addIdOperand(composite);
     for (int i = 0; i < (int)indexes.size(); ++i)
         extract->addImmediateOperand(indexes[i]);
-    buildPoint->addInstruction(extract);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(extract));
 
     return extract->getResultId();
 }
@@ -999,7 +999,7 @@ Id Builder::createCompositeInsert(Id object, Id composite, Id typeId, unsigned i
     insert->addIdOperand(object);
     insert->addIdOperand(composite);
     insert->addImmediateOperand(index);
-    buildPoint->addInstruction(insert);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(insert));
 
     return insert->getResultId();
 }
@@ -1011,7 +1011,7 @@ Id Builder::createCompositeInsert(Id object, Id composite, Id typeId, std::vecto
     insert->addIdOperand(composite);
     for (int i = 0; i < (int)indexes.size(); ++i)
         insert->addImmediateOperand(indexes[i]);
-    buildPoint->addInstruction(insert);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(insert));
 
     return insert->getResultId();
 }
@@ -1021,7 +1021,7 @@ Id Builder::createVectorExtractDynamic(Id vector, Id typeId, Id componentIndex)
     Instruction* extract = new Instruction(getUniqueId(), typeId, OpVectorExtractDynamic);
     extract->addIdOperand(vector);
     extract->addIdOperand(componentIndex);
-    buildPoint->addInstruction(extract);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(extract));
 
     return extract->getResultId();
 }
@@ -1032,7 +1032,7 @@ Id Builder::createVectorInsertDynamic(Id vector, Id typeId, Id component, Id com
     insert->addIdOperand(vector);
     insert->addIdOperand(component);
     insert->addIdOperand(componentIndex);
-    buildPoint->addInstruction(insert);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(insert));
 
     return insert->getResultId();
 }
@@ -1041,7 +1041,7 @@ Id Builder::createVectorInsertDynamic(Id vector, Id typeId, Id component, Id com
 void Builder::createNoResultOp(Op opCode)
 {
     Instruction* op = new Instruction(opCode);
-    buildPoint->addInstruction(op);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(op));
 }
 
 // An opcode that has one operand, no result id, and no type
@@ -1049,7 +1049,7 @@ void Builder::createNoResultOp(Op opCode, Id operand)
 {
     Instruction* op = new Instruction(opCode);
     op->addIdOperand(operand);
-    buildPoint->addInstruction(op);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(op));
 }
 
 // An opcode that has one operand, no result id, and no type
@@ -1058,7 +1058,7 @@ void Builder::createNoResultOp(Op opCode, const std::vector<Id>& operands)
     Instruction* op = new Instruction(opCode);
     for (auto operand : operands)
         op->addIdOperand(operand);
-    buildPoint->addInstruction(op);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(op));
 }
 
 void Builder::createControlBarrier(Scope execution, Scope memory, MemorySemanticsMask semantics)
@@ -1067,7 +1067,7 @@ void Builder::createControlBarrier(Scope execution, Scope memory, MemorySemantic
     op->addImmediateOperand(makeUintConstant(execution));
     op->addImmediateOperand(makeUintConstant(memory));
     op->addImmediateOperand(makeUintConstant(semantics));
-    buildPoint->addInstruction(op);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(op));
 }
 
 void Builder::createMemoryBarrier(unsigned executionScope, unsigned memorySemantics)
@@ -1075,7 +1075,7 @@ void Builder::createMemoryBarrier(unsigned executionScope, unsigned memorySemant
     Instruction* op = new Instruction(OpMemoryBarrier);
     op->addImmediateOperand(makeUintConstant(executionScope));
     op->addImmediateOperand(makeUintConstant(memorySemantics));
-    buildPoint->addInstruction(op);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(op));
 }
 
 // An opcode that has one operands, a result id, and a type
@@ -1083,7 +1083,7 @@ Id Builder::createUnaryOp(Op opCode, Id typeId, Id operand)
 {
     Instruction* op = new Instruction(getUniqueId(), typeId, opCode);
     op->addIdOperand(operand);
-    buildPoint->addInstruction(op);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(op));
 
     return op->getResultId();
 }
@@ -1093,7 +1093,7 @@ Id Builder::createBinOp(Op opCode, Id typeId, Id left, Id right)
     Instruction* op = new Instruction(getUniqueId(), typeId, opCode);
     op->addIdOperand(left);
     op->addIdOperand(right);
-    buildPoint->addInstruction(op);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(op));
 
     return op->getResultId();
 }
@@ -1104,7 +1104,7 @@ Id Builder::createTriOp(Op opCode, Id typeId, Id op1, Id op2, Id op3)
     op->addIdOperand(op1);
     op->addIdOperand(op2);
     op->addIdOperand(op3);
-    buildPoint->addInstruction(op);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(op));
 
     return op->getResultId();
 }
@@ -1114,7 +1114,7 @@ Id Builder::createOp(Op opCode, Id typeId, const std::vector<Id>& operands)
     Instruction* op = new Instruction(getUniqueId(), typeId, opCode);
     for (auto operand : operands)
         op->addIdOperand(operand);
-    buildPoint->addInstruction(op);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(op));
 
     return op->getResultId();
 }
@@ -1125,7 +1125,7 @@ Id Builder::createFunctionCall(spv::Function* function, std::vector<spv::Id>& ar
     op->addIdOperand(function->getId());
     for (int a = 0; a < (int)args.size(); ++a)
         op->addIdOperand(args[a]);
-    buildPoint->addInstruction(op);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(op));
 
     return op->getResultId();
 }
@@ -1142,7 +1142,7 @@ Id Builder::createRvalueSwizzle(Id typeId, Id source, std::vector<unsigned>& cha
     swizzle->addIdOperand(source);
     for (int i = 0; i < (int)channels.size(); ++i)
         swizzle->addImmediateOperand(channels[i]);
-    buildPoint->addInstruction(swizzle);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(swizzle));
 
     return swizzle->getResultId();
 }
@@ -1173,7 +1173,7 @@ Id Builder::createLvalueSwizzle(Id typeId, Id target, Id source, std::vector<uns
     // finish the instruction with these components selectors
     for (int i = 0; i < numTargetComponents; ++i)
         swizzle->addImmediateOperand(components[i]);
-    buildPoint->addInstruction(swizzle);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(swizzle));
 
     return swizzle->getResultId();
 }
@@ -1204,7 +1204,7 @@ Id Builder::smearScalar(Decoration /*precision*/, Id scalar, Id vectorType)
     Instruction* smear = new Instruction(getUniqueId(), vectorType, OpCompositeConstruct);
     for (int c = 0; c < numComponents; ++c)
         smear->addIdOperand(scalar);
-    buildPoint->addInstruction(smear);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(smear));
 
     return smear->getResultId();
 }
@@ -1218,7 +1218,7 @@ Id Builder::createBuiltinCall(Decoration /*precision*/, Id resultType, Id builti
     for (int arg = 0; arg < (int)args.size(); ++arg)
         inst->addIdOperand(args[arg]);
 
-    buildPoint->addInstruction(inst);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(inst));
     return inst->getResultId();
 }
 
@@ -1346,7 +1346,7 @@ Id Builder::createTextureCall(Decoration precision, Id resultType, bool fetch, b
     for (int op = optArgNum + 1; op < numArgs; ++op)
         textureInst->addIdOperand(texArgs[op]);
     setPrecision(textureInst->getResultId(), precision);
-    buildPoint->addInstruction(textureInst);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(textureInst));
 
     Id resultId = textureInst->getResultId();
 
@@ -1414,7 +1414,7 @@ Id Builder::createTextureQueryCall(Op opCode, const TextureParameters& parameter
         query->addIdOperand(parameters.coords);
     if (parameters.lod)
         query->addIdOperand(parameters.lod);
-    buildPoint->addInstruction(query);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(query));
 
     return query->getResultId();
 }
@@ -1496,7 +1496,7 @@ Id Builder::createCompositeConstruct(Id typeId, std::vector<Id>& constituents)
     Instruction* op = new Instruction(getUniqueId(), typeId, OpCompositeConstruct);
     for (int c = 0; c < (int)constituents.size(); ++c)
         op->addIdOperand(constituents[c]);
-    buildPoint->addInstruction(op);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(op));
 
     return op->getResultId();
 }
@@ -1712,7 +1712,7 @@ void Builder::makeSwitch(Id selector, int numSegments, std::vector<int>& caseVal
         switchInst->addImmediateOperand(caseValues[i]);
         switchInst->addIdOperand(segmentBlocks[valueIndexToSegment[i]]->getId());
     }
-    buildPoint->addInstruction(switchInst);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(switchInst));
 
     // push the merge block
     switchMerges.push(mergeBlock);
@@ -1783,7 +1783,7 @@ void Builder::makeNewLoop(bool loopTestFirst)
         // but we don't yet know where they will come from.
         loop.isFirstIteration->addIdOperand(makeBoolConstant(true));
         loop.isFirstIteration->addIdOperand(preheader->getId());
-        getBuildPoint()->addInstruction(loop.isFirstIteration);
+        getBuildPoint()->addInstruction(std::unique_ptr<Instruction>(loop.isFirstIteration));
 
         // Mark the end of the structured loop. This must exist in the loop header block.
         createLoopMerge(loop.merge, loop.header, LoopControlMaskNone);
@@ -2205,7 +2205,7 @@ void Builder::createBranch(Block* block)
 {
     Instruction* branch = new Instruction(OpBranch);
     branch->addIdOperand(block->getId());
-    buildPoint->addInstruction(branch);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(branch));
     block->addPredecessor(buildPoint);
 }
 
@@ -2214,7 +2214,7 @@ void Builder::createSelectionMerge(Block* mergeBlock, unsigned int control)
     Instruction* merge = new Instruction(OpSelectionMerge);
     merge->addIdOperand(mergeBlock->getId());
     merge->addImmediateOperand(control);
-    buildPoint->addInstruction(merge);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(merge));
 }
 
 void Builder::createLoopMerge(Block* mergeBlock, Block* continueBlock, unsigned int control)
@@ -2223,7 +2223,7 @@ void Builder::createLoopMerge(Block* mergeBlock, Block* continueBlock, unsigned 
     merge->addIdOperand(mergeBlock->getId());
     merge->addIdOperand(continueBlock->getId());
     merge->addImmediateOperand(control);
-    buildPoint->addInstruction(merge);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(merge));
 }
 
 void Builder::createConditionalBranch(Id condition, Block* thenBlock, Block* elseBlock)
@@ -2232,7 +2232,7 @@ void Builder::createConditionalBranch(Id condition, Block* thenBlock, Block* els
     branch->addIdOperand(condition);
     branch->addIdOperand(thenBlock->getId());
     branch->addIdOperand(elseBlock->getId());
-    buildPoint->addInstruction(branch);
+    buildPoint->addInstruction(std::unique_ptr<Instruction>(branch));
     thenBlock->addPredecessor(buildPoint);
     elseBlock->addPredecessor(buildPoint);
 }

--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -52,6 +52,7 @@
 #include "spvIR.h"
 
 #include <algorithm>
+#include <memory>
 #include <stack>
 #include <map>
 
@@ -201,11 +202,13 @@ public:
     void setBuildPoint(Block* bp) { buildPoint = bp; }
     Block* getBuildPoint() const { return buildPoint; }
 
-    // Make the main function.
+    // Make the main function. The returned pointer is only valid
+    // for the lifetime of this builder.
     Function* makeMain();
 
     // Make a shader-style function, and create its entry block if entry is non-zero.
     // Return the function, pass back the entry.
+	// The returned pointer is only valid for the lifetime of this builder.
     Function* makeFunctionEntry(Id returnType, const char* name, std::vector<Id>& paramTypes, Block **entry = 0);
 
     // Create a return. An 'implicit' return is one not appearing in the source
@@ -516,7 +519,7 @@ protected:
     void createSelectionMerge(Block* mergeBlock, unsigned int control);
     void createLoopMerge(Block* mergeBlock, Block* continueBlock, unsigned int control);
     void createConditionalBranch(Id condition, Block* thenBlock, Block* elseBlock);
-    void dumpInstructions(std::vector<unsigned int>&, const std::vector<Instruction*>&) const;
+    void dumpInstructions(std::vector<unsigned int>&, const std::vector<std::unique_ptr<Instruction> >&) const;
 
     struct Loop; // Defined below.
     void createBranchToLoopHeaderFromInside(const Loop& loop);
@@ -535,14 +538,15 @@ protected:
     AccessChain accessChain;
 
     // special blocks of instructions for output
-    std::vector<Instruction*> imports;
-    std::vector<Instruction*> entryPoints;
-    std::vector<Instruction*> executionModes;
-    std::vector<Instruction*> names;
-    std::vector<Instruction*> lines;
-    std::vector<Instruction*> decorations;
-    std::vector<Instruction*> constantsTypesGlobals;
-    std::vector<Instruction*> externals;
+    std::vector<std::unique_ptr<Instruction> > imports;
+    std::vector<std::unique_ptr<Instruction> > entryPoints;
+    std::vector<std::unique_ptr<Instruction> > executionModes;
+    std::vector<std::unique_ptr<Instruction> > names;
+    std::vector<std::unique_ptr<Instruction> > lines;
+    std::vector<std::unique_ptr<Instruction> > decorations;
+    std::vector<std::unique_ptr<Instruction> > constantsTypesGlobals;
+    std::vector<std::unique_ptr<Instruction> > externals;
+    std::vector<std::unique_ptr<Function> > functions;
 
      // not output, internally used for quick & dirty canonical (unique) creation
     std::vector<Instruction*> groupedConstants[OpConstant];  // all types appear before OpConstant

--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -208,7 +208,7 @@ public:
 
     // Make a shader-style function, and create its entry block if entry is non-zero.
     // Return the function, pass back the entry.
-	// The returned pointer is only valid for the lifetime of this builder.
+    // The returned pointer is only valid for the lifetime of this builder.
     Function* makeFunctionEntry(Id returnType, const char* name, std::vector<Id>& paramTypes, Block **entry = 0);
 
     // Create a return. An 'implicit' return is one not appearing in the source

--- a/SPIRV/spvIR.h
+++ b/SPIRV/spvIR.h
@@ -161,11 +161,9 @@ public:
     Id getId() { return instructions.front()->getResultId(); }
 
     Function& getParent() const { return parent; }
-    // addInstruction takes ownership of the instruction once it has
-    // been passed in. It will be destroyed when the Block is destroyed.
-    void addInstruction(Instruction* inst);
+    void addInstruction(std::unique_ptr<Instruction> inst);
     void addPredecessor(Block* pred) { predecessors.push_back(pred); }
-    void addLocalVariable(Instruction* inst) { localVariables.push_back(std::unique_ptr<Instruction>(inst)); }
+    void addLocalVariable(std::unique_ptr<Instruction> inst) { localVariables.push_back(std::move(inst)); }
     int getNumPredecessors() const { return (int)predecessors.size(); }
     void setUnreachable() { unreachable = true; }
     bool isUnreachable() const { return unreachable; }
@@ -242,7 +240,7 @@ public:
     Module& getParent() const { return parent; }
     Block* getEntryBlock() const { return blocks.front(); }
     Block* getLastBlock() const { return blocks.back(); }
-    void addLocalVariable(Instruction* inst);
+    void addLocalVariable(std::unique_ptr<Instruction> inst);
     Id getReturnType() const { return functionInstruction.getTypeId(); }
     void dump(std::vector<unsigned int>& out) const
     {
@@ -343,10 +341,11 @@ __inline Function::Function(Id id, Id resultType, Id functionType, Id firstParam
     }
 }
 
-__inline void Function::addLocalVariable(Instruction* inst)
+__inline void Function::addLocalVariable(std::unique_ptr<Instruction> inst)
 {
-    blocks[0]->addLocalVariable(inst);
-    parent.mapInstruction(inst);
+    Instruction* raw_instruction = inst.get();
+    blocks[0]->addLocalVariable(std::move(inst));
+    parent.mapInstruction(raw_instruction);
 }
 
 __inline Block::Block(Id id, Function& parent) : parent(parent), unreachable(false)
@@ -354,11 +353,12 @@ __inline Block::Block(Id id, Function& parent) : parent(parent), unreachable(fal
     instructions.push_back(std::unique_ptr<Instruction>(new Instruction(id, NoType, OpLabel)));
 }
 
-__inline void Block::addInstruction(Instruction* inst)
+__inline void Block::addInstruction(std::unique_ptr<Instruction> inst)
 {
-    instructions.push_back(std::unique_ptr<Instruction>(inst));
-    if (inst->getResultId())
-        parent.getParent().mapInstruction(inst);
+  Instruction* raw_instruction = inst.get();
+    instructions.push_back(std::move(inst));
+    if (raw_instruction->getResultId())
+        parent.getParent().mapInstruction(raw_instruction);
 }
 
 };  // end spv namespace

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -218,6 +218,7 @@ void ProcessConfigFile()
 {
     char** configStrings = 0;
     char* config = 0;
+    bool allocated_config = false;
     if (ConfigFile.size() > 0) {
         configStrings = ReadFileData(ConfigFile.c_str());
         if (configStrings)
@@ -230,6 +231,7 @@ void ProcessConfigFile()
 
     if (config == 0) {
         config = new char[strlen(DefaultConfig) + 1];
+        allocated_config = true;
         strcpy(config, DefaultConfig);
     }
 
@@ -435,6 +437,8 @@ void ProcessConfigFile()
     }
     if (configStrings)
         FreeFileData(configStrings);
+    if (allocated_config)
+        delete[] config;
 }
 
 // thread-safe list of shaders to asynchronously grab and compile
@@ -805,6 +809,11 @@ int C_DECL main(int argc, char* argv[])
         glslang::InitializeProcess();
         CompileAndLinkShaders();
         glslang::FinalizeProcess();
+        for (int w = 0; w < NumWorkItems; ++w) {
+          if (Work[w]) {
+            delete Work[w];
+          }
+        }
     } else {
         ShInitialize();
 
@@ -836,6 +845,8 @@ int C_DECL main(int argc, char* argv[])
 
         ShFinalize();
     }
+
+    delete[] Work;
 
     if (CompileFailed)
         return EFailCompile;

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -218,7 +218,6 @@ void ProcessConfigFile()
 {
     char** configStrings = 0;
     char* config = 0;
-    bool allocated_config = false;
     if (ConfigFile.size() > 0) {
         configStrings = ReadFileData(ConfigFile.c_str());
         if (configStrings)
@@ -231,7 +230,6 @@ void ProcessConfigFile()
 
     if (config == 0) {
         config = new char[strlen(DefaultConfig) + 1];
-        allocated_config = true;
         strcpy(config, DefaultConfig);
     }
 
@@ -437,7 +435,7 @@ void ProcessConfigFile()
     }
     if (configStrings)
         FreeFileData(configStrings);
-    if (allocated_config)
+    else
         delete[] config;
 }
 

--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -160,14 +160,20 @@ public:
 };
 
 template <class T> class TList  : public std::list<T, pool_allocator<T> > {
+ public:
+    POOL_ALLOCATOR_NEW_DELETE(GetThreadPoolAllocator())
 };
 
 template <class K, class D, class CMP = std::less<K> > 
 class TMap : public std::map<K, D, CMP, pool_allocator<std::pair<K, D> > > {
+ public:
+    POOL_ALLOCATOR_NEW_DELETE(GetThreadPoolAllocator())
 };
 
 template <class K, class D, class HASH = std::hash<K>, class PRED = std::equal_to<K> >
 class TUnorderedMap : public std::unordered_map<K, D, HASH, PRED, pool_allocator<std::pair<K const, D> > > {
+ public:
+    POOL_ALLOCATOR_NEW_DELETE(GetThreadPoolAllocator())
 };
 
 //

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1407,6 +1407,7 @@ TProgram::~TProgram()
     delete infoSink;
     delete reflection;
 
+    SetThreadPoolAllocator(*old_pool);
     for (int s = 0; s < EShLangCount; ++s)
         if (newedIntermediate[s])
             delete intermediate[s];
@@ -1429,6 +1430,7 @@ bool TProgram::link(EShMessages messages)
     bool error = false;
     
     pool = new TPoolAllocator();
+    old_pool = &GetThreadPoolAllocator();
     SetThreadPoolAllocator(*pool);
 
     for (int s = 0; s < EShLangCount; ++s) {

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -391,6 +391,7 @@ protected:
     bool linkStage(EShLanguage, EShMessages);
 
     TPoolAllocator* pool;
+    TPoolAllocator* old_pool;
     std::list<TShader*> stages[EShLangCount];
     TIntermediate* intermediate[EShLangCount];
     bool newedIntermediate[EShLangCount];      // track which intermediate were "new" versus reusing a singleton unit in a stage


### PR DESCRIPTION
This is mostly accomplished by switching some vectors in
SpirvBuilder to contain std::unique_ptrs so that they are
cleaned up automatically when the vectors go away.

The only remaining issues I have found seem to leak only once
per process so are lower priority.