### PR TITLE
Do not emit SPIR-V Capability GeometryStreams if streams are not used

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -115,9 +115,6 @@ TParseContext::TParseContext(TSymbolTable& symt, TIntermediate& interm, bool pb,
         language == EShLangTessEvaluation ||
         language == EShLangGeometry)
         globalOutputDefaults.layoutXfbBuffer = 0;
-
-    if (language == EShLangGeometry)
-        globalOutputDefaults.layoutStream = 0;
 }
 
 TParseContext::~TParseContext()


### PR DESCRIPTION
The GS global out layout defaults was set to "stream = 0", what implied
that streams were always used in shader - TLayoutFormat.hasStream()
was returning TRUE. This happened even when streams qualifier was not used in GLSL.

When compiling to SPIR-V, that has undesired effect of emitting GeometryStreams
capability, which may be not supported.

This change leaves layoutStream initialized to layoutStreamEnd by default,
what causes LayoutFormat.hasStream() to return TRUE only, if stream qualifier
was present in GLSL.