### PR TITLE
SPV: Correct an issue in createUnaryMatrixOperation().

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -3334,18 +3334,18 @@ spv::Id TGlslangToSpvTraverser::createUnaryMatrixOperation(spv::Op op, spv::Deco
     // get the types sorted out
     int numCols = builder.getNumColumns(operand);
     int numRows = builder.getNumRows(operand);
-    spv::Id scalarType = builder.getScalarTypeId(typeId);
-    spv::Id vecType = builder.makeVectorType(scalarType, numRows);
+    spv::Id srcVecType  = builder.makeVectorType(builder.getScalarTypeId(builder.getTypeId(operand)), numRows);
+    spv::Id destVecType = builder.makeVectorType(builder.getScalarTypeId(typeId), numRows);
     std::vector<spv::Id> results;
 
     // do each vector op
     for (int c = 0; c < numCols; ++c) {
         std::vector<unsigned int> indexes;
         indexes.push_back(c);
-        spv::Id vec =  builder.createCompositeExtract(operand, vecType, indexes);
-        spv::Id vec_result = builder.createUnaryOp(op, vecType, vec);
-        addDecoration(vec_result, noContraction);
-        results.push_back(builder.setPrecision(vec_result, precision));
+        spv::Id srcVec  = builder.createCompositeExtract(operand, srcVecType, indexes);
+        spv::Id destVec = builder.createUnaryOp(op, destVecType, srcVec);
+        addDecoration(destVec, noContraction);
+        results.push_back(builder.setPrecision(destVec, precision));
     }
 
     // put the pieces together

--- a/Test/baseResults/spv.matrix.frag.out
+++ b/Test/baseResults/spv.matrix.frag.out
@@ -195,20 +195,20 @@ Linked fragment stage:
              135:           8 CompositeConstruct 130 132 134
                               Store 10(sum34) 135
              141:           8 Load 10(sum34)
-             142:  137(fvec4) CompositeExtract 141 0
+             142:    7(fvec4) CompositeExtract 141 0
              143:  137(fvec4) FConvert 142
-             144:  137(fvec4) CompositeExtract 141 1
+             144:    7(fvec4) CompositeExtract 141 1
              145:  137(fvec4) FConvert 144
-             146:  137(fvec4) CompositeExtract 141 2
+             146:    7(fvec4) CompositeExtract 141 2
              147:  137(fvec4) FConvert 146
              148:         138 CompositeConstruct 143 145 147
                               Store 140(dm) 148
              149:         138 Load 140(dm)
-             150:    7(fvec4) CompositeExtract 149 0
+             150:  137(fvec4) CompositeExtract 149 0
              151:    7(fvec4) FConvert 150
-             152:    7(fvec4) CompositeExtract 149 1
+             152:  137(fvec4) CompositeExtract 149 1
              153:    7(fvec4) FConvert 152
-             154:    7(fvec4) CompositeExtract 149 2
+             154:  137(fvec4) CompositeExtract 149 2
              155:    7(fvec4) FConvert 154
              156:           8 CompositeConstruct 151 153 155
                               Store 10(sum34) 156


### PR DESCRIPTION
Originally, I use this function to perform OpFConvert for matrix. But I find type of the source is not necessarily the same as that of the destination. So this function should be revised accordingly. Otherwise, the generated results are erroneous.