### PR TITLE
remapper: do not eliminate interface variables in dce by default

### DIFF
--- a/SPIRV/SPVRemapper.cpp
+++ b/SPIRV/SPVRemapper.cpp
@@ -926,8 +926,17 @@ namespace spv {
         // Count function variable use
         process(
             [&](spv::Op opCode, unsigned start) {
-                if (opCode == spv::OpVariable) { ++varUseCount[asId(start+2)]; return true; }
-                return false;
+                if (opCode == spv::OpVariable) {
+                    ++varUseCount[asId(start+2)];
+                    return true;
+                } else if (opCode == spv::OpEntryPoint) {
+                    const int wordCount = asWordCount(start);
+                    for (int i = 4; i < wordCount; i++) {
+                        ++varUseCount[asId(start+i)];
+                    }
+                    return true;
+                } else
+                    return false;
             },
 
             [&](spv::Id& id) { if (varUseCount[id]) ++varUseCount[id]; }


### PR DESCRIPTION
this is done by counting op_entrypoint as a use/def

in lieu of a formal regression test for the remapper, I did before/after comparison across the glslang spv test shaders as well as our entire customer shader base.