### PR TITLE
Fix warnings/errors for strict aliasing & function prototypes

### DIFF
--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -698,7 +698,9 @@ Id Builder::makeFloatConstant(float f, bool specConstant)
 {
     Op opcode = specConstant ? OpSpecConstant : OpConstant;
     Id typeId = makeFloatType(32);
-    unsigned value = *(unsigned int*)&f;
+    union { float fl; unsigned int ui; } u;
+    u.fl = f;
+    unsigned value = u.ui;
 
     // See if we already made it. Applies only to regular constants, because specialization constants
     // must remain distinct for the purpose of applying a SpecId decoration.
@@ -721,7 +723,9 @@ Id Builder::makeDoubleConstant(double d, bool specConstant)
 {
     Op opcode = specConstant ? OpSpecConstant : OpConstant;
     Id typeId = makeFloatType(64);
-    unsigned long long value = *(unsigned long long*)&d;
+    union { double db; unsigned long long ull; } u;
+    u.db = d;
+    unsigned long long value = u.ull;
     unsigned op1 = value & 0xFFFFFFFF;
     unsigned op2 = value >> 32;
 

--- a/SPIRV/disassemble.cpp
+++ b/SPIRV/disassemble.cpp
@@ -59,7 +59,7 @@ const char* GlslStd450DebugNames[spv::GLSLstd450Count];
 
 namespace spv {
 
-void Kill(std::ostream& out, const char* message)
+static void Kill(std::ostream& out, const char* message)
 {
     out << std::endl << "Disassembly failed: " << message << std::endl;
     exit(1);
@@ -481,7 +481,7 @@ void SpirvStream::disassembleInstruction(Id resultId, Id /*typeId*/, Op opCode, 
     return;
 }
 
-void GLSLstd450GetDebugNames(const char** names)
+static void GLSLstd450GetDebugNames(const char** names)
 {
     for (int i = 0; i < GLSLstd450Count; ++i)
         names[i] = "Unknown";

--- a/SPIRV/doc.h
+++ b/SPIRV/doc.h
@@ -67,6 +67,8 @@ const char* SamplerFilterModeString(int);
 const char* ImageFormatString(int);
 const char* ImageChannelOrderString(int);
 const char* ImageChannelTypeString(int);
+const char* ImageChannelDataTypeString(int type);
+const char* ImageOperandsString(int format);
 const char* ImageOperands(int);
 const char* FPFastMathString(int);
 const char* FPRoundingModeString(int);
@@ -81,6 +83,7 @@ const char* KernelEnqueueFlagsString(int);
 const char* KernelProfilingInfoString(int);
 const char* CapabilityString(int);
 const char* OpcodeString(int);
+const char* ScopeString(int mem);
 
 // For grouping opcodes into subsections
 enum OpcodeClass {

--- a/glslang/Include/ShHandle.h
+++ b/glslang/Include/ShHandle.h
@@ -162,7 +162,9 @@ protected:
 TCompiler* ConstructCompiler(EShLanguage, int);
 
 TShHandleBase* ConstructLinker(EShExecutable, int);
+TShHandleBase* ConstructBindings();
 void DeleteLinker(TShHandleBase*);
+void DeleteBindingList(TShHandleBase* bindingList);
     
 TUniformMap* ConstructUniformMap();
 void DeleteCompiler(TCompiler*);

--- a/glslang/MachineIndependent/Constant.cpp
+++ b/glslang/MachineIndependent/Constant.cpp
@@ -43,22 +43,31 @@ namespace {
 
 using namespace glslang;
 
+typedef union {
+    double d;
+    int i[2];
+} DoubleIntUnion;
+
 // Some helper functions
 
 bool isNan(double x)
 {
+    DoubleIntUnion u;
     // tough to find a platform independent library function, do it directly
-    int bitPatternL = *(int*)&x;
-    int bitPatternH = *((int*)&x + 1);
+    u.d = x;
+    int bitPatternL = u.i[0];
+    int bitPatternH = u.i[1];
     return (bitPatternH & 0x7ff80000) == 0x7ff80000 && 
            ((bitPatternH & 0xFFFFF) != 0 || bitPatternL != 0);
 }
 
 bool isInf(double x)
 {
+    DoubleIntUnion u;
     // tough to find a platform independent library function, do it directly
-    int bitPatternL = *(int*)&x;
-    int bitPatternH = *((int*)&x + 1);
+    u.d = x;
+    int bitPatternL = u.i[0];
+    int bitPatternH = u.i[1];
     return (bitPatternH & 0x7ff00000) == 0x7ff00000 && 
            (bitPatternH & 0xFFFFF) == 0 && bitPatternL == 0;
 }
@@ -173,7 +182,7 @@ TIntermTyped* TIntermConstantUnion::fold(TOperator op, const TIntermTyped* right
             case EbtInt:
                 if (rightUnionArray[i] == 0)
                     newConstArray[i].setIConst(0x7FFFFFFF);
-                else if (rightUnionArray[i].getIConst() == -1 && leftUnionArray[i].getIConst() == 0x80000000)
+                else if (rightUnionArray[i].getIConst() == -1 && leftUnionArray[i].getIConst() == (int)0x80000000)
                     newConstArray[i].setIConst(0x80000000);
                 else
                     newConstArray[i].setIConst(leftUnionArray[i].getIConst() / rightUnionArray[i].getIConst());

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -3175,7 +3175,7 @@ void TBuiltIns::initialize(const TBuiltInResource &resources, int version, EProf
 // New built-in variables should use a generic (textually declarable) qualifier in
 // TStoraregQualifier and only call BuiltInVariable().
 //
-void SpecialQualifier(const char* name, TStorageQualifier qualifier, TBuiltInVariable builtIn, TSymbolTable& symbolTable)
+static void SpecialQualifier(const char* name, TStorageQualifier qualifier, TBuiltInVariable builtIn, TSymbolTable& symbolTable)
 {
     TSymbol* symbol = symbolTable.find(name);
     if (symbol) {
@@ -3195,7 +3195,7 @@ void SpecialQualifier(const char* name, TStorageQualifier qualifier, TBuiltInVar
 //
 // Safe to call even if name is not present.
 //
-void BuiltInVariable(const char* name, TBuiltInVariable builtIn, TSymbolTable& symbolTable)
+static void BuiltInVariable(const char* name, TBuiltInVariable builtIn, TSymbolTable& symbolTable)
 {
     TSymbol* symbol = symbolTable.find(name);
     if (! symbol)
@@ -3212,7 +3212,7 @@ void BuiltInVariable(const char* name, TBuiltInVariable builtIn, TSymbolTable& s
 //
 // See comments above for other detail.
 //
-void BuiltInVariable(const char* blockName, const char* name, TBuiltInVariable builtIn, TSymbolTable& symbolTable)
+static void BuiltInVariable(const char* blockName, const char* name, TBuiltInVariable builtIn, TSymbolTable& symbolTable)
 {
     TSymbol* symbol = symbolTable.find(blockName);
     if (! symbol)

--- a/glslang/MachineIndependent/PoolAlloc.cpp
+++ b/glslang/MachineIndependent/PoolAlloc.cpp
@@ -190,7 +190,7 @@ void TAllocation::checkGuardBlock(unsigned char*, unsigned char, const char*) co
 #endif
 {
 #ifdef GUARD_BLOCKS
-    for (int x = 0; x < guardBlockSize; x++) {
+    for (size_t x = 0; x < guardBlockSize; x++) {
         if (blockMem[x] != val) {
             const int maxSize = 80;
             char assertMsg[maxSize];

--- a/glslang/MachineIndependent/Scan.cpp
+++ b/glslang/MachineIndependent/Scan.cpp
@@ -53,8 +53,11 @@
 #include "preprocessor/PpContext.h"
 #include "preprocessor/PpTokens.h"
 
-namespace glslang {
+// Required to avoid missing prototype warnings for some compilers
+int yylex(YYSTYPE*, glslang::TParseContext&);
     
+namespace glslang {
+
 // read past any white space
 void TInputScanner::consumeWhiteSpace(bool& foundNonSpaceTab)
 {

--- a/glslang/MachineIndependent/intermOut.cpp
+++ b/glslang/MachineIndependent/intermOut.cpp
@@ -96,7 +96,7 @@ protected:
 // Helper functions for printing, not part of traversing.
 //
 
-void OutputTreeText(TInfoSink& infoSink, const TIntermNode* node, const int depth)
+static void OutputTreeText(TInfoSink& infoSink, const TIntermNode* node, const int depth)
 {
     int i;
 
@@ -529,7 +529,7 @@ bool TOutputTraverser::visitSelection(TVisit /* visit */, TIntermSelection* node
     return false;
 }
 
-void OutputConstantUnion(TInfoSink& out, const TIntermTyped* node, const TConstUnionArray& constUnion, int depth)
+static void OutputConstantUnion(TInfoSink& out, const TIntermTyped* node, const TConstUnionArray& constUnion, int depth)
 {
     int size = node->getType().computeNumComponents();
 

--- a/glslang/OSDependent/Unix/ossource.cpp
+++ b/glslang/OSDependent/Unix/ossource.cpp
@@ -54,7 +54,7 @@ namespace glslang {
 // Wrapper for Linux call to DetachThread.  This is required as pthread_cleanup_push() expects 
 // the cleanup routine to return void.
 // 
-void DetachThreadLinux(void *)
+static void DetachThreadLinux(void *)
 {
 	DetachThread();
 }

--- a/glslang/OSDependent/osinclude.h
+++ b/glslang/OSDependent/osinclude.h
@@ -56,6 +56,7 @@ typedef unsigned int (*TThreadEntrypoint)(void*);
 void* OS_CreateThread(TThreadEntrypoint);
 void OS_WaitForAllThreads(void* threads, int numThreads);
 
+void OS_CleanupThreadData(void);
 void OS_Sleep(int milliseconds);
 
 void OS_DumpMemoryCounters();


### PR DESCRIPTION
This fixes various issues related to gcc's strict-aliasing warning
by using unions. It also handles various cases hit with
gcc's missing-declarations warning.