### PR TITLE
atoi comes from stddef.h or cstddef

### DIFF
--- a/StandAlone/ResourceLimits.cpp
+++ b/StandAlone/ResourceLimits.cpp
@@ -32,7 +32,8 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include <sstream>
 
 #include "ResourceLimits.h"


### PR DESCRIPTION
This is required to fix the Android build for ARM.