### PR TITLE
Add support for querying vertex attributes in reflection API

### DIFF
--- a/Test/baseResults/reflection.vert.out
+++ b/Test/baseResults/reflection.vert.out
@@ -95,3 +95,10 @@ abl2[1]: offset -1, type ffffffff, size 4, index -1
 abl2[2]: offset -1, type ffffffff, size 4, index -1
 abl2[3]: offset -1, type ffffffff, size 4, index -1
 
+Vertex attribute reflection:
+attributeFloat: offset 0, type 1406, size 0, index 0
+attributeFloat2: offset 0, type 8b50, size 0, index 0
+attributeFloat3: offset 0, type 8b51, size 0, index 0
+attributeFloat4: offset 0, type 8b52, size 0, index 0
+attributeMat4: offset 0, type 8b5c, size 0, index 0
+

--- a/Test/reflection.vert
+++ b/Test/reflection.vert
@@ -94,6 +94,12 @@ struct deep3 {
     ivec3 v3;
 };
 
+in float attributeFloat;
+layout(location = 2) in vec2 attributeFloat2;
+in vec3 attributeFloat3;
+in vec4 attributeFloat4;
+in mat4 attributeMat4;
+
 uniform deep3 deepA[2], deepB[2], deepC[3], deepD[2];
 
 const bool control = true;
@@ -167,4 +173,10 @@ void main()
 
     f += arrBl[2].foo + arrBl[0].foo;
     f += arrBl2[i].foo;
+
+    f += attributeFloat;
+    f += attributeFloat2.x;
+    f += attributeFloat3.x;
+    f += attributeFloat4.x;
+    f += attributeMat4[0][1];
 }

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1572,6 +1572,9 @@ int TProgram::getUniformBlockIndex(int index)        { return reflection->getUni
 int TProgram::getUniformType(int index)              { return reflection->getUniform(index).glDefineType; }
 int TProgram::getUniformBufferOffset(int index)      { return reflection->getUniform(index).offset; }
 int TProgram::getUniformArraySize(int index)         { return reflection->getUniform(index).size; }
+int TProgram::getNumLiveAttributes()                 { return reflection->getNumAttributes(); }
+const char* TProgram::getAttributeName(int index)    { return reflection->getAttribute(index).name.c_str(); }
+int TProgram::getAttributeType(int index)            { return reflection->getAttribute(index).glDefineType; }
 
 void TProgram::dumpReflection()                      { reflection->dump(); }
 

--- a/glslang/MachineIndependent/reflection.h
+++ b/glslang/MachineIndependent/reflection.h
@@ -93,7 +93,17 @@ public:
             return badReflection;
     }
 
-    // for mapping any name to its index (both block names and uniforms names)
+    // for mapping an attribute index to the attribute's description
+    int getNumAttributes() { return (int)indexToAttribute.size(); }
+    const TObjectReflection& getAttribute(int i) const
+    {
+        if (i >= 0 && i < (int)indexToAttribute.size())
+            return indexToAttribute[i];
+        else
+            return badReflection;
+    }
+
+    // for mapping any name to its index (block names, uniform names and attribute names)
     int getIndex(const char* name) const 
     {
         TNameToIndex::const_iterator it = nameToIndex.find(name);
@@ -116,6 +126,7 @@ protected:
     TNameToIndex nameToIndex;        // maps names to indexes; can hold all types of data: uniform/buffer and which function names have been processed
     TMapIndexToReflection indexToUniform;
     TMapIndexToReflection indexToUniformBlock;
+    TMapIndexToReflection indexToAttribute;
 };
 
 } // end namespace glslang

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -461,6 +461,9 @@ public:
     int getUniformType(int index);                   // can be used for glGetActiveUniformsiv(GL_UNIFORM_TYPE)
     int getUniformBufferOffset(int index);           // can be used for glGetActiveUniformsiv(GL_UNIFORM_OFFSET)
     int getUniformArraySize(int index);              // can be used for glGetActiveUniformsiv(GL_UNIFORM_SIZE)
+    int getNumLiveAttributes();                      // can be used for glGetProgramiv(GL_ACTIVE_ATTRIBUTES)
+    const char *getAttributeName(int index);         // can be used for glGetActiveAttrib()
+    int getAttributeType(int index);                 // can be used for glGetActiveAttrib()
     void dumpReflection();
 
 protected:


### PR DESCRIPTION
This adds support for querying which vertex attributes are specified as inputs in the vertex shader and for querying the number of attributes, their names and types similar to querying uniform variables.