### PR TITLE
Defer capability decl for ClipDistance, CullDistance, PointSize until…

### DIFF
--- a/Test/baseResults/spv.430.vert.out
+++ b/Test/baseResults/spv.430.vert.out
@@ -10,6 +10,7 @@ Linked vertex stage:
 // Id's are bound by 66
 
                               Capability Shader
+                              Capability ClipDistance
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
                               EntryPoint Vertex 4  "main" 12 23 34 38 41 42 62 65

--- a/Test/baseResults/spv.precise.tese.out
+++ b/Test/baseResults/spv.precise.tese.out
@@ -10,7 +10,6 @@ Linked tessellation evaluation stage:
 // Id's are bound by 119
 
                               Capability Tessellation
-                              Capability TessellationPointSize
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
                               EntryPoint TessellationEvaluation 4  "main" 12 21 62 112


### PR DESCRIPTION
… actual use

The compiler will mark struct members with those builtins, but won't
declare the capability until that member is accessed by some executable
instruction.

Test changes:
- spv.430.vert: was missing ClipDistance capability.
- spv.precise.tese: remove TessellationPointSize capability.