### PR TITLE
[WIP]Fix missing location decoration for structures put directly on input/output interfaces

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -1961,6 +1961,14 @@ spv::Id TGlslangToSpvTraverser::convertGlslangToSpvType(const glslang::TType& ty
                 if (type.getQualifier().hasXfbBuffer())
                     builder.addDecoration(spvType, spv::DecorationXfbBuffer, type.getQualifier().layoutXfbBuffer);
             }
+
+            if (type.getBasicType() != glslang::EbtBlock && (type.getQualifier().storage == glslang::EvqVaryingIn || type.getQualifier().storage == glslang::EvqVaryingOut))
+            {
+                // The layout of a structure type used as an Input or Output depends on whether it is also a Block (i.e. has a Block decoration).
+                // If it is a not a Block, then the structure type must have a Location decoration.
+                if (type.getQualifier().hasLocation())
+                    builder.addDecoration(spvType, spv::DecorationLocation, type.getQualifier().layoutLocation);
+            }
         }
         break;
     default:
@@ -3918,8 +3926,6 @@ spv::Id TGlslangToSpvTraverser::getSymbolId(const glslang::TIntermSymbol* symbol
         addDecoration(id, TranslateInterpolationDecoration(symbol->getType().getQualifier()));
         if (symbol->getType().getQualifier().hasSpecConstantId())
             addDecoration(id, spv::DecorationSpecId, symbol->getType().getQualifier().layoutSpecConstantId);
-        if (symbol->getQualifier().hasLocation())
-            builder.addDecoration(id, spv::DecorationLocation, symbol->getQualifier().layoutLocation);
         if (symbol->getQualifier().hasIndex())
             builder.addDecoration(id, spv::DecorationIndex, symbol->getQualifier().layoutIndex);
         if (symbol->getQualifier().hasComponent())
@@ -3935,6 +3941,8 @@ spv::Id TGlslangToSpvTraverser::getSymbolId(const glslang::TIntermSymbol* symbol
         }
     }
 
+    if (symbol->getQualifier().hasLocation())
+        builder.addDecoration(id, spv::DecorationLocation, symbol->getQualifier().layoutLocation);
     addDecoration(id, TranslateInvariantDecoration(symbol->getType().getQualifier()));
     if (symbol->getQualifier().hasStream() && glslangIntermediate->isMultiStream()) {
         builder.addCapability(spv::CapabilityGeometryStreams);

--- a/Test/baseResults/spv.430.vert.out
+++ b/Test/baseResults/spv.430.vert.out
@@ -65,6 +65,8 @@ Linked vertex stage:
                               MemberDecorate 60(SS) 0 Flat
                               MemberDecorate 60(SS) 1 Flat
                               MemberDecorate 60(SS) 2 Flat
+                              Decorate 60(SS) Location 0
+                              Decorate 62(var) Location 0
                               MemberDecorate 63(MS) 0 Location 17
                               Decorate 63(MS) Block
                2:             TypeVoid


### PR DESCRIPTION
Spec for decorating the OpVariable:

> The remaining variables listed by OpEntryPoint with the Input or Output storage class form the user-defined variable interface. These variables must be identified with a Location decoration

Spec for decorating struct type:

> The layout of a structure type used as an Input or Output depends on whether it is also a Block (i.e. has a Block decoration).

> If it is a not a Block, then the structure type must have a Location decoration