### PR TITLE
add missing atom strings

### DIFF
--- a/glslang/MachineIndependent/preprocessor/PpAtom.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpAtom.cpp
@@ -57,7 +57,7 @@ Except as expressly stated in this notice, no other rights or licenses
 express or implied, are granted by NVIDIA herein, including but not
 limited to any patent rights that may be infringed by your derivative
 works or by other works in which the NVIDIA Software may be
-incorporated. No hardware is licensed hereunder. 
+incorporated. No hardware is licensed hereunder.
 
 THE NVIDIA SOFTWARE IS BEING PROVIDED ON AN "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
@@ -98,6 +98,34 @@ const struct {
     int val;
     const char* str;
 } tokens[] = {
+
+    { PpAtomAdd,            "+=" },
+    { PpAtomSub,            "-=" },
+    { PpAtomMul,            "*=" },
+    { PpAtomDiv,            "/=" },
+    { PpAtomMod,            "%=" },
+
+    { PpAtomRight,          ">>" },
+    { PpAtomLeft,           "<<" },
+
+    { PpAtomAnd,            "&&" },
+    { PpAtomOr,             "||" },
+    { PpAtomXor,            "^"  },
+
+    { PpAtomRightAssign,    ">>=" },
+    { PpAtomLeftAssign,     "<<=" },
+    { PpAtomAndAssign,      "&=" },
+    { PpAtomOrAssign,       "|=" },
+    { PpAtomXorAssign,      "^=" },
+
+    { PpAtomEQ,             "==" },
+    { PpAtomNE,             "!=" },
+    { PpAtomGE,             ">=" },
+    { PpAtomLE,             "<=" },
+
+    { PpAtomDecrement,      "--" },
+    { PpAtomIncrement,      "++" },
+
     { PpAtomDefine,         "define" },
     { PpAtomDefined,        "defined" },
     { PpAtomUndef,          "undef" },


### PR DESCRIPTION
Some atom didn't have their string associated in PpAtom.cpp.

This was causing pure preprocessing tools (like Google's shaderc with -E argument) to output invalid GLSL code.