### PR TITLE
Parser: Fix a build issue (VS2012).

### DIFF
--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -357,8 +357,9 @@ public:
         {
             static const char unexpected_include[] =
                 "unexpected include directive";
-            return new IncludeResult(
-                {"", unexpected_include, sizeof(unexpected_include) - 1, nullptr});
+            static const IncludeResult unexpectedIncludeResult =
+                {"", unexpected_include, sizeof(unexpected_include) - 1, nullptr};
+            return new IncludeResult(unexpectedIncludeResult);
         }
         virtual void releaseInclude(IncludeResult* result) override
         {


### PR DESCRIPTION
This issue is caused by the commit a132af5b78914e4dadcd66a9e8837de10b3a3c9f. VS2012 fails to compile the file `ShaderLang.h`.