### PR TITLE
SPV: Ensure Parameterize is called during Disassemble

### DIFF
--- a/SPIRV/disassemble.cpp
+++ b/SPIRV/disassemble.cpp
@@ -568,6 +568,7 @@ void GLSLstd450GetDebugNames(const char** names)
 void Disassemble(std::ostream& out, const std::vector<unsigned int>& stream)
 {
     SpirvStream SpirvStream(out, stream);
+    spv::Parameterize();
     GLSLstd450GetDebugNames(GlslStd450DebugNames);
     SpirvStream.validate();
     SpirvStream.processInstructions();

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -753,7 +753,6 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
                     if (! (Options & EOptionMemoryLeakMode)) {
                         glslang::OutputSpv(spirv, GetBinaryName((EShLanguage)stage));
                         if (Options & EOptionHumanReadableSpv) {
-                            spv::Parameterize();
                             spv::Disassemble(std::cout, spirv);
                         }
                     }


### PR DESCRIPTION
I figure it's safer to ensure `spv::Parameterize()` and InstructionDesc table is valid before any `spv::Disassemble()` attempt.