### PR TITLE
Defer capability, member decoration until use for: PointSize, ClipDis…

### DIFF
--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -920,6 +920,11 @@ void Builder::addDecoration(Id id, Decoration decoration, int num)
 
 void Builder::addMemberDecoration(Id id, unsigned int member, Decoration decoration, int num)
 {
+    // Only generate a new OpMemberDecoration instruction when we haven't seen this
+    // combination before.
+    if (recordedMemberDecorations.count(MemberDecoration(id, member, decoration, num)))
+	return;
+
     Instruction* dec = new Instruction(OpMemberDecorate);
     dec->addIdOperand(id);
     dec->addImmediateOperand(member);
@@ -928,6 +933,7 @@ void Builder::addMemberDecoration(Id id, unsigned int member, Decoration decorat
         dec->addImmediateOperand(num);
 
     decorations.push_back(std::unique_ptr<Instruction>(dec));
+    recordedMemberDecorations.insert(MemberDecoration(id, member, decoration, num));
 }
 
 // Comments in header

--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -55,6 +55,7 @@
 #include <set>
 #include <sstream>
 #include <stack>
+#include <unordered_set>
 
 namespace spv {
 
@@ -544,6 +545,32 @@ public:
     void createSelectionMerge(Block* mergeBlock, unsigned int control);
     void dumpInstructions(std::vector<unsigned int>&, const std::vector<std::unique_ptr<Instruction> >&) const;
 
+    // A member decoration.
+    struct MemberDecoration {
+         MemberDecoration(Id target_arg, unsigned int member_arg, Decoration decoration_arg, int value_arg)
+             : target(target_arg), member(member_arg), decoration(decoration_arg), value(value_arg) {}
+         spv::Id target;
+         unsigned int member;
+         Decoration decoration;
+         int value;
+    };
+
+    // A hasher for MemberDecoration.
+    struct MemberDecorationHasher {
+        size_t operator()(const MemberDecoration& m) const {
+            // Use a dumb but simple hash algorithm.
+            return static_cast<size_t>(int(m.target) ^ int(m.member) ^ int(m.decoration) ^ m.value);
+        }
+    };
+
+    // An equality tester for MemberDecoration.
+    struct MemberDecorationEqualityChecker {
+         bool operator()(const MemberDecoration& lhs, const MemberDecoration& rhs) const {
+             return lhs.target == rhs.target && lhs.member == rhs.member && lhs.decoration == rhs.decoration
+                 && lhs.value == rhs.value;
+         }
+    };
+
     SourceLanguage source;
     int sourceVersion;
     std::vector<const char*> extensions;
@@ -557,6 +584,8 @@ public:
     Function* mainFunction;
     bool generatingOpCodeForSpecConst;
     AccessChain accessChain;
+    std::unordered_set<MemberDecoration, MemberDecorationHasher, MemberDecorationEqualityChecker>
+        recordedMemberDecorations;
 
     // special blocks of instructions for output
     std::vector<std::unique_ptr<Instruction> > imports;

--- a/Test/baseResults/spv.150.geom.out
+++ b/Test/baseResults/spv.150.geom.out
@@ -46,15 +46,13 @@ Linked geometry stage:
                               Decorate 10 Stream 3
                               Decorate 13(fromVertex) Block
                               MemberDecorate 27(gl_PerVertex) 0 BuiltIn Position
-                              MemberDecorate 27(gl_PerVertex) 1 BuiltIn PointSize
-                              MemberDecorate 27(gl_PerVertex) 2 BuiltIn ClipDistance
                               Decorate 27(gl_PerVertex) Block
                               Decorate 27(gl_PerVertex) Stream 0
                               Decorate 29 Stream 0
                               MemberDecorate 30(gl_PerVertex) 0 BuiltIn Position
-                              MemberDecorate 30(gl_PerVertex) 1 BuiltIn PointSize
-                              MemberDecorate 30(gl_PerVertex) 2 BuiltIn ClipDistance
                               Decorate 30(gl_PerVertex) Block
+                              MemberDecorate 27(gl_PerVertex) 1 BuiltIn PointSize
+                              MemberDecorate 30(gl_PerVertex) 1 BuiltIn PointSize
                               Decorate 47(gl_PrimitiveID) Stream 0
                               Decorate 47(gl_PrimitiveID) BuiltIn PrimitiveId
                               Decorate 49(gl_PrimitiveIDIn) BuiltIn PrimitiveId

--- a/Test/baseResults/spv.150.vert.out
+++ b/Test/baseResults/spv.150.vert.out
@@ -34,9 +34,9 @@ Linked vertex stage:
                               Name 62  "ui"
                               MemberDecorate 11(gl_PerVertex) 0 Invariant
                               MemberDecorate 11(gl_PerVertex) 0 BuiltIn Position
+                              Decorate 11(gl_PerVertex) Block
                               MemberDecorate 11(gl_PerVertex) 1 BuiltIn PointSize
                               MemberDecorate 11(gl_PerVertex) 2 BuiltIn ClipDistance
-                              Decorate 11(gl_PerVertex) Block
                               Decorate 47(s2D) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2

--- a/Test/baseResults/spv.300BuiltIns.vert.out
+++ b/Test/baseResults/spv.300BuiltIns.vert.out
@@ -24,11 +24,11 @@ Linked vertex stage:
                               Name 34  "gl_InstanceIndex"
                               MemberDecorate 8(gl_PerVertex) 0 Invariant
                               MemberDecorate 8(gl_PerVertex) 0 BuiltIn Position
-                              MemberDecorate 8(gl_PerVertex) 1 BuiltIn PointSize
                               Decorate 8(gl_PerVertex) Block
                               Decorate 14(ps) RelaxedPrecision
                               Decorate 15 RelaxedPrecision
                               Decorate 21(gl_VertexIndex) BuiltIn VertexIndex
+                              MemberDecorate 8(gl_PerVertex) 1 BuiltIn PointSize
                               Decorate 30 RelaxedPrecision
                               Decorate 34(gl_InstanceIndex) BuiltIn InstanceIndex
                2:             TypeVoid

--- a/Test/baseResults/spv.330.geom.out
+++ b/Test/baseResults/spv.330.geom.out
@@ -28,11 +28,11 @@ Linked geometry stage:
                               MemberName 16(gl_PerVertex) 1  "gl_ClipDistance"
                               Name 20  "gl_in"
                               MemberDecorate 11(gl_PerVertex) 0 BuiltIn Position
-                              MemberDecorate 11(gl_PerVertex) 1 BuiltIn ClipDistance
                               Decorate 11(gl_PerVertex) Block
                               MemberDecorate 16(gl_PerVertex) 0 BuiltIn Position
-                              MemberDecorate 16(gl_PerVertex) 1 BuiltIn ClipDistance
                               Decorate 16(gl_PerVertex) Block
+                              MemberDecorate 11(gl_PerVertex) 1 BuiltIn ClipDistance
+                              MemberDecorate 16(gl_PerVertex) 1 BuiltIn ClipDistance
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32

--- a/Test/baseResults/spv.400.tesc.out
+++ b/Test/baseResults/spv.400.tesc.out
@@ -50,16 +50,16 @@ Linked tessellation control stage:
                               Name 92  "ovla"
                               Name 93  "ovlb"
                               MemberDecorate 20(gl_PerVertex) 0 BuiltIn Position
+                              Decorate 20(gl_PerVertex) Block
                               MemberDecorate 20(gl_PerVertex) 1 BuiltIn PointSize
                               MemberDecorate 20(gl_PerVertex) 2 BuiltIn ClipDistance
-                              Decorate 20(gl_PerVertex) Block
                               Decorate 41(gl_PatchVerticesIn) BuiltIn PatchVertices
                               Decorate 44(gl_PrimitiveID) BuiltIn PrimitiveId
                               Decorate 47(gl_InvocationID) BuiltIn InvocationId
                               MemberDecorate 51(gl_PerVertex) 0 BuiltIn Position
+                              Decorate 51(gl_PerVertex) Block
                               MemberDecorate 51(gl_PerVertex) 1 BuiltIn PointSize
                               MemberDecorate 51(gl_PerVertex) 2 BuiltIn ClipDistance
-                              Decorate 51(gl_PerVertex) Block
                               Decorate 69(gl_TessLevelOuter) Patch
                               Decorate 69(gl_TessLevelOuter) BuiltIn TessLevelOuter
                               Decorate 74(gl_TessLevelInner) Patch

--- a/Test/baseResults/spv.400.tese.out
+++ b/Test/baseResults/spv.400.tese.out
@@ -59,9 +59,9 @@ Linked tessellation evaluation stage:
                               Name 92  "ivlb"
                               Name 95  "ovla"
                               MemberDecorate 17(gl_PerVertex) 0 BuiltIn Position
+                              Decorate 17(gl_PerVertex) Block
                               MemberDecorate 17(gl_PerVertex) 1 BuiltIn PointSize
                               MemberDecorate 17(gl_PerVertex) 2 BuiltIn ClipDistance
-                              Decorate 17(gl_PerVertex) Block
                               Decorate 38(gl_PatchVerticesIn) BuiltIn PatchVertices
                               Decorate 41(gl_PrimitiveID) BuiltIn PrimitiveId
                               Decorate 47(gl_TessCoord) BuiltIn TessCoord
@@ -70,9 +70,9 @@ Linked tessellation evaluation stage:
                               Decorate 61(gl_TessLevelInner) Patch
                               Decorate 61(gl_TessLevelInner) BuiltIn TessLevelInner
                               MemberDecorate 64(gl_PerVertex) 0 BuiltIn Position
+                              Decorate 64(gl_PerVertex) Block
                               MemberDecorate 64(gl_PerVertex) 1 BuiltIn PointSize
                               MemberDecorate 64(gl_PerVertex) 2 BuiltIn ClipDistance
-                              Decorate 64(gl_PerVertex) Block
                               Decorate 75(patchIn) Patch
                               Decorate 81(testblb) Block
                               Decorate 85(testbld) Block

--- a/Test/baseResults/spv.420.geom.out
+++ b/Test/baseResults/spv.420.geom.out
@@ -38,12 +38,12 @@ Linked geometry stage:
                               Name 46  "coord"
                               Name 64  "i"
                               Name 67  "indexable"
-                              MemberDecorate 9(gl_PerVertex) 0 BuiltIn PointSize
                               Decorate 9(gl_PerVertex) Block
-                              MemberDecorate 21(gl_PerVertex) 0 BuiltIn PointSize
+                              MemberDecorate 9(gl_PerVertex) 0 BuiltIn PointSize
                               Decorate 21(gl_PerVertex) Block
                               Decorate 21(gl_PerVertex) Stream 0
                               Decorate 23 Stream 0
+                              MemberDecorate 21(gl_PerVertex) 0 BuiltIn PointSize
                               Decorate 28(gl_ViewportIndex) Stream 0
                               Decorate 28(gl_ViewportIndex) BuiltIn ViewportIndex
                               Decorate 33(gl_InvocationID) BuiltIn InvocationId

--- a/Test/baseResults/spv.430.vert.out
+++ b/Test/baseResults/spv.430.vert.out
@@ -10,6 +10,7 @@ Linked vertex stage:
 // Id's are bound by 66
 
                               Capability Shader
+                              Capability ClipDistance
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
                               EntryPoint Vertex 4  "main" 12 23 34 38 41 42 62 65
@@ -44,8 +45,8 @@ Linked vertex stage:
                               Name 63  "MS"
                               MemberName 63(MS) 0  "f"
                               Name 65  "outMS"
-                              MemberDecorate 10(gl_PerVertex) 0 BuiltIn ClipDistance
                               Decorate 10(gl_PerVertex) Block
+                              MemberDecorate 10(gl_PerVertex) 0 BuiltIn ClipDistance
                               Decorate 34(badorder3) Flat
                               Decorate 42(badorder2) Invariant
                               MemberDecorate 43(boundblock) 0 Offset 0

--- a/Test/baseResults/spv.bool.vert.out
+++ b/Test/baseResults/spv.bool.vert.out
@@ -28,9 +28,6 @@ Linked vertex stage:
                               Name 31  "ubinst"
                               Name 32  "param"
                               MemberDecorate 22(gl_PerVertex) 0 BuiltIn Position
-                              MemberDecorate 22(gl_PerVertex) 1 BuiltIn PointSize
-                              MemberDecorate 22(gl_PerVertex) 2 BuiltIn ClipDistance
-                              MemberDecorate 22(gl_PerVertex) 3 BuiltIn CullDistance
                               Decorate 22(gl_PerVertex) Block
                               MemberDecorate 29(ubname) 0 Offset 0
                               Decorate 29(ubname) Block

--- a/Test/baseResults/spv.branch-return.vert.out
+++ b/Test/baseResults/spv.branch-return.vert.out
@@ -22,7 +22,6 @@ Linked vertex stage:
                               Name 20  ""
                               Decorate 8(gl_InstanceIndex) BuiltIn InstanceIndex
                               MemberDecorate 18(gl_PerVertex) 0 BuiltIn Position
-                              MemberDecorate 18(gl_PerVertex) 1 BuiltIn PointSize
                               Decorate 18(gl_PerVertex) Block
                2:             TypeVoid
                3:             TypeFunction 2

--- a/Test/baseResults/spv.matFun.vert.out
+++ b/Test/baseResults/spv.matFun.vert.out
@@ -39,8 +39,6 @@ Linked vertex stage:
                               Name 89  "param"
                               Name 93  "param"
                               MemberDecorate 74(gl_PerVertex) 0 BuiltIn Position
-                              MemberDecorate 74(gl_PerVertex) 1 BuiltIn PointSize
-                              MemberDecorate 74(gl_PerVertex) 2 BuiltIn ClipDistance
                               Decorate 74(gl_PerVertex) Block
                               MemberDecorate 77(bl) 0 ColMajor
                               MemberDecorate 77(bl) 0 Offset 0

--- a/Test/baseResults/spv.noDeadDecorations.vert.out
+++ b/Test/baseResults/spv.noDeadDecorations.vert.out
@@ -27,7 +27,6 @@ Linked vertex stage:
                               Decorate 12 RelaxedPrecision
                               Decorate 13 RelaxedPrecision
                               MemberDecorate 20(gl_PerVertex) 0 BuiltIn Position
-                              MemberDecorate 20(gl_PerVertex) 1 BuiltIn PointSize
                               Decorate 20(gl_PerVertex) Block
                               Decorate 27 RelaxedPrecision
                2:             TypeVoid

--- a/Test/baseResults/spv.precise.tese.out
+++ b/Test/baseResults/spv.precise.tese.out
@@ -10,7 +10,6 @@ Linked tessellation evaluation stage:
 // Id's are bound by 119
 
                               Capability Tessellation
-                              Capability TessellationPointSize
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
                               EntryPoint TessellationEvaluation 4  "main" 12 21 62 112
@@ -53,7 +52,6 @@ Linked tessellation evaluation stage:
                               Decorate 106 NoContraction
                               Decorate 109 NoContraction
                               MemberDecorate 110(gl_PerVertex) 0 BuiltIn Position
-                              MemberDecorate 110(gl_PerVertex) 1 BuiltIn PointSize
                               Decorate 110(gl_PerVertex) Block
                2:             TypeVoid
                3:             TypeFunction 2


### PR DESCRIPTION
…tance, CullDistance

SpvBuilder: Only record member decorations when they are new.

Fixes an error in the base test results:
 - spv.430.vert: add the required ClipDistance capability

Fixes https://github.com/KhronosGroup/glslang/issues/315