### PR TITLE
Remove decoration of undefined IDs

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -719,6 +719,7 @@ void TGlslangToSpvTraverser::dumpSpv(std::vector<unsigned int>& out)
     for (auto it = iOSet.cbegin(); it != iOSet.cend(); ++it)
         entryPoint->addIdOperand(*it);
 
+    builder.eliminateDeadDecorations();
     builder.dump(out);
 }
 

--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -2137,14 +2137,21 @@ void Builder::eliminateDeadDecorations() {
     // Collect IDs defined in unreachable blocks. For each function, label the
     // reachable blocks first. Then for each unreachable block, collect the
     // result IDs of the instructions in it.
-    for (auto& f : module.getFunctions()) {
+    for (std::vector<Function*>::const_iterator fi = module.getFunctions().cbegin();
+        fi != module.getFunctions().cend(); fi++) {
+        Function* f = *fi;
         Block* entry = f->getEntryBlock();
         inReadableOrder(entry, [&reachable_blocks](const Block* b) {
             reachable_blocks.insert(b);
         });
-        for (auto& b : f->getBlocks()) {
+        for (std::vector<Block*>::const_iterator bi = f->getBlocks().cbegin();
+            bi != f->getBlocks().cend(); bi++) {
+            Block* b = *bi;
             if (!reachable_blocks.count(b)) {
-                for (auto& i : b->getInstructions()) {
+                for (std::vector<std::unique_ptr<Instruction> >::const_iterator
+                         ii = b->getInstructions().cbegin();
+                    ii != b->getInstructions().cend(); ii++) {
+                    Instruction* i = ii->get();
                     unreachable_definitions.insert(i->getResultId());
                 }
             }

--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -512,6 +512,9 @@ public:
     // based on the type of the base and the chain of dereferences.
     Id accessChainGetInferredType();
 
+    // Remove OpDecorate instructions whose operands are defined in unreachable
+    // blocks.
+    void eliminateDeadDecorations();
     void dump(std::vector<unsigned int>&) const;
 
     void createBranch(Block* block);

--- a/SPIRV/spvIR.h
+++ b/SPIRV/spvIR.h
@@ -182,6 +182,9 @@ public:
     void addLocalVariable(std::unique_ptr<Instruction> inst) { localVariables.push_back(std::move(inst)); }
     const std::vector<Block*>& getPredecessors() const { return predecessors; }
     const std::vector<Block*>& getSuccessors() const { return successors; }
+    const std::vector<std::unique_ptr<Instruction> >& getInstructions() const {
+        return instructions;
+    }
     void setUnreachable() { unreachable = true; }
     bool isUnreachable() const { return unreachable; }
     // Returns the block's merge instruction, if one exists (otherwise null).
@@ -275,6 +278,7 @@ public:
     Module& getParent() const { return parent; }
     Block* getEntryBlock() const { return blocks.front(); }
     Block* getLastBlock() const { return blocks.back(); }
+    const std::vector<Block*>& getBlocks() const { return blocks; }
     void addLocalVariable(std::unique_ptr<Instruction> inst);
     Id getReturnType() const { return functionInstruction.getTypeId(); }
     void dump(std::vector<unsigned int>& out) const
@@ -326,6 +330,7 @@ public:
     }
 
     Instruction* getInstruction(Id id) const { return idToInstruction[id]; }
+    const std::vector<Function*>& getFunctions() const { return functions; }
     spv::Id getTypeId(Id resultId) const { return idToInstruction[resultId]->getTypeId(); }
     StorageClass getStorageClass(Id typeId) const
     {


### PR DESCRIPTION
Fix issue #185 by removing OpDecorate instructions whose target IDs are
defined in unreachable blocks and thus not dumped in the generated
SPIR-V code.

Alternative to PR #193 