### PR TITLE
For MinGW, statically link exes against basic runtimes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,17 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     add_definitions(-std=c++11)
 endif()
 
+function(glslang_set_link_args TARGET)
+    # For MinGW compiles, statically link against the GCC and C++ runtimes.
+    # This avoids the need to ship those runtimes as DLLs.
+    if(WIN32)
+	if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+	    set_target_properties(${TARGET} PROPERTIES
+		    LINK_FLAGS "-static -static-libgcc -static-libstdc++")
+        endif()
+    endif(WIN32)
+endfunction(glslang_set_link_args)
+
 # We depend on these for later projects, so they should come first.
 add_subdirectory(External)
 

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -15,6 +15,8 @@ add_executable(glslangValidator ${SOURCES})
 add_executable(spirv-remap ${REMAPPER_SOURCES})
 set_property(TARGET glslangValidator PROPERTY FOLDER tools)
 set_property(TARGET spirv-remap PROPERTY FOLDER tools)
+glslang_set_link_args(glslangValidator)
+glslang_set_link_args(spirv-remap)
 
 set(LIBRARIES
     glslang

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -22,6 +22,7 @@ if (TARGET gmock)
 
   add_executable(glslangtests ${TEST_SOURCES})
   set_property(TARGET glslangtests PROPERTY FOLDER tests)
+  glslang_set_link_args(glslangtests)
   install(TARGETS glslangtests
         RUNTIME DESTINATION bin)
 


### PR DESCRIPTION
Avoids the need to ship basic runtimes like libgcc_s_sjlj-1.dll
with the executables.