### PR TITLE
Remove duplicated cmake_minimum_required() calls.

### DIFF
--- a/OGLCompilersDLL/CMakeLists.txt
+++ b/OGLCompilersDLL/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 set(SOURCES InitializeDll.cpp InitializeDll.h)
 
 add_library(OGLCompiler STATIC ${SOURCES})

--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 set(SOURCES
     GlslangToSpv.cpp
     InReadableOrder.cpp

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 add_library(glslang-default-resource-limits
     ${CMAKE_CURRENT_SOURCE_DIR}/DefaultResourceLimits.cpp
 )

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 if(WIN32)
     add_subdirectory(OSDependent/Windows)
 elseif(UNIX)

--- a/glslang/OSDependent/Unix/CMakeLists.txt
+++ b/glslang/OSDependent/Unix/CMakeLists.txt
@@ -1,7 +1,3 @@
-
-
-cmake_minimum_required(VERSION 2.8)
-
 add_library(OSDependent STATIC ossource.cpp ../osinclude.h)
 
 install(TARGETS OSDependent 

--- a/glslang/OSDependent/Windows/CMakeLists.txt
+++ b/glslang/OSDependent/Windows/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 set(SOURCES ossource.cpp ../osinclude.h)
 
 add_library(OSDependent STATIC ${SOURCES})

--- a/hlsl/CMakeLists.txt
+++ b/hlsl/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 set(SOURCES
     hlslParseHelper.cpp
     hlslScanContext.cpp


### PR DESCRIPTION
We only need one in the top directory CMakeLists.txt.