### PR TITLE
Fix compilation issues with MSVC 2010

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -688,8 +688,8 @@ TGlslangToSpvTraverser::TGlslangToSpvTraverser(const glslang::TIntermediate* gls
 void TGlslangToSpvTraverser::dumpSpv(std::vector<unsigned int>& out)
 {
     // finish off the entry-point SPV instruction by adding the Input/Output <id>
-    for (auto it : iOSet)
-        entryPoint->addIdOperand(it);
+    for (auto it = iOSet.cbegin(); it != iOSet.cend(); ++it)
+        entryPoint->addIdOperand(*it);
 
     builder.dump(out);
 }

--- a/SPIRV/InReadableOrder.cpp
+++ b/SPIRV/InReadableOrder.cpp
@@ -91,8 +91,9 @@ public:
                 delayed_[continueBlock] = true;
             }
         }
-        for (const auto succ : block->getSuccessors())
-            visit(succ);
+        const auto successors = block->getSuccessors();
+        for (auto it = successors.cbegin(); it != successors.cend(); ++it)
+            visit(*it);
         if (continueBlock) {
             delayed_[continueBlock] = false;
             visit(continueBlock);

--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -1141,8 +1141,8 @@ void Builder::createNoResultOp(Op opCode, Id operand)
 void Builder::createNoResultOp(Op opCode, const std::vector<Id>& operands)
 {
     Instruction* op = new Instruction(opCode);
-    for (auto operand : operands)
-        op->addIdOperand(operand);
+    for (auto it = operands.cbegin(); it != operands.cend(); ++it)
+        op->addIdOperand(*it);
     buildPoint->addInstruction(std::unique_ptr<Instruction>(op));
 }
 
@@ -1197,8 +1197,8 @@ Id Builder::createTriOp(Op opCode, Id typeId, Id op1, Id op2, Id op3)
 Id Builder::createOp(Op opCode, Id typeId, const std::vector<Id>& operands)
 {
     Instruction* op = new Instruction(getUniqueId(), typeId, opCode);
-    for (auto operand : operands)
-        op->addIdOperand(operand);
+    for (auto it = operands.cbegin(); it != operands.cend(); ++it)
+        op->addIdOperand(*it);
     buildPoint->addInstruction(std::unique_ptr<Instruction>(op));
 
     return op->getResultId();
@@ -2106,9 +2106,9 @@ Id Builder::accessChainGetInferredType()
         type = getContainedTypeId(type);
 
     // dereference each index
-    for (auto deref : accessChain.indexChain) {
+    for (auto it = accessChain.indexChain.cbegin(); it != accessChain.indexChain.cend(); ++it) {
         if (isStructType(type))
-            type = getContainedTypeId(type, getConstantScalar(deref));
+            type = getContainedTypeId(type, getConstantScalar(*it));
         else
             type = getContainedTypeId(type);
     }
@@ -2136,9 +2136,9 @@ void Builder::dump(std::vector<unsigned int>& out) const
     out.push_back(0);
 
     // Capabilities
-    for (auto cap : capabilities) {
+    for (auto it = capabilities.cbegin(); it != capabilities.cend(); ++it) {
         Instruction capInst(0, 0, OpCapability);
-        capInst.addImmediateOperand(cap);
+        capInst.addImmediateOperand(*it);
         capInst.dump(out);
     }
 

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -689,7 +689,8 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
     //
 
     glslang::TProgram& program = *new glslang::TProgram;
-    for (auto compUnit : compUnits) {
+    for (auto it = compUnits.cbegin(); it != compUnits.cend(); ++it) {
+        const auto &compUnit = *it;
         glslang::TShader* shader = new glslang::TShader(compUnit.stage);
         shader->setStrings(compUnit.text, 1);
         shaders.push_back(shader);
@@ -822,8 +823,8 @@ void CompileAndLinkShaderFiles()
             glslang::OS_DumpMemoryCounters();
     }
 
-    for (auto c : compUnits)
-        FreeFileData(c.text);
+    for (auto it = compUnits.begin(); it != compUnits.end(); ++it)
+        FreeFileData(it->text);
 }
 
 int C_DECL main(int argc, char* argv[])

--- a/StandAlone/spirv-remap.cpp
+++ b/StandAlone/spirv-remap.cpp
@@ -120,7 +120,8 @@ namespace {
         if (fp.fail())
             errHandler(std::string("error opening file for write: ") + outFile);
 
-        for (auto word : spv) {
+        for (auto it = spv.cbegin(); it != spv.cend(); ++it) {
+            SpvWord word = *it;
             fp.write((char *)&word, sizeof(word));
             if (fp.fail())
                 errHandler(std::string("error writing file: ") + outFile);
@@ -157,7 +158,8 @@ namespace {
     void execute(const std::vector<std::string>& inputFile, const std::string& outputDir,
         int opts, int verbosity)
     {
-        for (const auto& filename : inputFile) {
+        for (auto it = inputFile.cbegin(); it != inputFile.cend(); ++it) {
+            const std::string &filename = *it;
             std::vector<SpvWord> spv;
             read(spv, filename, verbosity);
             spv::spirvbin_t(verbosity).remap(spv, opts);

--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -206,7 +206,7 @@ struct TSourceLoc {
     {
         if (name != nullptr)
             return quoteStringName ? ("\"" + std::string(name) + "\"") : name;
-        return std::to_string(string);
+        return std::to_string((long long)string);
     }
     const char* name; // descriptive name for this string
     int string;

--- a/glslang/MachineIndependent/intermOut.cpp
+++ b/glslang/MachineIndependent/intermOut.cpp
@@ -757,13 +757,9 @@ void TIntermediate::output(TInfoSink& infoSink, bool tree)
     case EShLangCompute:
         infoSink.debug << "local_size = (" << localSize[0] << ", " << localSize[1] << ", " << localSize[2] << ")\n";
         {
-            bool dumpSpecIds = false;
-            for (auto c : localSizeSpecId) {
-                if (c != TQualifier::layoutNotSet)
-                    dumpSpecIds = true;
-            }
-
-            if (dumpSpecIds) {
+            if (localSizeSpecId[0] != TQualifier::layoutNotSet ||
+                localSizeSpecId[1] != TQualifier::layoutNotSet ||
+                localSizeSpecId[2] != TQualifier::layoutNotSet) {
                 infoSink.debug << "local_size ids = (" <<
                     localSizeSpecId[0] << ", " <<
                     localSizeSpecId[1] << ", " <<

--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
+++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
@@ -611,9 +611,9 @@ int TPpContext::CPPinclude(TPpToken* ppToken)
         if (token != '\n' && token != EndOfInput) {
             parseContext.ppError(ppToken->loc, "extra content after file designation", "#include", "");
         } else {
-            std::string sourceName;
-            std::string replacement;
-            std::tie(sourceName, replacement) = includer.include(filename.c_str());
+            auto include = includer.include(filename.c_str());
+            std::string sourceName = include.first;
+            std::string replacement = include.second;
             if (!sourceName.empty()) {
                 if (!replacement.empty()) {
                     const bool forNextLine = parseContext.lineDirectiveShouldSetNextLine();


### PR DESCRIPTION
This PR contains a handful of tiny changes that allow compilation using the MSVC 2010 compiler.  We still need to support MSVC 2010 for various reasons, and therefore we need to compile glslang with MSVC 2010 in order to be able to link it in.

Most of the changes replace the use of range-based for loops, and one replaces the use of std::tie.