### PR TITLE
TProgram exposes layout manipulation functions

### DIFF
--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -522,7 +522,7 @@ public:
     int layoutOffset;
     int layoutAlign;
 
-                 unsigned int layoutLocation            :12;
+         mutable unsigned int layoutLocation            :12;
     static const unsigned int layoutLocationEnd    =  0xFFF;
 
                  unsigned int layoutComponent           : 3;
@@ -531,7 +531,7 @@ public:
                  unsigned int layoutSet                 : 7;
     static const unsigned int layoutSetEnd         =   0x3F;
 
-                 unsigned int layoutBinding             : 8;
+         mutable unsigned int layoutBinding          : 8;
     static const unsigned int layoutBindingEnd    =    0xFF;
 
                  unsigned int layoutIndex              :  8;
@@ -585,6 +585,10 @@ public:
     {
         return layoutLocation != layoutLocationEnd;
     }
+    void setLocation(unsigned int location) const
+    {
+        layoutLocation = location;
+    }
     bool hasComponent() const
     {
         return layoutComponent != layoutComponentEnd;
@@ -600,6 +604,10 @@ public:
     bool hasBinding() const
     {
         return layoutBinding != layoutBindingEnd;
+    }
+    void setBinding(unsigned int binding) const
+    {
+        layoutBinding = binding;
     }
     bool hasStream() const
     {

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1527,17 +1527,53 @@ bool TProgram::buildReflection()
     return true;
 }
 
-int TProgram::getNumLiveUniformVariables()           { return reflection->getNumUniforms(); }
-int TProgram::getNumLiveUniformBlocks()              { return reflection->getNumUniformBlocks(); }
-const char* TProgram::getUniformName(int index)      { return reflection->getUniform(index).name.c_str(); }
-const char* TProgram::getUniformBlockName(int index) { return reflection->getUniformBlock(index).name.c_str(); }
-int TProgram::getUniformBlockSize(int index)         { return reflection->getUniformBlock(index).size; }
-int TProgram::getUniformIndex(const char* name)      { return reflection->getIndex(name); }
-int TProgram::getUniformBlockIndex(int index)        { return reflection->getUniform(index).index; }
-int TProgram::getUniformType(int index)              { return reflection->getUniform(index).glDefineType; }
-int TProgram::getUniformBufferOffset(int index)      { return reflection->getUniform(index).offset; }
-int TProgram::getUniformArraySize(int index)         { return reflection->getUniform(index).size; }
+/// Uniforms and uniform blocks
+int TProgram::getNumLiveUniformVariables()                   { return reflection->getNumUniforms(); }
+int TProgram::getNumLiveUniformBlocks()                      { return reflection->getNumUniformBlocks(); }
+const char* TProgram::getUniformName(int index)              { return reflection->getUniform(index).name.c_str(); }
+const char* TProgram::getUniformBlockName(int index)         { return reflection->getUniformBlock(index).name.c_str(); }
+int TProgram::getUniformBlockSize(int index)                 { return reflection->getUniformBlock(index).size; }
+int TProgram::getUniformIndex(const char* name)              { return reflection->getIndex(name); }
+int TProgram::getUniformBlockIndex(int index)                { return reflection->getUniform(index).index; }
+int TProgram::getUniformType(int index)                      { return reflection->getUniform(index).glDefineType; }
+int TProgram::getUniformBufferOffset(int index)              { return reflection->getUniform(index).offset; }
+int TProgram::getUniformArraySize(int index)                 { return reflection->getUniform(index).size; }
 
-void TProgram::dumpReflection()                      { reflection->dump(); }
+/// layout information
+bool TProgram::getUniformHasLocation(int index)              { return reflection->getUniformQualifier(index)->hasLocation(); }
+bool TProgram::getUniformHasBinding(int index)               { return reflection->getUniformQualifier(index)->hasBinding(); }
+int TProgram::getUniformLocation(int index)                  { return reflection->getUniformQualifier(index)->layoutLocation; }
+int TProgram::getUniformBinding(int index)                   { return reflection->getUniformQualifier(index)->layoutBinding; }
+
+void TProgram::setUniformBinding(int index, int binding)     { reflection->setUniformBinding(index, binding); }
+
+/// Vertex attributes
+int TProgram::getNumLiveAttributeVariables()                 { return reflection->getNumAttributes(); }
+const char* TProgram::getAttributeName(int index)            { return reflection->getAttribute(index).name.c_str(); }
+int TProgram::getAttributeIndex(const char* name)            { return reflection->getAttributeIndex(name); }
+int TProgram::getAttributeType(int index)                    { return reflection->getAttribute(index).glDefineType; }
+
+/// layout information
+bool TProgram::getAttributeHasLocation(int index)            { return reflection->getAttributeQualifier(index)->hasLocation(); }
+bool TProgram::getAttributeHasBinding(int index)             { return reflection->getAttributeQualifier(index)->hasBinding(); }
+int TProgram::getAttributeLocation(int index)                { return reflection->getAttributeQualifier(index)->layoutLocation; }
+int TProgram::getAttributeBinding(int index)                 { return reflection->getAttributeQualifier(index)->layoutBinding; }
+
+void TProgram::setAttributeLocation(int index, int location) { reflection->setAttributeLocation(index, location); }
+
+/// Varyings
+int TProgram::getNumLiveVaryingVariables()                   { return reflection->getNumVaryings(); }
+const char* TProgram::getVaryingName(int index)              { return reflection->getVarying(index).name.c_str(); }
+int TProgram::getVaryingIndex(const char* name)              { return reflection->getVaryingIndex(name); }
+int TProgram::getVaryingType(int index)                      { return reflection->getVarying(index).glDefineType; }
+
+/// layout information
+bool TProgram::getVaryingHasLocation(int index)              { return reflection->getVaryingQualifier(index)->hasLocation(); }
+bool TProgram::getVaryingHasBinding(int index)               { return reflection->getVaryingQualifier(index)->hasBinding(); }
+int TProgram::getVaryingLocation(int index)                  { return reflection->getVaryingQualifier(index)->layoutLocation; }
+int TProgram::getVaryingBinding(int index)                   { return reflection->getVaryingQualifier(index)->layoutBinding; }
+
+
+void TProgram::dumpReflection()                              { reflection->dump(); }
 
 } // end namespace glslang

--- a/glslang/MachineIndependent/reflection.h
+++ b/glslang/MachineIndependent/reflection.h
@@ -37,6 +37,7 @@
 #define _REFLECTION_INCLUDED
 
 #include "../Public/ShaderLang.h"
+#include "../Include/Types.h"
 
 #include <list>
 #include <set>
@@ -54,7 +55,7 @@ class TLiveTraverser;
 // Data needed for just a single object at the granularity exchanged by the reflection API
 class TObjectReflection {
 public:
-    TObjectReflection(const TString& pName, int pOffset, int pGLDefineType, int pSize, int pIndex) : 
+    TObjectReflection(const TString& pName, int pOffset, int pGLDefineType, int pSize, int pIndex) :
         name(pName), offset(pOffset), glDefineType(pGLDefineType), size(pSize), index(pIndex) { }
     void dump() const { printf("%s: offset %d, type %x, size %d, index %d\n", name.c_str(), offset, glDefineType, size, index); }
     TString name;
@@ -67,7 +68,7 @@ public:
 // The full reflection database
 class TReflection {
 public:
-    TReflection() : badReflection("__bad__", -1, -1, -1, -1) {}
+    TReflection() : badReflection("__bad__", -1, -1, -1, -1) { badQualifier.clear(); }
     virtual ~TReflection() {}
 
     // grow the reflection stage by stage
@@ -83,9 +84,18 @@ public:
             return badReflection;
     }
 
+    int getNumAttributes() { return (int)indexToAttribute.size(); }
+    const TObjectReflection& getAttribute(int i) const
+    {
+        if (i >= 0 && i < (int)indexToAttribute.size())
+            return indexToAttribute[i];
+        else
+            return badReflection;
+    }
+
     // for mapping a block index to the block's description
     int getNumUniformBlocks() const { return (int)indexToUniformBlock.size(); }
-    const TObjectReflection& getUniformBlock(int i) const 
+    const TObjectReflection& getUniformBlock(int i) const
     {
         if (i >= 0 && i < (int)indexToUniformBlock.size())
             return indexToUniformBlock[i];
@@ -94,13 +104,81 @@ public:
     }
 
     // for mapping any name to its index (both block names and uniforms names)
-    int getIndex(const char* name) const 
+    int getIndex(const char* name) const
     {
         TNameToIndex::const_iterator it = nameToIndex.find(name);
         if (it == nameToIndex.end())
             return -1;
         else
             return it->second;
+    }
+
+    int getAttributeIndex(const char* name) const
+    {
+        TNameToIndex::const_iterator it = attributeNameToIndex.find(name);
+        if (it == attributeNameToIndex.end())
+            return -1;
+        else
+            return it->second;
+    }
+
+     int getVaryingIndex(const char* name) const
+    {
+        TNameToIndex::const_iterator it = varyingNameToIndex.find(name);
+        if (it == varyingNameToIndex.end())
+            return -1;
+        else
+            return it->second;
+    }
+
+    int getNumVaryings() { return (int)indexToVarying.size(); }
+    const TObjectReflection& getVarying(int i) const
+    {
+        if (i >= 0 && i < (int)indexToVarying.size())
+            return indexToVarying[i];
+        else
+            return badReflection;
+    }
+
+    const TQualifier* getUniformQualifier(int i) const
+    {
+        if(i >=0 && i < (int)indexToUniform.size()) {
+            return uniformQualifiers[i];
+        } else {
+            return &badQualifier;
+        }
+    }
+
+    const TQualifier* getAttributeQualifier(int i) const
+    {
+        if(i >=0 && i < (int)indexToAttribute.size()) {
+            return attributQualifiers[i];
+        } else {
+            return &badQualifier;
+        }
+    }
+
+    const TQualifier* getVaryingQualifier(int i) const
+    {
+        if(i >=0 && i < (int)indexToVarying.size()) {
+            return varyingQualifiers[i];
+        } else {
+            return &badQualifier;
+        }
+    }
+
+    void setUniformBinding(int i, int binding)
+    {
+        if(i >=0 && i < (int)indexToUniform.size()) {
+            uniformQualifiers[i]->setBinding(binding);
+        }
+    }
+
+    void setAttributeLocation(int i, int location)
+    {
+        if(i >=0 && i < (int)indexToAttribute.size()) {
+            attributQualifiers[i]->setLocation(location);
+        }
     }
 
     void dump();
@@ -112,10 +190,21 @@ protected:
     typedef std::map<TString, int> TNameToIndex;
     typedef std::vector<TObjectReflection> TMapIndexToReflection;
 
-    TObjectReflection badReflection; // return for queries of -1 or generally out of range; has expected descriptions with in it for this
-    TNameToIndex nameToIndex;        // maps names to indexes; can hold all types of data: uniform/buffer and which function names have been processed
-    TMapIndexToReflection indexToUniform;
-    TMapIndexToReflection indexToUniformBlock;
+    TObjectReflection               badReflection;          // return for queries of -1 or generally out of range; has expected descriptions with in it for this
+    TQualifier                      badQualifier;
+    TNameToIndex                    nameToIndex;            // maps names to indexes; can hold all types of data: uniform/buffer and which function names have been processed
+
+    TMapIndexToReflection           indexToUniform;
+    TMapIndexToReflection           indexToUniformBlock;
+    std::vector<const TQualifier *> uniformQualifiers;
+
+    TNameToIndex                    attributeNameToIndex;
+    TMapIndexToReflection           indexToAttribute;
+    std::vector<const TQualifier *> attributQualifiers;
+
+    TNameToIndex                    varyingNameToIndex;
+    TMapIndexToReflection           indexToVarying;
+    std::vector<const TQualifier *> varyingQualifiers;
 };
 
 } // end namespace glslang

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -366,6 +366,8 @@ public:
     virtual ~TProgram();
     void addShader(TShader* shader) { stages[shader->stage].push_back(shader); }
 
+    bool hasReflection(void) const { return (bool)!!reflection; }
+
     // Link Validation interface
     bool link(EShMessages);
     const char* getInfoLog();
@@ -374,17 +376,47 @@ public:
     TIntermediate* getIntermediate(EShLanguage stage) const { return intermediate[stage]; }
 
     // Reflection Interface
-    bool buildReflection();                          // call first, to do liveness analysis, index mapping, etc.; returns false on failure
-    int getNumLiveUniformVariables();                // can be used for glGetProgramiv(GL_ACTIVE_UNIFORMS)
-    int getNumLiveUniformBlocks();                   // can be used for glGetProgramiv(GL_ACTIVE_UNIFORM_BLOCKS)
-    const char* getUniformName(int index);           // can be used for "name" part of glGetActiveUniform()
-    const char* getUniformBlockName(int blockIndex); // can be used for glGetActiveUniformBlockName()
-    int getUniformBlockSize(int blockIndex);         // can be used for glGetActiveUniformBlockiv(UNIFORM_BLOCK_DATA_SIZE)
-    int getUniformIndex(const char* name);           // can be used for glGetUniformIndices()
-    int getUniformBlockIndex(int index);             // can be used for glGetActiveUniformsiv(GL_UNIFORM_BLOCK_INDEX)
-    int getUniformType(int index);                   // can be used for glGetActiveUniformsiv(GL_UNIFORM_TYPE)
-    int getUniformBufferOffset(int index);           // can be used for glGetActiveUniformsiv(GL_UNIFORM_OFFSET)
-    int getUniformArraySize(int index);              // can be used for glGetActiveUniformsiv(GL_UNIFORM_SIZE)
+    bool buildReflection();                                 // call first, to do liveness analysis, index mapping, etc.; returns false on failure
+    int getNumLiveUniformVariables();                       // can be used for glGetProgramiv(GL_ACTIVE_UNIFORMS)
+    int getNumLiveUniformBlocks();                          // can be used for glGetProgramiv(GL_ACTIVE_UNIFORM_BLOCKS)
+    const char* getUniformName(int index);                  // can be used for "name" part of glGetActiveUniform()
+    const char* getUniformBlockName(int blockIndex);        // can be used for glGetActiveUniformBlockName()
+    int getUniformBlockSize(int blockIndex);                // can be used for glGetActiveUniformBlockiv(UNIFORM_BLOCK_DATA_SIZE)
+    int getUniformIndex(const char* name);                  // can be used for glGetUniformIndices()
+    int getUniformBlockIndex(int index);                    // can be used for glGetActiveUniformsiv(GL_UNIFORM_BLOCK_INDEX)
+    int getUniformType(int index);                          // can be used for glGetActiveUniformsiv(GL_UNIFORM_TYPE)
+    int getUniformBufferOffset(int index);                  // can be used for glGetActiveUniformsiv(GL_UNIFORM_OFFSET)
+    int getUniformArraySize(int index);                     // can be used for glGetActiveUniformsiv(GL_UNIFORM_SIZE)
+
+    bool getUniformHasLocation(int index);
+    bool getUniformHasBinding(int index);
+    int getUniformLocation(int index);
+    int getUniformBinding(int index);
+
+    void setUniformBinding(int index, int binding);
+
+    int getNumLiveAttributeVariables();                     // can be used for glGetProgramiv(GL_ACTIVE_ATTRIBUTES)
+    const char* getAttributeName(int index);                // can be used for glGetActiveAttrib()
+    int getAttributeIndex(const char* name);
+    int getAttributeType(int index);                        // can be used for glGetActiveAttrib()
+
+    bool getAttributeHasLocation(int index);
+    bool getAttributeHasBinding(int index);
+    int getAttributeLocation(int index);
+    int getAttributeBinding(int index);
+
+    void setAttributeLocation(int index, int location);     // can be used for glBindAttribLocation()
+
+    int getNumLiveVaryingVariables();
+    const char* getVaryingName(int index);
+    int getVaryingIndex(const char* name);
+    int getVaryingType(int index);
+
+    bool getVaryingHasLocation(int index);
+    bool getVaryingHasBinding(int index);
+    int getVaryingLocation(int index);
+    int getVaryingBinding(int index);
+
     void dumpReflection();
 
 protected:


### PR DESCRIPTION
New functions allow the manipulation of an already built reflection.
User can query and change the location/binding of the shader's uniforms,
vertex attributes and varyings.
Changes will be reflected in the generated spirv (if requested).