### PR TITLE
Also do link tests in the GTest framework

### DIFF
--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -14,6 +14,7 @@ if (TARGET gmock)
     ${CMAKE_CURRENT_SOURCE_DIR}/AST.FromFile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BuiltInResource.FromFile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Hlsl.FromFile.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Link.FromFile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Pp.FromFile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Spv.FromFile.cpp
   )

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -59,7 +59,7 @@ std::string FileNameAsCustomTestSuffix(
 using HlslCompileTest = GlslangTest<::testing::TestWithParam<FileNameEntryPointPair>>;
 
 // Compiling HLSL to SPIR-V under Vulkan semantics. Expected to successfully
-// generate SPIR-V.
+// generate both AST and SPIR-V.
 TEST_P(HlslCompileTest, FromFile)
 {
     loadFileCompileAndCheck(GLSLANG_TEST_DIRECTORY, GetParam().fileName,

--- a/gtests/Link.FromFile.cpp
+++ b/gtests/Link.FromFile.cpp
@@ -1,0 +1,107 @@
+//
+// Copyright (C) 2016 Google, Inc.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//    Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//    Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//    Neither the name of Google Inc. nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "TestFixture.h"
+
+namespace glslangtest {
+namespace {
+
+using LinkTest = GlslangTest<
+    ::testing::TestWithParam<std::vector<std::string>>>;
+
+TEST_P(LinkTest, FromFile)
+{
+    const auto& fileNames = GetParam();
+    const size_t fileCount = fileNames.size();
+    const EShMessages controls = DeriveOptions(
+            Source::GLSL, Semantics::OpenGL, Target::AST);
+    GlslangResult result;
+
+    // Compile each input shader file.
+    std::vector<std::unique_ptr<glslang::TShader>> shaders;
+    for (size_t i = 0; i < fileCount; ++i) {
+        std::string contents;
+        tryLoadFile(GLSLANG_TEST_DIRECTORY "/" + fileNames[i],
+                    "input", &contents);
+        shaders.emplace_back(
+                new glslang::TShader(GetShaderStage(GetSuffix(fileNames[i]))));
+        auto* shader = shaders.back().get();
+        compile(shader, contents, "", controls);
+        result.shaderResults.push_back(
+            {fileNames[i], shader->getInfoLog(), shader->getInfoDebugLog()});
+    }
+
+    // Link all of them.
+    glslang::TProgram program;
+    for (const auto& shader : shaders) program.addShader(shader.get());
+    program.link(controls);
+    result.linkingOutput = program.getInfoLog();
+    result.linkingError = program.getInfoDebugLog();
+
+    std::ostringstream stream;
+    outputResultToStream(&stream, result, controls);
+
+    // Check with expected results.
+    const std::string expectedOutputFname =
+        GLSLANG_TEST_DIRECTORY "/baseResults/" + fileNames.front() + ".out";
+    std::string expectedOutput;
+    tryLoadFile(expectedOutputFname, "expected output", &expectedOutput);
+
+    checkEqAndUpdateIfRequested(expectedOutput, stream.str(), expectedOutputFname);
+}
+
+// clang-format off
+INSTANTIATE_TEST_CASE_P(
+    Glsl, LinkTest,
+    ::testing::ValuesIn(std::vector<std::vector<std::string>>({
+        {"mains1.frag", "mains2.frag", "noMain1.geom", "noMain2.geom"},
+        {"noMain.vert", "mains.frag"},
+        {"link1.frag", "link2.frag", "link3.frag"},
+        {"recurse1.vert", "recurse1.frag", "recurse2.frag"},
+        {"300link.frag"},
+        {"300link2.frag"},
+        {"300link3.frag"},
+        {"empty.frag", "empty2.frag", "empty3.frag"},
+        {"150.tesc", "150.tese", "400.tesc", "400.tese", "410.tesc", "420.tesc", "420.tese"},
+        {"max_vertices_0.geom"},
+    })),
+);
+// clang-format on
+
+}  // anonymous namespace
+}  // namespace glslangtest

--- a/gtests/TestFixture.h
+++ b/gtests/TestFixture.h
@@ -129,14 +129,13 @@ public:
     }
 
     // Checks the equality of |expected| and |real|. If they are not equal,
-    // write
-    // |real| to the given file named as |fname| if update mode is on.
+    // write |real| to the given file named as |fname| if update mode is on.
     void checkEqAndUpdateIfRequested(const std::string& expected,
                                      const std::string& real,
                                      const std::string& fname)
     {
-        // In order to output the message we want under proper circumstances, we
-        // need the following operator<< stuff.
+        // In order to output the message we want under proper circumstances,
+        // we need the following operator<< stuff.
         EXPECT_EQ(expected, real)
             << (GlobalTestSettings.updateMode
                     ? ("Mismatch found and update mode turned on - "
@@ -145,10 +144,8 @@ public:
 
         // Update the expected output file if requested.
         // It looks weird to duplicate the comparison between expected_output
-        // and
-        // stream.str(). However, if creating a variable for the comparison
-        // result,
-        // we cannot have pretty print of the string diff in the above.
+        // and stream.str(). However, if creating a variable for the comparison
+        // result, we cannot have pretty print of the string diff in the above.
         if (GlobalTestSettings.updateMode && expected != real) {
             EXPECT_TRUE(WriteFile(fname, real)) << "Flushing failed";
         }
@@ -165,7 +162,7 @@ public:
         const std::string spirv;  // Optional SPIR-V disassembly text.
     };
 
-    // Compiles and linkes the given source |code| of the given shader
+    // Compiles and links the given source |code| of the given shader
     // |stage| into the given |target| under the given |semantics|. Returns
     // a GlslangResult instance containing all the information generated
     // during the process. If |target| is Target::Spirv, also disassembles


### PR DESCRIPTION
This PR is another step towards deprecating `runtests`.

Related to #279: I'm leaning towards to use `TOption` like bitmask now.