### PR TITLE
Have TProgram restore the original thread-allocator.

### DIFF
--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1407,6 +1407,7 @@ TProgram::~TProgram()
     delete infoSink;
     delete reflection;
 
+    SetThreadPoolAllocator(*old_pool);
     for (int s = 0; s < EShLangCount; ++s)
         if (newedIntermediate[s])
             delete intermediate[s];
@@ -1429,6 +1430,7 @@ bool TProgram::link(EShMessages messages)
     bool error = false;
     
     pool = new TPoolAllocator();
+    old_pool = &GetThreadPoolAllocator();
     SetThreadPoolAllocator(*pool);
 
     for (int s = 0; s < EShLangCount; ++s) {

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -391,6 +391,7 @@ protected:
     bool linkStage(EShLanguage, EShMessages);
 
     TPoolAllocator* pool;
+    TPoolAllocator* old_pool;
     std::list<TShader*> stages[EShLangCount];
     TIntermediate* intermediate[EShLangCount];
     bool newedIntermediate[EShLangCount];      // track which intermediate were "new" versus reusing a singleton unit in a stage


### PR DESCRIPTION
TProgram creates a new thread-pool allocator, and sets it.
The original allocator was created in InitializeProcess, and
can no longer be referenced or cleaned up after TProgram has been
run.
