### PR TITLE
Fix undefined forward referenced ID in decorations

### DIFF
--- a/SPIRV/spvIR.h
+++ b/SPIRV/spvIR.h
@@ -293,11 +293,11 @@ public:
         // instructions will be dumped after.
         std::unordered_set<const Block*> dumped;
         inReadableOrder(blocks[0], [&out, &dumped](const Block* b) {
-          b->dump(out);
-          dumped.insert(b);
+            b->dump(out);
+            dumped.insert(b);
         });
         for (auto b : blocks) {
-          if (!dumped.count(b) && b->isTerminated()) b->dump(out);
+            if (!dumped.count(b) && b->isTerminated()) b->dump(out);
         }
         Instruction end(0, 0, OpFunctionEnd);
         end.dump(out);

--- a/Test/baseResults/spv.100ops.frag.out
+++ b/Test/baseResults/spv.100ops.frag.out
@@ -101,4 +101,7 @@ Linked fragment stage:
                9:             Label
               46:    6(float) Load 13(face2)
                               ReturnValue 46
+              47:             Label
+              48:    6(float) Undef
+                              ReturnValue 48
                               FunctionEnd

--- a/Test/baseResults/spv.140.frag.out
+++ b/Test/baseResults/spv.140.frag.out
@@ -178,4 +178,7 @@ Linked fragment stage:
               79:    6(float) Load 24(i2)
               80:    6(float) FAdd 78 79
                               ReturnValue 80
+              81:             Label
+              82:    6(float) Undef
+                              ReturnValue 82
                               FunctionEnd

--- a/Test/baseResults/spv.AofA.frag.out
+++ b/Test/baseResults/spv.AofA.frag.out
@@ -153,4 +153,7 @@ Linked fragment stage:
               34:           9 Load 33
               35:          14 CompositeConstruct 27 30 31 34
                               ReturnValue 35
+              36:             Label
+              37:          14 Undef
+                              ReturnValue 37
                               FunctionEnd

--- a/Test/baseResults/spv.always-discard.frag.out
+++ b/Test/baseResults/spv.always-discard.frag.out
@@ -110,4 +110,23 @@ Linked fragment stage:
                                 Branch 49
               49:             Label
                               Kill
+              69:             Label
+              70:    6(float) Load 36(radius)
+              72:    46(bool) FOrdGreaterThanEqual 70 71
+                              SelectionMerge 74 None
+                              BranchConditional 72 73 74
+              73:               Label
+              75:    6(float)   Load 36(radius)
+              77:    6(float)   ExtInst 1(GLSL.std.450) 26(Pow) 75 76
+              78:    6(float)   FDiv 77 27
+              79:    6(float)   ExtInst 1(GLSL.std.450) 4(FAbs) 78
+              80:    7(fvec4)   Load 15(color)
+              81:    7(fvec4)   CompositeConstruct 79 79 79 79
+              82:    7(fvec4)   FSub 80 81
+                                Store 15(color) 82
+                                Branch 74
+              74:             Label
+              83:    7(fvec4) Load 15(color)
+                              Store 59(gl_FragColor) 83
+                              Return
                               FunctionEnd

--- a/Test/baseResults/spv.always-discard2.frag.out
+++ b/Test/baseResults/spv.always-discard2.frag.out
@@ -63,4 +63,8 @@ Linked fragment stage:
               35:    6(float) FSub 34 10
                               Store 30(y) 35
                               Kill
+              36:             Label
+              39:    7(fvec4) Load 15(color)
+                              Store 38(gl_FragColor) 39
+                              Return
                               FunctionEnd

--- a/Test/baseResults/spv.bool.vert.out
+++ b/Test/baseResults/spv.bool.vert.out
@@ -93,4 +93,7 @@ Linked vertex stage:
               12:     6(bool) Load 9(b)
               14:     6(bool) INotEqual 12 13
                               ReturnValue 14
+              15:             Label
+              16:     6(bool) Undef
+                              ReturnValue 16
                               FunctionEnd

--- a/Test/baseResults/spv.branch-return.vert.out
+++ b/Test/baseResults/spv.branch-return.vert.out
@@ -68,4 +68,12 @@ Linked vertex stage:
               37:     33(ptr) AccessChain 20 21 32
                               Store 37 36
                               Return
+              15:             Label
+                              Branch 11
+              26:             Label
+                              Branch 12
+              27:             Label
+                              Branch 13
+              28:             Label
+                              Branch 14
                               FunctionEnd

--- a/Test/baseResults/spv.conditionalDiscard.frag.out
+++ b/Test/baseResults/spv.conditionalDiscard.frag.out
@@ -60,4 +60,6 @@ Linked fragment stage:
               35:    7(fvec4) Load 9(v)
                               Store 34(gl_FragColor) 35
                               Return
+              32:             Label
+                              Branch 31
                               FunctionEnd

--- a/Test/baseResults/spv.discard-dce.frag.out
+++ b/Test/baseResults/spv.discard-dce.frag.out
@@ -127,4 +127,6 @@ Linked fragment stage:
               83:    7(fvec4) Load 15(color)
                               Store 59(gl_FragColor) 83
                               Return
+              69:             Label
+                              Branch 49
                               FunctionEnd

--- a/Test/baseResults/spv.do-while-continue-break.vert.out
+++ b/Test/baseResults/spv.do-while-continue-break.vert.out
@@ -81,4 +81,10 @@ Linked vertex stage:
               12:             Label
                               Store 41(G) 42
                               Return
+              23:             Label
+                              Store 24(C) 16
+                              Branch 20
+              32:             Label
+                              Store 33(E) 34
+                              Branch 29
                               FunctionEnd

--- a/Test/baseResults/spv.earlyReturnDiscard.frag.out
+++ b/Test/baseResults/spv.earlyReturnDiscard.frag.out
@@ -170,4 +170,16 @@ Linked fragment stage:
              108:    7(fvec4) FMul 106 107
                               Store 105(gl_FragColor) 108
                               Return
+              44:             Label
+                              Branch 43
+              56:             Label
+                              Branch 55
+              74:             Label
+                              Branch 73
+              92:             Label
+                              Branch 91
+             101:             Label
+                              Branch 100
+             103:             Label
+                              Branch 100
                               FunctionEnd

--- a/Test/baseResults/spv.for-continue-break.vert.out
+++ b/Test/baseResults/spv.for-continue-break.vert.out
@@ -84,4 +84,10 @@ Linked vertex stage:
               12:             Label
                               Store 43(G) 44
                               Return
+              28:             Label
+                              Store 29(C) 20
+                              Branch 26
+              37:             Label
+                              Store 38(E) 20
+                              Branch 35
                               FunctionEnd

--- a/Test/baseResults/spv.forwardFun.frag.out
+++ b/Test/baseResults/spv.forwardFun.frag.out
@@ -84,6 +84,10 @@ Linked fragment stage:
               42:             Label
               48:    8(float) Undef
                               ReturnValue 48
+              44:             Label
+                              Branch 42
+              47:             Label
+                              Branch 42
                               FunctionEnd
     16(foo(vf4;):    8(float) Function None 14
          15(bar):     13(ptr) FunctionParameter
@@ -94,4 +98,7 @@ Linked fragment stage:
               55:    8(float) Load 54
               56:    8(float) FAdd 52 55
                               ReturnValue 56
+              57:             Label
+              58:    8(float) Undef
+                              ReturnValue 58
                               FunctionEnd

--- a/Test/baseResults/spv.functionCall.frag.out
+++ b/Test/baseResults/spv.functionCall.frag.out
@@ -92,6 +92,9 @@ Linked fragment stage:
               30:    6(float) Load 29
               31:    6(float) FAdd 27 30
                               ReturnValue 31
+              32:             Label
+              33:    6(float) Undef
+                              ReturnValue 33
                               FunctionEnd
         13(bar():           2 Function None 3
               14:             Label
@@ -110,6 +113,10 @@ Linked fragment stage:
               41:             Label
               47:    6(float) Undef
                               ReturnValue 47
+              43:             Label
+                              Branch 41
+              46:             Label
+                              Branch 41
                               FunctionEnd
 18(missingReturn():    6(float) Function None 15
               19:             Label
@@ -124,4 +131,6 @@ Linked fragment stage:
               51:             Label
               55:    6(float) Undef
                               ReturnValue 55
+              54:             Label
+                              Branch 51
                               FunctionEnd

--- a/Test/baseResults/spv.functionSemantics.frag.out
+++ b/Test/baseResults/spv.functionSemantics.frag.out
@@ -203,6 +203,9 @@ Linked fragment stage:
                               Store 30(sum) 58
               59:      6(int) Load 30(sum)
                               ReturnValue 59
+              60:             Label
+              61:      6(int) Undef
+                              ReturnValue 61
                               FunctionEnd
 25(foo2(f1;vf3;i1;):      6(int) Function None 21
            22(a):     18(ptr) FunctionParameter
@@ -218,6 +221,9 @@ Linked fragment stage:
               71:   17(float) FMul 66 70
               72:      6(int) ConvertFToS 71
                               ReturnValue 72
+              73:             Label
+              74:      6(int) Undef
+                              ReturnValue 74
                               FunctionEnd
        28(foo3():      6(int) Function None 27
               29:             Label
@@ -229,4 +235,11 @@ Linked fragment stage:
                                 Kill
               82:             Label
                               ReturnValue 86
+              83:             Label
+                              ReturnValue 84
+              85:             Label
+                              Branch 82
+              87:             Label
+              88:      6(int) Undef
+                              ReturnValue 88
                               FunctionEnd

--- a/Test/baseResults/spv.loops.frag.out
+++ b/Test/baseResults/spv.loops.frag.out
@@ -1105,4 +1105,46 @@ Linked fragment stage:
              724:    7(fvec4) Load 9(color)
                               Store 615(gl_FragColor) 724
                               Return
+              32:             Label
+                              Branch 28
+              42:             Label
+                              Branch 38
+              45:             Label
+                              Branch 16
+              82:             Label
+                              Branch 81
+             142:             Label
+                              Branch 141
+             273:             Label
+                              Branch 272
+             298:             Label
+                              Branch 297
+             318:             Label
+                              Branch 317
+             423:             Label
+                              Branch 422
+             449:             Label
+                              Branch 448
+             461:             Label
+                              Branch 457
+             474:             Label
+                              Branch 473
+             497:             Label
+                              Branch 481
+             536:             Label
+                              Branch 531
+             574:             Label
+                              Branch 556
+             578:             Label
+                              Branch 540
+             604:             Label
+                              Branch 603
+             634:             Label
+                              Branch 633
+             680:             Label
+                              Branch 679
+             692:             Label
+                              Branch 691
+             716:             Label
+                              Branch 715
                               FunctionEnd

--- a/Test/baseResults/spv.loopsArtificial.frag.out
+++ b/Test/baseResults/spv.loopsArtificial.frag.out
@@ -240,4 +240,8 @@ Linked fragment stage:
              141:    7(fvec4) Load 9(color)
                               Store 140(gl_FragColor) 141
                               Return
+              49:             Label
+                              Branch 44
+             118:             Label
+                              Branch 114
                               FunctionEnd

--- a/Test/baseResults/spv.matFun.vert.out
+++ b/Test/baseResults/spv.matFun.vert.out
@@ -120,6 +120,9 @@ Linked vertex stage:
               29:           8 Load 12(m)
               30:    7(fvec3) VectorTimesMatrix 28 29
                               ReturnValue 30
+              31:             Label
+              32:    7(fvec3) Undef
+                              ReturnValue 32
                               FunctionEnd
   21(Mat3(mf44;):           8 Function None 19
            20(m):     18(ptr) FunctionParameter
@@ -147,6 +150,9 @@ Linked vertex stage:
               60:    7(fvec3) CompositeConstruct 55 56 57
               61:           8 CompositeConstruct 58 59 60
                               ReturnValue 61
+              62:             Label
+              63:           8 Undef
+                              ReturnValue 63
                               FunctionEnd
 26(mxv(mf44;vf3;):    7(fvec3) Function None 23
           24(m4):     18(ptr) FunctionParameter
@@ -159,4 +165,7 @@ Linked vertex stage:
               67:           8 FunctionCall 21(Mat3(mf44;) 65(param)
               68:    7(fvec3) VectorTimesMatrix 64 67
                               ReturnValue 68
+              69:             Label
+              70:    7(fvec3) Undef
+                              ReturnValue 70
                               FunctionEnd

--- a/Test/baseResults/spv.merge-unreachable.frag.out
+++ b/Test/baseResults/spv.merge-unreachable.frag.out
@@ -44,4 +44,8 @@ Linked fragment stage:
                                 Return
               21:             Label
                               Return
+              22:             Label
+                              Branch 21
+              24:             Label
+                              Branch 21
                               FunctionEnd

--- a/Test/baseResults/spv.precision.frag.out
+++ b/Test/baseResults/spv.precision.frag.out
@@ -223,6 +223,9 @@ Linked fragment stage:
               24:   21(fvec4) Load 23(highfin)
               25:    9(fvec2) VectorShuffle 24 24 0 1
                               ReturnValue 25
+              26:             Label
+              27:    9(fvec2) Undef
+                              ReturnValue 27
                               FunctionEnd
 19(boolfun(vb2;):    14(bool) Function None 17
          18(bv2):     16(ptr) FunctionParameter
@@ -231,4 +234,7 @@ Linked fragment stage:
               32:   15(bvec2) LogicalEqual 28 31
               33:    14(bool) All 32
                               ReturnValue 33
+              34:             Label
+              35:    14(bool) Undef
+                              ReturnValue 35
                               FunctionEnd

--- a/Test/baseResults/spv.pushConstant.vert.out
+++ b/Test/baseResults/spv.pushConstant.vert.out
@@ -65,4 +65,10 @@ Linked vertex stage:
                                 Branch 21
               21:             Label
                               Return
+              27:             Label
+                              Branch 19
+              30:             Label
+                              Branch 20
+              33:             Label
+                              Branch 21
                               FunctionEnd

--- a/Test/baseResults/spv.shortCircuit.frag.out
+++ b/Test/baseResults/spv.shortCircuit.frag.out
@@ -238,4 +238,7 @@ Linked fragment stage:
               16:   10(float) Load 12(of1)
               18:     6(bool) FOrdGreaterThan 16 17
                               ReturnValue 18
+              19:             Label
+              20:     6(bool) Undef
+                              ReturnValue 20
                               FunctionEnd

--- a/Test/baseResults/spv.simpleFunctionCall.frag.out
+++ b/Test/baseResults/spv.simpleFunctionCall.frag.out
@@ -36,4 +36,7 @@ Linked fragment stage:
               10:             Label
               13:    7(fvec4) Load 12(BaseColor)
                               ReturnValue 13
+              14:             Label
+              15:    7(fvec4) Undef
+                              ReturnValue 15
                               FunctionEnd

--- a/Test/baseResults/spv.switch.frag.out
+++ b/Test/baseResults/spv.switch.frag.out
@@ -475,6 +475,44 @@ Linked fragment stage:
                                 Branch 266
              266:             Label
                               Return
+              78:             Label
+                              Branch 69
+              81:             Label
+                              Branch 70
+              98:             Label
+                              Branch 88
+             112:             Label
+                              Branch 106
+             117:             Label
+                              Branch 107
+             128:             Label
+                              Branch 121
+             141:             Label
+                              Branch 132
+             147:             Label
+                              Branch 133
+             149:             Label
+                              Branch 122
+             192:             Label
+                              Branch 191
+             195:             Label
+                              Branch 168
+             200:             Label
+                              Branch 170
+             201:             Label
+                              Branch 169
+             212:             Label
+                              Branch 211
+             223:             Label
+                              Branch 217
+             224:             Label
+                              Branch 218
+             261:             Label
+                              Branch 259
+             262:             Label
+                              Branch 260
+             267:             Label
+                              Branch 266
                               FunctionEnd
 15(foo1(vf4;vf4;i1;):    7(fvec4) Function None 11
           12(v1):      8(ptr) FunctionParameter
@@ -501,6 +539,15 @@ Linked fragment stage:
                                 ReturnValue 33
               26:             Label
                               ReturnValue 37
+              28:             Label
+                              Branch 24
+              30:             Label
+                              Branch 25
+              34:             Label
+                              Branch 26
+              38:             Label
+              39:    7(fvec4) Undef
+                              ReturnValue 39
                               FunctionEnd
 20(foo2(vf4;vf4;i1;):    7(fvec4) Function None 11
           17(v1):      8(ptr) FunctionParameter
@@ -529,4 +576,15 @@ Linked fragment stage:
                                 ReturnValue 55
               45:             Label
                               ReturnValue 37
+              47:             Label
+                              Branch 42
+              50:             Label
+                              Branch 43
+              52:             Label
+                              Branch 44
+              56:             Label
+                              Branch 45
+              58:             Label
+              59:    7(fvec4) Undef
+                              ReturnValue 59
                               FunctionEnd

--- a/Test/baseResults/spv.voidFunction.frag.out
+++ b/Test/baseResults/spv.voidFunction.frag.out
@@ -60,12 +60,16 @@ Linked fragment stage:
               38:   20(fvec4) Load 22(outColor)
                               Store 37(gl_FragColor) 38
                               Return
+              39:             Label
+                              Return
                               FunctionEnd
          6(foo():           2 Function None 3
                7:             Label
               14:   10(float) Load 12(bar)
               16:   10(float) FAdd 14 15
                               Store 12(bar) 16
+                              Return
+              17:             Label
                               Return
                               FunctionEnd
         8(foo2():           2 Function None 3

--- a/Test/baseResults/spv.while-continue-break.vert.out
+++ b/Test/baseResults/spv.while-continue-break.vert.out
@@ -76,4 +76,10 @@ Linked vertex stage:
               12:             Label
                               Store 39(D) 40
                               Return
+              28:             Label
+                              Store 29(C) 22
+                              Branch 26
+              36:             Label
+                              Store 29(C) 22
+                              Branch 35
                               FunctionEnd


### PR DESCRIPTION
Fix issue #185 by dumping unreachable blocks (if they are terminated by
branch/return instructions).

Deadcode elimination will be implemented later to remove the unreachable code and related IDs.