### PR TITLE
VS2010 compilation fixes

### DIFF
--- a/SPIRV/Logger.cpp
+++ b/SPIRV/Logger.cpp
@@ -54,14 +54,14 @@ void SpvBuildLogger::missingFunctionality(const std::string& f)
 
 std::string SpvBuildLogger::getAllMessages() const {
     std::ostringstream messages;
-    for (const auto& f : tbdFeatures)
-        messages << "TBD functionality: " << f << "\n";
-    for (const auto& f : missingFeatures)
-        messages << "Missing functionality: " << f << "\n";
-    for (const auto& w : warnings)
-        messages << "warning: " << w << "\n";
-    for (const auto& e : errors)
-        messages << "error: " << e << "\n";
+    for (auto it = tbdFeatures.cbegin(); it != tbdFeatures.cend(); ++it)
+        messages << "TBD functionality: " << *it << "\n";
+    for (auto it = missingFeatures.cbegin(); it != missingFeatures.cend(); ++it)
+        messages << "Missing functionality: " << *it << "\n";
+    for (auto it = warnings.cbegin(); it != warnings.cend(); ++it)
+        messages << "warning: " << *it << "\n";
+    for (auto it = errors.cbegin(); it != errors.cend(); ++it)
+        messages << "error: " << *it << "\n";
     return messages.str();
 }
 

--- a/SPIRV/Logger.h
+++ b/SPIRV/Logger.h
@@ -44,8 +44,7 @@ namespace spv {
 // missing/TBD functionalities, warnings, and errors.
 class SpvBuildLogger {
 public:
-    SpvBuildLogger() = default;
-    SpvBuildLogger(const SpvBuildLogger&) = delete;
+    SpvBuildLogger() {}
 
     // Registers a TBD functionality.
     void tbdFunctionality(const std::string& f);
@@ -62,6 +61,8 @@ public:
     std::string getAllMessages() const;
 
 private:
+    SpvBuildLogger(const SpvBuildLogger&);
+
     std::vector<std::string> tbdFeatures;
     std::vector<std::string> missingFeatures;
     std::vector<std::string> warnings;

--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -63,7 +63,7 @@ std::string to_string(const T& val) {
 }
 #endif
 
-#if _MSC_VER < 1700
+#if defined(_MSC_VER) && _MSC_VER < 1700
 inline long long int strtoll (const char* str, char** endptr, int base)
 {
   return _strtoi64(str, endptr, base); 

--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -62,6 +62,18 @@ std::string to_string(const T& val) {
 }
 }
 #endif
+
+#if _MSC_VER < 1700
+inline long long int strtoll (const char* str, char** endptr, int base)
+{
+  return _strtoi64(str, endptr, base); 
+}
+inline long long int atoll (const char* str)
+{
+  return strtoll(str, NULL, 10);
+}
+#endif
+
 /* windows only pragma */
 #ifdef _MSC_VER
     #pragma warning(disable : 4786) // Don't warn about too long identifiers

--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -51,7 +51,7 @@
     #define UINT_PTR uintptr_t
 #endif
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__) || _MSC_VER < 1700
 #include <sstream>
 namespace std {
 template<typename T>

--- a/glslang/MachineIndependent/propagateNoContraction.cpp
+++ b/glslang/MachineIndependent/propagateNoContraction.cpp
@@ -58,7 +58,7 @@ namespace {
 // For members of vector, matrix and arrays, they will be represented with the
 // same symbol ID of their container symbol objects. This is because their
 // precise'ness is always the same as their container symbol objects.
-using ObjectAccessChain = std::string;
+typedef std::string ObjectAccessChain;
 
 // The delimiter used in the ObjectAccessChain string to separate symbol ID and
 // different level of struct indices.
@@ -66,14 +66,14 @@ const char ObjectAccesschainDelimiter = '/';
 
 // Mapping from Symbol IDs of symbol nodes, to their defining operation
 // nodes.
-using NodeMapping = std::unordered_multimap<ObjectAccessChain, glslang::TIntermOperator*>;
+typedef std::unordered_multimap<ObjectAccessChain, glslang::TIntermOperator*> NodeMapping;
 // Mapping from object nodes to their accesschain info string.
-using AccessChainMapping = std::unordered_map<glslang::TIntermTyped*, ObjectAccessChain>;
+typedef std::unordered_map<glslang::TIntermTyped*, ObjectAccessChain> AccessChainMapping;
 
 // Set of object IDs.
-using ObjectAccesschainSet = std::unordered_set<ObjectAccessChain>;
+typedef std::unordered_set<ObjectAccessChain> ObjectAccesschainSet;
 // Set of return branch nodes.
-using ReturnBranchNodeSet = std::unordered_set<glslang::TIntermBranch*>;
+typedef std::unordered_set<glslang::TIntermBranch*> ReturnBranchNodeSet;
 
 // A helper function to tell whether a node is 'noContraction'. Returns true if
 // the node has 'noContraction' qualifier, otherwise false.


### PR DESCRIPTION
I'm still a little fuzzy on whether VS2010 compilation is intended to be supported upstream here or not, if it's not then I can just keep this up to date in my own fork.

Anyway for perusal here are fixes for C++11 constructs not supported on VS2010 that should not regress any functionality or anything or break on other compilers, as far as I understand the C++11 semantics anyway.