### PR TITLE
Minor warning fixes

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -351,6 +351,8 @@ spv::BuiltIn TGlslangToSpvTraverser::TranslateBuiltInDecoration(glslang::TBuiltI
         case EShLangTessEvaluation:
             builder.addCapability(spv::CapabilityTessellationPointSize);
             break;
+        default:
+            break;
         }
         return spv::BuiltInPointSize;
 

--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -2121,7 +2121,7 @@ Id Builder::accessChainGetInferredType()
     if (accessChain.swizzle.size() == 1)
         type = getContainedTypeId(type);
     else if (accessChain.swizzle.size() > 1)
-        type = makeVectorType(getContainedTypeId(type), accessChain.swizzle.size());
+        type = makeVectorType(getContainedTypeId(type), (int)accessChain.swizzle.size());
 
     // dereference component selection
     if (accessChain.component)

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -267,7 +267,7 @@ public:
         localSizeSpecId[dim] = id;
         return true;
     }
-    unsigned int getLocalSizeSpecId(int dim) const { return localSizeSpecId[dim]; }
+    int getLocalSizeSpecId(int dim) const { return localSizeSpecId[dim]; }
 
     void setXfbMode() { xfbMode = true; }
     bool getXfbMode() const { return xfbMode; }


### PR DESCRIPTION
These are a few MSVC/GCC/Clang fixes I was sitting on on my local branch. I think they are all simple enough - the last one on getLocalSizeSpecId could be solved by casts in the calling code, but this seemed to be the cleanest fix.