### PR TITLE
Add negative intrinsics tests

### DIFF
--- a/Test/baseResults/hlsl.intrinsics.negative.frag.out
+++ b/Test/baseResults/hlsl.intrinsics.negative.frag.out
@@ -1,0 +1,702 @@
+hlsl.intrinsics.negative.frag
+ERROR: 0:5: 'asdouble' : no matching overloaded function found 
+ERROR: 0:6: 'CheckAccessFullyMapped' : no matching overloaded function found 
+ERROR: 0:7: 'countbits' : no matching overloaded function found 
+ERROR: 0:8: 'cross' : no matching overloaded function found 
+ERROR: 0:9: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
+ERROR: 0:10: 'determinant' : no matching overloaded function found 
+ERROR: 0:12: 'f16tof32' : no matching overloaded function found 
+ERROR: 0:13: 'firstbithigh' : no matching overloaded function found 
+ERROR: 0:14: 'firstbitlow' : no matching overloaded function found 
+ERROR: 0:15: 'fma' : no matching overloaded function found 
+ERROR: 0:23: 'length' : no matching overloaded function found 
+ERROR: 0:24: 'msad4' : no matching overloaded function found 
+ERROR: 0:25: 'normalize' : no matching overloaded function found 
+ERROR: 0:26: 'reflect' : no matching overloaded function found 
+ERROR: 0:27: 'refract' : no matching overloaded function found 
+ERROR: 0:28: 'refract' : no matching overloaded function found 
+ERROR: 0:29: 'reversebits' : no matching overloaded function found 
+ERROR: 0:30: 'transpose' : no matching overloaded function found 
+ERROR: 0:39: 'GetRenderTargetSamplePosition' : no matching overloaded function found 
+ERROR: 0:46: 'asdouble' : no matching overloaded function found 
+ERROR: 0:47: 'CheckAccessFullyMapped' : no matching overloaded function found 
+ERROR: 0:48: 'countbits' : no matching overloaded function found 
+ERROR: 0:49: 'cross' : no matching overloaded function found 
+ERROR: 0:50: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
+ERROR: 0:51: 'determinant' : no matching overloaded function found 
+ERROR: 0:52: 'f16tof32' : no matching overloaded function found 
+ERROR: 0:53: 'firstbithigh' : no matching overloaded function found 
+ERROR: 0:54: 'firstbitlow' : no matching overloaded function found 
+ERROR: 0:55: 'fma' : no matching overloaded function found 
+ERROR: 0:56: 'reversebits' : no matching overloaded function found 
+ERROR: 0:57: 'transpose' : no matching overloaded function found 
+ERROR: 0:64: 'CheckAccessFullyMapped' : no matching overloaded function found 
+ERROR: 0:65: 'countbits' : no matching overloaded function found 
+ERROR: 0:66: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
+ERROR: 0:67: 'determinant' : no matching overloaded function found 
+ERROR: 0:68: 'f16tof32' : no matching overloaded function found 
+ERROR: 0:69: 'firstbithigh' : no matching overloaded function found 
+ERROR: 0:70: 'firstbitlow' : no matching overloaded function found 
+ERROR: 0:71: 'fma' : no matching overloaded function found 
+ERROR: 0:72: 'reversebits' : no matching overloaded function found 
+ERROR: 0:73: 'transpose' : no matching overloaded function found 
+ERROR: 0:81: 'CheckAccessFullyMapped' : no matching overloaded function found 
+ERROR: 0:82: 'countbits' : no matching overloaded function found 
+ERROR: 0:83: 'cross' : no matching overloaded function found 
+ERROR: 0:84: 'determinant' : no matching overloaded function found 
+ERROR: 0:85: 'f16tof32' : no matching overloaded function found 
+ERROR: 0:86: 'firstbithigh' : no matching overloaded function found 
+ERROR: 0:87: 'firstbitlow' : no matching overloaded function found 
+ERROR: 0:88: 'fma' : no matching overloaded function found 
+ERROR: 0:89: 'reversebits' : no matching overloaded function found 
+ERROR: 0:90: 'transpose' : no matching overloaded function found 
+ERROR: 0:118: 'countbits' : no matching overloaded function found 
+ERROR: 0:118: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
+ERROR: 0:118: 'cross' : no matching overloaded function found 
+ERROR: 0:118: 'f16tof32' : no matching overloaded function found 
+ERROR: 0:118: 'firstbithigh' : no matching overloaded function found 
+ERROR: 0:118: 'firstbitlow' : no matching overloaded function found 
+ERROR: 0:118: 'fma' : no matching overloaded function found 
+ERROR: 0:118: 'reversebits' : no matching overloaded function found 
+ERROR: 0:118: 'length' : no matching overloaded function found 
+ERROR: 0:118: 'noise' : no matching overloaded function found 
+ERROR: 0:118: 'normalize' : no matching overloaded function found 
+ERROR: 0:118: 'reflect' : no matching overloaded function found 
+ERROR: 0:118: 'refract' : no matching overloaded function found 
+ERROR: 0:118: 'reversebits' : no matching overloaded function found 
+ERROR: 0:126: 'countbits' : no matching overloaded function found 
+ERROR: 0:126: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
+ERROR: 0:126: 'cross' : no matching overloaded function found 
+ERROR: 0:126: 'f16tof32' : no matching overloaded function found 
+ERROR: 0:126: 'firstbithigh' : no matching overloaded function found 
+ERROR: 0:126: 'firstbitlow' : no matching overloaded function found 
+ERROR: 0:126: 'fma' : no matching overloaded function found 
+ERROR: 0:126: 'reversebits' : no matching overloaded function found 
+ERROR: 0:126: 'length' : no matching overloaded function found 
+ERROR: 0:126: 'noise' : no matching overloaded function found 
+ERROR: 0:126: 'normalize' : no matching overloaded function found 
+ERROR: 0:126: 'reflect' : no matching overloaded function found 
+ERROR: 0:126: 'refract' : no matching overloaded function found 
+ERROR: 0:126: 'reversebits' : no matching overloaded function found 
+ERROR: 0:134: 'countbits' : no matching overloaded function found 
+ERROR: 0:134: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
+ERROR: 0:134: 'cross' : no matching overloaded function found 
+ERROR: 0:134: 'f16tof32' : no matching overloaded function found 
+ERROR: 0:134: 'firstbithigh' : no matching overloaded function found 
+ERROR: 0:134: 'firstbitlow' : no matching overloaded function found 
+ERROR: 0:134: 'fma' : no matching overloaded function found 
+ERROR: 0:134: 'reversebits' : no matching overloaded function found 
+ERROR: 0:134: 'length' : no matching overloaded function found 
+ERROR: 0:134: 'noise' : no matching overloaded function found 
+ERROR: 0:134: 'normalize' : no matching overloaded function found 
+ERROR: 0:134: 'reflect' : no matching overloaded function found 
+ERROR: 0:134: 'refract' : no matching overloaded function found 
+ERROR: 0:134: 'reversebits' : no matching overloaded function found 
+ERROR: 93 compilation errors.  No code generated.
+
+
+Shader version: 450
+gl_FragCoord origin is upper left
+ERROR: node is still EOpNull!
+0:35  Function Definition: PixelShaderFunction(f1;f1;f1;i1; (temp float)
+0:2    Function Parameters: 
+0:2      'inF0' (temp float)
+0:2      'inF1' (temp float)
+0:2      'inF2' (temp float)
+0:2      'inI0' (temp int)
+0:?     Sequence
+0:5      Constant:
+0:5        0.000000
+0:6      Constant:
+0:6        0.000000
+0:7      Constant:
+0:7        0.000000
+0:8      Constant:
+0:8        0.000000
+0:9      Constant:
+0:9        0.000000
+0:10      Constant:
+0:10        0.000000
+0:12      Constant:
+0:12        0.000000
+0:13      Constant:
+0:13        0.000000
+0:14      Constant:
+0:14        0.000000
+0:15      Constant:
+0:15        0.000000
+0:23      Constant:
+0:23        0.000000
+0:24      Constant:
+0:24        0.000000
+0:25      Constant:
+0:25        0.000000
+0:26      Constant:
+0:26        0.000000
+0:27      Constant:
+0:27        0.000000
+0:28      Constant:
+0:28        0.000000
+0:29      Constant:
+0:29        0.000000
+0:30      Constant:
+0:30        0.000000
+0:32      Branch: Return with expression
+0:32        Constant:
+0:32          0.000000
+0:44  Function Definition: PixelShaderFunction(vf1;vf1;vf1;i1; (temp 1-component vector of float)
+0:36    Function Parameters: 
+0:36      'inF0' (temp 1-component vector of float)
+0:36      'inF1' (temp 1-component vector of float)
+0:36      'inF2' (temp 1-component vector of float)
+0:36      'inI0' (temp int)
+0:?     Sequence
+0:39      Constant:
+0:39        0.000000
+0:41      Branch: Return with expression
+0:41        Constant:
+0:41          0.000000
+0:62  Function Definition: PixelShaderFunction(vf2;vf2;vf2;vi2; (temp 2-component vector of float)
+0:45    Function Parameters: 
+0:45      'inF0' (temp 2-component vector of float)
+0:45      'inF1' (temp 2-component vector of float)
+0:45      'inF2' (temp 2-component vector of float)
+0:45      'inI0' (temp 2-component vector of int)
+0:?     Sequence
+0:46      Constant:
+0:46        0.000000
+0:47      Constant:
+0:47        0.000000
+0:48      Constant:
+0:48        0.000000
+0:49      Constant:
+0:49        0.000000
+0:50      Constant:
+0:50        0.000000
+0:51      Constant:
+0:51        0.000000
+0:52      Constant:
+0:52        0.000000
+0:53      Constant:
+0:53        0.000000
+0:54      Constant:
+0:54        0.000000
+0:55      Constant:
+0:55        0.000000
+0:56      Constant:
+0:56        0.000000
+0:57      Constant:
+0:57        0.000000
+0:59      Branch: Return with expression
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:79  Function Definition: PixelShaderFunction(vf3;vf3;vf3;vi3; (temp 3-component vector of float)
+0:63    Function Parameters: 
+0:63      'inF0' (temp 3-component vector of float)
+0:63      'inF1' (temp 3-component vector of float)
+0:63      'inF2' (temp 3-component vector of float)
+0:63      'inI0' (temp 3-component vector of int)
+0:?     Sequence
+0:64      Constant:
+0:64        0.000000
+0:65      Constant:
+0:65        0.000000
+0:66      Constant:
+0:66        0.000000
+0:67      Constant:
+0:67        0.000000
+0:68      Constant:
+0:68        0.000000
+0:69      Constant:
+0:69        0.000000
+0:70      Constant:
+0:70        0.000000
+0:71      Constant:
+0:71        0.000000
+0:72      Constant:
+0:72        0.000000
+0:73      Constant:
+0:73        0.000000
+0:76      Branch: Return with expression
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:115  Function Definition: PixelShaderFunction(vf4;vf4;vf4;vi4; (temp 4-component vector of float)
+0:80    Function Parameters: 
+0:80      'inF0' (temp 4-component vector of float)
+0:80      'inF1' (temp 4-component vector of float)
+0:80      'inF2' (temp 4-component vector of float)
+0:80      'inI0' (temp 4-component vector of int)
+0:?     Sequence
+0:81      Constant:
+0:81        0.000000
+0:82      Constant:
+0:82        0.000000
+0:83      Constant:
+0:83        0.000000
+0:84      Constant:
+0:84        0.000000
+0:85      Constant:
+0:85        0.000000
+0:86      Constant:
+0:86        0.000000
+0:87      Constant:
+0:87        0.000000
+0:88      Constant:
+0:88        0.000000
+0:89      Constant:
+0:89        0.000000
+0:90      Constant:
+0:90        0.000000
+0:92      Branch: Return with expression
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:123  Function Definition: PixelShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:116    Function Parameters: 
+0:116      'inF0' (temp 2X2 matrix of float)
+0:116      'inF1' (temp 2X2 matrix of float)
+0:116      'inF2' (temp 2X2 matrix of float)
+0:?     Sequence
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:120      Branch: Return with expression
+0:?         Constant:
+0:?           2.000000
+0:?           2.000000
+0:?           2.000000
+0:?           2.000000
+0:131  Function Definition: PixelShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:124    Function Parameters: 
+0:124      'inF0' (temp 3X3 matrix of float)
+0:124      'inF1' (temp 3X3 matrix of float)
+0:124      'inF2' (temp 3X3 matrix of float)
+0:?     Sequence
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:128      Branch: Return with expression
+0:?         Constant:
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:138  Function Definition: PixelShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:132    Function Parameters: 
+0:132      'inF0' (temp 4X4 matrix of float)
+0:132      'inF1' (temp 4X4 matrix of float)
+0:132      'inF2' (temp 4X4 matrix of float)
+0:?     Sequence
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:136      Branch: Return with expression
+0:?         Constant:
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?   Linker Objects
+
+
+Linked fragment stage:
+
+
+Shader version: 450
+gl_FragCoord origin is upper left
+ERROR: node is still EOpNull!
+0:35  Function Definition: PixelShaderFunction(f1;f1;f1;i1; (temp float)
+0:2    Function Parameters: 
+0:2      'inF0' (temp float)
+0:2      'inF1' (temp float)
+0:2      'inF2' (temp float)
+0:2      'inI0' (temp int)
+0:?     Sequence
+0:5      Constant:
+0:5        0.000000
+0:6      Constant:
+0:6        0.000000
+0:7      Constant:
+0:7        0.000000
+0:8      Constant:
+0:8        0.000000
+0:9      Constant:
+0:9        0.000000
+0:10      Constant:
+0:10        0.000000
+0:12      Constant:
+0:12        0.000000
+0:13      Constant:
+0:13        0.000000
+0:14      Constant:
+0:14        0.000000
+0:15      Constant:
+0:15        0.000000
+0:23      Constant:
+0:23        0.000000
+0:24      Constant:
+0:24        0.000000
+0:25      Constant:
+0:25        0.000000
+0:26      Constant:
+0:26        0.000000
+0:27      Constant:
+0:27        0.000000
+0:28      Constant:
+0:28        0.000000
+0:29      Constant:
+0:29        0.000000
+0:30      Constant:
+0:30        0.000000
+0:32      Branch: Return with expression
+0:32        Constant:
+0:32          0.000000
+0:44  Function Definition: PixelShaderFunction(vf1;vf1;vf1;i1; (temp 1-component vector of float)
+0:36    Function Parameters: 
+0:36      'inF0' (temp 1-component vector of float)
+0:36      'inF1' (temp 1-component vector of float)
+0:36      'inF2' (temp 1-component vector of float)
+0:36      'inI0' (temp int)
+0:?     Sequence
+0:39      Constant:
+0:39        0.000000
+0:41      Branch: Return with expression
+0:41        Constant:
+0:41          0.000000
+0:62  Function Definition: PixelShaderFunction(vf2;vf2;vf2;vi2; (temp 2-component vector of float)
+0:45    Function Parameters: 
+0:45      'inF0' (temp 2-component vector of float)
+0:45      'inF1' (temp 2-component vector of float)
+0:45      'inF2' (temp 2-component vector of float)
+0:45      'inI0' (temp 2-component vector of int)
+0:?     Sequence
+0:46      Constant:
+0:46        0.000000
+0:47      Constant:
+0:47        0.000000
+0:48      Constant:
+0:48        0.000000
+0:49      Constant:
+0:49        0.000000
+0:50      Constant:
+0:50        0.000000
+0:51      Constant:
+0:51        0.000000
+0:52      Constant:
+0:52        0.000000
+0:53      Constant:
+0:53        0.000000
+0:54      Constant:
+0:54        0.000000
+0:55      Constant:
+0:55        0.000000
+0:56      Constant:
+0:56        0.000000
+0:57      Constant:
+0:57        0.000000
+0:59      Branch: Return with expression
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:79  Function Definition: PixelShaderFunction(vf3;vf3;vf3;vi3; (temp 3-component vector of float)
+0:63    Function Parameters: 
+0:63      'inF0' (temp 3-component vector of float)
+0:63      'inF1' (temp 3-component vector of float)
+0:63      'inF2' (temp 3-component vector of float)
+0:63      'inI0' (temp 3-component vector of int)
+0:?     Sequence
+0:64      Constant:
+0:64        0.000000
+0:65      Constant:
+0:65        0.000000
+0:66      Constant:
+0:66        0.000000
+0:67      Constant:
+0:67        0.000000
+0:68      Constant:
+0:68        0.000000
+0:69      Constant:
+0:69        0.000000
+0:70      Constant:
+0:70        0.000000
+0:71      Constant:
+0:71        0.000000
+0:72      Constant:
+0:72        0.000000
+0:73      Constant:
+0:73        0.000000
+0:76      Branch: Return with expression
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:115  Function Definition: PixelShaderFunction(vf4;vf4;vf4;vi4; (temp 4-component vector of float)
+0:80    Function Parameters: 
+0:80      'inF0' (temp 4-component vector of float)
+0:80      'inF1' (temp 4-component vector of float)
+0:80      'inF2' (temp 4-component vector of float)
+0:80      'inI0' (temp 4-component vector of int)
+0:?     Sequence
+0:81      Constant:
+0:81        0.000000
+0:82      Constant:
+0:82        0.000000
+0:83      Constant:
+0:83        0.000000
+0:84      Constant:
+0:84        0.000000
+0:85      Constant:
+0:85        0.000000
+0:86      Constant:
+0:86        0.000000
+0:87      Constant:
+0:87        0.000000
+0:88      Constant:
+0:88        0.000000
+0:89      Constant:
+0:89        0.000000
+0:90      Constant:
+0:90        0.000000
+0:92      Branch: Return with expression
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:123  Function Definition: PixelShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:116    Function Parameters: 
+0:116      'inF0' (temp 2X2 matrix of float)
+0:116      'inF1' (temp 2X2 matrix of float)
+0:116      'inF2' (temp 2X2 matrix of float)
+0:?     Sequence
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:118      Constant:
+0:118        0.000000
+0:120      Branch: Return with expression
+0:?         Constant:
+0:?           2.000000
+0:?           2.000000
+0:?           2.000000
+0:?           2.000000
+0:131  Function Definition: PixelShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:124    Function Parameters: 
+0:124      'inF0' (temp 3X3 matrix of float)
+0:124      'inF1' (temp 3X3 matrix of float)
+0:124      'inF2' (temp 3X3 matrix of float)
+0:?     Sequence
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:126      Constant:
+0:126        0.000000
+0:128      Branch: Return with expression
+0:?         Constant:
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:138  Function Definition: PixelShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:132    Function Parameters: 
+0:132      'inF0' (temp 4X4 matrix of float)
+0:132      'inF1' (temp 4X4 matrix of float)
+0:132      'inF2' (temp 4X4 matrix of float)
+0:?     Sequence
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:134      Constant:
+0:134        0.000000
+0:136      Branch: Return with expression
+0:?         Constant:
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?   Linker Objects
+
+SPIR-V is not generated for failed compile or link

--- a/Test/baseResults/hlsl.intrinsics.negative.vert.out
+++ b/Test/baseResults/hlsl.intrinsics.negative.vert.out
@@ -1,0 +1,1055 @@
+hlsl.intrinsics.negative.vert
+ERROR: 0:5: 'asdouble' : no matching overloaded function found 
+ERROR: 0:6: 'CheckAccessFullyMapped' : no matching overloaded function found 
+ERROR: 0:7: 'CheckAccessFullyMapped' : no matching overloaded function found 
+ERROR: 0:8: 'clip' : no matching overloaded function found 
+ERROR: 0:9: 'countbits' : no matching overloaded function found 
+ERROR: 0:10: 'cross' : no matching overloaded function found 
+ERROR: 0:11: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
+ERROR: 0:14: 'ddx' : no matching overloaded function found 
+ERROR: 0:15: 'ddx_coarse' : no matching overloaded function found 
+ERROR: 0:16: 'ddx_fine' : no matching overloaded function found 
+ERROR: 0:17: 'ddy' : no matching overloaded function found 
+ERROR: 0:18: 'ddy_coarse' : no matching overloaded function found 
+ERROR: 0:19: 'ddy_fine' : no matching overloaded function found 
+ERROR: 0:20: 'determinant' : no matching overloaded function found 
+ERROR: 0:21: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
+ERROR: 0:22: 'EvaluateAttributeAtSample' : no matching overloaded function found 
+ERROR: 0:23: 'EvaluateAttributeSnapped' : no matching overloaded function found 
+ERROR: 0:24: 'f16tof32' : no matching overloaded function found 
+ERROR: 0:25: 'firstbithigh' : no matching overloaded function found 
+ERROR: 0:26: 'firstbitlow' : no matching overloaded function found 
+ERROR: 0:27: 'fma' : no matching overloaded function found 
+ERROR: 0:35: 'length' : no matching overloaded function found 
+ERROR: 0:36: 'msad4' : no matching overloaded function found 
+ERROR: 0:37: 'normalize' : no matching overloaded function found 
+ERROR: 0:38: 'reflect' : no matching overloaded function found 
+ERROR: 0:39: 'refract' : no matching overloaded function found 
+ERROR: 0:40: 'refract' : no matching overloaded function found 
+ERROR: 0:41: 'reversebits' : no matching overloaded function found 
+ERROR: 0:42: 'transpose' : no matching overloaded function found 
+ERROR: 0:53: 'GetRenderTargetSamplePosition' : no matching overloaded function found 
+ERROR: 0:60: 'asdouble' : no matching overloaded function found 
+ERROR: 0:61: 'CheckAccessFullyMapped' : no matching overloaded function found 
+ERROR: 0:62: 'countbits' : no matching overloaded function found 
+ERROR: 0:63: 'cross' : no matching overloaded function found 
+ERROR: 0:64: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
+ERROR: 0:65: 'ddx' : no matching overloaded function found 
+ERROR: 0:66: 'ddx_coarse' : no matching overloaded function found 
+ERROR: 0:67: 'ddx_fine' : no matching overloaded function found 
+ERROR: 0:68: 'ddy' : no matching overloaded function found 
+ERROR: 0:69: 'ddy_coarse' : no matching overloaded function found 
+ERROR: 0:70: 'ddy_fine' : no matching overloaded function found 
+ERROR: 0:71: 'determinant' : no matching overloaded function found 
+ERROR: 0:72: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
+ERROR: 0:73: 'EvaluateAttributeAtSample' : no matching overloaded function found 
+ERROR: 0:74: 'EvaluateAttributeSnapped' : no matching overloaded function found 
+ERROR: 0:75: 'f16tof32' : no matching overloaded function found 
+ERROR: 0:76: 'firstbithigh' : no matching overloaded function found 
+ERROR: 0:77: 'firstbitlow' : no matching overloaded function found 
+ERROR: 0:78: 'fma' : no matching overloaded function found 
+ERROR: 0:79: 'noise' : no matching overloaded function found 
+ERROR: 0:80: 'reversebits' : no matching overloaded function found 
+ERROR: 0:81: 'transpose' : no matching overloaded function found 
+ERROR: 0:90: 'CheckAccessFullyMapped' : no matching overloaded function found 
+ERROR: 0:91: 'countbits' : no matching overloaded function found 
+ERROR: 0:92: 'ddx' : no matching overloaded function found 
+ERROR: 0:93: 'ddx_coarse' : no matching overloaded function found 
+ERROR: 0:94: 'ddx_fine' : no matching overloaded function found 
+ERROR: 0:95: 'ddy' : no matching overloaded function found 
+ERROR: 0:96: 'ddy_coarse' : no matching overloaded function found 
+ERROR: 0:97: 'ddy_fine' : no matching overloaded function found 
+ERROR: 0:98: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
+ERROR: 0:99: 'determinant' : no matching overloaded function found 
+ERROR: 0:100: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
+ERROR: 0:101: 'EvaluateAttributeAtSample' : no matching overloaded function found 
+ERROR: 0:102: 'EvaluateAttributeSnapped' : no matching overloaded function found 
+ERROR: 0:103: 'f16tof32' : no matching overloaded function found 
+ERROR: 0:104: 'firstbithigh' : no matching overloaded function found 
+ERROR: 0:105: 'firstbitlow' : no matching overloaded function found 
+ERROR: 0:106: 'fma' : no matching overloaded function found 
+ERROR: 0:107: 'noise' : no matching overloaded function found 
+ERROR: 0:108: 'reversebits' : no matching overloaded function found 
+ERROR: 0:109: 'transpose' : no matching overloaded function found 
+ERROR: 0:118: 'CheckAccessFullyMapped' : no matching overloaded function found 
+ERROR: 0:119: 'countbits' : no matching overloaded function found 
+ERROR: 0:120: 'cross' : no matching overloaded function found 
+ERROR: 0:121: 'determinant' : no matching overloaded function found 
+ERROR: 0:122: 'ddx' : no matching overloaded function found 
+ERROR: 0:123: 'ddx_coarse' : no matching overloaded function found 
+ERROR: 0:124: 'ddx_fine' : no matching overloaded function found 
+ERROR: 0:125: 'ddy' : no matching overloaded function found 
+ERROR: 0:126: 'ddy_coarse' : no matching overloaded function found 
+ERROR: 0:127: 'ddy_fine' : no matching overloaded function found 
+ERROR: 0:128: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
+ERROR: 0:129: 'EvaluateAttributeAtSample' : no matching overloaded function found 
+ERROR: 0:130: 'EvaluateAttributeSnapped' : no matching overloaded function found 
+ERROR: 0:131: 'f16tof32' : no matching overloaded function found 
+ERROR: 0:132: 'firstbithigh' : no matching overloaded function found 
+ERROR: 0:133: 'firstbitlow' : no matching overloaded function found 
+ERROR: 0:134: 'fma' : no matching overloaded function found 
+ERROR: 0:135: 'noise' : no matching overloaded function found 
+ERROR: 0:136: 'reversebits' : no matching overloaded function found 
+ERROR: 0:137: 'transpose' : no matching overloaded function found 
+ERROR: 0:177: 'countbits' : no matching overloaded function found 
+ERROR: 0:177: 'cross' : no matching overloaded function found 
+ERROR: 0:177: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
+ERROR: 0:177: 'ddx' : no matching overloaded function found 
+ERROR: 0:177: 'ddx_coarse' : no matching overloaded function found 
+ERROR: 0:177: 'ddx_fine' : no matching overloaded function found 
+ERROR: 0:177: 'ddy' : no matching overloaded function found 
+ERROR: 0:177: 'ddy_coarse' : no matching overloaded function found 
+ERROR: 0:177: 'ddy_fine' : no matching overloaded function found 
+ERROR: 0:177: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
+ERROR: 0:177: 'EvaluateAttributeAtSample' : no matching overloaded function found 
+ERROR: 0:177: 'EvaluateAttributeSnapped' : no matching overloaded function found 
+ERROR: 0:177: 'f16tof32' : no matching overloaded function found 
+ERROR: 0:177: 'firstbithigh' : no matching overloaded function found 
+ERROR: 0:177: 'firstbitlow' : no matching overloaded function found 
+ERROR: 0:177: 'fma' : no matching overloaded function found 
+ERROR: 0:177: 'noise' : no matching overloaded function found 
+ERROR: 0:177: 'reversebits' : no matching overloaded function found 
+ERROR: 0:177: 'length' : no matching overloaded function found 
+ERROR: 0:177: 'noise' : no matching overloaded function found 
+ERROR: 0:177: 'normalize' : no matching overloaded function found 
+ERROR: 0:177: 'reflect' : no matching overloaded function found 
+ERROR: 0:177: 'refract' : no matching overloaded function found 
+ERROR: 0:177: 'reversebits' : no matching overloaded function found 
+ERROR: 0:185: 'countbits' : no matching overloaded function found 
+ERROR: 0:185: 'cross' : no matching overloaded function found 
+ERROR: 0:185: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
+ERROR: 0:185: 'ddx' : no matching overloaded function found 
+ERROR: 0:185: 'ddx_coarse' : no matching overloaded function found 
+ERROR: 0:185: 'ddx_fine' : no matching overloaded function found 
+ERROR: 0:185: 'ddy' : no matching overloaded function found 
+ERROR: 0:185: 'ddy_coarse' : no matching overloaded function found 
+ERROR: 0:185: 'ddy_fine' : no matching overloaded function found 
+ERROR: 0:185: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
+ERROR: 0:185: 'EvaluateAttributeAtSample' : no matching overloaded function found 
+ERROR: 0:185: 'EvaluateAttributeSnapped' : no matching overloaded function found 
+ERROR: 0:185: 'f16tof32' : no matching overloaded function found 
+ERROR: 0:185: 'firstbithigh' : no matching overloaded function found 
+ERROR: 0:185: 'firstbitlow' : no matching overloaded function found 
+ERROR: 0:185: 'fma' : no matching overloaded function found 
+ERROR: 0:185: 'noise' : no matching overloaded function found 
+ERROR: 0:185: 'reversebits' : no matching overloaded function found 
+ERROR: 0:185: 'length' : no matching overloaded function found 
+ERROR: 0:185: 'noise' : no matching overloaded function found 
+ERROR: 0:185: 'normalize' : no matching overloaded function found 
+ERROR: 0:185: 'reflect' : no matching overloaded function found 
+ERROR: 0:185: 'refract' : no matching overloaded function found 
+ERROR: 0:185: 'reversebits' : no matching overloaded function found 
+ERROR: 0:193: 'countbits' : no matching overloaded function found 
+ERROR: 0:193: 'cross' : no matching overloaded function found 
+ERROR: 0:193: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
+ERROR: 0:193: 'ddx' : no matching overloaded function found 
+ERROR: 0:193: 'ddx_coarse' : no matching overloaded function found 
+ERROR: 0:193: 'ddx_fine' : no matching overloaded function found 
+ERROR: 0:193: 'ddy' : no matching overloaded function found 
+ERROR: 0:193: 'ddy_coarse' : no matching overloaded function found 
+ERROR: 0:193: 'ddy_fine' : no matching overloaded function found 
+ERROR: 0:193: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
+ERROR: 0:193: 'EvaluateAttributeAtSample' : no matching overloaded function found 
+ERROR: 0:193: 'EvaluateAttributeSnapped' : no matching overloaded function found 
+ERROR: 0:193: 'f16tof32' : no matching overloaded function found 
+ERROR: 0:193: 'firstbithigh' : no matching overloaded function found 
+ERROR: 0:193: 'firstbitlow' : no matching overloaded function found 
+ERROR: 0:193: 'fma' : no matching overloaded function found 
+ERROR: 0:193: 'noise' : no matching overloaded function found 
+ERROR: 0:193: 'reversebits' : no matching overloaded function found 
+ERROR: 0:193: 'length' : no matching overloaded function found 
+ERROR: 0:193: 'noise' : no matching overloaded function found 
+ERROR: 0:193: 'normalize' : no matching overloaded function found 
+ERROR: 0:193: 'reflect' : no matching overloaded function found 
+ERROR: 0:193: 'refract' : no matching overloaded function found 
+ERROR: 0:193: 'reversebits' : no matching overloaded function found 
+ERROR: 164 compilation errors.  No code generated.
+
+
+Shader version: 450
+ERROR: node is still EOpNull!
+0:49  Function Definition: VertexShaderFunction(f1;f1;f1;i1; (temp float)
+0:2    Function Parameters: 
+0:2      'inF0' (temp float)
+0:2      'inF1' (temp float)
+0:2      'inF2' (temp float)
+0:2      'inI0' (temp int)
+0:?     Sequence
+0:5      Constant:
+0:5        0.000000
+0:6      Constant:
+0:6        0.000000
+0:7      Constant:
+0:7        0.000000
+0:8      Constant:
+0:8        0.000000
+0:9      Constant:
+0:9        0.000000
+0:10      Constant:
+0:10        0.000000
+0:11      Constant:
+0:11        0.000000
+0:14      Constant:
+0:14        0.000000
+0:15      Constant:
+0:15        0.000000
+0:16      Constant:
+0:16        0.000000
+0:17      Constant:
+0:17        0.000000
+0:18      Constant:
+0:18        0.000000
+0:19      Constant:
+0:19        0.000000
+0:20      Constant:
+0:20        0.000000
+0:21      Constant:
+0:21        0.000000
+0:22      Constant:
+0:22        0.000000
+0:23      Constant:
+0:23        0.000000
+0:24      Constant:
+0:24        0.000000
+0:25      Constant:
+0:25        0.000000
+0:26      Constant:
+0:26        0.000000
+0:27      Constant:
+0:27        0.000000
+0:35      Constant:
+0:35        0.000000
+0:36      Constant:
+0:36        0.000000
+0:37      Constant:
+0:37        0.000000
+0:38      Constant:
+0:38        0.000000
+0:39      Constant:
+0:39        0.000000
+0:40      Constant:
+0:40        0.000000
+0:41      Constant:
+0:41        0.000000
+0:42      Constant:
+0:42        0.000000
+0:46      Branch: Return with expression
+0:46        Constant:
+0:46          0.000000
+0:58  Function Definition: VertexShaderFunction(vf1;vf1;vf1;i1; (temp 1-component vector of float)
+0:50    Function Parameters: 
+0:50      'inF0' (temp 1-component vector of float)
+0:50      'inF1' (temp 1-component vector of float)
+0:50      'inF2' (temp 1-component vector of float)
+0:50      'inI0' (temp int)
+0:?     Sequence
+0:53      Constant:
+0:53        0.000000
+0:55      Branch: Return with expression
+0:55        Constant:
+0:55          0.000000
+0:88  Function Definition: VertexShaderFunction(vf2;vf2;vf2;vi2; (temp 2-component vector of float)
+0:59    Function Parameters: 
+0:59      'inF0' (temp 2-component vector of float)
+0:59      'inF1' (temp 2-component vector of float)
+0:59      'inF2' (temp 2-component vector of float)
+0:59      'inI0' (temp 2-component vector of int)
+0:?     Sequence
+0:60      Constant:
+0:60        0.000000
+0:61      Constant:
+0:61        0.000000
+0:62      Constant:
+0:62        0.000000
+0:63      Constant:
+0:63        0.000000
+0:64      Constant:
+0:64        0.000000
+0:65      Constant:
+0:65        0.000000
+0:66      Constant:
+0:66        0.000000
+0:67      Constant:
+0:67        0.000000
+0:68      Constant:
+0:68        0.000000
+0:69      Constant:
+0:69        0.000000
+0:70      Constant:
+0:70        0.000000
+0:71      Constant:
+0:71        0.000000
+0:72      Constant:
+0:72        0.000000
+0:73      Constant:
+0:73        0.000000
+0:74      Constant:
+0:74        0.000000
+0:75      Constant:
+0:75        0.000000
+0:76      Constant:
+0:76        0.000000
+0:77      Constant:
+0:77        0.000000
+0:78      Constant:
+0:78        0.000000
+0:79      Constant:
+0:79        0.000000
+0:80      Constant:
+0:80        0.000000
+0:81      Constant:
+0:81        0.000000
+0:85      Branch: Return with expression
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:116  Function Definition: VertexShaderFunction(vf3;vf3;vf3;vi3; (temp 3-component vector of float)
+0:89    Function Parameters: 
+0:89      'inF0' (temp 3-component vector of float)
+0:89      'inF1' (temp 3-component vector of float)
+0:89      'inF2' (temp 3-component vector of float)
+0:89      'inI0' (temp 3-component vector of int)
+0:?     Sequence
+0:90      Constant:
+0:90        0.000000
+0:91      Constant:
+0:91        0.000000
+0:92      Constant:
+0:92        0.000000
+0:93      Constant:
+0:93        0.000000
+0:94      Constant:
+0:94        0.000000
+0:95      Constant:
+0:95        0.000000
+0:96      Constant:
+0:96        0.000000
+0:97      Constant:
+0:97        0.000000
+0:98      Constant:
+0:98        0.000000
+0:99      Constant:
+0:99        0.000000
+0:100      Constant:
+0:100        0.000000
+0:101      Constant:
+0:101        0.000000
+0:102      Constant:
+0:102        0.000000
+0:103      Constant:
+0:103        0.000000
+0:104      Constant:
+0:104        0.000000
+0:105      Constant:
+0:105        0.000000
+0:106      Constant:
+0:106        0.000000
+0:107      Constant:
+0:107        0.000000
+0:108      Constant:
+0:108        0.000000
+0:109      Constant:
+0:109        0.000000
+0:113      Branch: Return with expression
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:174  Function Definition: VertexShaderFunction(vf4;vf4;vf4;vi4; (temp 4-component vector of float)
+0:117    Function Parameters: 
+0:117      'inF0' (temp 4-component vector of float)
+0:117      'inF1' (temp 4-component vector of float)
+0:117      'inF2' (temp 4-component vector of float)
+0:117      'inI0' (temp 4-component vector of int)
+0:?     Sequence
+0:118      Constant:
+0:118        0.000000
+0:119      Constant:
+0:119        0.000000
+0:120      Constant:
+0:120        0.000000
+0:121      Constant:
+0:121        0.000000
+0:122      Constant:
+0:122        0.000000
+0:123      Constant:
+0:123        0.000000
+0:124      Constant:
+0:124        0.000000
+0:125      Constant:
+0:125        0.000000
+0:126      Constant:
+0:126        0.000000
+0:127      Constant:
+0:127        0.000000
+0:128      Constant:
+0:128        0.000000
+0:129      Constant:
+0:129        0.000000
+0:130      Constant:
+0:130        0.000000
+0:131      Constant:
+0:131        0.000000
+0:132      Constant:
+0:132        0.000000
+0:133      Constant:
+0:133        0.000000
+0:134      Constant:
+0:134        0.000000
+0:135      Constant:
+0:135        0.000000
+0:136      Constant:
+0:136        0.000000
+0:137      Constant:
+0:137        0.000000
+0:141      Branch: Return with expression
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:182  Function Definition: VertexShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:175    Function Parameters: 
+0:175      'inF0' (temp 2X2 matrix of float)
+0:175      'inF1' (temp 2X2 matrix of float)
+0:175      'inF2' (temp 2X2 matrix of float)
+0:?     Sequence
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:179      Branch: Return with expression
+0:?         Constant:
+0:?           2.000000
+0:?           2.000000
+0:?           2.000000
+0:?           2.000000
+0:190  Function Definition: VertexShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:183    Function Parameters: 
+0:183      'inF0' (temp 3X3 matrix of float)
+0:183      'inF1' (temp 3X3 matrix of float)
+0:183      'inF2' (temp 3X3 matrix of float)
+0:?     Sequence
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:187      Branch: Return with expression
+0:?         Constant:
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:197  Function Definition: VertexShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:191    Function Parameters: 
+0:191      'inF0' (temp 4X4 matrix of float)
+0:191      'inF1' (temp 4X4 matrix of float)
+0:191      'inF2' (temp 4X4 matrix of float)
+0:?     Sequence
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:195      Branch: Return with expression
+0:?         Constant:
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?   Linker Objects
+
+
+Linked vertex stage:
+
+
+Shader version: 450
+ERROR: node is still EOpNull!
+0:49  Function Definition: VertexShaderFunction(f1;f1;f1;i1; (temp float)
+0:2    Function Parameters: 
+0:2      'inF0' (temp float)
+0:2      'inF1' (temp float)
+0:2      'inF2' (temp float)
+0:2      'inI0' (temp int)
+0:?     Sequence
+0:5      Constant:
+0:5        0.000000
+0:6      Constant:
+0:6        0.000000
+0:7      Constant:
+0:7        0.000000
+0:8      Constant:
+0:8        0.000000
+0:9      Constant:
+0:9        0.000000
+0:10      Constant:
+0:10        0.000000
+0:11      Constant:
+0:11        0.000000
+0:14      Constant:
+0:14        0.000000
+0:15      Constant:
+0:15        0.000000
+0:16      Constant:
+0:16        0.000000
+0:17      Constant:
+0:17        0.000000
+0:18      Constant:
+0:18        0.000000
+0:19      Constant:
+0:19        0.000000
+0:20      Constant:
+0:20        0.000000
+0:21      Constant:
+0:21        0.000000
+0:22      Constant:
+0:22        0.000000
+0:23      Constant:
+0:23        0.000000
+0:24      Constant:
+0:24        0.000000
+0:25      Constant:
+0:25        0.000000
+0:26      Constant:
+0:26        0.000000
+0:27      Constant:
+0:27        0.000000
+0:35      Constant:
+0:35        0.000000
+0:36      Constant:
+0:36        0.000000
+0:37      Constant:
+0:37        0.000000
+0:38      Constant:
+0:38        0.000000
+0:39      Constant:
+0:39        0.000000
+0:40      Constant:
+0:40        0.000000
+0:41      Constant:
+0:41        0.000000
+0:42      Constant:
+0:42        0.000000
+0:46      Branch: Return with expression
+0:46        Constant:
+0:46          0.000000
+0:58  Function Definition: VertexShaderFunction(vf1;vf1;vf1;i1; (temp 1-component vector of float)
+0:50    Function Parameters: 
+0:50      'inF0' (temp 1-component vector of float)
+0:50      'inF1' (temp 1-component vector of float)
+0:50      'inF2' (temp 1-component vector of float)
+0:50      'inI0' (temp int)
+0:?     Sequence
+0:53      Constant:
+0:53        0.000000
+0:55      Branch: Return with expression
+0:55        Constant:
+0:55          0.000000
+0:88  Function Definition: VertexShaderFunction(vf2;vf2;vf2;vi2; (temp 2-component vector of float)
+0:59    Function Parameters: 
+0:59      'inF0' (temp 2-component vector of float)
+0:59      'inF1' (temp 2-component vector of float)
+0:59      'inF2' (temp 2-component vector of float)
+0:59      'inI0' (temp 2-component vector of int)
+0:?     Sequence
+0:60      Constant:
+0:60        0.000000
+0:61      Constant:
+0:61        0.000000
+0:62      Constant:
+0:62        0.000000
+0:63      Constant:
+0:63        0.000000
+0:64      Constant:
+0:64        0.000000
+0:65      Constant:
+0:65        0.000000
+0:66      Constant:
+0:66        0.000000
+0:67      Constant:
+0:67        0.000000
+0:68      Constant:
+0:68        0.000000
+0:69      Constant:
+0:69        0.000000
+0:70      Constant:
+0:70        0.000000
+0:71      Constant:
+0:71        0.000000
+0:72      Constant:
+0:72        0.000000
+0:73      Constant:
+0:73        0.000000
+0:74      Constant:
+0:74        0.000000
+0:75      Constant:
+0:75        0.000000
+0:76      Constant:
+0:76        0.000000
+0:77      Constant:
+0:77        0.000000
+0:78      Constant:
+0:78        0.000000
+0:79      Constant:
+0:79        0.000000
+0:80      Constant:
+0:80        0.000000
+0:81      Constant:
+0:81        0.000000
+0:85      Branch: Return with expression
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:116  Function Definition: VertexShaderFunction(vf3;vf3;vf3;vi3; (temp 3-component vector of float)
+0:89    Function Parameters: 
+0:89      'inF0' (temp 3-component vector of float)
+0:89      'inF1' (temp 3-component vector of float)
+0:89      'inF2' (temp 3-component vector of float)
+0:89      'inI0' (temp 3-component vector of int)
+0:?     Sequence
+0:90      Constant:
+0:90        0.000000
+0:91      Constant:
+0:91        0.000000
+0:92      Constant:
+0:92        0.000000
+0:93      Constant:
+0:93        0.000000
+0:94      Constant:
+0:94        0.000000
+0:95      Constant:
+0:95        0.000000
+0:96      Constant:
+0:96        0.000000
+0:97      Constant:
+0:97        0.000000
+0:98      Constant:
+0:98        0.000000
+0:99      Constant:
+0:99        0.000000
+0:100      Constant:
+0:100        0.000000
+0:101      Constant:
+0:101        0.000000
+0:102      Constant:
+0:102        0.000000
+0:103      Constant:
+0:103        0.000000
+0:104      Constant:
+0:104        0.000000
+0:105      Constant:
+0:105        0.000000
+0:106      Constant:
+0:106        0.000000
+0:107      Constant:
+0:107        0.000000
+0:108      Constant:
+0:108        0.000000
+0:109      Constant:
+0:109        0.000000
+0:113      Branch: Return with expression
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:174  Function Definition: VertexShaderFunction(vf4;vf4;vf4;vi4; (temp 4-component vector of float)
+0:117    Function Parameters: 
+0:117      'inF0' (temp 4-component vector of float)
+0:117      'inF1' (temp 4-component vector of float)
+0:117      'inF2' (temp 4-component vector of float)
+0:117      'inI0' (temp 4-component vector of int)
+0:?     Sequence
+0:118      Constant:
+0:118        0.000000
+0:119      Constant:
+0:119        0.000000
+0:120      Constant:
+0:120        0.000000
+0:121      Constant:
+0:121        0.000000
+0:122      Constant:
+0:122        0.000000
+0:123      Constant:
+0:123        0.000000
+0:124      Constant:
+0:124        0.000000
+0:125      Constant:
+0:125        0.000000
+0:126      Constant:
+0:126        0.000000
+0:127      Constant:
+0:127        0.000000
+0:128      Constant:
+0:128        0.000000
+0:129      Constant:
+0:129        0.000000
+0:130      Constant:
+0:130        0.000000
+0:131      Constant:
+0:131        0.000000
+0:132      Constant:
+0:132        0.000000
+0:133      Constant:
+0:133        0.000000
+0:134      Constant:
+0:134        0.000000
+0:135      Constant:
+0:135        0.000000
+0:136      Constant:
+0:136        0.000000
+0:137      Constant:
+0:137        0.000000
+0:141      Branch: Return with expression
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:182  Function Definition: VertexShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:175    Function Parameters: 
+0:175      'inF0' (temp 2X2 matrix of float)
+0:175      'inF1' (temp 2X2 matrix of float)
+0:175      'inF2' (temp 2X2 matrix of float)
+0:?     Sequence
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:177      Constant:
+0:177        0.000000
+0:179      Branch: Return with expression
+0:?         Constant:
+0:?           2.000000
+0:?           2.000000
+0:?           2.000000
+0:?           2.000000
+0:190  Function Definition: VertexShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:183    Function Parameters: 
+0:183      'inF0' (temp 3X3 matrix of float)
+0:183      'inF1' (temp 3X3 matrix of float)
+0:183      'inF2' (temp 3X3 matrix of float)
+0:?     Sequence
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:185      Constant:
+0:185        0.000000
+0:187      Branch: Return with expression
+0:?         Constant:
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:?           3.000000
+0:197  Function Definition: VertexShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:191    Function Parameters: 
+0:191      'inF0' (temp 4X4 matrix of float)
+0:191      'inF1' (temp 4X4 matrix of float)
+0:191      'inF2' (temp 4X4 matrix of float)
+0:?     Sequence
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:193      Constant:
+0:193        0.000000
+0:195      Branch: Return with expression
+0:?         Constant:
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?           4.000000
+0:?   Linker Objects
+
+SPIR-V is not generated for failed compile or link

--- a/Test/hlsl.intrinsics.negative.frag
+++ b/Test/hlsl.intrinsics.negative.frag
@@ -1,0 +1,137 @@
+float PixelShaderFunction(float inF0, float inF1, float inF2, int inI0)
+{
+    // AllMemoryBarrier();              // TODO: expected error: invalid in fragment stage
+    // AllMemoryBarrierWithGroupSync(); // TODO: expected error: invalid in fragment stage
+    asdouble(inF0, inF1);                     // expected error: only integer inputs
+    CheckAccessFullyMapped(3.0);              // expected error: only valid on integers
+    countbits(inF0);                          // expected error: only integer inputs
+    cross(inF0, inF1);                        // expected error: only on float3 inputs
+    D3DCOLORtoUBYTE4(inF0);                   // expected error: only on float4 inputs
+    determinant(inF0);                        // expected error: only valid on mats
+    // DeviceMemoryBarrierWithGroupSync();      // TODO: expected error: only valid in compute stage
+    f16tof32(inF0);                           // expected error: only integer inputs
+    firstbithigh(inF0);                       // expected error: only integer inputs
+    firstbitlow(inF0);                        // expected error: only integer inputs
+    fma(inF0, inF1, inF2);                    // expected error: only double inputs
+    // InterlockedAdd(inI0, inI0, 3);            // expected error: last parameter is out TODO: accepted even though marked as out in proto generator
+    // InterlockedAnd(inI0, inI0, 3);            // expected error: last parameter is out TODO: accepted even though marked as out i    // InterlockedMax(inI0, inI0, 3);            // expected error: last parameter is out TODO: accepted even though marked as out in proto generator
+    // InterlockedMin(inI0, inI0, 3);            // expected error: last parameter is out TODO: accepted even though marked as out in proto generator
+    // InterlockedOor(inI0, inI0, 3);            // expected error: last parameter is out TODO: accepted even though marked as out in proto generator
+    // InterlockedXor(inI0, inI0, 3);            // expected error: last parameter is out TODO: accepted even though marked as out in proto generator
+    // GroupMemoryBarrier();               // TODO: expected error: invalid in fragment stage
+    // GroupMemoryBarrierWithGroupSync();  // TODO: expected error: invalid in fragment stage
+    length(inF0);                             // expected error: invalid on scalars
+    msad4(inF0, float2(0), float4(0));        // expected error: only integer inputs
+    normalize(inF0);                          // expected error: invalid on scalars
+    reflect(inF0, inF1);                      // expected error: invalid on scalars
+    refract(inF0, inF1, inF2);                // expected error: invalid on scalars
+    refract(float2(0), float2(0), float2(0)); // expected error: last parameter only scalar
+    reversebits(inF0);                        // expected error: only integer inputs
+    transpose(inF0);                          // expected error: only valid on mats
+
+    return 0.0;
+}
+
+float1 PixelShaderFunction(float1 inF0, float1 inF1, float1 inF2, int1 inI0)
+{
+    // TODO: ... add when float1 prototypes are generated
+
+    GetRenderTargetSamplePosition(inF0); // expected error: only integer inputs
+
+    return 0.0;
+}
+
+float2 PixelShaderFunction(float2 inF0, float2 inF1, float2 inF2, int2 inI0)
+{
+    asdouble(inF0, inF1);         // expected error: only integer inputs
+    CheckAccessFullyMapped(inF0); // expected error: only valid on scalars
+    countbits(inF0);              // expected error: only integer inputs
+    cross(inF0, inF1);            // expected error: only on float3 inputs
+    D3DCOLORtoUBYTE4(inF0);       // expected error: only on float4 inputs
+    determinant(inF0);            // expected error: only valid on mats
+    f16tof32(inF0);               // expected error: only integer inputs
+    firstbithigh(inF0);           // expected error: only integer inputs
+    firstbitlow(inF0);            // expected error: only integer inputs
+    fma(inF0, inF1, inF2);        // expected error: only double inputs
+    reversebits(inF0);            // expected error: only integer inputs
+    transpose(inF0);              // expected error: only valid on mats
+
+    return float2(1,2);
+}
+
+float3 PixelShaderFunction(float3 inF0, float3 inF1, float3 inF2, int3 inI0)
+{
+    CheckAccessFullyMapped(inF0);  // expected error: only valid on scalars
+    countbits(inF0);            // expected error: only integer inputs
+    D3DCOLORtoUBYTE4(inF0);     // expected error: only on float4 inputs
+    determinant(inF0);          // expected error: only valid on mats
+    f16tof32(inF0);             // expected error: only integer inputs
+    firstbithigh(inF0);         // expected error: only integer inputs
+    firstbitlow(inF0);          // expected error: only integer inputs
+    fma(inF0, inF1, inF2);      // expected error: only double inputs
+    reversebits(inF0);          // expected error: only integer inputs
+    transpose(inF0);            // expected error: only valid on mats
+
+
+    return float3(1,2,3);
+}
+
+float4 PixelShaderFunction(float4 inF0, float4 inF1, float4 inF2, int4 inI0)
+{
+    CheckAccessFullyMapped(inF0);  // expected error: only valid on scalars
+    countbits(inF0);            // expected error: only integer inputs
+    cross(inF0, inF1);          // expected error: only on float3 inputs
+    determinant(inF0);          // expected error: only valid on mats
+    f16tof32(inF0);             // expected error: only integer inputs
+    firstbithigh(inF0);         // expected error: only integer inputs
+    firstbitlow(inF0);          // expected error: only integer inputs
+    fma(inF0, inF1, inF2);      // expected error: only double inputs
+    reversebits(inF0);          // expected error: only integer inputs
+    transpose(inF0);            // expected error: only valid on mats
+
+    return float4(1,2,3,4);
+}
+
+// TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
+#define MATFNS() \
+    countbits(inF0);          \
+    D3DCOLORtoUBYTE4(inF0);   \
+    cross(inF0, inF1);        \
+    f16tof32(inF0);           \
+    firstbithigh(inF0);       \
+    firstbitlow(inF0);        \
+    fma(inF0, inF1, inF2);    \
+    reversebits(inF0);        \
+    length(inF0);             \
+    noise(inF0);              \
+    normalize(inF0);          \
+    reflect(inF0, inF1);      \
+    refract(inF0, inF1, 1.0); \
+    reversebits(inF0);        \
+    
+
+// TODO: turn on non-square matrix tests when protos are available.
+
+float2x2 PixelShaderFunction(float2x2 inF0, float2x2 inF1, float2x2 inF2)
+{
+    // TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
+    MATFNS()
+
+    return float2x2(2,2,2,2);
+}
+
+float3x3 PixelShaderFunction(float3x3 inF0, float3x3 inF1, float3x3 inF2)
+{
+    // TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
+    MATFNS()
+
+    return float3x3(3,3,3,3,3,3,3,3,3);
+}
+
+float4x4 PixelShaderFunction(float4x4 inF0, float4x4 inF1, float4x4 inF2)
+{
+    // TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
+    MATFNS()
+
+    return float4x4(4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4);
+}

--- a/Test/hlsl.intrinsics.negative.vert
+++ b/Test/hlsl.intrinsics.negative.vert
@@ -1,0 +1,196 @@
+float VertexShaderFunction(float inF0, float inF1, float inF2, int inI0)
+{
+    // AllMemoryBarrier();              // invalid in fragment stage  TODO: parser currently crashes on empty arg list
+    // AllMemoryBarrierWithGroupSync(); // invalid in fragment stage  TODO: parser currently crashes on empty arg list
+    asdouble(inF0, inF1);                     // expected error: only integer inputs
+    CheckAccessFullyMapped(3.0);              // expected error: only valid on integers
+    CheckAccessFullyMapped(3);                // expected error: only valid in pixel & compute stages
+    clip(inF0);                               // expected error: only valid in pixel & compute stages
+    countbits(inF0);                          // expected error: only integer inputs
+    cross(inF0, inF1);                        // expected error: only on float3 inputs
+    D3DCOLORtoUBYTE4(inF0);                   // expected error: only on float4 inputs
+    // DeviceMemoryBarrier();                    // TODO: expected error: only valid in pixel & compute stages
+    // DeviceMemoryBarrierWithGroupSync();       // TODO: expected error: only valid in compute stage
+    ddx(inF0);                                // expected error: only valid in pixel & compute stages
+    ddx_coarse(inF0);                         // expected error: only valid in pixel & compute stages
+    ddx_fine(inF0);                           // expected error: only valid in pixel & compute stages
+    ddy(inF0);                                // expected error: only valid in pixel & compute stages
+    ddy_coarse(inF0);                         // expected error: only valid in pixel & compute stages
+    ddy_fine(inF0);                           // expected error: only valid in pixel & compute stages
+    determinant(inF0);                        // expected error: only valid on mats
+    EvaluateAttributeAtCentroid(inF0);        // expected error: only valid in pixel stage
+    EvaluateAttributeAtSample(inF0, 2);       // expected error: only valid in pixel stage
+    EvaluateAttributeSnapped(inF0, int2(2));  // expected error: only valid in pixel stage
+    f16tof32(inF0);                           // expected error: only integer inputs
+    firstbithigh(inF0);                       // expected error: only integer inputs
+    firstbitlow(inF0);                        // expected error: only integer inputs
+    fma(inF0, inF1, inF2);                    // expected error: only double inputs
+    // InterlockedAdd(inI0, inI0, 3);            // expected error: last parameter is out TODO: accepted even though marked as out in proto generator
+    // InterlockedAnd(inI0, inI0, 3);            // expected error: last parameter is out TODO: accepted even though marked as out i    // InterlockedMax(inI0, inI0, 3);            // expected error: last parameter is out TODO: accepted even though marked as out in proto generator
+    // InterlockedMin(inI0, inI0, 3);            // expected error: last parameter is out TODO: accepted even though marked as out in proto generator
+    // InterlockedOor(inI0, inI0, 3);            // expected error: last parameter is out TODO: accepted even though marked as out in proto generator
+    // InterlockedXor(inI0, inI0, 3);            // expected error: last parameter is out TODO: accepted even though marked as out in proto generator
+    // GroupMemoryBarrier();               // TODO: expected error: only valid in compute stage
+    // GroupMemoryBarrierWithGroupSync();  // TODO: expected error: only valid in compute stage
+    length(inF0);                             // expect error: invalid on scalars
+    msad4(inF0, float2(0), float4(0));        // expected error: only integer inputs
+    normalize(inF0);                          // expect error: invalid on scalars
+    reflect(inF0, inF1);                      // expect error: invalid on scalars
+    refract(inF0, inF1, inF2);                // expect error: invalid on scalars
+    refract(float2(0), float2(0), float2(0)); // expected error: last parameter only scalar
+    reversebits(inF0);                        // expected error: only integer inputs
+    transpose(inF0);                          // expect error: only valid on mats
+
+    // TODO: texture intrinsics, when we can declare samplers.
+
+    return 0.0;
+}
+
+float1 VertexShaderFunction(float1 inF0, float1 inF1, float1 inF2, int1 inI0)
+{
+    // TODO: ... add when float1 prototypes are generated
+
+    GetRenderTargetSamplePosition(inF0); // expected error: only integer inputs
+
+    return 0.0;
+}
+
+float2 VertexShaderFunction(float2 inF0, float2 inF1, float2 inF2, int2 inI0)
+{
+    asdouble(inF0, inF1);         // expected error: only integer inputs
+    CheckAccessFullyMapped(inF0); // expect error: only valid on scalars
+    countbits(inF0);              // expected error: only integer inputs
+    cross(inF0, inF1);            // expected error: only on float3 inputs
+    D3DCOLORtoUBYTE4(inF0);       // expected error: only on float4 inputs
+    ddx(inF0);                                // only valid in pixel & compute stages
+    ddx_coarse(inF0);                         // only valid in pixel & compute stages
+    ddx_fine(inF0);                           // only valid in pixel & compute stages
+    ddy(inF0);                                // only valid in pixel & compute stages
+    ddy_coarse(inF0);                         // only valid in pixel & compute stages
+    ddy_fine(inF0);                           // only valid in pixel & compute stages
+    determinant(inF0);            // expect error: only valid on mats
+    EvaluateAttributeAtCentroid(inF0);        // expected error: only valid in pixel stage
+    EvaluateAttributeAtSample(inF0, 2);       // expected error: only valid in pixel stage
+    EvaluateAttributeSnapped(inF0, int2(2));  // expected error: only valid in pixel stage
+    f16tof32(inF0);               // expected error: only integer inputs
+    firstbithigh(inF0);           // expected error: only integer inputs
+    firstbitlow(inF0);            // expected error: only integer inputs
+    fma(inF0, inF1, inF2);        // expected error: only double inputs
+    noise(inF0);                  // expected error: only valid in pixel stage
+    reversebits(inF0);            // expected error: only integer inputs
+    transpose(inF0);              // expect error: only valid on mats
+
+    // TODO: texture intrinsics, when we can declare samplers.
+
+    return float2(1,2);
+}
+
+float3 VertexShaderFunction(float3 inF0, float3 inF1, float3 inF2, int3 inI0)
+{
+    CheckAccessFullyMapped(inF0);  // expect error: only valid on scalars
+    countbits(inF0);            // expected error: only integer inputs
+    ddx(inF0);                                // only valid in pixel & compute stages
+    ddx_coarse(inF0);                         // only valid in pixel & compute stages
+    ddx_fine(inF0);                           // only valid in pixel & compute stages
+    ddy(inF0);                                // only valid in pixel & compute stages
+    ddy_coarse(inF0);                         // only valid in pixel & compute stages
+    ddy_fine(inF0);                           // only valid in pixel & compute stages
+    D3DCOLORtoUBYTE4(inF0);     // expected error: only on float4 inputs
+    determinant(inF0);          // expect error: only valid on mats
+    EvaluateAttributeAtCentroid(inF0);        // expected error: only valid in pixel stage
+    EvaluateAttributeAtSample(inF0, 2);       // expected error: only valid in pixel stage
+    EvaluateAttributeSnapped(inF0, int2(2));  // expected error: only valid in pixel stage
+    f16tof32(inF0);             // expected error: only integer inputs
+    firstbithigh(inF0);         // expected error: only integer inputs
+    firstbitlow(inF0);          // expected error: only integer inputs
+    fma(inF0, inF1, inF2);      // expected error: only double inputs
+    noise(inF0);                  // expected error: only valid in pixel stage
+    reversebits(inF0);          // expected error: only integer inputs
+    transpose(inF0);            // expect error: only valid on mats
+
+    // TODO: texture intrinsics, when we can declare samplers.
+
+    return float3(1,2,3);
+}
+
+float4 VertexShaderFunction(float4 inF0, float4 inF1, float4 inF2, int4 inI0)
+{
+    CheckAccessFullyMapped(inF0);  // expect error: only valid on scalars
+    countbits(inF0);            // expected error: only integer inputs
+    cross(inF0, inF1);          // expected error: only on float3 inputs
+    determinant(inF0);          // expect error: only valid on mats
+    ddx(inF0);                                // only valid in pixel & compute stages
+    ddx_coarse(inF0);                         // only valid in pixel & compute stages
+    ddx_fine(inF0);                           // only valid in pixel & compute stages
+    ddy(inF0);                                // only valid in pixel & compute stages
+    ddy_coarse(inF0);                         // only valid in pixel & compute stages
+    ddy_fine(inF0);                           // only valid in pixel & compute stages
+    EvaluateAttributeAtCentroid(inF0);        // expected error: only valid in pixel stage
+    EvaluateAttributeAtSample(inF0, 2);       // expected error: only valid in pixel stage
+    EvaluateAttributeSnapped(inF0, int2(2));  // expected error: only valid in pixel stage
+    f16tof32(inF0);             // expected error: only integer inputs
+    firstbithigh(inF0);         // expected error: only integer inputs
+    firstbitlow(inF0);          // expected error: only integer inputs
+    fma(inF0, inF1, inF2);      // expected error: only double inputs
+    noise(inF0);                  // expected error: only valid in pixel stage
+    reversebits(inF0);          // expected error: only integer inputs
+    transpose(inF0);            // expect error: only valid on mats
+
+    // TODO: texture intrinsics, when we can declare samplers.
+
+    return float4(1,2,3,4);
+}
+
+// TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
+#define MATFNS() \
+    countbits(inF0);                         \
+    cross(inF0, inF1);                       \
+    D3DCOLORtoUBYTE4(inF0);                  \
+    ddx(inF0);                               \
+    ddx_coarse(inF0);                        \
+    ddx_fine(inF0);                          \
+    ddy(inF0);                               \
+    ddy_coarse(inF0);                        \
+    ddy_fine(inF0);                          \
+    EvaluateAttributeAtCentroid(inF0);       \
+    EvaluateAttributeAtSample(inF0, 2);      \
+    EvaluateAttributeSnapped(inF0, int2(2)); \
+    f16tof32(inF0);                          \
+    firstbithigh(inF0);                      \
+    firstbitlow(inF0);                       \
+    fma(inF0, inF1, inF2);                   \
+    noise(inF0);                             \
+    reversebits(inF0);                       \
+    length(inF0);                            \
+    noise(inF0);                             \
+    normalize(inF0);                         \
+    reflect(inF0, inF1);                     \
+    refract(inF0, inF1, 1.0);                \
+    reversebits(inF0);                       \
+    
+
+// TODO: turn on non-square matrix tests when protos are available.
+
+float2x2 VertexShaderFunction(float2x2 inF0, float2x2 inF1, float2x2 inF2)
+{
+    // TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
+    MATFNS()
+
+    return float2x2(2,2,2,2);
+}
+
+float3x3 VertexShaderFunction(float3x3 inF0, float3x3 inF1, float3x3 inF2)
+{
+    // TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
+    MATFNS()
+
+    return float3x3(3,3,3,3,3,3,3,3,3);
+}
+
+float4x4 VertexShaderFunction(float4x4 inF0, float4x4 inF1, float4x4 inF2)
+{
+    // TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
+    MATFNS()
+
+    return float4x4(4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4);
+}

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -75,13 +75,15 @@ INSTANTIATE_TEST_CASE_P(
         {"hlsl.assoc.frag", "PixelShaderFunction"},
         {"hlsl.float1.frag", "PixelShaderFunction"},
         {"hlsl.float4.frag", "PixelShaderFunction"},
+        {"hlsl.intrinsics.frag", "PixelShaderFunction"},
+        {"hlsl.intrinsics.negative.frag", "PixelShaderFunction"},
+        {"hlsl.intrinsics.negative.vert", "VertexShaderFunction"},
+        {"hlsl.intrinsics.vert", "VertexShaderFunction"},
         {"hlsl.matType.frag", "PixelShaderFunction"},
         {"hlsl.max.frag", "PixelShaderFunction"},
         {"hlsl.precedence.frag", "PixelShaderFunction"},
         {"hlsl.precedence2.frag", "PixelShaderFunction"},
         {"hlsl.sin.frag", "PixelShaderFunction"},
-        {"hlsl.intrinsics.frag", "PixelShaderFunction"},
-        {"hlsl.intrinsics.vert", "VertexShaderFunction"},
     }),
     FileNameAsCustomTestSuffix
 );


### PR DESCRIPTION
This adds negative tests for intrinsics that should not appear in some stage, or which should not accept some argument types (for example, that a matrix-only function does not accept scalars or vectors).
