### PR TITLE
Fix #137 by avoiding a C++11 feature.

### DIFF
--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -1804,7 +1804,9 @@ Block& Builder::makeNewBlock()
 
 Builder::LoopBlocks& Builder::makeNewLoop()
 {
-    loops.push({makeNewBlock(), makeNewBlock(), makeNewBlock(), makeNewBlock()});
+    // Older MSVC versions don't allow inlining of blocks below.
+    LoopBlocks blocks = {makeNewBlock(), makeNewBlock(), makeNewBlock(), makeNewBlock()};
+    loops.push(blocks);
     return loops.top();
 }
 


### PR DESCRIPTION
Apparently, older MSVC versions don't support brace-initializers for
function arguments.

Thanks @baldurk for a suggestion on his branch.