### PR TITLE
Bump minimum required CMake version to 2.8.12.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 enable_testing()
 


### PR DESCRIPTION
CMake 2.8.12 added support for `target_include_directories()`, among
other features, and we would like to use it.

Addresses #259.