### PR TITLE
Add decompositions for some HLSL intrinsics.

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -3028,7 +3028,7 @@ spv::Id TGlslangToSpvTraverser::createBinaryMatrixOperation(spv::Op op, spv::Dec
         return builder.setPrecision(result, precision);
     }
 
-    // Handle component-wise +, -, *, and / for all combinations of type.
+    // Handle component-wise +, -, *, %, and / for all combinations of type.
     // The result type of all of them is the same type as the (a) matrix operand.
     // The algorithm is to:
     //   - break the matrix(es) into vectors
@@ -3039,6 +3039,7 @@ spv::Id TGlslangToSpvTraverser::createBinaryMatrixOperation(spv::Op op, spv::Dec
     case spv::OpFAdd:
     case spv::OpFSub:
     case spv::OpFDiv:
+    case spv::OpFMod:
     case spv::OpFMul:
     {
         // one time set up...
@@ -3204,6 +3205,9 @@ spv::Id TGlslangToSpvTraverser::createUnaryOperation(glslang::TOperator op, spv:
         break;
     case glslang::EOpIsInf:
         unaryOp = spv::OpIsInf;
+        break;
+    case glslang::EOpIsFinite:
+        unaryOp = spv::OpIsFinite;
         break;
 
     case glslang::EOpFloatBitsToInt:

--- a/Test/baseResults/hlsl.intrinsics.frag.out
+++ b/Test/baseResults/hlsl.intrinsics.frag.out
@@ -2,7 +2,7 @@ hlsl.intrinsics.frag
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:62  Function Definition: PixelShaderFunction(f1;f1;f1; (temp float)
+0:66  Function Definition: PixelShaderFunction(f1;f1;f1; (temp float)
 0:2    Function Parameters: 
 0:2      'inF0' (temp float)
 0:2      'inF1' (temp float)
@@ -29,802 +29,1008 @@ gl_FragCoord origin is upper left
 0:11        'inF0' (temp float)
 0:11        'inF1' (temp float)
 0:11        'inF2' (temp float)
-0:12      cosine (global float)
-0:12        'inF0' (temp float)
-0:13      hyp. cosine (global float)
+0:12      Test condition and select (temp void)
+0:12        Condition
+0:12        Compare Less Than (temp bool)
+0:12          'inF0' (temp float)
+0:12          Constant:
+0:12            0.000000
+0:12        true case
+0:12        Branch: Kill
+0:13      cosine (global float)
 0:13        'inF0' (temp float)
-0:14      bitCount (global uint)
-0:14        Constant:
-0:14          7 (const uint)
-0:15      dPdx (global float)
-0:15        'inF0' (temp float)
-0:16      dPdxCoarse (global float)
+0:14      hyp. cosine (global float)
+0:14        'inF0' (temp float)
+0:15      bitCount (global uint)
+0:15        Constant:
+0:15          7 (const uint)
+0:16      dPdx (global float)
 0:16        'inF0' (temp float)
-0:17      dPdxFine (global float)
+0:17      dPdxCoarse (global float)
 0:17        'inF0' (temp float)
-0:18      dPdy (global float)
+0:18      dPdxFine (global float)
 0:18        'inF0' (temp float)
-0:19      dPdyCoarse (global float)
+0:19      dPdy (global float)
 0:19        'inF0' (temp float)
-0:20      dPdyFine (global float)
+0:20      dPdyCoarse (global float)
 0:20        'inF0' (temp float)
-0:21      degrees (global float)
+0:21      dPdyFine (global float)
 0:21        'inF0' (temp float)
-0:25      exp (global float)
-0:25        'inF0' (temp float)
-0:26      exp2 (global float)
+0:22      degrees (global float)
+0:22        'inF0' (temp float)
+0:26      exp (global float)
 0:26        'inF0' (temp float)
-0:27      findMSB (global int)
-0:27        Constant:
-0:27          7 (const int)
-0:28      findLSB (global int)
+0:27      exp2 (global float)
+0:27        'inF0' (temp float)
+0:28      findMSB (global int)
 0:28        Constant:
 0:28          7 (const int)
-0:29      Floor (global float)
-0:29        'inF0' (temp float)
-0:31      Function Call: fmod(f1;f1; (global float)
-0:31        'inF0' (temp float)
-0:31        'inF1' (temp float)
-0:32      Fraction (global float)
+0:29      findLSB (global int)
+0:29        Constant:
+0:29          7 (const int)
+0:30      Floor (global float)
+0:30        'inF0' (temp float)
+0:32      mod (global float)
 0:32        'inF0' (temp float)
-0:33      frexp (global float)
+0:32        'inF1' (temp float)
+0:33      Fraction (global float)
 0:33        'inF0' (temp float)
-0:33        'inF1' (temp float)
-0:34      fwidth (global float)
+0:34      frexp (global float)
 0:34        'inF0' (temp float)
-0:35      isinf (global bool)
+0:34        'inF1' (temp float)
+0:35      fwidth (global float)
 0:35        'inF0' (temp float)
-0:36      isnan (global bool)
+0:36      isinf (global bool)
 0:36        'inF0' (temp float)
-0:37      ldexp (global float)
+0:37      isnan (global bool)
 0:37        'inF0' (temp float)
-0:37        'inF1' (temp float)
-0:38      log (global float)
+0:38      ldexp (global float)
 0:38        'inF0' (temp float)
-0:39      log2 (global float)
+0:38        'inF1' (temp float)
+0:39      log (global float)
 0:39        'inF0' (temp float)
-0:40      max (global float)
-0:40        'inF0' (temp float)
-0:40        'inF1' (temp float)
-0:41      min (global float)
+0:40      component-wise multiply (global float)
+0:40        log2 (global float)
+0:40          'inF0' (temp float)
+0:40        Constant:
+0:40          0.301030
+0:41      log2 (global float)
 0:41        'inF0' (temp float)
-0:41        'inF1' (temp float)
-0:43      pow (global float)
+0:42      max (global float)
+0:42        'inF0' (temp float)
+0:42        'inF1' (temp float)
+0:43      min (global float)
 0:43        'inF0' (temp float)
 0:43        'inF1' (temp float)
-0:44      radians (global float)
+0:44      pow (global float)
 0:44        'inF0' (temp float)
-0:45      bitFieldReverse (global uint)
-0:45        Constant:
-0:45          2 (const uint)
-0:46      roundEven (global float)
+0:44        'inF1' (temp float)
+0:45      radians (global float)
+0:45        'inF0' (temp float)
+0:46      divide (global float)
+0:46        Constant:
+0:46          1.000000
 0:46        'inF0' (temp float)
-0:47      inverse sqrt (global float)
-0:47        'inF0' (temp float)
-0:48      Sign (global float)
+0:47      bitFieldReverse (global uint)
+0:47        Constant:
+0:47          2 (const uint)
+0:48      roundEven (global float)
 0:48        'inF0' (temp float)
-0:49      sine (global float)
+0:49      inverse sqrt (global float)
 0:49        'inF0' (temp float)
-0:50      hyp. sine (global float)
+0:50      clamp (global float)
 0:50        'inF0' (temp float)
-0:51      smoothstep (global float)
+0:50        Constant:
+0:50          0.000000
+0:50        Constant:
+0:50          1.000000
+0:51      Sign (global float)
 0:51        'inF0' (temp float)
-0:51        'inF1' (temp float)
-0:51        'inF2' (temp float)
-0:52      sqrt (global float)
+0:52      sine (global float)
 0:52        'inF0' (temp float)
-0:53      step (global float)
-0:53        'inF0' (temp float)
-0:53        'inF1' (temp float)
-0:54      tangent (global float)
+0:53      Sequence
+0:53        move second child to first child (temp float)
+0:53          'inF1' (temp float)
+0:53          sine (temp float)
+0:53            'inF0' (temp float)
+0:53        move second child to first child (temp float)
+0:53          'inF2' (temp float)
+0:53          cosine (temp float)
+0:53            'inF0' (temp float)
+0:54      hyp. sine (global float)
 0:54        'inF0' (temp float)
-0:55      hyp. tangent (global float)
+0:55      smoothstep (global float)
 0:55        'inF0' (temp float)
-0:57      trunc (global float)
+0:55        'inF1' (temp float)
+0:55        'inF2' (temp float)
+0:56      sqrt (global float)
+0:56        'inF0' (temp float)
+0:57      step (global float)
 0:57        'inF0' (temp float)
-0:59      Branch: Return with expression
-0:59        Constant:
-0:59          0.000000
-0:68  Function Definition: PixelShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
-0:63    Function Parameters: 
-0:63      'inF0' (temp 1-component vector of float)
-0:63      'inF1' (temp 1-component vector of float)
-0:63      'inF2' (temp 1-component vector of float)
+0:57        'inF1' (temp float)
+0:58      tangent (global float)
+0:58        'inF0' (temp float)
+0:59      hyp. tangent (global float)
+0:59        'inF0' (temp float)
+0:61      trunc (global float)
+0:61        'inF0' (temp float)
+0:63      Branch: Return with expression
+0:63        Constant:
+0:63          0.000000
+0:72  Function Definition: PixelShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
+0:67    Function Parameters: 
+0:67      'inF0' (temp 1-component vector of float)
+0:67      'inF1' (temp 1-component vector of float)
+0:67      'inF2' (temp 1-component vector of float)
 0:?     Sequence
-0:65      Branch: Return with expression
-0:65        Constant:
-0:65          0.000000
-0:137  Function Definition: PixelShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
-0:69    Function Parameters: 
-0:69      'inF0' (temp 2-component vector of float)
-0:69      'inF1' (temp 2-component vector of float)
-0:69      'inF2' (temp 2-component vector of float)
+0:69      Branch: Return with expression
+0:69        Constant:
+0:69          0.000000
+0:145  Function Definition: PixelShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
+0:73    Function Parameters: 
+0:73      'inF0' (temp 2-component vector of float)
+0:73      'inF1' (temp 2-component vector of float)
+0:73      'inF2' (temp 2-component vector of float)
 0:?     Sequence
-0:70      all (global bool)
-0:70        'inF0' (temp 2-component vector of float)
-0:71      Absolute value (global 2-component vector of float)
-0:71        'inF0' (temp 2-component vector of float)
-0:72      arc cosine (global 2-component vector of float)
-0:72        'inF0' (temp 2-component vector of float)
-0:73      any (global bool)
-0:73        'inF0' (temp 2-component vector of float)
-0:74      arc sine (global 2-component vector of float)
+0:74      all (global bool)
 0:74        'inF0' (temp 2-component vector of float)
-0:75      arc tangent (global 2-component vector of float)
+0:75      Absolute value (global 2-component vector of float)
 0:75        'inF0' (temp 2-component vector of float)
-0:76      arc tangent (global 2-component vector of float)
+0:76      arc cosine (global 2-component vector of float)
 0:76        'inF0' (temp 2-component vector of float)
-0:76        'inF1' (temp 2-component vector of float)
-0:77      Ceiling (global 2-component vector of float)
+0:77      any (global bool)
 0:77        'inF0' (temp 2-component vector of float)
-0:78      clamp (global 2-component vector of float)
+0:78      arc sine (global 2-component vector of float)
 0:78        'inF0' (temp 2-component vector of float)
-0:78        'inF1' (temp 2-component vector of float)
-0:78        'inF2' (temp 2-component vector of float)
-0:79      cosine (global 2-component vector of float)
+0:79      arc tangent (global 2-component vector of float)
 0:79        'inF0' (temp 2-component vector of float)
-0:80      hyp. cosine (global 2-component vector of float)
+0:80      arc tangent (global 2-component vector of float)
 0:80        'inF0' (temp 2-component vector of float)
+0:80        'inF1' (temp 2-component vector of float)
+0:81      Ceiling (global 2-component vector of float)
+0:81        'inF0' (temp 2-component vector of float)
+0:82      clamp (global 2-component vector of float)
+0:82        'inF0' (temp 2-component vector of float)
+0:82        'inF1' (temp 2-component vector of float)
+0:82        'inF2' (temp 2-component vector of float)
+0:83      Test condition and select (temp void)
+0:83        Condition
+0:83        any (temp bool)
+0:83          Compare Less Than (temp 2-component vector of bool)
+0:83            'inF0' (temp 2-component vector of float)
+0:83            Constant:
+0:83              0.000000
+0:83              0.000000
+0:83        true case
+0:83        Branch: Kill
+0:84      cosine (global 2-component vector of float)
+0:84        'inF0' (temp 2-component vector of float)
+0:85      hyp. cosine (global 2-component vector of float)
+0:85        'inF0' (temp 2-component vector of float)
 0:?       bitCount (global 2-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
-0:82      dPdx (global 2-component vector of float)
-0:82        'inF0' (temp 2-component vector of float)
-0:83      dPdxCoarse (global 2-component vector of float)
-0:83        'inF0' (temp 2-component vector of float)
-0:84      dPdxFine (global 2-component vector of float)
-0:84        'inF0' (temp 2-component vector of float)
-0:85      dPdy (global 2-component vector of float)
-0:85        'inF0' (temp 2-component vector of float)
-0:86      dPdyCoarse (global 2-component vector of float)
-0:86        'inF0' (temp 2-component vector of float)
-0:87      dPdyFine (global 2-component vector of float)
+0:87      dPdx (global 2-component vector of float)
 0:87        'inF0' (temp 2-component vector of float)
-0:88      degrees (global 2-component vector of float)
+0:88      dPdxCoarse (global 2-component vector of float)
 0:88        'inF0' (temp 2-component vector of float)
-0:89      distance (global float)
+0:89      dPdxFine (global 2-component vector of float)
 0:89        'inF0' (temp 2-component vector of float)
-0:89        'inF1' (temp 2-component vector of float)
-0:90      dot-product (global float)
+0:90      dPdy (global 2-component vector of float)
 0:90        'inF0' (temp 2-component vector of float)
-0:90        'inF1' (temp 2-component vector of float)
-0:94      exp (global 2-component vector of float)
+0:91      dPdyCoarse (global 2-component vector of float)
+0:91        'inF0' (temp 2-component vector of float)
+0:92      dPdyFine (global 2-component vector of float)
+0:92        'inF0' (temp 2-component vector of float)
+0:93      degrees (global 2-component vector of float)
+0:93        'inF0' (temp 2-component vector of float)
+0:94      distance (global float)
 0:94        'inF0' (temp 2-component vector of float)
-0:95      exp2 (global 2-component vector of float)
+0:94        'inF1' (temp 2-component vector of float)
+0:95      dot-product (global float)
 0:95        'inF0' (temp 2-component vector of float)
-0:96      face-forward (global 2-component vector of float)
-0:96        'inF0' (temp 2-component vector of float)
-0:96        'inF1' (temp 2-component vector of float)
-0:96        'inF2' (temp 2-component vector of float)
-0:97      findMSB (global int)
-0:97        Constant:
-0:97          7 (const int)
-0:98      findLSB (global int)
-0:98        Constant:
-0:98          7 (const int)
-0:99      Floor (global 2-component vector of float)
+0:95        'inF1' (temp 2-component vector of float)
+0:99      exp (global 2-component vector of float)
 0:99        'inF0' (temp 2-component vector of float)
-0:101      Function Call: fmod(vf2;vf2; (global 2-component vector of float)
+0:100      exp2 (global 2-component vector of float)
+0:100        'inF0' (temp 2-component vector of float)
+0:101      face-forward (global 2-component vector of float)
 0:101        'inF0' (temp 2-component vector of float)
 0:101        'inF1' (temp 2-component vector of float)
-0:102      Fraction (global 2-component vector of float)
-0:102        'inF0' (temp 2-component vector of float)
-0:103      frexp (global 2-component vector of float)
-0:103        'inF0' (temp 2-component vector of float)
-0:103        'inF1' (temp 2-component vector of float)
-0:104      fwidth (global 2-component vector of float)
+0:101        'inF2' (temp 2-component vector of float)
+0:102      findMSB (global int)
+0:102        Constant:
+0:102          7 (const int)
+0:103      findLSB (global int)
+0:103        Constant:
+0:103          7 (const int)
+0:104      Floor (global 2-component vector of float)
 0:104        'inF0' (temp 2-component vector of float)
-0:105      isinf (global 2-component vector of bool)
-0:105        'inF0' (temp 2-component vector of float)
-0:106      isnan (global 2-component vector of bool)
+0:106      mod (global 2-component vector of float)
 0:106        'inF0' (temp 2-component vector of float)
-0:107      ldexp (global 2-component vector of float)
+0:106        'inF1' (temp 2-component vector of float)
+0:107      Fraction (global 2-component vector of float)
 0:107        'inF0' (temp 2-component vector of float)
-0:107        'inF1' (temp 2-component vector of float)
-0:108      length (global float)
+0:108      frexp (global 2-component vector of float)
 0:108        'inF0' (temp 2-component vector of float)
-0:109      log (global 2-component vector of float)
+0:108        'inF1' (temp 2-component vector of float)
+0:109      fwidth (global 2-component vector of float)
 0:109        'inF0' (temp 2-component vector of float)
-0:110      log2 (global 2-component vector of float)
+0:110      isinf (global 2-component vector of bool)
 0:110        'inF0' (temp 2-component vector of float)
-0:111      max (global 2-component vector of float)
+0:111      isnan (global 2-component vector of bool)
 0:111        'inF0' (temp 2-component vector of float)
-0:111        'inF1' (temp 2-component vector of float)
-0:112      min (global 2-component vector of float)
+0:112      ldexp (global 2-component vector of float)
 0:112        'inF0' (temp 2-component vector of float)
 0:112        'inF1' (temp 2-component vector of float)
-0:114      normalize (global 2-component vector of float)
+0:113      length (global float)
+0:113        'inF0' (temp 2-component vector of float)
+0:114      log (global 2-component vector of float)
 0:114        'inF0' (temp 2-component vector of float)
-0:115      pow (global 2-component vector of float)
-0:115        'inF0' (temp 2-component vector of float)
-0:115        'inF1' (temp 2-component vector of float)
-0:116      radians (global 2-component vector of float)
+0:115      component-wise multiply (global 2-component vector of float)
+0:115        log2 (global 2-component vector of float)
+0:115          'inF0' (temp 2-component vector of float)
+0:115        Constant:
+0:115          0.301030
+0:116      log2 (global 2-component vector of float)
 0:116        'inF0' (temp 2-component vector of float)
-0:117      reflect (global 2-component vector of float)
+0:117      max (global 2-component vector of float)
 0:117        'inF0' (temp 2-component vector of float)
 0:117        'inF1' (temp 2-component vector of float)
-0:118      refract (global 2-component vector of float)
+0:118      min (global 2-component vector of float)
 0:118        'inF0' (temp 2-component vector of float)
 0:118        'inF1' (temp 2-component vector of float)
-0:118        Constant:
-0:118          2.000000
+0:119      normalize (global 2-component vector of float)
+0:119        'inF0' (temp 2-component vector of float)
+0:120      pow (global 2-component vector of float)
+0:120        'inF0' (temp 2-component vector of float)
+0:120        'inF1' (temp 2-component vector of float)
+0:121      radians (global 2-component vector of float)
+0:121        'inF0' (temp 2-component vector of float)
+0:122      divide (global 2-component vector of float)
+0:122        Constant:
+0:122          1.000000
+0:122        'inF0' (temp 2-component vector of float)
+0:123      reflect (global 2-component vector of float)
+0:123        'inF0' (temp 2-component vector of float)
+0:123        'inF1' (temp 2-component vector of float)
+0:124      refract (global 2-component vector of float)
+0:124        'inF0' (temp 2-component vector of float)
+0:124        'inF1' (temp 2-component vector of float)
+0:124        Constant:
+0:124          2.000000
 0:?       bitFieldReverse (global 2-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
-0:120      roundEven (global 2-component vector of float)
-0:120        'inF0' (temp 2-component vector of float)
-0:121      inverse sqrt (global 2-component vector of float)
-0:121        'inF0' (temp 2-component vector of float)
-0:122      Sign (global 2-component vector of float)
-0:122        'inF0' (temp 2-component vector of float)
-0:123      sine (global 2-component vector of float)
-0:123        'inF0' (temp 2-component vector of float)
-0:124      hyp. sine (global 2-component vector of float)
-0:124        'inF0' (temp 2-component vector of float)
-0:125      smoothstep (global 2-component vector of float)
-0:125        'inF0' (temp 2-component vector of float)
-0:125        'inF1' (temp 2-component vector of float)
-0:125        'inF2' (temp 2-component vector of float)
-0:126      sqrt (global 2-component vector of float)
+0:126      roundEven (global 2-component vector of float)
 0:126        'inF0' (temp 2-component vector of float)
-0:127      step (global 2-component vector of float)
+0:127      inverse sqrt (global 2-component vector of float)
 0:127        'inF0' (temp 2-component vector of float)
-0:127        'inF1' (temp 2-component vector of float)
-0:128      tangent (global 2-component vector of float)
+0:128      clamp (global 2-component vector of float)
 0:128        'inF0' (temp 2-component vector of float)
-0:129      hyp. tangent (global 2-component vector of float)
+0:128        Constant:
+0:128          0.000000
+0:128        Constant:
+0:128          1.000000
+0:129      Sign (global 2-component vector of float)
 0:129        'inF0' (temp 2-component vector of float)
-0:131      trunc (global 2-component vector of float)
-0:131        'inF0' (temp 2-component vector of float)
-0:134      Branch: Return with expression
+0:130      sine (global 2-component vector of float)
+0:130        'inF0' (temp 2-component vector of float)
+0:131      Sequence
+0:131        move second child to first child (temp 2-component vector of float)
+0:131          'inF1' (temp 2-component vector of float)
+0:131          sine (temp 2-component vector of float)
+0:131            'inF0' (temp 2-component vector of float)
+0:131        move second child to first child (temp 2-component vector of float)
+0:131          'inF2' (temp 2-component vector of float)
+0:131          cosine (temp 2-component vector of float)
+0:131            'inF0' (temp 2-component vector of float)
+0:132      hyp. sine (global 2-component vector of float)
+0:132        'inF0' (temp 2-component vector of float)
+0:133      smoothstep (global 2-component vector of float)
+0:133        'inF0' (temp 2-component vector of float)
+0:133        'inF1' (temp 2-component vector of float)
+0:133        'inF2' (temp 2-component vector of float)
+0:134      sqrt (global 2-component vector of float)
+0:134        'inF0' (temp 2-component vector of float)
+0:135      step (global 2-component vector of float)
+0:135        'inF0' (temp 2-component vector of float)
+0:135        'inF1' (temp 2-component vector of float)
+0:136      tangent (global 2-component vector of float)
+0:136        'inF0' (temp 2-component vector of float)
+0:137      hyp. tangent (global 2-component vector of float)
+0:137        'inF0' (temp 2-component vector of float)
+0:139      trunc (global 2-component vector of float)
+0:139        'inF0' (temp 2-component vector of float)
+0:142      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
-0:207  Function Definition: PixelShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
-0:138    Function Parameters: 
-0:138      'inF0' (temp 3-component vector of float)
-0:138      'inF1' (temp 3-component vector of float)
-0:138      'inF2' (temp 3-component vector of float)
+0:219  Function Definition: PixelShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
+0:146    Function Parameters: 
+0:146      'inF0' (temp 3-component vector of float)
+0:146      'inF1' (temp 3-component vector of float)
+0:146      'inF2' (temp 3-component vector of float)
 0:?     Sequence
-0:139      all (global bool)
-0:139        'inF0' (temp 3-component vector of float)
-0:140      Absolute value (global 3-component vector of float)
-0:140        'inF0' (temp 3-component vector of float)
-0:141      arc cosine (global 3-component vector of float)
-0:141        'inF0' (temp 3-component vector of float)
-0:142      any (global bool)
-0:142        'inF0' (temp 3-component vector of float)
-0:143      arc sine (global 3-component vector of float)
-0:143        'inF0' (temp 3-component vector of float)
-0:144      arc tangent (global 3-component vector of float)
-0:144        'inF0' (temp 3-component vector of float)
-0:145      arc tangent (global 3-component vector of float)
-0:145        'inF0' (temp 3-component vector of float)
-0:145        'inF1' (temp 3-component vector of float)
-0:146      Ceiling (global 3-component vector of float)
-0:146        'inF0' (temp 3-component vector of float)
-0:147      clamp (global 3-component vector of float)
+0:147      all (global bool)
 0:147        'inF0' (temp 3-component vector of float)
-0:147        'inF1' (temp 3-component vector of float)
-0:147        'inF2' (temp 3-component vector of float)
-0:148      cosine (global 3-component vector of float)
+0:148      Absolute value (global 3-component vector of float)
 0:148        'inF0' (temp 3-component vector of float)
-0:149      hyp. cosine (global 3-component vector of float)
+0:149      arc cosine (global 3-component vector of float)
 0:149        'inF0' (temp 3-component vector of float)
+0:150      any (global bool)
+0:150        'inF0' (temp 3-component vector of float)
+0:151      arc sine (global 3-component vector of float)
+0:151        'inF0' (temp 3-component vector of float)
+0:152      arc tangent (global 3-component vector of float)
+0:152        'inF0' (temp 3-component vector of float)
+0:153      arc tangent (global 3-component vector of float)
+0:153        'inF0' (temp 3-component vector of float)
+0:153        'inF1' (temp 3-component vector of float)
+0:154      Ceiling (global 3-component vector of float)
+0:154        'inF0' (temp 3-component vector of float)
+0:155      clamp (global 3-component vector of float)
+0:155        'inF0' (temp 3-component vector of float)
+0:155        'inF1' (temp 3-component vector of float)
+0:155        'inF2' (temp 3-component vector of float)
+0:156      Test condition and select (temp void)
+0:156        Condition
+0:156        any (temp bool)
+0:156          Compare Less Than (temp 3-component vector of bool)
+0:156            'inF0' (temp 3-component vector of float)
+0:156            Constant:
+0:156              0.000000
+0:156              0.000000
+0:156              0.000000
+0:156        true case
+0:156        Branch: Kill
+0:157      cosine (global 3-component vector of float)
+0:157        'inF0' (temp 3-component vector of float)
+0:158      hyp. cosine (global 3-component vector of float)
+0:158        'inF0' (temp 3-component vector of float)
 0:?       bitCount (global 3-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
-0:151      cross-product (global 3-component vector of float)
-0:151        'inF0' (temp 3-component vector of float)
-0:151        'inF1' (temp 3-component vector of float)
-0:152      dPdx (global 3-component vector of float)
-0:152        'inF0' (temp 3-component vector of float)
-0:153      dPdxCoarse (global 3-component vector of float)
-0:153        'inF0' (temp 3-component vector of float)
-0:154      dPdxFine (global 3-component vector of float)
-0:154        'inF0' (temp 3-component vector of float)
-0:155      dPdy (global 3-component vector of float)
-0:155        'inF0' (temp 3-component vector of float)
-0:156      dPdyCoarse (global 3-component vector of float)
-0:156        'inF0' (temp 3-component vector of float)
-0:157      dPdyFine (global 3-component vector of float)
-0:157        'inF0' (temp 3-component vector of float)
-0:158      degrees (global 3-component vector of float)
-0:158        'inF0' (temp 3-component vector of float)
-0:159      distance (global float)
-0:159        'inF0' (temp 3-component vector of float)
-0:159        'inF1' (temp 3-component vector of float)
-0:160      dot-product (global float)
+0:160      cross-product (global 3-component vector of float)
 0:160        'inF0' (temp 3-component vector of float)
 0:160        'inF1' (temp 3-component vector of float)
-0:164      exp (global 3-component vector of float)
+0:161      dPdx (global 3-component vector of float)
+0:161        'inF0' (temp 3-component vector of float)
+0:162      dPdxCoarse (global 3-component vector of float)
+0:162        'inF0' (temp 3-component vector of float)
+0:163      dPdxFine (global 3-component vector of float)
+0:163        'inF0' (temp 3-component vector of float)
+0:164      dPdy (global 3-component vector of float)
 0:164        'inF0' (temp 3-component vector of float)
-0:165      exp2 (global 3-component vector of float)
+0:165      dPdyCoarse (global 3-component vector of float)
 0:165        'inF0' (temp 3-component vector of float)
-0:166      face-forward (global 3-component vector of float)
+0:166      dPdyFine (global 3-component vector of float)
 0:166        'inF0' (temp 3-component vector of float)
-0:166        'inF1' (temp 3-component vector of float)
-0:166        'inF2' (temp 3-component vector of float)
-0:167      findMSB (global int)
-0:167        Constant:
-0:167          7 (const int)
-0:168      findLSB (global int)
-0:168        Constant:
-0:168          7 (const int)
-0:169      Floor (global 3-component vector of float)
+0:167      degrees (global 3-component vector of float)
+0:167        'inF0' (temp 3-component vector of float)
+0:168      distance (global float)
+0:168        'inF0' (temp 3-component vector of float)
+0:168        'inF1' (temp 3-component vector of float)
+0:169      dot-product (global float)
 0:169        'inF0' (temp 3-component vector of float)
-0:171      Function Call: fmod(vf3;vf3; (global 3-component vector of float)
-0:171        'inF0' (temp 3-component vector of float)
-0:171        'inF1' (temp 3-component vector of float)
-0:172      Fraction (global 3-component vector of float)
-0:172        'inF0' (temp 3-component vector of float)
-0:173      frexp (global 3-component vector of float)
+0:169        'inF1' (temp 3-component vector of float)
+0:173      exp (global 3-component vector of float)
 0:173        'inF0' (temp 3-component vector of float)
-0:173        'inF1' (temp 3-component vector of float)
-0:174      fwidth (global 3-component vector of float)
+0:174      exp2 (global 3-component vector of float)
 0:174        'inF0' (temp 3-component vector of float)
-0:175      isinf (global 3-component vector of bool)
+0:175      face-forward (global 3-component vector of float)
 0:175        'inF0' (temp 3-component vector of float)
-0:176      isnan (global 3-component vector of bool)
-0:176        'inF0' (temp 3-component vector of float)
-0:177      ldexp (global 3-component vector of float)
-0:177        'inF0' (temp 3-component vector of float)
-0:177        'inF1' (temp 3-component vector of float)
-0:178      length (global float)
+0:175        'inF1' (temp 3-component vector of float)
+0:175        'inF2' (temp 3-component vector of float)
+0:176      findMSB (global int)
+0:176        Constant:
+0:176          7 (const int)
+0:177      findLSB (global int)
+0:177        Constant:
+0:177          7 (const int)
+0:178      Floor (global 3-component vector of float)
 0:178        'inF0' (temp 3-component vector of float)
-0:179      log (global 3-component vector of float)
-0:179        'inF0' (temp 3-component vector of float)
-0:180      log2 (global 3-component vector of float)
+0:180      mod (global 3-component vector of float)
 0:180        'inF0' (temp 3-component vector of float)
-0:181      max (global 3-component vector of float)
+0:180        'inF1' (temp 3-component vector of float)
+0:181      Fraction (global 3-component vector of float)
 0:181        'inF0' (temp 3-component vector of float)
-0:181        'inF1' (temp 3-component vector of float)
-0:182      min (global 3-component vector of float)
+0:182      frexp (global 3-component vector of float)
 0:182        'inF0' (temp 3-component vector of float)
 0:182        'inF1' (temp 3-component vector of float)
-0:184      normalize (global 3-component vector of float)
+0:183      fwidth (global 3-component vector of float)
+0:183        'inF0' (temp 3-component vector of float)
+0:184      isinf (global 3-component vector of bool)
 0:184        'inF0' (temp 3-component vector of float)
-0:185      pow (global 3-component vector of float)
+0:185      isnan (global 3-component vector of bool)
 0:185        'inF0' (temp 3-component vector of float)
-0:185        'inF1' (temp 3-component vector of float)
-0:186      radians (global 3-component vector of float)
+0:186      ldexp (global 3-component vector of float)
 0:186        'inF0' (temp 3-component vector of float)
-0:187      reflect (global 3-component vector of float)
+0:186        'inF1' (temp 3-component vector of float)
+0:187      length (global float)
 0:187        'inF0' (temp 3-component vector of float)
-0:187        'inF1' (temp 3-component vector of float)
-0:188      refract (global 3-component vector of float)
+0:188      log (global 3-component vector of float)
 0:188        'inF0' (temp 3-component vector of float)
-0:188        'inF1' (temp 3-component vector of float)
-0:188        Constant:
-0:188          2.000000
+0:189      component-wise multiply (global 3-component vector of float)
+0:189        log2 (global 3-component vector of float)
+0:189          'inF0' (temp 3-component vector of float)
+0:189        Constant:
+0:189          0.301030
+0:190      log2 (global 3-component vector of float)
+0:190        'inF0' (temp 3-component vector of float)
+0:191      max (global 3-component vector of float)
+0:191        'inF0' (temp 3-component vector of float)
+0:191        'inF1' (temp 3-component vector of float)
+0:192      min (global 3-component vector of float)
+0:192        'inF0' (temp 3-component vector of float)
+0:192        'inF1' (temp 3-component vector of float)
+0:193      normalize (global 3-component vector of float)
+0:193        'inF0' (temp 3-component vector of float)
+0:194      pow (global 3-component vector of float)
+0:194        'inF0' (temp 3-component vector of float)
+0:194        'inF1' (temp 3-component vector of float)
+0:195      radians (global 3-component vector of float)
+0:195        'inF0' (temp 3-component vector of float)
+0:196      divide (global 3-component vector of float)
+0:196        Constant:
+0:196          1.000000
+0:196        'inF0' (temp 3-component vector of float)
+0:197      reflect (global 3-component vector of float)
+0:197        'inF0' (temp 3-component vector of float)
+0:197        'inF1' (temp 3-component vector of float)
+0:198      refract (global 3-component vector of float)
+0:198        'inF0' (temp 3-component vector of float)
+0:198        'inF1' (temp 3-component vector of float)
+0:198        Constant:
+0:198          2.000000
 0:?       bitFieldReverse (global 3-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
-0:190      roundEven (global 3-component vector of float)
-0:190        'inF0' (temp 3-component vector of float)
-0:191      inverse sqrt (global 3-component vector of float)
-0:191        'inF0' (temp 3-component vector of float)
-0:192      Sign (global 3-component vector of float)
-0:192        'inF0' (temp 3-component vector of float)
-0:193      sine (global 3-component vector of float)
-0:193        'inF0' (temp 3-component vector of float)
-0:194      hyp. sine (global 3-component vector of float)
-0:194        'inF0' (temp 3-component vector of float)
-0:195      smoothstep (global 3-component vector of float)
-0:195        'inF0' (temp 3-component vector of float)
-0:195        'inF1' (temp 3-component vector of float)
-0:195        'inF2' (temp 3-component vector of float)
-0:196      sqrt (global 3-component vector of float)
-0:196        'inF0' (temp 3-component vector of float)
-0:197      step (global 3-component vector of float)
-0:197        'inF0' (temp 3-component vector of float)
-0:197        'inF1' (temp 3-component vector of float)
-0:198      tangent (global 3-component vector of float)
-0:198        'inF0' (temp 3-component vector of float)
-0:199      hyp. tangent (global 3-component vector of float)
-0:199        'inF0' (temp 3-component vector of float)
-0:201      trunc (global 3-component vector of float)
+0:200      roundEven (global 3-component vector of float)
+0:200        'inF0' (temp 3-component vector of float)
+0:201      inverse sqrt (global 3-component vector of float)
 0:201        'inF0' (temp 3-component vector of float)
-0:204      Branch: Return with expression
+0:202      clamp (global 3-component vector of float)
+0:202        'inF0' (temp 3-component vector of float)
+0:202        Constant:
+0:202          0.000000
+0:202        Constant:
+0:202          1.000000
+0:203      Sign (global 3-component vector of float)
+0:203        'inF0' (temp 3-component vector of float)
+0:204      sine (global 3-component vector of float)
+0:204        'inF0' (temp 3-component vector of float)
+0:205      Sequence
+0:205        move second child to first child (temp 3-component vector of float)
+0:205          'inF1' (temp 3-component vector of float)
+0:205          sine (temp 3-component vector of float)
+0:205            'inF0' (temp 3-component vector of float)
+0:205        move second child to first child (temp 3-component vector of float)
+0:205          'inF2' (temp 3-component vector of float)
+0:205          cosine (temp 3-component vector of float)
+0:205            'inF0' (temp 3-component vector of float)
+0:206      hyp. sine (global 3-component vector of float)
+0:206        'inF0' (temp 3-component vector of float)
+0:207      smoothstep (global 3-component vector of float)
+0:207        'inF0' (temp 3-component vector of float)
+0:207        'inF1' (temp 3-component vector of float)
+0:207        'inF2' (temp 3-component vector of float)
+0:208      sqrt (global 3-component vector of float)
+0:208        'inF0' (temp 3-component vector of float)
+0:209      step (global 3-component vector of float)
+0:209        'inF0' (temp 3-component vector of float)
+0:209        'inF1' (temp 3-component vector of float)
+0:210      tangent (global 3-component vector of float)
+0:210        'inF0' (temp 3-component vector of float)
+0:211      hyp. tangent (global 3-component vector of float)
+0:211        'inF0' (temp 3-component vector of float)
+0:213      trunc (global 3-component vector of float)
+0:213        'inF0' (temp 3-component vector of float)
+0:216      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
-0:328  Function Definition: PixelShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
-0:208    Function Parameters: 
-0:208      'inF0' (temp 4-component vector of float)
-0:208      'inF1' (temp 4-component vector of float)
-0:208      'inF2' (temp 4-component vector of float)
+0:348  Function Definition: PixelShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
+0:220    Function Parameters: 
+0:220      'inF0' (temp 4-component vector of float)
+0:220      'inF1' (temp 4-component vector of float)
+0:220      'inF2' (temp 4-component vector of float)
 0:?     Sequence
-0:209      all (global bool)
-0:209        'inF0' (temp 4-component vector of float)
-0:210      Absolute value (global 4-component vector of float)
-0:210        'inF0' (temp 4-component vector of float)
-0:211      arc cosine (global 4-component vector of float)
-0:211        'inF0' (temp 4-component vector of float)
-0:212      any (global bool)
-0:212        'inF0' (temp 4-component vector of float)
-0:213      arc sine (global 4-component vector of float)
-0:213        'inF0' (temp 4-component vector of float)
-0:214      arc tangent (global 4-component vector of float)
-0:214        'inF0' (temp 4-component vector of float)
-0:215      arc tangent (global 4-component vector of float)
-0:215        'inF0' (temp 4-component vector of float)
-0:215        'inF1' (temp 4-component vector of float)
-0:216      Ceiling (global 4-component vector of float)
-0:216        'inF0' (temp 4-component vector of float)
-0:217      clamp (global 4-component vector of float)
-0:217        'inF0' (temp 4-component vector of float)
-0:217        'inF1' (temp 4-component vector of float)
-0:217        'inF2' (temp 4-component vector of float)
-0:218      cosine (global 4-component vector of float)
-0:218        'inF0' (temp 4-component vector of float)
-0:219      hyp. cosine (global 4-component vector of float)
-0:219        'inF0' (temp 4-component vector of float)
+0:221      all (global bool)
+0:221        'inF0' (temp 4-component vector of float)
+0:222      Absolute value (global 4-component vector of float)
+0:222        'inF0' (temp 4-component vector of float)
+0:223      arc cosine (global 4-component vector of float)
+0:223        'inF0' (temp 4-component vector of float)
+0:224      any (global bool)
+0:224        'inF0' (temp 4-component vector of float)
+0:225      arc sine (global 4-component vector of float)
+0:225        'inF0' (temp 4-component vector of float)
+0:226      arc tangent (global 4-component vector of float)
+0:226        'inF0' (temp 4-component vector of float)
+0:227      arc tangent (global 4-component vector of float)
+0:227        'inF0' (temp 4-component vector of float)
+0:227        'inF1' (temp 4-component vector of float)
+0:228      Ceiling (global 4-component vector of float)
+0:228        'inF0' (temp 4-component vector of float)
+0:229      clamp (global 4-component vector of float)
+0:229        'inF0' (temp 4-component vector of float)
+0:229        'inF1' (temp 4-component vector of float)
+0:229        'inF2' (temp 4-component vector of float)
+0:230      Test condition and select (temp void)
+0:230        Condition
+0:230        any (temp bool)
+0:230          Compare Less Than (temp 4-component vector of bool)
+0:230            'inF0' (temp 4-component vector of float)
+0:230            Constant:
+0:230              0.000000
+0:230              0.000000
+0:230              0.000000
+0:230              0.000000
+0:230        true case
+0:230        Branch: Kill
+0:231      cosine (global 4-component vector of float)
+0:231        'inF0' (temp 4-component vector of float)
+0:232      hyp. cosine (global 4-component vector of float)
+0:232        'inF0' (temp 4-component vector of float)
 0:?       bitCount (global 4-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
 0:?           2 (const uint)
-0:221      dPdx (global 4-component vector of float)
-0:221        'inF0' (temp 4-component vector of float)
-0:222      dPdxCoarse (global 4-component vector of float)
-0:222        'inF0' (temp 4-component vector of float)
-0:223      dPdxFine (global 4-component vector of float)
-0:223        'inF0' (temp 4-component vector of float)
-0:224      dPdy (global 4-component vector of float)
-0:224        'inF0' (temp 4-component vector of float)
-0:225      dPdyCoarse (global 4-component vector of float)
-0:225        'inF0' (temp 4-component vector of float)
-0:226      dPdyFine (global 4-component vector of float)
-0:226        'inF0' (temp 4-component vector of float)
-0:227      degrees (global 4-component vector of float)
-0:227        'inF0' (temp 4-component vector of float)
-0:228      distance (global float)
-0:228        'inF0' (temp 4-component vector of float)
-0:228        'inF1' (temp 4-component vector of float)
-0:229      dot-product (global float)
-0:229        'inF0' (temp 4-component vector of float)
-0:229        'inF1' (temp 4-component vector of float)
-0:233      exp (global 4-component vector of float)
-0:233        'inF0' (temp 4-component vector of float)
-0:234      exp2 (global 4-component vector of float)
+0:234      dPdx (global 4-component vector of float)
 0:234        'inF0' (temp 4-component vector of float)
-0:235      face-forward (global 4-component vector of float)
+0:235      dPdxCoarse (global 4-component vector of float)
 0:235        'inF0' (temp 4-component vector of float)
-0:235        'inF1' (temp 4-component vector of float)
-0:235        'inF2' (temp 4-component vector of float)
-0:236      findMSB (global int)
-0:236        Constant:
-0:236          7 (const int)
-0:237      findLSB (global int)
-0:237        Constant:
-0:237          7 (const int)
-0:238      Floor (global 4-component vector of float)
+0:236      dPdxFine (global 4-component vector of float)
+0:236        'inF0' (temp 4-component vector of float)
+0:237      dPdy (global 4-component vector of float)
+0:237        'inF0' (temp 4-component vector of float)
+0:238      dPdyCoarse (global 4-component vector of float)
 0:238        'inF0' (temp 4-component vector of float)
-0:240      Function Call: fmod(vf4;vf4; (global 4-component vector of float)
+0:239      dPdyFine (global 4-component vector of float)
+0:239        'inF0' (temp 4-component vector of float)
+0:240      degrees (global 4-component vector of float)
 0:240        'inF0' (temp 4-component vector of float)
-0:240        'inF1' (temp 4-component vector of float)
-0:241      Fraction (global 4-component vector of float)
+0:241      distance (global float)
 0:241        'inF0' (temp 4-component vector of float)
-0:242      frexp (global 4-component vector of float)
+0:241        'inF1' (temp 4-component vector of float)
+0:242      dot-product (global float)
 0:242        'inF0' (temp 4-component vector of float)
 0:242        'inF1' (temp 4-component vector of float)
-0:243      fwidth (global 4-component vector of float)
-0:243        'inF0' (temp 4-component vector of float)
-0:244      isinf (global 4-component vector of bool)
-0:244        'inF0' (temp 4-component vector of float)
-0:245      isnan (global 4-component vector of bool)
-0:245        'inF0' (temp 4-component vector of float)
-0:246      ldexp (global 4-component vector of float)
+0:246      exp (global 4-component vector of float)
 0:246        'inF0' (temp 4-component vector of float)
-0:246        'inF1' (temp 4-component vector of float)
-0:247      length (global float)
+0:247      exp2 (global 4-component vector of float)
 0:247        'inF0' (temp 4-component vector of float)
-0:248      log (global 4-component vector of float)
+0:248      face-forward (global 4-component vector of float)
 0:248        'inF0' (temp 4-component vector of float)
-0:249      log2 (global 4-component vector of float)
-0:249        'inF0' (temp 4-component vector of float)
-0:250      max (global 4-component vector of float)
-0:250        'inF0' (temp 4-component vector of float)
-0:250        'inF1' (temp 4-component vector of float)
-0:251      min (global 4-component vector of float)
+0:248        'inF1' (temp 4-component vector of float)
+0:248        'inF2' (temp 4-component vector of float)
+0:249      findMSB (global int)
+0:249        Constant:
+0:249          7 (const int)
+0:250      findLSB (global int)
+0:250        Constant:
+0:250          7 (const int)
+0:251      Floor (global 4-component vector of float)
 0:251        'inF0' (temp 4-component vector of float)
-0:251        'inF1' (temp 4-component vector of float)
-0:253      normalize (global 4-component vector of float)
+0:253      mod (global 4-component vector of float)
 0:253        'inF0' (temp 4-component vector of float)
-0:254      pow (global 4-component vector of float)
+0:253        'inF1' (temp 4-component vector of float)
+0:254      Fraction (global 4-component vector of float)
 0:254        'inF0' (temp 4-component vector of float)
-0:254        'inF1' (temp 4-component vector of float)
-0:255      radians (global 4-component vector of float)
+0:255      frexp (global 4-component vector of float)
 0:255        'inF0' (temp 4-component vector of float)
-0:256      reflect (global 4-component vector of float)
+0:255        'inF1' (temp 4-component vector of float)
+0:256      fwidth (global 4-component vector of float)
 0:256        'inF0' (temp 4-component vector of float)
-0:256        'inF1' (temp 4-component vector of float)
-0:257      refract (global 4-component vector of float)
+0:257      isinf (global 4-component vector of bool)
 0:257        'inF0' (temp 4-component vector of float)
-0:257        'inF1' (temp 4-component vector of float)
-0:257        Constant:
-0:257          2.000000
+0:258      isnan (global 4-component vector of bool)
+0:258        'inF0' (temp 4-component vector of float)
+0:259      ldexp (global 4-component vector of float)
+0:259        'inF0' (temp 4-component vector of float)
+0:259        'inF1' (temp 4-component vector of float)
+0:260      length (global float)
+0:260        'inF0' (temp 4-component vector of float)
+0:261      log (global 4-component vector of float)
+0:261        'inF0' (temp 4-component vector of float)
+0:262      component-wise multiply (global 4-component vector of float)
+0:262        log2 (global 4-component vector of float)
+0:262          'inF0' (temp 4-component vector of float)
+0:262        Constant:
+0:262          0.301030
+0:263      log2 (global 4-component vector of float)
+0:263        'inF0' (temp 4-component vector of float)
+0:264      max (global 4-component vector of float)
+0:264        'inF0' (temp 4-component vector of float)
+0:264        'inF1' (temp 4-component vector of float)
+0:265      min (global 4-component vector of float)
+0:265        'inF0' (temp 4-component vector of float)
+0:265        'inF1' (temp 4-component vector of float)
+0:266      normalize (global 4-component vector of float)
+0:266        'inF0' (temp 4-component vector of float)
+0:267      pow (global 4-component vector of float)
+0:267        'inF0' (temp 4-component vector of float)
+0:267        'inF1' (temp 4-component vector of float)
+0:268      radians (global 4-component vector of float)
+0:268        'inF0' (temp 4-component vector of float)
+0:269      divide (global 4-component vector of float)
+0:269        Constant:
+0:269          1.000000
+0:269        'inF0' (temp 4-component vector of float)
+0:270      reflect (global 4-component vector of float)
+0:270        'inF0' (temp 4-component vector of float)
+0:270        'inF1' (temp 4-component vector of float)
+0:271      refract (global 4-component vector of float)
+0:271        'inF0' (temp 4-component vector of float)
+0:271        'inF1' (temp 4-component vector of float)
+0:271        Constant:
+0:271          2.000000
 0:?       bitFieldReverse (global 4-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
 0:?           4 (const uint)
-0:259      roundEven (global 4-component vector of float)
-0:259        'inF0' (temp 4-component vector of float)
-0:260      inverse sqrt (global 4-component vector of float)
-0:260        'inF0' (temp 4-component vector of float)
-0:261      Sign (global 4-component vector of float)
-0:261        'inF0' (temp 4-component vector of float)
-0:262      sine (global 4-component vector of float)
-0:262        'inF0' (temp 4-component vector of float)
-0:263      hyp. sine (global 4-component vector of float)
-0:263        'inF0' (temp 4-component vector of float)
-0:264      smoothstep (global 4-component vector of float)
-0:264        'inF0' (temp 4-component vector of float)
-0:264        'inF1' (temp 4-component vector of float)
-0:264        'inF2' (temp 4-component vector of float)
-0:265      sqrt (global 4-component vector of float)
-0:265        'inF0' (temp 4-component vector of float)
-0:266      step (global 4-component vector of float)
-0:266        'inF0' (temp 4-component vector of float)
-0:266        'inF1' (temp 4-component vector of float)
-0:267      tangent (global 4-component vector of float)
-0:267        'inF0' (temp 4-component vector of float)
-0:268      hyp. tangent (global 4-component vector of float)
-0:268        'inF0' (temp 4-component vector of float)
-0:270      trunc (global 4-component vector of float)
-0:270        'inF0' (temp 4-component vector of float)
-0:273      Branch: Return with expression
+0:273      roundEven (global 4-component vector of float)
+0:273        'inF0' (temp 4-component vector of float)
+0:274      inverse sqrt (global 4-component vector of float)
+0:274        'inF0' (temp 4-component vector of float)
+0:275      clamp (global 4-component vector of float)
+0:275        'inF0' (temp 4-component vector of float)
+0:275        Constant:
+0:275          0.000000
+0:275        Constant:
+0:275          1.000000
+0:276      Sign (global 4-component vector of float)
+0:276        'inF0' (temp 4-component vector of float)
+0:277      sine (global 4-component vector of float)
+0:277        'inF0' (temp 4-component vector of float)
+0:278      Sequence
+0:278        move second child to first child (temp 4-component vector of float)
+0:278          'inF1' (temp 4-component vector of float)
+0:278          sine (temp 4-component vector of float)
+0:278            'inF0' (temp 4-component vector of float)
+0:278        move second child to first child (temp 4-component vector of float)
+0:278          'inF2' (temp 4-component vector of float)
+0:278          cosine (temp 4-component vector of float)
+0:278            'inF0' (temp 4-component vector of float)
+0:279      hyp. sine (global 4-component vector of float)
+0:279        'inF0' (temp 4-component vector of float)
+0:280      smoothstep (global 4-component vector of float)
+0:280        'inF0' (temp 4-component vector of float)
+0:280        'inF1' (temp 4-component vector of float)
+0:280        'inF2' (temp 4-component vector of float)
+0:281      sqrt (global 4-component vector of float)
+0:281        'inF0' (temp 4-component vector of float)
+0:282      step (global 4-component vector of float)
+0:282        'inF0' (temp 4-component vector of float)
+0:282        'inF1' (temp 4-component vector of float)
+0:283      tangent (global 4-component vector of float)
+0:283        'inF0' (temp 4-component vector of float)
+0:284      hyp. tangent (global 4-component vector of float)
+0:284        'inF0' (temp 4-component vector of float)
+0:286      trunc (global 4-component vector of float)
+0:286        'inF0' (temp 4-component vector of float)
+0:289      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
 0:?           4.000000
-0:337  Function Definition: PixelShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
-0:329    Function Parameters: 
-0:329      'inF0' (temp 2X2 matrix of float)
-0:329      'inF1' (temp 2X2 matrix of float)
-0:329      'inF2' (temp 2X2 matrix of float)
+0:357  Function Definition: PixelShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:349    Function Parameters: 
+0:349      'inF0' (temp 2X2 matrix of float)
+0:349      'inF1' (temp 2X2 matrix of float)
+0:349      'inF2' (temp 2X2 matrix of float)
 0:?     Sequence
-0:331      all (global bool)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      Absolute value (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc cosine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      any (global bool)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc sine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      Ceiling (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      clamp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331        'inF2' (temp 2X2 matrix of float)
-0:331      cosine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      hyp. cosine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdx (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdxCoarse (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdxFine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdy (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdyCoarse (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdyFine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      degrees (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      determinant (global float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      exp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      exp2 (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      findMSB (global int)
-0:331        Constant:
-0:331          7 (const int)
-0:331      findLSB (global int)
-0:331        Constant:
-0:331          7 (const int)
-0:331      Floor (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      Function Call: fmod(mf22;mf22; (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      Fraction (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      frexp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      fwidth (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      ldexp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      log (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      log2 (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      max (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      min (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      pow (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      radians (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      roundEven (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      inverse sqrt (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      Sign (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      sine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      hyp. sine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      smoothstep (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331        'inF2' (temp 2X2 matrix of float)
-0:331      sqrt (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      step (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      hyp. tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      transpose (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      trunc (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:334      Branch: Return with expression
+0:351      all (global bool)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      Absolute value (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      arc cosine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      any (global bool)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      arc sine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      arc tangent (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      arc tangent (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      Ceiling (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      Test condition and select (temp void)
+0:351        Condition
+0:351        any (temp bool)
+0:351          Compare Less Than (temp 2X2 matrix of bool)
+0:351            'inF0' (temp 2X2 matrix of float)
+0:351            Constant:
+0:351              0.000000
+0:351              0.000000
+0:351              0.000000
+0:351              0.000000
+0:351        true case
+0:351        Branch: Kill
+0:351      clamp (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351        'inF2' (temp 2X2 matrix of float)
+0:351      cosine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      hyp. cosine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      dPdx (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      dPdxCoarse (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      dPdxFine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      dPdy (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      dPdyCoarse (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      dPdyFine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      degrees (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      determinant (global float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      exp (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      exp2 (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      findMSB (global int)
+0:351        Constant:
+0:351          7 (const int)
+0:351      findLSB (global int)
+0:351        Constant:
+0:351          7 (const int)
+0:351      Floor (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      mod (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      Fraction (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      frexp (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      fwidth (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      ldexp (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      log (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      component-wise multiply (global 2X2 matrix of float)
+0:351        log2 (global 2X2 matrix of float)
+0:351          'inF0' (temp 2X2 matrix of float)
+0:351        Constant:
+0:351          0.301030
+0:351      log2 (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      max (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      min (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      pow (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      radians (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      roundEven (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      inverse sqrt (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      clamp (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        Constant:
+0:351          0.000000
+0:351        Constant:
+0:351          1.000000
+0:351      Sign (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      sine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      Sequence
+0:351        move second child to first child (temp 2X2 matrix of float)
+0:351          'inF1' (temp 2X2 matrix of float)
+0:351          sine (temp 2X2 matrix of float)
+0:351            'inF0' (temp 2X2 matrix of float)
+0:351        move second child to first child (temp 2X2 matrix of float)
+0:351          'inF2' (temp 2X2 matrix of float)
+0:351          cosine (temp 2X2 matrix of float)
+0:351            'inF0' (temp 2X2 matrix of float)
+0:351      hyp. sine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      smoothstep (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351        'inF2' (temp 2X2 matrix of float)
+0:351      sqrt (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      step (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      tangent (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      hyp. tangent (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      transpose (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      trunc (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:354      Branch: Return with expression
 0:?         Constant:
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
-0:346  Function Definition: PixelShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
-0:338    Function Parameters: 
-0:338      'inF0' (temp 3X3 matrix of float)
-0:338      'inF1' (temp 3X3 matrix of float)
-0:338      'inF2' (temp 3X3 matrix of float)
+0:366  Function Definition: PixelShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:358    Function Parameters: 
+0:358      'inF0' (temp 3X3 matrix of float)
+0:358      'inF1' (temp 3X3 matrix of float)
+0:358      'inF2' (temp 3X3 matrix of float)
 0:?     Sequence
-0:340      all (global bool)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      Absolute value (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc cosine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      any (global bool)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc sine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      Ceiling (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      clamp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340        'inF2' (temp 3X3 matrix of float)
-0:340      cosine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      hyp. cosine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdx (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdxCoarse (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdxFine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdy (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdyCoarse (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdyFine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      degrees (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      determinant (global float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      exp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      exp2 (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      findMSB (global int)
-0:340        Constant:
-0:340          7 (const int)
-0:340      findLSB (global int)
-0:340        Constant:
-0:340          7 (const int)
-0:340      Floor (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      Function Call: fmod(mf33;mf33; (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      Fraction (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      frexp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      fwidth (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      ldexp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      log (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      log2 (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      max (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      min (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      pow (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      radians (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      roundEven (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      inverse sqrt (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      Sign (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      sine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      hyp. sine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      smoothstep (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340        'inF2' (temp 3X3 matrix of float)
-0:340      sqrt (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      step (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      hyp. tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      transpose (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      trunc (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:343      Branch: Return with expression
+0:360      all (global bool)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      Absolute value (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      arc cosine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      any (global bool)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      arc sine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      arc tangent (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      arc tangent (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      Ceiling (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      Test condition and select (temp void)
+0:360        Condition
+0:360        any (temp bool)
+0:360          Compare Less Than (temp 3X3 matrix of bool)
+0:360            'inF0' (temp 3X3 matrix of float)
+0:360            Constant:
+0:360              0.000000
+0:360              0.000000
+0:360              0.000000
+0:360              0.000000
+0:360              0.000000
+0:360              0.000000
+0:360              0.000000
+0:360              0.000000
+0:360              0.000000
+0:360        true case
+0:360        Branch: Kill
+0:360      clamp (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360        'inF2' (temp 3X3 matrix of float)
+0:360      cosine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      hyp. cosine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      dPdx (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      dPdxCoarse (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      dPdxFine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      dPdy (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      dPdyCoarse (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      dPdyFine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      degrees (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      determinant (global float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      exp (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      exp2 (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      findMSB (global int)
+0:360        Constant:
+0:360          7 (const int)
+0:360      findLSB (global int)
+0:360        Constant:
+0:360          7 (const int)
+0:360      Floor (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      mod (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      Fraction (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      frexp (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      fwidth (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      ldexp (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      log (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      component-wise multiply (global 3X3 matrix of float)
+0:360        log2 (global 3X3 matrix of float)
+0:360          'inF0' (temp 3X3 matrix of float)
+0:360        Constant:
+0:360          0.301030
+0:360      log2 (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      max (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      min (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      pow (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      radians (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      roundEven (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      inverse sqrt (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      clamp (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        Constant:
+0:360          0.000000
+0:360        Constant:
+0:360          1.000000
+0:360      Sign (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      sine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      Sequence
+0:360        move second child to first child (temp 3X3 matrix of float)
+0:360          'inF1' (temp 3X3 matrix of float)
+0:360          sine (temp 3X3 matrix of float)
+0:360            'inF0' (temp 3X3 matrix of float)
+0:360        move second child to first child (temp 3X3 matrix of float)
+0:360          'inF2' (temp 3X3 matrix of float)
+0:360          cosine (temp 3X3 matrix of float)
+0:360            'inF0' (temp 3X3 matrix of float)
+0:360      hyp. sine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      smoothstep (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360        'inF2' (temp 3X3 matrix of float)
+0:360      sqrt (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      step (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      tangent (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      hyp. tangent (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      transpose (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      trunc (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:363      Branch: Return with expression
 0:?         Constant:
 0:?           3.000000
 0:?           3.000000
@@ -835,121 +1041,165 @@ gl_FragCoord origin is upper left
 0:?           3.000000
 0:?           3.000000
 0:?           3.000000
-0:354  Function Definition: PixelShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
-0:347    Function Parameters: 
-0:347      'inF0' (temp 4X4 matrix of float)
-0:347      'inF1' (temp 4X4 matrix of float)
-0:347      'inF2' (temp 4X4 matrix of float)
+0:387  Function Definition: PixelShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:367    Function Parameters: 
+0:367      'inF0' (temp 4X4 matrix of float)
+0:367      'inF1' (temp 4X4 matrix of float)
+0:367      'inF2' (temp 4X4 matrix of float)
 0:?     Sequence
-0:349      all (global bool)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      Absolute value (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc cosine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      any (global bool)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc sine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      Ceiling (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      clamp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349        'inF2' (temp 4X4 matrix of float)
-0:349      cosine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      hyp. cosine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdx (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdxCoarse (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdxFine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdy (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdyCoarse (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdyFine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      degrees (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      determinant (global float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      exp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      exp2 (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      findMSB (global int)
-0:349        Constant:
-0:349          7 (const int)
-0:349      findLSB (global int)
-0:349        Constant:
-0:349          7 (const int)
-0:349      Floor (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      Function Call: fmod(mf44;mf44; (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      Fraction (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      frexp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      fwidth (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      ldexp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      log (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      log2 (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      max (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      min (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      pow (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      radians (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      roundEven (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      inverse sqrt (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      Sign (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      sine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      hyp. sine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      smoothstep (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349        'inF2' (temp 4X4 matrix of float)
-0:349      sqrt (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      step (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      hyp. tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      transpose (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      trunc (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:352      Branch: Return with expression
+0:369      all (global bool)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      Absolute value (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      arc cosine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      any (global bool)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      arc sine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      arc tangent (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      arc tangent (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      Ceiling (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      Test condition and select (temp void)
+0:369        Condition
+0:369        any (temp bool)
+0:369          Compare Less Than (temp 4X4 matrix of bool)
+0:369            'inF0' (temp 4X4 matrix of float)
+0:369            Constant:
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369        true case
+0:369        Branch: Kill
+0:369      clamp (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369        'inF2' (temp 4X4 matrix of float)
+0:369      cosine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      hyp. cosine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      dPdx (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      dPdxCoarse (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      dPdxFine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      dPdy (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      dPdyCoarse (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      dPdyFine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      degrees (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      determinant (global float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      exp (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      exp2 (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      findMSB (global int)
+0:369        Constant:
+0:369          7 (const int)
+0:369      findLSB (global int)
+0:369        Constant:
+0:369          7 (const int)
+0:369      Floor (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      mod (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      Fraction (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      frexp (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      fwidth (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      ldexp (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      log (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      component-wise multiply (global 4X4 matrix of float)
+0:369        log2 (global 4X4 matrix of float)
+0:369          'inF0' (temp 4X4 matrix of float)
+0:369        Constant:
+0:369          0.301030
+0:369      log2 (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      max (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      min (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      pow (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      radians (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      roundEven (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      inverse sqrt (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      clamp (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        Constant:
+0:369          0.000000
+0:369        Constant:
+0:369          1.000000
+0:369      Sign (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      sine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      Sequence
+0:369        move second child to first child (temp 4X4 matrix of float)
+0:369          'inF1' (temp 4X4 matrix of float)
+0:369          sine (temp 4X4 matrix of float)
+0:369            'inF0' (temp 4X4 matrix of float)
+0:369        move second child to first child (temp 4X4 matrix of float)
+0:369          'inF2' (temp 4X4 matrix of float)
+0:369          cosine (temp 4X4 matrix of float)
+0:369            'inF0' (temp 4X4 matrix of float)
+0:369      hyp. sine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      smoothstep (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369        'inF2' (temp 4X4 matrix of float)
+0:369      sqrt (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      step (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      tangent (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      hyp. tangent (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      transpose (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      trunc (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:372      Branch: Return with expression
 0:?         Constant:
 0:?           4.000000
 0:?           4.000000
@@ -967,6 +1217,168 @@ gl_FragCoord origin is upper left
 0:?           4.000000
 0:?           4.000000
 0:?           4.000000
+0:394  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
+0:390    Function Parameters: 
+0:390      'inF0' (temp float)
+0:390      'inF1' (temp float)
+0:390      'inFV0' (temp 2-component vector of float)
+0:390      'inFV1' (temp 2-component vector of float)
+0:390      'inFM0' (temp 2X2 matrix of float)
+0:390      'inFM1' (temp 2X2 matrix of float)
+0:?     Sequence
+0:391      move second child to first child (temp float)
+0:391        'r0' (temp float)
+0:391        component-wise multiply (global float)
+0:391          'inF0' (temp float)
+0:391          'inF1' (temp float)
+0:391      move second child to first child (temp 2-component vector of float)
+0:391        'r1' (temp 2-component vector of float)
+0:391        vector-scale (global 2-component vector of float)
+0:391          'inFV0' (temp 2-component vector of float)
+0:391          'inF0' (temp float)
+0:391      move second child to first child (temp 2-component vector of float)
+0:391        'r2' (temp 2-component vector of float)
+0:391        vector-scale (global 2-component vector of float)
+0:391          'inFV0' (temp 2-component vector of float)
+0:391          'inF0' (temp float)
+0:391      move second child to first child (temp float)
+0:391        'r3' (temp float)
+0:391        dot-product (global float)
+0:391          'inFV0' (temp 2-component vector of float)
+0:391          'inFV1' (temp 2-component vector of float)
+0:391      move second child to first child (temp 2-component vector of float)
+0:391        'r4' (temp 2-component vector of float)
+0:391        matrix-times-vector (global 2-component vector of float)
+0:391          'inFM0' (temp 2X2 matrix of float)
+0:391          'inFV0' (temp 2-component vector of float)
+0:391      move second child to first child (temp 2-component vector of float)
+0:391        'r5' (temp 2-component vector of float)
+0:391        vector-times-matrix (global 2-component vector of float)
+0:391          'inFV0' (temp 2-component vector of float)
+0:391          'inFM0' (temp 2X2 matrix of float)
+0:391      move second child to first child (temp 2X2 matrix of float)
+0:391        'r6' (temp 2X2 matrix of float)
+0:391        matrix-scale (global 2X2 matrix of float)
+0:391          'inFM0' (temp 2X2 matrix of float)
+0:391          'inF0' (temp float)
+0:391      move second child to first child (temp 2X2 matrix of float)
+0:391        'r7' (temp 2X2 matrix of float)
+0:391        matrix-scale (global 2X2 matrix of float)
+0:391          'inFM0' (temp 2X2 matrix of float)
+0:391          'inF0' (temp float)
+0:391      move second child to first child (temp 2X2 matrix of float)
+0:391        'r8' (temp 2X2 matrix of float)
+0:391        matrix-multiply (global 2X2 matrix of float)
+0:391          'inFM0' (temp 2X2 matrix of float)
+0:391          'inFM1' (temp 2X2 matrix of float)
+0:401  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
+0:397    Function Parameters: 
+0:397      'inF0' (temp float)
+0:397      'inF1' (temp float)
+0:397      'inFV0' (temp 3-component vector of float)
+0:397      'inFV1' (temp 3-component vector of float)
+0:397      'inFM0' (temp 3X3 matrix of float)
+0:397      'inFM1' (temp 3X3 matrix of float)
+0:?     Sequence
+0:398      move second child to first child (temp float)
+0:398        'r0' (temp float)
+0:398        component-wise multiply (global float)
+0:398          'inF0' (temp float)
+0:398          'inF1' (temp float)
+0:398      move second child to first child (temp 3-component vector of float)
+0:398        'r1' (temp 3-component vector of float)
+0:398        vector-scale (global 3-component vector of float)
+0:398          'inFV0' (temp 3-component vector of float)
+0:398          'inF0' (temp float)
+0:398      move second child to first child (temp 3-component vector of float)
+0:398        'r2' (temp 3-component vector of float)
+0:398        vector-scale (global 3-component vector of float)
+0:398          'inFV0' (temp 3-component vector of float)
+0:398          'inF0' (temp float)
+0:398      move second child to first child (temp float)
+0:398        'r3' (temp float)
+0:398        dot-product (global float)
+0:398          'inFV0' (temp 3-component vector of float)
+0:398          'inFV1' (temp 3-component vector of float)
+0:398      move second child to first child (temp 3-component vector of float)
+0:398        'r4' (temp 3-component vector of float)
+0:398        matrix-times-vector (global 3-component vector of float)
+0:398          'inFM0' (temp 3X3 matrix of float)
+0:398          'inFV0' (temp 3-component vector of float)
+0:398      move second child to first child (temp 3-component vector of float)
+0:398        'r5' (temp 3-component vector of float)
+0:398        vector-times-matrix (global 3-component vector of float)
+0:398          'inFV0' (temp 3-component vector of float)
+0:398          'inFM0' (temp 3X3 matrix of float)
+0:398      move second child to first child (temp 3X3 matrix of float)
+0:398        'r6' (temp 3X3 matrix of float)
+0:398        matrix-scale (global 3X3 matrix of float)
+0:398          'inFM0' (temp 3X3 matrix of float)
+0:398          'inF0' (temp float)
+0:398      move second child to first child (temp 3X3 matrix of float)
+0:398        'r7' (temp 3X3 matrix of float)
+0:398        matrix-scale (global 3X3 matrix of float)
+0:398          'inFM0' (temp 3X3 matrix of float)
+0:398          'inF0' (temp float)
+0:398      move second child to first child (temp 3X3 matrix of float)
+0:398        'r8' (temp 3X3 matrix of float)
+0:398        matrix-multiply (global 3X3 matrix of float)
+0:398          'inFM0' (temp 3X3 matrix of float)
+0:398          'inFM1' (temp 3X3 matrix of float)
+0:407  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
+0:404    Function Parameters: 
+0:404      'inF0' (temp float)
+0:404      'inF1' (temp float)
+0:404      'inFV0' (temp 4-component vector of float)
+0:404      'inFV1' (temp 4-component vector of float)
+0:404      'inFM0' (temp 4X4 matrix of float)
+0:404      'inFM1' (temp 4X4 matrix of float)
+0:?     Sequence
+0:405      move second child to first child (temp float)
+0:405        'r0' (temp float)
+0:405        component-wise multiply (global float)
+0:405          'inF0' (temp float)
+0:405          'inF1' (temp float)
+0:405      move second child to first child (temp 4-component vector of float)
+0:405        'r1' (temp 4-component vector of float)
+0:405        vector-scale (global 4-component vector of float)
+0:405          'inFV0' (temp 4-component vector of float)
+0:405          'inF0' (temp float)
+0:405      move second child to first child (temp 4-component vector of float)
+0:405        'r2' (temp 4-component vector of float)
+0:405        vector-scale (global 4-component vector of float)
+0:405          'inFV0' (temp 4-component vector of float)
+0:405          'inF0' (temp float)
+0:405      move second child to first child (temp float)
+0:405        'r3' (temp float)
+0:405        dot-product (global float)
+0:405          'inFV0' (temp 4-component vector of float)
+0:405          'inFV1' (temp 4-component vector of float)
+0:405      move second child to first child (temp 4-component vector of float)
+0:405        'r4' (temp 4-component vector of float)
+0:405        matrix-times-vector (global 4-component vector of float)
+0:405          'inFM0' (temp 4X4 matrix of float)
+0:405          'inFV0' (temp 4-component vector of float)
+0:405      move second child to first child (temp 4-component vector of float)
+0:405        'r5' (temp 4-component vector of float)
+0:405        vector-times-matrix (global 4-component vector of float)
+0:405          'inFV0' (temp 4-component vector of float)
+0:405          'inFM0' (temp 4X4 matrix of float)
+0:405      move second child to first child (temp 4X4 matrix of float)
+0:405        'r6' (temp 4X4 matrix of float)
+0:405        matrix-scale (global 4X4 matrix of float)
+0:405          'inFM0' (temp 4X4 matrix of float)
+0:405          'inF0' (temp float)
+0:405      move second child to first child (temp 4X4 matrix of float)
+0:405        'r7' (temp 4X4 matrix of float)
+0:405        matrix-scale (global 4X4 matrix of float)
+0:405          'inFM0' (temp 4X4 matrix of float)
+0:405          'inF0' (temp float)
+0:405      move second child to first child (temp 4X4 matrix of float)
+0:405        'r8' (temp 4X4 matrix of float)
+0:405        matrix-multiply (global 4X4 matrix of float)
+0:405          'inFM0' (temp 4X4 matrix of float)
+0:405          'inFM1' (temp 4X4 matrix of float)
 0:?   Linker Objects
 
 
@@ -976,7 +1388,7 @@ Linked fragment stage:
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:62  Function Definition: PixelShaderFunction(f1;f1;f1; (temp float)
+0:66  Function Definition: PixelShaderFunction(f1;f1;f1; (temp float)
 0:2    Function Parameters: 
 0:2      'inF0' (temp float)
 0:2      'inF1' (temp float)
@@ -1003,802 +1415,1008 @@ gl_FragCoord origin is upper left
 0:11        'inF0' (temp float)
 0:11        'inF1' (temp float)
 0:11        'inF2' (temp float)
-0:12      cosine (global float)
-0:12        'inF0' (temp float)
-0:13      hyp. cosine (global float)
+0:12      Test condition and select (temp void)
+0:12        Condition
+0:12        Compare Less Than (temp bool)
+0:12          'inF0' (temp float)
+0:12          Constant:
+0:12            0.000000
+0:12        true case
+0:12        Branch: Kill
+0:13      cosine (global float)
 0:13        'inF0' (temp float)
-0:14      bitCount (global uint)
-0:14        Constant:
-0:14          7 (const uint)
-0:15      dPdx (global float)
-0:15        'inF0' (temp float)
-0:16      dPdxCoarse (global float)
+0:14      hyp. cosine (global float)
+0:14        'inF0' (temp float)
+0:15      bitCount (global uint)
+0:15        Constant:
+0:15          7 (const uint)
+0:16      dPdx (global float)
 0:16        'inF0' (temp float)
-0:17      dPdxFine (global float)
+0:17      dPdxCoarse (global float)
 0:17        'inF0' (temp float)
-0:18      dPdy (global float)
+0:18      dPdxFine (global float)
 0:18        'inF0' (temp float)
-0:19      dPdyCoarse (global float)
+0:19      dPdy (global float)
 0:19        'inF0' (temp float)
-0:20      dPdyFine (global float)
+0:20      dPdyCoarse (global float)
 0:20        'inF0' (temp float)
-0:21      degrees (global float)
+0:21      dPdyFine (global float)
 0:21        'inF0' (temp float)
-0:25      exp (global float)
-0:25        'inF0' (temp float)
-0:26      exp2 (global float)
+0:22      degrees (global float)
+0:22        'inF0' (temp float)
+0:26      exp (global float)
 0:26        'inF0' (temp float)
-0:27      findMSB (global int)
-0:27        Constant:
-0:27          7 (const int)
-0:28      findLSB (global int)
+0:27      exp2 (global float)
+0:27        'inF0' (temp float)
+0:28      findMSB (global int)
 0:28        Constant:
 0:28          7 (const int)
-0:29      Floor (global float)
-0:29        'inF0' (temp float)
-0:31      Function Call: fmod(f1;f1; (global float)
-0:31        'inF0' (temp float)
-0:31        'inF1' (temp float)
-0:32      Fraction (global float)
+0:29      findLSB (global int)
+0:29        Constant:
+0:29          7 (const int)
+0:30      Floor (global float)
+0:30        'inF0' (temp float)
+0:32      mod (global float)
 0:32        'inF0' (temp float)
-0:33      frexp (global float)
+0:32        'inF1' (temp float)
+0:33      Fraction (global float)
 0:33        'inF0' (temp float)
-0:33        'inF1' (temp float)
-0:34      fwidth (global float)
+0:34      frexp (global float)
 0:34        'inF0' (temp float)
-0:35      isinf (global bool)
+0:34        'inF1' (temp float)
+0:35      fwidth (global float)
 0:35        'inF0' (temp float)
-0:36      isnan (global bool)
+0:36      isinf (global bool)
 0:36        'inF0' (temp float)
-0:37      ldexp (global float)
+0:37      isnan (global bool)
 0:37        'inF0' (temp float)
-0:37        'inF1' (temp float)
-0:38      log (global float)
+0:38      ldexp (global float)
 0:38        'inF0' (temp float)
-0:39      log2 (global float)
+0:38        'inF1' (temp float)
+0:39      log (global float)
 0:39        'inF0' (temp float)
-0:40      max (global float)
-0:40        'inF0' (temp float)
-0:40        'inF1' (temp float)
-0:41      min (global float)
+0:40      component-wise multiply (global float)
+0:40        log2 (global float)
+0:40          'inF0' (temp float)
+0:40        Constant:
+0:40          0.301030
+0:41      log2 (global float)
 0:41        'inF0' (temp float)
-0:41        'inF1' (temp float)
-0:43      pow (global float)
+0:42      max (global float)
+0:42        'inF0' (temp float)
+0:42        'inF1' (temp float)
+0:43      min (global float)
 0:43        'inF0' (temp float)
 0:43        'inF1' (temp float)
-0:44      radians (global float)
+0:44      pow (global float)
 0:44        'inF0' (temp float)
-0:45      bitFieldReverse (global uint)
-0:45        Constant:
-0:45          2 (const uint)
-0:46      roundEven (global float)
+0:44        'inF1' (temp float)
+0:45      radians (global float)
+0:45        'inF0' (temp float)
+0:46      divide (global float)
+0:46        Constant:
+0:46          1.000000
 0:46        'inF0' (temp float)
-0:47      inverse sqrt (global float)
-0:47        'inF0' (temp float)
-0:48      Sign (global float)
+0:47      bitFieldReverse (global uint)
+0:47        Constant:
+0:47          2 (const uint)
+0:48      roundEven (global float)
 0:48        'inF0' (temp float)
-0:49      sine (global float)
+0:49      inverse sqrt (global float)
 0:49        'inF0' (temp float)
-0:50      hyp. sine (global float)
+0:50      clamp (global float)
 0:50        'inF0' (temp float)
-0:51      smoothstep (global float)
+0:50        Constant:
+0:50          0.000000
+0:50        Constant:
+0:50          1.000000
+0:51      Sign (global float)
 0:51        'inF0' (temp float)
-0:51        'inF1' (temp float)
-0:51        'inF2' (temp float)
-0:52      sqrt (global float)
+0:52      sine (global float)
 0:52        'inF0' (temp float)
-0:53      step (global float)
-0:53        'inF0' (temp float)
-0:53        'inF1' (temp float)
-0:54      tangent (global float)
+0:53      Sequence
+0:53        move second child to first child (temp float)
+0:53          'inF1' (temp float)
+0:53          sine (temp float)
+0:53            'inF0' (temp float)
+0:53        move second child to first child (temp float)
+0:53          'inF2' (temp float)
+0:53          cosine (temp float)
+0:53            'inF0' (temp float)
+0:54      hyp. sine (global float)
 0:54        'inF0' (temp float)
-0:55      hyp. tangent (global float)
+0:55      smoothstep (global float)
 0:55        'inF0' (temp float)
-0:57      trunc (global float)
+0:55        'inF1' (temp float)
+0:55        'inF2' (temp float)
+0:56      sqrt (global float)
+0:56        'inF0' (temp float)
+0:57      step (global float)
 0:57        'inF0' (temp float)
-0:59      Branch: Return with expression
-0:59        Constant:
-0:59          0.000000
-0:68  Function Definition: PixelShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
-0:63    Function Parameters: 
-0:63      'inF0' (temp 1-component vector of float)
-0:63      'inF1' (temp 1-component vector of float)
-0:63      'inF2' (temp 1-component vector of float)
+0:57        'inF1' (temp float)
+0:58      tangent (global float)
+0:58        'inF0' (temp float)
+0:59      hyp. tangent (global float)
+0:59        'inF0' (temp float)
+0:61      trunc (global float)
+0:61        'inF0' (temp float)
+0:63      Branch: Return with expression
+0:63        Constant:
+0:63          0.000000
+0:72  Function Definition: PixelShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
+0:67    Function Parameters: 
+0:67      'inF0' (temp 1-component vector of float)
+0:67      'inF1' (temp 1-component vector of float)
+0:67      'inF2' (temp 1-component vector of float)
 0:?     Sequence
-0:65      Branch: Return with expression
-0:65        Constant:
-0:65          0.000000
-0:137  Function Definition: PixelShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
-0:69    Function Parameters: 
-0:69      'inF0' (temp 2-component vector of float)
-0:69      'inF1' (temp 2-component vector of float)
-0:69      'inF2' (temp 2-component vector of float)
+0:69      Branch: Return with expression
+0:69        Constant:
+0:69          0.000000
+0:145  Function Definition: PixelShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
+0:73    Function Parameters: 
+0:73      'inF0' (temp 2-component vector of float)
+0:73      'inF1' (temp 2-component vector of float)
+0:73      'inF2' (temp 2-component vector of float)
 0:?     Sequence
-0:70      all (global bool)
-0:70        'inF0' (temp 2-component vector of float)
-0:71      Absolute value (global 2-component vector of float)
-0:71        'inF0' (temp 2-component vector of float)
-0:72      arc cosine (global 2-component vector of float)
-0:72        'inF0' (temp 2-component vector of float)
-0:73      any (global bool)
-0:73        'inF0' (temp 2-component vector of float)
-0:74      arc sine (global 2-component vector of float)
+0:74      all (global bool)
 0:74        'inF0' (temp 2-component vector of float)
-0:75      arc tangent (global 2-component vector of float)
+0:75      Absolute value (global 2-component vector of float)
 0:75        'inF0' (temp 2-component vector of float)
-0:76      arc tangent (global 2-component vector of float)
+0:76      arc cosine (global 2-component vector of float)
 0:76        'inF0' (temp 2-component vector of float)
-0:76        'inF1' (temp 2-component vector of float)
-0:77      Ceiling (global 2-component vector of float)
+0:77      any (global bool)
 0:77        'inF0' (temp 2-component vector of float)
-0:78      clamp (global 2-component vector of float)
+0:78      arc sine (global 2-component vector of float)
 0:78        'inF0' (temp 2-component vector of float)
-0:78        'inF1' (temp 2-component vector of float)
-0:78        'inF2' (temp 2-component vector of float)
-0:79      cosine (global 2-component vector of float)
+0:79      arc tangent (global 2-component vector of float)
 0:79        'inF0' (temp 2-component vector of float)
-0:80      hyp. cosine (global 2-component vector of float)
+0:80      arc tangent (global 2-component vector of float)
 0:80        'inF0' (temp 2-component vector of float)
+0:80        'inF1' (temp 2-component vector of float)
+0:81      Ceiling (global 2-component vector of float)
+0:81        'inF0' (temp 2-component vector of float)
+0:82      clamp (global 2-component vector of float)
+0:82        'inF0' (temp 2-component vector of float)
+0:82        'inF1' (temp 2-component vector of float)
+0:82        'inF2' (temp 2-component vector of float)
+0:83      Test condition and select (temp void)
+0:83        Condition
+0:83        any (temp bool)
+0:83          Compare Less Than (temp 2-component vector of bool)
+0:83            'inF0' (temp 2-component vector of float)
+0:83            Constant:
+0:83              0.000000
+0:83              0.000000
+0:83        true case
+0:83        Branch: Kill
+0:84      cosine (global 2-component vector of float)
+0:84        'inF0' (temp 2-component vector of float)
+0:85      hyp. cosine (global 2-component vector of float)
+0:85        'inF0' (temp 2-component vector of float)
 0:?       bitCount (global 2-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
-0:82      dPdx (global 2-component vector of float)
-0:82        'inF0' (temp 2-component vector of float)
-0:83      dPdxCoarse (global 2-component vector of float)
-0:83        'inF0' (temp 2-component vector of float)
-0:84      dPdxFine (global 2-component vector of float)
-0:84        'inF0' (temp 2-component vector of float)
-0:85      dPdy (global 2-component vector of float)
-0:85        'inF0' (temp 2-component vector of float)
-0:86      dPdyCoarse (global 2-component vector of float)
-0:86        'inF0' (temp 2-component vector of float)
-0:87      dPdyFine (global 2-component vector of float)
+0:87      dPdx (global 2-component vector of float)
 0:87        'inF0' (temp 2-component vector of float)
-0:88      degrees (global 2-component vector of float)
+0:88      dPdxCoarse (global 2-component vector of float)
 0:88        'inF0' (temp 2-component vector of float)
-0:89      distance (global float)
+0:89      dPdxFine (global 2-component vector of float)
 0:89        'inF0' (temp 2-component vector of float)
-0:89        'inF1' (temp 2-component vector of float)
-0:90      dot-product (global float)
+0:90      dPdy (global 2-component vector of float)
 0:90        'inF0' (temp 2-component vector of float)
-0:90        'inF1' (temp 2-component vector of float)
-0:94      exp (global 2-component vector of float)
+0:91      dPdyCoarse (global 2-component vector of float)
+0:91        'inF0' (temp 2-component vector of float)
+0:92      dPdyFine (global 2-component vector of float)
+0:92        'inF0' (temp 2-component vector of float)
+0:93      degrees (global 2-component vector of float)
+0:93        'inF0' (temp 2-component vector of float)
+0:94      distance (global float)
 0:94        'inF0' (temp 2-component vector of float)
-0:95      exp2 (global 2-component vector of float)
+0:94        'inF1' (temp 2-component vector of float)
+0:95      dot-product (global float)
 0:95        'inF0' (temp 2-component vector of float)
-0:96      face-forward (global 2-component vector of float)
-0:96        'inF0' (temp 2-component vector of float)
-0:96        'inF1' (temp 2-component vector of float)
-0:96        'inF2' (temp 2-component vector of float)
-0:97      findMSB (global int)
-0:97        Constant:
-0:97          7 (const int)
-0:98      findLSB (global int)
-0:98        Constant:
-0:98          7 (const int)
-0:99      Floor (global 2-component vector of float)
+0:95        'inF1' (temp 2-component vector of float)
+0:99      exp (global 2-component vector of float)
 0:99        'inF0' (temp 2-component vector of float)
-0:101      Function Call: fmod(vf2;vf2; (global 2-component vector of float)
+0:100      exp2 (global 2-component vector of float)
+0:100        'inF0' (temp 2-component vector of float)
+0:101      face-forward (global 2-component vector of float)
 0:101        'inF0' (temp 2-component vector of float)
 0:101        'inF1' (temp 2-component vector of float)
-0:102      Fraction (global 2-component vector of float)
-0:102        'inF0' (temp 2-component vector of float)
-0:103      frexp (global 2-component vector of float)
-0:103        'inF0' (temp 2-component vector of float)
-0:103        'inF1' (temp 2-component vector of float)
-0:104      fwidth (global 2-component vector of float)
+0:101        'inF2' (temp 2-component vector of float)
+0:102      findMSB (global int)
+0:102        Constant:
+0:102          7 (const int)
+0:103      findLSB (global int)
+0:103        Constant:
+0:103          7 (const int)
+0:104      Floor (global 2-component vector of float)
 0:104        'inF0' (temp 2-component vector of float)
-0:105      isinf (global 2-component vector of bool)
-0:105        'inF0' (temp 2-component vector of float)
-0:106      isnan (global 2-component vector of bool)
+0:106      mod (global 2-component vector of float)
 0:106        'inF0' (temp 2-component vector of float)
-0:107      ldexp (global 2-component vector of float)
+0:106        'inF1' (temp 2-component vector of float)
+0:107      Fraction (global 2-component vector of float)
 0:107        'inF0' (temp 2-component vector of float)
-0:107        'inF1' (temp 2-component vector of float)
-0:108      length (global float)
+0:108      frexp (global 2-component vector of float)
 0:108        'inF0' (temp 2-component vector of float)
-0:109      log (global 2-component vector of float)
+0:108        'inF1' (temp 2-component vector of float)
+0:109      fwidth (global 2-component vector of float)
 0:109        'inF0' (temp 2-component vector of float)
-0:110      log2 (global 2-component vector of float)
+0:110      isinf (global 2-component vector of bool)
 0:110        'inF0' (temp 2-component vector of float)
-0:111      max (global 2-component vector of float)
+0:111      isnan (global 2-component vector of bool)
 0:111        'inF0' (temp 2-component vector of float)
-0:111        'inF1' (temp 2-component vector of float)
-0:112      min (global 2-component vector of float)
+0:112      ldexp (global 2-component vector of float)
 0:112        'inF0' (temp 2-component vector of float)
 0:112        'inF1' (temp 2-component vector of float)
-0:114      normalize (global 2-component vector of float)
+0:113      length (global float)
+0:113        'inF0' (temp 2-component vector of float)
+0:114      log (global 2-component vector of float)
 0:114        'inF0' (temp 2-component vector of float)
-0:115      pow (global 2-component vector of float)
-0:115        'inF0' (temp 2-component vector of float)
-0:115        'inF1' (temp 2-component vector of float)
-0:116      radians (global 2-component vector of float)
+0:115      component-wise multiply (global 2-component vector of float)
+0:115        log2 (global 2-component vector of float)
+0:115          'inF0' (temp 2-component vector of float)
+0:115        Constant:
+0:115          0.301030
+0:116      log2 (global 2-component vector of float)
 0:116        'inF0' (temp 2-component vector of float)
-0:117      reflect (global 2-component vector of float)
+0:117      max (global 2-component vector of float)
 0:117        'inF0' (temp 2-component vector of float)
 0:117        'inF1' (temp 2-component vector of float)
-0:118      refract (global 2-component vector of float)
+0:118      min (global 2-component vector of float)
 0:118        'inF0' (temp 2-component vector of float)
 0:118        'inF1' (temp 2-component vector of float)
-0:118        Constant:
-0:118          2.000000
+0:119      normalize (global 2-component vector of float)
+0:119        'inF0' (temp 2-component vector of float)
+0:120      pow (global 2-component vector of float)
+0:120        'inF0' (temp 2-component vector of float)
+0:120        'inF1' (temp 2-component vector of float)
+0:121      radians (global 2-component vector of float)
+0:121        'inF0' (temp 2-component vector of float)
+0:122      divide (global 2-component vector of float)
+0:122        Constant:
+0:122          1.000000
+0:122        'inF0' (temp 2-component vector of float)
+0:123      reflect (global 2-component vector of float)
+0:123        'inF0' (temp 2-component vector of float)
+0:123        'inF1' (temp 2-component vector of float)
+0:124      refract (global 2-component vector of float)
+0:124        'inF0' (temp 2-component vector of float)
+0:124        'inF1' (temp 2-component vector of float)
+0:124        Constant:
+0:124          2.000000
 0:?       bitFieldReverse (global 2-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
-0:120      roundEven (global 2-component vector of float)
-0:120        'inF0' (temp 2-component vector of float)
-0:121      inverse sqrt (global 2-component vector of float)
-0:121        'inF0' (temp 2-component vector of float)
-0:122      Sign (global 2-component vector of float)
-0:122        'inF0' (temp 2-component vector of float)
-0:123      sine (global 2-component vector of float)
-0:123        'inF0' (temp 2-component vector of float)
-0:124      hyp. sine (global 2-component vector of float)
-0:124        'inF0' (temp 2-component vector of float)
-0:125      smoothstep (global 2-component vector of float)
-0:125        'inF0' (temp 2-component vector of float)
-0:125        'inF1' (temp 2-component vector of float)
-0:125        'inF2' (temp 2-component vector of float)
-0:126      sqrt (global 2-component vector of float)
+0:126      roundEven (global 2-component vector of float)
 0:126        'inF0' (temp 2-component vector of float)
-0:127      step (global 2-component vector of float)
+0:127      inverse sqrt (global 2-component vector of float)
 0:127        'inF0' (temp 2-component vector of float)
-0:127        'inF1' (temp 2-component vector of float)
-0:128      tangent (global 2-component vector of float)
+0:128      clamp (global 2-component vector of float)
 0:128        'inF0' (temp 2-component vector of float)
-0:129      hyp. tangent (global 2-component vector of float)
+0:128        Constant:
+0:128          0.000000
+0:128        Constant:
+0:128          1.000000
+0:129      Sign (global 2-component vector of float)
 0:129        'inF0' (temp 2-component vector of float)
-0:131      trunc (global 2-component vector of float)
-0:131        'inF0' (temp 2-component vector of float)
-0:134      Branch: Return with expression
+0:130      sine (global 2-component vector of float)
+0:130        'inF0' (temp 2-component vector of float)
+0:131      Sequence
+0:131        move second child to first child (temp 2-component vector of float)
+0:131          'inF1' (temp 2-component vector of float)
+0:131          sine (temp 2-component vector of float)
+0:131            'inF0' (temp 2-component vector of float)
+0:131        move second child to first child (temp 2-component vector of float)
+0:131          'inF2' (temp 2-component vector of float)
+0:131          cosine (temp 2-component vector of float)
+0:131            'inF0' (temp 2-component vector of float)
+0:132      hyp. sine (global 2-component vector of float)
+0:132        'inF0' (temp 2-component vector of float)
+0:133      smoothstep (global 2-component vector of float)
+0:133        'inF0' (temp 2-component vector of float)
+0:133        'inF1' (temp 2-component vector of float)
+0:133        'inF2' (temp 2-component vector of float)
+0:134      sqrt (global 2-component vector of float)
+0:134        'inF0' (temp 2-component vector of float)
+0:135      step (global 2-component vector of float)
+0:135        'inF0' (temp 2-component vector of float)
+0:135        'inF1' (temp 2-component vector of float)
+0:136      tangent (global 2-component vector of float)
+0:136        'inF0' (temp 2-component vector of float)
+0:137      hyp. tangent (global 2-component vector of float)
+0:137        'inF0' (temp 2-component vector of float)
+0:139      trunc (global 2-component vector of float)
+0:139        'inF0' (temp 2-component vector of float)
+0:142      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
-0:207  Function Definition: PixelShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
-0:138    Function Parameters: 
-0:138      'inF0' (temp 3-component vector of float)
-0:138      'inF1' (temp 3-component vector of float)
-0:138      'inF2' (temp 3-component vector of float)
+0:219  Function Definition: PixelShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
+0:146    Function Parameters: 
+0:146      'inF0' (temp 3-component vector of float)
+0:146      'inF1' (temp 3-component vector of float)
+0:146      'inF2' (temp 3-component vector of float)
 0:?     Sequence
-0:139      all (global bool)
-0:139        'inF0' (temp 3-component vector of float)
-0:140      Absolute value (global 3-component vector of float)
-0:140        'inF0' (temp 3-component vector of float)
-0:141      arc cosine (global 3-component vector of float)
-0:141        'inF0' (temp 3-component vector of float)
-0:142      any (global bool)
-0:142        'inF0' (temp 3-component vector of float)
-0:143      arc sine (global 3-component vector of float)
-0:143        'inF0' (temp 3-component vector of float)
-0:144      arc tangent (global 3-component vector of float)
-0:144        'inF0' (temp 3-component vector of float)
-0:145      arc tangent (global 3-component vector of float)
-0:145        'inF0' (temp 3-component vector of float)
-0:145        'inF1' (temp 3-component vector of float)
-0:146      Ceiling (global 3-component vector of float)
-0:146        'inF0' (temp 3-component vector of float)
-0:147      clamp (global 3-component vector of float)
+0:147      all (global bool)
 0:147        'inF0' (temp 3-component vector of float)
-0:147        'inF1' (temp 3-component vector of float)
-0:147        'inF2' (temp 3-component vector of float)
-0:148      cosine (global 3-component vector of float)
+0:148      Absolute value (global 3-component vector of float)
 0:148        'inF0' (temp 3-component vector of float)
-0:149      hyp. cosine (global 3-component vector of float)
+0:149      arc cosine (global 3-component vector of float)
 0:149        'inF0' (temp 3-component vector of float)
+0:150      any (global bool)
+0:150        'inF0' (temp 3-component vector of float)
+0:151      arc sine (global 3-component vector of float)
+0:151        'inF0' (temp 3-component vector of float)
+0:152      arc tangent (global 3-component vector of float)
+0:152        'inF0' (temp 3-component vector of float)
+0:153      arc tangent (global 3-component vector of float)
+0:153        'inF0' (temp 3-component vector of float)
+0:153        'inF1' (temp 3-component vector of float)
+0:154      Ceiling (global 3-component vector of float)
+0:154        'inF0' (temp 3-component vector of float)
+0:155      clamp (global 3-component vector of float)
+0:155        'inF0' (temp 3-component vector of float)
+0:155        'inF1' (temp 3-component vector of float)
+0:155        'inF2' (temp 3-component vector of float)
+0:156      Test condition and select (temp void)
+0:156        Condition
+0:156        any (temp bool)
+0:156          Compare Less Than (temp 3-component vector of bool)
+0:156            'inF0' (temp 3-component vector of float)
+0:156            Constant:
+0:156              0.000000
+0:156              0.000000
+0:156              0.000000
+0:156        true case
+0:156        Branch: Kill
+0:157      cosine (global 3-component vector of float)
+0:157        'inF0' (temp 3-component vector of float)
+0:158      hyp. cosine (global 3-component vector of float)
+0:158        'inF0' (temp 3-component vector of float)
 0:?       bitCount (global 3-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
-0:151      cross-product (global 3-component vector of float)
-0:151        'inF0' (temp 3-component vector of float)
-0:151        'inF1' (temp 3-component vector of float)
-0:152      dPdx (global 3-component vector of float)
-0:152        'inF0' (temp 3-component vector of float)
-0:153      dPdxCoarse (global 3-component vector of float)
-0:153        'inF0' (temp 3-component vector of float)
-0:154      dPdxFine (global 3-component vector of float)
-0:154        'inF0' (temp 3-component vector of float)
-0:155      dPdy (global 3-component vector of float)
-0:155        'inF0' (temp 3-component vector of float)
-0:156      dPdyCoarse (global 3-component vector of float)
-0:156        'inF0' (temp 3-component vector of float)
-0:157      dPdyFine (global 3-component vector of float)
-0:157        'inF0' (temp 3-component vector of float)
-0:158      degrees (global 3-component vector of float)
-0:158        'inF0' (temp 3-component vector of float)
-0:159      distance (global float)
-0:159        'inF0' (temp 3-component vector of float)
-0:159        'inF1' (temp 3-component vector of float)
-0:160      dot-product (global float)
+0:160      cross-product (global 3-component vector of float)
 0:160        'inF0' (temp 3-component vector of float)
 0:160        'inF1' (temp 3-component vector of float)
-0:164      exp (global 3-component vector of float)
+0:161      dPdx (global 3-component vector of float)
+0:161        'inF0' (temp 3-component vector of float)
+0:162      dPdxCoarse (global 3-component vector of float)
+0:162        'inF0' (temp 3-component vector of float)
+0:163      dPdxFine (global 3-component vector of float)
+0:163        'inF0' (temp 3-component vector of float)
+0:164      dPdy (global 3-component vector of float)
 0:164        'inF0' (temp 3-component vector of float)
-0:165      exp2 (global 3-component vector of float)
+0:165      dPdyCoarse (global 3-component vector of float)
 0:165        'inF0' (temp 3-component vector of float)
-0:166      face-forward (global 3-component vector of float)
+0:166      dPdyFine (global 3-component vector of float)
 0:166        'inF0' (temp 3-component vector of float)
-0:166        'inF1' (temp 3-component vector of float)
-0:166        'inF2' (temp 3-component vector of float)
-0:167      findMSB (global int)
-0:167        Constant:
-0:167          7 (const int)
-0:168      findLSB (global int)
-0:168        Constant:
-0:168          7 (const int)
-0:169      Floor (global 3-component vector of float)
+0:167      degrees (global 3-component vector of float)
+0:167        'inF0' (temp 3-component vector of float)
+0:168      distance (global float)
+0:168        'inF0' (temp 3-component vector of float)
+0:168        'inF1' (temp 3-component vector of float)
+0:169      dot-product (global float)
 0:169        'inF0' (temp 3-component vector of float)
-0:171      Function Call: fmod(vf3;vf3; (global 3-component vector of float)
-0:171        'inF0' (temp 3-component vector of float)
-0:171        'inF1' (temp 3-component vector of float)
-0:172      Fraction (global 3-component vector of float)
-0:172        'inF0' (temp 3-component vector of float)
-0:173      frexp (global 3-component vector of float)
+0:169        'inF1' (temp 3-component vector of float)
+0:173      exp (global 3-component vector of float)
 0:173        'inF0' (temp 3-component vector of float)
-0:173        'inF1' (temp 3-component vector of float)
-0:174      fwidth (global 3-component vector of float)
+0:174      exp2 (global 3-component vector of float)
 0:174        'inF0' (temp 3-component vector of float)
-0:175      isinf (global 3-component vector of bool)
+0:175      face-forward (global 3-component vector of float)
 0:175        'inF0' (temp 3-component vector of float)
-0:176      isnan (global 3-component vector of bool)
-0:176        'inF0' (temp 3-component vector of float)
-0:177      ldexp (global 3-component vector of float)
-0:177        'inF0' (temp 3-component vector of float)
-0:177        'inF1' (temp 3-component vector of float)
-0:178      length (global float)
+0:175        'inF1' (temp 3-component vector of float)
+0:175        'inF2' (temp 3-component vector of float)
+0:176      findMSB (global int)
+0:176        Constant:
+0:176          7 (const int)
+0:177      findLSB (global int)
+0:177        Constant:
+0:177          7 (const int)
+0:178      Floor (global 3-component vector of float)
 0:178        'inF0' (temp 3-component vector of float)
-0:179      log (global 3-component vector of float)
-0:179        'inF0' (temp 3-component vector of float)
-0:180      log2 (global 3-component vector of float)
+0:180      mod (global 3-component vector of float)
 0:180        'inF0' (temp 3-component vector of float)
-0:181      max (global 3-component vector of float)
+0:180        'inF1' (temp 3-component vector of float)
+0:181      Fraction (global 3-component vector of float)
 0:181        'inF0' (temp 3-component vector of float)
-0:181        'inF1' (temp 3-component vector of float)
-0:182      min (global 3-component vector of float)
+0:182      frexp (global 3-component vector of float)
 0:182        'inF0' (temp 3-component vector of float)
 0:182        'inF1' (temp 3-component vector of float)
-0:184      normalize (global 3-component vector of float)
+0:183      fwidth (global 3-component vector of float)
+0:183        'inF0' (temp 3-component vector of float)
+0:184      isinf (global 3-component vector of bool)
 0:184        'inF0' (temp 3-component vector of float)
-0:185      pow (global 3-component vector of float)
+0:185      isnan (global 3-component vector of bool)
 0:185        'inF0' (temp 3-component vector of float)
-0:185        'inF1' (temp 3-component vector of float)
-0:186      radians (global 3-component vector of float)
+0:186      ldexp (global 3-component vector of float)
 0:186        'inF0' (temp 3-component vector of float)
-0:187      reflect (global 3-component vector of float)
+0:186        'inF1' (temp 3-component vector of float)
+0:187      length (global float)
 0:187        'inF0' (temp 3-component vector of float)
-0:187        'inF1' (temp 3-component vector of float)
-0:188      refract (global 3-component vector of float)
+0:188      log (global 3-component vector of float)
 0:188        'inF0' (temp 3-component vector of float)
-0:188        'inF1' (temp 3-component vector of float)
-0:188        Constant:
-0:188          2.000000
+0:189      component-wise multiply (global 3-component vector of float)
+0:189        log2 (global 3-component vector of float)
+0:189          'inF0' (temp 3-component vector of float)
+0:189        Constant:
+0:189          0.301030
+0:190      log2 (global 3-component vector of float)
+0:190        'inF0' (temp 3-component vector of float)
+0:191      max (global 3-component vector of float)
+0:191        'inF0' (temp 3-component vector of float)
+0:191        'inF1' (temp 3-component vector of float)
+0:192      min (global 3-component vector of float)
+0:192        'inF0' (temp 3-component vector of float)
+0:192        'inF1' (temp 3-component vector of float)
+0:193      normalize (global 3-component vector of float)
+0:193        'inF0' (temp 3-component vector of float)
+0:194      pow (global 3-component vector of float)
+0:194        'inF0' (temp 3-component vector of float)
+0:194        'inF1' (temp 3-component vector of float)
+0:195      radians (global 3-component vector of float)
+0:195        'inF0' (temp 3-component vector of float)
+0:196      divide (global 3-component vector of float)
+0:196        Constant:
+0:196          1.000000
+0:196        'inF0' (temp 3-component vector of float)
+0:197      reflect (global 3-component vector of float)
+0:197        'inF0' (temp 3-component vector of float)
+0:197        'inF1' (temp 3-component vector of float)
+0:198      refract (global 3-component vector of float)
+0:198        'inF0' (temp 3-component vector of float)
+0:198        'inF1' (temp 3-component vector of float)
+0:198        Constant:
+0:198          2.000000
 0:?       bitFieldReverse (global 3-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
-0:190      roundEven (global 3-component vector of float)
-0:190        'inF0' (temp 3-component vector of float)
-0:191      inverse sqrt (global 3-component vector of float)
-0:191        'inF0' (temp 3-component vector of float)
-0:192      Sign (global 3-component vector of float)
-0:192        'inF0' (temp 3-component vector of float)
-0:193      sine (global 3-component vector of float)
-0:193        'inF0' (temp 3-component vector of float)
-0:194      hyp. sine (global 3-component vector of float)
-0:194        'inF0' (temp 3-component vector of float)
-0:195      smoothstep (global 3-component vector of float)
-0:195        'inF0' (temp 3-component vector of float)
-0:195        'inF1' (temp 3-component vector of float)
-0:195        'inF2' (temp 3-component vector of float)
-0:196      sqrt (global 3-component vector of float)
-0:196        'inF0' (temp 3-component vector of float)
-0:197      step (global 3-component vector of float)
-0:197        'inF0' (temp 3-component vector of float)
-0:197        'inF1' (temp 3-component vector of float)
-0:198      tangent (global 3-component vector of float)
-0:198        'inF0' (temp 3-component vector of float)
-0:199      hyp. tangent (global 3-component vector of float)
-0:199        'inF0' (temp 3-component vector of float)
-0:201      trunc (global 3-component vector of float)
+0:200      roundEven (global 3-component vector of float)
+0:200        'inF0' (temp 3-component vector of float)
+0:201      inverse sqrt (global 3-component vector of float)
 0:201        'inF0' (temp 3-component vector of float)
-0:204      Branch: Return with expression
+0:202      clamp (global 3-component vector of float)
+0:202        'inF0' (temp 3-component vector of float)
+0:202        Constant:
+0:202          0.000000
+0:202        Constant:
+0:202          1.000000
+0:203      Sign (global 3-component vector of float)
+0:203        'inF0' (temp 3-component vector of float)
+0:204      sine (global 3-component vector of float)
+0:204        'inF0' (temp 3-component vector of float)
+0:205      Sequence
+0:205        move second child to first child (temp 3-component vector of float)
+0:205          'inF1' (temp 3-component vector of float)
+0:205          sine (temp 3-component vector of float)
+0:205            'inF0' (temp 3-component vector of float)
+0:205        move second child to first child (temp 3-component vector of float)
+0:205          'inF2' (temp 3-component vector of float)
+0:205          cosine (temp 3-component vector of float)
+0:205            'inF0' (temp 3-component vector of float)
+0:206      hyp. sine (global 3-component vector of float)
+0:206        'inF0' (temp 3-component vector of float)
+0:207      smoothstep (global 3-component vector of float)
+0:207        'inF0' (temp 3-component vector of float)
+0:207        'inF1' (temp 3-component vector of float)
+0:207        'inF2' (temp 3-component vector of float)
+0:208      sqrt (global 3-component vector of float)
+0:208        'inF0' (temp 3-component vector of float)
+0:209      step (global 3-component vector of float)
+0:209        'inF0' (temp 3-component vector of float)
+0:209        'inF1' (temp 3-component vector of float)
+0:210      tangent (global 3-component vector of float)
+0:210        'inF0' (temp 3-component vector of float)
+0:211      hyp. tangent (global 3-component vector of float)
+0:211        'inF0' (temp 3-component vector of float)
+0:213      trunc (global 3-component vector of float)
+0:213        'inF0' (temp 3-component vector of float)
+0:216      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
-0:328  Function Definition: PixelShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
-0:208    Function Parameters: 
-0:208      'inF0' (temp 4-component vector of float)
-0:208      'inF1' (temp 4-component vector of float)
-0:208      'inF2' (temp 4-component vector of float)
+0:348  Function Definition: PixelShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
+0:220    Function Parameters: 
+0:220      'inF0' (temp 4-component vector of float)
+0:220      'inF1' (temp 4-component vector of float)
+0:220      'inF2' (temp 4-component vector of float)
 0:?     Sequence
-0:209      all (global bool)
-0:209        'inF0' (temp 4-component vector of float)
-0:210      Absolute value (global 4-component vector of float)
-0:210        'inF0' (temp 4-component vector of float)
-0:211      arc cosine (global 4-component vector of float)
-0:211        'inF0' (temp 4-component vector of float)
-0:212      any (global bool)
-0:212        'inF0' (temp 4-component vector of float)
-0:213      arc sine (global 4-component vector of float)
-0:213        'inF0' (temp 4-component vector of float)
-0:214      arc tangent (global 4-component vector of float)
-0:214        'inF0' (temp 4-component vector of float)
-0:215      arc tangent (global 4-component vector of float)
-0:215        'inF0' (temp 4-component vector of float)
-0:215        'inF1' (temp 4-component vector of float)
-0:216      Ceiling (global 4-component vector of float)
-0:216        'inF0' (temp 4-component vector of float)
-0:217      clamp (global 4-component vector of float)
-0:217        'inF0' (temp 4-component vector of float)
-0:217        'inF1' (temp 4-component vector of float)
-0:217        'inF2' (temp 4-component vector of float)
-0:218      cosine (global 4-component vector of float)
-0:218        'inF0' (temp 4-component vector of float)
-0:219      hyp. cosine (global 4-component vector of float)
-0:219        'inF0' (temp 4-component vector of float)
+0:221      all (global bool)
+0:221        'inF0' (temp 4-component vector of float)
+0:222      Absolute value (global 4-component vector of float)
+0:222        'inF0' (temp 4-component vector of float)
+0:223      arc cosine (global 4-component vector of float)
+0:223        'inF0' (temp 4-component vector of float)
+0:224      any (global bool)
+0:224        'inF0' (temp 4-component vector of float)
+0:225      arc sine (global 4-component vector of float)
+0:225        'inF0' (temp 4-component vector of float)
+0:226      arc tangent (global 4-component vector of float)
+0:226        'inF0' (temp 4-component vector of float)
+0:227      arc tangent (global 4-component vector of float)
+0:227        'inF0' (temp 4-component vector of float)
+0:227        'inF1' (temp 4-component vector of float)
+0:228      Ceiling (global 4-component vector of float)
+0:228        'inF0' (temp 4-component vector of float)
+0:229      clamp (global 4-component vector of float)
+0:229        'inF0' (temp 4-component vector of float)
+0:229        'inF1' (temp 4-component vector of float)
+0:229        'inF2' (temp 4-component vector of float)
+0:230      Test condition and select (temp void)
+0:230        Condition
+0:230        any (temp bool)
+0:230          Compare Less Than (temp 4-component vector of bool)
+0:230            'inF0' (temp 4-component vector of float)
+0:230            Constant:
+0:230              0.000000
+0:230              0.000000
+0:230              0.000000
+0:230              0.000000
+0:230        true case
+0:230        Branch: Kill
+0:231      cosine (global 4-component vector of float)
+0:231        'inF0' (temp 4-component vector of float)
+0:232      hyp. cosine (global 4-component vector of float)
+0:232        'inF0' (temp 4-component vector of float)
 0:?       bitCount (global 4-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
 0:?           2 (const uint)
-0:221      dPdx (global 4-component vector of float)
-0:221        'inF0' (temp 4-component vector of float)
-0:222      dPdxCoarse (global 4-component vector of float)
-0:222        'inF0' (temp 4-component vector of float)
-0:223      dPdxFine (global 4-component vector of float)
-0:223        'inF0' (temp 4-component vector of float)
-0:224      dPdy (global 4-component vector of float)
-0:224        'inF0' (temp 4-component vector of float)
-0:225      dPdyCoarse (global 4-component vector of float)
-0:225        'inF0' (temp 4-component vector of float)
-0:226      dPdyFine (global 4-component vector of float)
-0:226        'inF0' (temp 4-component vector of float)
-0:227      degrees (global 4-component vector of float)
-0:227        'inF0' (temp 4-component vector of float)
-0:228      distance (global float)
-0:228        'inF0' (temp 4-component vector of float)
-0:228        'inF1' (temp 4-component vector of float)
-0:229      dot-product (global float)
-0:229        'inF0' (temp 4-component vector of float)
-0:229        'inF1' (temp 4-component vector of float)
-0:233      exp (global 4-component vector of float)
-0:233        'inF0' (temp 4-component vector of float)
-0:234      exp2 (global 4-component vector of float)
+0:234      dPdx (global 4-component vector of float)
 0:234        'inF0' (temp 4-component vector of float)
-0:235      face-forward (global 4-component vector of float)
+0:235      dPdxCoarse (global 4-component vector of float)
 0:235        'inF0' (temp 4-component vector of float)
-0:235        'inF1' (temp 4-component vector of float)
-0:235        'inF2' (temp 4-component vector of float)
-0:236      findMSB (global int)
-0:236        Constant:
-0:236          7 (const int)
-0:237      findLSB (global int)
-0:237        Constant:
-0:237          7 (const int)
-0:238      Floor (global 4-component vector of float)
+0:236      dPdxFine (global 4-component vector of float)
+0:236        'inF0' (temp 4-component vector of float)
+0:237      dPdy (global 4-component vector of float)
+0:237        'inF0' (temp 4-component vector of float)
+0:238      dPdyCoarse (global 4-component vector of float)
 0:238        'inF0' (temp 4-component vector of float)
-0:240      Function Call: fmod(vf4;vf4; (global 4-component vector of float)
+0:239      dPdyFine (global 4-component vector of float)
+0:239        'inF0' (temp 4-component vector of float)
+0:240      degrees (global 4-component vector of float)
 0:240        'inF0' (temp 4-component vector of float)
-0:240        'inF1' (temp 4-component vector of float)
-0:241      Fraction (global 4-component vector of float)
+0:241      distance (global float)
 0:241        'inF0' (temp 4-component vector of float)
-0:242      frexp (global 4-component vector of float)
+0:241        'inF1' (temp 4-component vector of float)
+0:242      dot-product (global float)
 0:242        'inF0' (temp 4-component vector of float)
 0:242        'inF1' (temp 4-component vector of float)
-0:243      fwidth (global 4-component vector of float)
-0:243        'inF0' (temp 4-component vector of float)
-0:244      isinf (global 4-component vector of bool)
-0:244        'inF0' (temp 4-component vector of float)
-0:245      isnan (global 4-component vector of bool)
-0:245        'inF0' (temp 4-component vector of float)
-0:246      ldexp (global 4-component vector of float)
+0:246      exp (global 4-component vector of float)
 0:246        'inF0' (temp 4-component vector of float)
-0:246        'inF1' (temp 4-component vector of float)
-0:247      length (global float)
+0:247      exp2 (global 4-component vector of float)
 0:247        'inF0' (temp 4-component vector of float)
-0:248      log (global 4-component vector of float)
+0:248      face-forward (global 4-component vector of float)
 0:248        'inF0' (temp 4-component vector of float)
-0:249      log2 (global 4-component vector of float)
-0:249        'inF0' (temp 4-component vector of float)
-0:250      max (global 4-component vector of float)
-0:250        'inF0' (temp 4-component vector of float)
-0:250        'inF1' (temp 4-component vector of float)
-0:251      min (global 4-component vector of float)
+0:248        'inF1' (temp 4-component vector of float)
+0:248        'inF2' (temp 4-component vector of float)
+0:249      findMSB (global int)
+0:249        Constant:
+0:249          7 (const int)
+0:250      findLSB (global int)
+0:250        Constant:
+0:250          7 (const int)
+0:251      Floor (global 4-component vector of float)
 0:251        'inF0' (temp 4-component vector of float)
-0:251        'inF1' (temp 4-component vector of float)
-0:253      normalize (global 4-component vector of float)
+0:253      mod (global 4-component vector of float)
 0:253        'inF0' (temp 4-component vector of float)
-0:254      pow (global 4-component vector of float)
+0:253        'inF1' (temp 4-component vector of float)
+0:254      Fraction (global 4-component vector of float)
 0:254        'inF0' (temp 4-component vector of float)
-0:254        'inF1' (temp 4-component vector of float)
-0:255      radians (global 4-component vector of float)
+0:255      frexp (global 4-component vector of float)
 0:255        'inF0' (temp 4-component vector of float)
-0:256      reflect (global 4-component vector of float)
+0:255        'inF1' (temp 4-component vector of float)
+0:256      fwidth (global 4-component vector of float)
 0:256        'inF0' (temp 4-component vector of float)
-0:256        'inF1' (temp 4-component vector of float)
-0:257      refract (global 4-component vector of float)
+0:257      isinf (global 4-component vector of bool)
 0:257        'inF0' (temp 4-component vector of float)
-0:257        'inF1' (temp 4-component vector of float)
-0:257        Constant:
-0:257          2.000000
+0:258      isnan (global 4-component vector of bool)
+0:258        'inF0' (temp 4-component vector of float)
+0:259      ldexp (global 4-component vector of float)
+0:259        'inF0' (temp 4-component vector of float)
+0:259        'inF1' (temp 4-component vector of float)
+0:260      length (global float)
+0:260        'inF0' (temp 4-component vector of float)
+0:261      log (global 4-component vector of float)
+0:261        'inF0' (temp 4-component vector of float)
+0:262      component-wise multiply (global 4-component vector of float)
+0:262        log2 (global 4-component vector of float)
+0:262          'inF0' (temp 4-component vector of float)
+0:262        Constant:
+0:262          0.301030
+0:263      log2 (global 4-component vector of float)
+0:263        'inF0' (temp 4-component vector of float)
+0:264      max (global 4-component vector of float)
+0:264        'inF0' (temp 4-component vector of float)
+0:264        'inF1' (temp 4-component vector of float)
+0:265      min (global 4-component vector of float)
+0:265        'inF0' (temp 4-component vector of float)
+0:265        'inF1' (temp 4-component vector of float)
+0:266      normalize (global 4-component vector of float)
+0:266        'inF0' (temp 4-component vector of float)
+0:267      pow (global 4-component vector of float)
+0:267        'inF0' (temp 4-component vector of float)
+0:267        'inF1' (temp 4-component vector of float)
+0:268      radians (global 4-component vector of float)
+0:268        'inF0' (temp 4-component vector of float)
+0:269      divide (global 4-component vector of float)
+0:269        Constant:
+0:269          1.000000
+0:269        'inF0' (temp 4-component vector of float)
+0:270      reflect (global 4-component vector of float)
+0:270        'inF0' (temp 4-component vector of float)
+0:270        'inF1' (temp 4-component vector of float)
+0:271      refract (global 4-component vector of float)
+0:271        'inF0' (temp 4-component vector of float)
+0:271        'inF1' (temp 4-component vector of float)
+0:271        Constant:
+0:271          2.000000
 0:?       bitFieldReverse (global 4-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
 0:?           4 (const uint)
-0:259      roundEven (global 4-component vector of float)
-0:259        'inF0' (temp 4-component vector of float)
-0:260      inverse sqrt (global 4-component vector of float)
-0:260        'inF0' (temp 4-component vector of float)
-0:261      Sign (global 4-component vector of float)
-0:261        'inF0' (temp 4-component vector of float)
-0:262      sine (global 4-component vector of float)
-0:262        'inF0' (temp 4-component vector of float)
-0:263      hyp. sine (global 4-component vector of float)
-0:263        'inF0' (temp 4-component vector of float)
-0:264      smoothstep (global 4-component vector of float)
-0:264        'inF0' (temp 4-component vector of float)
-0:264        'inF1' (temp 4-component vector of float)
-0:264        'inF2' (temp 4-component vector of float)
-0:265      sqrt (global 4-component vector of float)
-0:265        'inF0' (temp 4-component vector of float)
-0:266      step (global 4-component vector of float)
-0:266        'inF0' (temp 4-component vector of float)
-0:266        'inF1' (temp 4-component vector of float)
-0:267      tangent (global 4-component vector of float)
-0:267        'inF0' (temp 4-component vector of float)
-0:268      hyp. tangent (global 4-component vector of float)
-0:268        'inF0' (temp 4-component vector of float)
-0:270      trunc (global 4-component vector of float)
-0:270        'inF0' (temp 4-component vector of float)
-0:273      Branch: Return with expression
+0:273      roundEven (global 4-component vector of float)
+0:273        'inF0' (temp 4-component vector of float)
+0:274      inverse sqrt (global 4-component vector of float)
+0:274        'inF0' (temp 4-component vector of float)
+0:275      clamp (global 4-component vector of float)
+0:275        'inF0' (temp 4-component vector of float)
+0:275        Constant:
+0:275          0.000000
+0:275        Constant:
+0:275          1.000000
+0:276      Sign (global 4-component vector of float)
+0:276        'inF0' (temp 4-component vector of float)
+0:277      sine (global 4-component vector of float)
+0:277        'inF0' (temp 4-component vector of float)
+0:278      Sequence
+0:278        move second child to first child (temp 4-component vector of float)
+0:278          'inF1' (temp 4-component vector of float)
+0:278          sine (temp 4-component vector of float)
+0:278            'inF0' (temp 4-component vector of float)
+0:278        move second child to first child (temp 4-component vector of float)
+0:278          'inF2' (temp 4-component vector of float)
+0:278          cosine (temp 4-component vector of float)
+0:278            'inF0' (temp 4-component vector of float)
+0:279      hyp. sine (global 4-component vector of float)
+0:279        'inF0' (temp 4-component vector of float)
+0:280      smoothstep (global 4-component vector of float)
+0:280        'inF0' (temp 4-component vector of float)
+0:280        'inF1' (temp 4-component vector of float)
+0:280        'inF2' (temp 4-component vector of float)
+0:281      sqrt (global 4-component vector of float)
+0:281        'inF0' (temp 4-component vector of float)
+0:282      step (global 4-component vector of float)
+0:282        'inF0' (temp 4-component vector of float)
+0:282        'inF1' (temp 4-component vector of float)
+0:283      tangent (global 4-component vector of float)
+0:283        'inF0' (temp 4-component vector of float)
+0:284      hyp. tangent (global 4-component vector of float)
+0:284        'inF0' (temp 4-component vector of float)
+0:286      trunc (global 4-component vector of float)
+0:286        'inF0' (temp 4-component vector of float)
+0:289      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
 0:?           4.000000
-0:337  Function Definition: PixelShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
-0:329    Function Parameters: 
-0:329      'inF0' (temp 2X2 matrix of float)
-0:329      'inF1' (temp 2X2 matrix of float)
-0:329      'inF2' (temp 2X2 matrix of float)
+0:357  Function Definition: PixelShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:349    Function Parameters: 
+0:349      'inF0' (temp 2X2 matrix of float)
+0:349      'inF1' (temp 2X2 matrix of float)
+0:349      'inF2' (temp 2X2 matrix of float)
 0:?     Sequence
-0:331      all (global bool)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      Absolute value (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc cosine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      any (global bool)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc sine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      Ceiling (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      clamp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331        'inF2' (temp 2X2 matrix of float)
-0:331      cosine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      hyp. cosine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdx (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdxCoarse (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdxFine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdy (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdyCoarse (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdyFine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      degrees (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      determinant (global float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      exp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      exp2 (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      findMSB (global int)
-0:331        Constant:
-0:331          7 (const int)
-0:331      findLSB (global int)
-0:331        Constant:
-0:331          7 (const int)
-0:331      Floor (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      Function Call: fmod(mf22;mf22; (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      Fraction (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      frexp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      fwidth (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      ldexp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      log (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      log2 (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      max (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      min (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      pow (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      radians (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      roundEven (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      inverse sqrt (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      Sign (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      sine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      hyp. sine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      smoothstep (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331        'inF2' (temp 2X2 matrix of float)
-0:331      sqrt (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      step (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      hyp. tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      transpose (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      trunc (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:334      Branch: Return with expression
+0:351      all (global bool)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      Absolute value (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      arc cosine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      any (global bool)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      arc sine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      arc tangent (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      arc tangent (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      Ceiling (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      Test condition and select (temp void)
+0:351        Condition
+0:351        any (temp bool)
+0:351          Compare Less Than (temp 2X2 matrix of bool)
+0:351            'inF0' (temp 2X2 matrix of float)
+0:351            Constant:
+0:351              0.000000
+0:351              0.000000
+0:351              0.000000
+0:351              0.000000
+0:351        true case
+0:351        Branch: Kill
+0:351      clamp (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351        'inF2' (temp 2X2 matrix of float)
+0:351      cosine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      hyp. cosine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      dPdx (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      dPdxCoarse (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      dPdxFine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      dPdy (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      dPdyCoarse (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      dPdyFine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      degrees (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      determinant (global float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      exp (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      exp2 (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      findMSB (global int)
+0:351        Constant:
+0:351          7 (const int)
+0:351      findLSB (global int)
+0:351        Constant:
+0:351          7 (const int)
+0:351      Floor (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      mod (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      Fraction (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      frexp (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      fwidth (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      ldexp (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      log (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      component-wise multiply (global 2X2 matrix of float)
+0:351        log2 (global 2X2 matrix of float)
+0:351          'inF0' (temp 2X2 matrix of float)
+0:351        Constant:
+0:351          0.301030
+0:351      log2 (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      max (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      min (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      pow (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      radians (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      roundEven (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      inverse sqrt (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      clamp (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        Constant:
+0:351          0.000000
+0:351        Constant:
+0:351          1.000000
+0:351      Sign (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      sine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      Sequence
+0:351        move second child to first child (temp 2X2 matrix of float)
+0:351          'inF1' (temp 2X2 matrix of float)
+0:351          sine (temp 2X2 matrix of float)
+0:351            'inF0' (temp 2X2 matrix of float)
+0:351        move second child to first child (temp 2X2 matrix of float)
+0:351          'inF2' (temp 2X2 matrix of float)
+0:351          cosine (temp 2X2 matrix of float)
+0:351            'inF0' (temp 2X2 matrix of float)
+0:351      hyp. sine (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      smoothstep (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351        'inF2' (temp 2X2 matrix of float)
+0:351      sqrt (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      step (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351        'inF1' (temp 2X2 matrix of float)
+0:351      tangent (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      hyp. tangent (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      transpose (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:351      trunc (global 2X2 matrix of float)
+0:351        'inF0' (temp 2X2 matrix of float)
+0:354      Branch: Return with expression
 0:?         Constant:
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
-0:346  Function Definition: PixelShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
-0:338    Function Parameters: 
-0:338      'inF0' (temp 3X3 matrix of float)
-0:338      'inF1' (temp 3X3 matrix of float)
-0:338      'inF2' (temp 3X3 matrix of float)
+0:366  Function Definition: PixelShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:358    Function Parameters: 
+0:358      'inF0' (temp 3X3 matrix of float)
+0:358      'inF1' (temp 3X3 matrix of float)
+0:358      'inF2' (temp 3X3 matrix of float)
 0:?     Sequence
-0:340      all (global bool)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      Absolute value (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc cosine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      any (global bool)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc sine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      Ceiling (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      clamp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340        'inF2' (temp 3X3 matrix of float)
-0:340      cosine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      hyp. cosine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdx (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdxCoarse (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdxFine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdy (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdyCoarse (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdyFine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      degrees (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      determinant (global float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      exp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      exp2 (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      findMSB (global int)
-0:340        Constant:
-0:340          7 (const int)
-0:340      findLSB (global int)
-0:340        Constant:
-0:340          7 (const int)
-0:340      Floor (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      Function Call: fmod(mf33;mf33; (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      Fraction (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      frexp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      fwidth (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      ldexp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      log (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      log2 (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      max (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      min (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      pow (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      radians (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      roundEven (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      inverse sqrt (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      Sign (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      sine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      hyp. sine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      smoothstep (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340        'inF2' (temp 3X3 matrix of float)
-0:340      sqrt (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      step (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      hyp. tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      transpose (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      trunc (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:343      Branch: Return with expression
+0:360      all (global bool)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      Absolute value (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      arc cosine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      any (global bool)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      arc sine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      arc tangent (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      arc tangent (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      Ceiling (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      Test condition and select (temp void)
+0:360        Condition
+0:360        any (temp bool)
+0:360          Compare Less Than (temp 3X3 matrix of bool)
+0:360            'inF0' (temp 3X3 matrix of float)
+0:360            Constant:
+0:360              0.000000
+0:360              0.000000
+0:360              0.000000
+0:360              0.000000
+0:360              0.000000
+0:360              0.000000
+0:360              0.000000
+0:360              0.000000
+0:360              0.000000
+0:360        true case
+0:360        Branch: Kill
+0:360      clamp (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360        'inF2' (temp 3X3 matrix of float)
+0:360      cosine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      hyp. cosine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      dPdx (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      dPdxCoarse (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      dPdxFine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      dPdy (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      dPdyCoarse (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      dPdyFine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      degrees (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      determinant (global float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      exp (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      exp2 (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      findMSB (global int)
+0:360        Constant:
+0:360          7 (const int)
+0:360      findLSB (global int)
+0:360        Constant:
+0:360          7 (const int)
+0:360      Floor (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      mod (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      Fraction (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      frexp (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      fwidth (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      ldexp (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      log (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      component-wise multiply (global 3X3 matrix of float)
+0:360        log2 (global 3X3 matrix of float)
+0:360          'inF0' (temp 3X3 matrix of float)
+0:360        Constant:
+0:360          0.301030
+0:360      log2 (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      max (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      min (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      pow (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      radians (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      roundEven (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      inverse sqrt (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      clamp (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        Constant:
+0:360          0.000000
+0:360        Constant:
+0:360          1.000000
+0:360      Sign (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      sine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      Sequence
+0:360        move second child to first child (temp 3X3 matrix of float)
+0:360          'inF1' (temp 3X3 matrix of float)
+0:360          sine (temp 3X3 matrix of float)
+0:360            'inF0' (temp 3X3 matrix of float)
+0:360        move second child to first child (temp 3X3 matrix of float)
+0:360          'inF2' (temp 3X3 matrix of float)
+0:360          cosine (temp 3X3 matrix of float)
+0:360            'inF0' (temp 3X3 matrix of float)
+0:360      hyp. sine (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      smoothstep (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360        'inF2' (temp 3X3 matrix of float)
+0:360      sqrt (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      step (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360        'inF1' (temp 3X3 matrix of float)
+0:360      tangent (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      hyp. tangent (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      transpose (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:360      trunc (global 3X3 matrix of float)
+0:360        'inF0' (temp 3X3 matrix of float)
+0:363      Branch: Return with expression
 0:?         Constant:
 0:?           3.000000
 0:?           3.000000
@@ -1809,121 +2427,165 @@ gl_FragCoord origin is upper left
 0:?           3.000000
 0:?           3.000000
 0:?           3.000000
-0:354  Function Definition: PixelShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
-0:347    Function Parameters: 
-0:347      'inF0' (temp 4X4 matrix of float)
-0:347      'inF1' (temp 4X4 matrix of float)
-0:347      'inF2' (temp 4X4 matrix of float)
+0:387  Function Definition: PixelShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:367    Function Parameters: 
+0:367      'inF0' (temp 4X4 matrix of float)
+0:367      'inF1' (temp 4X4 matrix of float)
+0:367      'inF2' (temp 4X4 matrix of float)
 0:?     Sequence
-0:349      all (global bool)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      Absolute value (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc cosine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      any (global bool)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc sine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      Ceiling (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      clamp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349        'inF2' (temp 4X4 matrix of float)
-0:349      cosine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      hyp. cosine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdx (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdxCoarse (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdxFine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdy (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdyCoarse (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdyFine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      degrees (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      determinant (global float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      exp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      exp2 (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      findMSB (global int)
-0:349        Constant:
-0:349          7 (const int)
-0:349      findLSB (global int)
-0:349        Constant:
-0:349          7 (const int)
-0:349      Floor (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      Function Call: fmod(mf44;mf44; (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      Fraction (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      frexp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      fwidth (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      ldexp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      log (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      log2 (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      max (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      min (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      pow (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      radians (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      roundEven (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      inverse sqrt (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      Sign (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      sine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      hyp. sine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      smoothstep (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349        'inF2' (temp 4X4 matrix of float)
-0:349      sqrt (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      step (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      hyp. tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      transpose (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      trunc (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:352      Branch: Return with expression
+0:369      all (global bool)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      Absolute value (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      arc cosine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      any (global bool)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      arc sine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      arc tangent (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      arc tangent (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      Ceiling (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      Test condition and select (temp void)
+0:369        Condition
+0:369        any (temp bool)
+0:369          Compare Less Than (temp 4X4 matrix of bool)
+0:369            'inF0' (temp 4X4 matrix of float)
+0:369            Constant:
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369              0.000000
+0:369        true case
+0:369        Branch: Kill
+0:369      clamp (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369        'inF2' (temp 4X4 matrix of float)
+0:369      cosine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      hyp. cosine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      dPdx (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      dPdxCoarse (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      dPdxFine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      dPdy (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      dPdyCoarse (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      dPdyFine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      degrees (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      determinant (global float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      exp (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      exp2 (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      findMSB (global int)
+0:369        Constant:
+0:369          7 (const int)
+0:369      findLSB (global int)
+0:369        Constant:
+0:369          7 (const int)
+0:369      Floor (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      mod (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      Fraction (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      frexp (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      fwidth (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      ldexp (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      log (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      component-wise multiply (global 4X4 matrix of float)
+0:369        log2 (global 4X4 matrix of float)
+0:369          'inF0' (temp 4X4 matrix of float)
+0:369        Constant:
+0:369          0.301030
+0:369      log2 (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      max (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      min (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      pow (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      radians (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      roundEven (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      inverse sqrt (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      clamp (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        Constant:
+0:369          0.000000
+0:369        Constant:
+0:369          1.000000
+0:369      Sign (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      sine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      Sequence
+0:369        move second child to first child (temp 4X4 matrix of float)
+0:369          'inF1' (temp 4X4 matrix of float)
+0:369          sine (temp 4X4 matrix of float)
+0:369            'inF0' (temp 4X4 matrix of float)
+0:369        move second child to first child (temp 4X4 matrix of float)
+0:369          'inF2' (temp 4X4 matrix of float)
+0:369          cosine (temp 4X4 matrix of float)
+0:369            'inF0' (temp 4X4 matrix of float)
+0:369      hyp. sine (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      smoothstep (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369        'inF2' (temp 4X4 matrix of float)
+0:369      sqrt (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      step (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369        'inF1' (temp 4X4 matrix of float)
+0:369      tangent (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      hyp. tangent (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      transpose (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:369      trunc (global 4X4 matrix of float)
+0:369        'inF0' (temp 4X4 matrix of float)
+0:372      Branch: Return with expression
 0:?         Constant:
 0:?           4.000000
 0:?           4.000000
@@ -1941,12 +2603,173 @@ gl_FragCoord origin is upper left
 0:?           4.000000
 0:?           4.000000
 0:?           4.000000
+0:394  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
+0:390    Function Parameters: 
+0:390      'inF0' (temp float)
+0:390      'inF1' (temp float)
+0:390      'inFV0' (temp 2-component vector of float)
+0:390      'inFV1' (temp 2-component vector of float)
+0:390      'inFM0' (temp 2X2 matrix of float)
+0:390      'inFM1' (temp 2X2 matrix of float)
+0:?     Sequence
+0:391      move second child to first child (temp float)
+0:391        'r0' (temp float)
+0:391        component-wise multiply (global float)
+0:391          'inF0' (temp float)
+0:391          'inF1' (temp float)
+0:391      move second child to first child (temp 2-component vector of float)
+0:391        'r1' (temp 2-component vector of float)
+0:391        vector-scale (global 2-component vector of float)
+0:391          'inFV0' (temp 2-component vector of float)
+0:391          'inF0' (temp float)
+0:391      move second child to first child (temp 2-component vector of float)
+0:391        'r2' (temp 2-component vector of float)
+0:391        vector-scale (global 2-component vector of float)
+0:391          'inFV0' (temp 2-component vector of float)
+0:391          'inF0' (temp float)
+0:391      move second child to first child (temp float)
+0:391        'r3' (temp float)
+0:391        dot-product (global float)
+0:391          'inFV0' (temp 2-component vector of float)
+0:391          'inFV1' (temp 2-component vector of float)
+0:391      move second child to first child (temp 2-component vector of float)
+0:391        'r4' (temp 2-component vector of float)
+0:391        matrix-times-vector (global 2-component vector of float)
+0:391          'inFM0' (temp 2X2 matrix of float)
+0:391          'inFV0' (temp 2-component vector of float)
+0:391      move second child to first child (temp 2-component vector of float)
+0:391        'r5' (temp 2-component vector of float)
+0:391        vector-times-matrix (global 2-component vector of float)
+0:391          'inFV0' (temp 2-component vector of float)
+0:391          'inFM0' (temp 2X2 matrix of float)
+0:391      move second child to first child (temp 2X2 matrix of float)
+0:391        'r6' (temp 2X2 matrix of float)
+0:391        matrix-scale (global 2X2 matrix of float)
+0:391          'inFM0' (temp 2X2 matrix of float)
+0:391          'inF0' (temp float)
+0:391      move second child to first child (temp 2X2 matrix of float)
+0:391        'r7' (temp 2X2 matrix of float)
+0:391        matrix-scale (global 2X2 matrix of float)
+0:391          'inFM0' (temp 2X2 matrix of float)
+0:391          'inF0' (temp float)
+0:391      move second child to first child (temp 2X2 matrix of float)
+0:391        'r8' (temp 2X2 matrix of float)
+0:391        matrix-multiply (global 2X2 matrix of float)
+0:391          'inFM0' (temp 2X2 matrix of float)
+0:391          'inFM1' (temp 2X2 matrix of float)
+0:401  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
+0:397    Function Parameters: 
+0:397      'inF0' (temp float)
+0:397      'inF1' (temp float)
+0:397      'inFV0' (temp 3-component vector of float)
+0:397      'inFV1' (temp 3-component vector of float)
+0:397      'inFM0' (temp 3X3 matrix of float)
+0:397      'inFM1' (temp 3X3 matrix of float)
+0:?     Sequence
+0:398      move second child to first child (temp float)
+0:398        'r0' (temp float)
+0:398        component-wise multiply (global float)
+0:398          'inF0' (temp float)
+0:398          'inF1' (temp float)
+0:398      move second child to first child (temp 3-component vector of float)
+0:398        'r1' (temp 3-component vector of float)
+0:398        vector-scale (global 3-component vector of float)
+0:398          'inFV0' (temp 3-component vector of float)
+0:398          'inF0' (temp float)
+0:398      move second child to first child (temp 3-component vector of float)
+0:398        'r2' (temp 3-component vector of float)
+0:398        vector-scale (global 3-component vector of float)
+0:398          'inFV0' (temp 3-component vector of float)
+0:398          'inF0' (temp float)
+0:398      move second child to first child (temp float)
+0:398        'r3' (temp float)
+0:398        dot-product (global float)
+0:398          'inFV0' (temp 3-component vector of float)
+0:398          'inFV1' (temp 3-component vector of float)
+0:398      move second child to first child (temp 3-component vector of float)
+0:398        'r4' (temp 3-component vector of float)
+0:398        matrix-times-vector (global 3-component vector of float)
+0:398          'inFM0' (temp 3X3 matrix of float)
+0:398          'inFV0' (temp 3-component vector of float)
+0:398      move second child to first child (temp 3-component vector of float)
+0:398        'r5' (temp 3-component vector of float)
+0:398        vector-times-matrix (global 3-component vector of float)
+0:398          'inFV0' (temp 3-component vector of float)
+0:398          'inFM0' (temp 3X3 matrix of float)
+0:398      move second child to first child (temp 3X3 matrix of float)
+0:398        'r6' (temp 3X3 matrix of float)
+0:398        matrix-scale (global 3X3 matrix of float)
+0:398          'inFM0' (temp 3X3 matrix of float)
+0:398          'inF0' (temp float)
+0:398      move second child to first child (temp 3X3 matrix of float)
+0:398        'r7' (temp 3X3 matrix of float)
+0:398        matrix-scale (global 3X3 matrix of float)
+0:398          'inFM0' (temp 3X3 matrix of float)
+0:398          'inF0' (temp float)
+0:398      move second child to first child (temp 3X3 matrix of float)
+0:398        'r8' (temp 3X3 matrix of float)
+0:398        matrix-multiply (global 3X3 matrix of float)
+0:398          'inFM0' (temp 3X3 matrix of float)
+0:398          'inFM1' (temp 3X3 matrix of float)
+0:407  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
+0:404    Function Parameters: 
+0:404      'inF0' (temp float)
+0:404      'inF1' (temp float)
+0:404      'inFV0' (temp 4-component vector of float)
+0:404      'inFV1' (temp 4-component vector of float)
+0:404      'inFM0' (temp 4X4 matrix of float)
+0:404      'inFM1' (temp 4X4 matrix of float)
+0:?     Sequence
+0:405      move second child to first child (temp float)
+0:405        'r0' (temp float)
+0:405        component-wise multiply (global float)
+0:405          'inF0' (temp float)
+0:405          'inF1' (temp float)
+0:405      move second child to first child (temp 4-component vector of float)
+0:405        'r1' (temp 4-component vector of float)
+0:405        vector-scale (global 4-component vector of float)
+0:405          'inFV0' (temp 4-component vector of float)
+0:405          'inF0' (temp float)
+0:405      move second child to first child (temp 4-component vector of float)
+0:405        'r2' (temp 4-component vector of float)
+0:405        vector-scale (global 4-component vector of float)
+0:405          'inFV0' (temp 4-component vector of float)
+0:405          'inF0' (temp float)
+0:405      move second child to first child (temp float)
+0:405        'r3' (temp float)
+0:405        dot-product (global float)
+0:405          'inFV0' (temp 4-component vector of float)
+0:405          'inFV1' (temp 4-component vector of float)
+0:405      move second child to first child (temp 4-component vector of float)
+0:405        'r4' (temp 4-component vector of float)
+0:405        matrix-times-vector (global 4-component vector of float)
+0:405          'inFM0' (temp 4X4 matrix of float)
+0:405          'inFV0' (temp 4-component vector of float)
+0:405      move second child to first child (temp 4-component vector of float)
+0:405        'r5' (temp 4-component vector of float)
+0:405        vector-times-matrix (global 4-component vector of float)
+0:405          'inFV0' (temp 4-component vector of float)
+0:405          'inFM0' (temp 4X4 matrix of float)
+0:405      move second child to first child (temp 4X4 matrix of float)
+0:405        'r6' (temp 4X4 matrix of float)
+0:405        matrix-scale (global 4X4 matrix of float)
+0:405          'inFM0' (temp 4X4 matrix of float)
+0:405          'inF0' (temp float)
+0:405      move second child to first child (temp 4X4 matrix of float)
+0:405        'r7' (temp 4X4 matrix of float)
+0:405        matrix-scale (global 4X4 matrix of float)
+0:405          'inFM0' (temp 4X4 matrix of float)
+0:405          'inF0' (temp float)
+0:405      move second child to first child (temp 4X4 matrix of float)
+0:405        'r8' (temp 4X4 matrix of float)
+0:405        matrix-multiply (global 4X4 matrix of float)
+0:405          'inFM0' (temp 4X4 matrix of float)
+0:405          'inFM1' (temp 4X4 matrix of float)
 0:?   Linker Objects
 
-Missing functionality: missing user function; linker needs to catch that
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 880
+// Id's are bound by 1224
 
                               Capability Shader
                               Capability DerivativeControl
@@ -1956,223 +2779,472 @@ Missing functionality: missing user function; linker needs to catch that
                               ExecutionMode 4 OriginUpperLeft
                               Source HLSL 450
                               Name 4  "PixelShaderFunction"
-                              Name 8  "inF0"
-                              Name 23  "inF1"
-                              Name 30  "inF2"
-                              Name 67  "ResType"
-                              Name 127  "inF0"
-                              Name 141  "inF1"
-                              Name 148  "inF2"
-                              Name 195  "ResType"
-                              Name 268  "inF0"
-                              Name 282  "inF1"
-                              Name 289  "inF2"
-                              Name 339  "ResType"
-                              Name 410  "inF0"
-                              Name 424  "inF1"
-                              Name 431  "inF2"
-                              Name 477  "ResType"
-                              Name 549  "inF0"
-                              Name 563  "inF1"
-                              Name 570  "inF2"
-                              Name 604  "ResType"
-                              Name 660  "inF0"
-                              Name 674  "inF1"
-                              Name 681  "inF2"
-                              Name 715  "ResType"
-                              Name 771  "inF0"
-                              Name 785  "inF1"
-                              Name 792  "inF2"
-                              Name 826  "ResType"
+                              Name 19  "TestGenMul(f1;f1;vf2;vf2;mf22;mf22;"
+                              Name 13  "inF0"
+                              Name 14  "inF1"
+                              Name 15  "inFV0"
+                              Name 16  "inFV1"
+                              Name 17  "inFM0"
+                              Name 18  "inFM1"
+                              Name 32  "TestGenMul(f1;f1;vf3;vf3;mf33;mf33;"
+                              Name 26  "inF0"
+                              Name 27  "inF1"
+                              Name 28  "inFV0"
+                              Name 29  "inFV1"
+                              Name 30  "inFM0"
+                              Name 31  "inFM1"
+                              Name 45  "TestGenMul(f1;f1;vf4;vf4;mf44;mf44;"
+                              Name 39  "inF0"
+                              Name 40  "inF1"
+                              Name 41  "inFV0"
+                              Name 42  "inFV1"
+                              Name 43  "inFM0"
+                              Name 44  "inFM1"
+                              Name 47  "inF0"
+                              Name 62  "inF1"
+                              Name 69  "inF2"
+                              Name 115  "ResType"
+                              Name 185  "inF0"
+                              Name 199  "inF1"
+                              Name 206  "inF2"
+                              Name 264  "ResType"
+                              Name 348  "inF0"
+                              Name 362  "inF1"
+                              Name 369  "inF2"
+                              Name 430  "ResType"
+                              Name 513  "inF0"
+                              Name 527  "inF1"
+                              Name 534  "inF2"
+                              Name 591  "ResType"
+                              Name 675  "inF0"
+                              Name 689  "inF1"
+                              Name 704  "inF2"
+                              Name 747  "ResType"
+                              Name 817  "inF0"
+                              Name 831  "inF1"
+                              Name 846  "inF2"
+                              Name 892  "ResType"
+                              Name 964  "inF0"
+                              Name 978  "inF1"
+                              Name 993  "inF2"
+                              Name 1042  "ResType"
+                              Name 1116  "r0"
+                              Name 1120  "r1"
+                              Name 1124  "r2"
+                              Name 1128  "r3"
+                              Name 1132  "r4"
+                              Name 1136  "r5"
+                              Name 1140  "r6"
+                              Name 1144  "r7"
+                              Name 1148  "r8"
+                              Name 1152  "r0"
+                              Name 1156  "r1"
+                              Name 1160  "r2"
+                              Name 1164  "r3"
+                              Name 1168  "r4"
+                              Name 1172  "r5"
+                              Name 1176  "r6"
+                              Name 1180  "r7"
+                              Name 1184  "r8"
+                              Name 1188  "r0"
+                              Name 1192  "r1"
+                              Name 1196  "r2"
+                              Name 1200  "r3"
+                              Name 1204  "r4"
+                              Name 1208  "r5"
+                              Name 1212  "r6"
+                              Name 1216  "r7"
+                              Name 1220  "r8"
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
                7:             TypePointer Function 6(float)
-              10:             TypeBool
-              37:             TypeInt 32 0
-              38:     37(int) Constant 7
-              58:             TypeInt 32 1
-              59:     58(int) Constant 7
-     67(ResType):             TypeStruct 6(float) 58(int)
-              95:     37(int) Constant 2
-             122:    6(float) Constant 0
-             125:             TypeVector 6(float) 2
-             126:             TypePointer Function 125(fvec2)
-             155:             TypeVector 37(int) 2
-             156:     37(int) Constant 3
-             157:  155(ivec2) ConstantComposite 38 156
-             194:             TypeVector 58(int) 2
-    195(ResType):             TypeStruct 125(fvec2) 194(ivec2)
-             202:             TypeVector 10(bool) 2
-             233:    6(float) Constant 1073741824
-             235:     37(int) Constant 1
-             236:  155(ivec2) ConstantComposite 235 95
-             263:    6(float) Constant 1065353216
-             264:  125(fvec2) ConstantComposite 263 233
-             266:             TypeVector 6(float) 3
-             267:             TypePointer Function 266(fvec3)
-             296:             TypeVector 37(int) 3
-             297:     37(int) Constant 5
-             298:  296(ivec3) ConstantComposite 38 156 297
-             338:             TypeVector 58(int) 3
-    339(ResType):             TypeStruct 266(fvec3) 338(ivec3)
-             346:             TypeVector 10(bool) 3
-             378:  296(ivec3) ConstantComposite 235 95 156
-             405:    6(float) Constant 1077936128
-             406:  266(fvec3) ConstantComposite 263 233 405
-             408:             TypeVector 6(float) 4
-             409:             TypePointer Function 408(fvec4)
-             438:             TypeVector 37(int) 4
-             439:  438(ivec4) ConstantComposite 38 156 297 95
-             476:             TypeVector 58(int) 4
-    477(ResType):             TypeStruct 408(fvec4) 476(ivec4)
-             484:             TypeVector 10(bool) 4
-             516:     37(int) Constant 4
-             517:  438(ivec4) ConstantComposite 235 95 156 516
-             544:    6(float) Constant 1082130432
-             545:  408(fvec4) ConstantComposite 263 233 405 544
-             547:             TypeMatrix 125(fvec2) 2
-             548:             TypePointer Function 547
-    604(ResType):             TypeStruct 547 194(ivec2)
-             655:  125(fvec2) ConstantComposite 233 233
-             656:         547 ConstantComposite 655 655
-             658:             TypeMatrix 266(fvec3) 3
-             659:             TypePointer Function 658
-    715(ResType):             TypeStruct 658 338(ivec3)
-             766:  266(fvec3) ConstantComposite 405 405 405
-             767:         658 ConstantComposite 766 766 766
-             769:             TypeMatrix 408(fvec4) 4
-             770:             TypePointer Function 769
-    826(ResType):             TypeStruct 769 476(ivec4)
-             877:  408(fvec4) ConstantComposite 544 544 544 544
-             878:         769 ConstantComposite 877 877 877 877
+               8:             TypeVector 6(float) 2
+               9:             TypePointer Function 8(fvec2)
+              10:             TypeMatrix 8(fvec2) 2
+              11:             TypePointer Function 10
+              12:             TypeFunction 2 7(ptr) 7(ptr) 9(ptr) 9(ptr) 11(ptr) 11(ptr)
+              21:             TypeVector 6(float) 3
+              22:             TypePointer Function 21(fvec3)
+              23:             TypeMatrix 21(fvec3) 3
+              24:             TypePointer Function 23
+              25:             TypeFunction 2 7(ptr) 7(ptr) 22(ptr) 22(ptr) 24(ptr) 24(ptr)
+              34:             TypeVector 6(float) 4
+              35:             TypePointer Function 34(fvec4)
+              36:             TypeMatrix 34(fvec4) 4
+              37:             TypePointer Function 36
+              38:             TypeFunction 2 7(ptr) 7(ptr) 35(ptr) 35(ptr) 37(ptr) 37(ptr)
+              49:             TypeBool
+              73:    6(float) Constant 0
+              82:             TypeInt 32 0
+              83:     82(int) Constant 7
+             103:             TypeInt 32 1
+             104:    103(int) Constant 7
+    115(ResType):             TypeStruct 6(float) 103(int)
+             132:    6(float) Constant 1050288283
+             147:    6(float) Constant 1065353216
+             150:     82(int) Constant 2
+             210:    8(fvec2) ConstantComposite 73 73
+             211:             TypeVector 49(bool) 2
+             221:             TypeVector 82(int) 2
+             222:     82(int) Constant 3
+             223:  221(ivec2) ConstantComposite 83 222
+             263:             TypeVector 103(int) 2
+    264(ResType):             TypeStruct 8(fvec2) 263(ivec2)
+             308:    6(float) Constant 1073741824
+             310:     82(int) Constant 1
+             311:  221(ivec2) ConstantComposite 310 150
+             346:    8(fvec2) ConstantComposite 147 308
+             373:   21(fvec3) ConstantComposite 73 73 73
+             374:             TypeVector 49(bool) 3
+             384:             TypeVector 82(int) 3
+             385:     82(int) Constant 5
+             386:  384(ivec3) ConstantComposite 83 222 385
+             429:             TypeVector 103(int) 3
+    430(ResType):             TypeStruct 21(fvec3) 429(ivec3)
+             475:  384(ivec3) ConstantComposite 310 150 222
+             510:    6(float) Constant 1077936128
+             511:   21(fvec3) ConstantComposite 147 308 510
+             538:   34(fvec4) ConstantComposite 73 73 73 73
+             539:             TypeVector 49(bool) 4
+             549:             TypeVector 82(int) 4
+             550:  549(ivec4) ConstantComposite 83 222 385 150
+             590:             TypeVector 103(int) 4
+    591(ResType):             TypeStruct 34(fvec4) 590(ivec4)
+             636:     82(int) Constant 4
+             637:  549(ivec4) ConstantComposite 310 150 222 636
+             672:    6(float) Constant 1082130432
+             673:   34(fvec4) ConstantComposite 147 308 510 672
+             695:          10 ConstantComposite 210 210
+             696:             TypeMatrix 211(bvec2) 2
+    747(ResType):             TypeStruct 10 263(ivec2)
+             814:    8(fvec2) ConstantComposite 308 308
+             815:          10 ConstantComposite 814 814
+             837:          23 ConstantComposite 373 373 373
+             838:             TypeMatrix 374(bvec3) 3
+    892(ResType):             TypeStruct 23 429(ivec3)
+             961:   21(fvec3) ConstantComposite 510 510 510
+             962:          23 ConstantComposite 961 961 961
+             984:          36 ConstantComposite 538 538 538 538
+             985:             TypeMatrix 539(bvec4) 4
+   1042(ResType):             TypeStruct 36 590(ivec4)
+            1113:   34(fvec4) ConstantComposite 672 672 672 672
+            1114:          36 ConstantComposite 1113 1113 1113 1113
 4(PixelShaderFunction):           2 Function None 3
                5:             Label
-         8(inF0):      7(ptr) Variable Function
-        23(inF1):      7(ptr) Variable Function
-        30(inF2):      7(ptr) Variable Function
-       127(inF0):    126(ptr) Variable Function
-       141(inF1):    126(ptr) Variable Function
-       148(inF2):    126(ptr) Variable Function
-       268(inF0):    267(ptr) Variable Function
-       282(inF1):    267(ptr) Variable Function
-       289(inF2):    267(ptr) Variable Function
-       410(inF0):    409(ptr) Variable Function
-       424(inF1):    409(ptr) Variable Function
-       431(inF2):    409(ptr) Variable Function
-       549(inF0):    548(ptr) Variable Function
-       563(inF1):    548(ptr) Variable Function
-       570(inF2):    548(ptr) Variable Function
-       660(inF0):    659(ptr) Variable Function
-       674(inF1):    659(ptr) Variable Function
-       681(inF2):    659(ptr) Variable Function
-       771(inF0):    770(ptr) Variable Function
-       785(inF1):    770(ptr) Variable Function
-       792(inF2):    770(ptr) Variable Function
-               9:    6(float) Load 8(inF0)
-              11:    10(bool) All 9
-              12:    6(float) Load 8(inF0)
-              13:    6(float) ExtInst 1(GLSL.std.450) 4(FAbs) 12
-              14:    6(float) Load 8(inF0)
-              15:    6(float) ExtInst 1(GLSL.std.450) 17(Acos) 14
-              16:    6(float) Load 8(inF0)
-              17:    10(bool) Any 16
-              18:    6(float) Load 8(inF0)
-              19:    6(float) ExtInst 1(GLSL.std.450) 16(Asin) 18
-              20:    6(float) Load 8(inF0)
-              21:    6(float) ExtInst 1(GLSL.std.450) 18(Atan) 20
-              22:    6(float) Load 8(inF0)
-              24:    6(float) Load 23(inF1)
-              25:    6(float) ExtInst 1(GLSL.std.450) 25(Atan2) 22 24
-              26:    6(float) Load 8(inF0)
-              27:    6(float) ExtInst 1(GLSL.std.450) 9(Ceil) 26
-              28:    6(float) Load 8(inF0)
-              29:    6(float) Load 23(inF1)
-              31:    6(float) Load 30(inF2)
-              32:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 28 29 31
-              33:    6(float) Load 8(inF0)
-              34:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 33
-              35:    6(float) Load 8(inF0)
-              36:    6(float) ExtInst 1(GLSL.std.450) 20(Cosh) 35
-              39:     37(int) BitCount 38
-              40:    6(float) Load 8(inF0)
-              41:    6(float) DPdx 40
-              42:    6(float) Load 8(inF0)
-              43:    6(float) DPdxCoarse 42
-              44:    6(float) Load 8(inF0)
-              45:    6(float) DPdxFine 44
-              46:    6(float) Load 8(inF0)
-              47:    6(float) DPdy 46
-              48:    6(float) Load 8(inF0)
-              49:    6(float) DPdyCoarse 48
-              50:    6(float) Load 8(inF0)
-              51:    6(float) DPdyFine 50
-              52:    6(float) Load 8(inF0)
-              53:    6(float) ExtInst 1(GLSL.std.450) 12(Degrees) 52
-              54:    6(float) Load 8(inF0)
-              55:    6(float) ExtInst 1(GLSL.std.450) 27(Exp) 54
-              56:    6(float) Load 8(inF0)
-              57:    6(float) ExtInst 1(GLSL.std.450) 29(Exp2) 56
-              60:     58(int) ExtInst 1(GLSL.std.450) 74(FindSMsb) 59
-              61:     58(int) ExtInst 1(GLSL.std.450) 73(FindILsb) 59
-              62:    6(float) Load 8(inF0)
-              63:    6(float) ExtInst 1(GLSL.std.450) 8(Floor) 62
-              64:    6(float) Load 8(inF0)
-              65:    6(float) ExtInst 1(GLSL.std.450) 10(Fract) 64
-              66:    6(float) Load 8(inF0)
-              68: 67(ResType) ExtInst 1(GLSL.std.450) 52(FrexpStruct) 66
-              69:     58(int) CompositeExtract 68 1
-                              Store 23(inF1) 69
-              70:    6(float) CompositeExtract 68 0
-              71:    6(float) Load 8(inF0)
-              72:    6(float) Fwidth 71
-              73:    6(float) Load 8(inF0)
-              74:    10(bool) IsInf 73
-              75:    6(float) Load 8(inF0)
-              76:    10(bool) IsNan 75
-              77:    6(float) Load 8(inF0)
-              78:    6(float) Load 23(inF1)
-              79:    6(float) ExtInst 1(GLSL.std.450) 53(Ldexp) 77 78
-              80:    6(float) Load 8(inF0)
-              81:    6(float) ExtInst 1(GLSL.std.450) 28(Log) 80
-              82:    6(float) Load 8(inF0)
-              83:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 82
-              84:    6(float) Load 8(inF0)
-              85:    6(float) Load 23(inF1)
-              86:    6(float) ExtInst 1(GLSL.std.450) 40(FMax) 84 85
-              87:    6(float) Load 8(inF0)
-              88:    6(float) Load 23(inF1)
-              89:    6(float) ExtInst 1(GLSL.std.450) 37(FMin) 87 88
-              90:    6(float) Load 8(inF0)
-              91:    6(float) Load 23(inF1)
-              92:    6(float) ExtInst 1(GLSL.std.450) 26(Pow) 90 91
-              93:    6(float) Load 8(inF0)
-              94:    6(float) ExtInst 1(GLSL.std.450) 11(Radians) 93
-              96:     37(int) BitReverse 95
-              97:    6(float) Load 8(inF0)
-              98:    6(float) ExtInst 1(GLSL.std.450) 2(RoundEven) 97
-              99:    6(float) Load 8(inF0)
-             100:    6(float) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 99
-             101:    6(float) Load 8(inF0)
-             102:    6(float) ExtInst 1(GLSL.std.450) 6(FSign) 101
-             103:    6(float) Load 8(inF0)
-             104:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 103
-             105:    6(float) Load 8(inF0)
-             106:    6(float) ExtInst 1(GLSL.std.450) 19(Sinh) 105
-             107:    6(float) Load 8(inF0)
-             108:    6(float) Load 23(inF1)
-             109:    6(float) Load 30(inF2)
-             110:    6(float) ExtInst 1(GLSL.std.450) 49(SmoothStep) 107 108 109
-             111:    6(float) Load 8(inF0)
-             112:    6(float) ExtInst 1(GLSL.std.450) 31(Sqrt) 111
-             113:    6(float) Load 8(inF0)
-             114:    6(float) Load 23(inF1)
-             115:    6(float) ExtInst 1(GLSL.std.450) 48(Step) 113 114
-             116:    6(float) Load 8(inF0)
-             117:    6(float) ExtInst 1(GLSL.std.450) 15(Tan) 116
-             118:    6(float) Load 8(inF0)
-             119:    6(float) ExtInst 1(GLSL.std.450) 21(Tanh) 118
-             120:    6(float) Load 8(inF0)
-             121:    6(float) ExtInst 1(GLSL.std.450) 3(Trunc) 120
-                              ReturnValue 122
+        47(inF0):      7(ptr) Variable Function
+        62(inF1):      7(ptr) Variable Function
+        69(inF2):      7(ptr) Variable Function
+       185(inF0):      9(ptr) Variable Function
+       199(inF1):      9(ptr) Variable Function
+       206(inF2):      9(ptr) Variable Function
+       348(inF0):     22(ptr) Variable Function
+       362(inF1):     22(ptr) Variable Function
+       369(inF2):     22(ptr) Variable Function
+       513(inF0):     35(ptr) Variable Function
+       527(inF1):     35(ptr) Variable Function
+       534(inF2):     35(ptr) Variable Function
+       675(inF0):     11(ptr) Variable Function
+       689(inF1):     11(ptr) Variable Function
+       704(inF2):     11(ptr) Variable Function
+       817(inF0):     24(ptr) Variable Function
+       831(inF1):     24(ptr) Variable Function
+       846(inF2):     24(ptr) Variable Function
+       964(inF0):     37(ptr) Variable Function
+       978(inF1):     37(ptr) Variable Function
+       993(inF2):     37(ptr) Variable Function
+              48:    6(float) Load 47(inF0)
+              50:    49(bool) All 48
+              51:    6(float) Load 47(inF0)
+              52:    6(float) ExtInst 1(GLSL.std.450) 4(FAbs) 51
+              53:    6(float) Load 47(inF0)
+              54:    6(float) ExtInst 1(GLSL.std.450) 17(Acos) 53
+              55:    6(float) Load 47(inF0)
+              56:    49(bool) Any 55
+              57:    6(float) Load 47(inF0)
+              58:    6(float) ExtInst 1(GLSL.std.450) 16(Asin) 57
+              59:    6(float) Load 47(inF0)
+              60:    6(float) ExtInst 1(GLSL.std.450) 18(Atan) 59
+              61:    6(float) Load 47(inF0)
+              63:    6(float) Load 62(inF1)
+              64:    6(float) ExtInst 1(GLSL.std.450) 25(Atan2) 61 63
+              65:    6(float) Load 47(inF0)
+              66:    6(float) ExtInst 1(GLSL.std.450) 9(Ceil) 65
+              67:    6(float) Load 47(inF0)
+              68:    6(float) Load 62(inF1)
+              70:    6(float) Load 69(inF2)
+              71:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 67 68 70
+              72:    6(float) Load 47(inF0)
+              74:    49(bool) FOrdLessThan 72 73
+                              SelectionMerge 76 None
+                              BranchConditional 74 75 76
+              75:               Label
+                                Kill
+              76:             Label
+              78:    6(float) Load 47(inF0)
+              79:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 78
+              80:    6(float) Load 47(inF0)
+              81:    6(float) ExtInst 1(GLSL.std.450) 20(Cosh) 80
+              84:     82(int) BitCount 83
+              85:    6(float) Load 47(inF0)
+              86:    6(float) DPdx 85
+              87:    6(float) Load 47(inF0)
+              88:    6(float) DPdxCoarse 87
+              89:    6(float) Load 47(inF0)
+              90:    6(float) DPdxFine 89
+              91:    6(float) Load 47(inF0)
+              92:    6(float) DPdy 91
+              93:    6(float) Load 47(inF0)
+              94:    6(float) DPdyCoarse 93
+              95:    6(float) Load 47(inF0)
+              96:    6(float) DPdyFine 95
+              97:    6(float) Load 47(inF0)
+              98:    6(float) ExtInst 1(GLSL.std.450) 12(Degrees) 97
+              99:    6(float) Load 47(inF0)
+             100:    6(float) ExtInst 1(GLSL.std.450) 27(Exp) 99
+             101:    6(float) Load 47(inF0)
+             102:    6(float) ExtInst 1(GLSL.std.450) 29(Exp2) 101
+             105:    103(int) ExtInst 1(GLSL.std.450) 74(FindSMsb) 104
+             106:    103(int) ExtInst 1(GLSL.std.450) 73(FindILsb) 104
+             107:    6(float) Load 47(inF0)
+             108:    6(float) ExtInst 1(GLSL.std.450) 8(Floor) 107
+             109:    6(float) Load 47(inF0)
+             110:    6(float) Load 62(inF1)
+             111:    6(float) FMod 109 110
+             112:    6(float) Load 47(inF0)
+             113:    6(float) ExtInst 1(GLSL.std.450) 10(Fract) 112
+             114:    6(float) Load 47(inF0)
+             116:115(ResType) ExtInst 1(GLSL.std.450) 52(FrexpStruct) 114
+             117:    103(int) CompositeExtract 116 1
+                              Store 62(inF1) 117
+             118:    6(float) CompositeExtract 116 0
+             119:    6(float) Load 47(inF0)
+             120:    6(float) Fwidth 119
+             121:    6(float) Load 47(inF0)
+             122:    49(bool) IsInf 121
+             123:    6(float) Load 47(inF0)
+             124:    49(bool) IsNan 123
+             125:    6(float) Load 47(inF0)
+             126:    6(float) Load 62(inF1)
+             127:    6(float) ExtInst 1(GLSL.std.450) 53(Ldexp) 125 126
+             128:    6(float) Load 47(inF0)
+             129:    6(float) ExtInst 1(GLSL.std.450) 28(Log) 128
+             130:    6(float) Load 47(inF0)
+             131:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 130
+             133:    6(float) FMul 131 132
+             134:    6(float) Load 47(inF0)
+             135:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 134
+             136:    6(float) Load 47(inF0)
+             137:    6(float) Load 62(inF1)
+             138:    6(float) ExtInst 1(GLSL.std.450) 40(FMax) 136 137
+             139:    6(float) Load 47(inF0)
+             140:    6(float) Load 62(inF1)
+             141:    6(float) ExtInst 1(GLSL.std.450) 37(FMin) 139 140
+             142:    6(float) Load 47(inF0)
+             143:    6(float) Load 62(inF1)
+             144:    6(float) ExtInst 1(GLSL.std.450) 26(Pow) 142 143
+             145:    6(float) Load 47(inF0)
+             146:    6(float) ExtInst 1(GLSL.std.450) 11(Radians) 145
+             148:    6(float) Load 47(inF0)
+             149:    6(float) FDiv 147 148
+             151:     82(int) BitReverse 150
+             152:    6(float) Load 47(inF0)
+             153:    6(float) ExtInst 1(GLSL.std.450) 2(RoundEven) 152
+             154:    6(float) Load 47(inF0)
+             155:    6(float) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 154
+             156:    6(float) Load 47(inF0)
+             157:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 156 73 147
+             158:    6(float) Load 47(inF0)
+             159:    6(float) ExtInst 1(GLSL.std.450) 6(FSign) 158
+             160:    6(float) Load 47(inF0)
+             161:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 160
+             162:    6(float) Load 47(inF0)
+             163:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 162
+                              Store 62(inF1) 163
+             164:    6(float) Load 47(inF0)
+             165:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 164
+                              Store 69(inF2) 165
+             166:    6(float) Load 47(inF0)
+             167:    6(float) ExtInst 1(GLSL.std.450) 19(Sinh) 166
+             168:    6(float) Load 47(inF0)
+             169:    6(float) Load 62(inF1)
+             170:    6(float) Load 69(inF2)
+             171:    6(float) ExtInst 1(GLSL.std.450) 49(SmoothStep) 168 169 170
+             172:    6(float) Load 47(inF0)
+             173:    6(float) ExtInst 1(GLSL.std.450) 31(Sqrt) 172
+             174:    6(float) Load 47(inF0)
+             175:    6(float) Load 62(inF1)
+             176:    6(float) ExtInst 1(GLSL.std.450) 48(Step) 174 175
+             177:    6(float) Load 47(inF0)
+             178:    6(float) ExtInst 1(GLSL.std.450) 15(Tan) 177
+             179:    6(float) Load 47(inF0)
+             180:    6(float) ExtInst 1(GLSL.std.450) 21(Tanh) 179
+             181:    6(float) Load 47(inF0)
+             182:    6(float) ExtInst 1(GLSL.std.450) 3(Trunc) 181
+                              ReturnValue 73
+                              FunctionEnd
+19(TestGenMul(f1;f1;vf2;vf2;mf22;mf22;):           2 Function None 12
+        13(inF0):      7(ptr) FunctionParameter
+        14(inF1):      7(ptr) FunctionParameter
+       15(inFV0):      9(ptr) FunctionParameter
+       16(inFV1):      9(ptr) FunctionParameter
+       17(inFM0):     11(ptr) FunctionParameter
+       18(inFM1):     11(ptr) FunctionParameter
+              20:             Label
+        1116(r0):      7(ptr) Variable Function
+        1120(r1):      9(ptr) Variable Function
+        1124(r2):      9(ptr) Variable Function
+        1128(r3):      7(ptr) Variable Function
+        1132(r4):      9(ptr) Variable Function
+        1136(r5):      9(ptr) Variable Function
+        1140(r6):     11(ptr) Variable Function
+        1144(r7):     11(ptr) Variable Function
+        1148(r8):     11(ptr) Variable Function
+            1117:    6(float) Load 13(inF0)
+            1118:    6(float) Load 14(inF1)
+            1119:    6(float) FMul 1117 1118
+                              Store 1116(r0) 1119
+            1121:    8(fvec2) Load 15(inFV0)
+            1122:    6(float) Load 13(inF0)
+            1123:    8(fvec2) VectorTimesScalar 1121 1122
+                              Store 1120(r1) 1123
+            1125:    8(fvec2) Load 15(inFV0)
+            1126:    6(float) Load 13(inF0)
+            1127:    8(fvec2) VectorTimesScalar 1125 1126
+                              Store 1124(r2) 1127
+            1129:    8(fvec2) Load 15(inFV0)
+            1130:    8(fvec2) Load 16(inFV1)
+            1131:    6(float) Dot 1129 1130
+                              Store 1128(r3) 1131
+            1133:          10 Load 17(inFM0)
+            1134:    8(fvec2) Load 15(inFV0)
+            1135:    8(fvec2) MatrixTimesVector 1133 1134
+                              Store 1132(r4) 1135
+            1137:    8(fvec2) Load 15(inFV0)
+            1138:          10 Load 17(inFM0)
+            1139:    8(fvec2) VectorTimesMatrix 1137 1138
+                              Store 1136(r5) 1139
+            1141:          10 Load 17(inFM0)
+            1142:    6(float) Load 13(inF0)
+            1143:          10 MatrixTimesScalar 1141 1142
+                              Store 1140(r6) 1143
+            1145:          10 Load 17(inFM0)
+            1146:    6(float) Load 13(inF0)
+            1147:          10 MatrixTimesScalar 1145 1146
+                              Store 1144(r7) 1147
+            1149:          10 Load 17(inFM0)
+            1150:          10 Load 18(inFM1)
+            1151:          10 MatrixTimesMatrix 1149 1150
+                              Store 1148(r8) 1151
+                              Return
+                              FunctionEnd
+32(TestGenMul(f1;f1;vf3;vf3;mf33;mf33;):           2 Function None 25
+        26(inF0):      7(ptr) FunctionParameter
+        27(inF1):      7(ptr) FunctionParameter
+       28(inFV0):     22(ptr) FunctionParameter
+       29(inFV1):     22(ptr) FunctionParameter
+       30(inFM0):     24(ptr) FunctionParameter
+       31(inFM1):     24(ptr) FunctionParameter
+              33:             Label
+        1152(r0):      7(ptr) Variable Function
+        1156(r1):     22(ptr) Variable Function
+        1160(r2):     22(ptr) Variable Function
+        1164(r3):      7(ptr) Variable Function
+        1168(r4):     22(ptr) Variable Function
+        1172(r5):     22(ptr) Variable Function
+        1176(r6):     24(ptr) Variable Function
+        1180(r7):     24(ptr) Variable Function
+        1184(r8):     24(ptr) Variable Function
+            1153:    6(float) Load 26(inF0)
+            1154:    6(float) Load 27(inF1)
+            1155:    6(float) FMul 1153 1154
+                              Store 1152(r0) 1155
+            1157:   21(fvec3) Load 28(inFV0)
+            1158:    6(float) Load 26(inF0)
+            1159:   21(fvec3) VectorTimesScalar 1157 1158
+                              Store 1156(r1) 1159
+            1161:   21(fvec3) Load 28(inFV0)
+            1162:    6(float) Load 26(inF0)
+            1163:   21(fvec3) VectorTimesScalar 1161 1162
+                              Store 1160(r2) 1163
+            1165:   21(fvec3) Load 28(inFV0)
+            1166:   21(fvec3) Load 29(inFV1)
+            1167:    6(float) Dot 1165 1166
+                              Store 1164(r3) 1167
+            1169:          23 Load 30(inFM0)
+            1170:   21(fvec3) Load 28(inFV0)
+            1171:   21(fvec3) MatrixTimesVector 1169 1170
+                              Store 1168(r4) 1171
+            1173:   21(fvec3) Load 28(inFV0)
+            1174:          23 Load 30(inFM0)
+            1175:   21(fvec3) VectorTimesMatrix 1173 1174
+                              Store 1172(r5) 1175
+            1177:          23 Load 30(inFM0)
+            1178:    6(float) Load 26(inF0)
+            1179:          23 MatrixTimesScalar 1177 1178
+                              Store 1176(r6) 1179
+            1181:          23 Load 30(inFM0)
+            1182:    6(float) Load 26(inF0)
+            1183:          23 MatrixTimesScalar 1181 1182
+                              Store 1180(r7) 1183
+            1185:          23 Load 30(inFM0)
+            1186:          23 Load 31(inFM1)
+            1187:          23 MatrixTimesMatrix 1185 1186
+                              Store 1184(r8) 1187
+                              Return
+                              FunctionEnd
+45(TestGenMul(f1;f1;vf4;vf4;mf44;mf44;):           2 Function None 38
+        39(inF0):      7(ptr) FunctionParameter
+        40(inF1):      7(ptr) FunctionParameter
+       41(inFV0):     35(ptr) FunctionParameter
+       42(inFV1):     35(ptr) FunctionParameter
+       43(inFM0):     37(ptr) FunctionParameter
+       44(inFM1):     37(ptr) FunctionParameter
+              46:             Label
+        1188(r0):      7(ptr) Variable Function
+        1192(r1):     35(ptr) Variable Function
+        1196(r2):     35(ptr) Variable Function
+        1200(r3):      7(ptr) Variable Function
+        1204(r4):     35(ptr) Variable Function
+        1208(r5):     35(ptr) Variable Function
+        1212(r6):     37(ptr) Variable Function
+        1216(r7):     37(ptr) Variable Function
+        1220(r8):     37(ptr) Variable Function
+            1189:    6(float) Load 39(inF0)
+            1190:    6(float) Load 40(inF1)
+            1191:    6(float) FMul 1189 1190
+                              Store 1188(r0) 1191
+            1193:   34(fvec4) Load 41(inFV0)
+            1194:    6(float) Load 39(inF0)
+            1195:   34(fvec4) VectorTimesScalar 1193 1194
+                              Store 1192(r1) 1195
+            1197:   34(fvec4) Load 41(inFV0)
+            1198:    6(float) Load 39(inF0)
+            1199:   34(fvec4) VectorTimesScalar 1197 1198
+                              Store 1196(r2) 1199
+            1201:   34(fvec4) Load 41(inFV0)
+            1202:   34(fvec4) Load 42(inFV1)
+            1203:    6(float) Dot 1201 1202
+                              Store 1200(r3) 1203
+            1205:          36 Load 43(inFM0)
+            1206:   34(fvec4) Load 41(inFV0)
+            1207:   34(fvec4) MatrixTimesVector 1205 1206
+                              Store 1204(r4) 1207
+            1209:   34(fvec4) Load 41(inFV0)
+            1210:          36 Load 43(inFM0)
+            1211:   34(fvec4) VectorTimesMatrix 1209 1210
+                              Store 1208(r5) 1211
+            1213:          36 Load 43(inFM0)
+            1214:    6(float) Load 39(inF0)
+            1215:          36 MatrixTimesScalar 1213 1214
+                              Store 1212(r6) 1215
+            1217:          36 Load 43(inFM0)
+            1218:    6(float) Load 39(inF0)
+            1219:          36 MatrixTimesScalar 1217 1218
+                              Store 1216(r7) 1219
+            1221:          36 Load 43(inFM0)
+            1222:          36 Load 44(inFM1)
+            1223:          36 MatrixTimesMatrix 1221 1222
+                              Store 1220(r8) 1223
+                              Return
                               FunctionEnd

--- a/Test/baseResults/hlsl.intrinsics.vert.out
+++ b/Test/baseResults/hlsl.intrinsics.vert.out
@@ -1,7 +1,7 @@
 hlsl.intrinsics.vert
 Shader version: 450
 0:? Sequence
-0:56  Function Definition: VertexShaderFunction(f1;f1;f1; (temp float)
+0:59  Function Definition: VertexShaderFunction(f1;f1;f1; (temp float)
 0:2    Function Parameters: 
 0:2      'inF0' (temp float)
 0:2      'inF1' (temp float)
@@ -49,7 +49,7 @@ Shader version: 450
 0:22          7 (const int)
 0:23      Floor (global float)
 0:23        'inF0' (temp float)
-0:25      Function Call: fmod(f1;f1; (global float)
+0:25      mod (global float)
 0:25        'inF0' (temp float)
 0:25        'inF1' (temp float)
 0:26      Fraction (global float)
@@ -68,690 +68,810 @@ Shader version: 450
 0:31        'inF1' (temp float)
 0:32      log (global float)
 0:32        'inF0' (temp float)
-0:33      log2 (global float)
-0:33        'inF0' (temp float)
-0:34      max (global float)
+0:33      component-wise multiply (global float)
+0:33        log2 (global float)
+0:33          'inF0' (temp float)
+0:33        Constant:
+0:33          0.301030
+0:34      log2 (global float)
 0:34        'inF0' (temp float)
-0:34        'inF1' (temp float)
-0:35      min (global float)
+0:35      max (global float)
 0:35        'inF0' (temp float)
 0:35        'inF1' (temp float)
-0:37      pow (global float)
-0:37        'inF0' (temp float)
-0:37        'inF1' (temp float)
-0:38      radians (global float)
+0:36      min (global float)
+0:36        'inF0' (temp float)
+0:36        'inF1' (temp float)
+0:38      pow (global float)
 0:38        'inF0' (temp float)
-0:39      bitFieldReverse (global uint)
-0:39        Constant:
-0:39          2 (const uint)
-0:40      roundEven (global float)
-0:40        'inF0' (temp float)
-0:41      inverse sqrt (global float)
+0:38        'inF1' (temp float)
+0:39      radians (global float)
+0:39        'inF0' (temp float)
+0:40      bitFieldReverse (global uint)
+0:40        Constant:
+0:40          2 (const uint)
+0:41      roundEven (global float)
 0:41        'inF0' (temp float)
-0:42      Sign (global float)
+0:42      inverse sqrt (global float)
 0:42        'inF0' (temp float)
-0:43      sine (global float)
+0:43      clamp (global float)
 0:43        'inF0' (temp float)
-0:44      hyp. sine (global float)
+0:43        Constant:
+0:43          0.000000
+0:43        Constant:
+0:43          1.000000
+0:44      Sign (global float)
 0:44        'inF0' (temp float)
-0:45      smoothstep (global float)
+0:45      sine (global float)
 0:45        'inF0' (temp float)
-0:45        'inF1' (temp float)
-0:45        'inF2' (temp float)
-0:46      sqrt (global float)
-0:46        'inF0' (temp float)
-0:47      step (global float)
+0:46      Sequence
+0:46        move second child to first child (temp float)
+0:46          'inF1' (temp float)
+0:46          sine (temp float)
+0:46            'inF0' (temp float)
+0:46        move second child to first child (temp float)
+0:46          'inF2' (temp float)
+0:46          cosine (temp float)
+0:46            'inF0' (temp float)
+0:47      hyp. sine (global float)
 0:47        'inF0' (temp float)
-0:47        'inF1' (temp float)
-0:48      tangent (global float)
+0:48      smoothstep (global float)
 0:48        'inF0' (temp float)
-0:49      hyp. tangent (global float)
+0:48        'inF1' (temp float)
+0:48        'inF2' (temp float)
+0:49      sqrt (global float)
 0:49        'inF0' (temp float)
-0:51      trunc (global float)
+0:50      step (global float)
+0:50        'inF0' (temp float)
+0:50        'inF1' (temp float)
+0:51      tangent (global float)
 0:51        'inF0' (temp float)
-0:53      Branch: Return with expression
-0:53        Constant:
-0:53          0.000000
-0:62  Function Definition: VertexShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
-0:57    Function Parameters: 
-0:57      'inF0' (temp 1-component vector of float)
-0:57      'inF1' (temp 1-component vector of float)
-0:57      'inF2' (temp 1-component vector of float)
+0:52      hyp. tangent (global float)
+0:52        'inF0' (temp float)
+0:54      trunc (global float)
+0:54        'inF0' (temp float)
+0:56      Branch: Return with expression
+0:56        Constant:
+0:56          0.000000
+0:65  Function Definition: VertexShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
+0:60    Function Parameters: 
+0:60      'inF0' (temp 1-component vector of float)
+0:60      'inF1' (temp 1-component vector of float)
+0:60      'inF2' (temp 1-component vector of float)
 0:?     Sequence
-0:59      Branch: Return with expression
-0:59        Constant:
-0:59          0.000000
-0:125  Function Definition: VertexShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
-0:63    Function Parameters: 
-0:63      'inF0' (temp 2-component vector of float)
-0:63      'inF1' (temp 2-component vector of float)
-0:63      'inF2' (temp 2-component vector of float)
+0:62      Branch: Return with expression
+0:62        Constant:
+0:62          0.000000
+0:131  Function Definition: VertexShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
+0:66    Function Parameters: 
+0:66      'inF0' (temp 2-component vector of float)
+0:66      'inF1' (temp 2-component vector of float)
+0:66      'inF2' (temp 2-component vector of float)
 0:?     Sequence
-0:64      all (global bool)
-0:64        'inF0' (temp 2-component vector of float)
-0:65      Absolute value (global 2-component vector of float)
-0:65        'inF0' (temp 2-component vector of float)
-0:66      arc cosine (global 2-component vector of float)
-0:66        'inF0' (temp 2-component vector of float)
-0:67      any (global bool)
+0:67      all (global bool)
 0:67        'inF0' (temp 2-component vector of float)
-0:68      arc sine (global 2-component vector of float)
+0:68      Absolute value (global 2-component vector of float)
 0:68        'inF0' (temp 2-component vector of float)
-0:69      arc tangent (global 2-component vector of float)
+0:69      arc cosine (global 2-component vector of float)
 0:69        'inF0' (temp 2-component vector of float)
-0:70      arc tangent (global 2-component vector of float)
+0:70      any (global bool)
 0:70        'inF0' (temp 2-component vector of float)
-0:70        'inF1' (temp 2-component vector of float)
-0:71      Ceiling (global 2-component vector of float)
+0:71      arc sine (global 2-component vector of float)
 0:71        'inF0' (temp 2-component vector of float)
-0:72      clamp (global 2-component vector of float)
+0:72      arc tangent (global 2-component vector of float)
 0:72        'inF0' (temp 2-component vector of float)
-0:72        'inF1' (temp 2-component vector of float)
-0:72        'inF2' (temp 2-component vector of float)
-0:73      cosine (global 2-component vector of float)
+0:73      arc tangent (global 2-component vector of float)
 0:73        'inF0' (temp 2-component vector of float)
-0:74      hyp. cosine (global 2-component vector of float)
+0:73        'inF1' (temp 2-component vector of float)
+0:74      Ceiling (global 2-component vector of float)
 0:74        'inF0' (temp 2-component vector of float)
+0:75      clamp (global 2-component vector of float)
+0:75        'inF0' (temp 2-component vector of float)
+0:75        'inF1' (temp 2-component vector of float)
+0:75        'inF2' (temp 2-component vector of float)
+0:76      cosine (global 2-component vector of float)
+0:76        'inF0' (temp 2-component vector of float)
+0:77      hyp. cosine (global 2-component vector of float)
+0:77        'inF0' (temp 2-component vector of float)
 0:?       bitCount (global 2-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
-0:76      degrees (global 2-component vector of float)
-0:76        'inF0' (temp 2-component vector of float)
-0:77      distance (global float)
-0:77        'inF0' (temp 2-component vector of float)
-0:77        'inF1' (temp 2-component vector of float)
-0:78      dot-product (global float)
-0:78        'inF0' (temp 2-component vector of float)
-0:78        'inF1' (temp 2-component vector of float)
-0:82      exp (global 2-component vector of float)
-0:82        'inF0' (temp 2-component vector of float)
-0:83      exp2 (global 2-component vector of float)
-0:83        'inF0' (temp 2-component vector of float)
-0:84      face-forward (global 2-component vector of float)
-0:84        'inF0' (temp 2-component vector of float)
-0:84        'inF1' (temp 2-component vector of float)
-0:84        'inF2' (temp 2-component vector of float)
-0:85      findMSB (global int)
-0:85        Constant:
-0:85          7 (const int)
-0:86      findLSB (global int)
-0:86        Constant:
-0:86          7 (const int)
-0:87      Floor (global 2-component vector of float)
+0:79      degrees (global 2-component vector of float)
+0:79        'inF0' (temp 2-component vector of float)
+0:80      distance (global float)
+0:80        'inF0' (temp 2-component vector of float)
+0:80        'inF1' (temp 2-component vector of float)
+0:81      dot-product (global float)
+0:81        'inF0' (temp 2-component vector of float)
+0:81        'inF1' (temp 2-component vector of float)
+0:85      exp (global 2-component vector of float)
+0:85        'inF0' (temp 2-component vector of float)
+0:86      exp2 (global 2-component vector of float)
+0:86        'inF0' (temp 2-component vector of float)
+0:87      face-forward (global 2-component vector of float)
 0:87        'inF0' (temp 2-component vector of float)
-0:89      Function Call: fmod(vf2;vf2; (global 2-component vector of float)
-0:89        'inF0' (temp 2-component vector of float)
-0:89        'inF1' (temp 2-component vector of float)
-0:90      Fraction (global 2-component vector of float)
+0:87        'inF1' (temp 2-component vector of float)
+0:87        'inF2' (temp 2-component vector of float)
+0:88      findMSB (global int)
+0:88        Constant:
+0:88          7 (const int)
+0:89      findLSB (global int)
+0:89        Constant:
+0:89          7 (const int)
+0:90      Floor (global 2-component vector of float)
 0:90        'inF0' (temp 2-component vector of float)
-0:91      frexp (global 2-component vector of float)
-0:91        'inF0' (temp 2-component vector of float)
-0:91        'inF1' (temp 2-component vector of float)
-0:92      fwidth (global 2-component vector of float)
+0:92      mod (global 2-component vector of float)
 0:92        'inF0' (temp 2-component vector of float)
-0:93      isinf (global 2-component vector of bool)
+0:92        'inF1' (temp 2-component vector of float)
+0:93      Fraction (global 2-component vector of float)
 0:93        'inF0' (temp 2-component vector of float)
-0:94      isnan (global 2-component vector of bool)
+0:94      frexp (global 2-component vector of float)
 0:94        'inF0' (temp 2-component vector of float)
-0:95      ldexp (global 2-component vector of float)
+0:94        'inF1' (temp 2-component vector of float)
+0:95      fwidth (global 2-component vector of float)
 0:95        'inF0' (temp 2-component vector of float)
-0:95        'inF1' (temp 2-component vector of float)
-0:96      length (global float)
+0:96      isinf (global 2-component vector of bool)
 0:96        'inF0' (temp 2-component vector of float)
-0:97      log (global 2-component vector of float)
+0:97      isnan (global 2-component vector of bool)
 0:97        'inF0' (temp 2-component vector of float)
-0:98      log2 (global 2-component vector of float)
+0:98      ldexp (global 2-component vector of float)
 0:98        'inF0' (temp 2-component vector of float)
-0:99      max (global 2-component vector of float)
+0:98        'inF1' (temp 2-component vector of float)
+0:99      length (global float)
 0:99        'inF0' (temp 2-component vector of float)
-0:99        'inF1' (temp 2-component vector of float)
-0:100      min (global 2-component vector of float)
+0:100      log (global 2-component vector of float)
 0:100        'inF0' (temp 2-component vector of float)
-0:100        'inF1' (temp 2-component vector of float)
-0:102      normalize (global 2-component vector of float)
+0:101      component-wise multiply (global 2-component vector of float)
+0:101        log2 (global 2-component vector of float)
+0:101          'inF0' (temp 2-component vector of float)
+0:101        Constant:
+0:101          0.301030
+0:102      log2 (global 2-component vector of float)
 0:102        'inF0' (temp 2-component vector of float)
-0:103      pow (global 2-component vector of float)
+0:103      max (global 2-component vector of float)
 0:103        'inF0' (temp 2-component vector of float)
 0:103        'inF1' (temp 2-component vector of float)
-0:104      radians (global 2-component vector of float)
+0:104      min (global 2-component vector of float)
 0:104        'inF0' (temp 2-component vector of float)
-0:105      reflect (global 2-component vector of float)
-0:105        'inF0' (temp 2-component vector of float)
-0:105        'inF1' (temp 2-component vector of float)
-0:106      refract (global 2-component vector of float)
+0:104        'inF1' (temp 2-component vector of float)
+0:106      normalize (global 2-component vector of float)
 0:106        'inF0' (temp 2-component vector of float)
-0:106        'inF1' (temp 2-component vector of float)
-0:106        Constant:
-0:106          2.000000
+0:107      pow (global 2-component vector of float)
+0:107        'inF0' (temp 2-component vector of float)
+0:107        'inF1' (temp 2-component vector of float)
+0:108      radians (global 2-component vector of float)
+0:108        'inF0' (temp 2-component vector of float)
+0:109      reflect (global 2-component vector of float)
+0:109        'inF0' (temp 2-component vector of float)
+0:109        'inF1' (temp 2-component vector of float)
+0:110      refract (global 2-component vector of float)
+0:110        'inF0' (temp 2-component vector of float)
+0:110        'inF1' (temp 2-component vector of float)
+0:110        Constant:
+0:110          2.000000
 0:?       bitFieldReverse (global 2-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
-0:108      roundEven (global 2-component vector of float)
-0:108        'inF0' (temp 2-component vector of float)
-0:109      inverse sqrt (global 2-component vector of float)
-0:109        'inF0' (temp 2-component vector of float)
-0:110      Sign (global 2-component vector of float)
-0:110        'inF0' (temp 2-component vector of float)
-0:111      sine (global 2-component vector of float)
-0:111        'inF0' (temp 2-component vector of float)
-0:112      hyp. sine (global 2-component vector of float)
+0:112      roundEven (global 2-component vector of float)
 0:112        'inF0' (temp 2-component vector of float)
-0:113      smoothstep (global 2-component vector of float)
+0:113      inverse sqrt (global 2-component vector of float)
 0:113        'inF0' (temp 2-component vector of float)
-0:113        'inF1' (temp 2-component vector of float)
-0:113        'inF2' (temp 2-component vector of float)
-0:114      sqrt (global 2-component vector of float)
+0:114      clamp (global 2-component vector of float)
 0:114        'inF0' (temp 2-component vector of float)
-0:115      step (global 2-component vector of float)
+0:114        Constant:
+0:114          0.000000
+0:114        Constant:
+0:114          1.000000
+0:115      Sign (global 2-component vector of float)
 0:115        'inF0' (temp 2-component vector of float)
-0:115        'inF1' (temp 2-component vector of float)
-0:116      tangent (global 2-component vector of float)
+0:116      sine (global 2-component vector of float)
 0:116        'inF0' (temp 2-component vector of float)
-0:117      hyp. tangent (global 2-component vector of float)
-0:117        'inF0' (temp 2-component vector of float)
-0:119      trunc (global 2-component vector of float)
+0:117      Sequence
+0:117        move second child to first child (temp 2-component vector of float)
+0:117          'inF1' (temp 2-component vector of float)
+0:117          sine (temp 2-component vector of float)
+0:117            'inF0' (temp 2-component vector of float)
+0:117        move second child to first child (temp 2-component vector of float)
+0:117          'inF2' (temp 2-component vector of float)
+0:117          cosine (temp 2-component vector of float)
+0:117            'inF0' (temp 2-component vector of float)
+0:118      hyp. sine (global 2-component vector of float)
+0:118        'inF0' (temp 2-component vector of float)
+0:119      smoothstep (global 2-component vector of float)
 0:119        'inF0' (temp 2-component vector of float)
-0:122      Branch: Return with expression
+0:119        'inF1' (temp 2-component vector of float)
+0:119        'inF2' (temp 2-component vector of float)
+0:120      sqrt (global 2-component vector of float)
+0:120        'inF0' (temp 2-component vector of float)
+0:121      step (global 2-component vector of float)
+0:121        'inF0' (temp 2-component vector of float)
+0:121        'inF1' (temp 2-component vector of float)
+0:122      tangent (global 2-component vector of float)
+0:122        'inF0' (temp 2-component vector of float)
+0:123      hyp. tangent (global 2-component vector of float)
+0:123        'inF0' (temp 2-component vector of float)
+0:125      trunc (global 2-component vector of float)
+0:125        'inF0' (temp 2-component vector of float)
+0:128      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
-0:189  Function Definition: VertexShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
-0:126    Function Parameters: 
-0:126      'inF0' (temp 3-component vector of float)
-0:126      'inF1' (temp 3-component vector of float)
-0:126      'inF2' (temp 3-component vector of float)
+0:198  Function Definition: VertexShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
+0:132    Function Parameters: 
+0:132      'inF0' (temp 3-component vector of float)
+0:132      'inF1' (temp 3-component vector of float)
+0:132      'inF2' (temp 3-component vector of float)
 0:?     Sequence
-0:127      all (global bool)
-0:127        'inF0' (temp 3-component vector of float)
-0:128      Absolute value (global 3-component vector of float)
-0:128        'inF0' (temp 3-component vector of float)
-0:129      arc cosine (global 3-component vector of float)
-0:129        'inF0' (temp 3-component vector of float)
-0:130      any (global bool)
-0:130        'inF0' (temp 3-component vector of float)
-0:131      arc sine (global 3-component vector of float)
-0:131        'inF0' (temp 3-component vector of float)
-0:132      arc tangent (global 3-component vector of float)
-0:132        'inF0' (temp 3-component vector of float)
-0:133      arc tangent (global 3-component vector of float)
+0:133      all (global bool)
 0:133        'inF0' (temp 3-component vector of float)
-0:133        'inF1' (temp 3-component vector of float)
-0:134      Ceiling (global 3-component vector of float)
+0:134      Absolute value (global 3-component vector of float)
 0:134        'inF0' (temp 3-component vector of float)
-0:135      clamp (global 3-component vector of float)
+0:135      arc cosine (global 3-component vector of float)
 0:135        'inF0' (temp 3-component vector of float)
-0:135        'inF1' (temp 3-component vector of float)
-0:135        'inF2' (temp 3-component vector of float)
-0:136      cosine (global 3-component vector of float)
+0:136      any (global bool)
 0:136        'inF0' (temp 3-component vector of float)
-0:137      hyp. cosine (global 3-component vector of float)
+0:137      arc sine (global 3-component vector of float)
 0:137        'inF0' (temp 3-component vector of float)
+0:138      arc tangent (global 3-component vector of float)
+0:138        'inF0' (temp 3-component vector of float)
+0:139      arc tangent (global 3-component vector of float)
+0:139        'inF0' (temp 3-component vector of float)
+0:139        'inF1' (temp 3-component vector of float)
+0:140      Ceiling (global 3-component vector of float)
+0:140        'inF0' (temp 3-component vector of float)
+0:141      clamp (global 3-component vector of float)
+0:141        'inF0' (temp 3-component vector of float)
+0:141        'inF1' (temp 3-component vector of float)
+0:141        'inF2' (temp 3-component vector of float)
+0:142      cosine (global 3-component vector of float)
+0:142        'inF0' (temp 3-component vector of float)
+0:143      hyp. cosine (global 3-component vector of float)
+0:143        'inF0' (temp 3-component vector of float)
 0:?       bitCount (global 3-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
-0:139      cross-product (global 3-component vector of float)
-0:139        'inF0' (temp 3-component vector of float)
-0:139        'inF1' (temp 3-component vector of float)
-0:140      degrees (global 3-component vector of float)
-0:140        'inF0' (temp 3-component vector of float)
-0:141      distance (global float)
-0:141        'inF0' (temp 3-component vector of float)
-0:141        'inF1' (temp 3-component vector of float)
-0:142      dot-product (global float)
-0:142        'inF0' (temp 3-component vector of float)
-0:142        'inF1' (temp 3-component vector of float)
-0:146      exp (global 3-component vector of float)
+0:145      cross-product (global 3-component vector of float)
+0:145        'inF0' (temp 3-component vector of float)
+0:145        'inF1' (temp 3-component vector of float)
+0:146      degrees (global 3-component vector of float)
 0:146        'inF0' (temp 3-component vector of float)
-0:147      exp2 (global 3-component vector of float)
+0:147      distance (global float)
 0:147        'inF0' (temp 3-component vector of float)
-0:148      face-forward (global 3-component vector of float)
+0:147        'inF1' (temp 3-component vector of float)
+0:148      dot-product (global float)
 0:148        'inF0' (temp 3-component vector of float)
 0:148        'inF1' (temp 3-component vector of float)
-0:148        'inF2' (temp 3-component vector of float)
-0:149      findMSB (global int)
-0:149        Constant:
-0:149          7 (const int)
-0:150      findLSB (global int)
-0:150        Constant:
-0:150          7 (const int)
-0:151      Floor (global 3-component vector of float)
-0:151        'inF0' (temp 3-component vector of float)
-0:153      Function Call: fmod(vf3;vf3; (global 3-component vector of float)
+0:152      exp (global 3-component vector of float)
+0:152        'inF0' (temp 3-component vector of float)
+0:153      exp2 (global 3-component vector of float)
 0:153        'inF0' (temp 3-component vector of float)
-0:153        'inF1' (temp 3-component vector of float)
-0:154      Fraction (global 3-component vector of float)
+0:154      face-forward (global 3-component vector of float)
 0:154        'inF0' (temp 3-component vector of float)
-0:155      frexp (global 3-component vector of float)
-0:155        'inF0' (temp 3-component vector of float)
-0:155        'inF1' (temp 3-component vector of float)
-0:156      fwidth (global 3-component vector of float)
-0:156        'inF0' (temp 3-component vector of float)
-0:157      isinf (global 3-component vector of bool)
+0:154        'inF1' (temp 3-component vector of float)
+0:154        'inF2' (temp 3-component vector of float)
+0:155      findMSB (global int)
+0:155        Constant:
+0:155          7 (const int)
+0:156      findLSB (global int)
+0:156        Constant:
+0:156          7 (const int)
+0:157      Floor (global 3-component vector of float)
 0:157        'inF0' (temp 3-component vector of float)
-0:158      isnan (global 3-component vector of bool)
-0:158        'inF0' (temp 3-component vector of float)
-0:159      ldexp (global 3-component vector of float)
+0:159      mod (global 3-component vector of float)
 0:159        'inF0' (temp 3-component vector of float)
 0:159        'inF1' (temp 3-component vector of float)
-0:160      length (global float)
+0:160      Fraction (global 3-component vector of float)
 0:160        'inF0' (temp 3-component vector of float)
-0:161      log (global 3-component vector of float)
+0:161      frexp (global 3-component vector of float)
 0:161        'inF0' (temp 3-component vector of float)
-0:162      log2 (global 3-component vector of float)
+0:161        'inF1' (temp 3-component vector of float)
+0:162      fwidth (global 3-component vector of float)
 0:162        'inF0' (temp 3-component vector of float)
-0:163      max (global 3-component vector of float)
+0:163      isinf (global 3-component vector of bool)
 0:163        'inF0' (temp 3-component vector of float)
-0:163        'inF1' (temp 3-component vector of float)
-0:164      min (global 3-component vector of float)
+0:164      isnan (global 3-component vector of bool)
 0:164        'inF0' (temp 3-component vector of float)
-0:164        'inF1' (temp 3-component vector of float)
-0:166      normalize (global 3-component vector of float)
+0:165      ldexp (global 3-component vector of float)
+0:165        'inF0' (temp 3-component vector of float)
+0:165        'inF1' (temp 3-component vector of float)
+0:166      length (global float)
 0:166        'inF0' (temp 3-component vector of float)
-0:167      pow (global 3-component vector of float)
+0:167      log (global 3-component vector of float)
 0:167        'inF0' (temp 3-component vector of float)
-0:167        'inF1' (temp 3-component vector of float)
-0:168      radians (global 3-component vector of float)
-0:168        'inF0' (temp 3-component vector of float)
-0:169      reflect (global 3-component vector of float)
+0:168      component-wise multiply (global 3-component vector of float)
+0:168        log2 (global 3-component vector of float)
+0:168          'inF0' (temp 3-component vector of float)
+0:168        Constant:
+0:168          0.301030
+0:169      log2 (global 3-component vector of float)
 0:169        'inF0' (temp 3-component vector of float)
-0:169        'inF1' (temp 3-component vector of float)
-0:170      refract (global 3-component vector of float)
+0:170      max (global 3-component vector of float)
 0:170        'inF0' (temp 3-component vector of float)
 0:170        'inF1' (temp 3-component vector of float)
-0:170        Constant:
-0:170          2.000000
+0:171      min (global 3-component vector of float)
+0:171        'inF0' (temp 3-component vector of float)
+0:171        'inF1' (temp 3-component vector of float)
+0:173      normalize (global 3-component vector of float)
+0:173        'inF0' (temp 3-component vector of float)
+0:174      pow (global 3-component vector of float)
+0:174        'inF0' (temp 3-component vector of float)
+0:174        'inF1' (temp 3-component vector of float)
+0:175      radians (global 3-component vector of float)
+0:175        'inF0' (temp 3-component vector of float)
+0:176      reflect (global 3-component vector of float)
+0:176        'inF0' (temp 3-component vector of float)
+0:176        'inF1' (temp 3-component vector of float)
+0:177      refract (global 3-component vector of float)
+0:177        'inF0' (temp 3-component vector of float)
+0:177        'inF1' (temp 3-component vector of float)
+0:177        Constant:
+0:177          2.000000
 0:?       bitFieldReverse (global 3-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
-0:172      roundEven (global 3-component vector of float)
-0:172        'inF0' (temp 3-component vector of float)
-0:173      inverse sqrt (global 3-component vector of float)
-0:173        'inF0' (temp 3-component vector of float)
-0:174      Sign (global 3-component vector of float)
-0:174        'inF0' (temp 3-component vector of float)
-0:175      sine (global 3-component vector of float)
-0:175        'inF0' (temp 3-component vector of float)
-0:176      hyp. sine (global 3-component vector of float)
-0:176        'inF0' (temp 3-component vector of float)
-0:177      smoothstep (global 3-component vector of float)
-0:177        'inF0' (temp 3-component vector of float)
-0:177        'inF1' (temp 3-component vector of float)
-0:177        'inF2' (temp 3-component vector of float)
-0:178      sqrt (global 3-component vector of float)
-0:178        'inF0' (temp 3-component vector of float)
-0:179      step (global 3-component vector of float)
+0:179      roundEven (global 3-component vector of float)
 0:179        'inF0' (temp 3-component vector of float)
-0:179        'inF1' (temp 3-component vector of float)
-0:180      tangent (global 3-component vector of float)
+0:180      inverse sqrt (global 3-component vector of float)
 0:180        'inF0' (temp 3-component vector of float)
-0:181      hyp. tangent (global 3-component vector of float)
+0:181      clamp (global 3-component vector of float)
 0:181        'inF0' (temp 3-component vector of float)
-0:183      trunc (global 3-component vector of float)
+0:181        Constant:
+0:181          0.000000
+0:181        Constant:
+0:181          1.000000
+0:182      Sign (global 3-component vector of float)
+0:182        'inF0' (temp 3-component vector of float)
+0:183      sine (global 3-component vector of float)
 0:183        'inF0' (temp 3-component vector of float)
-0:186      Branch: Return with expression
+0:184      Sequence
+0:184        move second child to first child (temp 3-component vector of float)
+0:184          'inF1' (temp 3-component vector of float)
+0:184          sine (temp 3-component vector of float)
+0:184            'inF0' (temp 3-component vector of float)
+0:184        move second child to first child (temp 3-component vector of float)
+0:184          'inF2' (temp 3-component vector of float)
+0:184          cosine (temp 3-component vector of float)
+0:184            'inF0' (temp 3-component vector of float)
+0:185      hyp. sine (global 3-component vector of float)
+0:185        'inF0' (temp 3-component vector of float)
+0:186      smoothstep (global 3-component vector of float)
+0:186        'inF0' (temp 3-component vector of float)
+0:186        'inF1' (temp 3-component vector of float)
+0:186        'inF2' (temp 3-component vector of float)
+0:187      sqrt (global 3-component vector of float)
+0:187        'inF0' (temp 3-component vector of float)
+0:188      step (global 3-component vector of float)
+0:188        'inF0' (temp 3-component vector of float)
+0:188        'inF1' (temp 3-component vector of float)
+0:189      tangent (global 3-component vector of float)
+0:189        'inF0' (temp 3-component vector of float)
+0:190      hyp. tangent (global 3-component vector of float)
+0:190        'inF0' (temp 3-component vector of float)
+0:192      trunc (global 3-component vector of float)
+0:192        'inF0' (temp 3-component vector of float)
+0:195      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
-0:298  Function Definition: VertexShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
-0:190    Function Parameters: 
-0:190      'inF0' (temp 4-component vector of float)
-0:190      'inF1' (temp 4-component vector of float)
-0:190      'inF2' (temp 4-component vector of float)
+0:313  Function Definition: VertexShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
+0:199    Function Parameters: 
+0:199      'inF0' (temp 4-component vector of float)
+0:199      'inF1' (temp 4-component vector of float)
+0:199      'inF2' (temp 4-component vector of float)
 0:?     Sequence
-0:191      all (global bool)
-0:191        'inF0' (temp 4-component vector of float)
-0:192      Absolute value (global 4-component vector of float)
-0:192        'inF0' (temp 4-component vector of float)
-0:193      arc cosine (global 4-component vector of float)
-0:193        'inF0' (temp 4-component vector of float)
-0:194      any (global bool)
-0:194        'inF0' (temp 4-component vector of float)
-0:195      arc sine (global 4-component vector of float)
-0:195        'inF0' (temp 4-component vector of float)
-0:196      arc tangent (global 4-component vector of float)
-0:196        'inF0' (temp 4-component vector of float)
-0:197      arc tangent (global 4-component vector of float)
-0:197        'inF0' (temp 4-component vector of float)
-0:197        'inF1' (temp 4-component vector of float)
-0:198      Ceiling (global 4-component vector of float)
-0:198        'inF0' (temp 4-component vector of float)
-0:199      clamp (global 4-component vector of float)
-0:199        'inF0' (temp 4-component vector of float)
-0:199        'inF1' (temp 4-component vector of float)
-0:199        'inF2' (temp 4-component vector of float)
-0:200      cosine (global 4-component vector of float)
+0:200      all (global bool)
 0:200        'inF0' (temp 4-component vector of float)
-0:201      hyp. cosine (global 4-component vector of float)
+0:201      Absolute value (global 4-component vector of float)
 0:201        'inF0' (temp 4-component vector of float)
+0:202      arc cosine (global 4-component vector of float)
+0:202        'inF0' (temp 4-component vector of float)
+0:203      any (global bool)
+0:203        'inF0' (temp 4-component vector of float)
+0:204      arc sine (global 4-component vector of float)
+0:204        'inF0' (temp 4-component vector of float)
+0:205      arc tangent (global 4-component vector of float)
+0:205        'inF0' (temp 4-component vector of float)
+0:206      arc tangent (global 4-component vector of float)
+0:206        'inF0' (temp 4-component vector of float)
+0:206        'inF1' (temp 4-component vector of float)
+0:207      Ceiling (global 4-component vector of float)
+0:207        'inF0' (temp 4-component vector of float)
+0:208      clamp (global 4-component vector of float)
+0:208        'inF0' (temp 4-component vector of float)
+0:208        'inF1' (temp 4-component vector of float)
+0:208        'inF2' (temp 4-component vector of float)
+0:209      cosine (global 4-component vector of float)
+0:209        'inF0' (temp 4-component vector of float)
+0:210      hyp. cosine (global 4-component vector of float)
+0:210        'inF0' (temp 4-component vector of float)
 0:?       bitCount (global 4-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
 0:?           2 (const uint)
-0:203      degrees (global 4-component vector of float)
-0:203        'inF0' (temp 4-component vector of float)
-0:204      distance (global float)
-0:204        'inF0' (temp 4-component vector of float)
-0:204        'inF1' (temp 4-component vector of float)
-0:205      dot-product (global float)
-0:205        'inF0' (temp 4-component vector of float)
-0:205        'inF1' (temp 4-component vector of float)
-0:209      exp (global 4-component vector of float)
-0:209        'inF0' (temp 4-component vector of float)
-0:210      exp2 (global 4-component vector of float)
-0:210        'inF0' (temp 4-component vector of float)
-0:211      face-forward (global 4-component vector of float)
-0:211        'inF0' (temp 4-component vector of float)
-0:211        'inF1' (temp 4-component vector of float)
-0:211        'inF2' (temp 4-component vector of float)
-0:212      findMSB (global int)
-0:212        Constant:
-0:212          7 (const int)
-0:213      findLSB (global int)
-0:213        Constant:
-0:213          7 (const int)
-0:214      Floor (global 4-component vector of float)
+0:212      degrees (global 4-component vector of float)
+0:212        'inF0' (temp 4-component vector of float)
+0:213      distance (global float)
+0:213        'inF0' (temp 4-component vector of float)
+0:213        'inF1' (temp 4-component vector of float)
+0:214      dot-product (global float)
 0:214        'inF0' (temp 4-component vector of float)
-0:216      Function Call: fmod(vf4;vf4; (global 4-component vector of float)
-0:216        'inF0' (temp 4-component vector of float)
-0:216        'inF1' (temp 4-component vector of float)
-0:217      Fraction (global 4-component vector of float)
-0:217        'inF0' (temp 4-component vector of float)
-0:218      frexp (global 4-component vector of float)
+0:214        'inF1' (temp 4-component vector of float)
+0:218      exp (global 4-component vector of float)
 0:218        'inF0' (temp 4-component vector of float)
-0:218        'inF1' (temp 4-component vector of float)
-0:219      fwidth (global 4-component vector of float)
+0:219      exp2 (global 4-component vector of float)
 0:219        'inF0' (temp 4-component vector of float)
-0:220      isinf (global 4-component vector of bool)
+0:220      face-forward (global 4-component vector of float)
 0:220        'inF0' (temp 4-component vector of float)
-0:221      isnan (global 4-component vector of bool)
-0:221        'inF0' (temp 4-component vector of float)
-0:222      ldexp (global 4-component vector of float)
-0:222        'inF0' (temp 4-component vector of float)
-0:222        'inF1' (temp 4-component vector of float)
-0:223      length (global float)
+0:220        'inF1' (temp 4-component vector of float)
+0:220        'inF2' (temp 4-component vector of float)
+0:221      findMSB (global int)
+0:221        Constant:
+0:221          7 (const int)
+0:222      findLSB (global int)
+0:222        Constant:
+0:222          7 (const int)
+0:223      Floor (global 4-component vector of float)
 0:223        'inF0' (temp 4-component vector of float)
-0:224      log (global 4-component vector of float)
-0:224        'inF0' (temp 4-component vector of float)
-0:225      log2 (global 4-component vector of float)
+0:225      mod (global 4-component vector of float)
 0:225        'inF0' (temp 4-component vector of float)
-0:226      max (global 4-component vector of float)
+0:225        'inF1' (temp 4-component vector of float)
+0:226      Fraction (global 4-component vector of float)
 0:226        'inF0' (temp 4-component vector of float)
-0:226        'inF1' (temp 4-component vector of float)
-0:227      min (global 4-component vector of float)
+0:227      frexp (global 4-component vector of float)
 0:227        'inF0' (temp 4-component vector of float)
 0:227        'inF1' (temp 4-component vector of float)
-0:229      normalize (global 4-component vector of float)
+0:228      fwidth (global 4-component vector of float)
+0:228        'inF0' (temp 4-component vector of float)
+0:229      isinf (global 4-component vector of bool)
 0:229        'inF0' (temp 4-component vector of float)
-0:230      pow (global 4-component vector of float)
+0:230      isnan (global 4-component vector of bool)
 0:230        'inF0' (temp 4-component vector of float)
-0:230        'inF1' (temp 4-component vector of float)
-0:231      radians (global 4-component vector of float)
+0:231      ldexp (global 4-component vector of float)
 0:231        'inF0' (temp 4-component vector of float)
-0:232      reflect (global 4-component vector of float)
+0:231        'inF1' (temp 4-component vector of float)
+0:232      length (global float)
 0:232        'inF0' (temp 4-component vector of float)
-0:232        'inF1' (temp 4-component vector of float)
-0:233      refract (global 4-component vector of float)
+0:233      log (global 4-component vector of float)
 0:233        'inF0' (temp 4-component vector of float)
-0:233        'inF1' (temp 4-component vector of float)
-0:233        Constant:
-0:233          2.000000
+0:234      component-wise multiply (global 4-component vector of float)
+0:234        log2 (global 4-component vector of float)
+0:234          'inF0' (temp 4-component vector of float)
+0:234        Constant:
+0:234          0.301030
+0:235      log2 (global 4-component vector of float)
+0:235        'inF0' (temp 4-component vector of float)
+0:236      max (global 4-component vector of float)
+0:236        'inF0' (temp 4-component vector of float)
+0:236        'inF1' (temp 4-component vector of float)
+0:237      min (global 4-component vector of float)
+0:237        'inF0' (temp 4-component vector of float)
+0:237        'inF1' (temp 4-component vector of float)
+0:239      normalize (global 4-component vector of float)
+0:239        'inF0' (temp 4-component vector of float)
+0:240      pow (global 4-component vector of float)
+0:240        'inF0' (temp 4-component vector of float)
+0:240        'inF1' (temp 4-component vector of float)
+0:241      radians (global 4-component vector of float)
+0:241        'inF0' (temp 4-component vector of float)
+0:242      reflect (global 4-component vector of float)
+0:242        'inF0' (temp 4-component vector of float)
+0:242        'inF1' (temp 4-component vector of float)
+0:243      refract (global 4-component vector of float)
+0:243        'inF0' (temp 4-component vector of float)
+0:243        'inF1' (temp 4-component vector of float)
+0:243        Constant:
+0:243          2.000000
 0:?       bitFieldReverse (global 4-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
 0:?           4 (const uint)
-0:235      roundEven (global 4-component vector of float)
-0:235        'inF0' (temp 4-component vector of float)
-0:236      inverse sqrt (global 4-component vector of float)
-0:236        'inF0' (temp 4-component vector of float)
-0:237      Sign (global 4-component vector of float)
-0:237        'inF0' (temp 4-component vector of float)
-0:238      sine (global 4-component vector of float)
-0:238        'inF0' (temp 4-component vector of float)
-0:239      hyp. sine (global 4-component vector of float)
-0:239        'inF0' (temp 4-component vector of float)
-0:240      smoothstep (global 4-component vector of float)
-0:240        'inF0' (temp 4-component vector of float)
-0:240        'inF1' (temp 4-component vector of float)
-0:240        'inF2' (temp 4-component vector of float)
-0:241      sqrt (global 4-component vector of float)
-0:241        'inF0' (temp 4-component vector of float)
-0:242      step (global 4-component vector of float)
-0:242        'inF0' (temp 4-component vector of float)
-0:242        'inF1' (temp 4-component vector of float)
-0:243      tangent (global 4-component vector of float)
-0:243        'inF0' (temp 4-component vector of float)
-0:244      hyp. tangent (global 4-component vector of float)
-0:244        'inF0' (temp 4-component vector of float)
-0:246      trunc (global 4-component vector of float)
+0:245      roundEven (global 4-component vector of float)
+0:245        'inF0' (temp 4-component vector of float)
+0:246      inverse sqrt (global 4-component vector of float)
 0:246        'inF0' (temp 4-component vector of float)
-0:249      Branch: Return with expression
+0:247      clamp (global 4-component vector of float)
+0:247        'inF0' (temp 4-component vector of float)
+0:247        Constant:
+0:247          0.000000
+0:247        Constant:
+0:247          1.000000
+0:248      Sign (global 4-component vector of float)
+0:248        'inF0' (temp 4-component vector of float)
+0:249      sine (global 4-component vector of float)
+0:249        'inF0' (temp 4-component vector of float)
+0:250      Sequence
+0:250        move second child to first child (temp 4-component vector of float)
+0:250          'inF1' (temp 4-component vector of float)
+0:250          sine (temp 4-component vector of float)
+0:250            'inF0' (temp 4-component vector of float)
+0:250        move second child to first child (temp 4-component vector of float)
+0:250          'inF2' (temp 4-component vector of float)
+0:250          cosine (temp 4-component vector of float)
+0:250            'inF0' (temp 4-component vector of float)
+0:251      hyp. sine (global 4-component vector of float)
+0:251        'inF0' (temp 4-component vector of float)
+0:252      smoothstep (global 4-component vector of float)
+0:252        'inF0' (temp 4-component vector of float)
+0:252        'inF1' (temp 4-component vector of float)
+0:252        'inF2' (temp 4-component vector of float)
+0:253      sqrt (global 4-component vector of float)
+0:253        'inF0' (temp 4-component vector of float)
+0:254      step (global 4-component vector of float)
+0:254        'inF0' (temp 4-component vector of float)
+0:254        'inF1' (temp 4-component vector of float)
+0:255      tangent (global 4-component vector of float)
+0:255        'inF0' (temp 4-component vector of float)
+0:256      hyp. tangent (global 4-component vector of float)
+0:256        'inF0' (temp 4-component vector of float)
+0:258      trunc (global 4-component vector of float)
+0:258        'inF0' (temp 4-component vector of float)
+0:261      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
 0:?           4.000000
-0:307  Function Definition: VertexShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
-0:299    Function Parameters: 
-0:299      'inF0' (temp 2X2 matrix of float)
-0:299      'inF1' (temp 2X2 matrix of float)
-0:299      'inF2' (temp 2X2 matrix of float)
+0:322  Function Definition: VertexShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:314    Function Parameters: 
+0:314      'inF0' (temp 2X2 matrix of float)
+0:314      'inF1' (temp 2X2 matrix of float)
+0:314      'inF2' (temp 2X2 matrix of float)
 0:?     Sequence
-0:301      all (global bool)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      Absolute value (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc cosine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      any (global bool)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc sine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      Ceiling (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      clamp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301        'inF2' (temp 2X2 matrix of float)
-0:301      cosine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      hyp. cosine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      degrees (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      determinant (global float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      exp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      exp2 (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      findMSB (global int)
-0:301        Constant:
-0:301          7 (const int)
-0:301      findLSB (global int)
-0:301        Constant:
-0:301          7 (const int)
-0:301      Floor (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      Function Call: fmod(mf22;mf22; (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      Fraction (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      frexp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      fwidth (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      ldexp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      log (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      log2 (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      max (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      min (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      pow (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      radians (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      roundEven (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      inverse sqrt (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      Sign (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      sine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      hyp. sine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      smoothstep (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301        'inF2' (temp 2X2 matrix of float)
-0:301      sqrt (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      step (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      hyp. tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      transpose (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      trunc (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:304      Branch: Return with expression
+0:316      all (global bool)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      Absolute value (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      arc cosine (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      any (global bool)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      arc sine (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      arc tangent (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      arc tangent (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      Ceiling (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      clamp (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316        'inF2' (temp 2X2 matrix of float)
+0:316      cosine (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      hyp. cosine (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      degrees (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      determinant (global float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      exp (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      exp2 (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      findMSB (global int)
+0:316        Constant:
+0:316          7 (const int)
+0:316      findLSB (global int)
+0:316        Constant:
+0:316          7 (const int)
+0:316      Floor (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      mod (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      Fraction (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      frexp (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      fwidth (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      ldexp (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      log (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      component-wise multiply (global 2X2 matrix of float)
+0:316        log2 (global 2X2 matrix of float)
+0:316          'inF0' (temp 2X2 matrix of float)
+0:316        Constant:
+0:316          0.301030
+0:316      log2 (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      max (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      min (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      pow (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      radians (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      roundEven (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      inverse sqrt (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      clamp (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        Constant:
+0:316          0.000000
+0:316        Constant:
+0:316          1.000000
+0:316      Sign (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      sine (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      Sequence
+0:316        move second child to first child (temp 2X2 matrix of float)
+0:316          'inF1' (temp 2X2 matrix of float)
+0:316          sine (temp 2X2 matrix of float)
+0:316            'inF0' (temp 2X2 matrix of float)
+0:316        move second child to first child (temp 2X2 matrix of float)
+0:316          'inF2' (temp 2X2 matrix of float)
+0:316          cosine (temp 2X2 matrix of float)
+0:316            'inF0' (temp 2X2 matrix of float)
+0:316      hyp. sine (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      smoothstep (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316        'inF2' (temp 2X2 matrix of float)
+0:316      sqrt (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      step (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      tangent (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      hyp. tangent (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      transpose (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      trunc (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:319      Branch: Return with expression
 0:?         Constant:
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
-0:316  Function Definition: VertexShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
-0:308    Function Parameters: 
-0:308      'inF0' (temp 3X3 matrix of float)
-0:308      'inF1' (temp 3X3 matrix of float)
-0:308      'inF2' (temp 3X3 matrix of float)
+0:331  Function Definition: VertexShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:323    Function Parameters: 
+0:323      'inF0' (temp 3X3 matrix of float)
+0:323      'inF1' (temp 3X3 matrix of float)
+0:323      'inF2' (temp 3X3 matrix of float)
 0:?     Sequence
-0:310      all (global bool)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      Absolute value (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc cosine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      any (global bool)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc sine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      Ceiling (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      clamp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310        'inF2' (temp 3X3 matrix of float)
-0:310      cosine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      hyp. cosine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      degrees (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      determinant (global float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      exp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      exp2 (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      findMSB (global int)
-0:310        Constant:
-0:310          7 (const int)
-0:310      findLSB (global int)
-0:310        Constant:
-0:310          7 (const int)
-0:310      Floor (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      Function Call: fmod(mf33;mf33; (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      Fraction (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      frexp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      fwidth (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      ldexp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      log (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      log2 (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      max (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      min (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      pow (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      radians (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      roundEven (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      inverse sqrt (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      Sign (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      sine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      hyp. sine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      smoothstep (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310        'inF2' (temp 3X3 matrix of float)
-0:310      sqrt (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      step (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      hyp. tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      transpose (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      trunc (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:313      Branch: Return with expression
+0:325      all (global bool)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      Absolute value (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      arc cosine (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      any (global bool)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      arc sine (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      arc tangent (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      arc tangent (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      Ceiling (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      clamp (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325        'inF2' (temp 3X3 matrix of float)
+0:325      cosine (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      hyp. cosine (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      degrees (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      determinant (global float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      exp (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      exp2 (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      findMSB (global int)
+0:325        Constant:
+0:325          7 (const int)
+0:325      findLSB (global int)
+0:325        Constant:
+0:325          7 (const int)
+0:325      Floor (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      mod (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      Fraction (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      frexp (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      fwidth (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      ldexp (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      log (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      component-wise multiply (global 3X3 matrix of float)
+0:325        log2 (global 3X3 matrix of float)
+0:325          'inF0' (temp 3X3 matrix of float)
+0:325        Constant:
+0:325          0.301030
+0:325      log2 (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      max (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      min (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      pow (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      radians (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      roundEven (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      inverse sqrt (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      clamp (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        Constant:
+0:325          0.000000
+0:325        Constant:
+0:325          1.000000
+0:325      Sign (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      sine (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      Sequence
+0:325        move second child to first child (temp 3X3 matrix of float)
+0:325          'inF1' (temp 3X3 matrix of float)
+0:325          sine (temp 3X3 matrix of float)
+0:325            'inF0' (temp 3X3 matrix of float)
+0:325        move second child to first child (temp 3X3 matrix of float)
+0:325          'inF2' (temp 3X3 matrix of float)
+0:325          cosine (temp 3X3 matrix of float)
+0:325            'inF0' (temp 3X3 matrix of float)
+0:325      hyp. sine (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      smoothstep (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325        'inF2' (temp 3X3 matrix of float)
+0:325      sqrt (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      step (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      tangent (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      hyp. tangent (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      transpose (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      trunc (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:328      Branch: Return with expression
 0:?         Constant:
 0:?           3.000000
 0:?           3.000000
@@ -762,109 +882,129 @@ Shader version: 450
 0:?           3.000000
 0:?           3.000000
 0:?           3.000000
-0:324  Function Definition: VertexShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
-0:317    Function Parameters: 
-0:317      'inF0' (temp 4X4 matrix of float)
-0:317      'inF1' (temp 4X4 matrix of float)
-0:317      'inF2' (temp 4X4 matrix of float)
+0:352  Function Definition: VertexShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:332    Function Parameters: 
+0:332      'inF0' (temp 4X4 matrix of float)
+0:332      'inF1' (temp 4X4 matrix of float)
+0:332      'inF2' (temp 4X4 matrix of float)
 0:?     Sequence
-0:319      all (global bool)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      Absolute value (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc cosine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      any (global bool)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc sine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      Ceiling (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      clamp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319        'inF2' (temp 4X4 matrix of float)
-0:319      cosine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      hyp. cosine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      degrees (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      determinant (global float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      exp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      exp2 (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      findMSB (global int)
-0:319        Constant:
-0:319          7 (const int)
-0:319      findLSB (global int)
-0:319        Constant:
-0:319          7 (const int)
-0:319      Floor (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      Function Call: fmod(mf44;mf44; (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      Fraction (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      frexp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      fwidth (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      ldexp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      log (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      log2 (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      max (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      min (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      pow (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      radians (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      roundEven (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      inverse sqrt (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      Sign (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      sine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      hyp. sine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      smoothstep (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319        'inF2' (temp 4X4 matrix of float)
-0:319      sqrt (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      step (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      hyp. tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      transpose (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      trunc (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:322      Branch: Return with expression
+0:334      all (global bool)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      Absolute value (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      arc cosine (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      any (global bool)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      arc sine (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      arc tangent (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      arc tangent (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      Ceiling (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      clamp (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334        'inF2' (temp 4X4 matrix of float)
+0:334      cosine (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      hyp. cosine (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      degrees (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      determinant (global float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      exp (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      exp2 (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      findMSB (global int)
+0:334        Constant:
+0:334          7 (const int)
+0:334      findLSB (global int)
+0:334        Constant:
+0:334          7 (const int)
+0:334      Floor (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      mod (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      Fraction (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      frexp (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      fwidth (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      ldexp (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      log (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      component-wise multiply (global 4X4 matrix of float)
+0:334        log2 (global 4X4 matrix of float)
+0:334          'inF0' (temp 4X4 matrix of float)
+0:334        Constant:
+0:334          0.301030
+0:334      log2 (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      max (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      min (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      pow (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      radians (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      roundEven (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      inverse sqrt (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      clamp (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        Constant:
+0:334          0.000000
+0:334        Constant:
+0:334          1.000000
+0:334      Sign (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      sine (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      Sequence
+0:334        move second child to first child (temp 4X4 matrix of float)
+0:334          'inF1' (temp 4X4 matrix of float)
+0:334          sine (temp 4X4 matrix of float)
+0:334            'inF0' (temp 4X4 matrix of float)
+0:334        move second child to first child (temp 4X4 matrix of float)
+0:334          'inF2' (temp 4X4 matrix of float)
+0:334          cosine (temp 4X4 matrix of float)
+0:334            'inF0' (temp 4X4 matrix of float)
+0:334      hyp. sine (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      smoothstep (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334        'inF2' (temp 4X4 matrix of float)
+0:334      sqrt (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      step (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      tangent (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      hyp. tangent (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      transpose (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      trunc (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:337      Branch: Return with expression
 0:?         Constant:
 0:?           4.000000
 0:?           4.000000
@@ -882,6 +1022,168 @@ Shader version: 450
 0:?           4.000000
 0:?           4.000000
 0:?           4.000000
+0:359  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
+0:355    Function Parameters: 
+0:355      'inF0' (temp float)
+0:355      'inF1' (temp float)
+0:355      'inFV0' (temp 2-component vector of float)
+0:355      'inFV1' (temp 2-component vector of float)
+0:355      'inFM0' (temp 2X2 matrix of float)
+0:355      'inFM1' (temp 2X2 matrix of float)
+0:?     Sequence
+0:356      move second child to first child (temp float)
+0:356        'r0' (temp float)
+0:356        component-wise multiply (global float)
+0:356          'inF0' (temp float)
+0:356          'inF1' (temp float)
+0:356      move second child to first child (temp 2-component vector of float)
+0:356        'r1' (temp 2-component vector of float)
+0:356        vector-scale (global 2-component vector of float)
+0:356          'inFV0' (temp 2-component vector of float)
+0:356          'inF0' (temp float)
+0:356      move second child to first child (temp 2-component vector of float)
+0:356        'r2' (temp 2-component vector of float)
+0:356        vector-scale (global 2-component vector of float)
+0:356          'inFV0' (temp 2-component vector of float)
+0:356          'inF0' (temp float)
+0:356      move second child to first child (temp float)
+0:356        'r3' (temp float)
+0:356        dot-product (global float)
+0:356          'inFV0' (temp 2-component vector of float)
+0:356          'inFV1' (temp 2-component vector of float)
+0:356      move second child to first child (temp 2-component vector of float)
+0:356        'r4' (temp 2-component vector of float)
+0:356        matrix-times-vector (global 2-component vector of float)
+0:356          'inFM0' (temp 2X2 matrix of float)
+0:356          'inFV0' (temp 2-component vector of float)
+0:356      move second child to first child (temp 2-component vector of float)
+0:356        'r5' (temp 2-component vector of float)
+0:356        vector-times-matrix (global 2-component vector of float)
+0:356          'inFV0' (temp 2-component vector of float)
+0:356          'inFM0' (temp 2X2 matrix of float)
+0:356      move second child to first child (temp 2X2 matrix of float)
+0:356        'r6' (temp 2X2 matrix of float)
+0:356        matrix-scale (global 2X2 matrix of float)
+0:356          'inFM0' (temp 2X2 matrix of float)
+0:356          'inF0' (temp float)
+0:356      move second child to first child (temp 2X2 matrix of float)
+0:356        'r7' (temp 2X2 matrix of float)
+0:356        matrix-scale (global 2X2 matrix of float)
+0:356          'inFM0' (temp 2X2 matrix of float)
+0:356          'inF0' (temp float)
+0:356      move second child to first child (temp 2X2 matrix of float)
+0:356        'r8' (temp 2X2 matrix of float)
+0:356        matrix-multiply (global 2X2 matrix of float)
+0:356          'inFM0' (temp 2X2 matrix of float)
+0:356          'inFM1' (temp 2X2 matrix of float)
+0:366  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
+0:362    Function Parameters: 
+0:362      'inF0' (temp float)
+0:362      'inF1' (temp float)
+0:362      'inFV0' (temp 3-component vector of float)
+0:362      'inFV1' (temp 3-component vector of float)
+0:362      'inFM0' (temp 3X3 matrix of float)
+0:362      'inFM1' (temp 3X3 matrix of float)
+0:?     Sequence
+0:363      move second child to first child (temp float)
+0:363        'r0' (temp float)
+0:363        component-wise multiply (global float)
+0:363          'inF0' (temp float)
+0:363          'inF1' (temp float)
+0:363      move second child to first child (temp 3-component vector of float)
+0:363        'r1' (temp 3-component vector of float)
+0:363        vector-scale (global 3-component vector of float)
+0:363          'inFV0' (temp 3-component vector of float)
+0:363          'inF0' (temp float)
+0:363      move second child to first child (temp 3-component vector of float)
+0:363        'r2' (temp 3-component vector of float)
+0:363        vector-scale (global 3-component vector of float)
+0:363          'inFV0' (temp 3-component vector of float)
+0:363          'inF0' (temp float)
+0:363      move second child to first child (temp float)
+0:363        'r3' (temp float)
+0:363        dot-product (global float)
+0:363          'inFV0' (temp 3-component vector of float)
+0:363          'inFV1' (temp 3-component vector of float)
+0:363      move second child to first child (temp 3-component vector of float)
+0:363        'r4' (temp 3-component vector of float)
+0:363        matrix-times-vector (global 3-component vector of float)
+0:363          'inFM0' (temp 3X3 matrix of float)
+0:363          'inFV0' (temp 3-component vector of float)
+0:363      move second child to first child (temp 3-component vector of float)
+0:363        'r5' (temp 3-component vector of float)
+0:363        vector-times-matrix (global 3-component vector of float)
+0:363          'inFV0' (temp 3-component vector of float)
+0:363          'inFM0' (temp 3X3 matrix of float)
+0:363      move second child to first child (temp 3X3 matrix of float)
+0:363        'r6' (temp 3X3 matrix of float)
+0:363        matrix-scale (global 3X3 matrix of float)
+0:363          'inFM0' (temp 3X3 matrix of float)
+0:363          'inF0' (temp float)
+0:363      move second child to first child (temp 3X3 matrix of float)
+0:363        'r7' (temp 3X3 matrix of float)
+0:363        matrix-scale (global 3X3 matrix of float)
+0:363          'inFM0' (temp 3X3 matrix of float)
+0:363          'inF0' (temp float)
+0:363      move second child to first child (temp 3X3 matrix of float)
+0:363        'r8' (temp 3X3 matrix of float)
+0:363        matrix-multiply (global 3X3 matrix of float)
+0:363          'inFM0' (temp 3X3 matrix of float)
+0:363          'inFM1' (temp 3X3 matrix of float)
+0:372  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
+0:369    Function Parameters: 
+0:369      'inF0' (temp float)
+0:369      'inF1' (temp float)
+0:369      'inFV0' (temp 4-component vector of float)
+0:369      'inFV1' (temp 4-component vector of float)
+0:369      'inFM0' (temp 4X4 matrix of float)
+0:369      'inFM1' (temp 4X4 matrix of float)
+0:?     Sequence
+0:370      move second child to first child (temp float)
+0:370        'r0' (temp float)
+0:370        component-wise multiply (global float)
+0:370          'inF0' (temp float)
+0:370          'inF1' (temp float)
+0:370      move second child to first child (temp 4-component vector of float)
+0:370        'r1' (temp 4-component vector of float)
+0:370        vector-scale (global 4-component vector of float)
+0:370          'inFV0' (temp 4-component vector of float)
+0:370          'inF0' (temp float)
+0:370      move second child to first child (temp 4-component vector of float)
+0:370        'r2' (temp 4-component vector of float)
+0:370        vector-scale (global 4-component vector of float)
+0:370          'inFV0' (temp 4-component vector of float)
+0:370          'inF0' (temp float)
+0:370      move second child to first child (temp float)
+0:370        'r3' (temp float)
+0:370        dot-product (global float)
+0:370          'inFV0' (temp 4-component vector of float)
+0:370          'inFV1' (temp 4-component vector of float)
+0:370      move second child to first child (temp 4-component vector of float)
+0:370        'r4' (temp 4-component vector of float)
+0:370        matrix-times-vector (global 4-component vector of float)
+0:370          'inFM0' (temp 4X4 matrix of float)
+0:370          'inFV0' (temp 4-component vector of float)
+0:370      move second child to first child (temp 4-component vector of float)
+0:370        'r5' (temp 4-component vector of float)
+0:370        vector-times-matrix (global 4-component vector of float)
+0:370          'inFV0' (temp 4-component vector of float)
+0:370          'inFM0' (temp 4X4 matrix of float)
+0:370      move second child to first child (temp 4X4 matrix of float)
+0:370        'r6' (temp 4X4 matrix of float)
+0:370        matrix-scale (global 4X4 matrix of float)
+0:370          'inFM0' (temp 4X4 matrix of float)
+0:370          'inF0' (temp float)
+0:370      move second child to first child (temp 4X4 matrix of float)
+0:370        'r7' (temp 4X4 matrix of float)
+0:370        matrix-scale (global 4X4 matrix of float)
+0:370          'inFM0' (temp 4X4 matrix of float)
+0:370          'inF0' (temp float)
+0:370      move second child to first child (temp 4X4 matrix of float)
+0:370        'r8' (temp 4X4 matrix of float)
+0:370        matrix-multiply (global 4X4 matrix of float)
+0:370          'inFM0' (temp 4X4 matrix of float)
+0:370          'inFM1' (temp 4X4 matrix of float)
 0:?   Linker Objects
 
 
@@ -890,7 +1192,7 @@ Linked vertex stage:
 
 Shader version: 450
 0:? Sequence
-0:56  Function Definition: VertexShaderFunction(f1;f1;f1; (temp float)
+0:59  Function Definition: VertexShaderFunction(f1;f1;f1; (temp float)
 0:2    Function Parameters: 
 0:2      'inF0' (temp float)
 0:2      'inF1' (temp float)
@@ -938,7 +1240,7 @@ Shader version: 450
 0:22          7 (const int)
 0:23      Floor (global float)
 0:23        'inF0' (temp float)
-0:25      Function Call: fmod(f1;f1; (global float)
+0:25      mod (global float)
 0:25        'inF0' (temp float)
 0:25        'inF1' (temp float)
 0:26      Fraction (global float)
@@ -957,690 +1259,810 @@ Shader version: 450
 0:31        'inF1' (temp float)
 0:32      log (global float)
 0:32        'inF0' (temp float)
-0:33      log2 (global float)
-0:33        'inF0' (temp float)
-0:34      max (global float)
+0:33      component-wise multiply (global float)
+0:33        log2 (global float)
+0:33          'inF0' (temp float)
+0:33        Constant:
+0:33          0.301030
+0:34      log2 (global float)
 0:34        'inF0' (temp float)
-0:34        'inF1' (temp float)
-0:35      min (global float)
+0:35      max (global float)
 0:35        'inF0' (temp float)
 0:35        'inF1' (temp float)
-0:37      pow (global float)
-0:37        'inF0' (temp float)
-0:37        'inF1' (temp float)
-0:38      radians (global float)
+0:36      min (global float)
+0:36        'inF0' (temp float)
+0:36        'inF1' (temp float)
+0:38      pow (global float)
 0:38        'inF0' (temp float)
-0:39      bitFieldReverse (global uint)
-0:39        Constant:
-0:39          2 (const uint)
-0:40      roundEven (global float)
-0:40        'inF0' (temp float)
-0:41      inverse sqrt (global float)
+0:38        'inF1' (temp float)
+0:39      radians (global float)
+0:39        'inF0' (temp float)
+0:40      bitFieldReverse (global uint)
+0:40        Constant:
+0:40          2 (const uint)
+0:41      roundEven (global float)
 0:41        'inF0' (temp float)
-0:42      Sign (global float)
+0:42      inverse sqrt (global float)
 0:42        'inF0' (temp float)
-0:43      sine (global float)
+0:43      clamp (global float)
 0:43        'inF0' (temp float)
-0:44      hyp. sine (global float)
+0:43        Constant:
+0:43          0.000000
+0:43        Constant:
+0:43          1.000000
+0:44      Sign (global float)
 0:44        'inF0' (temp float)
-0:45      smoothstep (global float)
+0:45      sine (global float)
 0:45        'inF0' (temp float)
-0:45        'inF1' (temp float)
-0:45        'inF2' (temp float)
-0:46      sqrt (global float)
-0:46        'inF0' (temp float)
-0:47      step (global float)
+0:46      Sequence
+0:46        move second child to first child (temp float)
+0:46          'inF1' (temp float)
+0:46          sine (temp float)
+0:46            'inF0' (temp float)
+0:46        move second child to first child (temp float)
+0:46          'inF2' (temp float)
+0:46          cosine (temp float)
+0:46            'inF0' (temp float)
+0:47      hyp. sine (global float)
 0:47        'inF0' (temp float)
-0:47        'inF1' (temp float)
-0:48      tangent (global float)
+0:48      smoothstep (global float)
 0:48        'inF0' (temp float)
-0:49      hyp. tangent (global float)
+0:48        'inF1' (temp float)
+0:48        'inF2' (temp float)
+0:49      sqrt (global float)
 0:49        'inF0' (temp float)
-0:51      trunc (global float)
+0:50      step (global float)
+0:50        'inF0' (temp float)
+0:50        'inF1' (temp float)
+0:51      tangent (global float)
 0:51        'inF0' (temp float)
-0:53      Branch: Return with expression
-0:53        Constant:
-0:53          0.000000
-0:62  Function Definition: VertexShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
-0:57    Function Parameters: 
-0:57      'inF0' (temp 1-component vector of float)
-0:57      'inF1' (temp 1-component vector of float)
-0:57      'inF2' (temp 1-component vector of float)
+0:52      hyp. tangent (global float)
+0:52        'inF0' (temp float)
+0:54      trunc (global float)
+0:54        'inF0' (temp float)
+0:56      Branch: Return with expression
+0:56        Constant:
+0:56          0.000000
+0:65  Function Definition: VertexShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
+0:60    Function Parameters: 
+0:60      'inF0' (temp 1-component vector of float)
+0:60      'inF1' (temp 1-component vector of float)
+0:60      'inF2' (temp 1-component vector of float)
 0:?     Sequence
-0:59      Branch: Return with expression
-0:59        Constant:
-0:59          0.000000
-0:125  Function Definition: VertexShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
-0:63    Function Parameters: 
-0:63      'inF0' (temp 2-component vector of float)
-0:63      'inF1' (temp 2-component vector of float)
-0:63      'inF2' (temp 2-component vector of float)
+0:62      Branch: Return with expression
+0:62        Constant:
+0:62          0.000000
+0:131  Function Definition: VertexShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
+0:66    Function Parameters: 
+0:66      'inF0' (temp 2-component vector of float)
+0:66      'inF1' (temp 2-component vector of float)
+0:66      'inF2' (temp 2-component vector of float)
 0:?     Sequence
-0:64      all (global bool)
-0:64        'inF0' (temp 2-component vector of float)
-0:65      Absolute value (global 2-component vector of float)
-0:65        'inF0' (temp 2-component vector of float)
-0:66      arc cosine (global 2-component vector of float)
-0:66        'inF0' (temp 2-component vector of float)
-0:67      any (global bool)
+0:67      all (global bool)
 0:67        'inF0' (temp 2-component vector of float)
-0:68      arc sine (global 2-component vector of float)
+0:68      Absolute value (global 2-component vector of float)
 0:68        'inF0' (temp 2-component vector of float)
-0:69      arc tangent (global 2-component vector of float)
+0:69      arc cosine (global 2-component vector of float)
 0:69        'inF0' (temp 2-component vector of float)
-0:70      arc tangent (global 2-component vector of float)
+0:70      any (global bool)
 0:70        'inF0' (temp 2-component vector of float)
-0:70        'inF1' (temp 2-component vector of float)
-0:71      Ceiling (global 2-component vector of float)
+0:71      arc sine (global 2-component vector of float)
 0:71        'inF0' (temp 2-component vector of float)
-0:72      clamp (global 2-component vector of float)
+0:72      arc tangent (global 2-component vector of float)
 0:72        'inF0' (temp 2-component vector of float)
-0:72        'inF1' (temp 2-component vector of float)
-0:72        'inF2' (temp 2-component vector of float)
-0:73      cosine (global 2-component vector of float)
+0:73      arc tangent (global 2-component vector of float)
 0:73        'inF0' (temp 2-component vector of float)
-0:74      hyp. cosine (global 2-component vector of float)
+0:73        'inF1' (temp 2-component vector of float)
+0:74      Ceiling (global 2-component vector of float)
 0:74        'inF0' (temp 2-component vector of float)
+0:75      clamp (global 2-component vector of float)
+0:75        'inF0' (temp 2-component vector of float)
+0:75        'inF1' (temp 2-component vector of float)
+0:75        'inF2' (temp 2-component vector of float)
+0:76      cosine (global 2-component vector of float)
+0:76        'inF0' (temp 2-component vector of float)
+0:77      hyp. cosine (global 2-component vector of float)
+0:77        'inF0' (temp 2-component vector of float)
 0:?       bitCount (global 2-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
-0:76      degrees (global 2-component vector of float)
-0:76        'inF0' (temp 2-component vector of float)
-0:77      distance (global float)
-0:77        'inF0' (temp 2-component vector of float)
-0:77        'inF1' (temp 2-component vector of float)
-0:78      dot-product (global float)
-0:78        'inF0' (temp 2-component vector of float)
-0:78        'inF1' (temp 2-component vector of float)
-0:82      exp (global 2-component vector of float)
-0:82        'inF0' (temp 2-component vector of float)
-0:83      exp2 (global 2-component vector of float)
-0:83        'inF0' (temp 2-component vector of float)
-0:84      face-forward (global 2-component vector of float)
-0:84        'inF0' (temp 2-component vector of float)
-0:84        'inF1' (temp 2-component vector of float)
-0:84        'inF2' (temp 2-component vector of float)
-0:85      findMSB (global int)
-0:85        Constant:
-0:85          7 (const int)
-0:86      findLSB (global int)
-0:86        Constant:
-0:86          7 (const int)
-0:87      Floor (global 2-component vector of float)
+0:79      degrees (global 2-component vector of float)
+0:79        'inF0' (temp 2-component vector of float)
+0:80      distance (global float)
+0:80        'inF0' (temp 2-component vector of float)
+0:80        'inF1' (temp 2-component vector of float)
+0:81      dot-product (global float)
+0:81        'inF0' (temp 2-component vector of float)
+0:81        'inF1' (temp 2-component vector of float)
+0:85      exp (global 2-component vector of float)
+0:85        'inF0' (temp 2-component vector of float)
+0:86      exp2 (global 2-component vector of float)
+0:86        'inF0' (temp 2-component vector of float)
+0:87      face-forward (global 2-component vector of float)
 0:87        'inF0' (temp 2-component vector of float)
-0:89      Function Call: fmod(vf2;vf2; (global 2-component vector of float)
-0:89        'inF0' (temp 2-component vector of float)
-0:89        'inF1' (temp 2-component vector of float)
-0:90      Fraction (global 2-component vector of float)
+0:87        'inF1' (temp 2-component vector of float)
+0:87        'inF2' (temp 2-component vector of float)
+0:88      findMSB (global int)
+0:88        Constant:
+0:88          7 (const int)
+0:89      findLSB (global int)
+0:89        Constant:
+0:89          7 (const int)
+0:90      Floor (global 2-component vector of float)
 0:90        'inF0' (temp 2-component vector of float)
-0:91      frexp (global 2-component vector of float)
-0:91        'inF0' (temp 2-component vector of float)
-0:91        'inF1' (temp 2-component vector of float)
-0:92      fwidth (global 2-component vector of float)
+0:92      mod (global 2-component vector of float)
 0:92        'inF0' (temp 2-component vector of float)
-0:93      isinf (global 2-component vector of bool)
+0:92        'inF1' (temp 2-component vector of float)
+0:93      Fraction (global 2-component vector of float)
 0:93        'inF0' (temp 2-component vector of float)
-0:94      isnan (global 2-component vector of bool)
+0:94      frexp (global 2-component vector of float)
 0:94        'inF0' (temp 2-component vector of float)
-0:95      ldexp (global 2-component vector of float)
+0:94        'inF1' (temp 2-component vector of float)
+0:95      fwidth (global 2-component vector of float)
 0:95        'inF0' (temp 2-component vector of float)
-0:95        'inF1' (temp 2-component vector of float)
-0:96      length (global float)
+0:96      isinf (global 2-component vector of bool)
 0:96        'inF0' (temp 2-component vector of float)
-0:97      log (global 2-component vector of float)
+0:97      isnan (global 2-component vector of bool)
 0:97        'inF0' (temp 2-component vector of float)
-0:98      log2 (global 2-component vector of float)
+0:98      ldexp (global 2-component vector of float)
 0:98        'inF0' (temp 2-component vector of float)
-0:99      max (global 2-component vector of float)
+0:98        'inF1' (temp 2-component vector of float)
+0:99      length (global float)
 0:99        'inF0' (temp 2-component vector of float)
-0:99        'inF1' (temp 2-component vector of float)
-0:100      min (global 2-component vector of float)
+0:100      log (global 2-component vector of float)
 0:100        'inF0' (temp 2-component vector of float)
-0:100        'inF1' (temp 2-component vector of float)
-0:102      normalize (global 2-component vector of float)
+0:101      component-wise multiply (global 2-component vector of float)
+0:101        log2 (global 2-component vector of float)
+0:101          'inF0' (temp 2-component vector of float)
+0:101        Constant:
+0:101          0.301030
+0:102      log2 (global 2-component vector of float)
 0:102        'inF0' (temp 2-component vector of float)
-0:103      pow (global 2-component vector of float)
+0:103      max (global 2-component vector of float)
 0:103        'inF0' (temp 2-component vector of float)
 0:103        'inF1' (temp 2-component vector of float)
-0:104      radians (global 2-component vector of float)
+0:104      min (global 2-component vector of float)
 0:104        'inF0' (temp 2-component vector of float)
-0:105      reflect (global 2-component vector of float)
-0:105        'inF0' (temp 2-component vector of float)
-0:105        'inF1' (temp 2-component vector of float)
-0:106      refract (global 2-component vector of float)
+0:104        'inF1' (temp 2-component vector of float)
+0:106      normalize (global 2-component vector of float)
 0:106        'inF0' (temp 2-component vector of float)
-0:106        'inF1' (temp 2-component vector of float)
-0:106        Constant:
-0:106          2.000000
+0:107      pow (global 2-component vector of float)
+0:107        'inF0' (temp 2-component vector of float)
+0:107        'inF1' (temp 2-component vector of float)
+0:108      radians (global 2-component vector of float)
+0:108        'inF0' (temp 2-component vector of float)
+0:109      reflect (global 2-component vector of float)
+0:109        'inF0' (temp 2-component vector of float)
+0:109        'inF1' (temp 2-component vector of float)
+0:110      refract (global 2-component vector of float)
+0:110        'inF0' (temp 2-component vector of float)
+0:110        'inF1' (temp 2-component vector of float)
+0:110        Constant:
+0:110          2.000000
 0:?       bitFieldReverse (global 2-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
-0:108      roundEven (global 2-component vector of float)
-0:108        'inF0' (temp 2-component vector of float)
-0:109      inverse sqrt (global 2-component vector of float)
-0:109        'inF0' (temp 2-component vector of float)
-0:110      Sign (global 2-component vector of float)
-0:110        'inF0' (temp 2-component vector of float)
-0:111      sine (global 2-component vector of float)
-0:111        'inF0' (temp 2-component vector of float)
-0:112      hyp. sine (global 2-component vector of float)
+0:112      roundEven (global 2-component vector of float)
 0:112        'inF0' (temp 2-component vector of float)
-0:113      smoothstep (global 2-component vector of float)
+0:113      inverse sqrt (global 2-component vector of float)
 0:113        'inF0' (temp 2-component vector of float)
-0:113        'inF1' (temp 2-component vector of float)
-0:113        'inF2' (temp 2-component vector of float)
-0:114      sqrt (global 2-component vector of float)
+0:114      clamp (global 2-component vector of float)
 0:114        'inF0' (temp 2-component vector of float)
-0:115      step (global 2-component vector of float)
+0:114        Constant:
+0:114          0.000000
+0:114        Constant:
+0:114          1.000000
+0:115      Sign (global 2-component vector of float)
 0:115        'inF0' (temp 2-component vector of float)
-0:115        'inF1' (temp 2-component vector of float)
-0:116      tangent (global 2-component vector of float)
+0:116      sine (global 2-component vector of float)
 0:116        'inF0' (temp 2-component vector of float)
-0:117      hyp. tangent (global 2-component vector of float)
-0:117        'inF0' (temp 2-component vector of float)
-0:119      trunc (global 2-component vector of float)
+0:117      Sequence
+0:117        move second child to first child (temp 2-component vector of float)
+0:117          'inF1' (temp 2-component vector of float)
+0:117          sine (temp 2-component vector of float)
+0:117            'inF0' (temp 2-component vector of float)
+0:117        move second child to first child (temp 2-component vector of float)
+0:117          'inF2' (temp 2-component vector of float)
+0:117          cosine (temp 2-component vector of float)
+0:117            'inF0' (temp 2-component vector of float)
+0:118      hyp. sine (global 2-component vector of float)
+0:118        'inF0' (temp 2-component vector of float)
+0:119      smoothstep (global 2-component vector of float)
 0:119        'inF0' (temp 2-component vector of float)
-0:122      Branch: Return with expression
+0:119        'inF1' (temp 2-component vector of float)
+0:119        'inF2' (temp 2-component vector of float)
+0:120      sqrt (global 2-component vector of float)
+0:120        'inF0' (temp 2-component vector of float)
+0:121      step (global 2-component vector of float)
+0:121        'inF0' (temp 2-component vector of float)
+0:121        'inF1' (temp 2-component vector of float)
+0:122      tangent (global 2-component vector of float)
+0:122        'inF0' (temp 2-component vector of float)
+0:123      hyp. tangent (global 2-component vector of float)
+0:123        'inF0' (temp 2-component vector of float)
+0:125      trunc (global 2-component vector of float)
+0:125        'inF0' (temp 2-component vector of float)
+0:128      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
-0:189  Function Definition: VertexShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
-0:126    Function Parameters: 
-0:126      'inF0' (temp 3-component vector of float)
-0:126      'inF1' (temp 3-component vector of float)
-0:126      'inF2' (temp 3-component vector of float)
+0:198  Function Definition: VertexShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
+0:132    Function Parameters: 
+0:132      'inF0' (temp 3-component vector of float)
+0:132      'inF1' (temp 3-component vector of float)
+0:132      'inF2' (temp 3-component vector of float)
 0:?     Sequence
-0:127      all (global bool)
-0:127        'inF0' (temp 3-component vector of float)
-0:128      Absolute value (global 3-component vector of float)
-0:128        'inF0' (temp 3-component vector of float)
-0:129      arc cosine (global 3-component vector of float)
-0:129        'inF0' (temp 3-component vector of float)
-0:130      any (global bool)
-0:130        'inF0' (temp 3-component vector of float)
-0:131      arc sine (global 3-component vector of float)
-0:131        'inF0' (temp 3-component vector of float)
-0:132      arc tangent (global 3-component vector of float)
-0:132        'inF0' (temp 3-component vector of float)
-0:133      arc tangent (global 3-component vector of float)
+0:133      all (global bool)
 0:133        'inF0' (temp 3-component vector of float)
-0:133        'inF1' (temp 3-component vector of float)
-0:134      Ceiling (global 3-component vector of float)
+0:134      Absolute value (global 3-component vector of float)
 0:134        'inF0' (temp 3-component vector of float)
-0:135      clamp (global 3-component vector of float)
+0:135      arc cosine (global 3-component vector of float)
 0:135        'inF0' (temp 3-component vector of float)
-0:135        'inF1' (temp 3-component vector of float)
-0:135        'inF2' (temp 3-component vector of float)
-0:136      cosine (global 3-component vector of float)
+0:136      any (global bool)
 0:136        'inF0' (temp 3-component vector of float)
-0:137      hyp. cosine (global 3-component vector of float)
+0:137      arc sine (global 3-component vector of float)
 0:137        'inF0' (temp 3-component vector of float)
+0:138      arc tangent (global 3-component vector of float)
+0:138        'inF0' (temp 3-component vector of float)
+0:139      arc tangent (global 3-component vector of float)
+0:139        'inF0' (temp 3-component vector of float)
+0:139        'inF1' (temp 3-component vector of float)
+0:140      Ceiling (global 3-component vector of float)
+0:140        'inF0' (temp 3-component vector of float)
+0:141      clamp (global 3-component vector of float)
+0:141        'inF0' (temp 3-component vector of float)
+0:141        'inF1' (temp 3-component vector of float)
+0:141        'inF2' (temp 3-component vector of float)
+0:142      cosine (global 3-component vector of float)
+0:142        'inF0' (temp 3-component vector of float)
+0:143      hyp. cosine (global 3-component vector of float)
+0:143        'inF0' (temp 3-component vector of float)
 0:?       bitCount (global 3-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
-0:139      cross-product (global 3-component vector of float)
-0:139        'inF0' (temp 3-component vector of float)
-0:139        'inF1' (temp 3-component vector of float)
-0:140      degrees (global 3-component vector of float)
-0:140        'inF0' (temp 3-component vector of float)
-0:141      distance (global float)
-0:141        'inF0' (temp 3-component vector of float)
-0:141        'inF1' (temp 3-component vector of float)
-0:142      dot-product (global float)
-0:142        'inF0' (temp 3-component vector of float)
-0:142        'inF1' (temp 3-component vector of float)
-0:146      exp (global 3-component vector of float)
+0:145      cross-product (global 3-component vector of float)
+0:145        'inF0' (temp 3-component vector of float)
+0:145        'inF1' (temp 3-component vector of float)
+0:146      degrees (global 3-component vector of float)
 0:146        'inF0' (temp 3-component vector of float)
-0:147      exp2 (global 3-component vector of float)
+0:147      distance (global float)
 0:147        'inF0' (temp 3-component vector of float)
-0:148      face-forward (global 3-component vector of float)
+0:147        'inF1' (temp 3-component vector of float)
+0:148      dot-product (global float)
 0:148        'inF0' (temp 3-component vector of float)
 0:148        'inF1' (temp 3-component vector of float)
-0:148        'inF2' (temp 3-component vector of float)
-0:149      findMSB (global int)
-0:149        Constant:
-0:149          7 (const int)
-0:150      findLSB (global int)
-0:150        Constant:
-0:150          7 (const int)
-0:151      Floor (global 3-component vector of float)
-0:151        'inF0' (temp 3-component vector of float)
-0:153      Function Call: fmod(vf3;vf3; (global 3-component vector of float)
+0:152      exp (global 3-component vector of float)
+0:152        'inF0' (temp 3-component vector of float)
+0:153      exp2 (global 3-component vector of float)
 0:153        'inF0' (temp 3-component vector of float)
-0:153        'inF1' (temp 3-component vector of float)
-0:154      Fraction (global 3-component vector of float)
+0:154      face-forward (global 3-component vector of float)
 0:154        'inF0' (temp 3-component vector of float)
-0:155      frexp (global 3-component vector of float)
-0:155        'inF0' (temp 3-component vector of float)
-0:155        'inF1' (temp 3-component vector of float)
-0:156      fwidth (global 3-component vector of float)
-0:156        'inF0' (temp 3-component vector of float)
-0:157      isinf (global 3-component vector of bool)
+0:154        'inF1' (temp 3-component vector of float)
+0:154        'inF2' (temp 3-component vector of float)
+0:155      findMSB (global int)
+0:155        Constant:
+0:155          7 (const int)
+0:156      findLSB (global int)
+0:156        Constant:
+0:156          7 (const int)
+0:157      Floor (global 3-component vector of float)
 0:157        'inF0' (temp 3-component vector of float)
-0:158      isnan (global 3-component vector of bool)
-0:158        'inF0' (temp 3-component vector of float)
-0:159      ldexp (global 3-component vector of float)
+0:159      mod (global 3-component vector of float)
 0:159        'inF0' (temp 3-component vector of float)
 0:159        'inF1' (temp 3-component vector of float)
-0:160      length (global float)
+0:160      Fraction (global 3-component vector of float)
 0:160        'inF0' (temp 3-component vector of float)
-0:161      log (global 3-component vector of float)
+0:161      frexp (global 3-component vector of float)
 0:161        'inF0' (temp 3-component vector of float)
-0:162      log2 (global 3-component vector of float)
+0:161        'inF1' (temp 3-component vector of float)
+0:162      fwidth (global 3-component vector of float)
 0:162        'inF0' (temp 3-component vector of float)
-0:163      max (global 3-component vector of float)
+0:163      isinf (global 3-component vector of bool)
 0:163        'inF0' (temp 3-component vector of float)
-0:163        'inF1' (temp 3-component vector of float)
-0:164      min (global 3-component vector of float)
+0:164      isnan (global 3-component vector of bool)
 0:164        'inF0' (temp 3-component vector of float)
-0:164        'inF1' (temp 3-component vector of float)
-0:166      normalize (global 3-component vector of float)
+0:165      ldexp (global 3-component vector of float)
+0:165        'inF0' (temp 3-component vector of float)
+0:165        'inF1' (temp 3-component vector of float)
+0:166      length (global float)
 0:166        'inF0' (temp 3-component vector of float)
-0:167      pow (global 3-component vector of float)
+0:167      log (global 3-component vector of float)
 0:167        'inF0' (temp 3-component vector of float)
-0:167        'inF1' (temp 3-component vector of float)
-0:168      radians (global 3-component vector of float)
-0:168        'inF0' (temp 3-component vector of float)
-0:169      reflect (global 3-component vector of float)
+0:168      component-wise multiply (global 3-component vector of float)
+0:168        log2 (global 3-component vector of float)
+0:168          'inF0' (temp 3-component vector of float)
+0:168        Constant:
+0:168          0.301030
+0:169      log2 (global 3-component vector of float)
 0:169        'inF0' (temp 3-component vector of float)
-0:169        'inF1' (temp 3-component vector of float)
-0:170      refract (global 3-component vector of float)
+0:170      max (global 3-component vector of float)
 0:170        'inF0' (temp 3-component vector of float)
 0:170        'inF1' (temp 3-component vector of float)
-0:170        Constant:
-0:170          2.000000
+0:171      min (global 3-component vector of float)
+0:171        'inF0' (temp 3-component vector of float)
+0:171        'inF1' (temp 3-component vector of float)
+0:173      normalize (global 3-component vector of float)
+0:173        'inF0' (temp 3-component vector of float)
+0:174      pow (global 3-component vector of float)
+0:174        'inF0' (temp 3-component vector of float)
+0:174        'inF1' (temp 3-component vector of float)
+0:175      radians (global 3-component vector of float)
+0:175        'inF0' (temp 3-component vector of float)
+0:176      reflect (global 3-component vector of float)
+0:176        'inF0' (temp 3-component vector of float)
+0:176        'inF1' (temp 3-component vector of float)
+0:177      refract (global 3-component vector of float)
+0:177        'inF0' (temp 3-component vector of float)
+0:177        'inF1' (temp 3-component vector of float)
+0:177        Constant:
+0:177          2.000000
 0:?       bitFieldReverse (global 3-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
-0:172      roundEven (global 3-component vector of float)
-0:172        'inF0' (temp 3-component vector of float)
-0:173      inverse sqrt (global 3-component vector of float)
-0:173        'inF0' (temp 3-component vector of float)
-0:174      Sign (global 3-component vector of float)
-0:174        'inF0' (temp 3-component vector of float)
-0:175      sine (global 3-component vector of float)
-0:175        'inF0' (temp 3-component vector of float)
-0:176      hyp. sine (global 3-component vector of float)
-0:176        'inF0' (temp 3-component vector of float)
-0:177      smoothstep (global 3-component vector of float)
-0:177        'inF0' (temp 3-component vector of float)
-0:177        'inF1' (temp 3-component vector of float)
-0:177        'inF2' (temp 3-component vector of float)
-0:178      sqrt (global 3-component vector of float)
-0:178        'inF0' (temp 3-component vector of float)
-0:179      step (global 3-component vector of float)
+0:179      roundEven (global 3-component vector of float)
 0:179        'inF0' (temp 3-component vector of float)
-0:179        'inF1' (temp 3-component vector of float)
-0:180      tangent (global 3-component vector of float)
+0:180      inverse sqrt (global 3-component vector of float)
 0:180        'inF0' (temp 3-component vector of float)
-0:181      hyp. tangent (global 3-component vector of float)
+0:181      clamp (global 3-component vector of float)
 0:181        'inF0' (temp 3-component vector of float)
-0:183      trunc (global 3-component vector of float)
+0:181        Constant:
+0:181          0.000000
+0:181        Constant:
+0:181          1.000000
+0:182      Sign (global 3-component vector of float)
+0:182        'inF0' (temp 3-component vector of float)
+0:183      sine (global 3-component vector of float)
 0:183        'inF0' (temp 3-component vector of float)
-0:186      Branch: Return with expression
+0:184      Sequence
+0:184        move second child to first child (temp 3-component vector of float)
+0:184          'inF1' (temp 3-component vector of float)
+0:184          sine (temp 3-component vector of float)
+0:184            'inF0' (temp 3-component vector of float)
+0:184        move second child to first child (temp 3-component vector of float)
+0:184          'inF2' (temp 3-component vector of float)
+0:184          cosine (temp 3-component vector of float)
+0:184            'inF0' (temp 3-component vector of float)
+0:185      hyp. sine (global 3-component vector of float)
+0:185        'inF0' (temp 3-component vector of float)
+0:186      smoothstep (global 3-component vector of float)
+0:186        'inF0' (temp 3-component vector of float)
+0:186        'inF1' (temp 3-component vector of float)
+0:186        'inF2' (temp 3-component vector of float)
+0:187      sqrt (global 3-component vector of float)
+0:187        'inF0' (temp 3-component vector of float)
+0:188      step (global 3-component vector of float)
+0:188        'inF0' (temp 3-component vector of float)
+0:188        'inF1' (temp 3-component vector of float)
+0:189      tangent (global 3-component vector of float)
+0:189        'inF0' (temp 3-component vector of float)
+0:190      hyp. tangent (global 3-component vector of float)
+0:190        'inF0' (temp 3-component vector of float)
+0:192      trunc (global 3-component vector of float)
+0:192        'inF0' (temp 3-component vector of float)
+0:195      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
-0:298  Function Definition: VertexShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
-0:190    Function Parameters: 
-0:190      'inF0' (temp 4-component vector of float)
-0:190      'inF1' (temp 4-component vector of float)
-0:190      'inF2' (temp 4-component vector of float)
+0:313  Function Definition: VertexShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
+0:199    Function Parameters: 
+0:199      'inF0' (temp 4-component vector of float)
+0:199      'inF1' (temp 4-component vector of float)
+0:199      'inF2' (temp 4-component vector of float)
 0:?     Sequence
-0:191      all (global bool)
-0:191        'inF0' (temp 4-component vector of float)
-0:192      Absolute value (global 4-component vector of float)
-0:192        'inF0' (temp 4-component vector of float)
-0:193      arc cosine (global 4-component vector of float)
-0:193        'inF0' (temp 4-component vector of float)
-0:194      any (global bool)
-0:194        'inF0' (temp 4-component vector of float)
-0:195      arc sine (global 4-component vector of float)
-0:195        'inF0' (temp 4-component vector of float)
-0:196      arc tangent (global 4-component vector of float)
-0:196        'inF0' (temp 4-component vector of float)
-0:197      arc tangent (global 4-component vector of float)
-0:197        'inF0' (temp 4-component vector of float)
-0:197        'inF1' (temp 4-component vector of float)
-0:198      Ceiling (global 4-component vector of float)
-0:198        'inF0' (temp 4-component vector of float)
-0:199      clamp (global 4-component vector of float)
-0:199        'inF0' (temp 4-component vector of float)
-0:199        'inF1' (temp 4-component vector of float)
-0:199        'inF2' (temp 4-component vector of float)
-0:200      cosine (global 4-component vector of float)
+0:200      all (global bool)
 0:200        'inF0' (temp 4-component vector of float)
-0:201      hyp. cosine (global 4-component vector of float)
+0:201      Absolute value (global 4-component vector of float)
 0:201        'inF0' (temp 4-component vector of float)
+0:202      arc cosine (global 4-component vector of float)
+0:202        'inF0' (temp 4-component vector of float)
+0:203      any (global bool)
+0:203        'inF0' (temp 4-component vector of float)
+0:204      arc sine (global 4-component vector of float)
+0:204        'inF0' (temp 4-component vector of float)
+0:205      arc tangent (global 4-component vector of float)
+0:205        'inF0' (temp 4-component vector of float)
+0:206      arc tangent (global 4-component vector of float)
+0:206        'inF0' (temp 4-component vector of float)
+0:206        'inF1' (temp 4-component vector of float)
+0:207      Ceiling (global 4-component vector of float)
+0:207        'inF0' (temp 4-component vector of float)
+0:208      clamp (global 4-component vector of float)
+0:208        'inF0' (temp 4-component vector of float)
+0:208        'inF1' (temp 4-component vector of float)
+0:208        'inF2' (temp 4-component vector of float)
+0:209      cosine (global 4-component vector of float)
+0:209        'inF0' (temp 4-component vector of float)
+0:210      hyp. cosine (global 4-component vector of float)
+0:210        'inF0' (temp 4-component vector of float)
 0:?       bitCount (global 4-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
 0:?           2 (const uint)
-0:203      degrees (global 4-component vector of float)
-0:203        'inF0' (temp 4-component vector of float)
-0:204      distance (global float)
-0:204        'inF0' (temp 4-component vector of float)
-0:204        'inF1' (temp 4-component vector of float)
-0:205      dot-product (global float)
-0:205        'inF0' (temp 4-component vector of float)
-0:205        'inF1' (temp 4-component vector of float)
-0:209      exp (global 4-component vector of float)
-0:209        'inF0' (temp 4-component vector of float)
-0:210      exp2 (global 4-component vector of float)
-0:210        'inF0' (temp 4-component vector of float)
-0:211      face-forward (global 4-component vector of float)
-0:211        'inF0' (temp 4-component vector of float)
-0:211        'inF1' (temp 4-component vector of float)
-0:211        'inF2' (temp 4-component vector of float)
-0:212      findMSB (global int)
-0:212        Constant:
-0:212          7 (const int)
-0:213      findLSB (global int)
-0:213        Constant:
-0:213          7 (const int)
-0:214      Floor (global 4-component vector of float)
+0:212      degrees (global 4-component vector of float)
+0:212        'inF0' (temp 4-component vector of float)
+0:213      distance (global float)
+0:213        'inF0' (temp 4-component vector of float)
+0:213        'inF1' (temp 4-component vector of float)
+0:214      dot-product (global float)
 0:214        'inF0' (temp 4-component vector of float)
-0:216      Function Call: fmod(vf4;vf4; (global 4-component vector of float)
-0:216        'inF0' (temp 4-component vector of float)
-0:216        'inF1' (temp 4-component vector of float)
-0:217      Fraction (global 4-component vector of float)
-0:217        'inF0' (temp 4-component vector of float)
-0:218      frexp (global 4-component vector of float)
+0:214        'inF1' (temp 4-component vector of float)
+0:218      exp (global 4-component vector of float)
 0:218        'inF0' (temp 4-component vector of float)
-0:218        'inF1' (temp 4-component vector of float)
-0:219      fwidth (global 4-component vector of float)
+0:219      exp2 (global 4-component vector of float)
 0:219        'inF0' (temp 4-component vector of float)
-0:220      isinf (global 4-component vector of bool)
+0:220      face-forward (global 4-component vector of float)
 0:220        'inF0' (temp 4-component vector of float)
-0:221      isnan (global 4-component vector of bool)
-0:221        'inF0' (temp 4-component vector of float)
-0:222      ldexp (global 4-component vector of float)
-0:222        'inF0' (temp 4-component vector of float)
-0:222        'inF1' (temp 4-component vector of float)
-0:223      length (global float)
+0:220        'inF1' (temp 4-component vector of float)
+0:220        'inF2' (temp 4-component vector of float)
+0:221      findMSB (global int)
+0:221        Constant:
+0:221          7 (const int)
+0:222      findLSB (global int)
+0:222        Constant:
+0:222          7 (const int)
+0:223      Floor (global 4-component vector of float)
 0:223        'inF0' (temp 4-component vector of float)
-0:224      log (global 4-component vector of float)
-0:224        'inF0' (temp 4-component vector of float)
-0:225      log2 (global 4-component vector of float)
+0:225      mod (global 4-component vector of float)
 0:225        'inF0' (temp 4-component vector of float)
-0:226      max (global 4-component vector of float)
+0:225        'inF1' (temp 4-component vector of float)
+0:226      Fraction (global 4-component vector of float)
 0:226        'inF0' (temp 4-component vector of float)
-0:226        'inF1' (temp 4-component vector of float)
-0:227      min (global 4-component vector of float)
+0:227      frexp (global 4-component vector of float)
 0:227        'inF0' (temp 4-component vector of float)
 0:227        'inF1' (temp 4-component vector of float)
-0:229      normalize (global 4-component vector of float)
+0:228      fwidth (global 4-component vector of float)
+0:228        'inF0' (temp 4-component vector of float)
+0:229      isinf (global 4-component vector of bool)
 0:229        'inF0' (temp 4-component vector of float)
-0:230      pow (global 4-component vector of float)
+0:230      isnan (global 4-component vector of bool)
 0:230        'inF0' (temp 4-component vector of float)
-0:230        'inF1' (temp 4-component vector of float)
-0:231      radians (global 4-component vector of float)
+0:231      ldexp (global 4-component vector of float)
 0:231        'inF0' (temp 4-component vector of float)
-0:232      reflect (global 4-component vector of float)
+0:231        'inF1' (temp 4-component vector of float)
+0:232      length (global float)
 0:232        'inF0' (temp 4-component vector of float)
-0:232        'inF1' (temp 4-component vector of float)
-0:233      refract (global 4-component vector of float)
+0:233      log (global 4-component vector of float)
 0:233        'inF0' (temp 4-component vector of float)
-0:233        'inF1' (temp 4-component vector of float)
-0:233        Constant:
-0:233          2.000000
+0:234      component-wise multiply (global 4-component vector of float)
+0:234        log2 (global 4-component vector of float)
+0:234          'inF0' (temp 4-component vector of float)
+0:234        Constant:
+0:234          0.301030
+0:235      log2 (global 4-component vector of float)
+0:235        'inF0' (temp 4-component vector of float)
+0:236      max (global 4-component vector of float)
+0:236        'inF0' (temp 4-component vector of float)
+0:236        'inF1' (temp 4-component vector of float)
+0:237      min (global 4-component vector of float)
+0:237        'inF0' (temp 4-component vector of float)
+0:237        'inF1' (temp 4-component vector of float)
+0:239      normalize (global 4-component vector of float)
+0:239        'inF0' (temp 4-component vector of float)
+0:240      pow (global 4-component vector of float)
+0:240        'inF0' (temp 4-component vector of float)
+0:240        'inF1' (temp 4-component vector of float)
+0:241      radians (global 4-component vector of float)
+0:241        'inF0' (temp 4-component vector of float)
+0:242      reflect (global 4-component vector of float)
+0:242        'inF0' (temp 4-component vector of float)
+0:242        'inF1' (temp 4-component vector of float)
+0:243      refract (global 4-component vector of float)
+0:243        'inF0' (temp 4-component vector of float)
+0:243        'inF1' (temp 4-component vector of float)
+0:243        Constant:
+0:243          2.000000
 0:?       bitFieldReverse (global 4-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
 0:?           4 (const uint)
-0:235      roundEven (global 4-component vector of float)
-0:235        'inF0' (temp 4-component vector of float)
-0:236      inverse sqrt (global 4-component vector of float)
-0:236        'inF0' (temp 4-component vector of float)
-0:237      Sign (global 4-component vector of float)
-0:237        'inF0' (temp 4-component vector of float)
-0:238      sine (global 4-component vector of float)
-0:238        'inF0' (temp 4-component vector of float)
-0:239      hyp. sine (global 4-component vector of float)
-0:239        'inF0' (temp 4-component vector of float)
-0:240      smoothstep (global 4-component vector of float)
-0:240        'inF0' (temp 4-component vector of float)
-0:240        'inF1' (temp 4-component vector of float)
-0:240        'inF2' (temp 4-component vector of float)
-0:241      sqrt (global 4-component vector of float)
-0:241        'inF0' (temp 4-component vector of float)
-0:242      step (global 4-component vector of float)
-0:242        'inF0' (temp 4-component vector of float)
-0:242        'inF1' (temp 4-component vector of float)
-0:243      tangent (global 4-component vector of float)
-0:243        'inF0' (temp 4-component vector of float)
-0:244      hyp. tangent (global 4-component vector of float)
-0:244        'inF0' (temp 4-component vector of float)
-0:246      trunc (global 4-component vector of float)
+0:245      roundEven (global 4-component vector of float)
+0:245        'inF0' (temp 4-component vector of float)
+0:246      inverse sqrt (global 4-component vector of float)
 0:246        'inF0' (temp 4-component vector of float)
-0:249      Branch: Return with expression
+0:247      clamp (global 4-component vector of float)
+0:247        'inF0' (temp 4-component vector of float)
+0:247        Constant:
+0:247          0.000000
+0:247        Constant:
+0:247          1.000000
+0:248      Sign (global 4-component vector of float)
+0:248        'inF0' (temp 4-component vector of float)
+0:249      sine (global 4-component vector of float)
+0:249        'inF0' (temp 4-component vector of float)
+0:250      Sequence
+0:250        move second child to first child (temp 4-component vector of float)
+0:250          'inF1' (temp 4-component vector of float)
+0:250          sine (temp 4-component vector of float)
+0:250            'inF0' (temp 4-component vector of float)
+0:250        move second child to first child (temp 4-component vector of float)
+0:250          'inF2' (temp 4-component vector of float)
+0:250          cosine (temp 4-component vector of float)
+0:250            'inF0' (temp 4-component vector of float)
+0:251      hyp. sine (global 4-component vector of float)
+0:251        'inF0' (temp 4-component vector of float)
+0:252      smoothstep (global 4-component vector of float)
+0:252        'inF0' (temp 4-component vector of float)
+0:252        'inF1' (temp 4-component vector of float)
+0:252        'inF2' (temp 4-component vector of float)
+0:253      sqrt (global 4-component vector of float)
+0:253        'inF0' (temp 4-component vector of float)
+0:254      step (global 4-component vector of float)
+0:254        'inF0' (temp 4-component vector of float)
+0:254        'inF1' (temp 4-component vector of float)
+0:255      tangent (global 4-component vector of float)
+0:255        'inF0' (temp 4-component vector of float)
+0:256      hyp. tangent (global 4-component vector of float)
+0:256        'inF0' (temp 4-component vector of float)
+0:258      trunc (global 4-component vector of float)
+0:258        'inF0' (temp 4-component vector of float)
+0:261      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
 0:?           4.000000
-0:307  Function Definition: VertexShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
-0:299    Function Parameters: 
-0:299      'inF0' (temp 2X2 matrix of float)
-0:299      'inF1' (temp 2X2 matrix of float)
-0:299      'inF2' (temp 2X2 matrix of float)
+0:322  Function Definition: VertexShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:314    Function Parameters: 
+0:314      'inF0' (temp 2X2 matrix of float)
+0:314      'inF1' (temp 2X2 matrix of float)
+0:314      'inF2' (temp 2X2 matrix of float)
 0:?     Sequence
-0:301      all (global bool)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      Absolute value (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc cosine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      any (global bool)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc sine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      Ceiling (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      clamp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301        'inF2' (temp 2X2 matrix of float)
-0:301      cosine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      hyp. cosine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      degrees (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      determinant (global float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      exp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      exp2 (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      findMSB (global int)
-0:301        Constant:
-0:301          7 (const int)
-0:301      findLSB (global int)
-0:301        Constant:
-0:301          7 (const int)
-0:301      Floor (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      Function Call: fmod(mf22;mf22; (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      Fraction (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      frexp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      fwidth (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      ldexp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      log (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      log2 (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      max (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      min (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      pow (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      radians (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      roundEven (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      inverse sqrt (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      Sign (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      sine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      hyp. sine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      smoothstep (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301        'inF2' (temp 2X2 matrix of float)
-0:301      sqrt (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      step (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      hyp. tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      transpose (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      trunc (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:304      Branch: Return with expression
+0:316      all (global bool)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      Absolute value (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      arc cosine (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      any (global bool)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      arc sine (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      arc tangent (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      arc tangent (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      Ceiling (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      clamp (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316        'inF2' (temp 2X2 matrix of float)
+0:316      cosine (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      hyp. cosine (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      degrees (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      determinant (global float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      exp (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      exp2 (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      findMSB (global int)
+0:316        Constant:
+0:316          7 (const int)
+0:316      findLSB (global int)
+0:316        Constant:
+0:316          7 (const int)
+0:316      Floor (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      mod (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      Fraction (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      frexp (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      fwidth (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      ldexp (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      log (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      component-wise multiply (global 2X2 matrix of float)
+0:316        log2 (global 2X2 matrix of float)
+0:316          'inF0' (temp 2X2 matrix of float)
+0:316        Constant:
+0:316          0.301030
+0:316      log2 (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      max (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      min (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      pow (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      radians (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      roundEven (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      inverse sqrt (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      clamp (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        Constant:
+0:316          0.000000
+0:316        Constant:
+0:316          1.000000
+0:316      Sign (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      sine (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      Sequence
+0:316        move second child to first child (temp 2X2 matrix of float)
+0:316          'inF1' (temp 2X2 matrix of float)
+0:316          sine (temp 2X2 matrix of float)
+0:316            'inF0' (temp 2X2 matrix of float)
+0:316        move second child to first child (temp 2X2 matrix of float)
+0:316          'inF2' (temp 2X2 matrix of float)
+0:316          cosine (temp 2X2 matrix of float)
+0:316            'inF0' (temp 2X2 matrix of float)
+0:316      hyp. sine (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      smoothstep (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316        'inF2' (temp 2X2 matrix of float)
+0:316      sqrt (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      step (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316        'inF1' (temp 2X2 matrix of float)
+0:316      tangent (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      hyp. tangent (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      transpose (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:316      trunc (global 2X2 matrix of float)
+0:316        'inF0' (temp 2X2 matrix of float)
+0:319      Branch: Return with expression
 0:?         Constant:
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
-0:316  Function Definition: VertexShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
-0:308    Function Parameters: 
-0:308      'inF0' (temp 3X3 matrix of float)
-0:308      'inF1' (temp 3X3 matrix of float)
-0:308      'inF2' (temp 3X3 matrix of float)
+0:331  Function Definition: VertexShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:323    Function Parameters: 
+0:323      'inF0' (temp 3X3 matrix of float)
+0:323      'inF1' (temp 3X3 matrix of float)
+0:323      'inF2' (temp 3X3 matrix of float)
 0:?     Sequence
-0:310      all (global bool)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      Absolute value (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc cosine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      any (global bool)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc sine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      Ceiling (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      clamp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310        'inF2' (temp 3X3 matrix of float)
-0:310      cosine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      hyp. cosine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      degrees (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      determinant (global float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      exp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      exp2 (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      findMSB (global int)
-0:310        Constant:
-0:310          7 (const int)
-0:310      findLSB (global int)
-0:310        Constant:
-0:310          7 (const int)
-0:310      Floor (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      Function Call: fmod(mf33;mf33; (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      Fraction (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      frexp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      fwidth (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      ldexp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      log (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      log2 (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      max (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      min (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      pow (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      radians (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      roundEven (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      inverse sqrt (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      Sign (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      sine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      hyp. sine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      smoothstep (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310        'inF2' (temp 3X3 matrix of float)
-0:310      sqrt (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      step (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      hyp. tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      transpose (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      trunc (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:313      Branch: Return with expression
+0:325      all (global bool)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      Absolute value (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      arc cosine (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      any (global bool)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      arc sine (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      arc tangent (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      arc tangent (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      Ceiling (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      clamp (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325        'inF2' (temp 3X3 matrix of float)
+0:325      cosine (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      hyp. cosine (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      degrees (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      determinant (global float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      exp (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      exp2 (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      findMSB (global int)
+0:325        Constant:
+0:325          7 (const int)
+0:325      findLSB (global int)
+0:325        Constant:
+0:325          7 (const int)
+0:325      Floor (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      mod (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      Fraction (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      frexp (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      fwidth (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      ldexp (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      log (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      component-wise multiply (global 3X3 matrix of float)
+0:325        log2 (global 3X3 matrix of float)
+0:325          'inF0' (temp 3X3 matrix of float)
+0:325        Constant:
+0:325          0.301030
+0:325      log2 (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      max (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      min (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      pow (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      radians (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      roundEven (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      inverse sqrt (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      clamp (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        Constant:
+0:325          0.000000
+0:325        Constant:
+0:325          1.000000
+0:325      Sign (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      sine (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      Sequence
+0:325        move second child to first child (temp 3X3 matrix of float)
+0:325          'inF1' (temp 3X3 matrix of float)
+0:325          sine (temp 3X3 matrix of float)
+0:325            'inF0' (temp 3X3 matrix of float)
+0:325        move second child to first child (temp 3X3 matrix of float)
+0:325          'inF2' (temp 3X3 matrix of float)
+0:325          cosine (temp 3X3 matrix of float)
+0:325            'inF0' (temp 3X3 matrix of float)
+0:325      hyp. sine (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      smoothstep (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325        'inF2' (temp 3X3 matrix of float)
+0:325      sqrt (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      step (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325        'inF1' (temp 3X3 matrix of float)
+0:325      tangent (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      hyp. tangent (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      transpose (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:325      trunc (global 3X3 matrix of float)
+0:325        'inF0' (temp 3X3 matrix of float)
+0:328      Branch: Return with expression
 0:?         Constant:
 0:?           3.000000
 0:?           3.000000
@@ -1651,109 +2073,129 @@ Shader version: 450
 0:?           3.000000
 0:?           3.000000
 0:?           3.000000
-0:324  Function Definition: VertexShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
-0:317    Function Parameters: 
-0:317      'inF0' (temp 4X4 matrix of float)
-0:317      'inF1' (temp 4X4 matrix of float)
-0:317      'inF2' (temp 4X4 matrix of float)
+0:352  Function Definition: VertexShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:332    Function Parameters: 
+0:332      'inF0' (temp 4X4 matrix of float)
+0:332      'inF1' (temp 4X4 matrix of float)
+0:332      'inF2' (temp 4X4 matrix of float)
 0:?     Sequence
-0:319      all (global bool)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      Absolute value (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc cosine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      any (global bool)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc sine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      Ceiling (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      clamp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319        'inF2' (temp 4X4 matrix of float)
-0:319      cosine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      hyp. cosine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      degrees (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      determinant (global float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      exp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      exp2 (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      findMSB (global int)
-0:319        Constant:
-0:319          7 (const int)
-0:319      findLSB (global int)
-0:319        Constant:
-0:319          7 (const int)
-0:319      Floor (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      Function Call: fmod(mf44;mf44; (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      Fraction (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      frexp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      fwidth (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      ldexp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      log (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      log2 (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      max (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      min (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      pow (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      radians (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      roundEven (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      inverse sqrt (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      Sign (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      sine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      hyp. sine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      smoothstep (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319        'inF2' (temp 4X4 matrix of float)
-0:319      sqrt (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      step (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      hyp. tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      transpose (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      trunc (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:322      Branch: Return with expression
+0:334      all (global bool)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      Absolute value (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      arc cosine (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      any (global bool)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      arc sine (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      arc tangent (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      arc tangent (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      Ceiling (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      clamp (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334        'inF2' (temp 4X4 matrix of float)
+0:334      cosine (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      hyp. cosine (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      degrees (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      determinant (global float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      exp (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      exp2 (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      findMSB (global int)
+0:334        Constant:
+0:334          7 (const int)
+0:334      findLSB (global int)
+0:334        Constant:
+0:334          7 (const int)
+0:334      Floor (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      mod (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      Fraction (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      frexp (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      fwidth (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      ldexp (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      log (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      component-wise multiply (global 4X4 matrix of float)
+0:334        log2 (global 4X4 matrix of float)
+0:334          'inF0' (temp 4X4 matrix of float)
+0:334        Constant:
+0:334          0.301030
+0:334      log2 (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      max (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      min (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      pow (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      radians (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      roundEven (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      inverse sqrt (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      clamp (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        Constant:
+0:334          0.000000
+0:334        Constant:
+0:334          1.000000
+0:334      Sign (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      sine (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      Sequence
+0:334        move second child to first child (temp 4X4 matrix of float)
+0:334          'inF1' (temp 4X4 matrix of float)
+0:334          sine (temp 4X4 matrix of float)
+0:334            'inF0' (temp 4X4 matrix of float)
+0:334        move second child to first child (temp 4X4 matrix of float)
+0:334          'inF2' (temp 4X4 matrix of float)
+0:334          cosine (temp 4X4 matrix of float)
+0:334            'inF0' (temp 4X4 matrix of float)
+0:334      hyp. sine (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      smoothstep (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334        'inF2' (temp 4X4 matrix of float)
+0:334      sqrt (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      step (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334        'inF1' (temp 4X4 matrix of float)
+0:334      tangent (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      hyp. tangent (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      transpose (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:334      trunc (global 4X4 matrix of float)
+0:334        'inF0' (temp 4X4 matrix of float)
+0:337      Branch: Return with expression
 0:?         Constant:
 0:?           4.000000
 0:?           4.000000
@@ -1771,12 +2213,173 @@ Shader version: 450
 0:?           4.000000
 0:?           4.000000
 0:?           4.000000
+0:359  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
+0:355    Function Parameters: 
+0:355      'inF0' (temp float)
+0:355      'inF1' (temp float)
+0:355      'inFV0' (temp 2-component vector of float)
+0:355      'inFV1' (temp 2-component vector of float)
+0:355      'inFM0' (temp 2X2 matrix of float)
+0:355      'inFM1' (temp 2X2 matrix of float)
+0:?     Sequence
+0:356      move second child to first child (temp float)
+0:356        'r0' (temp float)
+0:356        component-wise multiply (global float)
+0:356          'inF0' (temp float)
+0:356          'inF1' (temp float)
+0:356      move second child to first child (temp 2-component vector of float)
+0:356        'r1' (temp 2-component vector of float)
+0:356        vector-scale (global 2-component vector of float)
+0:356          'inFV0' (temp 2-component vector of float)
+0:356          'inF0' (temp float)
+0:356      move second child to first child (temp 2-component vector of float)
+0:356        'r2' (temp 2-component vector of float)
+0:356        vector-scale (global 2-component vector of float)
+0:356          'inFV0' (temp 2-component vector of float)
+0:356          'inF0' (temp float)
+0:356      move second child to first child (temp float)
+0:356        'r3' (temp float)
+0:356        dot-product (global float)
+0:356          'inFV0' (temp 2-component vector of float)
+0:356          'inFV1' (temp 2-component vector of float)
+0:356      move second child to first child (temp 2-component vector of float)
+0:356        'r4' (temp 2-component vector of float)
+0:356        matrix-times-vector (global 2-component vector of float)
+0:356          'inFM0' (temp 2X2 matrix of float)
+0:356          'inFV0' (temp 2-component vector of float)
+0:356      move second child to first child (temp 2-component vector of float)
+0:356        'r5' (temp 2-component vector of float)
+0:356        vector-times-matrix (global 2-component vector of float)
+0:356          'inFV0' (temp 2-component vector of float)
+0:356          'inFM0' (temp 2X2 matrix of float)
+0:356      move second child to first child (temp 2X2 matrix of float)
+0:356        'r6' (temp 2X2 matrix of float)
+0:356        matrix-scale (global 2X2 matrix of float)
+0:356          'inFM0' (temp 2X2 matrix of float)
+0:356          'inF0' (temp float)
+0:356      move second child to first child (temp 2X2 matrix of float)
+0:356        'r7' (temp 2X2 matrix of float)
+0:356        matrix-scale (global 2X2 matrix of float)
+0:356          'inFM0' (temp 2X2 matrix of float)
+0:356          'inF0' (temp float)
+0:356      move second child to first child (temp 2X2 matrix of float)
+0:356        'r8' (temp 2X2 matrix of float)
+0:356        matrix-multiply (global 2X2 matrix of float)
+0:356          'inFM0' (temp 2X2 matrix of float)
+0:356          'inFM1' (temp 2X2 matrix of float)
+0:366  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
+0:362    Function Parameters: 
+0:362      'inF0' (temp float)
+0:362      'inF1' (temp float)
+0:362      'inFV0' (temp 3-component vector of float)
+0:362      'inFV1' (temp 3-component vector of float)
+0:362      'inFM0' (temp 3X3 matrix of float)
+0:362      'inFM1' (temp 3X3 matrix of float)
+0:?     Sequence
+0:363      move second child to first child (temp float)
+0:363        'r0' (temp float)
+0:363        component-wise multiply (global float)
+0:363          'inF0' (temp float)
+0:363          'inF1' (temp float)
+0:363      move second child to first child (temp 3-component vector of float)
+0:363        'r1' (temp 3-component vector of float)
+0:363        vector-scale (global 3-component vector of float)
+0:363          'inFV0' (temp 3-component vector of float)
+0:363          'inF0' (temp float)
+0:363      move second child to first child (temp 3-component vector of float)
+0:363        'r2' (temp 3-component vector of float)
+0:363        vector-scale (global 3-component vector of float)
+0:363          'inFV0' (temp 3-component vector of float)
+0:363          'inF0' (temp float)
+0:363      move second child to first child (temp float)
+0:363        'r3' (temp float)
+0:363        dot-product (global float)
+0:363          'inFV0' (temp 3-component vector of float)
+0:363          'inFV1' (temp 3-component vector of float)
+0:363      move second child to first child (temp 3-component vector of float)
+0:363        'r4' (temp 3-component vector of float)
+0:363        matrix-times-vector (global 3-component vector of float)
+0:363          'inFM0' (temp 3X3 matrix of float)
+0:363          'inFV0' (temp 3-component vector of float)
+0:363      move second child to first child (temp 3-component vector of float)
+0:363        'r5' (temp 3-component vector of float)
+0:363        vector-times-matrix (global 3-component vector of float)
+0:363          'inFV0' (temp 3-component vector of float)
+0:363          'inFM0' (temp 3X3 matrix of float)
+0:363      move second child to first child (temp 3X3 matrix of float)
+0:363        'r6' (temp 3X3 matrix of float)
+0:363        matrix-scale (global 3X3 matrix of float)
+0:363          'inFM0' (temp 3X3 matrix of float)
+0:363          'inF0' (temp float)
+0:363      move second child to first child (temp 3X3 matrix of float)
+0:363        'r7' (temp 3X3 matrix of float)
+0:363        matrix-scale (global 3X3 matrix of float)
+0:363          'inFM0' (temp 3X3 matrix of float)
+0:363          'inF0' (temp float)
+0:363      move second child to first child (temp 3X3 matrix of float)
+0:363        'r8' (temp 3X3 matrix of float)
+0:363        matrix-multiply (global 3X3 matrix of float)
+0:363          'inFM0' (temp 3X3 matrix of float)
+0:363          'inFM1' (temp 3X3 matrix of float)
+0:372  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
+0:369    Function Parameters: 
+0:369      'inF0' (temp float)
+0:369      'inF1' (temp float)
+0:369      'inFV0' (temp 4-component vector of float)
+0:369      'inFV1' (temp 4-component vector of float)
+0:369      'inFM0' (temp 4X4 matrix of float)
+0:369      'inFM1' (temp 4X4 matrix of float)
+0:?     Sequence
+0:370      move second child to first child (temp float)
+0:370        'r0' (temp float)
+0:370        component-wise multiply (global float)
+0:370          'inF0' (temp float)
+0:370          'inF1' (temp float)
+0:370      move second child to first child (temp 4-component vector of float)
+0:370        'r1' (temp 4-component vector of float)
+0:370        vector-scale (global 4-component vector of float)
+0:370          'inFV0' (temp 4-component vector of float)
+0:370          'inF0' (temp float)
+0:370      move second child to first child (temp 4-component vector of float)
+0:370        'r2' (temp 4-component vector of float)
+0:370        vector-scale (global 4-component vector of float)
+0:370          'inFV0' (temp 4-component vector of float)
+0:370          'inF0' (temp float)
+0:370      move second child to first child (temp float)
+0:370        'r3' (temp float)
+0:370        dot-product (global float)
+0:370          'inFV0' (temp 4-component vector of float)
+0:370          'inFV1' (temp 4-component vector of float)
+0:370      move second child to first child (temp 4-component vector of float)
+0:370        'r4' (temp 4-component vector of float)
+0:370        matrix-times-vector (global 4-component vector of float)
+0:370          'inFM0' (temp 4X4 matrix of float)
+0:370          'inFV0' (temp 4-component vector of float)
+0:370      move second child to first child (temp 4-component vector of float)
+0:370        'r5' (temp 4-component vector of float)
+0:370        vector-times-matrix (global 4-component vector of float)
+0:370          'inFV0' (temp 4-component vector of float)
+0:370          'inFM0' (temp 4X4 matrix of float)
+0:370      move second child to first child (temp 4X4 matrix of float)
+0:370        'r6' (temp 4X4 matrix of float)
+0:370        matrix-scale (global 4X4 matrix of float)
+0:370          'inFM0' (temp 4X4 matrix of float)
+0:370          'inF0' (temp float)
+0:370      move second child to first child (temp 4X4 matrix of float)
+0:370        'r7' (temp 4X4 matrix of float)
+0:370        matrix-scale (global 4X4 matrix of float)
+0:370          'inFM0' (temp 4X4 matrix of float)
+0:370          'inF0' (temp float)
+0:370      move second child to first child (temp 4X4 matrix of float)
+0:370        'r8' (temp 4X4 matrix of float)
+0:370        matrix-multiply (global 4X4 matrix of float)
+0:370          'inFM0' (temp 4X4 matrix of float)
+0:370          'inFM1' (temp 4X4 matrix of float)
 0:?   Linker Objects
 
-Missing functionality: missing user function; linker needs to catch that
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 796
+// Id's are bound by 1079
 
                               Capability Shader
                1:             ExtInstImport  "GLSL.std.450"
@@ -1784,211 +2387,442 @@ Missing functionality: missing user function; linker needs to catch that
                               EntryPoint Vertex 4  "VertexShaderFunction"
                               Source HLSL 450
                               Name 4  "VertexShaderFunction"
-                              Name 8  "inF0"
-                              Name 23  "inF1"
-                              Name 30  "inF2"
-                              Name 55  "ResType"
-                              Name 115  "inF0"
-                              Name 129  "inF1"
-                              Name 136  "inF2"
-                              Name 171  "ResType"
-                              Name 244  "inF0"
-                              Name 258  "inF1"
-                              Name 265  "inF2"
-                              Name 303  "ResType"
-                              Name 374  "inF0"
-                              Name 388  "inF1"
-                              Name 395  "inF2"
-                              Name 429  "ResType"
-                              Name 501  "inF0"
-                              Name 515  "inF1"
-                              Name 522  "inF2"
-                              Name 544  "ResType"
-                              Name 600  "inF0"
-                              Name 614  "inF1"
-                              Name 621  "inF2"
-                              Name 643  "ResType"
-                              Name 699  "inF0"
-                              Name 713  "inF1"
-                              Name 720  "inF2"
-                              Name 742  "ResType"
+                              Name 19  "TestGenMul(f1;f1;vf2;vf2;mf22;mf22;"
+                              Name 13  "inF0"
+                              Name 14  "inF1"
+                              Name 15  "inFV0"
+                              Name 16  "inFV1"
+                              Name 17  "inFM0"
+                              Name 18  "inFM1"
+                              Name 32  "TestGenMul(f1;f1;vf3;vf3;mf33;mf33;"
+                              Name 26  "inF0"
+                              Name 27  "inF1"
+                              Name 28  "inFV0"
+                              Name 29  "inFV1"
+                              Name 30  "inFM0"
+                              Name 31  "inFM1"
+                              Name 45  "TestGenMul(f1;f1;vf4;vf4;mf44;mf44;"
+                              Name 39  "inF0"
+                              Name 40  "inF1"
+                              Name 41  "inFV0"
+                              Name 42  "inFV1"
+                              Name 43  "inFM0"
+                              Name 44  "inFM1"
+                              Name 47  "inF0"
+                              Name 62  "inF1"
+                              Name 69  "inF2"
+                              Name 97  "ResType"
+                              Name 166  "inF0"
+                              Name 180  "inF1"
+                              Name 187  "inF2"
+                              Name 225  "ResType"
+                              Name 307  "inF0"
+                              Name 321  "inF1"
+                              Name 328  "inF2"
+                              Name 369  "ResType"
+                              Name 450  "inF0"
+                              Name 464  "inF1"
+                              Name 471  "inF2"
+                              Name 508  "ResType"
+                              Name 590  "inF0"
+                              Name 604  "inF1"
+                              Name 611  "inF2"
+                              Name 642  "ResType"
+                              Name 712  "inF0"
+                              Name 726  "inF1"
+                              Name 733  "inF2"
+                              Name 767  "ResType"
+                              Name 839  "inF0"
+                              Name 853  "inF1"
+                              Name 860  "inF2"
+                              Name 897  "ResType"
+                              Name 971  "r0"
+                              Name 975  "r1"
+                              Name 979  "r2"
+                              Name 983  "r3"
+                              Name 987  "r4"
+                              Name 991  "r5"
+                              Name 995  "r6"
+                              Name 999  "r7"
+                              Name 1003  "r8"
+                              Name 1007  "r0"
+                              Name 1011  "r1"
+                              Name 1015  "r2"
+                              Name 1019  "r3"
+                              Name 1023  "r4"
+                              Name 1027  "r5"
+                              Name 1031  "r6"
+                              Name 1035  "r7"
+                              Name 1039  "r8"
+                              Name 1043  "r0"
+                              Name 1047  "r1"
+                              Name 1051  "r2"
+                              Name 1055  "r3"
+                              Name 1059  "r4"
+                              Name 1063  "r5"
+                              Name 1067  "r6"
+                              Name 1071  "r7"
+                              Name 1075  "r8"
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
                7:             TypePointer Function 6(float)
-              10:             TypeBool
-              37:             TypeInt 32 0
-              38:     37(int) Constant 7
-              46:             TypeInt 32 1
-              47:     46(int) Constant 7
-     55(ResType):             TypeStruct 6(float) 46(int)
-              83:     37(int) Constant 2
-             110:    6(float) Constant 0
-             113:             TypeVector 6(float) 2
-             114:             TypePointer Function 113(fvec2)
-             143:             TypeVector 37(int) 2
-             144:     37(int) Constant 3
-             145:  143(ivec2) ConstantComposite 38 144
-             170:             TypeVector 46(int) 2
-    171(ResType):             TypeStruct 113(fvec2) 170(ivec2)
-             178:             TypeVector 10(bool) 2
-             209:    6(float) Constant 1073741824
-             211:     37(int) Constant 1
-             212:  143(ivec2) ConstantComposite 211 83
-             239:    6(float) Constant 1065353216
-             240:  113(fvec2) ConstantComposite 239 209
-             242:             TypeVector 6(float) 3
-             243:             TypePointer Function 242(fvec3)
-             272:             TypeVector 37(int) 3
-             273:     37(int) Constant 5
-             274:  272(ivec3) ConstantComposite 38 144 273
-             302:             TypeVector 46(int) 3
-    303(ResType):             TypeStruct 242(fvec3) 302(ivec3)
-             310:             TypeVector 10(bool) 3
-             342:  272(ivec3) ConstantComposite 211 83 144
-             369:    6(float) Constant 1077936128
-             370:  242(fvec3) ConstantComposite 239 209 369
-             372:             TypeVector 6(float) 4
-             373:             TypePointer Function 372(fvec4)
-             402:             TypeVector 37(int) 4
-             403:  402(ivec4) ConstantComposite 38 144 273 83
-             428:             TypeVector 46(int) 4
-    429(ResType):             TypeStruct 372(fvec4) 428(ivec4)
-             436:             TypeVector 10(bool) 4
-             468:     37(int) Constant 4
-             469:  402(ivec4) ConstantComposite 211 83 144 468
-             496:    6(float) Constant 1082130432
-             497:  372(fvec4) ConstantComposite 239 209 369 496
-             499:             TypeMatrix 113(fvec2) 2
-             500:             TypePointer Function 499
-    544(ResType):             TypeStruct 499 170(ivec2)
-             595:  113(fvec2) ConstantComposite 209 209
-             596:         499 ConstantComposite 595 595
-             598:             TypeMatrix 242(fvec3) 3
-             599:             TypePointer Function 598
-    643(ResType):             TypeStruct 598 302(ivec3)
-             694:  242(fvec3) ConstantComposite 369 369 369
-             695:         598 ConstantComposite 694 694 694
-             697:             TypeMatrix 372(fvec4) 4
-             698:             TypePointer Function 697
-    742(ResType):             TypeStruct 697 428(ivec4)
-             793:  372(fvec4) ConstantComposite 496 496 496 496
-             794:         697 ConstantComposite 793 793 793 793
+               8:             TypeVector 6(float) 2
+               9:             TypePointer Function 8(fvec2)
+              10:             TypeMatrix 8(fvec2) 2
+              11:             TypePointer Function 10
+              12:             TypeFunction 2 7(ptr) 7(ptr) 9(ptr) 9(ptr) 11(ptr) 11(ptr)
+              21:             TypeVector 6(float) 3
+              22:             TypePointer Function 21(fvec3)
+              23:             TypeMatrix 21(fvec3) 3
+              24:             TypePointer Function 23
+              25:             TypeFunction 2 7(ptr) 7(ptr) 22(ptr) 22(ptr) 24(ptr) 24(ptr)
+              34:             TypeVector 6(float) 4
+              35:             TypePointer Function 34(fvec4)
+              36:             TypeMatrix 34(fvec4) 4
+              37:             TypePointer Function 36
+              38:             TypeFunction 2 7(ptr) 7(ptr) 35(ptr) 35(ptr) 37(ptr) 37(ptr)
+              49:             TypeBool
+              76:             TypeInt 32 0
+              77:     76(int) Constant 7
+              85:             TypeInt 32 1
+              86:     85(int) Constant 7
+     97(ResType):             TypeStruct 6(float) 85(int)
+             114:    6(float) Constant 1050288283
+             129:     76(int) Constant 2
+             136:    6(float) Constant 0
+             137:    6(float) Constant 1065353216
+             194:             TypeVector 76(int) 2
+             195:     76(int) Constant 3
+             196:  194(ivec2) ConstantComposite 77 195
+             224:             TypeVector 85(int) 2
+    225(ResType):             TypeStruct 8(fvec2) 224(ivec2)
+             232:             TypeVector 49(bool) 2
+             267:    6(float) Constant 1073741824
+             269:     76(int) Constant 1
+             270:  194(ivec2) ConstantComposite 269 129
+             305:    8(fvec2) ConstantComposite 137 267
+             335:             TypeVector 76(int) 3
+             336:     76(int) Constant 5
+             337:  335(ivec3) ConstantComposite 77 195 336
+             368:             TypeVector 85(int) 3
+    369(ResType):             TypeStruct 21(fvec3) 368(ivec3)
+             376:             TypeVector 49(bool) 3
+             412:  335(ivec3) ConstantComposite 269 129 195
+             447:    6(float) Constant 1077936128
+             448:   21(fvec3) ConstantComposite 137 267 447
+             478:             TypeVector 76(int) 4
+             479:  478(ivec4) ConstantComposite 77 195 336 129
+             507:             TypeVector 85(int) 4
+    508(ResType):             TypeStruct 34(fvec4) 507(ivec4)
+             515:             TypeVector 49(bool) 4
+             551:     76(int) Constant 4
+             552:  478(ivec4) ConstantComposite 269 129 195 551
+             587:    6(float) Constant 1082130432
+             588:   34(fvec4) ConstantComposite 137 267 447 587
+    642(ResType):             TypeStruct 10 224(ivec2)
+             709:    8(fvec2) ConstantComposite 267 267
+             710:          10 ConstantComposite 709 709
+    767(ResType):             TypeStruct 23 368(ivec3)
+             836:   21(fvec3) ConstantComposite 447 447 447
+             837:          23 ConstantComposite 836 836 836
+    897(ResType):             TypeStruct 36 507(ivec4)
+             968:   34(fvec4) ConstantComposite 587 587 587 587
+             969:          36 ConstantComposite 968 968 968 968
 4(VertexShaderFunction):           2 Function None 3
                5:             Label
-         8(inF0):      7(ptr) Variable Function
-        23(inF1):      7(ptr) Variable Function
-        30(inF2):      7(ptr) Variable Function
-       115(inF0):    114(ptr) Variable Function
-       129(inF1):    114(ptr) Variable Function
-       136(inF2):    114(ptr) Variable Function
-       244(inF0):    243(ptr) Variable Function
-       258(inF1):    243(ptr) Variable Function
-       265(inF2):    243(ptr) Variable Function
-       374(inF0):    373(ptr) Variable Function
-       388(inF1):    373(ptr) Variable Function
-       395(inF2):    373(ptr) Variable Function
-       501(inF0):    500(ptr) Variable Function
-       515(inF1):    500(ptr) Variable Function
-       522(inF2):    500(ptr) Variable Function
-       600(inF0):    599(ptr) Variable Function
-       614(inF1):    599(ptr) Variable Function
-       621(inF2):    599(ptr) Variable Function
-       699(inF0):    698(ptr) Variable Function
-       713(inF1):    698(ptr) Variable Function
-       720(inF2):    698(ptr) Variable Function
-               9:    6(float) Load 8(inF0)
-              11:    10(bool) All 9
-              12:    6(float) Load 8(inF0)
-              13:    6(float) ExtInst 1(GLSL.std.450) 4(FAbs) 12
-              14:    6(float) Load 8(inF0)
-              15:    6(float) ExtInst 1(GLSL.std.450) 17(Acos) 14
-              16:    6(float) Load 8(inF0)
-              17:    10(bool) Any 16
-              18:    6(float) Load 8(inF0)
-              19:    6(float) ExtInst 1(GLSL.std.450) 16(Asin) 18
-              20:    6(float) Load 8(inF0)
-              21:    6(float) ExtInst 1(GLSL.std.450) 18(Atan) 20
-              22:    6(float) Load 8(inF0)
-              24:    6(float) Load 23(inF1)
-              25:    6(float) ExtInst 1(GLSL.std.450) 25(Atan2) 22 24
-              26:    6(float) Load 8(inF0)
-              27:    6(float) ExtInst 1(GLSL.std.450) 9(Ceil) 26
-              28:    6(float) Load 8(inF0)
-              29:    6(float) Load 23(inF1)
-              31:    6(float) Load 30(inF2)
-              32:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 28 29 31
-              33:    6(float) Load 8(inF0)
-              34:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 33
-              35:    6(float) Load 8(inF0)
-              36:    6(float) ExtInst 1(GLSL.std.450) 20(Cosh) 35
-              39:     37(int) BitCount 38
-              40:    6(float) Load 8(inF0)
-              41:    6(float) ExtInst 1(GLSL.std.450) 12(Degrees) 40
-              42:    6(float) Load 8(inF0)
-              43:    6(float) ExtInst 1(GLSL.std.450) 27(Exp) 42
-              44:    6(float) Load 8(inF0)
-              45:    6(float) ExtInst 1(GLSL.std.450) 29(Exp2) 44
-              48:     46(int) ExtInst 1(GLSL.std.450) 74(FindSMsb) 47
-              49:     46(int) ExtInst 1(GLSL.std.450) 73(FindILsb) 47
-              50:    6(float) Load 8(inF0)
-              51:    6(float) ExtInst 1(GLSL.std.450) 8(Floor) 50
-              52:    6(float) Load 8(inF0)
-              53:    6(float) ExtInst 1(GLSL.std.450) 10(Fract) 52
-              54:    6(float) Load 8(inF0)
-              56: 55(ResType) ExtInst 1(GLSL.std.450) 52(FrexpStruct) 54
-              57:     46(int) CompositeExtract 56 1
-                              Store 23(inF1) 57
-              58:    6(float) CompositeExtract 56 0
-              59:    6(float) Load 8(inF0)
-              60:    6(float) Fwidth 59
-              61:    6(float) Load 8(inF0)
-              62:    10(bool) IsInf 61
-              63:    6(float) Load 8(inF0)
-              64:    10(bool) IsNan 63
-              65:    6(float) Load 8(inF0)
-              66:    6(float) Load 23(inF1)
-              67:    6(float) ExtInst 1(GLSL.std.450) 53(Ldexp) 65 66
-              68:    6(float) Load 8(inF0)
-              69:    6(float) ExtInst 1(GLSL.std.450) 28(Log) 68
-              70:    6(float) Load 8(inF0)
-              71:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 70
-              72:    6(float) Load 8(inF0)
-              73:    6(float) Load 23(inF1)
-              74:    6(float) ExtInst 1(GLSL.std.450) 40(FMax) 72 73
-              75:    6(float) Load 8(inF0)
-              76:    6(float) Load 23(inF1)
-              77:    6(float) ExtInst 1(GLSL.std.450) 37(FMin) 75 76
-              78:    6(float) Load 8(inF0)
-              79:    6(float) Load 23(inF1)
-              80:    6(float) ExtInst 1(GLSL.std.450) 26(Pow) 78 79
-              81:    6(float) Load 8(inF0)
-              82:    6(float) ExtInst 1(GLSL.std.450) 11(Radians) 81
-              84:     37(int) BitReverse 83
-              85:    6(float) Load 8(inF0)
-              86:    6(float) ExtInst 1(GLSL.std.450) 2(RoundEven) 85
-              87:    6(float) Load 8(inF0)
-              88:    6(float) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 87
-              89:    6(float) Load 8(inF0)
-              90:    6(float) ExtInst 1(GLSL.std.450) 6(FSign) 89
-              91:    6(float) Load 8(inF0)
-              92:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 91
-              93:    6(float) Load 8(inF0)
-              94:    6(float) ExtInst 1(GLSL.std.450) 19(Sinh) 93
-              95:    6(float) Load 8(inF0)
-              96:    6(float) Load 23(inF1)
-              97:    6(float) Load 30(inF2)
-              98:    6(float) ExtInst 1(GLSL.std.450) 49(SmoothStep) 95 96 97
-              99:    6(float) Load 8(inF0)
-             100:    6(float) ExtInst 1(GLSL.std.450) 31(Sqrt) 99
-             101:    6(float) Load 8(inF0)
-             102:    6(float) Load 23(inF1)
-             103:    6(float) ExtInst 1(GLSL.std.450) 48(Step) 101 102
-             104:    6(float) Load 8(inF0)
-             105:    6(float) ExtInst 1(GLSL.std.450) 15(Tan) 104
-             106:    6(float) Load 8(inF0)
-             107:    6(float) ExtInst 1(GLSL.std.450) 21(Tanh) 106
-             108:    6(float) Load 8(inF0)
-             109:    6(float) ExtInst 1(GLSL.std.450) 3(Trunc) 108
-                              ReturnValue 110
+        47(inF0):      7(ptr) Variable Function
+        62(inF1):      7(ptr) Variable Function
+        69(inF2):      7(ptr) Variable Function
+       166(inF0):      9(ptr) Variable Function
+       180(inF1):      9(ptr) Variable Function
+       187(inF2):      9(ptr) Variable Function
+       307(inF0):     22(ptr) Variable Function
+       321(inF1):     22(ptr) Variable Function
+       328(inF2):     22(ptr) Variable Function
+       450(inF0):     35(ptr) Variable Function
+       464(inF1):     35(ptr) Variable Function
+       471(inF2):     35(ptr) Variable Function
+       590(inF0):     11(ptr) Variable Function
+       604(inF1):     11(ptr) Variable Function
+       611(inF2):     11(ptr) Variable Function
+       712(inF0):     24(ptr) Variable Function
+       726(inF1):     24(ptr) Variable Function
+       733(inF2):     24(ptr) Variable Function
+       839(inF0):     37(ptr) Variable Function
+       853(inF1):     37(ptr) Variable Function
+       860(inF2):     37(ptr) Variable Function
+              48:    6(float) Load 47(inF0)
+              50:    49(bool) All 48
+              51:    6(float) Load 47(inF0)
+              52:    6(float) ExtInst 1(GLSL.std.450) 4(FAbs) 51
+              53:    6(float) Load 47(inF0)
+              54:    6(float) ExtInst 1(GLSL.std.450) 17(Acos) 53
+              55:    6(float) Load 47(inF0)
+              56:    49(bool) Any 55
+              57:    6(float) Load 47(inF0)
+              58:    6(float) ExtInst 1(GLSL.std.450) 16(Asin) 57
+              59:    6(float) Load 47(inF0)
+              60:    6(float) ExtInst 1(GLSL.std.450) 18(Atan) 59
+              61:    6(float) Load 47(inF0)
+              63:    6(float) Load 62(inF1)
+              64:    6(float) ExtInst 1(GLSL.std.450) 25(Atan2) 61 63
+              65:    6(float) Load 47(inF0)
+              66:    6(float) ExtInst 1(GLSL.std.450) 9(Ceil) 65
+              67:    6(float) Load 47(inF0)
+              68:    6(float) Load 62(inF1)
+              70:    6(float) Load 69(inF2)
+              71:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 67 68 70
+              72:    6(float) Load 47(inF0)
+              73:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 72
+              74:    6(float) Load 47(inF0)
+              75:    6(float) ExtInst 1(GLSL.std.450) 20(Cosh) 74
+              78:     76(int) BitCount 77
+              79:    6(float) Load 47(inF0)
+              80:    6(float) ExtInst 1(GLSL.std.450) 12(Degrees) 79
+              81:    6(float) Load 47(inF0)
+              82:    6(float) ExtInst 1(GLSL.std.450) 27(Exp) 81
+              83:    6(float) Load 47(inF0)
+              84:    6(float) ExtInst 1(GLSL.std.450) 29(Exp2) 83
+              87:     85(int) ExtInst 1(GLSL.std.450) 74(FindSMsb) 86
+              88:     85(int) ExtInst 1(GLSL.std.450) 73(FindILsb) 86
+              89:    6(float) Load 47(inF0)
+              90:    6(float) ExtInst 1(GLSL.std.450) 8(Floor) 89
+              91:    6(float) Load 47(inF0)
+              92:    6(float) Load 62(inF1)
+              93:    6(float) FMod 91 92
+              94:    6(float) Load 47(inF0)
+              95:    6(float) ExtInst 1(GLSL.std.450) 10(Fract) 94
+              96:    6(float) Load 47(inF0)
+              98: 97(ResType) ExtInst 1(GLSL.std.450) 52(FrexpStruct) 96
+              99:     85(int) CompositeExtract 98 1
+                              Store 62(inF1) 99
+             100:    6(float) CompositeExtract 98 0
+             101:    6(float) Load 47(inF0)
+             102:    6(float) Fwidth 101
+             103:    6(float) Load 47(inF0)
+             104:    49(bool) IsInf 103
+             105:    6(float) Load 47(inF0)
+             106:    49(bool) IsNan 105
+             107:    6(float) Load 47(inF0)
+             108:    6(float) Load 62(inF1)
+             109:    6(float) ExtInst 1(GLSL.std.450) 53(Ldexp) 107 108
+             110:    6(float) Load 47(inF0)
+             111:    6(float) ExtInst 1(GLSL.std.450) 28(Log) 110
+             112:    6(float) Load 47(inF0)
+             113:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 112
+             115:    6(float) FMul 113 114
+             116:    6(float) Load 47(inF0)
+             117:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 116
+             118:    6(float) Load 47(inF0)
+             119:    6(float) Load 62(inF1)
+             120:    6(float) ExtInst 1(GLSL.std.450) 40(FMax) 118 119
+             121:    6(float) Load 47(inF0)
+             122:    6(float) Load 62(inF1)
+             123:    6(float) ExtInst 1(GLSL.std.450) 37(FMin) 121 122
+             124:    6(float) Load 47(inF0)
+             125:    6(float) Load 62(inF1)
+             126:    6(float) ExtInst 1(GLSL.std.450) 26(Pow) 124 125
+             127:    6(float) Load 47(inF0)
+             128:    6(float) ExtInst 1(GLSL.std.450) 11(Radians) 127
+             130:     76(int) BitReverse 129
+             131:    6(float) Load 47(inF0)
+             132:    6(float) ExtInst 1(GLSL.std.450) 2(RoundEven) 131
+             133:    6(float) Load 47(inF0)
+             134:    6(float) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 133
+             135:    6(float) Load 47(inF0)
+             138:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 135 136 137
+             139:    6(float) Load 47(inF0)
+             140:    6(float) ExtInst 1(GLSL.std.450) 6(FSign) 139
+             141:    6(float) Load 47(inF0)
+             142:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 141
+             143:    6(float) Load 47(inF0)
+             144:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 143
+                              Store 62(inF1) 144
+             145:    6(float) Load 47(inF0)
+             146:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 145
+                              Store 69(inF2) 146
+             147:    6(float) Load 47(inF0)
+             148:    6(float) ExtInst 1(GLSL.std.450) 19(Sinh) 147
+             149:    6(float) Load 47(inF0)
+             150:    6(float) Load 62(inF1)
+             151:    6(float) Load 69(inF2)
+             152:    6(float) ExtInst 1(GLSL.std.450) 49(SmoothStep) 149 150 151
+             153:    6(float) Load 47(inF0)
+             154:    6(float) ExtInst 1(GLSL.std.450) 31(Sqrt) 153
+             155:    6(float) Load 47(inF0)
+             156:    6(float) Load 62(inF1)
+             157:    6(float) ExtInst 1(GLSL.std.450) 48(Step) 155 156
+             158:    6(float) Load 47(inF0)
+             159:    6(float) ExtInst 1(GLSL.std.450) 15(Tan) 158
+             160:    6(float) Load 47(inF0)
+             161:    6(float) ExtInst 1(GLSL.std.450) 21(Tanh) 160
+             162:    6(float) Load 47(inF0)
+             163:    6(float) ExtInst 1(GLSL.std.450) 3(Trunc) 162
+                              ReturnValue 136
+                              FunctionEnd
+19(TestGenMul(f1;f1;vf2;vf2;mf22;mf22;):           2 Function None 12
+        13(inF0):      7(ptr) FunctionParameter
+        14(inF1):      7(ptr) FunctionParameter
+       15(inFV0):      9(ptr) FunctionParameter
+       16(inFV1):      9(ptr) FunctionParameter
+       17(inFM0):     11(ptr) FunctionParameter
+       18(inFM1):     11(ptr) FunctionParameter
+              20:             Label
+         971(r0):      7(ptr) Variable Function
+         975(r1):      9(ptr) Variable Function
+         979(r2):      9(ptr) Variable Function
+         983(r3):      7(ptr) Variable Function
+         987(r4):      9(ptr) Variable Function
+         991(r5):      9(ptr) Variable Function
+         995(r6):     11(ptr) Variable Function
+         999(r7):     11(ptr) Variable Function
+        1003(r8):     11(ptr) Variable Function
+             972:    6(float) Load 13(inF0)
+             973:    6(float) Load 14(inF1)
+             974:    6(float) FMul 972 973
+                              Store 971(r0) 974
+             976:    8(fvec2) Load 15(inFV0)
+             977:    6(float) Load 13(inF0)
+             978:    8(fvec2) VectorTimesScalar 976 977
+                              Store 975(r1) 978
+             980:    8(fvec2) Load 15(inFV0)
+             981:    6(float) Load 13(inF0)
+             982:    8(fvec2) VectorTimesScalar 980 981
+                              Store 979(r2) 982
+             984:    8(fvec2) Load 15(inFV0)
+             985:    8(fvec2) Load 16(inFV1)
+             986:    6(float) Dot 984 985
+                              Store 983(r3) 986
+             988:          10 Load 17(inFM0)
+             989:    8(fvec2) Load 15(inFV0)
+             990:    8(fvec2) MatrixTimesVector 988 989
+                              Store 987(r4) 990
+             992:    8(fvec2) Load 15(inFV0)
+             993:          10 Load 17(inFM0)
+             994:    8(fvec2) VectorTimesMatrix 992 993
+                              Store 991(r5) 994
+             996:          10 Load 17(inFM0)
+             997:    6(float) Load 13(inF0)
+             998:          10 MatrixTimesScalar 996 997
+                              Store 995(r6) 998
+            1000:          10 Load 17(inFM0)
+            1001:    6(float) Load 13(inF0)
+            1002:          10 MatrixTimesScalar 1000 1001
+                              Store 999(r7) 1002
+            1004:          10 Load 17(inFM0)
+            1005:          10 Load 18(inFM1)
+            1006:          10 MatrixTimesMatrix 1004 1005
+                              Store 1003(r8) 1006
+                              Return
+                              FunctionEnd
+32(TestGenMul(f1;f1;vf3;vf3;mf33;mf33;):           2 Function None 25
+        26(inF0):      7(ptr) FunctionParameter
+        27(inF1):      7(ptr) FunctionParameter
+       28(inFV0):     22(ptr) FunctionParameter
+       29(inFV1):     22(ptr) FunctionParameter
+       30(inFM0):     24(ptr) FunctionParameter
+       31(inFM1):     24(ptr) FunctionParameter
+              33:             Label
+        1007(r0):      7(ptr) Variable Function
+        1011(r1):     22(ptr) Variable Function
+        1015(r2):     22(ptr) Variable Function
+        1019(r3):      7(ptr) Variable Function
+        1023(r4):     22(ptr) Variable Function
+        1027(r5):     22(ptr) Variable Function
+        1031(r6):     24(ptr) Variable Function
+        1035(r7):     24(ptr) Variable Function
+        1039(r8):     24(ptr) Variable Function
+            1008:    6(float) Load 26(inF0)
+            1009:    6(float) Load 27(inF1)
+            1010:    6(float) FMul 1008 1009
+                              Store 1007(r0) 1010
+            1012:   21(fvec3) Load 28(inFV0)
+            1013:    6(float) Load 26(inF0)
+            1014:   21(fvec3) VectorTimesScalar 1012 1013
+                              Store 1011(r1) 1014
+            1016:   21(fvec3) Load 28(inFV0)
+            1017:    6(float) Load 26(inF0)
+            1018:   21(fvec3) VectorTimesScalar 1016 1017
+                              Store 1015(r2) 1018
+            1020:   21(fvec3) Load 28(inFV0)
+            1021:   21(fvec3) Load 29(inFV1)
+            1022:    6(float) Dot 1020 1021
+                              Store 1019(r3) 1022
+            1024:          23 Load 30(inFM0)
+            1025:   21(fvec3) Load 28(inFV0)
+            1026:   21(fvec3) MatrixTimesVector 1024 1025
+                              Store 1023(r4) 1026
+            1028:   21(fvec3) Load 28(inFV0)
+            1029:          23 Load 30(inFM0)
+            1030:   21(fvec3) VectorTimesMatrix 1028 1029
+                              Store 1027(r5) 1030
+            1032:          23 Load 30(inFM0)
+            1033:    6(float) Load 26(inF0)
+            1034:          23 MatrixTimesScalar 1032 1033
+                              Store 1031(r6) 1034
+            1036:          23 Load 30(inFM0)
+            1037:    6(float) Load 26(inF0)
+            1038:          23 MatrixTimesScalar 1036 1037
+                              Store 1035(r7) 1038
+            1040:          23 Load 30(inFM0)
+            1041:          23 Load 31(inFM1)
+            1042:          23 MatrixTimesMatrix 1040 1041
+                              Store 1039(r8) 1042
+                              Return
+                              FunctionEnd
+45(TestGenMul(f1;f1;vf4;vf4;mf44;mf44;):           2 Function None 38
+        39(inF0):      7(ptr) FunctionParameter
+        40(inF1):      7(ptr) FunctionParameter
+       41(inFV0):     35(ptr) FunctionParameter
+       42(inFV1):     35(ptr) FunctionParameter
+       43(inFM0):     37(ptr) FunctionParameter
+       44(inFM1):     37(ptr) FunctionParameter
+              46:             Label
+        1043(r0):      7(ptr) Variable Function
+        1047(r1):     35(ptr) Variable Function
+        1051(r2):     35(ptr) Variable Function
+        1055(r3):      7(ptr) Variable Function
+        1059(r4):     35(ptr) Variable Function
+        1063(r5):     35(ptr) Variable Function
+        1067(r6):     37(ptr) Variable Function
+        1071(r7):     37(ptr) Variable Function
+        1075(r8):     37(ptr) Variable Function
+            1044:    6(float) Load 39(inF0)
+            1045:    6(float) Load 40(inF1)
+            1046:    6(float) FMul 1044 1045
+                              Store 1043(r0) 1046
+            1048:   34(fvec4) Load 41(inFV0)
+            1049:    6(float) Load 39(inF0)
+            1050:   34(fvec4) VectorTimesScalar 1048 1049
+                              Store 1047(r1) 1050
+            1052:   34(fvec4) Load 41(inFV0)
+            1053:    6(float) Load 39(inF0)
+            1054:   34(fvec4) VectorTimesScalar 1052 1053
+                              Store 1051(r2) 1054
+            1056:   34(fvec4) Load 41(inFV0)
+            1057:   34(fvec4) Load 42(inFV1)
+            1058:    6(float) Dot 1056 1057
+                              Store 1055(r3) 1058
+            1060:          36 Load 43(inFM0)
+            1061:   34(fvec4) Load 41(inFV0)
+            1062:   34(fvec4) MatrixTimesVector 1060 1061
+                              Store 1059(r4) 1062
+            1064:   34(fvec4) Load 41(inFV0)
+            1065:          36 Load 43(inFM0)
+            1066:   34(fvec4) VectorTimesMatrix 1064 1065
+                              Store 1063(r5) 1066
+            1068:          36 Load 43(inFM0)
+            1069:    6(float) Load 39(inF0)
+            1070:          36 MatrixTimesScalar 1068 1069
+                              Store 1067(r6) 1070
+            1072:          36 Load 43(inFM0)
+            1073:    6(float) Load 39(inF0)
+            1074:          36 MatrixTimesScalar 1072 1073
+                              Store 1071(r7) 1074
+            1076:          36 Load 43(inFM0)
+            1077:          36 Load 44(inFM1)
+            1078:          36 MatrixTimesMatrix 1076 1077
+                              Store 1075(r8) 1078
+                              Return
                               FunctionEnd

--- a/Test/hlsl.intrinsics.frag
+++ b/Test/hlsl.intrinsics.frag
@@ -9,6 +9,7 @@ float PixelShaderFunction(float inF0, float inF1, float inF2)
     atan2(inF0, inF1);
     ceil(inF0);
     clamp(inF0, inF1, inF2);
+    clip(inF0);
     cos(inF0);
     cosh(inF0);
     countbits(7);
@@ -36,17 +37,20 @@ float PixelShaderFunction(float inF0, float inF1, float inF2)
     isnan(inF0);
     ldexp(inF0, inF1);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
-    // TODO: mul(inF0, inF1);
     pow(inF0, inF1);
     radians(inF0);
+    rcp(inF0);
     reversebits(2);
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -76,6 +80,7 @@ float2 PixelShaderFunction(float2 inF0, float2 inF1, float2 inF2)
     atan2(inF0, inF1);
     ceil(inF0);
     clamp(inF0, inF1, inF2);
+    clip(inF0);
     cos(inF0);
     cosh(inF0);
     countbits(int2(7,3));
@@ -107,20 +112,23 @@ float2 PixelShaderFunction(float2 inF0, float2 inF1, float2 inF2)
     ldexp(inF0, inF1);
     length(inF0);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
-    // TODO: mul(inF0, inF1);
     normalize(inF0);
     pow(inF0, inF1);
     radians(inF0);
+    rcp(inF0);
     reflect(inF0, inF1);
     refract(inF0, inF1, 2.0);
     reversebits(int2(1,2));
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -145,6 +153,7 @@ float3 PixelShaderFunction(float3 inF0, float3 inF1, float3 inF2)
     atan2(inF0, inF1);
     ceil(inF0);
     clamp(inF0, inF1, inF2);
+    clip(inF0);
     cos(inF0);
     cosh(inF0);
     countbits(int3(7,3,5));
@@ -177,20 +186,23 @@ float3 PixelShaderFunction(float3 inF0, float3 inF1, float3 inF2)
     ldexp(inF0, inF1);
     length(inF0);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
-    // TODO: mul(inF0, inF1);
     normalize(inF0);
     pow(inF0, inF1);
     radians(inF0);
+    rcp(inF0);
     reflect(inF0, inF1);
     refract(inF0, inF1, 2.0);
     reversebits(int3(1,2,3));
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -215,6 +227,7 @@ float4 PixelShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     atan2(inF0, inF1);
     ceil(inF0);
     clamp(inF0, inF1, inF2);
+    clip(inF0);
     cos(inF0);
     cosh(inF0);
     countbits(int4(7,3,5,2));
@@ -246,20 +259,23 @@ float4 PixelShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     ldexp(inF0, inF1);
     length(inF0);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
-    // TODO: mul(inF0, inF1);
     normalize(inF0);
     pow(inF0, inF1);
     radians(inF0);
+    rcp(inF0);
     reflect(inF0, inF1);
     refract(inF0, inF1, 2.0);
     reversebits(int4(1,2,3,4));
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -283,6 +299,7 @@ float4 PixelShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     atan(inF0); \
     atan2(inF0, inF1); \
     ceil(inF0); \
+    clip(inF0); \
     clamp(inF0, inF1, inF2); \
     cos(inF0); \
     cosh(inF0); \
@@ -305,15 +322,18 @@ float4 PixelShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     fwidth(inF0); \
     ldexp(inF0, inF1); \
     log(inF0); \
-    log2(inF0); \
+    log10(inF0); \
+    log2(inF0);      \
     max(inF0, inF1); \
     min(inF0, inF1); \
     pow(inF0, inF1); \
     radians(inF0); \
     round(inF0); \
     rsqrt(inF0); \
+    saturate(inF0); \
     sign(inF0); \
     sin(inF0); \
+    sincos(inF0, inF1, inF2); \
     sinh(inF0); \
     smoothstep(inF0, inF1, inF2); \
     sqrt(inF0); \
@@ -350,4 +370,37 @@ float4x4 PixelShaderFunction(float4x4 inF0, float4x4 inF1, float4x4 inF2)
 
     // TODO: ... add when float1 prototypes are generated
     return float4x4(4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4);
+}
+
+#define TESTGENMUL(ST, VT, MT) \
+    ST r0 = mul(inF0,  inF1);  \
+    VT r1 = mul(inFV0, inF0);  \
+    VT r2 = mul(inF0,  inFV0); \
+    ST r3 = mul(inFV0, inFV1); \
+    VT r4 = mul(inFM0, inFV0); \
+    VT r5 = mul(inFV0, inFM0); \
+    MT r6 = mul(inFM0, inF0);  \
+    MT r7 = mul(inF0, inFM0);  \
+    MT r8 = mul(inFM0, inFM1);
+
+
+void TestGenMul(float inF0, float inF1,
+                float2 inFV0, float2 inFV1,
+                float2x2 inFM0, float2x2 inFM1)
+{
+    TESTGENMUL(float, float2, float2x2);
+}
+
+void TestGenMul(float inF0, float inF1,
+                float3 inFV0, float3 inFV1,
+                float3x3 inFM0, float3x3 inFM1)
+{
+    TESTGENMUL(float, float3, float3x3);
+}
+
+void TestGenMul(float inF0, float inF1,
+                float4 inFV0, float4 inFV1,
+                float4x4 inFM0, float4x4 inFM1)
+{
+    TESTGENMUL(float, float4, float4x4);
 }

--- a/Test/hlsl.intrinsics.vert
+++ b/Test/hlsl.intrinsics.vert
@@ -30,6 +30,7 @@ float VertexShaderFunction(float inF0, float inF1, float inF2)
     isnan(inF0);
     ldexp(inF0, inF1);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
@@ -39,8 +40,10 @@ float VertexShaderFunction(float inF0, float inF1, float inF2)
     reversebits(2);
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -95,6 +98,7 @@ float2 VertexShaderFunction(float2 inF0, float2 inF1, float2 inF2)
     ldexp(inF0, inF1);
     length(inF0);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
@@ -107,8 +111,10 @@ float2 VertexShaderFunction(float2 inF0, float2 inF1, float2 inF2)
     reversebits(int2(1,2));
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -159,6 +165,7 @@ float3 VertexShaderFunction(float3 inF0, float3 inF1, float3 inF2)
     ldexp(inF0, inF1);
     length(inF0);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
@@ -171,8 +178,10 @@ float3 VertexShaderFunction(float3 inF0, float3 inF1, float3 inF2)
     reversebits(int3(1,2,3));
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -222,6 +231,7 @@ float4 VertexShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     ldexp(inF0, inF1);
     length(inF0);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
@@ -234,8 +244,10 @@ float4 VertexShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     reversebits(int4(1,2,3,4));
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -275,6 +287,7 @@ float4 VertexShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     fwidth(inF0); \
     ldexp(inF0, inF1); \
     log(inF0); \
+    log10(inF0); \
     log2(inF0); \
     max(inF0, inF1); \
     min(inF0, inF1); \
@@ -282,8 +295,10 @@ float4 VertexShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     radians(inF0); \
     round(inF0); \
     rsqrt(inF0); \
+    saturate(inF0); \
     sign(inF0); \
     sin(inF0); \
+    sincos(inF0, inF1, inF2); \
     sinh(inF0); \
     smoothstep(inF0, inF1, inF2); \
     sqrt(inF0); \
@@ -320,4 +335,37 @@ float4x4 VertexShaderFunction(float4x4 inF0, float4x4 inF1, float4x4 inF2)
 
     // TODO: ... add when float1 prototypes are generated
     return float4x4(4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4);
+}
+
+#define TESTGENMUL(ST, VT, MT) \
+    ST r0 = mul(inF0,  inF1);  \
+    VT r1 = mul(inFV0, inF0);  \
+    VT r2 = mul(inF0,  inFV0); \
+    ST r3 = mul(inFV0, inFV1); \
+    VT r4 = mul(inFM0, inFV0); \
+    VT r5 = mul(inFV0, inFM0); \
+    MT r6 = mul(inFM0, inF0);  \
+    MT r7 = mul(inF0, inFM0);  \
+    MT r8 = mul(inFM0, inFM1);
+
+
+void TestGenMul(float inF0, float inF1,
+                float2 inFV0, float2 inFV1,
+                float2x2 inFM0, float2x2 inFM1)
+{
+    TESTGENMUL(float, float2, float2x2);
+}
+
+void TestGenMul(float inF0, float inF1,
+                float3 inFV0, float3 inFV1,
+                float3x3 inFM0, float3x3 inFM1)
+{
+    TESTGENMUL(float, float3, float3x3);
+}
+
+void TestGenMul(float inF0, float inF1,
+                float4 inFV0, float4 inFV1,
+                float4x4 inFM0, float4x4 inFM1)
+{
+    TESTGENMUL(float, float4, float4x4);
 }

--- a/glslang/Include/intermediate.h
+++ b/glslang/Include/intermediate.h
@@ -493,6 +493,18 @@ enum TOperator {
     EOpBitCount,
     EOpFindLSB,
     EOpFindMSB,
+
+    //
+    // HLSL operations
+    //
+
+    EOpClip,
+    EOpIsFinite,
+    EOpLog10,
+    EOpRcp,
+    EOpSaturate,
+    EOpSinCos,
+    EOpGenMul,  // mul(x,y) on any of mat/vec/scalars
 };
 
 class TIntermTraverser;

--- a/glslang/MachineIndependent/intermOut.cpp
+++ b/glslang/MachineIndependent/intermOut.cpp
@@ -359,6 +359,12 @@ bool TOutputTraverser::visitUnary(TVisit /* visit */, TIntermUnary* node)
     case EOpAllInvocations:         out.debug << "allInvocations";        break;
     case EOpAllInvocationsEqual:    out.debug << "allInvocationsEqual";   break;
 
+    case EOpClip:                   out.debug << "clip";                  break;
+    case EOpIsFinite:               out.debug << "isfinite";              break;
+    case EOpLog10:                  out.debug << "log10";                 break;
+    case EOpRcp:                    out.debug << "rcp";                   break;
+    case EOpSaturate:               out.debug << "saturate";              break;
+
     default: out.debug.message(EPrefixError, "Bad unary op");
     }
 
@@ -533,6 +539,9 @@ bool TOutputTraverser::visitAggregate(TVisit /* visit */, TIntermAggregate* node
 
     case EOpInterpolateAtSample:   out.debug << "interpolateAtSample";    break;
     case EOpInterpolateAtOffset:   out.debug << "interpolateAtOffset";    break;
+
+    case EOpSinCos:                     out.debug << "sincos";                break;
+    case EOpGenMul:                     out.debug << "mul";                   break;
 
     default: out.debug.message(EPrefixError, "Bad aggregation op");
     }

--- a/hlsl/hlslGrammar.h
+++ b/hlsl/hlslGrammar.h
@@ -1,5 +1,6 @@
 //
 //Copyright (C) 2016 Google, Inc.
+//Copyright (C) 2016 LunarG, Inc.
 //
 //All rights reserved.
 //
@@ -87,6 +88,8 @@ namespace glslang {
         bool acceptCaseLabel(TIntermNode*&);
 
         bool acceptSemantic();
+
+        void decomposeIntrinsic(HlslToken, TIntermTyped*&, TIntermTyped* arguments);
 
         HlslParseContext& parseContext;  // state of parsing and helper functions for building the intermediate
         TIntermediate& intermediate;     // the final product, the intermediate representation, includes the AST

--- a/hlsl/hlslParseables.cpp
+++ b/hlsl/hlslParseables.cpp
@@ -324,6 +324,7 @@ void TBuiltInParseablesHlsl::initialize(int version, EProfile profile, int spv, 
         { "min",                              nullptr, nullptr,   "SVM,",       "FI,",    EShLangAll },
         { "modf",                             nullptr, nullptr,   "SVM,>",      "FI,",    EShLangAll },
         { "msad4",                            "V4",    "U",       "S,V2,V4",    "U,,",    EShLangAll },
+        // TODO: fix matrix return size for non-square mats used with mul opcode
         { "mul",                              "S",     nullptr,   "S,S",        "FI,",    EShLangAll },
         { "mul",                              "V",     nullptr,   "S,V",        "FI,",    EShLangAll },
         { "mul",                              "M",     nullptr,   "S,M",        "FI,",    EShLangAll },
@@ -508,7 +509,7 @@ void TBuiltInParseablesHlsl::initialize(const TBuiltInResource &resources, int v
 void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, int spv, int vulkan, EShLanguage language,
                                               TSymbolTable& symbolTable)
 {
-    // symbolTable.relateToOperator("abort");
+    // symbolTable.relateToOperator("abort",                       EOpAbort);
     symbolTable.relateToOperator("abs",                         EOpAbs);
     symbolTable.relateToOperator("acos",                        EOpAcos);
     symbolTable.relateToOperator("all",                         EOpAll);
@@ -525,12 +526,12 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, int
     symbolTable.relateToOperator("ceil",                        EOpCeil);
     // symbolTable.relateToOperator("CheckAccessFullyMapped");
     symbolTable.relateToOperator("clamp",                       EOpClamp);
-    // symbolTable.relateToOperator("clip");
+    symbolTable.relateToOperator("clip",                        EOpClip);
     symbolTable.relateToOperator("cos",                         EOpCos);
     symbolTable.relateToOperator("cosh",                        EOpCosh);
     symbolTable.relateToOperator("countbits",                   EOpBitCount);
     symbolTable.relateToOperator("cross",                       EOpCross);
-    // symbolTable.relateToOperator("D3DCOLORtoUBYTE4");
+    // symbolTable.relateToOperator("D3DCOLORtoUBYTE4",            EOpD3DCOLORtoUBYTE4);
     symbolTable.relateToOperator("ddx",                         EOpDPdx);
     symbolTable.relateToOperator("ddx_coarse",                  EOpDPdxCoarse);
     symbolTable.relateToOperator("ddx_fine",                    EOpDPdxFine);
@@ -543,7 +544,7 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, int
     // symbolTable.relateToOperator("DeviceMemoryBarrierWithGroupSync");
     symbolTable.relateToOperator("distance",                    EOpDistance);
     symbolTable.relateToOperator("dot",                         EOpDot);
-    // symbolTable.relateToOperator("dst");
+    // symbolTable.relateToOperator("dst",                         EOpDst);
     // symbolTable.relateToOperator("errorf");
     symbolTable.relateToOperator("EvaluateAttributeAtCentroid", EOpInterpolateAtCentroid);
     symbolTable.relateToOperator("EvaluateAttributeAtSample",   EOpInterpolateAtSample);
@@ -557,7 +558,7 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, int
     symbolTable.relateToOperator("firstbitlow",                 EOpFindLSB);
     symbolTable.relateToOperator("floor",                       EOpFloor);
     symbolTable.relateToOperator("fma",                         EOpFma);
-    // symbolTable.relateToOperator("fmod");
+    symbolTable.relateToOperator("fmod",                        EOpMod);
     symbolTable.relateToOperator("frac",                        EOpFract);
     symbolTable.relateToOperator("frexp",                       EOpFrexp);
     symbolTable.relateToOperator("fwidth",                      EOpFwidth);
@@ -574,21 +575,21 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, int
     // symbolTable.relateToOperator("InterlockedMin");
     // symbolTable.relateToOperator("InterlockedOr");
     // symbolTable.relateToOperator("InterlockedXor");
-    // symbolTable.relateToOperator("isfinite");
+    symbolTable.relateToOperator("isfinite",                    EOpIsFinite);
     symbolTable.relateToOperator("isinf",                       EOpIsInf);
     symbolTable.relateToOperator("isnan",                       EOpIsNan);
     symbolTable.relateToOperator("ldexp",                       EOpLdexp);
     symbolTable.relateToOperator("length",                      EOpLength);
     // symbolTable.relateToOperator("lit");
     symbolTable.relateToOperator("log",                         EOpLog);
-    // symbolTable.relateToOperator("log10");
+    symbolTable.relateToOperator("log10",                       EOpLog10);
     symbolTable.relateToOperator("log2",                        EOpLog2);
     // symbolTable.relateToOperator("mad");
     symbolTable.relateToOperator("max",                         EOpMax);
     symbolTable.relateToOperator("min",                         EOpMin);
     symbolTable.relateToOperator("modf",                        EOpModf);
-    // symbolTable.relateToOperator("msad4");
-    // symbolTable.relateToOperator("mul");
+    // symbolTable.relateToOperator("msad4",                       EOpMsad4);
+    symbolTable.relateToOperator("mul",                         EOpGenMul);
     // symbolTable.relateToOperator("noise",                    EOpNoise); // TODO: check return type
     symbolTable.relateToOperator("normalize",                   EOpNormalize);
     symbolTable.relateToOperator("pow",                         EOpPow);
@@ -604,16 +605,16 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, int
     // symbolTable.relateToOperator("ProcessTriTessFactorsMax");
     // symbolTable.relateToOperator("ProcessTriTessFactorsMin");
     symbolTable.relateToOperator("radians",                     EOpRadians);
-    // symbolTable.relateToOperator("rcp");
+    symbolTable.relateToOperator("rcp",                         EOpRcp);
     symbolTable.relateToOperator("reflect",                     EOpReflect);
     symbolTable.relateToOperator("refract",                     EOpRefract);
     symbolTable.relateToOperator("reversebits",                 EOpBitFieldReverse);
     symbolTable.relateToOperator("round",                       EOpRoundEven);
     symbolTable.relateToOperator("rsqrt",                       EOpInverseSqrt);
-    // symbolTable.relateToOperator("saturate"); 
+    symbolTable.relateToOperator("saturate",                    EOpSaturate);
     symbolTable.relateToOperator("sign",                        EOpSign);
     symbolTable.relateToOperator("sin",                         EOpSin);
-    // symbolTable.relateToOperator("sincos");
+    symbolTable.relateToOperator("sincos",                      EOpSinCos);
     symbolTable.relateToOperator("sinh",                        EOpSinh);
     symbolTable.relateToOperator("smoothstep",                  EOpSmoothStep);
     symbolTable.relateToOperator("sqrt",                        EOpSqrt);


### PR DESCRIPTION
Connect new HLSL intrinsics which require simple decompositions:

clip
isfinite
log10
mul (generic mat/vec/scalar forms)
rcp
saturate
sincos

This PR adds decomposeIntrinsic(), which is either (A) a no-op to pass intrinsics through unmodified to AST opcodes for downstream native handling, or (B) a set of simple decompositions to current AST opcodes, for compatibility with existing downstream code.  Only (B) is currently implemented.

* mul is turned into one of the MatrixTimesMatrix, MatrixTimesVector, MatrixTimesScalar, VectorTimesMatrix, VectorTimesScalar, Dot, or Mul opcodes.  This is only available with square matrices presently.

* clip is turned into either a test for <0 and branch with pixel kill, or a component-wise test with any() followed by same.  The HLSL docs don't specify the behavior on vectors, but experiments with FXC showed any() is what happens.

* log10 is turned into a log2 + a multiply to achieve base 10 log.

* sincos is turned into a separate sin and cos which assign to the output parameters.

* saturate is turned into a clamp to 0,1.

* rcp is turned into a divide.

* isfinite is passed through to an existing SPIR-V opcode via a new AST opcode.

