### PR TITLE
Updated cmake to better organize folders and options.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8.12)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 enable_testing()
 

--- a/External/CMakeLists.txt
+++ b/External/CMakeLists.txt
@@ -10,6 +10,24 @@ elseif(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/googletest)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
   endif(WIN32)
   add_subdirectory(googletest)
+  set(GTEST_TARGETS
+    gtest
+    gtest_main
+    gmock
+    gmock_main
+  )
+  foreach(target ${GTEST_TARGETS})
+    set_property(TARGET ${target} PROPERTY FOLDER gtest)
+  endforeach()
+  mark_as_advanced(gmock_build_tests
+    BUILD_GMOCK
+    BUILD_GTEST
+    BUILD_SHARED_LIBS
+    gtest_build_samples
+    gtest_build_tests
+    gtest_disable_pthreads
+    gtest_force_shared_crt
+    gtest_hide_internal_symbols)
 else()
   message(STATUS
     "Google Mock was not found - tests based on that will not build")

--- a/OGLCompilersDLL/CMakeLists.txt
+++ b/OGLCompilersDLL/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES InitializeDll.cpp InitializeDll.h)
 
 add_library(OGLCompiler STATIC ${SOURCES})
+set_property(TARGET OGLCompiler PROPERTY FOLDER glslang)
 
 if(WIN32)
     source_group("Source" FILES ${SOURCES})

--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -17,6 +17,7 @@ set(HEADERS
     disassemble.h)
 
 add_library(SPIRV STATIC ${SOURCES} ${HEADERS})
+set_property(TARGET SPIRV PROPERTY FOLDER glslang)
 
 if(WIN32)
     source_group("Source" FILES ${SOURCES} ${HEADERS})

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(glslang-default-resource-limits
     ${CMAKE_CURRENT_SOURCE_DIR}/DefaultResourceLimits.cpp
 )
+set_property(TARGET glslang-default-resource-limits PROPERTY FOLDER glslang)
+
 target_include_directories(glslang-default-resource-limits
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
     PUBLIC ${PROJECT_SOURCE_DIR}
@@ -11,6 +13,8 @@ set(REMAPPER_SOURCES spirv-remap.cpp)
 
 add_executable(glslangValidator ${SOURCES})
 add_executable(spirv-remap ${REMAPPER_SOURCES})
+set_property(TARGET glslangValidator PROPERTY FOLDER tools)
+set_property(TARGET spirv-remap PROPERTY FOLDER tools)
 
 set(LIBRARIES
     glslang

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -75,6 +75,7 @@ set(HEADERS
 # set(BISON_GLSLParser_OUTPUT_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/MachineIndependent/glslang_tab.cpp)
 
 add_library(glslang STATIC ${BISON_GLSLParser_OUTPUT_SOURCE} ${SOURCES} ${HEADERS})
+set_property(TARGET glslang PROPERTY FOLDER glslang)
 
 if(WIN32)
     source_group("Public" REGULAR_EXPRESSION "Public/*")

--- a/glslang/OSDependent/Unix/CMakeLists.txt
+++ b/glslang/OSDependent/Unix/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(OSDependent STATIC ossource.cpp ../osinclude.h)
+set_property(TARGET OSDependent PROPERTY FOLDER glslang)
 
 install(TARGETS OSDependent 
         ARCHIVE DESTINATION lib)

--- a/glslang/OSDependent/Windows/CMakeLists.txt
+++ b/glslang/OSDependent/Windows/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES ossource.cpp ../osinclude.h)
 
 add_library(OSDependent STATIC ${SOURCES})
+set_property(TARGET OSDependent PROPERTY FOLDER glslang)
 
 # MinGW GCC complains about function pointer casts to void*.
 # Turn that off with -fpermissive.

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -19,6 +19,9 @@ if (TARGET gmock)
 
   add_executable(glslangtests ${TEST_SOURCES})
   set_property(TARGET glslangtests PROPERTY FOLDER tests)
+  install(TARGETS glslangtests
+        RUNTIME DESTINATION bin)
+
   target_compile_definitions(glslangtests
     PRIVATE GLSLANG_TEST_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/../Test")
   target_include_directories(glslangtests PRIVATE

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -18,6 +18,7 @@ if (TARGET gmock)
   )
 
   add_executable(glslangtests ${TEST_SOURCES})
+  set_property(TARGET glslangtests PROPERTY FOLDER tests)
   target_compile_definitions(glslangtests
     PRIVATE GLSLANG_TEST_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/../Test")
   target_include_directories(glslangtests PRIVATE

--- a/hlsl/CMakeLists.txt
+++ b/hlsl/CMakeLists.txt
@@ -14,6 +14,7 @@ set(HEADERS
     hlslGrammar.h)
 
 add_library(HLSL STATIC ${SOURCES} ${HEADERS})
+set_property(TARGET HLSL PROPERTY FOLDER hlsl)
 
 if(WIN32)
     source_group("Source" FILES ${SOURCES} ${HEADERS})


### PR DESCRIPTION
This adds solution folders that properly group gtest/glslang/hlsl.
This also marks gtest options as advanced so they don't show up
in cmake-gui by default.