### PR TITLE
Fix for empty statement segfault

### DIFF
--- a/Test/hlsl.intrinsics.vert
+++ b/Test/hlsl.intrinsics.vert
@@ -298,7 +298,7 @@ float4 VertexShaderFunction(float4 inF0, float4 inF1, float4 inF2)
 float2x2 VertexShaderFunction(float2x2 inF0, float2x2 inF1, float2x2 inF2)
 {
     // TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
-    MATFNS()
+    MATFNS();
 
     // TODO: ... add when float1 prototypes are generated
     return float2x2(2,2,2,2);
@@ -307,7 +307,7 @@ float2x2 VertexShaderFunction(float2x2 inF0, float2x2 inF1, float2x2 inF2)
 float3x3 VertexShaderFunction(float3x3 inF0, float3x3 inF1, float3x3 inF2)
 {
     // TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
-    MATFNS()
+    MATFNS();
 
     // TODO: ... add when float1 prototypes are generated
     return float3x3(3,3,3,3,3,3,3,3,3);
@@ -316,7 +316,7 @@ float3x3 VertexShaderFunction(float3x3 inF0, float3x3 inF1, float3x3 inF2)
 float4x4 VertexShaderFunction(float4x4 inF0, float4x4 inF1, float4x4 inF2)
 {
     // TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
-    MATFNS()
+    MATFNS();
 
     // TODO: ... add when float1 prototypes are generated
     return float4x4(4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4);

--- a/hlsl/hlslGrammar.cpp
+++ b/hlsl/hlslGrammar.cpp
@@ -492,6 +492,8 @@ bool HlslGrammar::acceptFunctionDefinition(TFunction& function, TIntermNode*& no
 //
 bool HlslGrammar::acceptExpression(TIntermTyped*& node)
 {
+    node = nullptr;
+
     // assignment_expression
     if (! acceptAssignmentExpression(node))
         return false;


### PR DESCRIPTION
This is a small fix for a segfault in the HLSL parser on empty statements (such as ";;").  HlslGrammar::acceptExpression() would accept them with success, but was leaving "node" pointing to garbage in that case, causing later code to crash.

The PR also adds back in a test case for this as part of the intrinsics tests.
