### PR TITLE
SPV: Do not decorate struct members with location or nested members with interpolation qualifiers

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -1862,7 +1862,11 @@ spv::Id TGlslangToSpvTraverser::convertGlslangToSpvType(const glslang::TType& ty
                     builder.addMemberName(spvType, member, glslangType.getFieldName().c_str());
                     addMemberDecoration(spvType, member, TranslateLayoutDecoration(glslangType, subQualifier.layoutMatrix));
                     addMemberDecoration(spvType, member, TranslatePrecisionDecoration(glslangType));
-                    addMemberDecoration(spvType, member, TranslateInterpolationDecoration(subQualifier));
+                    // Add interpolation decorations only to top-level members of Input and Output storage classes
+                    if (type.getQualifier().storage == glslang::EvqVaryingIn || type.getQualifier().storage == glslang::EvqVaryingOut)
+                    {
+                        addMemberDecoration(spvType, member, TranslateInterpolationDecoration(subQualifier));
+                    }
                     addMemberDecoration(spvType, member, TranslateInvariantDecoration(subQualifier));
 
                     if (qualifier.storage == glslang::EvqBuffer) {
@@ -1878,7 +1882,16 @@ spv::Id TGlslangToSpvTraverser::convertGlslangToSpvType(const glslang::TType& ty
                     //       answer sitting already distributed throughout the individual member locations.
                     int location = -1;                // will only decorate if present or inherited
                     if (subQualifier.hasLocation())   // no inheritance, or override of inheritance
+                    {
+                        // struct members should not have explicit locations
+                        assert(type.getBasicType() != glslang::EbtStruct);
                         location = subQualifier.layoutLocation;
+                    }
+                    else if (type.getBasicType() != glslang::EbtBlock)
+                    {
+                        //  If it is a not a Block, (...) Its members are assigned consecutive locations (...)
+                        //  The members, and their nested types, must not themselves have Location decorations.
+                    }
                     else if (qualifier.hasLocation()) // inheritance
                         location = qualifier.layoutLocation + locationOffset;
                     if (qualifier.hasLocation())      // track for upcoming inheritance

--- a/Test/baseResults/spv.430.vert.out
+++ b/Test/baseResults/spv.430.vert.out
@@ -63,18 +63,9 @@ Linked vertex stage:
                               Decorate 55(sampb2) Binding 5
                               Decorate 56(sampb4) DescriptorSet 0
                               Decorate 56(sampb4) Binding 31
-                              MemberDecorate 59(S) 0 Flat
-                              MemberDecorate 59(S) 0 Location 1
-                              MemberDecorate 59(S) 1 Flat
-                              MemberDecorate 59(S) 1 Location 2
-                              MemberDecorate 59(S) 2 Flat
-                              MemberDecorate 59(S) 2 Location 3
                               MemberDecorate 60(SS) 0 Flat
-                              MemberDecorate 60(SS) 0 Location 0
                               MemberDecorate 60(SS) 1 Flat
-                              MemberDecorate 60(SS) 1 Location 1
                               MemberDecorate 60(SS) 2 Flat
-                              MemberDecorate 60(SS) 2 Location 4
                               MemberDecorate 63(MS) 0 Location 17
                               Decorate 63(MS) Block
                2:             TypeVoid

--- a/Test/baseResults/spv.localAggregates.frag.out
+++ b/Test/baseResults/spv.localAggregates.frag.out
@@ -66,14 +66,6 @@ Linked fragment stage:
                               MemberName 140(s2) 2  "s1_1"
                               MemberName 140(s2) 3  "bleh"
                               Name 142  "foo2"
-                              MemberDecorate 13(s1) 0 Flat
-                              MemberDecorate 13(s1) 1 Flat
-                              MemberDecorate 14(s2) 0 Flat
-                              MemberDecorate 14(s2) 1 Flat
-                              MemberDecorate 14(s2) 2 Flat
-                              MemberDecorate 14(s2) 3 Flat
-                              MemberDecorate 15(s1) 0 Flat
-                              MemberDecorate 15(s1) 1 Flat
                               MemberDecorate 16(s3) 0 Flat
                               MemberDecorate 16(s3) 1 Flat
                               MemberDecorate 16(s3) 2 Flat
@@ -82,8 +74,6 @@ Linked fragment stage:
                               Decorate 131(samp2D) DescriptorSet 0
                               MemberDecorate 136(s1) 0 Flat
                               MemberDecorate 136(s1) 1 Flat
-                              MemberDecorate 139(s1) 0 Flat
-                              MemberDecorate 139(s1) 1 Flat
                               MemberDecorate 140(s2) 0 Flat
                               MemberDecorate 140(s2) 1 Flat
                               MemberDecorate 140(s2) 2 Flat

--- a/Test/baseResults/spv.variableArrayIndex.frag.out
+++ b/Test/baseResults/spv.variableArrayIndex.frag.out
@@ -52,19 +52,10 @@ Linked fragment stage:
                               Name 67  "coord"
                               Name 73  "constructed"
                               Decorate 10(Count) Flat
-                              MemberDecorate 13(lunarStruct1) 0 Flat
-                              MemberDecorate 13(lunarStruct1) 1 Flat
-                              MemberDecorate 14(lunarStruct2) 0 Flat
-                              MemberDecorate 14(lunarStruct2) 1 Flat
-                              MemberDecorate 14(lunarStruct2) 2 Flat
-                              MemberDecorate 18(lunarStruct1) 0 Flat
-                              MemberDecorate 18(lunarStruct1) 1 Flat
                               MemberDecorate 19(lunarStruct3) 0 Flat
                               MemberDecorate 19(lunarStruct3) 1 Flat
                               MemberDecorate 19(lunarStruct3) 2 Flat
                               MemberDecorate 19(lunarStruct3) 3 Flat
-                              MemberDecorate 32(lunarStruct1) 0 Flat
-                              MemberDecorate 32(lunarStruct1) 1 Flat
                               MemberDecorate 33(lunarStruct2) 0 Flat
                               MemberDecorate 33(lunarStruct2) 1 Flat
                               MemberDecorate 33(lunarStruct2) 2 Flat


### PR DESCRIPTION
This fixes some vulkanCTS tests that use struct arrays as a member of in/out interface blocks.

From Vulkan spec:

> If it is a not a Block, then the structure type must have a Location decoration. Its members are assigned consecutive locations in their declaration order, with the first member assigned to the location specified for the structure type. **The members, and their nested types, must not themselves have Location decorations**

From SPIR-V spec:

>When applied to structure-type members, the Decorations Noperspective, Flat, Patch, Centroid, and Sample can only be applied to the top-level members of the structure type. (Nested objects' types cannot be structures whose members are decorated with these decorations.)