### PR TITLE
Fix array out of bounds bug in processing if-else-endif macros.

### DIFF
--- a/Test/baseResults/preprocessor.many.endif.vert.err
+++ b/Test/baseResults/preprocessor.many.endif.vert.err
@@ -1,0 +1,12 @@
+ERROR: 0:1: '#endif' : mismatched statements 
+ERROR: 0:2: '#endif' : mismatched statements 
+ERROR: 0:3: '#endif' : mismatched statements 
+ERROR: 0:4: '#endif' : mismatched statements 
+ERROR: 0:5: '#endif' : mismatched statements 
+ERROR: 0:6: '#endif' : mismatched statements 
+ERROR: 0:7: '#endif' : mismatched statements 
+ERROR: 0:10: 'preprocessor evaluation' : bad expression 
+ERROR: 0:11: '' : missing #endif 
+ERROR: 9 compilation errors.  No code generated.
+
+

--- a/Test/preprocessor.many.endif.vert
+++ b/Test/preprocessor.many.endif.vert
@@ -1,0 +1,10 @@
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+#endif
+
+#if
+#else

--- a/Test/test-preprocessor-list
+++ b/Test/test-preprocessor-list
@@ -12,3 +12,4 @@ preprocessor.pragma.vert
 preprocessor.simple.vert
 preprocessor.success_if_parse_would_fail.vert
 preprocessor.defined.vert
+preprocessor.many.endif.vert

--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
+++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
@@ -867,12 +867,13 @@ int TPpContext::readCPPline(TPpToken* ppToken)
             token = CPPelse(0, ppToken);
             break;
         case PpAtomEndif:
-            elseSeen[elsetracker] = false;
-            --elsetracker;
             if (! ifdepth)
                 parseContext.ppError(ppToken->loc, "mismatched statements", "#endif", "");
-            else
+            else {
+                elseSeen[elsetracker] = false;
+                --elsetracker;
                 --ifdepth;
+            }
             token = extraTokenCheck(PpAtomEndif, ppToken, scanToken(ppToken));
             break;
         case PpAtomIf:


### PR DESCRIPTION
If we are not inside an `if` macro, we cannot simply decrease
`elsetracker`.

Fixes https://github.com/KhronosGroup/glslang/issues/29.