### PR TITLE
Parser: Redeclaration of gl_CullDistance is disallowed mistakenly.

### DIFF
--- a/Test/450.frag
+++ b/Test/450.frag
@@ -47,3 +47,10 @@ void foo()
     s += imageSamples(i2dmsa);
     float f = imageAtomicExchange(i2dmsa, ivec3(in3), 2, 4.5);
 }
+
+in float gl_CullDistance[6];
+
+float cull(int i)
+{
+    return (i >= 6) ? gl_CullDistance[5] : gl_CullDistance[i];
+}

--- a/Test/baseResults/450.frag.out
+++ b/Test/baseResults/450.frag.out
@@ -51,7 +51,7 @@ Shader version: 450
 0:18        move second child to first child (temp float)
 0:18          'cull' (temp float)
 0:18          direct index (smooth temp float CullDistance)
-0:18            'gl_CullDistance' (smooth in implicitly-sized array of float CullDistance)
+0:18            'gl_CullDistance' (smooth in 6-element array of float CullDistance)
 0:18            Constant:
 0:18              2 (const int)
 0:19      Sequence
@@ -130,12 +130,32 @@ Shader version: 450
 0:48              2 (const int)
 0:48            Constant:
 0:48              4.500000
+0:53  Function Definition: cull(i1; (global float)
+0:53    Function Parameters: 
+0:53      'i' (in int)
+0:55    Sequence
+0:55      Branch: Return with expression
+0:55        Test condition and select (temp float)
+0:55          Condition
+0:55          Compare Greater Than or Equal (temp bool)
+0:55            'i' (in int)
+0:55            Constant:
+0:55              6 (const int)
+0:55          true case
+0:55          direct index (smooth temp float CullDistance)
+0:55            'gl_CullDistance' (smooth in 6-element array of float CullDistance)
+0:55            Constant:
+0:55              5 (const int)
+0:55          false case
+0:55          indirect index (smooth temp float CullDistance)
+0:55            'gl_CullDistance' (smooth in 6-element array of float CullDistance)
+0:55            'i' (in int)
 0:?   Linker Objects
 0:?     'in1' (smooth in float)
 0:?     'in2' (smooth in 2-component vector of float)
 0:?     'in3' (smooth in 3-component vector of float)
 0:?     'in4' (smooth in 4-component vector of float)
-0:?     'gl_CullDistance' (smooth in implicitly-sized array of float CullDistance)
+0:?     'gl_CullDistance' (smooth in 6-element array of float CullDistance)
 0:?     's2dms' (uniform sampler2DMS)
 0:?     'us2dmsa' (uniform usampler2DMSArray)
 0:?     'ii2dms' (layout(rgba32i ) uniform iimage2DMS)
@@ -195,7 +215,7 @@ Shader version: 450
 0:18        move second child to first child (temp float)
 0:18          'cull' (temp float)
 0:18          direct index (smooth temp float CullDistance)
-0:18            'gl_CullDistance' (smooth in 3-element array of float CullDistance)
+0:18            'gl_CullDistance' (smooth in 6-element array of float CullDistance)
 0:18            Constant:
 0:18              2 (const int)
 0:19      Sequence
@@ -274,12 +294,32 @@ Shader version: 450
 0:48              2 (const int)
 0:48            Constant:
 0:48              4.500000
+0:53  Function Definition: cull(i1; (global float)
+0:53    Function Parameters: 
+0:53      'i' (in int)
+0:55    Sequence
+0:55      Branch: Return with expression
+0:55        Test condition and select (temp float)
+0:55          Condition
+0:55          Compare Greater Than or Equal (temp bool)
+0:55            'i' (in int)
+0:55            Constant:
+0:55              6 (const int)
+0:55          true case
+0:55          direct index (smooth temp float CullDistance)
+0:55            'gl_CullDistance' (smooth in 6-element array of float CullDistance)
+0:55            Constant:
+0:55              5 (const int)
+0:55          false case
+0:55          indirect index (smooth temp float CullDistance)
+0:55            'gl_CullDistance' (smooth in 6-element array of float CullDistance)
+0:55            'i' (in int)
 0:?   Linker Objects
 0:?     'in1' (smooth in float)
 0:?     'in2' (smooth in 2-component vector of float)
 0:?     'in3' (smooth in 3-component vector of float)
 0:?     'in4' (smooth in 4-component vector of float)
-0:?     'gl_CullDistance' (smooth in 3-element array of float CullDistance)
+0:?     'gl_CullDistance' (smooth in 6-element array of float CullDistance)
 0:?     's2dms' (uniform sampler2DMS)
 0:?     'us2dmsa' (uniform usampler2DMSArray)
 0:?     'ii2dms' (layout(rgba32i ) uniform iimage2DMS)

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -3268,6 +3268,7 @@ TSymbol* TParseContext::redeclareBuiltinVariable(const TSourceLoc& loc, const TS
         (identifier == "gl_FragDepth"           && ((nonEsRedecls && version >= 420) || esRedecls)) ||
         (identifier == "gl_FragCoord"           && ((nonEsRedecls && version >= 150) || esRedecls)) ||
          identifier == "gl_ClipDistance"                                                            ||
+         identifier == "gl_CullDistance"                                                            ||
          identifier == "gl_FrontColor"                                                              ||
          identifier == "gl_BackColor"                                                               ||
          identifier == "gl_FrontSecondaryColor"                                                     ||
@@ -3320,8 +3321,9 @@ TSymbol* TParseContext::redeclareBuiltinVariable(const TSourceLoc& loc, const TS
                 error(loc, "cannot apply layout qualifier to", "redeclaration", symbol->getName().c_str());
             if (qualifier.isMemory() || qualifier.isAuxiliary() || symbol->getType().getQualifier().storage != qualifier.storage)
                 error(loc, "cannot change storage, memory, or auxiliary qualification of", "redeclaration", symbol->getName().c_str());
-        } else if (identifier == "gl_TexCoord" ||
-                   identifier == "gl_ClipDistance") {
+        } else if (identifier == "gl_TexCoord"     ||
+                   identifier == "gl_ClipDistance" ||
+                   identifier == "gl_CullDistance") {
             if (qualifier.hasLayout() || qualifier.isMemory() || qualifier.isAuxiliary() ||
                 qualifier.nopersp != symbolQualifier.nopersp || qualifier.flat != symbolQualifier.flat ||
                 symbolQualifier.storage != qualifier.storage)
@@ -3744,6 +3746,8 @@ void TParseContext::arrayLimitCheck(const TSourceLoc& loc, const TString& identi
         limitCheck(loc, size, "gl_MaxTextureCoords", "gl_TexCoord array size");
     else if (identifier.compare("gl_ClipDistance") == 0)
         limitCheck(loc, size, "gl_MaxClipDistances", "gl_ClipDistance array size");
+    else if (identifier.compare("gl_CullDistance") == 0)
+        limitCheck(loc, size, "gl_MaxCullDistances", "gl_CullDistance array size");
 }
 
 // See if the provided value is less than the symbol indicated by limit,

--- a/glslang/MachineIndependent/linkValidate.cpp
+++ b/glslang/MachineIndependent/linkValidate.cpp
@@ -392,6 +392,8 @@ void TIntermediate::finalCheck(TInfoSink& infoSink)
 
     if (inIoAccessed("gl_ClipDistance") && inIoAccessed("gl_ClipVertex"))
         error(infoSink, "Can only use one of gl_ClipDistance or gl_ClipVertex (gl_ClipDistance is preferred)");
+    if (inIoAccessed("gl_CullDistance") && inIoAccessed("gl_ClipVertex"))
+        error(infoSink, "Can only use one of gl_CullDistance or gl_ClipVertex (gl_ClipDistance is preferred)");
 
     if (userOutputUsed() && (inIoAccessed("gl_FragColor") || inIoAccessed("gl_FragData")))
         error(infoSink, "Cannot use gl_FragColor or gl_FragData when using user-defined outputs");


### PR DESCRIPTION
I have this fragment shader which causes the compilation fails. Redeclaration of `gl_CullDistance `should be allowed.

```
#version 450

layout(location = 0) out float o1;
layout(location = 1) out float o2;

layout(binding = 0) uniform Uniforms
{
    int i;
};

in float gl_ClipDistance[6];
in float gl_CullDistance[2];

layout(location = 1) in float in1;

void main()
{
    o1 = gl_ClipDistance[3] + gl_CullDistance[1];
    o2 = gl_ClipDistance[i] + gl_CullDistance[i] + in1;
}
```