### PR TITLE
SPV: Fix an issue of interpolation decoration.

### DIFF
--- a/Test/baseResults/spv.qualifiers.vert.out
+++ b/Test/baseResults/spv.qualifiers.vert.out
@@ -21,9 +21,11 @@ Linked vertex stage:
                               Name 15  "outVf"
                               Name 17  "outVn"
                               Name 19  "outVcn"
+                              Decorate 9(outVc) Centroid
                               Decorate 15(outVf) Flat
                               Decorate 17(outVn) NoPerspective
                               Decorate 19(outVcn) NoPerspective
+                              Decorate 19(outVcn) Centroid
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32


### PR DESCRIPTION
I have this fragment shader and the "noperspective" and "sample" qualifiers do not coexist in SPIR-V. TranslateInterpolationDecoration() makes them mutually exclusive. This is unexpected.

```
#version 450

layout(location = 0) out float o1;
layout(location = 1) in noperspective sample float in1;

void main()
{
    o1 = in1;
}
```

Problematic line:
`layout(location = 1) in noperspective sample float in1;`