### PR TITLE
Minor android compile warning fix

### DIFF
--- a/glslang/OSDependent/Unix/ossource.cpp
+++ b/glslang/OSDependent/Unix/ossource.cpp
@@ -69,7 +69,7 @@ static void DetachThreadLinux(void *)
 void OS_CleanupThreadData(void)
 {
 #ifdef __ANDROID__
-  DetachThread();
+	DetachThreadLinux(NULL);
 #else
 	int old_cancel_state, old_cancel_type;
 	void *cleanupArg = NULL;


### PR DESCRIPTION
Fixes a build warning because the DetachThreadLinux function is still declared on android but then not used.

Also just in case any more code is added to DetachThreadLinux, this will go through the same path on both platforms which is less surprising.