### PR TITLE
Add base class TParseables for intrinsic / builtin generation.

### DIFF
--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -1,6 +1,6 @@
 //
 //Copyright (C) 2002-2005  3Dlabs Inc. Ltd.
-//Copyright (C) 2012-2015 LunarG, Inc.
+//Copyright (C) 2012-2016 LunarG, Inc.
 //Copyright (C) 2015-2016 Google, Inc.
 //
 //All rights reserved.
@@ -43,9 +43,9 @@
 // Where to put a built-in:
 //   TBuiltIns::initialize(version,profile)       context-independent textual built-ins; add them to the right string
 //   TBuiltIns::initialize(resources,...)         context-dependent textual built-ins; add them to the right string
-//   IdentifyBuiltIns(...,symbolTable)            context-independent programmatic additions/mappings to the symbol table,
+//   TBuiltIns::identifyBuiltIns(...,symbolTable) context-independent programmatic additions/mappings to the symbol table,
 //                                                including identifying what extensions are needed if a version does not allow a symbol
-//   IdentifyBuiltIns(...,symbolTable, resources) context-dependent programmatic additions/mappings to the symbol table,
+//   TBuiltIns::identifyBuiltIns(...,symbolTable, resources) context-dependent programmatic additions/mappings to the symbol table,
 //                                                including identifying what extensions are needed if a version does not allow a symbol
 //
 
@@ -66,6 +66,16 @@ bool PureOperatorBuiltins = true;
 inline bool IncludeLegacy(int version, EProfile profile, int spv)
 {
     return profile != EEsProfile && (version <= 130 || (spv == 0 && ARBCompatibility) || profile == ECompatibilityProfile);
+}
+
+// Construct TBuiltInParseables base class.  This can be used for language-common constructs.
+TBuiltInParseables::TBuiltInParseables()
+{
+}
+
+// Destroy TBuiltInParseables.
+TBuiltInParseables::~TBuiltInParseables()
+{
 }
 
 TBuiltIns::TBuiltIns()
@@ -94,6 +104,7 @@ TBuiltIns::TBuiltIns()
 TBuiltIns::~TBuiltIns()
 {
 }
+
 
 //
 // Add all context-independent built-in functions and variables that are present
@@ -3525,7 +3536,7 @@ static void BuiltInVariable(const char* blockName, const char* name, TBuiltInVar
 // 3) Tag extension-related symbols added to their base version with their extensions, so
 //    that if an early version has the extension turned off, there is an error reported on use.
 //
-void IdentifyBuiltIns(int version, EProfile profile, int spv, int vulkan, EShLanguage language, TSymbolTable& symbolTable)
+void TBuiltIns::identifyBuiltIns(int version, EProfile profile, int spv, int vulkan, EShLanguage language, TSymbolTable& symbolTable)
 {
     //
     // Tag built-in variables and functions with additional qualifier and extension information
@@ -4221,7 +4232,7 @@ void IdentifyBuiltIns(int version, EProfile profile, int spv, int vulkan, EShLan
 // 2) Tag extension-related symbols added to their base version with their extensions, so
 //    that if an early version has the extension turned off, there is an error reported on use.
 //
-void IdentifyBuiltIns(int version, EProfile profile, int spv, int /*vulkan*/, EShLanguage language, TSymbolTable& symbolTable, const TBuiltInResource &resources)
+void TBuiltIns::identifyBuiltIns(int version, EProfile profile, int spv, int /*vulkan*/, EShLanguage language, TSymbolTable& symbolTable, const TBuiltInResource &resources)
 {
     if (profile != EEsProfile && version >= 430 && version < 440) {
         symbolTable.setVariableExtensions("gl_MaxTransformFeedbackBuffers", 1, &E_GL_ARB_enhanced_layouts);

--- a/glslang/MachineIndependent/Initialize.h
+++ b/glslang/MachineIndependent/Initialize.h
@@ -1,6 +1,6 @@
 //
 //Copyright (C) 2002-2005  3Dlabs Inc. Ltd.
-//Copyright (C) 2013 LunarG, Inc.
+//Copyright (C) 2013-2016 LunarG, Inc.
 //
 //All rights reserved.
 //
@@ -49,20 +49,48 @@ namespace glslang {
 // This is made to hold parseable strings for almost all the built-in
 // functions and variables for one specific combination of version
 // and profile.  (Some still need to be added programmatically.)
+// This is a base class for language-specific derivations, which
+// can be used for language independent builtins.
 //
 // The strings are organized by
 //    commonBuiltins:  intersection of all stages' built-ins, processed just once
 //    stageBuiltins[]: anything a stage needs that's not in commonBuiltins
 //
-class TBuiltIns {
+class TBuiltInParseables {
+public:
+    POOL_ALLOCATOR_NEW_DELETE(GetThreadPoolAllocator())
+    TBuiltInParseables();
+    virtual ~TBuiltInParseables();
+    virtual void initialize(int version, EProfile, int spv, int vulkan) = 0;
+    virtual void initialize(const TBuiltInResource& resources, int version, EProfile, int spv, int vulkan, EShLanguage) = 0;
+    virtual const TString& getCommonString() const { return commonBuiltins; }
+    virtual const TString& getStageString(EShLanguage language) const { return stageBuiltins[language]; }
+
+    virtual void identifyBuiltIns(int version, EProfile profile, int spv, int vulkan, EShLanguage language, TSymbolTable& symbolTable) = 0;
+    
+    virtual void identifyBuiltIns(int version, EProfile profile, int spv, int /*vulkan*/, EShLanguage language, TSymbolTable& symbolTable, const TBuiltInResource &resources) = 0;
+
+protected:
+    TString commonBuiltins;
+    TString stageBuiltins[EShLangCount];
+};
+
+//
+// This is a GLSL specific derivation of TBuiltInParseables.  To present a stable
+// interface and match other similar code, it is called TBuiltIns, rather
+// than TBuiltInParseablesGlsl.
+//
+class TBuiltIns : public TBuiltInParseables {
 public:
     POOL_ALLOCATOR_NEW_DELETE(GetThreadPoolAllocator())
     TBuiltIns();
     virtual ~TBuiltIns();
     void initialize(int version, EProfile, int spv, int vulkan);
     void initialize(const TBuiltInResource& resources, int version, EProfile, int spv, int vulkan, EShLanguage);
-    const TString& getCommonString() const { return commonBuiltins; }
-    const TString& getStageString(EShLanguage language) const { return stageBuiltins[language]; }
+
+    void identifyBuiltIns(int version, EProfile profile, int spv, int vulkan, EShLanguage language, TSymbolTable& symbolTable);
+    
+    void identifyBuiltIns(int version, EProfile profile, int spv, int /*vulkan*/, EShLanguage language, TSymbolTable& symbolTable, const TBuiltInResource &resources);
 
 protected:
     void add2ndGenerationSamplingImaging(int version, EProfile profile, int spv, int vulkan);
@@ -72,9 +100,6 @@ protected:
     void addSamplingFunctions(TSampler, TString& typeName, int version, EProfile profile);
     void addGatherFunctions(TSampler, TString& typeName, int version, EProfile profile);
 
-    TString commonBuiltins;
-    TString stageBuiltins[EShLangCount];
-
     // Helpers for making textual representations of the permutations
     // of texturing/imaging functions.
     const char* postfixes[5];
@@ -82,8 +107,6 @@ protected:
     int dimMap[EsdNumDims];
 };
 
-void IdentifyBuiltIns(int version, EProfile profile, int spv, int vulkan, EShLanguage, TSymbolTable&);
-void IdentifyBuiltIns(int version, EProfile profile, int spv, int vulkan, EShLanguage, TSymbolTable&, const TBuiltInResource &resources);
 
 } // end namespace glslang
 

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1,6 +1,6 @@
 //
 //Copyright (C) 2002-2005  3Dlabs Inc. Ltd.
-//Copyright (C) 2013-2015 LunarG, Inc.
+//Copyright (C) 2013-2016 LunarG, Inc.
 //Copyright (C) 2015-2016 Google, Inc.
 //
 //All rights reserved.
@@ -44,9 +44,11 @@
 #include <string.h>
 #include <iostream>
 #include <sstream>
+#include <memory>
 #include "SymbolTable.h"
 #include "ParseHelper.h"
 #include "../../hlsl/hlslParseHelper.h"
+#include "../../hlsl/hlslParseables.h"
 #include "Scan.h"
 #include "ScanContext.h"
 
@@ -64,6 +66,22 @@ namespace { // anonymous namespace for file-local functions and symbols
 
 using namespace glslang;
 
+// Create a language specific version of parseables.
+TBuiltInParseables* CreateBuiltInParseables(TInfoSink& infoSink, EShSource source)
+{
+    // TODO: hardcode to the GLSL path, until HLSL intrinsics are available.
+    source = EShSourceGlsl; // REMOVE
+
+    switch (source) {
+    case EShSourceGlsl: return new TBuiltIns();              // GLSL builtIns
+    case EShSourceHlsl: return new TBuiltInParseablesHlsl(); // HLSL intrinsics
+
+    default:
+        infoSink.info.message(EPrefixInternalError, "Unable to determine source language");
+        return nullptr;
+    }
+}
+    
 // Local mapping functions for making arrays of symbol tables....
 
 int MapVersionToIndex(int version)
@@ -171,11 +189,12 @@ int CommonIndex(EProfile profile, EShLanguage language)
 //
 // To initialize per-stage shared tables, with the common table already complete.
 //
-void InitializeStageSymbolTable(TBuiltIns& builtIns, int version, EProfile profile, int spv, int vulkan, EShLanguage language, TInfoSink& infoSink, TSymbolTable** commonTable, TSymbolTable** symbolTables)
+void InitializeStageSymbolTable(TBuiltInParseables& builtInParseables, int version, EProfile profile, int spv, int vulkan,
+                                EShLanguage language, TInfoSink& infoSink, TSymbolTable** commonTable, TSymbolTable** symbolTables)
 {
     (*symbolTables[language]).adoptLevels(*commonTable[CommonIndex(profile, language)]);
-    InitializeSymbolTable(builtIns.getStageString(language), version, profile, spv, vulkan, language, infoSink, *symbolTables[language]);
-    IdentifyBuiltIns(version, profile, spv, vulkan, language, *symbolTables[language]);
+    InitializeSymbolTable(builtInParseables.getStageString(language), version, profile, spv, vulkan, language, infoSink, *symbolTables[language]);
+    builtInParseables.identifyBuiltIns(version, profile, spv, vulkan, language, *symbolTables[language]);
     if (profile == EEsProfile && version >= 300)
         (*symbolTables[language]).setNoBuiltInRedeclarations();
     if (version == 110)
@@ -186,49 +205,51 @@ void InitializeStageSymbolTable(TBuiltIns& builtIns, int version, EProfile profi
 // Initialize the full set of shareable symbol tables;
 // The common (cross-stage) and those shareable per-stage.
 //
-bool InitializeSymbolTables(TInfoSink& infoSink, TSymbolTable** commonTable,  TSymbolTable** symbolTables, int version, EProfile profile, int spv, int vulkan)
+bool InitializeSymbolTables(TInfoSink& infoSink, TSymbolTable** commonTable,  TSymbolTable** symbolTables, int version, EProfile profile, int spv, int vulkan, EShSource source)
 {
-    TBuiltIns builtIns;
-    builtIns.initialize(version, profile, spv, vulkan);
+    std::unique_ptr<TBuiltInParseables> builtInParseables(CreateBuiltInParseables(infoSink, source));
+
+    builtInParseables->initialize(version, profile, spv, vulkan);
 
     // do the common tables
-    InitializeSymbolTable(builtIns.getCommonString(), version, profile, spv, vulkan, EShLangVertex, infoSink, *commonTable[EPcGeneral]);
+    InitializeSymbolTable(builtInParseables->getCommonString(), version, profile, spv, vulkan, EShLangVertex, infoSink, *commonTable[EPcGeneral]);
     if (profile == EEsProfile)
-        InitializeSymbolTable(builtIns.getCommonString(), version, profile, spv, vulkan, EShLangFragment, infoSink, *commonTable[EPcFragment]);
+        InitializeSymbolTable(builtInParseables->getCommonString(), version, profile, spv, vulkan, EShLangFragment, infoSink, *commonTable[EPcFragment]);
 
     // do the per-stage tables
 
     // always have vertex and fragment
-    InitializeStageSymbolTable(builtIns, version, profile, spv, vulkan, EShLangVertex, infoSink, commonTable, symbolTables);
-    InitializeStageSymbolTable(builtIns, version, profile, spv, vulkan, EShLangFragment, infoSink, commonTable, symbolTables);
+    InitializeStageSymbolTable(*builtInParseables, version, profile, spv, vulkan, EShLangVertex, infoSink, commonTable, symbolTables);
+    InitializeStageSymbolTable(*builtInParseables, version, profile, spv, vulkan, EShLangFragment, infoSink, commonTable, symbolTables);
 
     // check for tessellation
     if ((profile != EEsProfile && version >= 150) ||
         (profile == EEsProfile && version >= 310)) {
-        InitializeStageSymbolTable(builtIns, version, profile, spv, vulkan, EShLangTessControl, infoSink, commonTable, symbolTables);
-        InitializeStageSymbolTable(builtIns, version, profile, spv, vulkan, EShLangTessEvaluation, infoSink, commonTable, symbolTables);
+        InitializeStageSymbolTable(*builtInParseables, version, profile, spv, vulkan, EShLangTessControl, infoSink, commonTable, symbolTables);
+        InitializeStageSymbolTable(*builtInParseables, version, profile, spv, vulkan, EShLangTessEvaluation, infoSink, commonTable, symbolTables);
     }
 
     // check for geometry
     if ((profile != EEsProfile && version >= 150) ||
         (profile == EEsProfile && version >= 310))
-        InitializeStageSymbolTable(builtIns, version, profile, spv, vulkan, EShLangGeometry, infoSink, commonTable, symbolTables);
+        InitializeStageSymbolTable(*builtInParseables, version, profile, spv, vulkan, EShLangGeometry, infoSink, commonTable, symbolTables);
 
     // check for compute
     if ((profile != EEsProfile && version >= 430) ||
         (profile == EEsProfile && version >= 310))
-        InitializeStageSymbolTable(builtIns, version, profile, spv, vulkan, EShLangCompute, infoSink, commonTable, symbolTables);
-
+        InitializeStageSymbolTable(*builtInParseables, version, profile, spv, vulkan, EShLangCompute, infoSink, commonTable, symbolTables);
+    
     return true;
 }
 
-bool AddContextSpecificSymbols(const TBuiltInResource* resources, TInfoSink& infoSink, TSymbolTable& symbolTable, int version, EProfile profile, int spv, int vulkan, EShLanguage language)
+bool AddContextSpecificSymbols(const TBuiltInResource* resources, TInfoSink& infoSink, TSymbolTable& symbolTable, int version,
+                               EProfile profile, int spv, int vulkan, EShLanguage language, EShSource source)
 {
-    TBuiltIns builtIns;
+    std::unique_ptr<TBuiltInParseables> builtInParseables(CreateBuiltInParseables(infoSink, source));
     
-    builtIns.initialize(*resources, version, profile, spv, vulkan, language);
-    InitializeSymbolTable(builtIns.getCommonString(), version, profile, spv, vulkan, language, infoSink, symbolTable);
-    IdentifyBuiltIns(version, profile, spv, vulkan, language, symbolTable, *resources);
+    builtInParseables->initialize(*resources, version, profile, spv, vulkan, language);
+    InitializeSymbolTable(builtInParseables->getCommonString(), version, profile, spv, vulkan, language, infoSink, symbolTable);
+    builtInParseables->identifyBuiltIns(version, profile, spv, vulkan, language, symbolTable, *resources);
 
     return true;
 }
@@ -245,7 +266,7 @@ bool AddContextSpecificSymbols(const TBuiltInResource* resources, TInfoSink& inf
 // This only gets done the first time any thread needs a particular symbol table
 // (lazy evaluation).
 //
-void SetupBuiltinSymbolTable(int version, EProfile profile, int spv, int vulkan)
+void SetupBuiltinSymbolTable(int version, EProfile profile, int spv, int vulkan, EShSource source)
 {
     TInfoSink infoSink;
 
@@ -275,7 +296,7 @@ void SetupBuiltinSymbolTable(int version, EProfile profile, int spv, int vulkan)
         stageTables[stage] = new TSymbolTable;
 
     // Generate the local symbol tables using the new pool
-    InitializeSymbolTables(infoSink, commonTable, stageTables, version, profile, spv, vulkan);
+    InitializeSymbolTables(infoSink, commonTable, stageTables, version, profile, spv, vulkan, source);
 
     // Switch to the process-global pool
     SetThreadPoolAllocator(*PerProcessGPA);
@@ -579,7 +600,7 @@ bool ProcessDeferred(
     intermediate.setSpv(spv);
     if (vulkan)
         intermediate.setOriginUpperLeft();
-    SetupBuiltinSymbolTable(version, profile, spv, vulkan);
+    SetupBuiltinSymbolTable(version, profile, spv, vulkan, source);
     
     TSymbolTable* cachedTable = SharedSymbolTables[MapVersionToIndex(version)]
                                                   [MapProfileToIndex(profile)]
@@ -593,7 +614,8 @@ bool ProcessDeferred(
     
     // Add built-in symbols that are potentially context dependent;
     // they get popped again further down.
-    AddContextSpecificSymbols(resources, compiler->infoSink, symbolTable, version, profile, spv, vulkan, compiler->getLanguage());
+    AddContextSpecificSymbols(resources, compiler->infoSink, symbolTable, version, profile, spv, vulkan,
+                              compiler->getLanguage(), source);
     
     //
     // Now we can process the full shader under proper symbols and rules.

--- a/hlsl/CMakeLists.txt
+++ b/hlsl/CMakeLists.txt
@@ -3,7 +3,8 @@ set(SOURCES
     hlslScanContext.cpp
     hlslOpMap.cpp
     hlslTokenStream.cpp
-    hlslGrammar.cpp)
+    hlslGrammar.cpp
+    hlslParseables.cpp)
 
 set(HEADERS
     hlslParseHelper.h
@@ -11,7 +12,8 @@ set(HEADERS
     hlslScanContext.h
     hlslOpMap.h
     hlslTokenStream.h
-    hlslGrammar.h)
+    hlslGrammar.h
+    hlslParseables.h)
 
 add_library(HLSL STATIC ${SOURCES} ${HEADERS})
 set_property(TARGET HLSL PROPERTY FOLDER hlsl)

--- a/hlsl/hlslParseables.cpp
+++ b/hlsl/hlslParseables.cpp
@@ -1,0 +1,117 @@
+//
+//Copyright (C) 2016 LunarG, Inc.
+//
+//All rights reserved.
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions
+//are met:
+//
+//    Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//    Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//    Neither the name of 3Dlabs Inc. Ltd. nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+//"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+//LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+//FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+//COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+//CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+//LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+//ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//POSSIBILITY OF SUCH DAMAGE.
+//
+
+//
+// Create strings that declare built-in definitions, add built-ins programmatically 
+// that cannot be expressed in the strings, and establish mappings between
+// built-in functions and operators.
+//
+// Where to put a built-in:
+//   TBuiltInParseablesHlsl::initialize(version,profile) context-independent textual built-ins; add them to the right string
+//   TBuiltInParseablesHlsl::initialize(resources,...)   context-dependent textual built-ins; add them to the right string
+//   TBuiltInParseablesHlsl::identifyBuiltIns(...,symbolTable) context-independent programmatic additions/mappings to the symbol table,
+//                                                including identifying what extensions are needed if a version does not allow a symbol
+//   TBuiltInParseablesHlsl::identifyBuiltIns(...,symbolTable, resources) context-dependent programmatic additions/mappings to the
+//                                                symbol table, including identifying what extensions are needed if a version does
+//                                                not allow a symbol
+//
+
+#include "hlslParseables.h"
+
+namespace glslang {
+
+TBuiltInParseablesHlsl::TBuiltInParseablesHlsl()
+{
+    assert(0 && "Unimplemented TBuiltInParseablesHlsl::TBuiltInParseablesHlsl");
+}
+
+//
+// Add all context-independent built-in functions and variables that are present
+// for the given version and profile.  Share common ones across stages, otherwise
+// make stage-specific entries.
+//
+// Most built-ins variables can be added as simple text strings.  Some need to
+// be added programmatically, which is done later in IdentifyBuiltIns() below.
+//
+void TBuiltInParseablesHlsl::initialize(int version, EProfile profile, int spv, int vulkan)
+{
+    assert(0 && "Unimplemented TBuiltInParseablesHlsl::initialize");
+}
+
+//
+// Add context-dependent built-in functions and variables that are present
+// for the given version and profile.  All the results are put into just the
+// commonBuiltins, because it is called for just a specific stage.  So,
+// add stage-specific entries to the commonBuiltins, and only if that stage
+// was requested.
+//
+void TBuiltInParseablesHlsl::initialize(const TBuiltInResource &resources, int version, EProfile profile, int spv,
+                                        int vulkan, EShLanguage language)
+{
+    assert(0 && "Unimplemented TBuiltInParseablesHlsl::initialize");
+}
+
+
+//
+// Finish adding/processing context-independent built-in symbols.
+// 1) Programmatically add symbols that could not be added by simple text strings above.
+// 2) Map built-in functions to operators, for those that will turn into an operation node
+//    instead of remaining a function call.
+// 3) Tag extension-related symbols added to their base version with their extensions, so
+//    that if an early version has the extension turned off, there is an error reported on use.
+//
+void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, int spv, int vulkan, EShLanguage language,
+                                              TSymbolTable& symbolTable)
+{
+    assert(0 && "Unimplemented TBuiltInParseablesHlsl::identifyBuiltIns");
+}
+
+//
+// Add context-dependent (resource-specific) built-ins not handled by the above.  These
+// would be ones that need to be programmatically added because they cannot 
+// be added by simple text strings.  For these, also
+// 1) Map built-in functions to operators, for those that will turn into an operation node
+//    instead of remaining a function call.
+// 2) Tag extension-related symbols added to their base version with their extensions, so
+//    that if an early version has the extension turned off, there is an error reported on use.
+//
+void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, int spv, int /*vulkan*/, EShLanguage language,
+                                              TSymbolTable& symbolTable, const TBuiltInResource &resources)
+{
+    assert(0 && "Unimplemented TBuiltInParseablesHlsl::identifyBuiltIns");
+}
+
+
+} // end namespace glslang

--- a/hlsl/hlslParseables.h
+++ b/hlsl/hlslParseables.h
@@ -1,0 +1,61 @@
+//
+//Copyright (C) 2016 LunarG, Inc.
+//
+//All rights reserved.
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions
+//are met:
+//
+//    Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//    Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//    Neither the name of 3Dlabs Inc. Ltd. nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+//"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+//LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+//FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+//COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+//CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+//LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+//ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef _HLSLPARSEABLES_INCLUDED_
+#define _HLSLPARSEABLES_INCLUDED_
+
+#include "../glslang/MachineIndependent/Initialize.h"
+
+namespace glslang {
+
+//
+// This is an HLSL specific derivation of TBuiltInParseables.  See comment
+// above TBuiltInParseables for details.
+//
+class TBuiltInParseablesHlsl : public TBuiltInParseables {
+public:
+    POOL_ALLOCATOR_NEW_DELETE(GetThreadPoolAllocator())
+    TBuiltInParseablesHlsl();
+    void initialize(int version, EProfile, int spv, int vulkan);
+    void initialize(const TBuiltInResource& resources, int version, EProfile, int spv, int vulkan, EShLanguage);
+
+    void identifyBuiltIns(int version, EProfile profile, int spv, int vulkan, EShLanguage language, TSymbolTable& symbolTable);
+    
+    void identifyBuiltIns(int version, EProfile profile, int spv, int /*vulkan*/, EShLanguage language, TSymbolTable& symbolTable, const TBuiltInResource &resources);
+};
+
+} // end namespace glslang
+
+#endif // _HLSLPARSEABLES_INCLUDED_


### PR DESCRIPTION
Add base class TParseableBuiltInss for language-dependent intrinsics / builtins generation.  Add stubbed HLSL derivation.  GLSL derivation is still called TBuiltIns (its original name), for historical compatibility.
