### PR TITLE
fix #171 - error: ‘isinf’ was not declared in this scope

### DIFF
--- a/glslang/MachineIndependent/intermOut.cpp
+++ b/glslang/MachineIndependent/intermOut.cpp
@@ -48,7 +48,7 @@ namespace {
 bool is_positive_infinity(double x) {
 #ifdef _MSC_VER
   return _fpclass(x) == _FPCLASS_PINF;
-#elif defined __ANDROID__
+#elif defined __ANDROID__ || defined __linux__
   return std::isinf(x) && (x >= 0);
 #else
   return isinf(x) && (x >= 0);


### PR DESCRIPTION
fixes #171 
glslang/MachineIndependent/intermOut.cpp used `isinf`,
but it's in `std` namespace, so should use `std::isinf`.