### PR TITLE
ParseHelper: do not use default precision for build-in functions

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -70,7 +70,11 @@ TParseContext::TParseContext(TSymbolTable& symbolTable, TIntermediate& interm, b
         defaultSamplerPrecision[type] = EpqNone;
 
     // replace with real defaults for those that have them
-    if (profile == EEsProfile) {
+
+	// do not set default precision for build ins: build-in functions 
+	// precision depends on arguments, build in values precision should be set
+	// in declaration
+    if (profile == EEsProfile && !parsingBuiltins) {
         TSampler sampler;
         sampler.set(EbtFloat, Esd2D);
         defaultSamplerPrecision[computeSamplerTypeIndex(sampler)] = EpqLow;
@@ -4805,6 +4809,13 @@ TIntermNode* TParseContext::declareVariable(const TSourceLoc& loc, TString& iden
     // see if it's a linker-level object to track
     if (newDeclaration && symbolTable.atGlobalLevel())
         intermediate.addSymbolLinkageNode(linkage, *symbol);
+
+	// check if all build-in variables have precision set on ES profile
+	assert(profile != EEsProfile || !parsingBuiltins ||
+		symbol->getType().getBasicType() != EbtUint  ||
+		symbol->getType().getBasicType() != EbtInt   ||
+		symbol->getType().getBasicType() != EbtFloat ||
+		symbol->getType().getQualifier().precision != EpqNone);
 
     return initNode;
 }


### PR DESCRIPTION
This removes default precision qualifiers from parsing the build-ins. This is needed for functions,
so they get precision computed from their arguments (that is already handled in glslang).

Without that all FS build-in functions other than pack/unpack and sampler/image operations are performed in mediump.

Additionally, all build-in variables are checked to have explicit precision qualifier in declaration.