### PR TITLE
Add decompositions for some HLSL intrinsics.

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -1,5 +1,5 @@
 //
-//Copyright (C) 2014-2015 LunarG, Inc.
+//Copyright (C) 2014-2016 LunarG, Inc.
 //Copyright (C) 2015-2016 Google, Inc.
 //
 //All rights reserved.
@@ -3032,7 +3032,7 @@ spv::Id TGlslangToSpvTraverser::createBinaryMatrixOperation(spv::Op op, spv::Dec
         return builder.setPrecision(result, precision);
     }
 
-    // Handle component-wise +, -, *, and / for all combinations of type.
+    // Handle component-wise +, -, *, %, and / for all combinations of type.
     // The result type of all of them is the same type as the (a) matrix operand.
     // The algorithm is to:
     //   - break the matrix(es) into vectors
@@ -3043,6 +3043,7 @@ spv::Id TGlslangToSpvTraverser::createBinaryMatrixOperation(spv::Op op, spv::Dec
     case spv::OpFAdd:
     case spv::OpFSub:
     case spv::OpFDiv:
+    case spv::OpFMod:
     case spv::OpFMul:
     {
         // one time set up...
@@ -3208,6 +3209,9 @@ spv::Id TGlslangToSpvTraverser::createUnaryOperation(glslang::TOperator op, spv:
         break;
     case glslang::EOpIsInf:
         unaryOp = spv::OpIsInf;
+        break;
+    case glslang::EOpIsFinite:
+        unaryOp = spv::OpIsFinite;
         break;
 
     case glslang::EOpFloatBitsToInt:

--- a/Test/baseResults/hlsl.intrinsics.frag.out
+++ b/Test/baseResults/hlsl.intrinsics.frag.out
@@ -2,7 +2,7 @@ hlsl.intrinsics.frag
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:62  Function Definition: PixelShaderFunction(f1;f1;f1; (temp float)
+0:66  Function Definition: PixelShaderFunction(f1;f1;f1; (temp float)
 0:2    Function Parameters: 
 0:2      'inF0' (temp float)
 0:2      'inF1' (temp float)
@@ -29,802 +29,1028 @@ gl_FragCoord origin is upper left
 0:11        'inF0' (temp float)
 0:11        'inF1' (temp float)
 0:11        'inF2' (temp float)
-0:12      cosine (global float)
-0:12        'inF0' (temp float)
-0:13      hyp. cosine (global float)
+0:12      Test condition and select (temp void)
+0:12        Condition
+0:12        Compare Less Than (temp bool)
+0:12          'inF0' (temp float)
+0:12          Constant:
+0:12            0.000000
+0:12        true case
+0:12        Branch: Kill
+0:13      cosine (global float)
 0:13        'inF0' (temp float)
-0:14      bitCount (global uint)
-0:14        Constant:
-0:14          7 (const uint)
-0:15      dPdx (global float)
-0:15        'inF0' (temp float)
-0:16      dPdxCoarse (global float)
+0:14      hyp. cosine (global float)
+0:14        'inF0' (temp float)
+0:15      bitCount (global uint)
+0:15        Constant:
+0:15          7 (const uint)
+0:16      dPdx (global float)
 0:16        'inF0' (temp float)
-0:17      dPdxFine (global float)
+0:17      dPdxCoarse (global float)
 0:17        'inF0' (temp float)
-0:18      dPdy (global float)
+0:18      dPdxFine (global float)
 0:18        'inF0' (temp float)
-0:19      dPdyCoarse (global float)
+0:19      dPdy (global float)
 0:19        'inF0' (temp float)
-0:20      dPdyFine (global float)
+0:20      dPdyCoarse (global float)
 0:20        'inF0' (temp float)
-0:21      degrees (global float)
+0:21      dPdyFine (global float)
 0:21        'inF0' (temp float)
-0:25      exp (global float)
-0:25        'inF0' (temp float)
-0:26      exp2 (global float)
+0:22      degrees (global float)
+0:22        'inF0' (temp float)
+0:26      exp (global float)
 0:26        'inF0' (temp float)
-0:27      findMSB (global int)
-0:27        Constant:
-0:27          7 (const int)
-0:28      findLSB (global int)
+0:27      exp2 (global float)
+0:27        'inF0' (temp float)
+0:28      findMSB (global int)
 0:28        Constant:
 0:28          7 (const int)
-0:29      Floor (global float)
-0:29        'inF0' (temp float)
-0:31      Function Call: fmod(f1;f1; (global float)
-0:31        'inF0' (temp float)
-0:31        'inF1' (temp float)
-0:32      Fraction (global float)
+0:29      findLSB (global int)
+0:29        Constant:
+0:29          7 (const int)
+0:30      Floor (global float)
+0:30        'inF0' (temp float)
+0:32      mod (global float)
 0:32        'inF0' (temp float)
-0:33      frexp (global float)
+0:32        'inF1' (temp float)
+0:33      Fraction (global float)
 0:33        'inF0' (temp float)
-0:33        'inF1' (temp float)
-0:34      fwidth (global float)
+0:34      frexp (global float)
 0:34        'inF0' (temp float)
-0:35      isinf (global bool)
+0:34        'inF1' (temp float)
+0:35      fwidth (global float)
 0:35        'inF0' (temp float)
-0:36      isnan (global bool)
+0:36      isinf (global bool)
 0:36        'inF0' (temp float)
-0:37      ldexp (global float)
+0:37      isnan (global bool)
 0:37        'inF0' (temp float)
-0:37        'inF1' (temp float)
-0:38      log (global float)
+0:38      ldexp (global float)
 0:38        'inF0' (temp float)
-0:39      log2 (global float)
+0:38        'inF1' (temp float)
+0:39      log (global float)
 0:39        'inF0' (temp float)
-0:40      max (global float)
-0:40        'inF0' (temp float)
-0:40        'inF1' (temp float)
-0:41      min (global float)
+0:40      component-wise multiply (temp float)
+0:40        log2 (temp float)
+0:40          'inF0' (temp float)
+0:40        Constant:
+0:40          0.301030
+0:41      log2 (global float)
 0:41        'inF0' (temp float)
-0:41        'inF1' (temp float)
-0:43      pow (global float)
+0:42      max (global float)
+0:42        'inF0' (temp float)
+0:42        'inF1' (temp float)
+0:43      min (global float)
 0:43        'inF0' (temp float)
 0:43        'inF1' (temp float)
-0:44      radians (global float)
+0:44      pow (global float)
 0:44        'inF0' (temp float)
-0:45      bitFieldReverse (global uint)
-0:45        Constant:
-0:45          2 (const uint)
-0:46      roundEven (global float)
+0:44        'inF1' (temp float)
+0:45      radians (global float)
+0:45        'inF0' (temp float)
+0:46      divide (temp float)
+0:46        Constant:
+0:46          1.000000
 0:46        'inF0' (temp float)
-0:47      inverse sqrt (global float)
-0:47        'inF0' (temp float)
-0:48      Sign (global float)
+0:47      bitFieldReverse (global uint)
+0:47        Constant:
+0:47          2 (const uint)
+0:48      roundEven (global float)
 0:48        'inF0' (temp float)
-0:49      sine (global float)
+0:49      inverse sqrt (global float)
 0:49        'inF0' (temp float)
-0:50      hyp. sine (global float)
+0:50      clamp (global float)
 0:50        'inF0' (temp float)
-0:51      smoothstep (global float)
+0:50        Constant:
+0:50          0.000000
+0:50        Constant:
+0:50          1.000000
+0:51      Sign (global float)
 0:51        'inF0' (temp float)
-0:51        'inF1' (temp float)
-0:51        'inF2' (temp float)
-0:52      sqrt (global float)
+0:52      sine (global float)
 0:52        'inF0' (temp float)
-0:53      step (global float)
-0:53        'inF0' (temp float)
-0:53        'inF1' (temp float)
-0:54      tangent (global float)
+0:53      Sequence
+0:53        move second child to first child (temp float)
+0:53          'inF1' (temp float)
+0:53          sine (temp float)
+0:53            'inF0' (temp float)
+0:53        move second child to first child (temp float)
+0:53          'inF2' (temp float)
+0:53          cosine (temp float)
+0:53            'inF0' (temp float)
+0:54      hyp. sine (global float)
 0:54        'inF0' (temp float)
-0:55      hyp. tangent (global float)
+0:55      smoothstep (global float)
 0:55        'inF0' (temp float)
-0:57      trunc (global float)
+0:55        'inF1' (temp float)
+0:55        'inF2' (temp float)
+0:56      sqrt (global float)
+0:56        'inF0' (temp float)
+0:57      step (global float)
 0:57        'inF0' (temp float)
-0:59      Branch: Return with expression
-0:59        Constant:
-0:59          0.000000
-0:68  Function Definition: PixelShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
-0:63    Function Parameters: 
-0:63      'inF0' (temp 1-component vector of float)
-0:63      'inF1' (temp 1-component vector of float)
-0:63      'inF2' (temp 1-component vector of float)
+0:57        'inF1' (temp float)
+0:58      tangent (global float)
+0:58        'inF0' (temp float)
+0:59      hyp. tangent (global float)
+0:59        'inF0' (temp float)
+0:61      trunc (global float)
+0:61        'inF0' (temp float)
+0:63      Branch: Return with expression
+0:63        Constant:
+0:63          0.000000
+0:72  Function Definition: PixelShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
+0:67    Function Parameters: 
+0:67      'inF0' (temp 1-component vector of float)
+0:67      'inF1' (temp 1-component vector of float)
+0:67      'inF2' (temp 1-component vector of float)
 0:?     Sequence
-0:65      Branch: Return with expression
-0:65        Constant:
-0:65          0.000000
-0:137  Function Definition: PixelShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
-0:69    Function Parameters: 
-0:69      'inF0' (temp 2-component vector of float)
-0:69      'inF1' (temp 2-component vector of float)
-0:69      'inF2' (temp 2-component vector of float)
+0:69      Branch: Return with expression
+0:69        Constant:
+0:69          0.000000
+0:145  Function Definition: PixelShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
+0:73    Function Parameters: 
+0:73      'inF0' (temp 2-component vector of float)
+0:73      'inF1' (temp 2-component vector of float)
+0:73      'inF2' (temp 2-component vector of float)
 0:?     Sequence
-0:70      all (global bool)
-0:70        'inF0' (temp 2-component vector of float)
-0:71      Absolute value (global 2-component vector of float)
-0:71        'inF0' (temp 2-component vector of float)
-0:72      arc cosine (global 2-component vector of float)
-0:72        'inF0' (temp 2-component vector of float)
-0:73      any (global bool)
-0:73        'inF0' (temp 2-component vector of float)
-0:74      arc sine (global 2-component vector of float)
+0:74      all (global bool)
 0:74        'inF0' (temp 2-component vector of float)
-0:75      arc tangent (global 2-component vector of float)
+0:75      Absolute value (global 2-component vector of float)
 0:75        'inF0' (temp 2-component vector of float)
-0:76      arc tangent (global 2-component vector of float)
+0:76      arc cosine (global 2-component vector of float)
 0:76        'inF0' (temp 2-component vector of float)
-0:76        'inF1' (temp 2-component vector of float)
-0:77      Ceiling (global 2-component vector of float)
+0:77      any (global bool)
 0:77        'inF0' (temp 2-component vector of float)
-0:78      clamp (global 2-component vector of float)
+0:78      arc sine (global 2-component vector of float)
 0:78        'inF0' (temp 2-component vector of float)
-0:78        'inF1' (temp 2-component vector of float)
-0:78        'inF2' (temp 2-component vector of float)
-0:79      cosine (global 2-component vector of float)
+0:79      arc tangent (global 2-component vector of float)
 0:79        'inF0' (temp 2-component vector of float)
-0:80      hyp. cosine (global 2-component vector of float)
+0:80      arc tangent (global 2-component vector of float)
 0:80        'inF0' (temp 2-component vector of float)
+0:80        'inF1' (temp 2-component vector of float)
+0:81      Ceiling (global 2-component vector of float)
+0:81        'inF0' (temp 2-component vector of float)
+0:82      clamp (global 2-component vector of float)
+0:82        'inF0' (temp 2-component vector of float)
+0:82        'inF1' (temp 2-component vector of float)
+0:82        'inF2' (temp 2-component vector of float)
+0:83      Test condition and select (temp void)
+0:83        Condition
+0:83        any (temp bool)
+0:83          Compare Less Than (temp 2-component vector of bool)
+0:83            'inF0' (temp 2-component vector of float)
+0:83            Constant:
+0:83              0.000000
+0:83              0.000000
+0:83        true case
+0:83        Branch: Kill
+0:84      cosine (global 2-component vector of float)
+0:84        'inF0' (temp 2-component vector of float)
+0:85      hyp. cosine (global 2-component vector of float)
+0:85        'inF0' (temp 2-component vector of float)
 0:?       bitCount (global 2-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
-0:82      dPdx (global 2-component vector of float)
-0:82        'inF0' (temp 2-component vector of float)
-0:83      dPdxCoarse (global 2-component vector of float)
-0:83        'inF0' (temp 2-component vector of float)
-0:84      dPdxFine (global 2-component vector of float)
-0:84        'inF0' (temp 2-component vector of float)
-0:85      dPdy (global 2-component vector of float)
-0:85        'inF0' (temp 2-component vector of float)
-0:86      dPdyCoarse (global 2-component vector of float)
-0:86        'inF0' (temp 2-component vector of float)
-0:87      dPdyFine (global 2-component vector of float)
+0:87      dPdx (global 2-component vector of float)
 0:87        'inF0' (temp 2-component vector of float)
-0:88      degrees (global 2-component vector of float)
+0:88      dPdxCoarse (global 2-component vector of float)
 0:88        'inF0' (temp 2-component vector of float)
-0:89      distance (global float)
+0:89      dPdxFine (global 2-component vector of float)
 0:89        'inF0' (temp 2-component vector of float)
-0:89        'inF1' (temp 2-component vector of float)
-0:90      dot-product (global float)
+0:90      dPdy (global 2-component vector of float)
 0:90        'inF0' (temp 2-component vector of float)
-0:90        'inF1' (temp 2-component vector of float)
-0:94      exp (global 2-component vector of float)
+0:91      dPdyCoarse (global 2-component vector of float)
+0:91        'inF0' (temp 2-component vector of float)
+0:92      dPdyFine (global 2-component vector of float)
+0:92        'inF0' (temp 2-component vector of float)
+0:93      degrees (global 2-component vector of float)
+0:93        'inF0' (temp 2-component vector of float)
+0:94      distance (global float)
 0:94        'inF0' (temp 2-component vector of float)
-0:95      exp2 (global 2-component vector of float)
+0:94        'inF1' (temp 2-component vector of float)
+0:95      dot-product (global float)
 0:95        'inF0' (temp 2-component vector of float)
-0:96      face-forward (global 2-component vector of float)
-0:96        'inF0' (temp 2-component vector of float)
-0:96        'inF1' (temp 2-component vector of float)
-0:96        'inF2' (temp 2-component vector of float)
-0:97      findMSB (global int)
-0:97        Constant:
-0:97          7 (const int)
-0:98      findLSB (global int)
-0:98        Constant:
-0:98          7 (const int)
-0:99      Floor (global 2-component vector of float)
+0:95        'inF1' (temp 2-component vector of float)
+0:99      exp (global 2-component vector of float)
 0:99        'inF0' (temp 2-component vector of float)
-0:101      Function Call: fmod(vf2;vf2; (global 2-component vector of float)
+0:100      exp2 (global 2-component vector of float)
+0:100        'inF0' (temp 2-component vector of float)
+0:101      face-forward (global 2-component vector of float)
 0:101        'inF0' (temp 2-component vector of float)
 0:101        'inF1' (temp 2-component vector of float)
-0:102      Fraction (global 2-component vector of float)
-0:102        'inF0' (temp 2-component vector of float)
-0:103      frexp (global 2-component vector of float)
-0:103        'inF0' (temp 2-component vector of float)
-0:103        'inF1' (temp 2-component vector of float)
-0:104      fwidth (global 2-component vector of float)
+0:101        'inF2' (temp 2-component vector of float)
+0:102      findMSB (global int)
+0:102        Constant:
+0:102          7 (const int)
+0:103      findLSB (global int)
+0:103        Constant:
+0:103          7 (const int)
+0:104      Floor (global 2-component vector of float)
 0:104        'inF0' (temp 2-component vector of float)
-0:105      isinf (global 2-component vector of bool)
-0:105        'inF0' (temp 2-component vector of float)
-0:106      isnan (global 2-component vector of bool)
+0:106      mod (global 2-component vector of float)
 0:106        'inF0' (temp 2-component vector of float)
-0:107      ldexp (global 2-component vector of float)
+0:106        'inF1' (temp 2-component vector of float)
+0:107      Fraction (global 2-component vector of float)
 0:107        'inF0' (temp 2-component vector of float)
-0:107        'inF1' (temp 2-component vector of float)
-0:108      length (global float)
+0:108      frexp (global 2-component vector of float)
 0:108        'inF0' (temp 2-component vector of float)
-0:109      log (global 2-component vector of float)
+0:108        'inF1' (temp 2-component vector of float)
+0:109      fwidth (global 2-component vector of float)
 0:109        'inF0' (temp 2-component vector of float)
-0:110      log2 (global 2-component vector of float)
+0:110      isinf (global 2-component vector of bool)
 0:110        'inF0' (temp 2-component vector of float)
-0:111      max (global 2-component vector of float)
+0:111      isnan (global 2-component vector of bool)
 0:111        'inF0' (temp 2-component vector of float)
-0:111        'inF1' (temp 2-component vector of float)
-0:112      min (global 2-component vector of float)
+0:112      ldexp (global 2-component vector of float)
 0:112        'inF0' (temp 2-component vector of float)
 0:112        'inF1' (temp 2-component vector of float)
-0:114      normalize (global 2-component vector of float)
+0:113      length (global float)
+0:113        'inF0' (temp 2-component vector of float)
+0:114      log (global 2-component vector of float)
 0:114        'inF0' (temp 2-component vector of float)
-0:115      pow (global 2-component vector of float)
-0:115        'inF0' (temp 2-component vector of float)
-0:115        'inF1' (temp 2-component vector of float)
-0:116      radians (global 2-component vector of float)
+0:115      vector-scale (temp 2-component vector of float)
+0:115        log2 (temp 2-component vector of float)
+0:115          'inF0' (temp 2-component vector of float)
+0:115        Constant:
+0:115          0.301030
+0:116      log2 (global 2-component vector of float)
 0:116        'inF0' (temp 2-component vector of float)
-0:117      reflect (global 2-component vector of float)
+0:117      max (global 2-component vector of float)
 0:117        'inF0' (temp 2-component vector of float)
 0:117        'inF1' (temp 2-component vector of float)
-0:118      refract (global 2-component vector of float)
+0:118      min (global 2-component vector of float)
 0:118        'inF0' (temp 2-component vector of float)
 0:118        'inF1' (temp 2-component vector of float)
-0:118        Constant:
-0:118          2.000000
+0:119      normalize (global 2-component vector of float)
+0:119        'inF0' (temp 2-component vector of float)
+0:120      pow (global 2-component vector of float)
+0:120        'inF0' (temp 2-component vector of float)
+0:120        'inF1' (temp 2-component vector of float)
+0:121      radians (global 2-component vector of float)
+0:121        'inF0' (temp 2-component vector of float)
+0:122      divide (temp 2-component vector of float)
+0:122        Constant:
+0:122          1.000000
+0:122        'inF0' (temp 2-component vector of float)
+0:123      reflect (global 2-component vector of float)
+0:123        'inF0' (temp 2-component vector of float)
+0:123        'inF1' (temp 2-component vector of float)
+0:124      refract (global 2-component vector of float)
+0:124        'inF0' (temp 2-component vector of float)
+0:124        'inF1' (temp 2-component vector of float)
+0:124        Constant:
+0:124          2.000000
 0:?       bitFieldReverse (global 2-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
-0:120      roundEven (global 2-component vector of float)
-0:120        'inF0' (temp 2-component vector of float)
-0:121      inverse sqrt (global 2-component vector of float)
-0:121        'inF0' (temp 2-component vector of float)
-0:122      Sign (global 2-component vector of float)
-0:122        'inF0' (temp 2-component vector of float)
-0:123      sine (global 2-component vector of float)
-0:123        'inF0' (temp 2-component vector of float)
-0:124      hyp. sine (global 2-component vector of float)
-0:124        'inF0' (temp 2-component vector of float)
-0:125      smoothstep (global 2-component vector of float)
-0:125        'inF0' (temp 2-component vector of float)
-0:125        'inF1' (temp 2-component vector of float)
-0:125        'inF2' (temp 2-component vector of float)
-0:126      sqrt (global 2-component vector of float)
+0:126      roundEven (global 2-component vector of float)
 0:126        'inF0' (temp 2-component vector of float)
-0:127      step (global 2-component vector of float)
+0:127      inverse sqrt (global 2-component vector of float)
 0:127        'inF0' (temp 2-component vector of float)
-0:127        'inF1' (temp 2-component vector of float)
-0:128      tangent (global 2-component vector of float)
+0:128      clamp (global 2-component vector of float)
 0:128        'inF0' (temp 2-component vector of float)
-0:129      hyp. tangent (global 2-component vector of float)
+0:128        Constant:
+0:128          0.000000
+0:128        Constant:
+0:128          1.000000
+0:129      Sign (global 2-component vector of float)
 0:129        'inF0' (temp 2-component vector of float)
-0:131      trunc (global 2-component vector of float)
-0:131        'inF0' (temp 2-component vector of float)
-0:134      Branch: Return with expression
+0:130      sine (global 2-component vector of float)
+0:130        'inF0' (temp 2-component vector of float)
+0:131      Sequence
+0:131        move second child to first child (temp 2-component vector of float)
+0:131          'inF1' (temp 2-component vector of float)
+0:131          sine (temp 2-component vector of float)
+0:131            'inF0' (temp 2-component vector of float)
+0:131        move second child to first child (temp 2-component vector of float)
+0:131          'inF2' (temp 2-component vector of float)
+0:131          cosine (temp 2-component vector of float)
+0:131            'inF0' (temp 2-component vector of float)
+0:132      hyp. sine (global 2-component vector of float)
+0:132        'inF0' (temp 2-component vector of float)
+0:133      smoothstep (global 2-component vector of float)
+0:133        'inF0' (temp 2-component vector of float)
+0:133        'inF1' (temp 2-component vector of float)
+0:133        'inF2' (temp 2-component vector of float)
+0:134      sqrt (global 2-component vector of float)
+0:134        'inF0' (temp 2-component vector of float)
+0:135      step (global 2-component vector of float)
+0:135        'inF0' (temp 2-component vector of float)
+0:135        'inF1' (temp 2-component vector of float)
+0:136      tangent (global 2-component vector of float)
+0:136        'inF0' (temp 2-component vector of float)
+0:137      hyp. tangent (global 2-component vector of float)
+0:137        'inF0' (temp 2-component vector of float)
+0:139      trunc (global 2-component vector of float)
+0:139        'inF0' (temp 2-component vector of float)
+0:142      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
-0:207  Function Definition: PixelShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
-0:138    Function Parameters: 
-0:138      'inF0' (temp 3-component vector of float)
-0:138      'inF1' (temp 3-component vector of float)
-0:138      'inF2' (temp 3-component vector of float)
+0:219  Function Definition: PixelShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
+0:146    Function Parameters: 
+0:146      'inF0' (temp 3-component vector of float)
+0:146      'inF1' (temp 3-component vector of float)
+0:146      'inF2' (temp 3-component vector of float)
 0:?     Sequence
-0:139      all (global bool)
-0:139        'inF0' (temp 3-component vector of float)
-0:140      Absolute value (global 3-component vector of float)
-0:140        'inF0' (temp 3-component vector of float)
-0:141      arc cosine (global 3-component vector of float)
-0:141        'inF0' (temp 3-component vector of float)
-0:142      any (global bool)
-0:142        'inF0' (temp 3-component vector of float)
-0:143      arc sine (global 3-component vector of float)
-0:143        'inF0' (temp 3-component vector of float)
-0:144      arc tangent (global 3-component vector of float)
-0:144        'inF0' (temp 3-component vector of float)
-0:145      arc tangent (global 3-component vector of float)
-0:145        'inF0' (temp 3-component vector of float)
-0:145        'inF1' (temp 3-component vector of float)
-0:146      Ceiling (global 3-component vector of float)
-0:146        'inF0' (temp 3-component vector of float)
-0:147      clamp (global 3-component vector of float)
+0:147      all (global bool)
 0:147        'inF0' (temp 3-component vector of float)
-0:147        'inF1' (temp 3-component vector of float)
-0:147        'inF2' (temp 3-component vector of float)
-0:148      cosine (global 3-component vector of float)
+0:148      Absolute value (global 3-component vector of float)
 0:148        'inF0' (temp 3-component vector of float)
-0:149      hyp. cosine (global 3-component vector of float)
+0:149      arc cosine (global 3-component vector of float)
 0:149        'inF0' (temp 3-component vector of float)
+0:150      any (global bool)
+0:150        'inF0' (temp 3-component vector of float)
+0:151      arc sine (global 3-component vector of float)
+0:151        'inF0' (temp 3-component vector of float)
+0:152      arc tangent (global 3-component vector of float)
+0:152        'inF0' (temp 3-component vector of float)
+0:153      arc tangent (global 3-component vector of float)
+0:153        'inF0' (temp 3-component vector of float)
+0:153        'inF1' (temp 3-component vector of float)
+0:154      Ceiling (global 3-component vector of float)
+0:154        'inF0' (temp 3-component vector of float)
+0:155      clamp (global 3-component vector of float)
+0:155        'inF0' (temp 3-component vector of float)
+0:155        'inF1' (temp 3-component vector of float)
+0:155        'inF2' (temp 3-component vector of float)
+0:156      Test condition and select (temp void)
+0:156        Condition
+0:156        any (temp bool)
+0:156          Compare Less Than (temp 3-component vector of bool)
+0:156            'inF0' (temp 3-component vector of float)
+0:156            Constant:
+0:156              0.000000
+0:156              0.000000
+0:156              0.000000
+0:156        true case
+0:156        Branch: Kill
+0:157      cosine (global 3-component vector of float)
+0:157        'inF0' (temp 3-component vector of float)
+0:158      hyp. cosine (global 3-component vector of float)
+0:158        'inF0' (temp 3-component vector of float)
 0:?       bitCount (global 3-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
-0:151      cross-product (global 3-component vector of float)
-0:151        'inF0' (temp 3-component vector of float)
-0:151        'inF1' (temp 3-component vector of float)
-0:152      dPdx (global 3-component vector of float)
-0:152        'inF0' (temp 3-component vector of float)
-0:153      dPdxCoarse (global 3-component vector of float)
-0:153        'inF0' (temp 3-component vector of float)
-0:154      dPdxFine (global 3-component vector of float)
-0:154        'inF0' (temp 3-component vector of float)
-0:155      dPdy (global 3-component vector of float)
-0:155        'inF0' (temp 3-component vector of float)
-0:156      dPdyCoarse (global 3-component vector of float)
-0:156        'inF0' (temp 3-component vector of float)
-0:157      dPdyFine (global 3-component vector of float)
-0:157        'inF0' (temp 3-component vector of float)
-0:158      degrees (global 3-component vector of float)
-0:158        'inF0' (temp 3-component vector of float)
-0:159      distance (global float)
-0:159        'inF0' (temp 3-component vector of float)
-0:159        'inF1' (temp 3-component vector of float)
-0:160      dot-product (global float)
+0:160      cross-product (global 3-component vector of float)
 0:160        'inF0' (temp 3-component vector of float)
 0:160        'inF1' (temp 3-component vector of float)
-0:164      exp (global 3-component vector of float)
+0:161      dPdx (global 3-component vector of float)
+0:161        'inF0' (temp 3-component vector of float)
+0:162      dPdxCoarse (global 3-component vector of float)
+0:162        'inF0' (temp 3-component vector of float)
+0:163      dPdxFine (global 3-component vector of float)
+0:163        'inF0' (temp 3-component vector of float)
+0:164      dPdy (global 3-component vector of float)
 0:164        'inF0' (temp 3-component vector of float)
-0:165      exp2 (global 3-component vector of float)
+0:165      dPdyCoarse (global 3-component vector of float)
 0:165        'inF0' (temp 3-component vector of float)
-0:166      face-forward (global 3-component vector of float)
+0:166      dPdyFine (global 3-component vector of float)
 0:166        'inF0' (temp 3-component vector of float)
-0:166        'inF1' (temp 3-component vector of float)
-0:166        'inF2' (temp 3-component vector of float)
-0:167      findMSB (global int)
-0:167        Constant:
-0:167          7 (const int)
-0:168      findLSB (global int)
-0:168        Constant:
-0:168          7 (const int)
-0:169      Floor (global 3-component vector of float)
+0:167      degrees (global 3-component vector of float)
+0:167        'inF0' (temp 3-component vector of float)
+0:168      distance (global float)
+0:168        'inF0' (temp 3-component vector of float)
+0:168        'inF1' (temp 3-component vector of float)
+0:169      dot-product (global float)
 0:169        'inF0' (temp 3-component vector of float)
-0:171      Function Call: fmod(vf3;vf3; (global 3-component vector of float)
-0:171        'inF0' (temp 3-component vector of float)
-0:171        'inF1' (temp 3-component vector of float)
-0:172      Fraction (global 3-component vector of float)
-0:172        'inF0' (temp 3-component vector of float)
-0:173      frexp (global 3-component vector of float)
+0:169        'inF1' (temp 3-component vector of float)
+0:173      exp (global 3-component vector of float)
 0:173        'inF0' (temp 3-component vector of float)
-0:173        'inF1' (temp 3-component vector of float)
-0:174      fwidth (global 3-component vector of float)
+0:174      exp2 (global 3-component vector of float)
 0:174        'inF0' (temp 3-component vector of float)
-0:175      isinf (global 3-component vector of bool)
+0:175      face-forward (global 3-component vector of float)
 0:175        'inF0' (temp 3-component vector of float)
-0:176      isnan (global 3-component vector of bool)
-0:176        'inF0' (temp 3-component vector of float)
-0:177      ldexp (global 3-component vector of float)
-0:177        'inF0' (temp 3-component vector of float)
-0:177        'inF1' (temp 3-component vector of float)
-0:178      length (global float)
+0:175        'inF1' (temp 3-component vector of float)
+0:175        'inF2' (temp 3-component vector of float)
+0:176      findMSB (global int)
+0:176        Constant:
+0:176          7 (const int)
+0:177      findLSB (global int)
+0:177        Constant:
+0:177          7 (const int)
+0:178      Floor (global 3-component vector of float)
 0:178        'inF0' (temp 3-component vector of float)
-0:179      log (global 3-component vector of float)
-0:179        'inF0' (temp 3-component vector of float)
-0:180      log2 (global 3-component vector of float)
+0:180      mod (global 3-component vector of float)
 0:180        'inF0' (temp 3-component vector of float)
-0:181      max (global 3-component vector of float)
+0:180        'inF1' (temp 3-component vector of float)
+0:181      Fraction (global 3-component vector of float)
 0:181        'inF0' (temp 3-component vector of float)
-0:181        'inF1' (temp 3-component vector of float)
-0:182      min (global 3-component vector of float)
+0:182      frexp (global 3-component vector of float)
 0:182        'inF0' (temp 3-component vector of float)
 0:182        'inF1' (temp 3-component vector of float)
-0:184      normalize (global 3-component vector of float)
+0:183      fwidth (global 3-component vector of float)
+0:183        'inF0' (temp 3-component vector of float)
+0:184      isinf (global 3-component vector of bool)
 0:184        'inF0' (temp 3-component vector of float)
-0:185      pow (global 3-component vector of float)
+0:185      isnan (global 3-component vector of bool)
 0:185        'inF0' (temp 3-component vector of float)
-0:185        'inF1' (temp 3-component vector of float)
-0:186      radians (global 3-component vector of float)
+0:186      ldexp (global 3-component vector of float)
 0:186        'inF0' (temp 3-component vector of float)
-0:187      reflect (global 3-component vector of float)
+0:186        'inF1' (temp 3-component vector of float)
+0:187      length (global float)
 0:187        'inF0' (temp 3-component vector of float)
-0:187        'inF1' (temp 3-component vector of float)
-0:188      refract (global 3-component vector of float)
+0:188      log (global 3-component vector of float)
 0:188        'inF0' (temp 3-component vector of float)
-0:188        'inF1' (temp 3-component vector of float)
-0:188        Constant:
-0:188          2.000000
+0:189      vector-scale (temp 3-component vector of float)
+0:189        log2 (temp 3-component vector of float)
+0:189          'inF0' (temp 3-component vector of float)
+0:189        Constant:
+0:189          0.301030
+0:190      log2 (global 3-component vector of float)
+0:190        'inF0' (temp 3-component vector of float)
+0:191      max (global 3-component vector of float)
+0:191        'inF0' (temp 3-component vector of float)
+0:191        'inF1' (temp 3-component vector of float)
+0:192      min (global 3-component vector of float)
+0:192        'inF0' (temp 3-component vector of float)
+0:192        'inF1' (temp 3-component vector of float)
+0:193      normalize (global 3-component vector of float)
+0:193        'inF0' (temp 3-component vector of float)
+0:194      pow (global 3-component vector of float)
+0:194        'inF0' (temp 3-component vector of float)
+0:194        'inF1' (temp 3-component vector of float)
+0:195      radians (global 3-component vector of float)
+0:195        'inF0' (temp 3-component vector of float)
+0:196      divide (temp 3-component vector of float)
+0:196        Constant:
+0:196          1.000000
+0:196        'inF0' (temp 3-component vector of float)
+0:197      reflect (global 3-component vector of float)
+0:197        'inF0' (temp 3-component vector of float)
+0:197        'inF1' (temp 3-component vector of float)
+0:198      refract (global 3-component vector of float)
+0:198        'inF0' (temp 3-component vector of float)
+0:198        'inF1' (temp 3-component vector of float)
+0:198        Constant:
+0:198          2.000000
 0:?       bitFieldReverse (global 3-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
-0:190      roundEven (global 3-component vector of float)
-0:190        'inF0' (temp 3-component vector of float)
-0:191      inverse sqrt (global 3-component vector of float)
-0:191        'inF0' (temp 3-component vector of float)
-0:192      Sign (global 3-component vector of float)
-0:192        'inF0' (temp 3-component vector of float)
-0:193      sine (global 3-component vector of float)
-0:193        'inF0' (temp 3-component vector of float)
-0:194      hyp. sine (global 3-component vector of float)
-0:194        'inF0' (temp 3-component vector of float)
-0:195      smoothstep (global 3-component vector of float)
-0:195        'inF0' (temp 3-component vector of float)
-0:195        'inF1' (temp 3-component vector of float)
-0:195        'inF2' (temp 3-component vector of float)
-0:196      sqrt (global 3-component vector of float)
-0:196        'inF0' (temp 3-component vector of float)
-0:197      step (global 3-component vector of float)
-0:197        'inF0' (temp 3-component vector of float)
-0:197        'inF1' (temp 3-component vector of float)
-0:198      tangent (global 3-component vector of float)
-0:198        'inF0' (temp 3-component vector of float)
-0:199      hyp. tangent (global 3-component vector of float)
-0:199        'inF0' (temp 3-component vector of float)
-0:201      trunc (global 3-component vector of float)
+0:200      roundEven (global 3-component vector of float)
+0:200        'inF0' (temp 3-component vector of float)
+0:201      inverse sqrt (global 3-component vector of float)
 0:201        'inF0' (temp 3-component vector of float)
-0:204      Branch: Return with expression
+0:202      clamp (global 3-component vector of float)
+0:202        'inF0' (temp 3-component vector of float)
+0:202        Constant:
+0:202          0.000000
+0:202        Constant:
+0:202          1.000000
+0:203      Sign (global 3-component vector of float)
+0:203        'inF0' (temp 3-component vector of float)
+0:204      sine (global 3-component vector of float)
+0:204        'inF0' (temp 3-component vector of float)
+0:205      Sequence
+0:205        move second child to first child (temp 3-component vector of float)
+0:205          'inF1' (temp 3-component vector of float)
+0:205          sine (temp 3-component vector of float)
+0:205            'inF0' (temp 3-component vector of float)
+0:205        move second child to first child (temp 3-component vector of float)
+0:205          'inF2' (temp 3-component vector of float)
+0:205          cosine (temp 3-component vector of float)
+0:205            'inF0' (temp 3-component vector of float)
+0:206      hyp. sine (global 3-component vector of float)
+0:206        'inF0' (temp 3-component vector of float)
+0:207      smoothstep (global 3-component vector of float)
+0:207        'inF0' (temp 3-component vector of float)
+0:207        'inF1' (temp 3-component vector of float)
+0:207        'inF2' (temp 3-component vector of float)
+0:208      sqrt (global 3-component vector of float)
+0:208        'inF0' (temp 3-component vector of float)
+0:209      step (global 3-component vector of float)
+0:209        'inF0' (temp 3-component vector of float)
+0:209        'inF1' (temp 3-component vector of float)
+0:210      tangent (global 3-component vector of float)
+0:210        'inF0' (temp 3-component vector of float)
+0:211      hyp. tangent (global 3-component vector of float)
+0:211        'inF0' (temp 3-component vector of float)
+0:213      trunc (global 3-component vector of float)
+0:213        'inF0' (temp 3-component vector of float)
+0:216      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
-0:328  Function Definition: PixelShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
-0:208    Function Parameters: 
-0:208      'inF0' (temp 4-component vector of float)
-0:208      'inF1' (temp 4-component vector of float)
-0:208      'inF2' (temp 4-component vector of float)
+0:349  Function Definition: PixelShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
+0:220    Function Parameters: 
+0:220      'inF0' (temp 4-component vector of float)
+0:220      'inF1' (temp 4-component vector of float)
+0:220      'inF2' (temp 4-component vector of float)
 0:?     Sequence
-0:209      all (global bool)
-0:209        'inF0' (temp 4-component vector of float)
-0:210      Absolute value (global 4-component vector of float)
-0:210        'inF0' (temp 4-component vector of float)
-0:211      arc cosine (global 4-component vector of float)
-0:211        'inF0' (temp 4-component vector of float)
-0:212      any (global bool)
-0:212        'inF0' (temp 4-component vector of float)
-0:213      arc sine (global 4-component vector of float)
-0:213        'inF0' (temp 4-component vector of float)
-0:214      arc tangent (global 4-component vector of float)
-0:214        'inF0' (temp 4-component vector of float)
-0:215      arc tangent (global 4-component vector of float)
-0:215        'inF0' (temp 4-component vector of float)
-0:215        'inF1' (temp 4-component vector of float)
-0:216      Ceiling (global 4-component vector of float)
-0:216        'inF0' (temp 4-component vector of float)
-0:217      clamp (global 4-component vector of float)
-0:217        'inF0' (temp 4-component vector of float)
-0:217        'inF1' (temp 4-component vector of float)
-0:217        'inF2' (temp 4-component vector of float)
-0:218      cosine (global 4-component vector of float)
-0:218        'inF0' (temp 4-component vector of float)
-0:219      hyp. cosine (global 4-component vector of float)
-0:219        'inF0' (temp 4-component vector of float)
+0:221      all (global bool)
+0:221        'inF0' (temp 4-component vector of float)
+0:222      Absolute value (global 4-component vector of float)
+0:222        'inF0' (temp 4-component vector of float)
+0:223      arc cosine (global 4-component vector of float)
+0:223        'inF0' (temp 4-component vector of float)
+0:224      any (global bool)
+0:224        'inF0' (temp 4-component vector of float)
+0:225      arc sine (global 4-component vector of float)
+0:225        'inF0' (temp 4-component vector of float)
+0:226      arc tangent (global 4-component vector of float)
+0:226        'inF0' (temp 4-component vector of float)
+0:227      arc tangent (global 4-component vector of float)
+0:227        'inF0' (temp 4-component vector of float)
+0:227        'inF1' (temp 4-component vector of float)
+0:228      Ceiling (global 4-component vector of float)
+0:228        'inF0' (temp 4-component vector of float)
+0:229      clamp (global 4-component vector of float)
+0:229        'inF0' (temp 4-component vector of float)
+0:229        'inF1' (temp 4-component vector of float)
+0:229        'inF2' (temp 4-component vector of float)
+0:230      Test condition and select (temp void)
+0:230        Condition
+0:230        any (temp bool)
+0:230          Compare Less Than (temp 4-component vector of bool)
+0:230            'inF0' (temp 4-component vector of float)
+0:230            Constant:
+0:230              0.000000
+0:230              0.000000
+0:230              0.000000
+0:230              0.000000
+0:230        true case
+0:230        Branch: Kill
+0:231      cosine (global 4-component vector of float)
+0:231        'inF0' (temp 4-component vector of float)
+0:232      hyp. cosine (global 4-component vector of float)
+0:232        'inF0' (temp 4-component vector of float)
 0:?       bitCount (global 4-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
 0:?           2 (const uint)
-0:221      dPdx (global 4-component vector of float)
-0:221        'inF0' (temp 4-component vector of float)
-0:222      dPdxCoarse (global 4-component vector of float)
-0:222        'inF0' (temp 4-component vector of float)
-0:223      dPdxFine (global 4-component vector of float)
-0:223        'inF0' (temp 4-component vector of float)
-0:224      dPdy (global 4-component vector of float)
-0:224        'inF0' (temp 4-component vector of float)
-0:225      dPdyCoarse (global 4-component vector of float)
-0:225        'inF0' (temp 4-component vector of float)
-0:226      dPdyFine (global 4-component vector of float)
-0:226        'inF0' (temp 4-component vector of float)
-0:227      degrees (global 4-component vector of float)
-0:227        'inF0' (temp 4-component vector of float)
-0:228      distance (global float)
-0:228        'inF0' (temp 4-component vector of float)
-0:228        'inF1' (temp 4-component vector of float)
-0:229      dot-product (global float)
-0:229        'inF0' (temp 4-component vector of float)
-0:229        'inF1' (temp 4-component vector of float)
-0:233      exp (global 4-component vector of float)
-0:233        'inF0' (temp 4-component vector of float)
-0:234      exp2 (global 4-component vector of float)
+0:234      dPdx (global 4-component vector of float)
 0:234        'inF0' (temp 4-component vector of float)
-0:235      face-forward (global 4-component vector of float)
+0:235      dPdxCoarse (global 4-component vector of float)
 0:235        'inF0' (temp 4-component vector of float)
-0:235        'inF1' (temp 4-component vector of float)
-0:235        'inF2' (temp 4-component vector of float)
-0:236      findMSB (global int)
-0:236        Constant:
-0:236          7 (const int)
-0:237      findLSB (global int)
-0:237        Constant:
-0:237          7 (const int)
-0:238      Floor (global 4-component vector of float)
+0:236      dPdxFine (global 4-component vector of float)
+0:236        'inF0' (temp 4-component vector of float)
+0:237      dPdy (global 4-component vector of float)
+0:237        'inF0' (temp 4-component vector of float)
+0:238      dPdyCoarse (global 4-component vector of float)
 0:238        'inF0' (temp 4-component vector of float)
-0:240      Function Call: fmod(vf4;vf4; (global 4-component vector of float)
+0:239      dPdyFine (global 4-component vector of float)
+0:239        'inF0' (temp 4-component vector of float)
+0:240      degrees (global 4-component vector of float)
 0:240        'inF0' (temp 4-component vector of float)
-0:240        'inF1' (temp 4-component vector of float)
-0:241      Fraction (global 4-component vector of float)
+0:241      distance (global float)
 0:241        'inF0' (temp 4-component vector of float)
-0:242      frexp (global 4-component vector of float)
+0:241        'inF1' (temp 4-component vector of float)
+0:242      dot-product (global float)
 0:242        'inF0' (temp 4-component vector of float)
 0:242        'inF1' (temp 4-component vector of float)
-0:243      fwidth (global 4-component vector of float)
-0:243        'inF0' (temp 4-component vector of float)
-0:244      isinf (global 4-component vector of bool)
-0:244        'inF0' (temp 4-component vector of float)
-0:245      isnan (global 4-component vector of bool)
-0:245        'inF0' (temp 4-component vector of float)
-0:246      ldexp (global 4-component vector of float)
-0:246        'inF0' (temp 4-component vector of float)
-0:246        'inF1' (temp 4-component vector of float)
-0:247      length (global float)
+0:243      Construct vec4 (temp float)
+0:243        Constant:
+0:243          1.000000
+0:243        component-wise multiply (temp float)
+0:243          direct index (temp float)
+0:243            'inF0' (temp 4-component vector of float)
+0:243            Constant:
+0:243              1 (const int)
+0:243          direct index (temp float)
+0:243            'inF1' (temp 4-component vector of float)
+0:243            Constant:
+0:243              1 (const int)
+0:243        direct index (temp float)
+0:243          'inF0' (temp 4-component vector of float)
+0:243          Constant:
+0:243            2 (const int)
+0:243        direct index (temp float)
+0:243          'inF1' (temp 4-component vector of float)
+0:243          Constant:
+0:243            3 (const int)
+0:247      exp (global 4-component vector of float)
 0:247        'inF0' (temp 4-component vector of float)
-0:248      log (global 4-component vector of float)
+0:248      exp2 (global 4-component vector of float)
 0:248        'inF0' (temp 4-component vector of float)
-0:249      log2 (global 4-component vector of float)
+0:249      face-forward (global 4-component vector of float)
 0:249        'inF0' (temp 4-component vector of float)
-0:250      max (global 4-component vector of float)
-0:250        'inF0' (temp 4-component vector of float)
-0:250        'inF1' (temp 4-component vector of float)
-0:251      min (global 4-component vector of float)
-0:251        'inF0' (temp 4-component vector of float)
-0:251        'inF1' (temp 4-component vector of float)
-0:253      normalize (global 4-component vector of float)
-0:253        'inF0' (temp 4-component vector of float)
-0:254      pow (global 4-component vector of float)
+0:249        'inF1' (temp 4-component vector of float)
+0:249        'inF2' (temp 4-component vector of float)
+0:250      findMSB (global int)
+0:250        Constant:
+0:250          7 (const int)
+0:251      findLSB (global int)
+0:251        Constant:
+0:251          7 (const int)
+0:252      Floor (global 4-component vector of float)
+0:252        'inF0' (temp 4-component vector of float)
+0:254      mod (global 4-component vector of float)
 0:254        'inF0' (temp 4-component vector of float)
 0:254        'inF1' (temp 4-component vector of float)
-0:255      radians (global 4-component vector of float)
+0:255      Fraction (global 4-component vector of float)
 0:255        'inF0' (temp 4-component vector of float)
-0:256      reflect (global 4-component vector of float)
+0:256      frexp (global 4-component vector of float)
 0:256        'inF0' (temp 4-component vector of float)
 0:256        'inF1' (temp 4-component vector of float)
-0:257      refract (global 4-component vector of float)
+0:257      fwidth (global 4-component vector of float)
 0:257        'inF0' (temp 4-component vector of float)
-0:257        'inF1' (temp 4-component vector of float)
-0:257        Constant:
-0:257          2.000000
+0:258      isinf (global 4-component vector of bool)
+0:258        'inF0' (temp 4-component vector of float)
+0:259      isnan (global 4-component vector of bool)
+0:259        'inF0' (temp 4-component vector of float)
+0:260      ldexp (global 4-component vector of float)
+0:260        'inF0' (temp 4-component vector of float)
+0:260        'inF1' (temp 4-component vector of float)
+0:261      length (global float)
+0:261        'inF0' (temp 4-component vector of float)
+0:262      log (global 4-component vector of float)
+0:262        'inF0' (temp 4-component vector of float)
+0:263      vector-scale (temp 4-component vector of float)
+0:263        log2 (temp 4-component vector of float)
+0:263          'inF0' (temp 4-component vector of float)
+0:263        Constant:
+0:263          0.301030
+0:264      log2 (global 4-component vector of float)
+0:264        'inF0' (temp 4-component vector of float)
+0:265      max (global 4-component vector of float)
+0:265        'inF0' (temp 4-component vector of float)
+0:265        'inF1' (temp 4-component vector of float)
+0:266      min (global 4-component vector of float)
+0:266        'inF0' (temp 4-component vector of float)
+0:266        'inF1' (temp 4-component vector of float)
+0:267      normalize (global 4-component vector of float)
+0:267        'inF0' (temp 4-component vector of float)
+0:268      pow (global 4-component vector of float)
+0:268        'inF0' (temp 4-component vector of float)
+0:268        'inF1' (temp 4-component vector of float)
+0:269      radians (global 4-component vector of float)
+0:269        'inF0' (temp 4-component vector of float)
+0:270      divide (temp 4-component vector of float)
+0:270        Constant:
+0:270          1.000000
+0:270        'inF0' (temp 4-component vector of float)
+0:271      reflect (global 4-component vector of float)
+0:271        'inF0' (temp 4-component vector of float)
+0:271        'inF1' (temp 4-component vector of float)
+0:272      refract (global 4-component vector of float)
+0:272        'inF0' (temp 4-component vector of float)
+0:272        'inF1' (temp 4-component vector of float)
+0:272        Constant:
+0:272          2.000000
 0:?       bitFieldReverse (global 4-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
 0:?           4 (const uint)
-0:259      roundEven (global 4-component vector of float)
-0:259        'inF0' (temp 4-component vector of float)
-0:260      inverse sqrt (global 4-component vector of float)
-0:260        'inF0' (temp 4-component vector of float)
-0:261      Sign (global 4-component vector of float)
-0:261        'inF0' (temp 4-component vector of float)
-0:262      sine (global 4-component vector of float)
-0:262        'inF0' (temp 4-component vector of float)
-0:263      hyp. sine (global 4-component vector of float)
-0:263        'inF0' (temp 4-component vector of float)
-0:264      smoothstep (global 4-component vector of float)
-0:264        'inF0' (temp 4-component vector of float)
-0:264        'inF1' (temp 4-component vector of float)
-0:264        'inF2' (temp 4-component vector of float)
-0:265      sqrt (global 4-component vector of float)
-0:265        'inF0' (temp 4-component vector of float)
-0:266      step (global 4-component vector of float)
-0:266        'inF0' (temp 4-component vector of float)
-0:266        'inF1' (temp 4-component vector of float)
-0:267      tangent (global 4-component vector of float)
-0:267        'inF0' (temp 4-component vector of float)
-0:268      hyp. tangent (global 4-component vector of float)
-0:268        'inF0' (temp 4-component vector of float)
-0:270      trunc (global 4-component vector of float)
-0:270        'inF0' (temp 4-component vector of float)
-0:273      Branch: Return with expression
+0:274      roundEven (global 4-component vector of float)
+0:274        'inF0' (temp 4-component vector of float)
+0:275      inverse sqrt (global 4-component vector of float)
+0:275        'inF0' (temp 4-component vector of float)
+0:276      clamp (global 4-component vector of float)
+0:276        'inF0' (temp 4-component vector of float)
+0:276        Constant:
+0:276          0.000000
+0:276        Constant:
+0:276          1.000000
+0:277      Sign (global 4-component vector of float)
+0:277        'inF0' (temp 4-component vector of float)
+0:278      sine (global 4-component vector of float)
+0:278        'inF0' (temp 4-component vector of float)
+0:279      Sequence
+0:279        move second child to first child (temp 4-component vector of float)
+0:279          'inF1' (temp 4-component vector of float)
+0:279          sine (temp 4-component vector of float)
+0:279            'inF0' (temp 4-component vector of float)
+0:279        move second child to first child (temp 4-component vector of float)
+0:279          'inF2' (temp 4-component vector of float)
+0:279          cosine (temp 4-component vector of float)
+0:279            'inF0' (temp 4-component vector of float)
+0:280      hyp. sine (global 4-component vector of float)
+0:280        'inF0' (temp 4-component vector of float)
+0:281      smoothstep (global 4-component vector of float)
+0:281        'inF0' (temp 4-component vector of float)
+0:281        'inF1' (temp 4-component vector of float)
+0:281        'inF2' (temp 4-component vector of float)
+0:282      sqrt (global 4-component vector of float)
+0:282        'inF0' (temp 4-component vector of float)
+0:283      step (global 4-component vector of float)
+0:283        'inF0' (temp 4-component vector of float)
+0:283        'inF1' (temp 4-component vector of float)
+0:284      tangent (global 4-component vector of float)
+0:284        'inF0' (temp 4-component vector of float)
+0:285      hyp. tangent (global 4-component vector of float)
+0:285        'inF0' (temp 4-component vector of float)
+0:287      trunc (global 4-component vector of float)
+0:287        'inF0' (temp 4-component vector of float)
+0:290      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
 0:?           4.000000
-0:337  Function Definition: PixelShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
-0:329    Function Parameters: 
-0:329      'inF0' (temp 2X2 matrix of float)
-0:329      'inF1' (temp 2X2 matrix of float)
-0:329      'inF2' (temp 2X2 matrix of float)
+0:358  Function Definition: PixelShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:350    Function Parameters: 
+0:350      'inF0' (temp 2X2 matrix of float)
+0:350      'inF1' (temp 2X2 matrix of float)
+0:350      'inF2' (temp 2X2 matrix of float)
 0:?     Sequence
-0:331      all (global bool)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      Absolute value (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc cosine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      any (global bool)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc sine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      Ceiling (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      clamp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331        'inF2' (temp 2X2 matrix of float)
-0:331      cosine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      hyp. cosine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdx (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdxCoarse (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdxFine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdy (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdyCoarse (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdyFine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      degrees (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      determinant (global float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      exp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      exp2 (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      findMSB (global int)
-0:331        Constant:
-0:331          7 (const int)
-0:331      findLSB (global int)
-0:331        Constant:
-0:331          7 (const int)
-0:331      Floor (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      Function Call: fmod(mf22;mf22; (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      Fraction (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      frexp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      fwidth (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      ldexp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      log (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      log2 (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      max (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      min (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      pow (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      radians (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      roundEven (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      inverse sqrt (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      Sign (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      sine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      hyp. sine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      smoothstep (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331        'inF2' (temp 2X2 matrix of float)
-0:331      sqrt (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      step (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      hyp. tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      transpose (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      trunc (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:334      Branch: Return with expression
+0:352      all (global bool)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      Absolute value (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      arc cosine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      any (global bool)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      arc sine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      arc tangent (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      arc tangent (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      Ceiling (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      Test condition and select (temp void)
+0:352        Condition
+0:352        any (temp bool)
+0:352          Compare Less Than (temp 2X2 matrix of bool)
+0:352            'inF0' (temp 2X2 matrix of float)
+0:352            Constant:
+0:352              0.000000
+0:352              0.000000
+0:352              0.000000
+0:352              0.000000
+0:352        true case
+0:352        Branch: Kill
+0:352      clamp (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352        'inF2' (temp 2X2 matrix of float)
+0:352      cosine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      hyp. cosine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      dPdx (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      dPdxCoarse (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      dPdxFine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      dPdy (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      dPdyCoarse (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      dPdyFine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      degrees (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      determinant (global float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      exp (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      exp2 (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      findMSB (global int)
+0:352        Constant:
+0:352          7 (const int)
+0:352      findLSB (global int)
+0:352        Constant:
+0:352          7 (const int)
+0:352      Floor (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      mod (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      Fraction (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      frexp (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      fwidth (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      ldexp (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      log (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      matrix-scale (temp 2X2 matrix of float)
+0:352        log2 (temp 2X2 matrix of float)
+0:352          'inF0' (temp 2X2 matrix of float)
+0:352        Constant:
+0:352          0.301030
+0:352      log2 (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      max (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      min (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      pow (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      radians (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      roundEven (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      inverse sqrt (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      clamp (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        Constant:
+0:352          0.000000
+0:352        Constant:
+0:352          1.000000
+0:352      Sign (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      sine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      Sequence
+0:352        move second child to first child (temp 2X2 matrix of float)
+0:352          'inF1' (temp 2X2 matrix of float)
+0:352          sine (temp 2X2 matrix of float)
+0:352            'inF0' (temp 2X2 matrix of float)
+0:352        move second child to first child (temp 2X2 matrix of float)
+0:352          'inF2' (temp 2X2 matrix of float)
+0:352          cosine (temp 2X2 matrix of float)
+0:352            'inF0' (temp 2X2 matrix of float)
+0:352      hyp. sine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      smoothstep (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352        'inF2' (temp 2X2 matrix of float)
+0:352      sqrt (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      step (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      tangent (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      hyp. tangent (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      transpose (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      trunc (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:355      Branch: Return with expression
 0:?         Constant:
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
-0:346  Function Definition: PixelShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
-0:338    Function Parameters: 
-0:338      'inF0' (temp 3X3 matrix of float)
-0:338      'inF1' (temp 3X3 matrix of float)
-0:338      'inF2' (temp 3X3 matrix of float)
+0:367  Function Definition: PixelShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:359    Function Parameters: 
+0:359      'inF0' (temp 3X3 matrix of float)
+0:359      'inF1' (temp 3X3 matrix of float)
+0:359      'inF2' (temp 3X3 matrix of float)
 0:?     Sequence
-0:340      all (global bool)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      Absolute value (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc cosine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      any (global bool)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc sine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      Ceiling (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      clamp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340        'inF2' (temp 3X3 matrix of float)
-0:340      cosine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      hyp. cosine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdx (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdxCoarse (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdxFine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdy (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdyCoarse (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdyFine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      degrees (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      determinant (global float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      exp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      exp2 (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      findMSB (global int)
-0:340        Constant:
-0:340          7 (const int)
-0:340      findLSB (global int)
-0:340        Constant:
-0:340          7 (const int)
-0:340      Floor (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      Function Call: fmod(mf33;mf33; (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      Fraction (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      frexp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      fwidth (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      ldexp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      log (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      log2 (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      max (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      min (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      pow (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      radians (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      roundEven (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      inverse sqrt (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      Sign (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      sine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      hyp. sine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      smoothstep (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340        'inF2' (temp 3X3 matrix of float)
-0:340      sqrt (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      step (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      hyp. tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      transpose (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      trunc (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:343      Branch: Return with expression
+0:361      all (global bool)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      Absolute value (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      arc cosine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      any (global bool)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      arc sine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      arc tangent (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      arc tangent (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      Ceiling (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      Test condition and select (temp void)
+0:361        Condition
+0:361        any (temp bool)
+0:361          Compare Less Than (temp 3X3 matrix of bool)
+0:361            'inF0' (temp 3X3 matrix of float)
+0:361            Constant:
+0:361              0.000000
+0:361              0.000000
+0:361              0.000000
+0:361              0.000000
+0:361              0.000000
+0:361              0.000000
+0:361              0.000000
+0:361              0.000000
+0:361              0.000000
+0:361        true case
+0:361        Branch: Kill
+0:361      clamp (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361        'inF2' (temp 3X3 matrix of float)
+0:361      cosine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      hyp. cosine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      dPdx (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      dPdxCoarse (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      dPdxFine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      dPdy (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      dPdyCoarse (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      dPdyFine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      degrees (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      determinant (global float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      exp (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      exp2 (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      findMSB (global int)
+0:361        Constant:
+0:361          7 (const int)
+0:361      findLSB (global int)
+0:361        Constant:
+0:361          7 (const int)
+0:361      Floor (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      mod (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      Fraction (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      frexp (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      fwidth (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      ldexp (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      log (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      matrix-scale (temp 3X3 matrix of float)
+0:361        log2 (temp 3X3 matrix of float)
+0:361          'inF0' (temp 3X3 matrix of float)
+0:361        Constant:
+0:361          0.301030
+0:361      log2 (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      max (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      min (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      pow (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      radians (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      roundEven (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      inverse sqrt (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      clamp (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        Constant:
+0:361          0.000000
+0:361        Constant:
+0:361          1.000000
+0:361      Sign (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      sine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      Sequence
+0:361        move second child to first child (temp 3X3 matrix of float)
+0:361          'inF1' (temp 3X3 matrix of float)
+0:361          sine (temp 3X3 matrix of float)
+0:361            'inF0' (temp 3X3 matrix of float)
+0:361        move second child to first child (temp 3X3 matrix of float)
+0:361          'inF2' (temp 3X3 matrix of float)
+0:361          cosine (temp 3X3 matrix of float)
+0:361            'inF0' (temp 3X3 matrix of float)
+0:361      hyp. sine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      smoothstep (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361        'inF2' (temp 3X3 matrix of float)
+0:361      sqrt (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      step (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      tangent (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      hyp. tangent (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      transpose (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      trunc (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:364      Branch: Return with expression
 0:?         Constant:
 0:?           3.000000
 0:?           3.000000
@@ -835,121 +1061,165 @@ gl_FragCoord origin is upper left
 0:?           3.000000
 0:?           3.000000
 0:?           3.000000
-0:354  Function Definition: PixelShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
-0:347    Function Parameters: 
-0:347      'inF0' (temp 4X4 matrix of float)
-0:347      'inF1' (temp 4X4 matrix of float)
-0:347      'inF2' (temp 4X4 matrix of float)
+0:388  Function Definition: PixelShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:368    Function Parameters: 
+0:368      'inF0' (temp 4X4 matrix of float)
+0:368      'inF1' (temp 4X4 matrix of float)
+0:368      'inF2' (temp 4X4 matrix of float)
 0:?     Sequence
-0:349      all (global bool)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      Absolute value (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc cosine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      any (global bool)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc sine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      Ceiling (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      clamp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349        'inF2' (temp 4X4 matrix of float)
-0:349      cosine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      hyp. cosine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdx (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdxCoarse (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdxFine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdy (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdyCoarse (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdyFine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      degrees (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      determinant (global float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      exp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      exp2 (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      findMSB (global int)
-0:349        Constant:
-0:349          7 (const int)
-0:349      findLSB (global int)
-0:349        Constant:
-0:349          7 (const int)
-0:349      Floor (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      Function Call: fmod(mf44;mf44; (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      Fraction (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      frexp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      fwidth (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      ldexp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      log (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      log2 (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      max (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      min (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      pow (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      radians (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      roundEven (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      inverse sqrt (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      Sign (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      sine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      hyp. sine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      smoothstep (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349        'inF2' (temp 4X4 matrix of float)
-0:349      sqrt (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      step (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      hyp. tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      transpose (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      trunc (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:352      Branch: Return with expression
+0:370      all (global bool)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      Absolute value (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      arc cosine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      any (global bool)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      arc sine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      arc tangent (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      arc tangent (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      Ceiling (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      Test condition and select (temp void)
+0:370        Condition
+0:370        any (temp bool)
+0:370          Compare Less Than (temp 4X4 matrix of bool)
+0:370            'inF0' (temp 4X4 matrix of float)
+0:370            Constant:
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370        true case
+0:370        Branch: Kill
+0:370      clamp (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370        'inF2' (temp 4X4 matrix of float)
+0:370      cosine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      hyp. cosine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      dPdx (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      dPdxCoarse (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      dPdxFine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      dPdy (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      dPdyCoarse (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      dPdyFine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      degrees (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      determinant (global float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      exp (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      exp2 (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      findMSB (global int)
+0:370        Constant:
+0:370          7 (const int)
+0:370      findLSB (global int)
+0:370        Constant:
+0:370          7 (const int)
+0:370      Floor (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      mod (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      Fraction (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      frexp (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      fwidth (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      ldexp (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      log (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      matrix-scale (temp 4X4 matrix of float)
+0:370        log2 (temp 4X4 matrix of float)
+0:370          'inF0' (temp 4X4 matrix of float)
+0:370        Constant:
+0:370          0.301030
+0:370      log2 (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      max (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      min (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      pow (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      radians (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      roundEven (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      inverse sqrt (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      clamp (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        Constant:
+0:370          0.000000
+0:370        Constant:
+0:370          1.000000
+0:370      Sign (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      sine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      Sequence
+0:370        move second child to first child (temp 4X4 matrix of float)
+0:370          'inF1' (temp 4X4 matrix of float)
+0:370          sine (temp 4X4 matrix of float)
+0:370            'inF0' (temp 4X4 matrix of float)
+0:370        move second child to first child (temp 4X4 matrix of float)
+0:370          'inF2' (temp 4X4 matrix of float)
+0:370          cosine (temp 4X4 matrix of float)
+0:370            'inF0' (temp 4X4 matrix of float)
+0:370      hyp. sine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      smoothstep (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370        'inF2' (temp 4X4 matrix of float)
+0:370      sqrt (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      step (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      tangent (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      hyp. tangent (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      transpose (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      trunc (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:373      Branch: Return with expression
 0:?         Constant:
 0:?           4.000000
 0:?           4.000000
@@ -967,6 +1237,168 @@ gl_FragCoord origin is upper left
 0:?           4.000000
 0:?           4.000000
 0:?           4.000000
+0:395  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
+0:391    Function Parameters: 
+0:391      'inF0' (temp float)
+0:391      'inF1' (temp float)
+0:391      'inFV0' (temp 2-component vector of float)
+0:391      'inFV1' (temp 2-component vector of float)
+0:391      'inFM0' (temp 2X2 matrix of float)
+0:391      'inFM1' (temp 2X2 matrix of float)
+0:?     Sequence
+0:392      move second child to first child (temp float)
+0:392        'r0' (temp float)
+0:392        component-wise multiply (temp float)
+0:392          'inF0' (temp float)
+0:392          'inF1' (temp float)
+0:392      move second child to first child (temp 2-component vector of float)
+0:392        'r1' (temp 2-component vector of float)
+0:392        vector-scale (temp 2-component vector of float)
+0:392          'inFV0' (temp 2-component vector of float)
+0:392          'inF0' (temp float)
+0:392      move second child to first child (temp 2-component vector of float)
+0:392        'r2' (temp 2-component vector of float)
+0:392        vector-scale (temp 2-component vector of float)
+0:392          'inF0' (temp float)
+0:392          'inFV0' (temp 2-component vector of float)
+0:392      move second child to first child (temp float)
+0:392        'r3' (temp float)
+0:392        dot-product (global float)
+0:392          'inFV0' (temp 2-component vector of float)
+0:392          'inFV1' (temp 2-component vector of float)
+0:392      move second child to first child (temp 2-component vector of float)
+0:392        'r4' (temp 2-component vector of float)
+0:392        matrix-times-vector (temp 2-component vector of float)
+0:392          'inFM0' (temp 2X2 matrix of float)
+0:392          'inFV0' (temp 2-component vector of float)
+0:392      move second child to first child (temp 2-component vector of float)
+0:392        'r5' (temp 2-component vector of float)
+0:392        vector-times-matrix (temp 2-component vector of float)
+0:392          'inFV0' (temp 2-component vector of float)
+0:392          'inFM0' (temp 2X2 matrix of float)
+0:392      move second child to first child (temp 2X2 matrix of float)
+0:392        'r6' (temp 2X2 matrix of float)
+0:392        matrix-scale (temp 2X2 matrix of float)
+0:392          'inFM0' (temp 2X2 matrix of float)
+0:392          'inF0' (temp float)
+0:392      move second child to first child (temp 2X2 matrix of float)
+0:392        'r7' (temp 2X2 matrix of float)
+0:392        matrix-scale (temp 2X2 matrix of float)
+0:392          'inF0' (temp float)
+0:392          'inFM0' (temp 2X2 matrix of float)
+0:392      move second child to first child (temp 2X2 matrix of float)
+0:392        'r8' (temp 2X2 matrix of float)
+0:392        matrix-multiply (temp 2X2 matrix of float)
+0:392          'inFM0' (temp 2X2 matrix of float)
+0:392          'inFM1' (temp 2X2 matrix of float)
+0:402  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
+0:398    Function Parameters: 
+0:398      'inF0' (temp float)
+0:398      'inF1' (temp float)
+0:398      'inFV0' (temp 3-component vector of float)
+0:398      'inFV1' (temp 3-component vector of float)
+0:398      'inFM0' (temp 3X3 matrix of float)
+0:398      'inFM1' (temp 3X3 matrix of float)
+0:?     Sequence
+0:399      move second child to first child (temp float)
+0:399        'r0' (temp float)
+0:399        component-wise multiply (temp float)
+0:399          'inF0' (temp float)
+0:399          'inF1' (temp float)
+0:399      move second child to first child (temp 3-component vector of float)
+0:399        'r1' (temp 3-component vector of float)
+0:399        vector-scale (temp 3-component vector of float)
+0:399          'inFV0' (temp 3-component vector of float)
+0:399          'inF0' (temp float)
+0:399      move second child to first child (temp 3-component vector of float)
+0:399        'r2' (temp 3-component vector of float)
+0:399        vector-scale (temp 3-component vector of float)
+0:399          'inF0' (temp float)
+0:399          'inFV0' (temp 3-component vector of float)
+0:399      move second child to first child (temp float)
+0:399        'r3' (temp float)
+0:399        dot-product (global float)
+0:399          'inFV0' (temp 3-component vector of float)
+0:399          'inFV1' (temp 3-component vector of float)
+0:399      move second child to first child (temp 3-component vector of float)
+0:399        'r4' (temp 3-component vector of float)
+0:399        matrix-times-vector (temp 3-component vector of float)
+0:399          'inFM0' (temp 3X3 matrix of float)
+0:399          'inFV0' (temp 3-component vector of float)
+0:399      move second child to first child (temp 3-component vector of float)
+0:399        'r5' (temp 3-component vector of float)
+0:399        vector-times-matrix (temp 3-component vector of float)
+0:399          'inFV0' (temp 3-component vector of float)
+0:399          'inFM0' (temp 3X3 matrix of float)
+0:399      move second child to first child (temp 3X3 matrix of float)
+0:399        'r6' (temp 3X3 matrix of float)
+0:399        matrix-scale (temp 3X3 matrix of float)
+0:399          'inFM0' (temp 3X3 matrix of float)
+0:399          'inF0' (temp float)
+0:399      move second child to first child (temp 3X3 matrix of float)
+0:399        'r7' (temp 3X3 matrix of float)
+0:399        matrix-scale (temp 3X3 matrix of float)
+0:399          'inF0' (temp float)
+0:399          'inFM0' (temp 3X3 matrix of float)
+0:399      move second child to first child (temp 3X3 matrix of float)
+0:399        'r8' (temp 3X3 matrix of float)
+0:399        matrix-multiply (temp 3X3 matrix of float)
+0:399          'inFM0' (temp 3X3 matrix of float)
+0:399          'inFM1' (temp 3X3 matrix of float)
+0:408  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
+0:405    Function Parameters: 
+0:405      'inF0' (temp float)
+0:405      'inF1' (temp float)
+0:405      'inFV0' (temp 4-component vector of float)
+0:405      'inFV1' (temp 4-component vector of float)
+0:405      'inFM0' (temp 4X4 matrix of float)
+0:405      'inFM1' (temp 4X4 matrix of float)
+0:?     Sequence
+0:406      move second child to first child (temp float)
+0:406        'r0' (temp float)
+0:406        component-wise multiply (temp float)
+0:406          'inF0' (temp float)
+0:406          'inF1' (temp float)
+0:406      move second child to first child (temp 4-component vector of float)
+0:406        'r1' (temp 4-component vector of float)
+0:406        vector-scale (temp 4-component vector of float)
+0:406          'inFV0' (temp 4-component vector of float)
+0:406          'inF0' (temp float)
+0:406      move second child to first child (temp 4-component vector of float)
+0:406        'r2' (temp 4-component vector of float)
+0:406        vector-scale (temp 4-component vector of float)
+0:406          'inF0' (temp float)
+0:406          'inFV0' (temp 4-component vector of float)
+0:406      move second child to first child (temp float)
+0:406        'r3' (temp float)
+0:406        dot-product (global float)
+0:406          'inFV0' (temp 4-component vector of float)
+0:406          'inFV1' (temp 4-component vector of float)
+0:406      move second child to first child (temp 4-component vector of float)
+0:406        'r4' (temp 4-component vector of float)
+0:406        matrix-times-vector (temp 4-component vector of float)
+0:406          'inFM0' (temp 4X4 matrix of float)
+0:406          'inFV0' (temp 4-component vector of float)
+0:406      move second child to first child (temp 4-component vector of float)
+0:406        'r5' (temp 4-component vector of float)
+0:406        vector-times-matrix (temp 4-component vector of float)
+0:406          'inFV0' (temp 4-component vector of float)
+0:406          'inFM0' (temp 4X4 matrix of float)
+0:406      move second child to first child (temp 4X4 matrix of float)
+0:406        'r6' (temp 4X4 matrix of float)
+0:406        matrix-scale (temp 4X4 matrix of float)
+0:406          'inFM0' (temp 4X4 matrix of float)
+0:406          'inF0' (temp float)
+0:406      move second child to first child (temp 4X4 matrix of float)
+0:406        'r7' (temp 4X4 matrix of float)
+0:406        matrix-scale (temp 4X4 matrix of float)
+0:406          'inF0' (temp float)
+0:406          'inFM0' (temp 4X4 matrix of float)
+0:406      move second child to first child (temp 4X4 matrix of float)
+0:406        'r8' (temp 4X4 matrix of float)
+0:406        matrix-multiply (temp 4X4 matrix of float)
+0:406          'inFM0' (temp 4X4 matrix of float)
+0:406          'inFM1' (temp 4X4 matrix of float)
 0:?   Linker Objects
 
 
@@ -976,7 +1408,7 @@ Linked fragment stage:
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:62  Function Definition: PixelShaderFunction(f1;f1;f1; (temp float)
+0:66  Function Definition: PixelShaderFunction(f1;f1;f1; (temp float)
 0:2    Function Parameters: 
 0:2      'inF0' (temp float)
 0:2      'inF1' (temp float)
@@ -1003,802 +1435,1028 @@ gl_FragCoord origin is upper left
 0:11        'inF0' (temp float)
 0:11        'inF1' (temp float)
 0:11        'inF2' (temp float)
-0:12      cosine (global float)
-0:12        'inF0' (temp float)
-0:13      hyp. cosine (global float)
+0:12      Test condition and select (temp void)
+0:12        Condition
+0:12        Compare Less Than (temp bool)
+0:12          'inF0' (temp float)
+0:12          Constant:
+0:12            0.000000
+0:12        true case
+0:12        Branch: Kill
+0:13      cosine (global float)
 0:13        'inF0' (temp float)
-0:14      bitCount (global uint)
-0:14        Constant:
-0:14          7 (const uint)
-0:15      dPdx (global float)
-0:15        'inF0' (temp float)
-0:16      dPdxCoarse (global float)
+0:14      hyp. cosine (global float)
+0:14        'inF0' (temp float)
+0:15      bitCount (global uint)
+0:15        Constant:
+0:15          7 (const uint)
+0:16      dPdx (global float)
 0:16        'inF0' (temp float)
-0:17      dPdxFine (global float)
+0:17      dPdxCoarse (global float)
 0:17        'inF0' (temp float)
-0:18      dPdy (global float)
+0:18      dPdxFine (global float)
 0:18        'inF0' (temp float)
-0:19      dPdyCoarse (global float)
+0:19      dPdy (global float)
 0:19        'inF0' (temp float)
-0:20      dPdyFine (global float)
+0:20      dPdyCoarse (global float)
 0:20        'inF0' (temp float)
-0:21      degrees (global float)
+0:21      dPdyFine (global float)
 0:21        'inF0' (temp float)
-0:25      exp (global float)
-0:25        'inF0' (temp float)
-0:26      exp2 (global float)
+0:22      degrees (global float)
+0:22        'inF0' (temp float)
+0:26      exp (global float)
 0:26        'inF0' (temp float)
-0:27      findMSB (global int)
-0:27        Constant:
-0:27          7 (const int)
-0:28      findLSB (global int)
+0:27      exp2 (global float)
+0:27        'inF0' (temp float)
+0:28      findMSB (global int)
 0:28        Constant:
 0:28          7 (const int)
-0:29      Floor (global float)
-0:29        'inF0' (temp float)
-0:31      Function Call: fmod(f1;f1; (global float)
-0:31        'inF0' (temp float)
-0:31        'inF1' (temp float)
-0:32      Fraction (global float)
+0:29      findLSB (global int)
+0:29        Constant:
+0:29          7 (const int)
+0:30      Floor (global float)
+0:30        'inF0' (temp float)
+0:32      mod (global float)
 0:32        'inF0' (temp float)
-0:33      frexp (global float)
+0:32        'inF1' (temp float)
+0:33      Fraction (global float)
 0:33        'inF0' (temp float)
-0:33        'inF1' (temp float)
-0:34      fwidth (global float)
+0:34      frexp (global float)
 0:34        'inF0' (temp float)
-0:35      isinf (global bool)
+0:34        'inF1' (temp float)
+0:35      fwidth (global float)
 0:35        'inF0' (temp float)
-0:36      isnan (global bool)
+0:36      isinf (global bool)
 0:36        'inF0' (temp float)
-0:37      ldexp (global float)
+0:37      isnan (global bool)
 0:37        'inF0' (temp float)
-0:37        'inF1' (temp float)
-0:38      log (global float)
+0:38      ldexp (global float)
 0:38        'inF0' (temp float)
-0:39      log2 (global float)
+0:38        'inF1' (temp float)
+0:39      log (global float)
 0:39        'inF0' (temp float)
-0:40      max (global float)
-0:40        'inF0' (temp float)
-0:40        'inF1' (temp float)
-0:41      min (global float)
+0:40      component-wise multiply (temp float)
+0:40        log2 (temp float)
+0:40          'inF0' (temp float)
+0:40        Constant:
+0:40          0.301030
+0:41      log2 (global float)
 0:41        'inF0' (temp float)
-0:41        'inF1' (temp float)
-0:43      pow (global float)
+0:42      max (global float)
+0:42        'inF0' (temp float)
+0:42        'inF1' (temp float)
+0:43      min (global float)
 0:43        'inF0' (temp float)
 0:43        'inF1' (temp float)
-0:44      radians (global float)
+0:44      pow (global float)
 0:44        'inF0' (temp float)
-0:45      bitFieldReverse (global uint)
-0:45        Constant:
-0:45          2 (const uint)
-0:46      roundEven (global float)
+0:44        'inF1' (temp float)
+0:45      radians (global float)
+0:45        'inF0' (temp float)
+0:46      divide (temp float)
+0:46        Constant:
+0:46          1.000000
 0:46        'inF0' (temp float)
-0:47      inverse sqrt (global float)
-0:47        'inF0' (temp float)
-0:48      Sign (global float)
+0:47      bitFieldReverse (global uint)
+0:47        Constant:
+0:47          2 (const uint)
+0:48      roundEven (global float)
 0:48        'inF0' (temp float)
-0:49      sine (global float)
+0:49      inverse sqrt (global float)
 0:49        'inF0' (temp float)
-0:50      hyp. sine (global float)
+0:50      clamp (global float)
 0:50        'inF0' (temp float)
-0:51      smoothstep (global float)
+0:50        Constant:
+0:50          0.000000
+0:50        Constant:
+0:50          1.000000
+0:51      Sign (global float)
 0:51        'inF0' (temp float)
-0:51        'inF1' (temp float)
-0:51        'inF2' (temp float)
-0:52      sqrt (global float)
+0:52      sine (global float)
 0:52        'inF0' (temp float)
-0:53      step (global float)
-0:53        'inF0' (temp float)
-0:53        'inF1' (temp float)
-0:54      tangent (global float)
+0:53      Sequence
+0:53        move second child to first child (temp float)
+0:53          'inF1' (temp float)
+0:53          sine (temp float)
+0:53            'inF0' (temp float)
+0:53        move second child to first child (temp float)
+0:53          'inF2' (temp float)
+0:53          cosine (temp float)
+0:53            'inF0' (temp float)
+0:54      hyp. sine (global float)
 0:54        'inF0' (temp float)
-0:55      hyp. tangent (global float)
+0:55      smoothstep (global float)
 0:55        'inF0' (temp float)
-0:57      trunc (global float)
+0:55        'inF1' (temp float)
+0:55        'inF2' (temp float)
+0:56      sqrt (global float)
+0:56        'inF0' (temp float)
+0:57      step (global float)
 0:57        'inF0' (temp float)
-0:59      Branch: Return with expression
-0:59        Constant:
-0:59          0.000000
-0:68  Function Definition: PixelShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
-0:63    Function Parameters: 
-0:63      'inF0' (temp 1-component vector of float)
-0:63      'inF1' (temp 1-component vector of float)
-0:63      'inF2' (temp 1-component vector of float)
+0:57        'inF1' (temp float)
+0:58      tangent (global float)
+0:58        'inF0' (temp float)
+0:59      hyp. tangent (global float)
+0:59        'inF0' (temp float)
+0:61      trunc (global float)
+0:61        'inF0' (temp float)
+0:63      Branch: Return with expression
+0:63        Constant:
+0:63          0.000000
+0:72  Function Definition: PixelShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
+0:67    Function Parameters: 
+0:67      'inF0' (temp 1-component vector of float)
+0:67      'inF1' (temp 1-component vector of float)
+0:67      'inF2' (temp 1-component vector of float)
 0:?     Sequence
-0:65      Branch: Return with expression
-0:65        Constant:
-0:65          0.000000
-0:137  Function Definition: PixelShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
-0:69    Function Parameters: 
-0:69      'inF0' (temp 2-component vector of float)
-0:69      'inF1' (temp 2-component vector of float)
-0:69      'inF2' (temp 2-component vector of float)
+0:69      Branch: Return with expression
+0:69        Constant:
+0:69          0.000000
+0:145  Function Definition: PixelShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
+0:73    Function Parameters: 
+0:73      'inF0' (temp 2-component vector of float)
+0:73      'inF1' (temp 2-component vector of float)
+0:73      'inF2' (temp 2-component vector of float)
 0:?     Sequence
-0:70      all (global bool)
-0:70        'inF0' (temp 2-component vector of float)
-0:71      Absolute value (global 2-component vector of float)
-0:71        'inF0' (temp 2-component vector of float)
-0:72      arc cosine (global 2-component vector of float)
-0:72        'inF0' (temp 2-component vector of float)
-0:73      any (global bool)
-0:73        'inF0' (temp 2-component vector of float)
-0:74      arc sine (global 2-component vector of float)
+0:74      all (global bool)
 0:74        'inF0' (temp 2-component vector of float)
-0:75      arc tangent (global 2-component vector of float)
+0:75      Absolute value (global 2-component vector of float)
 0:75        'inF0' (temp 2-component vector of float)
-0:76      arc tangent (global 2-component vector of float)
+0:76      arc cosine (global 2-component vector of float)
 0:76        'inF0' (temp 2-component vector of float)
-0:76        'inF1' (temp 2-component vector of float)
-0:77      Ceiling (global 2-component vector of float)
+0:77      any (global bool)
 0:77        'inF0' (temp 2-component vector of float)
-0:78      clamp (global 2-component vector of float)
+0:78      arc sine (global 2-component vector of float)
 0:78        'inF0' (temp 2-component vector of float)
-0:78        'inF1' (temp 2-component vector of float)
-0:78        'inF2' (temp 2-component vector of float)
-0:79      cosine (global 2-component vector of float)
+0:79      arc tangent (global 2-component vector of float)
 0:79        'inF0' (temp 2-component vector of float)
-0:80      hyp. cosine (global 2-component vector of float)
+0:80      arc tangent (global 2-component vector of float)
 0:80        'inF0' (temp 2-component vector of float)
+0:80        'inF1' (temp 2-component vector of float)
+0:81      Ceiling (global 2-component vector of float)
+0:81        'inF0' (temp 2-component vector of float)
+0:82      clamp (global 2-component vector of float)
+0:82        'inF0' (temp 2-component vector of float)
+0:82        'inF1' (temp 2-component vector of float)
+0:82        'inF2' (temp 2-component vector of float)
+0:83      Test condition and select (temp void)
+0:83        Condition
+0:83        any (temp bool)
+0:83          Compare Less Than (temp 2-component vector of bool)
+0:83            'inF0' (temp 2-component vector of float)
+0:83            Constant:
+0:83              0.000000
+0:83              0.000000
+0:83        true case
+0:83        Branch: Kill
+0:84      cosine (global 2-component vector of float)
+0:84        'inF0' (temp 2-component vector of float)
+0:85      hyp. cosine (global 2-component vector of float)
+0:85        'inF0' (temp 2-component vector of float)
 0:?       bitCount (global 2-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
-0:82      dPdx (global 2-component vector of float)
-0:82        'inF0' (temp 2-component vector of float)
-0:83      dPdxCoarse (global 2-component vector of float)
-0:83        'inF0' (temp 2-component vector of float)
-0:84      dPdxFine (global 2-component vector of float)
-0:84        'inF0' (temp 2-component vector of float)
-0:85      dPdy (global 2-component vector of float)
-0:85        'inF0' (temp 2-component vector of float)
-0:86      dPdyCoarse (global 2-component vector of float)
-0:86        'inF0' (temp 2-component vector of float)
-0:87      dPdyFine (global 2-component vector of float)
+0:87      dPdx (global 2-component vector of float)
 0:87        'inF0' (temp 2-component vector of float)
-0:88      degrees (global 2-component vector of float)
+0:88      dPdxCoarse (global 2-component vector of float)
 0:88        'inF0' (temp 2-component vector of float)
-0:89      distance (global float)
+0:89      dPdxFine (global 2-component vector of float)
 0:89        'inF0' (temp 2-component vector of float)
-0:89        'inF1' (temp 2-component vector of float)
-0:90      dot-product (global float)
+0:90      dPdy (global 2-component vector of float)
 0:90        'inF0' (temp 2-component vector of float)
-0:90        'inF1' (temp 2-component vector of float)
-0:94      exp (global 2-component vector of float)
+0:91      dPdyCoarse (global 2-component vector of float)
+0:91        'inF0' (temp 2-component vector of float)
+0:92      dPdyFine (global 2-component vector of float)
+0:92        'inF0' (temp 2-component vector of float)
+0:93      degrees (global 2-component vector of float)
+0:93        'inF0' (temp 2-component vector of float)
+0:94      distance (global float)
 0:94        'inF0' (temp 2-component vector of float)
-0:95      exp2 (global 2-component vector of float)
+0:94        'inF1' (temp 2-component vector of float)
+0:95      dot-product (global float)
 0:95        'inF0' (temp 2-component vector of float)
-0:96      face-forward (global 2-component vector of float)
-0:96        'inF0' (temp 2-component vector of float)
-0:96        'inF1' (temp 2-component vector of float)
-0:96        'inF2' (temp 2-component vector of float)
-0:97      findMSB (global int)
-0:97        Constant:
-0:97          7 (const int)
-0:98      findLSB (global int)
-0:98        Constant:
-0:98          7 (const int)
-0:99      Floor (global 2-component vector of float)
+0:95        'inF1' (temp 2-component vector of float)
+0:99      exp (global 2-component vector of float)
 0:99        'inF0' (temp 2-component vector of float)
-0:101      Function Call: fmod(vf2;vf2; (global 2-component vector of float)
+0:100      exp2 (global 2-component vector of float)
+0:100        'inF0' (temp 2-component vector of float)
+0:101      face-forward (global 2-component vector of float)
 0:101        'inF0' (temp 2-component vector of float)
 0:101        'inF1' (temp 2-component vector of float)
-0:102      Fraction (global 2-component vector of float)
-0:102        'inF0' (temp 2-component vector of float)
-0:103      frexp (global 2-component vector of float)
-0:103        'inF0' (temp 2-component vector of float)
-0:103        'inF1' (temp 2-component vector of float)
-0:104      fwidth (global 2-component vector of float)
+0:101        'inF2' (temp 2-component vector of float)
+0:102      findMSB (global int)
+0:102        Constant:
+0:102          7 (const int)
+0:103      findLSB (global int)
+0:103        Constant:
+0:103          7 (const int)
+0:104      Floor (global 2-component vector of float)
 0:104        'inF0' (temp 2-component vector of float)
-0:105      isinf (global 2-component vector of bool)
-0:105        'inF0' (temp 2-component vector of float)
-0:106      isnan (global 2-component vector of bool)
+0:106      mod (global 2-component vector of float)
 0:106        'inF0' (temp 2-component vector of float)
-0:107      ldexp (global 2-component vector of float)
+0:106        'inF1' (temp 2-component vector of float)
+0:107      Fraction (global 2-component vector of float)
 0:107        'inF0' (temp 2-component vector of float)
-0:107        'inF1' (temp 2-component vector of float)
-0:108      length (global float)
+0:108      frexp (global 2-component vector of float)
 0:108        'inF0' (temp 2-component vector of float)
-0:109      log (global 2-component vector of float)
+0:108        'inF1' (temp 2-component vector of float)
+0:109      fwidth (global 2-component vector of float)
 0:109        'inF0' (temp 2-component vector of float)
-0:110      log2 (global 2-component vector of float)
+0:110      isinf (global 2-component vector of bool)
 0:110        'inF0' (temp 2-component vector of float)
-0:111      max (global 2-component vector of float)
+0:111      isnan (global 2-component vector of bool)
 0:111        'inF0' (temp 2-component vector of float)
-0:111        'inF1' (temp 2-component vector of float)
-0:112      min (global 2-component vector of float)
+0:112      ldexp (global 2-component vector of float)
 0:112        'inF0' (temp 2-component vector of float)
 0:112        'inF1' (temp 2-component vector of float)
-0:114      normalize (global 2-component vector of float)
+0:113      length (global float)
+0:113        'inF0' (temp 2-component vector of float)
+0:114      log (global 2-component vector of float)
 0:114        'inF0' (temp 2-component vector of float)
-0:115      pow (global 2-component vector of float)
-0:115        'inF0' (temp 2-component vector of float)
-0:115        'inF1' (temp 2-component vector of float)
-0:116      radians (global 2-component vector of float)
+0:115      vector-scale (temp 2-component vector of float)
+0:115        log2 (temp 2-component vector of float)
+0:115          'inF0' (temp 2-component vector of float)
+0:115        Constant:
+0:115          0.301030
+0:116      log2 (global 2-component vector of float)
 0:116        'inF0' (temp 2-component vector of float)
-0:117      reflect (global 2-component vector of float)
+0:117      max (global 2-component vector of float)
 0:117        'inF0' (temp 2-component vector of float)
 0:117        'inF1' (temp 2-component vector of float)
-0:118      refract (global 2-component vector of float)
+0:118      min (global 2-component vector of float)
 0:118        'inF0' (temp 2-component vector of float)
 0:118        'inF1' (temp 2-component vector of float)
-0:118        Constant:
-0:118          2.000000
+0:119      normalize (global 2-component vector of float)
+0:119        'inF0' (temp 2-component vector of float)
+0:120      pow (global 2-component vector of float)
+0:120        'inF0' (temp 2-component vector of float)
+0:120        'inF1' (temp 2-component vector of float)
+0:121      radians (global 2-component vector of float)
+0:121        'inF0' (temp 2-component vector of float)
+0:122      divide (temp 2-component vector of float)
+0:122        Constant:
+0:122          1.000000
+0:122        'inF0' (temp 2-component vector of float)
+0:123      reflect (global 2-component vector of float)
+0:123        'inF0' (temp 2-component vector of float)
+0:123        'inF1' (temp 2-component vector of float)
+0:124      refract (global 2-component vector of float)
+0:124        'inF0' (temp 2-component vector of float)
+0:124        'inF1' (temp 2-component vector of float)
+0:124        Constant:
+0:124          2.000000
 0:?       bitFieldReverse (global 2-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
-0:120      roundEven (global 2-component vector of float)
-0:120        'inF0' (temp 2-component vector of float)
-0:121      inverse sqrt (global 2-component vector of float)
-0:121        'inF0' (temp 2-component vector of float)
-0:122      Sign (global 2-component vector of float)
-0:122        'inF0' (temp 2-component vector of float)
-0:123      sine (global 2-component vector of float)
-0:123        'inF0' (temp 2-component vector of float)
-0:124      hyp. sine (global 2-component vector of float)
-0:124        'inF0' (temp 2-component vector of float)
-0:125      smoothstep (global 2-component vector of float)
-0:125        'inF0' (temp 2-component vector of float)
-0:125        'inF1' (temp 2-component vector of float)
-0:125        'inF2' (temp 2-component vector of float)
-0:126      sqrt (global 2-component vector of float)
+0:126      roundEven (global 2-component vector of float)
 0:126        'inF0' (temp 2-component vector of float)
-0:127      step (global 2-component vector of float)
+0:127      inverse sqrt (global 2-component vector of float)
 0:127        'inF0' (temp 2-component vector of float)
-0:127        'inF1' (temp 2-component vector of float)
-0:128      tangent (global 2-component vector of float)
+0:128      clamp (global 2-component vector of float)
 0:128        'inF0' (temp 2-component vector of float)
-0:129      hyp. tangent (global 2-component vector of float)
+0:128        Constant:
+0:128          0.000000
+0:128        Constant:
+0:128          1.000000
+0:129      Sign (global 2-component vector of float)
 0:129        'inF0' (temp 2-component vector of float)
-0:131      trunc (global 2-component vector of float)
-0:131        'inF0' (temp 2-component vector of float)
-0:134      Branch: Return with expression
+0:130      sine (global 2-component vector of float)
+0:130        'inF0' (temp 2-component vector of float)
+0:131      Sequence
+0:131        move second child to first child (temp 2-component vector of float)
+0:131          'inF1' (temp 2-component vector of float)
+0:131          sine (temp 2-component vector of float)
+0:131            'inF0' (temp 2-component vector of float)
+0:131        move second child to first child (temp 2-component vector of float)
+0:131          'inF2' (temp 2-component vector of float)
+0:131          cosine (temp 2-component vector of float)
+0:131            'inF0' (temp 2-component vector of float)
+0:132      hyp. sine (global 2-component vector of float)
+0:132        'inF0' (temp 2-component vector of float)
+0:133      smoothstep (global 2-component vector of float)
+0:133        'inF0' (temp 2-component vector of float)
+0:133        'inF1' (temp 2-component vector of float)
+0:133        'inF2' (temp 2-component vector of float)
+0:134      sqrt (global 2-component vector of float)
+0:134        'inF0' (temp 2-component vector of float)
+0:135      step (global 2-component vector of float)
+0:135        'inF0' (temp 2-component vector of float)
+0:135        'inF1' (temp 2-component vector of float)
+0:136      tangent (global 2-component vector of float)
+0:136        'inF0' (temp 2-component vector of float)
+0:137      hyp. tangent (global 2-component vector of float)
+0:137        'inF0' (temp 2-component vector of float)
+0:139      trunc (global 2-component vector of float)
+0:139        'inF0' (temp 2-component vector of float)
+0:142      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
-0:207  Function Definition: PixelShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
-0:138    Function Parameters: 
-0:138      'inF0' (temp 3-component vector of float)
-0:138      'inF1' (temp 3-component vector of float)
-0:138      'inF2' (temp 3-component vector of float)
+0:219  Function Definition: PixelShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
+0:146    Function Parameters: 
+0:146      'inF0' (temp 3-component vector of float)
+0:146      'inF1' (temp 3-component vector of float)
+0:146      'inF2' (temp 3-component vector of float)
 0:?     Sequence
-0:139      all (global bool)
-0:139        'inF0' (temp 3-component vector of float)
-0:140      Absolute value (global 3-component vector of float)
-0:140        'inF0' (temp 3-component vector of float)
-0:141      arc cosine (global 3-component vector of float)
-0:141        'inF0' (temp 3-component vector of float)
-0:142      any (global bool)
-0:142        'inF0' (temp 3-component vector of float)
-0:143      arc sine (global 3-component vector of float)
-0:143        'inF0' (temp 3-component vector of float)
-0:144      arc tangent (global 3-component vector of float)
-0:144        'inF0' (temp 3-component vector of float)
-0:145      arc tangent (global 3-component vector of float)
-0:145        'inF0' (temp 3-component vector of float)
-0:145        'inF1' (temp 3-component vector of float)
-0:146      Ceiling (global 3-component vector of float)
-0:146        'inF0' (temp 3-component vector of float)
-0:147      clamp (global 3-component vector of float)
+0:147      all (global bool)
 0:147        'inF0' (temp 3-component vector of float)
-0:147        'inF1' (temp 3-component vector of float)
-0:147        'inF2' (temp 3-component vector of float)
-0:148      cosine (global 3-component vector of float)
+0:148      Absolute value (global 3-component vector of float)
 0:148        'inF0' (temp 3-component vector of float)
-0:149      hyp. cosine (global 3-component vector of float)
+0:149      arc cosine (global 3-component vector of float)
 0:149        'inF0' (temp 3-component vector of float)
+0:150      any (global bool)
+0:150        'inF0' (temp 3-component vector of float)
+0:151      arc sine (global 3-component vector of float)
+0:151        'inF0' (temp 3-component vector of float)
+0:152      arc tangent (global 3-component vector of float)
+0:152        'inF0' (temp 3-component vector of float)
+0:153      arc tangent (global 3-component vector of float)
+0:153        'inF0' (temp 3-component vector of float)
+0:153        'inF1' (temp 3-component vector of float)
+0:154      Ceiling (global 3-component vector of float)
+0:154        'inF0' (temp 3-component vector of float)
+0:155      clamp (global 3-component vector of float)
+0:155        'inF0' (temp 3-component vector of float)
+0:155        'inF1' (temp 3-component vector of float)
+0:155        'inF2' (temp 3-component vector of float)
+0:156      Test condition and select (temp void)
+0:156        Condition
+0:156        any (temp bool)
+0:156          Compare Less Than (temp 3-component vector of bool)
+0:156            'inF0' (temp 3-component vector of float)
+0:156            Constant:
+0:156              0.000000
+0:156              0.000000
+0:156              0.000000
+0:156        true case
+0:156        Branch: Kill
+0:157      cosine (global 3-component vector of float)
+0:157        'inF0' (temp 3-component vector of float)
+0:158      hyp. cosine (global 3-component vector of float)
+0:158        'inF0' (temp 3-component vector of float)
 0:?       bitCount (global 3-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
-0:151      cross-product (global 3-component vector of float)
-0:151        'inF0' (temp 3-component vector of float)
-0:151        'inF1' (temp 3-component vector of float)
-0:152      dPdx (global 3-component vector of float)
-0:152        'inF0' (temp 3-component vector of float)
-0:153      dPdxCoarse (global 3-component vector of float)
-0:153        'inF0' (temp 3-component vector of float)
-0:154      dPdxFine (global 3-component vector of float)
-0:154        'inF0' (temp 3-component vector of float)
-0:155      dPdy (global 3-component vector of float)
-0:155        'inF0' (temp 3-component vector of float)
-0:156      dPdyCoarse (global 3-component vector of float)
-0:156        'inF0' (temp 3-component vector of float)
-0:157      dPdyFine (global 3-component vector of float)
-0:157        'inF0' (temp 3-component vector of float)
-0:158      degrees (global 3-component vector of float)
-0:158        'inF0' (temp 3-component vector of float)
-0:159      distance (global float)
-0:159        'inF0' (temp 3-component vector of float)
-0:159        'inF1' (temp 3-component vector of float)
-0:160      dot-product (global float)
+0:160      cross-product (global 3-component vector of float)
 0:160        'inF0' (temp 3-component vector of float)
 0:160        'inF1' (temp 3-component vector of float)
-0:164      exp (global 3-component vector of float)
+0:161      dPdx (global 3-component vector of float)
+0:161        'inF0' (temp 3-component vector of float)
+0:162      dPdxCoarse (global 3-component vector of float)
+0:162        'inF0' (temp 3-component vector of float)
+0:163      dPdxFine (global 3-component vector of float)
+0:163        'inF0' (temp 3-component vector of float)
+0:164      dPdy (global 3-component vector of float)
 0:164        'inF0' (temp 3-component vector of float)
-0:165      exp2 (global 3-component vector of float)
+0:165      dPdyCoarse (global 3-component vector of float)
 0:165        'inF0' (temp 3-component vector of float)
-0:166      face-forward (global 3-component vector of float)
+0:166      dPdyFine (global 3-component vector of float)
 0:166        'inF0' (temp 3-component vector of float)
-0:166        'inF1' (temp 3-component vector of float)
-0:166        'inF2' (temp 3-component vector of float)
-0:167      findMSB (global int)
-0:167        Constant:
-0:167          7 (const int)
-0:168      findLSB (global int)
-0:168        Constant:
-0:168          7 (const int)
-0:169      Floor (global 3-component vector of float)
+0:167      degrees (global 3-component vector of float)
+0:167        'inF0' (temp 3-component vector of float)
+0:168      distance (global float)
+0:168        'inF0' (temp 3-component vector of float)
+0:168        'inF1' (temp 3-component vector of float)
+0:169      dot-product (global float)
 0:169        'inF0' (temp 3-component vector of float)
-0:171      Function Call: fmod(vf3;vf3; (global 3-component vector of float)
-0:171        'inF0' (temp 3-component vector of float)
-0:171        'inF1' (temp 3-component vector of float)
-0:172      Fraction (global 3-component vector of float)
-0:172        'inF0' (temp 3-component vector of float)
-0:173      frexp (global 3-component vector of float)
+0:169        'inF1' (temp 3-component vector of float)
+0:173      exp (global 3-component vector of float)
 0:173        'inF0' (temp 3-component vector of float)
-0:173        'inF1' (temp 3-component vector of float)
-0:174      fwidth (global 3-component vector of float)
+0:174      exp2 (global 3-component vector of float)
 0:174        'inF0' (temp 3-component vector of float)
-0:175      isinf (global 3-component vector of bool)
+0:175      face-forward (global 3-component vector of float)
 0:175        'inF0' (temp 3-component vector of float)
-0:176      isnan (global 3-component vector of bool)
-0:176        'inF0' (temp 3-component vector of float)
-0:177      ldexp (global 3-component vector of float)
-0:177        'inF0' (temp 3-component vector of float)
-0:177        'inF1' (temp 3-component vector of float)
-0:178      length (global float)
+0:175        'inF1' (temp 3-component vector of float)
+0:175        'inF2' (temp 3-component vector of float)
+0:176      findMSB (global int)
+0:176        Constant:
+0:176          7 (const int)
+0:177      findLSB (global int)
+0:177        Constant:
+0:177          7 (const int)
+0:178      Floor (global 3-component vector of float)
 0:178        'inF0' (temp 3-component vector of float)
-0:179      log (global 3-component vector of float)
-0:179        'inF0' (temp 3-component vector of float)
-0:180      log2 (global 3-component vector of float)
+0:180      mod (global 3-component vector of float)
 0:180        'inF0' (temp 3-component vector of float)
-0:181      max (global 3-component vector of float)
+0:180        'inF1' (temp 3-component vector of float)
+0:181      Fraction (global 3-component vector of float)
 0:181        'inF0' (temp 3-component vector of float)
-0:181        'inF1' (temp 3-component vector of float)
-0:182      min (global 3-component vector of float)
+0:182      frexp (global 3-component vector of float)
 0:182        'inF0' (temp 3-component vector of float)
 0:182        'inF1' (temp 3-component vector of float)
-0:184      normalize (global 3-component vector of float)
+0:183      fwidth (global 3-component vector of float)
+0:183        'inF0' (temp 3-component vector of float)
+0:184      isinf (global 3-component vector of bool)
 0:184        'inF0' (temp 3-component vector of float)
-0:185      pow (global 3-component vector of float)
+0:185      isnan (global 3-component vector of bool)
 0:185        'inF0' (temp 3-component vector of float)
-0:185        'inF1' (temp 3-component vector of float)
-0:186      radians (global 3-component vector of float)
+0:186      ldexp (global 3-component vector of float)
 0:186        'inF0' (temp 3-component vector of float)
-0:187      reflect (global 3-component vector of float)
+0:186        'inF1' (temp 3-component vector of float)
+0:187      length (global float)
 0:187        'inF0' (temp 3-component vector of float)
-0:187        'inF1' (temp 3-component vector of float)
-0:188      refract (global 3-component vector of float)
+0:188      log (global 3-component vector of float)
 0:188        'inF0' (temp 3-component vector of float)
-0:188        'inF1' (temp 3-component vector of float)
-0:188        Constant:
-0:188          2.000000
+0:189      vector-scale (temp 3-component vector of float)
+0:189        log2 (temp 3-component vector of float)
+0:189          'inF0' (temp 3-component vector of float)
+0:189        Constant:
+0:189          0.301030
+0:190      log2 (global 3-component vector of float)
+0:190        'inF0' (temp 3-component vector of float)
+0:191      max (global 3-component vector of float)
+0:191        'inF0' (temp 3-component vector of float)
+0:191        'inF1' (temp 3-component vector of float)
+0:192      min (global 3-component vector of float)
+0:192        'inF0' (temp 3-component vector of float)
+0:192        'inF1' (temp 3-component vector of float)
+0:193      normalize (global 3-component vector of float)
+0:193        'inF0' (temp 3-component vector of float)
+0:194      pow (global 3-component vector of float)
+0:194        'inF0' (temp 3-component vector of float)
+0:194        'inF1' (temp 3-component vector of float)
+0:195      radians (global 3-component vector of float)
+0:195        'inF0' (temp 3-component vector of float)
+0:196      divide (temp 3-component vector of float)
+0:196        Constant:
+0:196          1.000000
+0:196        'inF0' (temp 3-component vector of float)
+0:197      reflect (global 3-component vector of float)
+0:197        'inF0' (temp 3-component vector of float)
+0:197        'inF1' (temp 3-component vector of float)
+0:198      refract (global 3-component vector of float)
+0:198        'inF0' (temp 3-component vector of float)
+0:198        'inF1' (temp 3-component vector of float)
+0:198        Constant:
+0:198          2.000000
 0:?       bitFieldReverse (global 3-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
-0:190      roundEven (global 3-component vector of float)
-0:190        'inF0' (temp 3-component vector of float)
-0:191      inverse sqrt (global 3-component vector of float)
-0:191        'inF0' (temp 3-component vector of float)
-0:192      Sign (global 3-component vector of float)
-0:192        'inF0' (temp 3-component vector of float)
-0:193      sine (global 3-component vector of float)
-0:193        'inF0' (temp 3-component vector of float)
-0:194      hyp. sine (global 3-component vector of float)
-0:194        'inF0' (temp 3-component vector of float)
-0:195      smoothstep (global 3-component vector of float)
-0:195        'inF0' (temp 3-component vector of float)
-0:195        'inF1' (temp 3-component vector of float)
-0:195        'inF2' (temp 3-component vector of float)
-0:196      sqrt (global 3-component vector of float)
-0:196        'inF0' (temp 3-component vector of float)
-0:197      step (global 3-component vector of float)
-0:197        'inF0' (temp 3-component vector of float)
-0:197        'inF1' (temp 3-component vector of float)
-0:198      tangent (global 3-component vector of float)
-0:198        'inF0' (temp 3-component vector of float)
-0:199      hyp. tangent (global 3-component vector of float)
-0:199        'inF0' (temp 3-component vector of float)
-0:201      trunc (global 3-component vector of float)
+0:200      roundEven (global 3-component vector of float)
+0:200        'inF0' (temp 3-component vector of float)
+0:201      inverse sqrt (global 3-component vector of float)
 0:201        'inF0' (temp 3-component vector of float)
-0:204      Branch: Return with expression
+0:202      clamp (global 3-component vector of float)
+0:202        'inF0' (temp 3-component vector of float)
+0:202        Constant:
+0:202          0.000000
+0:202        Constant:
+0:202          1.000000
+0:203      Sign (global 3-component vector of float)
+0:203        'inF0' (temp 3-component vector of float)
+0:204      sine (global 3-component vector of float)
+0:204        'inF0' (temp 3-component vector of float)
+0:205      Sequence
+0:205        move second child to first child (temp 3-component vector of float)
+0:205          'inF1' (temp 3-component vector of float)
+0:205          sine (temp 3-component vector of float)
+0:205            'inF0' (temp 3-component vector of float)
+0:205        move second child to first child (temp 3-component vector of float)
+0:205          'inF2' (temp 3-component vector of float)
+0:205          cosine (temp 3-component vector of float)
+0:205            'inF0' (temp 3-component vector of float)
+0:206      hyp. sine (global 3-component vector of float)
+0:206        'inF0' (temp 3-component vector of float)
+0:207      smoothstep (global 3-component vector of float)
+0:207        'inF0' (temp 3-component vector of float)
+0:207        'inF1' (temp 3-component vector of float)
+0:207        'inF2' (temp 3-component vector of float)
+0:208      sqrt (global 3-component vector of float)
+0:208        'inF0' (temp 3-component vector of float)
+0:209      step (global 3-component vector of float)
+0:209        'inF0' (temp 3-component vector of float)
+0:209        'inF1' (temp 3-component vector of float)
+0:210      tangent (global 3-component vector of float)
+0:210        'inF0' (temp 3-component vector of float)
+0:211      hyp. tangent (global 3-component vector of float)
+0:211        'inF0' (temp 3-component vector of float)
+0:213      trunc (global 3-component vector of float)
+0:213        'inF0' (temp 3-component vector of float)
+0:216      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
-0:328  Function Definition: PixelShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
-0:208    Function Parameters: 
-0:208      'inF0' (temp 4-component vector of float)
-0:208      'inF1' (temp 4-component vector of float)
-0:208      'inF2' (temp 4-component vector of float)
+0:349  Function Definition: PixelShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
+0:220    Function Parameters: 
+0:220      'inF0' (temp 4-component vector of float)
+0:220      'inF1' (temp 4-component vector of float)
+0:220      'inF2' (temp 4-component vector of float)
 0:?     Sequence
-0:209      all (global bool)
-0:209        'inF0' (temp 4-component vector of float)
-0:210      Absolute value (global 4-component vector of float)
-0:210        'inF0' (temp 4-component vector of float)
-0:211      arc cosine (global 4-component vector of float)
-0:211        'inF0' (temp 4-component vector of float)
-0:212      any (global bool)
-0:212        'inF0' (temp 4-component vector of float)
-0:213      arc sine (global 4-component vector of float)
-0:213        'inF0' (temp 4-component vector of float)
-0:214      arc tangent (global 4-component vector of float)
-0:214        'inF0' (temp 4-component vector of float)
-0:215      arc tangent (global 4-component vector of float)
-0:215        'inF0' (temp 4-component vector of float)
-0:215        'inF1' (temp 4-component vector of float)
-0:216      Ceiling (global 4-component vector of float)
-0:216        'inF0' (temp 4-component vector of float)
-0:217      clamp (global 4-component vector of float)
-0:217        'inF0' (temp 4-component vector of float)
-0:217        'inF1' (temp 4-component vector of float)
-0:217        'inF2' (temp 4-component vector of float)
-0:218      cosine (global 4-component vector of float)
-0:218        'inF0' (temp 4-component vector of float)
-0:219      hyp. cosine (global 4-component vector of float)
-0:219        'inF0' (temp 4-component vector of float)
+0:221      all (global bool)
+0:221        'inF0' (temp 4-component vector of float)
+0:222      Absolute value (global 4-component vector of float)
+0:222        'inF0' (temp 4-component vector of float)
+0:223      arc cosine (global 4-component vector of float)
+0:223        'inF0' (temp 4-component vector of float)
+0:224      any (global bool)
+0:224        'inF0' (temp 4-component vector of float)
+0:225      arc sine (global 4-component vector of float)
+0:225        'inF0' (temp 4-component vector of float)
+0:226      arc tangent (global 4-component vector of float)
+0:226        'inF0' (temp 4-component vector of float)
+0:227      arc tangent (global 4-component vector of float)
+0:227        'inF0' (temp 4-component vector of float)
+0:227        'inF1' (temp 4-component vector of float)
+0:228      Ceiling (global 4-component vector of float)
+0:228        'inF0' (temp 4-component vector of float)
+0:229      clamp (global 4-component vector of float)
+0:229        'inF0' (temp 4-component vector of float)
+0:229        'inF1' (temp 4-component vector of float)
+0:229        'inF2' (temp 4-component vector of float)
+0:230      Test condition and select (temp void)
+0:230        Condition
+0:230        any (temp bool)
+0:230          Compare Less Than (temp 4-component vector of bool)
+0:230            'inF0' (temp 4-component vector of float)
+0:230            Constant:
+0:230              0.000000
+0:230              0.000000
+0:230              0.000000
+0:230              0.000000
+0:230        true case
+0:230        Branch: Kill
+0:231      cosine (global 4-component vector of float)
+0:231        'inF0' (temp 4-component vector of float)
+0:232      hyp. cosine (global 4-component vector of float)
+0:232        'inF0' (temp 4-component vector of float)
 0:?       bitCount (global 4-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
 0:?           2 (const uint)
-0:221      dPdx (global 4-component vector of float)
-0:221        'inF0' (temp 4-component vector of float)
-0:222      dPdxCoarse (global 4-component vector of float)
-0:222        'inF0' (temp 4-component vector of float)
-0:223      dPdxFine (global 4-component vector of float)
-0:223        'inF0' (temp 4-component vector of float)
-0:224      dPdy (global 4-component vector of float)
-0:224        'inF0' (temp 4-component vector of float)
-0:225      dPdyCoarse (global 4-component vector of float)
-0:225        'inF0' (temp 4-component vector of float)
-0:226      dPdyFine (global 4-component vector of float)
-0:226        'inF0' (temp 4-component vector of float)
-0:227      degrees (global 4-component vector of float)
-0:227        'inF0' (temp 4-component vector of float)
-0:228      distance (global float)
-0:228        'inF0' (temp 4-component vector of float)
-0:228        'inF1' (temp 4-component vector of float)
-0:229      dot-product (global float)
-0:229        'inF0' (temp 4-component vector of float)
-0:229        'inF1' (temp 4-component vector of float)
-0:233      exp (global 4-component vector of float)
-0:233        'inF0' (temp 4-component vector of float)
-0:234      exp2 (global 4-component vector of float)
+0:234      dPdx (global 4-component vector of float)
 0:234        'inF0' (temp 4-component vector of float)
-0:235      face-forward (global 4-component vector of float)
+0:235      dPdxCoarse (global 4-component vector of float)
 0:235        'inF0' (temp 4-component vector of float)
-0:235        'inF1' (temp 4-component vector of float)
-0:235        'inF2' (temp 4-component vector of float)
-0:236      findMSB (global int)
-0:236        Constant:
-0:236          7 (const int)
-0:237      findLSB (global int)
-0:237        Constant:
-0:237          7 (const int)
-0:238      Floor (global 4-component vector of float)
+0:236      dPdxFine (global 4-component vector of float)
+0:236        'inF0' (temp 4-component vector of float)
+0:237      dPdy (global 4-component vector of float)
+0:237        'inF0' (temp 4-component vector of float)
+0:238      dPdyCoarse (global 4-component vector of float)
 0:238        'inF0' (temp 4-component vector of float)
-0:240      Function Call: fmod(vf4;vf4; (global 4-component vector of float)
+0:239      dPdyFine (global 4-component vector of float)
+0:239        'inF0' (temp 4-component vector of float)
+0:240      degrees (global 4-component vector of float)
 0:240        'inF0' (temp 4-component vector of float)
-0:240        'inF1' (temp 4-component vector of float)
-0:241      Fraction (global 4-component vector of float)
+0:241      distance (global float)
 0:241        'inF0' (temp 4-component vector of float)
-0:242      frexp (global 4-component vector of float)
+0:241        'inF1' (temp 4-component vector of float)
+0:242      dot-product (global float)
 0:242        'inF0' (temp 4-component vector of float)
 0:242        'inF1' (temp 4-component vector of float)
-0:243      fwidth (global 4-component vector of float)
-0:243        'inF0' (temp 4-component vector of float)
-0:244      isinf (global 4-component vector of bool)
-0:244        'inF0' (temp 4-component vector of float)
-0:245      isnan (global 4-component vector of bool)
-0:245        'inF0' (temp 4-component vector of float)
-0:246      ldexp (global 4-component vector of float)
-0:246        'inF0' (temp 4-component vector of float)
-0:246        'inF1' (temp 4-component vector of float)
-0:247      length (global float)
+0:243      Construct vec4 (temp float)
+0:243        Constant:
+0:243          1.000000
+0:243        component-wise multiply (temp float)
+0:243          direct index (temp float)
+0:243            'inF0' (temp 4-component vector of float)
+0:243            Constant:
+0:243              1 (const int)
+0:243          direct index (temp float)
+0:243            'inF1' (temp 4-component vector of float)
+0:243            Constant:
+0:243              1 (const int)
+0:243        direct index (temp float)
+0:243          'inF0' (temp 4-component vector of float)
+0:243          Constant:
+0:243            2 (const int)
+0:243        direct index (temp float)
+0:243          'inF1' (temp 4-component vector of float)
+0:243          Constant:
+0:243            3 (const int)
+0:247      exp (global 4-component vector of float)
 0:247        'inF0' (temp 4-component vector of float)
-0:248      log (global 4-component vector of float)
+0:248      exp2 (global 4-component vector of float)
 0:248        'inF0' (temp 4-component vector of float)
-0:249      log2 (global 4-component vector of float)
+0:249      face-forward (global 4-component vector of float)
 0:249        'inF0' (temp 4-component vector of float)
-0:250      max (global 4-component vector of float)
-0:250        'inF0' (temp 4-component vector of float)
-0:250        'inF1' (temp 4-component vector of float)
-0:251      min (global 4-component vector of float)
-0:251        'inF0' (temp 4-component vector of float)
-0:251        'inF1' (temp 4-component vector of float)
-0:253      normalize (global 4-component vector of float)
-0:253        'inF0' (temp 4-component vector of float)
-0:254      pow (global 4-component vector of float)
+0:249        'inF1' (temp 4-component vector of float)
+0:249        'inF2' (temp 4-component vector of float)
+0:250      findMSB (global int)
+0:250        Constant:
+0:250          7 (const int)
+0:251      findLSB (global int)
+0:251        Constant:
+0:251          7 (const int)
+0:252      Floor (global 4-component vector of float)
+0:252        'inF0' (temp 4-component vector of float)
+0:254      mod (global 4-component vector of float)
 0:254        'inF0' (temp 4-component vector of float)
 0:254        'inF1' (temp 4-component vector of float)
-0:255      radians (global 4-component vector of float)
+0:255      Fraction (global 4-component vector of float)
 0:255        'inF0' (temp 4-component vector of float)
-0:256      reflect (global 4-component vector of float)
+0:256      frexp (global 4-component vector of float)
 0:256        'inF0' (temp 4-component vector of float)
 0:256        'inF1' (temp 4-component vector of float)
-0:257      refract (global 4-component vector of float)
+0:257      fwidth (global 4-component vector of float)
 0:257        'inF0' (temp 4-component vector of float)
-0:257        'inF1' (temp 4-component vector of float)
-0:257        Constant:
-0:257          2.000000
+0:258      isinf (global 4-component vector of bool)
+0:258        'inF0' (temp 4-component vector of float)
+0:259      isnan (global 4-component vector of bool)
+0:259        'inF0' (temp 4-component vector of float)
+0:260      ldexp (global 4-component vector of float)
+0:260        'inF0' (temp 4-component vector of float)
+0:260        'inF1' (temp 4-component vector of float)
+0:261      length (global float)
+0:261        'inF0' (temp 4-component vector of float)
+0:262      log (global 4-component vector of float)
+0:262        'inF0' (temp 4-component vector of float)
+0:263      vector-scale (temp 4-component vector of float)
+0:263        log2 (temp 4-component vector of float)
+0:263          'inF0' (temp 4-component vector of float)
+0:263        Constant:
+0:263          0.301030
+0:264      log2 (global 4-component vector of float)
+0:264        'inF0' (temp 4-component vector of float)
+0:265      max (global 4-component vector of float)
+0:265        'inF0' (temp 4-component vector of float)
+0:265        'inF1' (temp 4-component vector of float)
+0:266      min (global 4-component vector of float)
+0:266        'inF0' (temp 4-component vector of float)
+0:266        'inF1' (temp 4-component vector of float)
+0:267      normalize (global 4-component vector of float)
+0:267        'inF0' (temp 4-component vector of float)
+0:268      pow (global 4-component vector of float)
+0:268        'inF0' (temp 4-component vector of float)
+0:268        'inF1' (temp 4-component vector of float)
+0:269      radians (global 4-component vector of float)
+0:269        'inF0' (temp 4-component vector of float)
+0:270      divide (temp 4-component vector of float)
+0:270        Constant:
+0:270          1.000000
+0:270        'inF0' (temp 4-component vector of float)
+0:271      reflect (global 4-component vector of float)
+0:271        'inF0' (temp 4-component vector of float)
+0:271        'inF1' (temp 4-component vector of float)
+0:272      refract (global 4-component vector of float)
+0:272        'inF0' (temp 4-component vector of float)
+0:272        'inF1' (temp 4-component vector of float)
+0:272        Constant:
+0:272          2.000000
 0:?       bitFieldReverse (global 4-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
 0:?           4 (const uint)
-0:259      roundEven (global 4-component vector of float)
-0:259        'inF0' (temp 4-component vector of float)
-0:260      inverse sqrt (global 4-component vector of float)
-0:260        'inF0' (temp 4-component vector of float)
-0:261      Sign (global 4-component vector of float)
-0:261        'inF0' (temp 4-component vector of float)
-0:262      sine (global 4-component vector of float)
-0:262        'inF0' (temp 4-component vector of float)
-0:263      hyp. sine (global 4-component vector of float)
-0:263        'inF0' (temp 4-component vector of float)
-0:264      smoothstep (global 4-component vector of float)
-0:264        'inF0' (temp 4-component vector of float)
-0:264        'inF1' (temp 4-component vector of float)
-0:264        'inF2' (temp 4-component vector of float)
-0:265      sqrt (global 4-component vector of float)
-0:265        'inF0' (temp 4-component vector of float)
-0:266      step (global 4-component vector of float)
-0:266        'inF0' (temp 4-component vector of float)
-0:266        'inF1' (temp 4-component vector of float)
-0:267      tangent (global 4-component vector of float)
-0:267        'inF0' (temp 4-component vector of float)
-0:268      hyp. tangent (global 4-component vector of float)
-0:268        'inF0' (temp 4-component vector of float)
-0:270      trunc (global 4-component vector of float)
-0:270        'inF0' (temp 4-component vector of float)
-0:273      Branch: Return with expression
+0:274      roundEven (global 4-component vector of float)
+0:274        'inF0' (temp 4-component vector of float)
+0:275      inverse sqrt (global 4-component vector of float)
+0:275        'inF0' (temp 4-component vector of float)
+0:276      clamp (global 4-component vector of float)
+0:276        'inF0' (temp 4-component vector of float)
+0:276        Constant:
+0:276          0.000000
+0:276        Constant:
+0:276          1.000000
+0:277      Sign (global 4-component vector of float)
+0:277        'inF0' (temp 4-component vector of float)
+0:278      sine (global 4-component vector of float)
+0:278        'inF0' (temp 4-component vector of float)
+0:279      Sequence
+0:279        move second child to first child (temp 4-component vector of float)
+0:279          'inF1' (temp 4-component vector of float)
+0:279          sine (temp 4-component vector of float)
+0:279            'inF0' (temp 4-component vector of float)
+0:279        move second child to first child (temp 4-component vector of float)
+0:279          'inF2' (temp 4-component vector of float)
+0:279          cosine (temp 4-component vector of float)
+0:279            'inF0' (temp 4-component vector of float)
+0:280      hyp. sine (global 4-component vector of float)
+0:280        'inF0' (temp 4-component vector of float)
+0:281      smoothstep (global 4-component vector of float)
+0:281        'inF0' (temp 4-component vector of float)
+0:281        'inF1' (temp 4-component vector of float)
+0:281        'inF2' (temp 4-component vector of float)
+0:282      sqrt (global 4-component vector of float)
+0:282        'inF0' (temp 4-component vector of float)
+0:283      step (global 4-component vector of float)
+0:283        'inF0' (temp 4-component vector of float)
+0:283        'inF1' (temp 4-component vector of float)
+0:284      tangent (global 4-component vector of float)
+0:284        'inF0' (temp 4-component vector of float)
+0:285      hyp. tangent (global 4-component vector of float)
+0:285        'inF0' (temp 4-component vector of float)
+0:287      trunc (global 4-component vector of float)
+0:287        'inF0' (temp 4-component vector of float)
+0:290      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
 0:?           4.000000
-0:337  Function Definition: PixelShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
-0:329    Function Parameters: 
-0:329      'inF0' (temp 2X2 matrix of float)
-0:329      'inF1' (temp 2X2 matrix of float)
-0:329      'inF2' (temp 2X2 matrix of float)
+0:358  Function Definition: PixelShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:350    Function Parameters: 
+0:350      'inF0' (temp 2X2 matrix of float)
+0:350      'inF1' (temp 2X2 matrix of float)
+0:350      'inF2' (temp 2X2 matrix of float)
 0:?     Sequence
-0:331      all (global bool)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      Absolute value (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc cosine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      any (global bool)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc sine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      arc tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      Ceiling (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      clamp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331        'inF2' (temp 2X2 matrix of float)
-0:331      cosine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      hyp. cosine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdx (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdxCoarse (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdxFine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdy (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdyCoarse (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      dPdyFine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      degrees (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      determinant (global float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      exp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      exp2 (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      findMSB (global int)
-0:331        Constant:
-0:331          7 (const int)
-0:331      findLSB (global int)
-0:331        Constant:
-0:331          7 (const int)
-0:331      Floor (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      Function Call: fmod(mf22;mf22; (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      Fraction (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      frexp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      fwidth (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      ldexp (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      log (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      log2 (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      max (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      min (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      pow (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      radians (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      roundEven (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      inverse sqrt (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      Sign (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      sine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      hyp. sine (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      smoothstep (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331        'inF2' (temp 2X2 matrix of float)
-0:331      sqrt (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      step (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331        'inF1' (temp 2X2 matrix of float)
-0:331      tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      hyp. tangent (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      transpose (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:331      trunc (global 2X2 matrix of float)
-0:331        'inF0' (temp 2X2 matrix of float)
-0:334      Branch: Return with expression
+0:352      all (global bool)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      Absolute value (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      arc cosine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      any (global bool)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      arc sine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      arc tangent (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      arc tangent (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      Ceiling (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      Test condition and select (temp void)
+0:352        Condition
+0:352        any (temp bool)
+0:352          Compare Less Than (temp 2X2 matrix of bool)
+0:352            'inF0' (temp 2X2 matrix of float)
+0:352            Constant:
+0:352              0.000000
+0:352              0.000000
+0:352              0.000000
+0:352              0.000000
+0:352        true case
+0:352        Branch: Kill
+0:352      clamp (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352        'inF2' (temp 2X2 matrix of float)
+0:352      cosine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      hyp. cosine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      dPdx (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      dPdxCoarse (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      dPdxFine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      dPdy (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      dPdyCoarse (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      dPdyFine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      degrees (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      determinant (global float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      exp (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      exp2 (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      findMSB (global int)
+0:352        Constant:
+0:352          7 (const int)
+0:352      findLSB (global int)
+0:352        Constant:
+0:352          7 (const int)
+0:352      Floor (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      mod (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      Fraction (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      frexp (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      fwidth (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      ldexp (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      log (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      matrix-scale (temp 2X2 matrix of float)
+0:352        log2 (temp 2X2 matrix of float)
+0:352          'inF0' (temp 2X2 matrix of float)
+0:352        Constant:
+0:352          0.301030
+0:352      log2 (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      max (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      min (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      pow (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      radians (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      roundEven (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      inverse sqrt (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      clamp (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        Constant:
+0:352          0.000000
+0:352        Constant:
+0:352          1.000000
+0:352      Sign (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      sine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      Sequence
+0:352        move second child to first child (temp 2X2 matrix of float)
+0:352          'inF1' (temp 2X2 matrix of float)
+0:352          sine (temp 2X2 matrix of float)
+0:352            'inF0' (temp 2X2 matrix of float)
+0:352        move second child to first child (temp 2X2 matrix of float)
+0:352          'inF2' (temp 2X2 matrix of float)
+0:352          cosine (temp 2X2 matrix of float)
+0:352            'inF0' (temp 2X2 matrix of float)
+0:352      hyp. sine (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      smoothstep (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352        'inF2' (temp 2X2 matrix of float)
+0:352      sqrt (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      step (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352        'inF1' (temp 2X2 matrix of float)
+0:352      tangent (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      hyp. tangent (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      transpose (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:352      trunc (global 2X2 matrix of float)
+0:352        'inF0' (temp 2X2 matrix of float)
+0:355      Branch: Return with expression
 0:?         Constant:
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
-0:346  Function Definition: PixelShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
-0:338    Function Parameters: 
-0:338      'inF0' (temp 3X3 matrix of float)
-0:338      'inF1' (temp 3X3 matrix of float)
-0:338      'inF2' (temp 3X3 matrix of float)
+0:367  Function Definition: PixelShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:359    Function Parameters: 
+0:359      'inF0' (temp 3X3 matrix of float)
+0:359      'inF1' (temp 3X3 matrix of float)
+0:359      'inF2' (temp 3X3 matrix of float)
 0:?     Sequence
-0:340      all (global bool)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      Absolute value (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc cosine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      any (global bool)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc sine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      arc tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      Ceiling (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      clamp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340        'inF2' (temp 3X3 matrix of float)
-0:340      cosine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      hyp. cosine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdx (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdxCoarse (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdxFine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdy (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdyCoarse (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      dPdyFine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      degrees (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      determinant (global float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      exp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      exp2 (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      findMSB (global int)
-0:340        Constant:
-0:340          7 (const int)
-0:340      findLSB (global int)
-0:340        Constant:
-0:340          7 (const int)
-0:340      Floor (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      Function Call: fmod(mf33;mf33; (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      Fraction (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      frexp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      fwidth (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      ldexp (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      log (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      log2 (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      max (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      min (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      pow (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      radians (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      roundEven (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      inverse sqrt (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      Sign (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      sine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      hyp. sine (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      smoothstep (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340        'inF2' (temp 3X3 matrix of float)
-0:340      sqrt (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      step (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340        'inF1' (temp 3X3 matrix of float)
-0:340      tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      hyp. tangent (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      transpose (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:340      trunc (global 3X3 matrix of float)
-0:340        'inF0' (temp 3X3 matrix of float)
-0:343      Branch: Return with expression
+0:361      all (global bool)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      Absolute value (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      arc cosine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      any (global bool)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      arc sine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      arc tangent (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      arc tangent (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      Ceiling (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      Test condition and select (temp void)
+0:361        Condition
+0:361        any (temp bool)
+0:361          Compare Less Than (temp 3X3 matrix of bool)
+0:361            'inF0' (temp 3X3 matrix of float)
+0:361            Constant:
+0:361              0.000000
+0:361              0.000000
+0:361              0.000000
+0:361              0.000000
+0:361              0.000000
+0:361              0.000000
+0:361              0.000000
+0:361              0.000000
+0:361              0.000000
+0:361        true case
+0:361        Branch: Kill
+0:361      clamp (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361        'inF2' (temp 3X3 matrix of float)
+0:361      cosine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      hyp. cosine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      dPdx (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      dPdxCoarse (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      dPdxFine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      dPdy (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      dPdyCoarse (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      dPdyFine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      degrees (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      determinant (global float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      exp (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      exp2 (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      findMSB (global int)
+0:361        Constant:
+0:361          7 (const int)
+0:361      findLSB (global int)
+0:361        Constant:
+0:361          7 (const int)
+0:361      Floor (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      mod (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      Fraction (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      frexp (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      fwidth (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      ldexp (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      log (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      matrix-scale (temp 3X3 matrix of float)
+0:361        log2 (temp 3X3 matrix of float)
+0:361          'inF0' (temp 3X3 matrix of float)
+0:361        Constant:
+0:361          0.301030
+0:361      log2 (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      max (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      min (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      pow (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      radians (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      roundEven (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      inverse sqrt (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      clamp (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        Constant:
+0:361          0.000000
+0:361        Constant:
+0:361          1.000000
+0:361      Sign (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      sine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      Sequence
+0:361        move second child to first child (temp 3X3 matrix of float)
+0:361          'inF1' (temp 3X3 matrix of float)
+0:361          sine (temp 3X3 matrix of float)
+0:361            'inF0' (temp 3X3 matrix of float)
+0:361        move second child to first child (temp 3X3 matrix of float)
+0:361          'inF2' (temp 3X3 matrix of float)
+0:361          cosine (temp 3X3 matrix of float)
+0:361            'inF0' (temp 3X3 matrix of float)
+0:361      hyp. sine (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      smoothstep (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361        'inF2' (temp 3X3 matrix of float)
+0:361      sqrt (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      step (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361        'inF1' (temp 3X3 matrix of float)
+0:361      tangent (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      hyp. tangent (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      transpose (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:361      trunc (global 3X3 matrix of float)
+0:361        'inF0' (temp 3X3 matrix of float)
+0:364      Branch: Return with expression
 0:?         Constant:
 0:?           3.000000
 0:?           3.000000
@@ -1809,121 +2467,165 @@ gl_FragCoord origin is upper left
 0:?           3.000000
 0:?           3.000000
 0:?           3.000000
-0:354  Function Definition: PixelShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
-0:347    Function Parameters: 
-0:347      'inF0' (temp 4X4 matrix of float)
-0:347      'inF1' (temp 4X4 matrix of float)
-0:347      'inF2' (temp 4X4 matrix of float)
+0:388  Function Definition: PixelShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:368    Function Parameters: 
+0:368      'inF0' (temp 4X4 matrix of float)
+0:368      'inF1' (temp 4X4 matrix of float)
+0:368      'inF2' (temp 4X4 matrix of float)
 0:?     Sequence
-0:349      all (global bool)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      Absolute value (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc cosine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      any (global bool)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc sine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      arc tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      Ceiling (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      clamp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349        'inF2' (temp 4X4 matrix of float)
-0:349      cosine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      hyp. cosine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdx (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdxCoarse (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdxFine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdy (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdyCoarse (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      dPdyFine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      degrees (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      determinant (global float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      exp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      exp2 (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      findMSB (global int)
-0:349        Constant:
-0:349          7 (const int)
-0:349      findLSB (global int)
-0:349        Constant:
-0:349          7 (const int)
-0:349      Floor (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      Function Call: fmod(mf44;mf44; (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      Fraction (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      frexp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      fwidth (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      ldexp (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      log (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      log2 (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      max (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      min (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      pow (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      radians (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      roundEven (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      inverse sqrt (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      Sign (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      sine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      hyp. sine (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      smoothstep (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349        'inF2' (temp 4X4 matrix of float)
-0:349      sqrt (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      step (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349        'inF1' (temp 4X4 matrix of float)
-0:349      tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      hyp. tangent (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      transpose (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:349      trunc (global 4X4 matrix of float)
-0:349        'inF0' (temp 4X4 matrix of float)
-0:352      Branch: Return with expression
+0:370      all (global bool)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      Absolute value (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      arc cosine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      any (global bool)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      arc sine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      arc tangent (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      arc tangent (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      Ceiling (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      Test condition and select (temp void)
+0:370        Condition
+0:370        any (temp bool)
+0:370          Compare Less Than (temp 4X4 matrix of bool)
+0:370            'inF0' (temp 4X4 matrix of float)
+0:370            Constant:
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370              0.000000
+0:370        true case
+0:370        Branch: Kill
+0:370      clamp (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370        'inF2' (temp 4X4 matrix of float)
+0:370      cosine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      hyp. cosine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      dPdx (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      dPdxCoarse (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      dPdxFine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      dPdy (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      dPdyCoarse (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      dPdyFine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      degrees (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      determinant (global float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      exp (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      exp2 (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      findMSB (global int)
+0:370        Constant:
+0:370          7 (const int)
+0:370      findLSB (global int)
+0:370        Constant:
+0:370          7 (const int)
+0:370      Floor (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      mod (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      Fraction (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      frexp (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      fwidth (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      ldexp (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      log (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      matrix-scale (temp 4X4 matrix of float)
+0:370        log2 (temp 4X4 matrix of float)
+0:370          'inF0' (temp 4X4 matrix of float)
+0:370        Constant:
+0:370          0.301030
+0:370      log2 (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      max (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      min (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      pow (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      radians (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      roundEven (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      inverse sqrt (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      clamp (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        Constant:
+0:370          0.000000
+0:370        Constant:
+0:370          1.000000
+0:370      Sign (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      sine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      Sequence
+0:370        move second child to first child (temp 4X4 matrix of float)
+0:370          'inF1' (temp 4X4 matrix of float)
+0:370          sine (temp 4X4 matrix of float)
+0:370            'inF0' (temp 4X4 matrix of float)
+0:370        move second child to first child (temp 4X4 matrix of float)
+0:370          'inF2' (temp 4X4 matrix of float)
+0:370          cosine (temp 4X4 matrix of float)
+0:370            'inF0' (temp 4X4 matrix of float)
+0:370      hyp. sine (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      smoothstep (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370        'inF2' (temp 4X4 matrix of float)
+0:370      sqrt (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      step (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370        'inF1' (temp 4X4 matrix of float)
+0:370      tangent (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      hyp. tangent (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      transpose (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:370      trunc (global 4X4 matrix of float)
+0:370        'inF0' (temp 4X4 matrix of float)
+0:373      Branch: Return with expression
 0:?         Constant:
 0:?           4.000000
 0:?           4.000000
@@ -1941,12 +2643,173 @@ gl_FragCoord origin is upper left
 0:?           4.000000
 0:?           4.000000
 0:?           4.000000
+0:395  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
+0:391    Function Parameters: 
+0:391      'inF0' (temp float)
+0:391      'inF1' (temp float)
+0:391      'inFV0' (temp 2-component vector of float)
+0:391      'inFV1' (temp 2-component vector of float)
+0:391      'inFM0' (temp 2X2 matrix of float)
+0:391      'inFM1' (temp 2X2 matrix of float)
+0:?     Sequence
+0:392      move second child to first child (temp float)
+0:392        'r0' (temp float)
+0:392        component-wise multiply (temp float)
+0:392          'inF0' (temp float)
+0:392          'inF1' (temp float)
+0:392      move second child to first child (temp 2-component vector of float)
+0:392        'r1' (temp 2-component vector of float)
+0:392        vector-scale (temp 2-component vector of float)
+0:392          'inFV0' (temp 2-component vector of float)
+0:392          'inF0' (temp float)
+0:392      move second child to first child (temp 2-component vector of float)
+0:392        'r2' (temp 2-component vector of float)
+0:392        vector-scale (temp 2-component vector of float)
+0:392          'inF0' (temp float)
+0:392          'inFV0' (temp 2-component vector of float)
+0:392      move second child to first child (temp float)
+0:392        'r3' (temp float)
+0:392        dot-product (global float)
+0:392          'inFV0' (temp 2-component vector of float)
+0:392          'inFV1' (temp 2-component vector of float)
+0:392      move second child to first child (temp 2-component vector of float)
+0:392        'r4' (temp 2-component vector of float)
+0:392        matrix-times-vector (temp 2-component vector of float)
+0:392          'inFM0' (temp 2X2 matrix of float)
+0:392          'inFV0' (temp 2-component vector of float)
+0:392      move second child to first child (temp 2-component vector of float)
+0:392        'r5' (temp 2-component vector of float)
+0:392        vector-times-matrix (temp 2-component vector of float)
+0:392          'inFV0' (temp 2-component vector of float)
+0:392          'inFM0' (temp 2X2 matrix of float)
+0:392      move second child to first child (temp 2X2 matrix of float)
+0:392        'r6' (temp 2X2 matrix of float)
+0:392        matrix-scale (temp 2X2 matrix of float)
+0:392          'inFM0' (temp 2X2 matrix of float)
+0:392          'inF0' (temp float)
+0:392      move second child to first child (temp 2X2 matrix of float)
+0:392        'r7' (temp 2X2 matrix of float)
+0:392        matrix-scale (temp 2X2 matrix of float)
+0:392          'inF0' (temp float)
+0:392          'inFM0' (temp 2X2 matrix of float)
+0:392      move second child to first child (temp 2X2 matrix of float)
+0:392        'r8' (temp 2X2 matrix of float)
+0:392        matrix-multiply (temp 2X2 matrix of float)
+0:392          'inFM0' (temp 2X2 matrix of float)
+0:392          'inFM1' (temp 2X2 matrix of float)
+0:402  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
+0:398    Function Parameters: 
+0:398      'inF0' (temp float)
+0:398      'inF1' (temp float)
+0:398      'inFV0' (temp 3-component vector of float)
+0:398      'inFV1' (temp 3-component vector of float)
+0:398      'inFM0' (temp 3X3 matrix of float)
+0:398      'inFM1' (temp 3X3 matrix of float)
+0:?     Sequence
+0:399      move second child to first child (temp float)
+0:399        'r0' (temp float)
+0:399        component-wise multiply (temp float)
+0:399          'inF0' (temp float)
+0:399          'inF1' (temp float)
+0:399      move second child to first child (temp 3-component vector of float)
+0:399        'r1' (temp 3-component vector of float)
+0:399        vector-scale (temp 3-component vector of float)
+0:399          'inFV0' (temp 3-component vector of float)
+0:399          'inF0' (temp float)
+0:399      move second child to first child (temp 3-component vector of float)
+0:399        'r2' (temp 3-component vector of float)
+0:399        vector-scale (temp 3-component vector of float)
+0:399          'inF0' (temp float)
+0:399          'inFV0' (temp 3-component vector of float)
+0:399      move second child to first child (temp float)
+0:399        'r3' (temp float)
+0:399        dot-product (global float)
+0:399          'inFV0' (temp 3-component vector of float)
+0:399          'inFV1' (temp 3-component vector of float)
+0:399      move second child to first child (temp 3-component vector of float)
+0:399        'r4' (temp 3-component vector of float)
+0:399        matrix-times-vector (temp 3-component vector of float)
+0:399          'inFM0' (temp 3X3 matrix of float)
+0:399          'inFV0' (temp 3-component vector of float)
+0:399      move second child to first child (temp 3-component vector of float)
+0:399        'r5' (temp 3-component vector of float)
+0:399        vector-times-matrix (temp 3-component vector of float)
+0:399          'inFV0' (temp 3-component vector of float)
+0:399          'inFM0' (temp 3X3 matrix of float)
+0:399      move second child to first child (temp 3X3 matrix of float)
+0:399        'r6' (temp 3X3 matrix of float)
+0:399        matrix-scale (temp 3X3 matrix of float)
+0:399          'inFM0' (temp 3X3 matrix of float)
+0:399          'inF0' (temp float)
+0:399      move second child to first child (temp 3X3 matrix of float)
+0:399        'r7' (temp 3X3 matrix of float)
+0:399        matrix-scale (temp 3X3 matrix of float)
+0:399          'inF0' (temp float)
+0:399          'inFM0' (temp 3X3 matrix of float)
+0:399      move second child to first child (temp 3X3 matrix of float)
+0:399        'r8' (temp 3X3 matrix of float)
+0:399        matrix-multiply (temp 3X3 matrix of float)
+0:399          'inFM0' (temp 3X3 matrix of float)
+0:399          'inFM1' (temp 3X3 matrix of float)
+0:408  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
+0:405    Function Parameters: 
+0:405      'inF0' (temp float)
+0:405      'inF1' (temp float)
+0:405      'inFV0' (temp 4-component vector of float)
+0:405      'inFV1' (temp 4-component vector of float)
+0:405      'inFM0' (temp 4X4 matrix of float)
+0:405      'inFM1' (temp 4X4 matrix of float)
+0:?     Sequence
+0:406      move second child to first child (temp float)
+0:406        'r0' (temp float)
+0:406        component-wise multiply (temp float)
+0:406          'inF0' (temp float)
+0:406          'inF1' (temp float)
+0:406      move second child to first child (temp 4-component vector of float)
+0:406        'r1' (temp 4-component vector of float)
+0:406        vector-scale (temp 4-component vector of float)
+0:406          'inFV0' (temp 4-component vector of float)
+0:406          'inF0' (temp float)
+0:406      move second child to first child (temp 4-component vector of float)
+0:406        'r2' (temp 4-component vector of float)
+0:406        vector-scale (temp 4-component vector of float)
+0:406          'inF0' (temp float)
+0:406          'inFV0' (temp 4-component vector of float)
+0:406      move second child to first child (temp float)
+0:406        'r3' (temp float)
+0:406        dot-product (global float)
+0:406          'inFV0' (temp 4-component vector of float)
+0:406          'inFV1' (temp 4-component vector of float)
+0:406      move second child to first child (temp 4-component vector of float)
+0:406        'r4' (temp 4-component vector of float)
+0:406        matrix-times-vector (temp 4-component vector of float)
+0:406          'inFM0' (temp 4X4 matrix of float)
+0:406          'inFV0' (temp 4-component vector of float)
+0:406      move second child to first child (temp 4-component vector of float)
+0:406        'r5' (temp 4-component vector of float)
+0:406        vector-times-matrix (temp 4-component vector of float)
+0:406          'inFV0' (temp 4-component vector of float)
+0:406          'inFM0' (temp 4X4 matrix of float)
+0:406      move second child to first child (temp 4X4 matrix of float)
+0:406        'r6' (temp 4X4 matrix of float)
+0:406        matrix-scale (temp 4X4 matrix of float)
+0:406          'inFM0' (temp 4X4 matrix of float)
+0:406          'inF0' (temp float)
+0:406      move second child to first child (temp 4X4 matrix of float)
+0:406        'r7' (temp 4X4 matrix of float)
+0:406        matrix-scale (temp 4X4 matrix of float)
+0:406          'inF0' (temp float)
+0:406          'inFM0' (temp 4X4 matrix of float)
+0:406      move second child to first child (temp 4X4 matrix of float)
+0:406        'r8' (temp 4X4 matrix of float)
+0:406        matrix-multiply (temp 4X4 matrix of float)
+0:406          'inFM0' (temp 4X4 matrix of float)
+0:406          'inFM1' (temp 4X4 matrix of float)
 0:?   Linker Objects
 
-Missing functionality: missing user function; linker needs to catch that
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 880
+// Id's are bound by 1209
 
                               Capability Shader
                               Capability DerivativeControl
@@ -1956,223 +2819,472 @@ Missing functionality: missing user function; linker needs to catch that
                               ExecutionMode 4 OriginUpperLeft
                               Source HLSL 450
                               Name 4  "PixelShaderFunction"
-                              Name 8  "inF0"
-                              Name 23  "inF1"
-                              Name 30  "inF2"
-                              Name 67  "ResType"
-                              Name 127  "inF0"
-                              Name 141  "inF1"
-                              Name 148  "inF2"
-                              Name 195  "ResType"
-                              Name 268  "inF0"
-                              Name 282  "inF1"
-                              Name 289  "inF2"
-                              Name 339  "ResType"
-                              Name 410  "inF0"
-                              Name 424  "inF1"
-                              Name 431  "inF2"
-                              Name 477  "ResType"
-                              Name 549  "inF0"
-                              Name 563  "inF1"
-                              Name 570  "inF2"
-                              Name 604  "ResType"
-                              Name 660  "inF0"
-                              Name 674  "inF1"
-                              Name 681  "inF2"
-                              Name 715  "ResType"
-                              Name 771  "inF0"
-                              Name 785  "inF1"
-                              Name 792  "inF2"
-                              Name 826  "ResType"
+                              Name 19  "TestGenMul(f1;f1;vf2;vf2;mf22;mf22;"
+                              Name 13  "inF0"
+                              Name 14  "inF1"
+                              Name 15  "inFV0"
+                              Name 16  "inFV1"
+                              Name 17  "inFM0"
+                              Name 18  "inFM1"
+                              Name 32  "TestGenMul(f1;f1;vf3;vf3;mf33;mf33;"
+                              Name 26  "inF0"
+                              Name 27  "inF1"
+                              Name 28  "inFV0"
+                              Name 29  "inFV1"
+                              Name 30  "inFM0"
+                              Name 31  "inFM1"
+                              Name 45  "TestGenMul(f1;f1;vf4;vf4;mf44;mf44;"
+                              Name 39  "inF0"
+                              Name 40  "inF1"
+                              Name 41  "inFV0"
+                              Name 42  "inFV1"
+                              Name 43  "inFM0"
+                              Name 44  "inFM1"
+                              Name 47  "inF0"
+                              Name 62  "inF1"
+                              Name 69  "inF2"
+                              Name 115  "ResType"
+                              Name 185  "inF0"
+                              Name 199  "inF1"
+                              Name 206  "inF2"
+                              Name 264  "ResType"
+                              Name 347  "inF0"
+                              Name 361  "inF1"
+                              Name 368  "inF2"
+                              Name 429  "ResType"
+                              Name 511  "inF0"
+                              Name 525  "inF1"
+                              Name 532  "inF2"
+                              Name 598  "ResType"
+                              Name 681  "inF0"
+                              Name 695  "inF1"
+                              Name 710  "inF2"
+                              Name 753  "ResType"
+                              Name 818  "inF0"
+                              Name 832  "inF1"
+                              Name 847  "inF2"
+                              Name 893  "ResType"
+                              Name 958  "inF0"
+                              Name 972  "inF1"
+                              Name 987  "inF2"
+                              Name 1036  "ResType"
+                              Name 1101  "r0"
+                              Name 1105  "r1"
+                              Name 1109  "r2"
+                              Name 1113  "r3"
+                              Name 1117  "r4"
+                              Name 1121  "r5"
+                              Name 1125  "r6"
+                              Name 1129  "r7"
+                              Name 1133  "r8"
+                              Name 1137  "r0"
+                              Name 1141  "r1"
+                              Name 1145  "r2"
+                              Name 1149  "r3"
+                              Name 1153  "r4"
+                              Name 1157  "r5"
+                              Name 1161  "r6"
+                              Name 1165  "r7"
+                              Name 1169  "r8"
+                              Name 1173  "r0"
+                              Name 1177  "r1"
+                              Name 1181  "r2"
+                              Name 1185  "r3"
+                              Name 1189  "r4"
+                              Name 1193  "r5"
+                              Name 1197  "r6"
+                              Name 1201  "r7"
+                              Name 1205  "r8"
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
                7:             TypePointer Function 6(float)
-              10:             TypeBool
-              37:             TypeInt 32 0
-              38:     37(int) Constant 7
-              58:             TypeInt 32 1
-              59:     58(int) Constant 7
-     67(ResType):             TypeStruct 6(float) 58(int)
-              95:     37(int) Constant 2
-             122:    6(float) Constant 0
-             125:             TypeVector 6(float) 2
-             126:             TypePointer Function 125(fvec2)
-             155:             TypeVector 37(int) 2
-             156:     37(int) Constant 3
-             157:  155(ivec2) ConstantComposite 38 156
-             194:             TypeVector 58(int) 2
-    195(ResType):             TypeStruct 125(fvec2) 194(ivec2)
-             202:             TypeVector 10(bool) 2
-             233:    6(float) Constant 1073741824
-             235:     37(int) Constant 1
-             236:  155(ivec2) ConstantComposite 235 95
-             263:    6(float) Constant 1065353216
-             264:  125(fvec2) ConstantComposite 263 233
-             266:             TypeVector 6(float) 3
-             267:             TypePointer Function 266(fvec3)
-             296:             TypeVector 37(int) 3
-             297:     37(int) Constant 5
-             298:  296(ivec3) ConstantComposite 38 156 297
-             338:             TypeVector 58(int) 3
-    339(ResType):             TypeStruct 266(fvec3) 338(ivec3)
-             346:             TypeVector 10(bool) 3
-             378:  296(ivec3) ConstantComposite 235 95 156
-             405:    6(float) Constant 1077936128
-             406:  266(fvec3) ConstantComposite 263 233 405
-             408:             TypeVector 6(float) 4
-             409:             TypePointer Function 408(fvec4)
-             438:             TypeVector 37(int) 4
-             439:  438(ivec4) ConstantComposite 38 156 297 95
-             476:             TypeVector 58(int) 4
-    477(ResType):             TypeStruct 408(fvec4) 476(ivec4)
-             484:             TypeVector 10(bool) 4
-             516:     37(int) Constant 4
-             517:  438(ivec4) ConstantComposite 235 95 156 516
-             544:    6(float) Constant 1082130432
-             545:  408(fvec4) ConstantComposite 263 233 405 544
-             547:             TypeMatrix 125(fvec2) 2
-             548:             TypePointer Function 547
-    604(ResType):             TypeStruct 547 194(ivec2)
-             655:  125(fvec2) ConstantComposite 233 233
-             656:         547 ConstantComposite 655 655
-             658:             TypeMatrix 266(fvec3) 3
-             659:             TypePointer Function 658
-    715(ResType):             TypeStruct 658 338(ivec3)
-             766:  266(fvec3) ConstantComposite 405 405 405
-             767:         658 ConstantComposite 766 766 766
-             769:             TypeMatrix 408(fvec4) 4
-             770:             TypePointer Function 769
-    826(ResType):             TypeStruct 769 476(ivec4)
-             877:  408(fvec4) ConstantComposite 544 544 544 544
-             878:         769 ConstantComposite 877 877 877 877
+               8:             TypeVector 6(float) 2
+               9:             TypePointer Function 8(fvec2)
+              10:             TypeMatrix 8(fvec2) 2
+              11:             TypePointer Function 10
+              12:             TypeFunction 2 7(ptr) 7(ptr) 9(ptr) 9(ptr) 11(ptr) 11(ptr)
+              21:             TypeVector 6(float) 3
+              22:             TypePointer Function 21(fvec3)
+              23:             TypeMatrix 21(fvec3) 3
+              24:             TypePointer Function 23
+              25:             TypeFunction 2 7(ptr) 7(ptr) 22(ptr) 22(ptr) 24(ptr) 24(ptr)
+              34:             TypeVector 6(float) 4
+              35:             TypePointer Function 34(fvec4)
+              36:             TypeMatrix 34(fvec4) 4
+              37:             TypePointer Function 36
+              38:             TypeFunction 2 7(ptr) 7(ptr) 35(ptr) 35(ptr) 37(ptr) 37(ptr)
+              49:             TypeBool
+              73:    6(float) Constant 0
+              82:             TypeInt 32 0
+              83:     82(int) Constant 7
+             103:             TypeInt 32 1
+             104:    103(int) Constant 7
+    115(ResType):             TypeStruct 6(float) 103(int)
+             132:    6(float) Constant 1050288283
+             147:    6(float) Constant 1065353216
+             150:     82(int) Constant 2
+             210:    8(fvec2) ConstantComposite 73 73
+             211:             TypeVector 49(bool) 2
+             221:             TypeVector 82(int) 2
+             222:     82(int) Constant 3
+             223:  221(ivec2) ConstantComposite 83 222
+             263:             TypeVector 103(int) 2
+    264(ResType):             TypeStruct 8(fvec2) 263(ivec2)
+             307:    6(float) Constant 1073741824
+             309:     82(int) Constant 1
+             310:  221(ivec2) ConstantComposite 309 150
+             345:    8(fvec2) ConstantComposite 147 307
+             372:   21(fvec3) ConstantComposite 73 73 73
+             373:             TypeVector 49(bool) 3
+             383:             TypeVector 82(int) 3
+             384:     82(int) Constant 5
+             385:  383(ivec3) ConstantComposite 83 222 384
+             428:             TypeVector 103(int) 3
+    429(ResType):             TypeStruct 21(fvec3) 428(ivec3)
+             473:  383(ivec3) ConstantComposite 309 150 222
+             508:    6(float) Constant 1077936128
+             509:   21(fvec3) ConstantComposite 147 307 508
+             536:   34(fvec4) ConstantComposite 73 73 73 73
+             537:             TypeVector 49(bool) 4
+             547:             TypeVector 82(int) 4
+             548:  547(ivec4) ConstantComposite 83 222 384 150
+             597:             TypeVector 103(int) 4
+    598(ResType):             TypeStruct 34(fvec4) 597(ivec4)
+             642:     82(int) Constant 4
+             643:  547(ivec4) ConstantComposite 309 150 222 642
+             678:    6(float) Constant 1082130432
+             679:   34(fvec4) ConstantComposite 147 307 508 678
+             701:          10 ConstantComposite 210 210
+             702:             TypeMatrix 211(bvec2) 2
+    753(ResType):             TypeStruct 10 263(ivec2)
+             815:    8(fvec2) ConstantComposite 307 307
+             816:          10 ConstantComposite 815 815
+             838:          23 ConstantComposite 372 372 372
+             839:             TypeMatrix 373(bvec3) 3
+    893(ResType):             TypeStruct 23 428(ivec3)
+             955:   21(fvec3) ConstantComposite 508 508 508
+             956:          23 ConstantComposite 955 955 955
+             978:          36 ConstantComposite 536 536 536 536
+             979:             TypeMatrix 537(bvec4) 4
+   1036(ResType):             TypeStruct 36 597(ivec4)
+            1098:   34(fvec4) ConstantComposite 678 678 678 678
+            1099:          36 ConstantComposite 1098 1098 1098 1098
 4(PixelShaderFunction):           2 Function None 3
                5:             Label
-         8(inF0):      7(ptr) Variable Function
-        23(inF1):      7(ptr) Variable Function
-        30(inF2):      7(ptr) Variable Function
-       127(inF0):    126(ptr) Variable Function
-       141(inF1):    126(ptr) Variable Function
-       148(inF2):    126(ptr) Variable Function
-       268(inF0):    267(ptr) Variable Function
-       282(inF1):    267(ptr) Variable Function
-       289(inF2):    267(ptr) Variable Function
-       410(inF0):    409(ptr) Variable Function
-       424(inF1):    409(ptr) Variable Function
-       431(inF2):    409(ptr) Variable Function
-       549(inF0):    548(ptr) Variable Function
-       563(inF1):    548(ptr) Variable Function
-       570(inF2):    548(ptr) Variable Function
-       660(inF0):    659(ptr) Variable Function
-       674(inF1):    659(ptr) Variable Function
-       681(inF2):    659(ptr) Variable Function
-       771(inF0):    770(ptr) Variable Function
-       785(inF1):    770(ptr) Variable Function
-       792(inF2):    770(ptr) Variable Function
-               9:    6(float) Load 8(inF0)
-              11:    10(bool) All 9
-              12:    6(float) Load 8(inF0)
-              13:    6(float) ExtInst 1(GLSL.std.450) 4(FAbs) 12
-              14:    6(float) Load 8(inF0)
-              15:    6(float) ExtInst 1(GLSL.std.450) 17(Acos) 14
-              16:    6(float) Load 8(inF0)
-              17:    10(bool) Any 16
-              18:    6(float) Load 8(inF0)
-              19:    6(float) ExtInst 1(GLSL.std.450) 16(Asin) 18
-              20:    6(float) Load 8(inF0)
-              21:    6(float) ExtInst 1(GLSL.std.450) 18(Atan) 20
-              22:    6(float) Load 8(inF0)
-              24:    6(float) Load 23(inF1)
-              25:    6(float) ExtInst 1(GLSL.std.450) 25(Atan2) 22 24
-              26:    6(float) Load 8(inF0)
-              27:    6(float) ExtInst 1(GLSL.std.450) 9(Ceil) 26
-              28:    6(float) Load 8(inF0)
-              29:    6(float) Load 23(inF1)
-              31:    6(float) Load 30(inF2)
-              32:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 28 29 31
-              33:    6(float) Load 8(inF0)
-              34:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 33
-              35:    6(float) Load 8(inF0)
-              36:    6(float) ExtInst 1(GLSL.std.450) 20(Cosh) 35
-              39:     37(int) BitCount 38
-              40:    6(float) Load 8(inF0)
-              41:    6(float) DPdx 40
-              42:    6(float) Load 8(inF0)
-              43:    6(float) DPdxCoarse 42
-              44:    6(float) Load 8(inF0)
-              45:    6(float) DPdxFine 44
-              46:    6(float) Load 8(inF0)
-              47:    6(float) DPdy 46
-              48:    6(float) Load 8(inF0)
-              49:    6(float) DPdyCoarse 48
-              50:    6(float) Load 8(inF0)
-              51:    6(float) DPdyFine 50
-              52:    6(float) Load 8(inF0)
-              53:    6(float) ExtInst 1(GLSL.std.450) 12(Degrees) 52
-              54:    6(float) Load 8(inF0)
-              55:    6(float) ExtInst 1(GLSL.std.450) 27(Exp) 54
-              56:    6(float) Load 8(inF0)
-              57:    6(float) ExtInst 1(GLSL.std.450) 29(Exp2) 56
-              60:     58(int) ExtInst 1(GLSL.std.450) 74(FindSMsb) 59
-              61:     58(int) ExtInst 1(GLSL.std.450) 73(FindILsb) 59
-              62:    6(float) Load 8(inF0)
-              63:    6(float) ExtInst 1(GLSL.std.450) 8(Floor) 62
-              64:    6(float) Load 8(inF0)
-              65:    6(float) ExtInst 1(GLSL.std.450) 10(Fract) 64
-              66:    6(float) Load 8(inF0)
-              68: 67(ResType) ExtInst 1(GLSL.std.450) 52(FrexpStruct) 66
-              69:     58(int) CompositeExtract 68 1
-                              Store 23(inF1) 69
-              70:    6(float) CompositeExtract 68 0
-              71:    6(float) Load 8(inF0)
-              72:    6(float) Fwidth 71
-              73:    6(float) Load 8(inF0)
-              74:    10(bool) IsInf 73
-              75:    6(float) Load 8(inF0)
-              76:    10(bool) IsNan 75
-              77:    6(float) Load 8(inF0)
-              78:    6(float) Load 23(inF1)
-              79:    6(float) ExtInst 1(GLSL.std.450) 53(Ldexp) 77 78
-              80:    6(float) Load 8(inF0)
-              81:    6(float) ExtInst 1(GLSL.std.450) 28(Log) 80
-              82:    6(float) Load 8(inF0)
-              83:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 82
-              84:    6(float) Load 8(inF0)
-              85:    6(float) Load 23(inF1)
-              86:    6(float) ExtInst 1(GLSL.std.450) 40(FMax) 84 85
-              87:    6(float) Load 8(inF0)
-              88:    6(float) Load 23(inF1)
-              89:    6(float) ExtInst 1(GLSL.std.450) 37(FMin) 87 88
-              90:    6(float) Load 8(inF0)
-              91:    6(float) Load 23(inF1)
-              92:    6(float) ExtInst 1(GLSL.std.450) 26(Pow) 90 91
-              93:    6(float) Load 8(inF0)
-              94:    6(float) ExtInst 1(GLSL.std.450) 11(Radians) 93
-              96:     37(int) BitReverse 95
-              97:    6(float) Load 8(inF0)
-              98:    6(float) ExtInst 1(GLSL.std.450) 2(RoundEven) 97
-              99:    6(float) Load 8(inF0)
-             100:    6(float) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 99
-             101:    6(float) Load 8(inF0)
-             102:    6(float) ExtInst 1(GLSL.std.450) 6(FSign) 101
-             103:    6(float) Load 8(inF0)
-             104:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 103
-             105:    6(float) Load 8(inF0)
-             106:    6(float) ExtInst 1(GLSL.std.450) 19(Sinh) 105
-             107:    6(float) Load 8(inF0)
-             108:    6(float) Load 23(inF1)
-             109:    6(float) Load 30(inF2)
-             110:    6(float) ExtInst 1(GLSL.std.450) 49(SmoothStep) 107 108 109
-             111:    6(float) Load 8(inF0)
-             112:    6(float) ExtInst 1(GLSL.std.450) 31(Sqrt) 111
-             113:    6(float) Load 8(inF0)
-             114:    6(float) Load 23(inF1)
-             115:    6(float) ExtInst 1(GLSL.std.450) 48(Step) 113 114
-             116:    6(float) Load 8(inF0)
-             117:    6(float) ExtInst 1(GLSL.std.450) 15(Tan) 116
-             118:    6(float) Load 8(inF0)
-             119:    6(float) ExtInst 1(GLSL.std.450) 21(Tanh) 118
-             120:    6(float) Load 8(inF0)
-             121:    6(float) ExtInst 1(GLSL.std.450) 3(Trunc) 120
-                              ReturnValue 122
+        47(inF0):      7(ptr) Variable Function
+        62(inF1):      7(ptr) Variable Function
+        69(inF2):      7(ptr) Variable Function
+       185(inF0):      9(ptr) Variable Function
+       199(inF1):      9(ptr) Variable Function
+       206(inF2):      9(ptr) Variable Function
+       347(inF0):     22(ptr) Variable Function
+       361(inF1):     22(ptr) Variable Function
+       368(inF2):     22(ptr) Variable Function
+       511(inF0):     35(ptr) Variable Function
+       525(inF1):     35(ptr) Variable Function
+       532(inF2):     35(ptr) Variable Function
+       681(inF0):     11(ptr) Variable Function
+       695(inF1):     11(ptr) Variable Function
+       710(inF2):     11(ptr) Variable Function
+       818(inF0):     24(ptr) Variable Function
+       832(inF1):     24(ptr) Variable Function
+       847(inF2):     24(ptr) Variable Function
+       958(inF0):     37(ptr) Variable Function
+       972(inF1):     37(ptr) Variable Function
+       987(inF2):     37(ptr) Variable Function
+              48:    6(float) Load 47(inF0)
+              50:    49(bool) All 48
+              51:    6(float) Load 47(inF0)
+              52:    6(float) ExtInst 1(GLSL.std.450) 4(FAbs) 51
+              53:    6(float) Load 47(inF0)
+              54:    6(float) ExtInst 1(GLSL.std.450) 17(Acos) 53
+              55:    6(float) Load 47(inF0)
+              56:    49(bool) Any 55
+              57:    6(float) Load 47(inF0)
+              58:    6(float) ExtInst 1(GLSL.std.450) 16(Asin) 57
+              59:    6(float) Load 47(inF0)
+              60:    6(float) ExtInst 1(GLSL.std.450) 18(Atan) 59
+              61:    6(float) Load 47(inF0)
+              63:    6(float) Load 62(inF1)
+              64:    6(float) ExtInst 1(GLSL.std.450) 25(Atan2) 61 63
+              65:    6(float) Load 47(inF0)
+              66:    6(float) ExtInst 1(GLSL.std.450) 9(Ceil) 65
+              67:    6(float) Load 47(inF0)
+              68:    6(float) Load 62(inF1)
+              70:    6(float) Load 69(inF2)
+              71:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 67 68 70
+              72:    6(float) Load 47(inF0)
+              74:    49(bool) FOrdLessThan 72 73
+                              SelectionMerge 76 None
+                              BranchConditional 74 75 76
+              75:               Label
+                                Kill
+              76:             Label
+              78:    6(float) Load 47(inF0)
+              79:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 78
+              80:    6(float) Load 47(inF0)
+              81:    6(float) ExtInst 1(GLSL.std.450) 20(Cosh) 80
+              84:     82(int) BitCount 83
+              85:    6(float) Load 47(inF0)
+              86:    6(float) DPdx 85
+              87:    6(float) Load 47(inF0)
+              88:    6(float) DPdxCoarse 87
+              89:    6(float) Load 47(inF0)
+              90:    6(float) DPdxFine 89
+              91:    6(float) Load 47(inF0)
+              92:    6(float) DPdy 91
+              93:    6(float) Load 47(inF0)
+              94:    6(float) DPdyCoarse 93
+              95:    6(float) Load 47(inF0)
+              96:    6(float) DPdyFine 95
+              97:    6(float) Load 47(inF0)
+              98:    6(float) ExtInst 1(GLSL.std.450) 12(Degrees) 97
+              99:    6(float) Load 47(inF0)
+             100:    6(float) ExtInst 1(GLSL.std.450) 27(Exp) 99
+             101:    6(float) Load 47(inF0)
+             102:    6(float) ExtInst 1(GLSL.std.450) 29(Exp2) 101
+             105:    103(int) ExtInst 1(GLSL.std.450) 74(FindSMsb) 104
+             106:    103(int) ExtInst 1(GLSL.std.450) 73(FindILsb) 104
+             107:    6(float) Load 47(inF0)
+             108:    6(float) ExtInst 1(GLSL.std.450) 8(Floor) 107
+             109:    6(float) Load 47(inF0)
+             110:    6(float) Load 62(inF1)
+             111:    6(float) FMod 109 110
+             112:    6(float) Load 47(inF0)
+             113:    6(float) ExtInst 1(GLSL.std.450) 10(Fract) 112
+             114:    6(float) Load 47(inF0)
+             116:115(ResType) ExtInst 1(GLSL.std.450) 52(FrexpStruct) 114
+             117:    103(int) CompositeExtract 116 1
+                              Store 62(inF1) 117
+             118:    6(float) CompositeExtract 116 0
+             119:    6(float) Load 47(inF0)
+             120:    6(float) Fwidth 119
+             121:    6(float) Load 47(inF0)
+             122:    49(bool) IsInf 121
+             123:    6(float) Load 47(inF0)
+             124:    49(bool) IsNan 123
+             125:    6(float) Load 47(inF0)
+             126:    6(float) Load 62(inF1)
+             127:    6(float) ExtInst 1(GLSL.std.450) 53(Ldexp) 125 126
+             128:    6(float) Load 47(inF0)
+             129:    6(float) ExtInst 1(GLSL.std.450) 28(Log) 128
+             130:    6(float) Load 47(inF0)
+             131:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 130
+             133:    6(float) FMul 131 132
+             134:    6(float) Load 47(inF0)
+             135:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 134
+             136:    6(float) Load 47(inF0)
+             137:    6(float) Load 62(inF1)
+             138:    6(float) ExtInst 1(GLSL.std.450) 40(FMax) 136 137
+             139:    6(float) Load 47(inF0)
+             140:    6(float) Load 62(inF1)
+             141:    6(float) ExtInst 1(GLSL.std.450) 37(FMin) 139 140
+             142:    6(float) Load 47(inF0)
+             143:    6(float) Load 62(inF1)
+             144:    6(float) ExtInst 1(GLSL.std.450) 26(Pow) 142 143
+             145:    6(float) Load 47(inF0)
+             146:    6(float) ExtInst 1(GLSL.std.450) 11(Radians) 145
+             148:    6(float) Load 47(inF0)
+             149:    6(float) FDiv 147 148
+             151:     82(int) BitReverse 150
+             152:    6(float) Load 47(inF0)
+             153:    6(float) ExtInst 1(GLSL.std.450) 2(RoundEven) 152
+             154:    6(float) Load 47(inF0)
+             155:    6(float) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 154
+             156:    6(float) Load 47(inF0)
+             157:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 156 73 147
+             158:    6(float) Load 47(inF0)
+             159:    6(float) ExtInst 1(GLSL.std.450) 6(FSign) 158
+             160:    6(float) Load 47(inF0)
+             161:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 160
+             162:    6(float) Load 47(inF0)
+             163:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 162
+                              Store 62(inF1) 163
+             164:    6(float) Load 47(inF0)
+             165:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 164
+                              Store 69(inF2) 165
+             166:    6(float) Load 47(inF0)
+             167:    6(float) ExtInst 1(GLSL.std.450) 19(Sinh) 166
+             168:    6(float) Load 47(inF0)
+             169:    6(float) Load 62(inF1)
+             170:    6(float) Load 69(inF2)
+             171:    6(float) ExtInst 1(GLSL.std.450) 49(SmoothStep) 168 169 170
+             172:    6(float) Load 47(inF0)
+             173:    6(float) ExtInst 1(GLSL.std.450) 31(Sqrt) 172
+             174:    6(float) Load 47(inF0)
+             175:    6(float) Load 62(inF1)
+             176:    6(float) ExtInst 1(GLSL.std.450) 48(Step) 174 175
+             177:    6(float) Load 47(inF0)
+             178:    6(float) ExtInst 1(GLSL.std.450) 15(Tan) 177
+             179:    6(float) Load 47(inF0)
+             180:    6(float) ExtInst 1(GLSL.std.450) 21(Tanh) 179
+             181:    6(float) Load 47(inF0)
+             182:    6(float) ExtInst 1(GLSL.std.450) 3(Trunc) 181
+                              ReturnValue 73
+                              FunctionEnd
+19(TestGenMul(f1;f1;vf2;vf2;mf22;mf22;):           2 Function None 12
+        13(inF0):      7(ptr) FunctionParameter
+        14(inF1):      7(ptr) FunctionParameter
+       15(inFV0):      9(ptr) FunctionParameter
+       16(inFV1):      9(ptr) FunctionParameter
+       17(inFM0):     11(ptr) FunctionParameter
+       18(inFM1):     11(ptr) FunctionParameter
+              20:             Label
+        1101(r0):      7(ptr) Variable Function
+        1105(r1):      9(ptr) Variable Function
+        1109(r2):      9(ptr) Variable Function
+        1113(r3):      7(ptr) Variable Function
+        1117(r4):      9(ptr) Variable Function
+        1121(r5):      9(ptr) Variable Function
+        1125(r6):     11(ptr) Variable Function
+        1129(r7):     11(ptr) Variable Function
+        1133(r8):     11(ptr) Variable Function
+            1102:    6(float) Load 13(inF0)
+            1103:    6(float) Load 14(inF1)
+            1104:    6(float) FMul 1102 1103
+                              Store 1101(r0) 1104
+            1106:    8(fvec2) Load 15(inFV0)
+            1107:    6(float) Load 13(inF0)
+            1108:    8(fvec2) VectorTimesScalar 1106 1107
+                              Store 1105(r1) 1108
+            1110:    6(float) Load 13(inF0)
+            1111:    8(fvec2) Load 15(inFV0)
+            1112:    8(fvec2) VectorTimesScalar 1111 1110
+                              Store 1109(r2) 1112
+            1114:    8(fvec2) Load 15(inFV0)
+            1115:    8(fvec2) Load 16(inFV1)
+            1116:    6(float) Dot 1114 1115
+                              Store 1113(r3) 1116
+            1118:          10 Load 17(inFM0)
+            1119:    8(fvec2) Load 15(inFV0)
+            1120:    8(fvec2) MatrixTimesVector 1118 1119
+                              Store 1117(r4) 1120
+            1122:    8(fvec2) Load 15(inFV0)
+            1123:          10 Load 17(inFM0)
+            1124:    8(fvec2) VectorTimesMatrix 1122 1123
+                              Store 1121(r5) 1124
+            1126:          10 Load 17(inFM0)
+            1127:    6(float) Load 13(inF0)
+            1128:          10 MatrixTimesScalar 1126 1127
+                              Store 1125(r6) 1128
+            1130:    6(float) Load 13(inF0)
+            1131:          10 Load 17(inFM0)
+            1132:          10 MatrixTimesScalar 1131 1130
+                              Store 1129(r7) 1132
+            1134:          10 Load 17(inFM0)
+            1135:          10 Load 18(inFM1)
+            1136:          10 MatrixTimesMatrix 1134 1135
+                              Store 1133(r8) 1136
+                              Return
+                              FunctionEnd
+32(TestGenMul(f1;f1;vf3;vf3;mf33;mf33;):           2 Function None 25
+        26(inF0):      7(ptr) FunctionParameter
+        27(inF1):      7(ptr) FunctionParameter
+       28(inFV0):     22(ptr) FunctionParameter
+       29(inFV1):     22(ptr) FunctionParameter
+       30(inFM0):     24(ptr) FunctionParameter
+       31(inFM1):     24(ptr) FunctionParameter
+              33:             Label
+        1137(r0):      7(ptr) Variable Function
+        1141(r1):     22(ptr) Variable Function
+        1145(r2):     22(ptr) Variable Function
+        1149(r3):      7(ptr) Variable Function
+        1153(r4):     22(ptr) Variable Function
+        1157(r5):     22(ptr) Variable Function
+        1161(r6):     24(ptr) Variable Function
+        1165(r7):     24(ptr) Variable Function
+        1169(r8):     24(ptr) Variable Function
+            1138:    6(float) Load 26(inF0)
+            1139:    6(float) Load 27(inF1)
+            1140:    6(float) FMul 1138 1139
+                              Store 1137(r0) 1140
+            1142:   21(fvec3) Load 28(inFV0)
+            1143:    6(float) Load 26(inF0)
+            1144:   21(fvec3) VectorTimesScalar 1142 1143
+                              Store 1141(r1) 1144
+            1146:    6(float) Load 26(inF0)
+            1147:   21(fvec3) Load 28(inFV0)
+            1148:   21(fvec3) VectorTimesScalar 1147 1146
+                              Store 1145(r2) 1148
+            1150:   21(fvec3) Load 28(inFV0)
+            1151:   21(fvec3) Load 29(inFV1)
+            1152:    6(float) Dot 1150 1151
+                              Store 1149(r3) 1152
+            1154:          23 Load 30(inFM0)
+            1155:   21(fvec3) Load 28(inFV0)
+            1156:   21(fvec3) MatrixTimesVector 1154 1155
+                              Store 1153(r4) 1156
+            1158:   21(fvec3) Load 28(inFV0)
+            1159:          23 Load 30(inFM0)
+            1160:   21(fvec3) VectorTimesMatrix 1158 1159
+                              Store 1157(r5) 1160
+            1162:          23 Load 30(inFM0)
+            1163:    6(float) Load 26(inF0)
+            1164:          23 MatrixTimesScalar 1162 1163
+                              Store 1161(r6) 1164
+            1166:    6(float) Load 26(inF0)
+            1167:          23 Load 30(inFM0)
+            1168:          23 MatrixTimesScalar 1167 1166
+                              Store 1165(r7) 1168
+            1170:          23 Load 30(inFM0)
+            1171:          23 Load 31(inFM1)
+            1172:          23 MatrixTimesMatrix 1170 1171
+                              Store 1169(r8) 1172
+                              Return
+                              FunctionEnd
+45(TestGenMul(f1;f1;vf4;vf4;mf44;mf44;):           2 Function None 38
+        39(inF0):      7(ptr) FunctionParameter
+        40(inF1):      7(ptr) FunctionParameter
+       41(inFV0):     35(ptr) FunctionParameter
+       42(inFV1):     35(ptr) FunctionParameter
+       43(inFM0):     37(ptr) FunctionParameter
+       44(inFM1):     37(ptr) FunctionParameter
+              46:             Label
+        1173(r0):      7(ptr) Variable Function
+        1177(r1):     35(ptr) Variable Function
+        1181(r2):     35(ptr) Variable Function
+        1185(r3):      7(ptr) Variable Function
+        1189(r4):     35(ptr) Variable Function
+        1193(r5):     35(ptr) Variable Function
+        1197(r6):     37(ptr) Variable Function
+        1201(r7):     37(ptr) Variable Function
+        1205(r8):     37(ptr) Variable Function
+            1174:    6(float) Load 39(inF0)
+            1175:    6(float) Load 40(inF1)
+            1176:    6(float) FMul 1174 1175
+                              Store 1173(r0) 1176
+            1178:   34(fvec4) Load 41(inFV0)
+            1179:    6(float) Load 39(inF0)
+            1180:   34(fvec4) VectorTimesScalar 1178 1179
+                              Store 1177(r1) 1180
+            1182:    6(float) Load 39(inF0)
+            1183:   34(fvec4) Load 41(inFV0)
+            1184:   34(fvec4) VectorTimesScalar 1183 1182
+                              Store 1181(r2) 1184
+            1186:   34(fvec4) Load 41(inFV0)
+            1187:   34(fvec4) Load 42(inFV1)
+            1188:    6(float) Dot 1186 1187
+                              Store 1185(r3) 1188
+            1190:          36 Load 43(inFM0)
+            1191:   34(fvec4) Load 41(inFV0)
+            1192:   34(fvec4) MatrixTimesVector 1190 1191
+                              Store 1189(r4) 1192
+            1194:   34(fvec4) Load 41(inFV0)
+            1195:          36 Load 43(inFM0)
+            1196:   34(fvec4) VectorTimesMatrix 1194 1195
+                              Store 1193(r5) 1196
+            1198:          36 Load 43(inFM0)
+            1199:    6(float) Load 39(inF0)
+            1200:          36 MatrixTimesScalar 1198 1199
+                              Store 1197(r6) 1200
+            1202:    6(float) Load 39(inF0)
+            1203:          36 Load 43(inFM0)
+            1204:          36 MatrixTimesScalar 1203 1202
+                              Store 1201(r7) 1204
+            1206:          36 Load 43(inFM0)
+            1207:          36 Load 44(inFM1)
+            1208:          36 MatrixTimesMatrix 1206 1207
+                              Store 1205(r8) 1208
+                              Return
                               FunctionEnd

--- a/Test/baseResults/hlsl.intrinsics.vert.out
+++ b/Test/baseResults/hlsl.intrinsics.vert.out
@@ -1,7 +1,7 @@
 hlsl.intrinsics.vert
 Shader version: 450
 0:? Sequence
-0:56  Function Definition: VertexShaderFunction(f1;f1;f1; (temp float)
+0:59  Function Definition: VertexShaderFunction(f1;f1;f1; (temp float)
 0:2    Function Parameters: 
 0:2      'inF0' (temp float)
 0:2      'inF1' (temp float)
@@ -49,7 +49,7 @@ Shader version: 450
 0:22          7 (const int)
 0:23      Floor (global float)
 0:23        'inF0' (temp float)
-0:25      Function Call: fmod(f1;f1; (global float)
+0:25      mod (global float)
 0:25        'inF0' (temp float)
 0:25        'inF1' (temp float)
 0:26      Fraction (global float)
@@ -68,690 +68,830 @@ Shader version: 450
 0:31        'inF1' (temp float)
 0:32      log (global float)
 0:32        'inF0' (temp float)
-0:33      log2 (global float)
-0:33        'inF0' (temp float)
-0:34      max (global float)
+0:33      component-wise multiply (temp float)
+0:33        log2 (temp float)
+0:33          'inF0' (temp float)
+0:33        Constant:
+0:33          0.301030
+0:34      log2 (global float)
 0:34        'inF0' (temp float)
-0:34        'inF1' (temp float)
-0:35      min (global float)
+0:35      max (global float)
 0:35        'inF0' (temp float)
 0:35        'inF1' (temp float)
-0:37      pow (global float)
-0:37        'inF0' (temp float)
-0:37        'inF1' (temp float)
-0:38      radians (global float)
+0:36      min (global float)
+0:36        'inF0' (temp float)
+0:36        'inF1' (temp float)
+0:38      pow (global float)
 0:38        'inF0' (temp float)
-0:39      bitFieldReverse (global uint)
-0:39        Constant:
-0:39          2 (const uint)
-0:40      roundEven (global float)
-0:40        'inF0' (temp float)
-0:41      inverse sqrt (global float)
+0:38        'inF1' (temp float)
+0:39      radians (global float)
+0:39        'inF0' (temp float)
+0:40      bitFieldReverse (global uint)
+0:40        Constant:
+0:40          2 (const uint)
+0:41      roundEven (global float)
 0:41        'inF0' (temp float)
-0:42      Sign (global float)
+0:42      inverse sqrt (global float)
 0:42        'inF0' (temp float)
-0:43      sine (global float)
+0:43      clamp (global float)
 0:43        'inF0' (temp float)
-0:44      hyp. sine (global float)
+0:43        Constant:
+0:43          0.000000
+0:43        Constant:
+0:43          1.000000
+0:44      Sign (global float)
 0:44        'inF0' (temp float)
-0:45      smoothstep (global float)
+0:45      sine (global float)
 0:45        'inF0' (temp float)
-0:45        'inF1' (temp float)
-0:45        'inF2' (temp float)
-0:46      sqrt (global float)
-0:46        'inF0' (temp float)
-0:47      step (global float)
+0:46      Sequence
+0:46        move second child to first child (temp float)
+0:46          'inF1' (temp float)
+0:46          sine (temp float)
+0:46            'inF0' (temp float)
+0:46        move second child to first child (temp float)
+0:46          'inF2' (temp float)
+0:46          cosine (temp float)
+0:46            'inF0' (temp float)
+0:47      hyp. sine (global float)
 0:47        'inF0' (temp float)
-0:47        'inF1' (temp float)
-0:48      tangent (global float)
+0:48      smoothstep (global float)
 0:48        'inF0' (temp float)
-0:49      hyp. tangent (global float)
+0:48        'inF1' (temp float)
+0:48        'inF2' (temp float)
+0:49      sqrt (global float)
 0:49        'inF0' (temp float)
-0:51      trunc (global float)
+0:50      step (global float)
+0:50        'inF0' (temp float)
+0:50        'inF1' (temp float)
+0:51      tangent (global float)
 0:51        'inF0' (temp float)
-0:53      Branch: Return with expression
-0:53        Constant:
-0:53          0.000000
-0:62  Function Definition: VertexShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
-0:57    Function Parameters: 
-0:57      'inF0' (temp 1-component vector of float)
-0:57      'inF1' (temp 1-component vector of float)
-0:57      'inF2' (temp 1-component vector of float)
+0:52      hyp. tangent (global float)
+0:52        'inF0' (temp float)
+0:54      trunc (global float)
+0:54        'inF0' (temp float)
+0:56      Branch: Return with expression
+0:56        Constant:
+0:56          0.000000
+0:65  Function Definition: VertexShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
+0:60    Function Parameters: 
+0:60      'inF0' (temp 1-component vector of float)
+0:60      'inF1' (temp 1-component vector of float)
+0:60      'inF2' (temp 1-component vector of float)
 0:?     Sequence
-0:59      Branch: Return with expression
-0:59        Constant:
-0:59          0.000000
-0:125  Function Definition: VertexShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
-0:63    Function Parameters: 
-0:63      'inF0' (temp 2-component vector of float)
-0:63      'inF1' (temp 2-component vector of float)
-0:63      'inF2' (temp 2-component vector of float)
+0:62      Branch: Return with expression
+0:62        Constant:
+0:62          0.000000
+0:131  Function Definition: VertexShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
+0:66    Function Parameters: 
+0:66      'inF0' (temp 2-component vector of float)
+0:66      'inF1' (temp 2-component vector of float)
+0:66      'inF2' (temp 2-component vector of float)
 0:?     Sequence
-0:64      all (global bool)
-0:64        'inF0' (temp 2-component vector of float)
-0:65      Absolute value (global 2-component vector of float)
-0:65        'inF0' (temp 2-component vector of float)
-0:66      arc cosine (global 2-component vector of float)
-0:66        'inF0' (temp 2-component vector of float)
-0:67      any (global bool)
+0:67      all (global bool)
 0:67        'inF0' (temp 2-component vector of float)
-0:68      arc sine (global 2-component vector of float)
+0:68      Absolute value (global 2-component vector of float)
 0:68        'inF0' (temp 2-component vector of float)
-0:69      arc tangent (global 2-component vector of float)
+0:69      arc cosine (global 2-component vector of float)
 0:69        'inF0' (temp 2-component vector of float)
-0:70      arc tangent (global 2-component vector of float)
+0:70      any (global bool)
 0:70        'inF0' (temp 2-component vector of float)
-0:70        'inF1' (temp 2-component vector of float)
-0:71      Ceiling (global 2-component vector of float)
+0:71      arc sine (global 2-component vector of float)
 0:71        'inF0' (temp 2-component vector of float)
-0:72      clamp (global 2-component vector of float)
+0:72      arc tangent (global 2-component vector of float)
 0:72        'inF0' (temp 2-component vector of float)
-0:72        'inF1' (temp 2-component vector of float)
-0:72        'inF2' (temp 2-component vector of float)
-0:73      cosine (global 2-component vector of float)
+0:73      arc tangent (global 2-component vector of float)
 0:73        'inF0' (temp 2-component vector of float)
-0:74      hyp. cosine (global 2-component vector of float)
+0:73        'inF1' (temp 2-component vector of float)
+0:74      Ceiling (global 2-component vector of float)
 0:74        'inF0' (temp 2-component vector of float)
+0:75      clamp (global 2-component vector of float)
+0:75        'inF0' (temp 2-component vector of float)
+0:75        'inF1' (temp 2-component vector of float)
+0:75        'inF2' (temp 2-component vector of float)
+0:76      cosine (global 2-component vector of float)
+0:76        'inF0' (temp 2-component vector of float)
+0:77      hyp. cosine (global 2-component vector of float)
+0:77        'inF0' (temp 2-component vector of float)
 0:?       bitCount (global 2-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
-0:76      degrees (global 2-component vector of float)
-0:76        'inF0' (temp 2-component vector of float)
-0:77      distance (global float)
-0:77        'inF0' (temp 2-component vector of float)
-0:77        'inF1' (temp 2-component vector of float)
-0:78      dot-product (global float)
-0:78        'inF0' (temp 2-component vector of float)
-0:78        'inF1' (temp 2-component vector of float)
-0:82      exp (global 2-component vector of float)
-0:82        'inF0' (temp 2-component vector of float)
-0:83      exp2 (global 2-component vector of float)
-0:83        'inF0' (temp 2-component vector of float)
-0:84      face-forward (global 2-component vector of float)
-0:84        'inF0' (temp 2-component vector of float)
-0:84        'inF1' (temp 2-component vector of float)
-0:84        'inF2' (temp 2-component vector of float)
-0:85      findMSB (global int)
-0:85        Constant:
-0:85          7 (const int)
-0:86      findLSB (global int)
-0:86        Constant:
-0:86          7 (const int)
-0:87      Floor (global 2-component vector of float)
+0:79      degrees (global 2-component vector of float)
+0:79        'inF0' (temp 2-component vector of float)
+0:80      distance (global float)
+0:80        'inF0' (temp 2-component vector of float)
+0:80        'inF1' (temp 2-component vector of float)
+0:81      dot-product (global float)
+0:81        'inF0' (temp 2-component vector of float)
+0:81        'inF1' (temp 2-component vector of float)
+0:85      exp (global 2-component vector of float)
+0:85        'inF0' (temp 2-component vector of float)
+0:86      exp2 (global 2-component vector of float)
+0:86        'inF0' (temp 2-component vector of float)
+0:87      face-forward (global 2-component vector of float)
 0:87        'inF0' (temp 2-component vector of float)
-0:89      Function Call: fmod(vf2;vf2; (global 2-component vector of float)
-0:89        'inF0' (temp 2-component vector of float)
-0:89        'inF1' (temp 2-component vector of float)
-0:90      Fraction (global 2-component vector of float)
+0:87        'inF1' (temp 2-component vector of float)
+0:87        'inF2' (temp 2-component vector of float)
+0:88      findMSB (global int)
+0:88        Constant:
+0:88          7 (const int)
+0:89      findLSB (global int)
+0:89        Constant:
+0:89          7 (const int)
+0:90      Floor (global 2-component vector of float)
 0:90        'inF0' (temp 2-component vector of float)
-0:91      frexp (global 2-component vector of float)
-0:91        'inF0' (temp 2-component vector of float)
-0:91        'inF1' (temp 2-component vector of float)
-0:92      fwidth (global 2-component vector of float)
+0:92      mod (global 2-component vector of float)
 0:92        'inF0' (temp 2-component vector of float)
-0:93      isinf (global 2-component vector of bool)
+0:92        'inF1' (temp 2-component vector of float)
+0:93      Fraction (global 2-component vector of float)
 0:93        'inF0' (temp 2-component vector of float)
-0:94      isnan (global 2-component vector of bool)
+0:94      frexp (global 2-component vector of float)
 0:94        'inF0' (temp 2-component vector of float)
-0:95      ldexp (global 2-component vector of float)
+0:94        'inF1' (temp 2-component vector of float)
+0:95      fwidth (global 2-component vector of float)
 0:95        'inF0' (temp 2-component vector of float)
-0:95        'inF1' (temp 2-component vector of float)
-0:96      length (global float)
+0:96      isinf (global 2-component vector of bool)
 0:96        'inF0' (temp 2-component vector of float)
-0:97      log (global 2-component vector of float)
+0:97      isnan (global 2-component vector of bool)
 0:97        'inF0' (temp 2-component vector of float)
-0:98      log2 (global 2-component vector of float)
+0:98      ldexp (global 2-component vector of float)
 0:98        'inF0' (temp 2-component vector of float)
-0:99      max (global 2-component vector of float)
+0:98        'inF1' (temp 2-component vector of float)
+0:99      length (global float)
 0:99        'inF0' (temp 2-component vector of float)
-0:99        'inF1' (temp 2-component vector of float)
-0:100      min (global 2-component vector of float)
+0:100      log (global 2-component vector of float)
 0:100        'inF0' (temp 2-component vector of float)
-0:100        'inF1' (temp 2-component vector of float)
-0:102      normalize (global 2-component vector of float)
+0:101      vector-scale (temp 2-component vector of float)
+0:101        log2 (temp 2-component vector of float)
+0:101          'inF0' (temp 2-component vector of float)
+0:101        Constant:
+0:101          0.301030
+0:102      log2 (global 2-component vector of float)
 0:102        'inF0' (temp 2-component vector of float)
-0:103      pow (global 2-component vector of float)
+0:103      max (global 2-component vector of float)
 0:103        'inF0' (temp 2-component vector of float)
 0:103        'inF1' (temp 2-component vector of float)
-0:104      radians (global 2-component vector of float)
+0:104      min (global 2-component vector of float)
 0:104        'inF0' (temp 2-component vector of float)
-0:105      reflect (global 2-component vector of float)
-0:105        'inF0' (temp 2-component vector of float)
-0:105        'inF1' (temp 2-component vector of float)
-0:106      refract (global 2-component vector of float)
+0:104        'inF1' (temp 2-component vector of float)
+0:106      normalize (global 2-component vector of float)
 0:106        'inF0' (temp 2-component vector of float)
-0:106        'inF1' (temp 2-component vector of float)
-0:106        Constant:
-0:106          2.000000
+0:107      pow (global 2-component vector of float)
+0:107        'inF0' (temp 2-component vector of float)
+0:107        'inF1' (temp 2-component vector of float)
+0:108      radians (global 2-component vector of float)
+0:108        'inF0' (temp 2-component vector of float)
+0:109      reflect (global 2-component vector of float)
+0:109        'inF0' (temp 2-component vector of float)
+0:109        'inF1' (temp 2-component vector of float)
+0:110      refract (global 2-component vector of float)
+0:110        'inF0' (temp 2-component vector of float)
+0:110        'inF1' (temp 2-component vector of float)
+0:110        Constant:
+0:110          2.000000
 0:?       bitFieldReverse (global 2-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
-0:108      roundEven (global 2-component vector of float)
-0:108        'inF0' (temp 2-component vector of float)
-0:109      inverse sqrt (global 2-component vector of float)
-0:109        'inF0' (temp 2-component vector of float)
-0:110      Sign (global 2-component vector of float)
-0:110        'inF0' (temp 2-component vector of float)
-0:111      sine (global 2-component vector of float)
-0:111        'inF0' (temp 2-component vector of float)
-0:112      hyp. sine (global 2-component vector of float)
+0:112      roundEven (global 2-component vector of float)
 0:112        'inF0' (temp 2-component vector of float)
-0:113      smoothstep (global 2-component vector of float)
+0:113      inverse sqrt (global 2-component vector of float)
 0:113        'inF0' (temp 2-component vector of float)
-0:113        'inF1' (temp 2-component vector of float)
-0:113        'inF2' (temp 2-component vector of float)
-0:114      sqrt (global 2-component vector of float)
+0:114      clamp (global 2-component vector of float)
 0:114        'inF0' (temp 2-component vector of float)
-0:115      step (global 2-component vector of float)
+0:114        Constant:
+0:114          0.000000
+0:114        Constant:
+0:114          1.000000
+0:115      Sign (global 2-component vector of float)
 0:115        'inF0' (temp 2-component vector of float)
-0:115        'inF1' (temp 2-component vector of float)
-0:116      tangent (global 2-component vector of float)
+0:116      sine (global 2-component vector of float)
 0:116        'inF0' (temp 2-component vector of float)
-0:117      hyp. tangent (global 2-component vector of float)
-0:117        'inF0' (temp 2-component vector of float)
-0:119      trunc (global 2-component vector of float)
+0:117      Sequence
+0:117        move second child to first child (temp 2-component vector of float)
+0:117          'inF1' (temp 2-component vector of float)
+0:117          sine (temp 2-component vector of float)
+0:117            'inF0' (temp 2-component vector of float)
+0:117        move second child to first child (temp 2-component vector of float)
+0:117          'inF2' (temp 2-component vector of float)
+0:117          cosine (temp 2-component vector of float)
+0:117            'inF0' (temp 2-component vector of float)
+0:118      hyp. sine (global 2-component vector of float)
+0:118        'inF0' (temp 2-component vector of float)
+0:119      smoothstep (global 2-component vector of float)
 0:119        'inF0' (temp 2-component vector of float)
-0:122      Branch: Return with expression
+0:119        'inF1' (temp 2-component vector of float)
+0:119        'inF2' (temp 2-component vector of float)
+0:120      sqrt (global 2-component vector of float)
+0:120        'inF0' (temp 2-component vector of float)
+0:121      step (global 2-component vector of float)
+0:121        'inF0' (temp 2-component vector of float)
+0:121        'inF1' (temp 2-component vector of float)
+0:122      tangent (global 2-component vector of float)
+0:122        'inF0' (temp 2-component vector of float)
+0:123      hyp. tangent (global 2-component vector of float)
+0:123        'inF0' (temp 2-component vector of float)
+0:125      trunc (global 2-component vector of float)
+0:125        'inF0' (temp 2-component vector of float)
+0:128      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
-0:189  Function Definition: VertexShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
-0:126    Function Parameters: 
-0:126      'inF0' (temp 3-component vector of float)
-0:126      'inF1' (temp 3-component vector of float)
-0:126      'inF2' (temp 3-component vector of float)
+0:198  Function Definition: VertexShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
+0:132    Function Parameters: 
+0:132      'inF0' (temp 3-component vector of float)
+0:132      'inF1' (temp 3-component vector of float)
+0:132      'inF2' (temp 3-component vector of float)
 0:?     Sequence
-0:127      all (global bool)
-0:127        'inF0' (temp 3-component vector of float)
-0:128      Absolute value (global 3-component vector of float)
-0:128        'inF0' (temp 3-component vector of float)
-0:129      arc cosine (global 3-component vector of float)
-0:129        'inF0' (temp 3-component vector of float)
-0:130      any (global bool)
-0:130        'inF0' (temp 3-component vector of float)
-0:131      arc sine (global 3-component vector of float)
-0:131        'inF0' (temp 3-component vector of float)
-0:132      arc tangent (global 3-component vector of float)
-0:132        'inF0' (temp 3-component vector of float)
-0:133      arc tangent (global 3-component vector of float)
+0:133      all (global bool)
 0:133        'inF0' (temp 3-component vector of float)
-0:133        'inF1' (temp 3-component vector of float)
-0:134      Ceiling (global 3-component vector of float)
+0:134      Absolute value (global 3-component vector of float)
 0:134        'inF0' (temp 3-component vector of float)
-0:135      clamp (global 3-component vector of float)
+0:135      arc cosine (global 3-component vector of float)
 0:135        'inF0' (temp 3-component vector of float)
-0:135        'inF1' (temp 3-component vector of float)
-0:135        'inF2' (temp 3-component vector of float)
-0:136      cosine (global 3-component vector of float)
+0:136      any (global bool)
 0:136        'inF0' (temp 3-component vector of float)
-0:137      hyp. cosine (global 3-component vector of float)
+0:137      arc sine (global 3-component vector of float)
 0:137        'inF0' (temp 3-component vector of float)
+0:138      arc tangent (global 3-component vector of float)
+0:138        'inF0' (temp 3-component vector of float)
+0:139      arc tangent (global 3-component vector of float)
+0:139        'inF0' (temp 3-component vector of float)
+0:139        'inF1' (temp 3-component vector of float)
+0:140      Ceiling (global 3-component vector of float)
+0:140        'inF0' (temp 3-component vector of float)
+0:141      clamp (global 3-component vector of float)
+0:141        'inF0' (temp 3-component vector of float)
+0:141        'inF1' (temp 3-component vector of float)
+0:141        'inF2' (temp 3-component vector of float)
+0:142      cosine (global 3-component vector of float)
+0:142        'inF0' (temp 3-component vector of float)
+0:143      hyp. cosine (global 3-component vector of float)
+0:143        'inF0' (temp 3-component vector of float)
 0:?       bitCount (global 3-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
-0:139      cross-product (global 3-component vector of float)
-0:139        'inF0' (temp 3-component vector of float)
-0:139        'inF1' (temp 3-component vector of float)
-0:140      degrees (global 3-component vector of float)
-0:140        'inF0' (temp 3-component vector of float)
-0:141      distance (global float)
-0:141        'inF0' (temp 3-component vector of float)
-0:141        'inF1' (temp 3-component vector of float)
-0:142      dot-product (global float)
-0:142        'inF0' (temp 3-component vector of float)
-0:142        'inF1' (temp 3-component vector of float)
-0:146      exp (global 3-component vector of float)
+0:145      cross-product (global 3-component vector of float)
+0:145        'inF0' (temp 3-component vector of float)
+0:145        'inF1' (temp 3-component vector of float)
+0:146      degrees (global 3-component vector of float)
 0:146        'inF0' (temp 3-component vector of float)
-0:147      exp2 (global 3-component vector of float)
+0:147      distance (global float)
 0:147        'inF0' (temp 3-component vector of float)
-0:148      face-forward (global 3-component vector of float)
+0:147        'inF1' (temp 3-component vector of float)
+0:148      dot-product (global float)
 0:148        'inF0' (temp 3-component vector of float)
 0:148        'inF1' (temp 3-component vector of float)
-0:148        'inF2' (temp 3-component vector of float)
-0:149      findMSB (global int)
-0:149        Constant:
-0:149          7 (const int)
-0:150      findLSB (global int)
-0:150        Constant:
-0:150          7 (const int)
-0:151      Floor (global 3-component vector of float)
-0:151        'inF0' (temp 3-component vector of float)
-0:153      Function Call: fmod(vf3;vf3; (global 3-component vector of float)
+0:152      exp (global 3-component vector of float)
+0:152        'inF0' (temp 3-component vector of float)
+0:153      exp2 (global 3-component vector of float)
 0:153        'inF0' (temp 3-component vector of float)
-0:153        'inF1' (temp 3-component vector of float)
-0:154      Fraction (global 3-component vector of float)
+0:154      face-forward (global 3-component vector of float)
 0:154        'inF0' (temp 3-component vector of float)
-0:155      frexp (global 3-component vector of float)
-0:155        'inF0' (temp 3-component vector of float)
-0:155        'inF1' (temp 3-component vector of float)
-0:156      fwidth (global 3-component vector of float)
-0:156        'inF0' (temp 3-component vector of float)
-0:157      isinf (global 3-component vector of bool)
+0:154        'inF1' (temp 3-component vector of float)
+0:154        'inF2' (temp 3-component vector of float)
+0:155      findMSB (global int)
+0:155        Constant:
+0:155          7 (const int)
+0:156      findLSB (global int)
+0:156        Constant:
+0:156          7 (const int)
+0:157      Floor (global 3-component vector of float)
 0:157        'inF0' (temp 3-component vector of float)
-0:158      isnan (global 3-component vector of bool)
-0:158        'inF0' (temp 3-component vector of float)
-0:159      ldexp (global 3-component vector of float)
+0:159      mod (global 3-component vector of float)
 0:159        'inF0' (temp 3-component vector of float)
 0:159        'inF1' (temp 3-component vector of float)
-0:160      length (global float)
+0:160      Fraction (global 3-component vector of float)
 0:160        'inF0' (temp 3-component vector of float)
-0:161      log (global 3-component vector of float)
+0:161      frexp (global 3-component vector of float)
 0:161        'inF0' (temp 3-component vector of float)
-0:162      log2 (global 3-component vector of float)
+0:161        'inF1' (temp 3-component vector of float)
+0:162      fwidth (global 3-component vector of float)
 0:162        'inF0' (temp 3-component vector of float)
-0:163      max (global 3-component vector of float)
+0:163      isinf (global 3-component vector of bool)
 0:163        'inF0' (temp 3-component vector of float)
-0:163        'inF1' (temp 3-component vector of float)
-0:164      min (global 3-component vector of float)
+0:164      isnan (global 3-component vector of bool)
 0:164        'inF0' (temp 3-component vector of float)
-0:164        'inF1' (temp 3-component vector of float)
-0:166      normalize (global 3-component vector of float)
+0:165      ldexp (global 3-component vector of float)
+0:165        'inF0' (temp 3-component vector of float)
+0:165        'inF1' (temp 3-component vector of float)
+0:166      length (global float)
 0:166        'inF0' (temp 3-component vector of float)
-0:167      pow (global 3-component vector of float)
+0:167      log (global 3-component vector of float)
 0:167        'inF0' (temp 3-component vector of float)
-0:167        'inF1' (temp 3-component vector of float)
-0:168      radians (global 3-component vector of float)
-0:168        'inF0' (temp 3-component vector of float)
-0:169      reflect (global 3-component vector of float)
+0:168      vector-scale (temp 3-component vector of float)
+0:168        log2 (temp 3-component vector of float)
+0:168          'inF0' (temp 3-component vector of float)
+0:168        Constant:
+0:168          0.301030
+0:169      log2 (global 3-component vector of float)
 0:169        'inF0' (temp 3-component vector of float)
-0:169        'inF1' (temp 3-component vector of float)
-0:170      refract (global 3-component vector of float)
+0:170      max (global 3-component vector of float)
 0:170        'inF0' (temp 3-component vector of float)
 0:170        'inF1' (temp 3-component vector of float)
-0:170        Constant:
-0:170          2.000000
+0:171      min (global 3-component vector of float)
+0:171        'inF0' (temp 3-component vector of float)
+0:171        'inF1' (temp 3-component vector of float)
+0:173      normalize (global 3-component vector of float)
+0:173        'inF0' (temp 3-component vector of float)
+0:174      pow (global 3-component vector of float)
+0:174        'inF0' (temp 3-component vector of float)
+0:174        'inF1' (temp 3-component vector of float)
+0:175      radians (global 3-component vector of float)
+0:175        'inF0' (temp 3-component vector of float)
+0:176      reflect (global 3-component vector of float)
+0:176        'inF0' (temp 3-component vector of float)
+0:176        'inF1' (temp 3-component vector of float)
+0:177      refract (global 3-component vector of float)
+0:177        'inF0' (temp 3-component vector of float)
+0:177        'inF1' (temp 3-component vector of float)
+0:177        Constant:
+0:177          2.000000
 0:?       bitFieldReverse (global 3-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
-0:172      roundEven (global 3-component vector of float)
-0:172        'inF0' (temp 3-component vector of float)
-0:173      inverse sqrt (global 3-component vector of float)
-0:173        'inF0' (temp 3-component vector of float)
-0:174      Sign (global 3-component vector of float)
-0:174        'inF0' (temp 3-component vector of float)
-0:175      sine (global 3-component vector of float)
-0:175        'inF0' (temp 3-component vector of float)
-0:176      hyp. sine (global 3-component vector of float)
-0:176        'inF0' (temp 3-component vector of float)
-0:177      smoothstep (global 3-component vector of float)
-0:177        'inF0' (temp 3-component vector of float)
-0:177        'inF1' (temp 3-component vector of float)
-0:177        'inF2' (temp 3-component vector of float)
-0:178      sqrt (global 3-component vector of float)
-0:178        'inF0' (temp 3-component vector of float)
-0:179      step (global 3-component vector of float)
+0:179      roundEven (global 3-component vector of float)
 0:179        'inF0' (temp 3-component vector of float)
-0:179        'inF1' (temp 3-component vector of float)
-0:180      tangent (global 3-component vector of float)
+0:180      inverse sqrt (global 3-component vector of float)
 0:180        'inF0' (temp 3-component vector of float)
-0:181      hyp. tangent (global 3-component vector of float)
+0:181      clamp (global 3-component vector of float)
 0:181        'inF0' (temp 3-component vector of float)
-0:183      trunc (global 3-component vector of float)
+0:181        Constant:
+0:181          0.000000
+0:181        Constant:
+0:181          1.000000
+0:182      Sign (global 3-component vector of float)
+0:182        'inF0' (temp 3-component vector of float)
+0:183      sine (global 3-component vector of float)
 0:183        'inF0' (temp 3-component vector of float)
-0:186      Branch: Return with expression
+0:184      Sequence
+0:184        move second child to first child (temp 3-component vector of float)
+0:184          'inF1' (temp 3-component vector of float)
+0:184          sine (temp 3-component vector of float)
+0:184            'inF0' (temp 3-component vector of float)
+0:184        move second child to first child (temp 3-component vector of float)
+0:184          'inF2' (temp 3-component vector of float)
+0:184          cosine (temp 3-component vector of float)
+0:184            'inF0' (temp 3-component vector of float)
+0:185      hyp. sine (global 3-component vector of float)
+0:185        'inF0' (temp 3-component vector of float)
+0:186      smoothstep (global 3-component vector of float)
+0:186        'inF0' (temp 3-component vector of float)
+0:186        'inF1' (temp 3-component vector of float)
+0:186        'inF2' (temp 3-component vector of float)
+0:187      sqrt (global 3-component vector of float)
+0:187        'inF0' (temp 3-component vector of float)
+0:188      step (global 3-component vector of float)
+0:188        'inF0' (temp 3-component vector of float)
+0:188        'inF1' (temp 3-component vector of float)
+0:189      tangent (global 3-component vector of float)
+0:189        'inF0' (temp 3-component vector of float)
+0:190      hyp. tangent (global 3-component vector of float)
+0:190        'inF0' (temp 3-component vector of float)
+0:192      trunc (global 3-component vector of float)
+0:192        'inF0' (temp 3-component vector of float)
+0:195      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
-0:298  Function Definition: VertexShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
-0:190    Function Parameters: 
-0:190      'inF0' (temp 4-component vector of float)
-0:190      'inF1' (temp 4-component vector of float)
-0:190      'inF2' (temp 4-component vector of float)
+0:314  Function Definition: VertexShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
+0:199    Function Parameters: 
+0:199      'inF0' (temp 4-component vector of float)
+0:199      'inF1' (temp 4-component vector of float)
+0:199      'inF2' (temp 4-component vector of float)
 0:?     Sequence
-0:191      all (global bool)
-0:191        'inF0' (temp 4-component vector of float)
-0:192      Absolute value (global 4-component vector of float)
-0:192        'inF0' (temp 4-component vector of float)
-0:193      arc cosine (global 4-component vector of float)
-0:193        'inF0' (temp 4-component vector of float)
-0:194      any (global bool)
-0:194        'inF0' (temp 4-component vector of float)
-0:195      arc sine (global 4-component vector of float)
-0:195        'inF0' (temp 4-component vector of float)
-0:196      arc tangent (global 4-component vector of float)
-0:196        'inF0' (temp 4-component vector of float)
-0:197      arc tangent (global 4-component vector of float)
-0:197        'inF0' (temp 4-component vector of float)
-0:197        'inF1' (temp 4-component vector of float)
-0:198      Ceiling (global 4-component vector of float)
-0:198        'inF0' (temp 4-component vector of float)
-0:199      clamp (global 4-component vector of float)
-0:199        'inF0' (temp 4-component vector of float)
-0:199        'inF1' (temp 4-component vector of float)
-0:199        'inF2' (temp 4-component vector of float)
-0:200      cosine (global 4-component vector of float)
+0:200      all (global bool)
 0:200        'inF0' (temp 4-component vector of float)
-0:201      hyp. cosine (global 4-component vector of float)
+0:201      Absolute value (global 4-component vector of float)
 0:201        'inF0' (temp 4-component vector of float)
+0:202      arc cosine (global 4-component vector of float)
+0:202        'inF0' (temp 4-component vector of float)
+0:203      any (global bool)
+0:203        'inF0' (temp 4-component vector of float)
+0:204      arc sine (global 4-component vector of float)
+0:204        'inF0' (temp 4-component vector of float)
+0:205      arc tangent (global 4-component vector of float)
+0:205        'inF0' (temp 4-component vector of float)
+0:206      arc tangent (global 4-component vector of float)
+0:206        'inF0' (temp 4-component vector of float)
+0:206        'inF1' (temp 4-component vector of float)
+0:207      Ceiling (global 4-component vector of float)
+0:207        'inF0' (temp 4-component vector of float)
+0:208      clamp (global 4-component vector of float)
+0:208        'inF0' (temp 4-component vector of float)
+0:208        'inF1' (temp 4-component vector of float)
+0:208        'inF2' (temp 4-component vector of float)
+0:209      cosine (global 4-component vector of float)
+0:209        'inF0' (temp 4-component vector of float)
+0:210      hyp. cosine (global 4-component vector of float)
+0:210        'inF0' (temp 4-component vector of float)
 0:?       bitCount (global 4-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
 0:?           2 (const uint)
-0:203      degrees (global 4-component vector of float)
-0:203        'inF0' (temp 4-component vector of float)
-0:204      distance (global float)
-0:204        'inF0' (temp 4-component vector of float)
-0:204        'inF1' (temp 4-component vector of float)
-0:205      dot-product (global float)
-0:205        'inF0' (temp 4-component vector of float)
-0:205        'inF1' (temp 4-component vector of float)
-0:209      exp (global 4-component vector of float)
-0:209        'inF0' (temp 4-component vector of float)
-0:210      exp2 (global 4-component vector of float)
-0:210        'inF0' (temp 4-component vector of float)
-0:211      face-forward (global 4-component vector of float)
-0:211        'inF0' (temp 4-component vector of float)
-0:211        'inF1' (temp 4-component vector of float)
-0:211        'inF2' (temp 4-component vector of float)
-0:212      findMSB (global int)
-0:212        Constant:
-0:212          7 (const int)
-0:213      findLSB (global int)
-0:213        Constant:
-0:213          7 (const int)
-0:214      Floor (global 4-component vector of float)
+0:212      degrees (global 4-component vector of float)
+0:212        'inF0' (temp 4-component vector of float)
+0:213      distance (global float)
+0:213        'inF0' (temp 4-component vector of float)
+0:213        'inF1' (temp 4-component vector of float)
+0:214      dot-product (global float)
 0:214        'inF0' (temp 4-component vector of float)
-0:216      Function Call: fmod(vf4;vf4; (global 4-component vector of float)
-0:216        'inF0' (temp 4-component vector of float)
-0:216        'inF1' (temp 4-component vector of float)
-0:217      Fraction (global 4-component vector of float)
-0:217        'inF0' (temp 4-component vector of float)
-0:218      frexp (global 4-component vector of float)
-0:218        'inF0' (temp 4-component vector of float)
-0:218        'inF1' (temp 4-component vector of float)
-0:219      fwidth (global 4-component vector of float)
+0:214        'inF1' (temp 4-component vector of float)
+0:215      Construct vec4 (temp float)
+0:215        Constant:
+0:215          1.000000
+0:215        component-wise multiply (temp float)
+0:215          direct index (temp float)
+0:215            'inF0' (temp 4-component vector of float)
+0:215            Constant:
+0:215              1 (const int)
+0:215          direct index (temp float)
+0:215            'inF1' (temp 4-component vector of float)
+0:215            Constant:
+0:215              1 (const int)
+0:215        direct index (temp float)
+0:215          'inF0' (temp 4-component vector of float)
+0:215          Constant:
+0:215            2 (const int)
+0:215        direct index (temp float)
+0:215          'inF1' (temp 4-component vector of float)
+0:215          Constant:
+0:215            3 (const int)
+0:219      exp (global 4-component vector of float)
 0:219        'inF0' (temp 4-component vector of float)
-0:220      isinf (global 4-component vector of bool)
+0:220      exp2 (global 4-component vector of float)
 0:220        'inF0' (temp 4-component vector of float)
-0:221      isnan (global 4-component vector of bool)
+0:221      face-forward (global 4-component vector of float)
 0:221        'inF0' (temp 4-component vector of float)
-0:222      ldexp (global 4-component vector of float)
-0:222        'inF0' (temp 4-component vector of float)
-0:222        'inF1' (temp 4-component vector of float)
-0:223      length (global float)
-0:223        'inF0' (temp 4-component vector of float)
-0:224      log (global 4-component vector of float)
+0:221        'inF1' (temp 4-component vector of float)
+0:221        'inF2' (temp 4-component vector of float)
+0:222      findMSB (global int)
+0:222        Constant:
+0:222          7 (const int)
+0:223      findLSB (global int)
+0:223        Constant:
+0:223          7 (const int)
+0:224      Floor (global 4-component vector of float)
 0:224        'inF0' (temp 4-component vector of float)
-0:225      log2 (global 4-component vector of float)
-0:225        'inF0' (temp 4-component vector of float)
-0:226      max (global 4-component vector of float)
+0:226      mod (global 4-component vector of float)
 0:226        'inF0' (temp 4-component vector of float)
 0:226        'inF1' (temp 4-component vector of float)
-0:227      min (global 4-component vector of float)
+0:227      Fraction (global 4-component vector of float)
 0:227        'inF0' (temp 4-component vector of float)
-0:227        'inF1' (temp 4-component vector of float)
-0:229      normalize (global 4-component vector of float)
+0:228      frexp (global 4-component vector of float)
+0:228        'inF0' (temp 4-component vector of float)
+0:228        'inF1' (temp 4-component vector of float)
+0:229      fwidth (global 4-component vector of float)
 0:229        'inF0' (temp 4-component vector of float)
-0:230      pow (global 4-component vector of float)
+0:230      isinf (global 4-component vector of bool)
 0:230        'inF0' (temp 4-component vector of float)
-0:230        'inF1' (temp 4-component vector of float)
-0:231      radians (global 4-component vector of float)
+0:231      isnan (global 4-component vector of bool)
 0:231        'inF0' (temp 4-component vector of float)
-0:232      reflect (global 4-component vector of float)
+0:232      ldexp (global 4-component vector of float)
 0:232        'inF0' (temp 4-component vector of float)
 0:232        'inF1' (temp 4-component vector of float)
-0:233      refract (global 4-component vector of float)
+0:233      length (global float)
 0:233        'inF0' (temp 4-component vector of float)
-0:233        'inF1' (temp 4-component vector of float)
-0:233        Constant:
-0:233          2.000000
+0:234      log (global 4-component vector of float)
+0:234        'inF0' (temp 4-component vector of float)
+0:235      vector-scale (temp 4-component vector of float)
+0:235        log2 (temp 4-component vector of float)
+0:235          'inF0' (temp 4-component vector of float)
+0:235        Constant:
+0:235          0.301030
+0:236      log2 (global 4-component vector of float)
+0:236        'inF0' (temp 4-component vector of float)
+0:237      max (global 4-component vector of float)
+0:237        'inF0' (temp 4-component vector of float)
+0:237        'inF1' (temp 4-component vector of float)
+0:238      min (global 4-component vector of float)
+0:238        'inF0' (temp 4-component vector of float)
+0:238        'inF1' (temp 4-component vector of float)
+0:240      normalize (global 4-component vector of float)
+0:240        'inF0' (temp 4-component vector of float)
+0:241      pow (global 4-component vector of float)
+0:241        'inF0' (temp 4-component vector of float)
+0:241        'inF1' (temp 4-component vector of float)
+0:242      radians (global 4-component vector of float)
+0:242        'inF0' (temp 4-component vector of float)
+0:243      reflect (global 4-component vector of float)
+0:243        'inF0' (temp 4-component vector of float)
+0:243        'inF1' (temp 4-component vector of float)
+0:244      refract (global 4-component vector of float)
+0:244        'inF0' (temp 4-component vector of float)
+0:244        'inF1' (temp 4-component vector of float)
+0:244        Constant:
+0:244          2.000000
 0:?       bitFieldReverse (global 4-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
 0:?           4 (const uint)
-0:235      roundEven (global 4-component vector of float)
-0:235        'inF0' (temp 4-component vector of float)
-0:236      inverse sqrt (global 4-component vector of float)
-0:236        'inF0' (temp 4-component vector of float)
-0:237      Sign (global 4-component vector of float)
-0:237        'inF0' (temp 4-component vector of float)
-0:238      sine (global 4-component vector of float)
-0:238        'inF0' (temp 4-component vector of float)
-0:239      hyp. sine (global 4-component vector of float)
-0:239        'inF0' (temp 4-component vector of float)
-0:240      smoothstep (global 4-component vector of float)
-0:240        'inF0' (temp 4-component vector of float)
-0:240        'inF1' (temp 4-component vector of float)
-0:240        'inF2' (temp 4-component vector of float)
-0:241      sqrt (global 4-component vector of float)
-0:241        'inF0' (temp 4-component vector of float)
-0:242      step (global 4-component vector of float)
-0:242        'inF0' (temp 4-component vector of float)
-0:242        'inF1' (temp 4-component vector of float)
-0:243      tangent (global 4-component vector of float)
-0:243        'inF0' (temp 4-component vector of float)
-0:244      hyp. tangent (global 4-component vector of float)
-0:244        'inF0' (temp 4-component vector of float)
-0:246      trunc (global 4-component vector of float)
+0:246      roundEven (global 4-component vector of float)
 0:246        'inF0' (temp 4-component vector of float)
-0:249      Branch: Return with expression
+0:247      inverse sqrt (global 4-component vector of float)
+0:247        'inF0' (temp 4-component vector of float)
+0:248      clamp (global 4-component vector of float)
+0:248        'inF0' (temp 4-component vector of float)
+0:248        Constant:
+0:248          0.000000
+0:248        Constant:
+0:248          1.000000
+0:249      Sign (global 4-component vector of float)
+0:249        'inF0' (temp 4-component vector of float)
+0:250      sine (global 4-component vector of float)
+0:250        'inF0' (temp 4-component vector of float)
+0:251      Sequence
+0:251        move second child to first child (temp 4-component vector of float)
+0:251          'inF1' (temp 4-component vector of float)
+0:251          sine (temp 4-component vector of float)
+0:251            'inF0' (temp 4-component vector of float)
+0:251        move second child to first child (temp 4-component vector of float)
+0:251          'inF2' (temp 4-component vector of float)
+0:251          cosine (temp 4-component vector of float)
+0:251            'inF0' (temp 4-component vector of float)
+0:252      hyp. sine (global 4-component vector of float)
+0:252        'inF0' (temp 4-component vector of float)
+0:253      smoothstep (global 4-component vector of float)
+0:253        'inF0' (temp 4-component vector of float)
+0:253        'inF1' (temp 4-component vector of float)
+0:253        'inF2' (temp 4-component vector of float)
+0:254      sqrt (global 4-component vector of float)
+0:254        'inF0' (temp 4-component vector of float)
+0:255      step (global 4-component vector of float)
+0:255        'inF0' (temp 4-component vector of float)
+0:255        'inF1' (temp 4-component vector of float)
+0:256      tangent (global 4-component vector of float)
+0:256        'inF0' (temp 4-component vector of float)
+0:257      hyp. tangent (global 4-component vector of float)
+0:257        'inF0' (temp 4-component vector of float)
+0:259      trunc (global 4-component vector of float)
+0:259        'inF0' (temp 4-component vector of float)
+0:262      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
 0:?           4.000000
-0:307  Function Definition: VertexShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
-0:299    Function Parameters: 
-0:299      'inF0' (temp 2X2 matrix of float)
-0:299      'inF1' (temp 2X2 matrix of float)
-0:299      'inF2' (temp 2X2 matrix of float)
+0:323  Function Definition: VertexShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:315    Function Parameters: 
+0:315      'inF0' (temp 2X2 matrix of float)
+0:315      'inF1' (temp 2X2 matrix of float)
+0:315      'inF2' (temp 2X2 matrix of float)
 0:?     Sequence
-0:301      all (global bool)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      Absolute value (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc cosine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      any (global bool)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc sine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      Ceiling (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      clamp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301        'inF2' (temp 2X2 matrix of float)
-0:301      cosine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      hyp. cosine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      degrees (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      determinant (global float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      exp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      exp2 (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      findMSB (global int)
-0:301        Constant:
-0:301          7 (const int)
-0:301      findLSB (global int)
-0:301        Constant:
-0:301          7 (const int)
-0:301      Floor (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      Function Call: fmod(mf22;mf22; (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      Fraction (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      frexp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      fwidth (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      ldexp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      log (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      log2 (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      max (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      min (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      pow (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      radians (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      roundEven (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      inverse sqrt (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      Sign (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      sine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      hyp. sine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      smoothstep (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301        'inF2' (temp 2X2 matrix of float)
-0:301      sqrt (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      step (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      hyp. tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      transpose (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      trunc (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:304      Branch: Return with expression
+0:317      all (global bool)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      Absolute value (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      arc cosine (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      any (global bool)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      arc sine (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      arc tangent (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      arc tangent (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      Ceiling (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      clamp (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317        'inF2' (temp 2X2 matrix of float)
+0:317      cosine (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      hyp. cosine (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      degrees (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      determinant (global float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      exp (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      exp2 (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      findMSB (global int)
+0:317        Constant:
+0:317          7 (const int)
+0:317      findLSB (global int)
+0:317        Constant:
+0:317          7 (const int)
+0:317      Floor (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      mod (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      Fraction (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      frexp (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      fwidth (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      ldexp (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      log (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      matrix-scale (temp 2X2 matrix of float)
+0:317        log2 (temp 2X2 matrix of float)
+0:317          'inF0' (temp 2X2 matrix of float)
+0:317        Constant:
+0:317          0.301030
+0:317      log2 (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      max (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      min (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      pow (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      radians (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      roundEven (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      inverse sqrt (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      clamp (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        Constant:
+0:317          0.000000
+0:317        Constant:
+0:317          1.000000
+0:317      Sign (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      sine (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      Sequence
+0:317        move second child to first child (temp 2X2 matrix of float)
+0:317          'inF1' (temp 2X2 matrix of float)
+0:317          sine (temp 2X2 matrix of float)
+0:317            'inF0' (temp 2X2 matrix of float)
+0:317        move second child to first child (temp 2X2 matrix of float)
+0:317          'inF2' (temp 2X2 matrix of float)
+0:317          cosine (temp 2X2 matrix of float)
+0:317            'inF0' (temp 2X2 matrix of float)
+0:317      hyp. sine (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      smoothstep (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317        'inF2' (temp 2X2 matrix of float)
+0:317      sqrt (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      step (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      tangent (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      hyp. tangent (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      transpose (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      trunc (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:320      Branch: Return with expression
 0:?         Constant:
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
-0:316  Function Definition: VertexShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
-0:308    Function Parameters: 
-0:308      'inF0' (temp 3X3 matrix of float)
-0:308      'inF1' (temp 3X3 matrix of float)
-0:308      'inF2' (temp 3X3 matrix of float)
+0:332  Function Definition: VertexShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:324    Function Parameters: 
+0:324      'inF0' (temp 3X3 matrix of float)
+0:324      'inF1' (temp 3X3 matrix of float)
+0:324      'inF2' (temp 3X3 matrix of float)
 0:?     Sequence
-0:310      all (global bool)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      Absolute value (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc cosine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      any (global bool)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc sine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      Ceiling (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      clamp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310        'inF2' (temp 3X3 matrix of float)
-0:310      cosine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      hyp. cosine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      degrees (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      determinant (global float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      exp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      exp2 (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      findMSB (global int)
-0:310        Constant:
-0:310          7 (const int)
-0:310      findLSB (global int)
-0:310        Constant:
-0:310          7 (const int)
-0:310      Floor (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      Function Call: fmod(mf33;mf33; (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      Fraction (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      frexp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      fwidth (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      ldexp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      log (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      log2 (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      max (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      min (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      pow (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      radians (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      roundEven (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      inverse sqrt (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      Sign (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      sine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      hyp. sine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      smoothstep (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310        'inF2' (temp 3X3 matrix of float)
-0:310      sqrt (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      step (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      hyp. tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      transpose (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      trunc (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:313      Branch: Return with expression
+0:326      all (global bool)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      Absolute value (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      arc cosine (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      any (global bool)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      arc sine (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      arc tangent (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      arc tangent (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      Ceiling (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      clamp (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326        'inF2' (temp 3X3 matrix of float)
+0:326      cosine (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      hyp. cosine (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      degrees (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      determinant (global float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      exp (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      exp2 (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      findMSB (global int)
+0:326        Constant:
+0:326          7 (const int)
+0:326      findLSB (global int)
+0:326        Constant:
+0:326          7 (const int)
+0:326      Floor (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      mod (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      Fraction (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      frexp (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      fwidth (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      ldexp (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      log (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      matrix-scale (temp 3X3 matrix of float)
+0:326        log2 (temp 3X3 matrix of float)
+0:326          'inF0' (temp 3X3 matrix of float)
+0:326        Constant:
+0:326          0.301030
+0:326      log2 (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      max (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      min (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      pow (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      radians (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      roundEven (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      inverse sqrt (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      clamp (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        Constant:
+0:326          0.000000
+0:326        Constant:
+0:326          1.000000
+0:326      Sign (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      sine (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      Sequence
+0:326        move second child to first child (temp 3X3 matrix of float)
+0:326          'inF1' (temp 3X3 matrix of float)
+0:326          sine (temp 3X3 matrix of float)
+0:326            'inF0' (temp 3X3 matrix of float)
+0:326        move second child to first child (temp 3X3 matrix of float)
+0:326          'inF2' (temp 3X3 matrix of float)
+0:326          cosine (temp 3X3 matrix of float)
+0:326            'inF0' (temp 3X3 matrix of float)
+0:326      hyp. sine (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      smoothstep (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326        'inF2' (temp 3X3 matrix of float)
+0:326      sqrt (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      step (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      tangent (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      hyp. tangent (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      transpose (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      trunc (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:329      Branch: Return with expression
 0:?         Constant:
 0:?           3.000000
 0:?           3.000000
@@ -762,109 +902,129 @@ Shader version: 450
 0:?           3.000000
 0:?           3.000000
 0:?           3.000000
-0:324  Function Definition: VertexShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
-0:317    Function Parameters: 
-0:317      'inF0' (temp 4X4 matrix of float)
-0:317      'inF1' (temp 4X4 matrix of float)
-0:317      'inF2' (temp 4X4 matrix of float)
+0:353  Function Definition: VertexShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:333    Function Parameters: 
+0:333      'inF0' (temp 4X4 matrix of float)
+0:333      'inF1' (temp 4X4 matrix of float)
+0:333      'inF2' (temp 4X4 matrix of float)
 0:?     Sequence
-0:319      all (global bool)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      Absolute value (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc cosine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      any (global bool)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc sine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      Ceiling (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      clamp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319        'inF2' (temp 4X4 matrix of float)
-0:319      cosine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      hyp. cosine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      degrees (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      determinant (global float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      exp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      exp2 (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      findMSB (global int)
-0:319        Constant:
-0:319          7 (const int)
-0:319      findLSB (global int)
-0:319        Constant:
-0:319          7 (const int)
-0:319      Floor (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      Function Call: fmod(mf44;mf44; (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      Fraction (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      frexp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      fwidth (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      ldexp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      log (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      log2 (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      max (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      min (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      pow (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      radians (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      roundEven (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      inverse sqrt (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      Sign (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      sine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      hyp. sine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      smoothstep (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319        'inF2' (temp 4X4 matrix of float)
-0:319      sqrt (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      step (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      hyp. tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      transpose (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      trunc (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:322      Branch: Return with expression
+0:335      all (global bool)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      Absolute value (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      arc cosine (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      any (global bool)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      arc sine (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      arc tangent (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      arc tangent (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      Ceiling (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      clamp (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335        'inF2' (temp 4X4 matrix of float)
+0:335      cosine (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      hyp. cosine (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      degrees (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      determinant (global float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      exp (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      exp2 (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      findMSB (global int)
+0:335        Constant:
+0:335          7 (const int)
+0:335      findLSB (global int)
+0:335        Constant:
+0:335          7 (const int)
+0:335      Floor (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      mod (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      Fraction (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      frexp (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      fwidth (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      ldexp (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      log (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      matrix-scale (temp 4X4 matrix of float)
+0:335        log2 (temp 4X4 matrix of float)
+0:335          'inF0' (temp 4X4 matrix of float)
+0:335        Constant:
+0:335          0.301030
+0:335      log2 (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      max (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      min (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      pow (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      radians (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      roundEven (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      inverse sqrt (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      clamp (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        Constant:
+0:335          0.000000
+0:335        Constant:
+0:335          1.000000
+0:335      Sign (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      sine (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      Sequence
+0:335        move second child to first child (temp 4X4 matrix of float)
+0:335          'inF1' (temp 4X4 matrix of float)
+0:335          sine (temp 4X4 matrix of float)
+0:335            'inF0' (temp 4X4 matrix of float)
+0:335        move second child to first child (temp 4X4 matrix of float)
+0:335          'inF2' (temp 4X4 matrix of float)
+0:335          cosine (temp 4X4 matrix of float)
+0:335            'inF0' (temp 4X4 matrix of float)
+0:335      hyp. sine (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      smoothstep (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335        'inF2' (temp 4X4 matrix of float)
+0:335      sqrt (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      step (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      tangent (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      hyp. tangent (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      transpose (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      trunc (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:338      Branch: Return with expression
 0:?         Constant:
 0:?           4.000000
 0:?           4.000000
@@ -882,6 +1042,168 @@ Shader version: 450
 0:?           4.000000
 0:?           4.000000
 0:?           4.000000
+0:360  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
+0:356    Function Parameters: 
+0:356      'inF0' (temp float)
+0:356      'inF1' (temp float)
+0:356      'inFV0' (temp 2-component vector of float)
+0:356      'inFV1' (temp 2-component vector of float)
+0:356      'inFM0' (temp 2X2 matrix of float)
+0:356      'inFM1' (temp 2X2 matrix of float)
+0:?     Sequence
+0:357      move second child to first child (temp float)
+0:357        'r0' (temp float)
+0:357        component-wise multiply (temp float)
+0:357          'inF0' (temp float)
+0:357          'inF1' (temp float)
+0:357      move second child to first child (temp 2-component vector of float)
+0:357        'r1' (temp 2-component vector of float)
+0:357        vector-scale (temp 2-component vector of float)
+0:357          'inFV0' (temp 2-component vector of float)
+0:357          'inF0' (temp float)
+0:357      move second child to first child (temp 2-component vector of float)
+0:357        'r2' (temp 2-component vector of float)
+0:357        vector-scale (temp 2-component vector of float)
+0:357          'inF0' (temp float)
+0:357          'inFV0' (temp 2-component vector of float)
+0:357      move second child to first child (temp float)
+0:357        'r3' (temp float)
+0:357        dot-product (global float)
+0:357          'inFV0' (temp 2-component vector of float)
+0:357          'inFV1' (temp 2-component vector of float)
+0:357      move second child to first child (temp 2-component vector of float)
+0:357        'r4' (temp 2-component vector of float)
+0:357        matrix-times-vector (temp 2-component vector of float)
+0:357          'inFM0' (temp 2X2 matrix of float)
+0:357          'inFV0' (temp 2-component vector of float)
+0:357      move second child to first child (temp 2-component vector of float)
+0:357        'r5' (temp 2-component vector of float)
+0:357        vector-times-matrix (temp 2-component vector of float)
+0:357          'inFV0' (temp 2-component vector of float)
+0:357          'inFM0' (temp 2X2 matrix of float)
+0:357      move second child to first child (temp 2X2 matrix of float)
+0:357        'r6' (temp 2X2 matrix of float)
+0:357        matrix-scale (temp 2X2 matrix of float)
+0:357          'inFM0' (temp 2X2 matrix of float)
+0:357          'inF0' (temp float)
+0:357      move second child to first child (temp 2X2 matrix of float)
+0:357        'r7' (temp 2X2 matrix of float)
+0:357        matrix-scale (temp 2X2 matrix of float)
+0:357          'inF0' (temp float)
+0:357          'inFM0' (temp 2X2 matrix of float)
+0:357      move second child to first child (temp 2X2 matrix of float)
+0:357        'r8' (temp 2X2 matrix of float)
+0:357        matrix-multiply (temp 2X2 matrix of float)
+0:357          'inFM0' (temp 2X2 matrix of float)
+0:357          'inFM1' (temp 2X2 matrix of float)
+0:367  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
+0:363    Function Parameters: 
+0:363      'inF0' (temp float)
+0:363      'inF1' (temp float)
+0:363      'inFV0' (temp 3-component vector of float)
+0:363      'inFV1' (temp 3-component vector of float)
+0:363      'inFM0' (temp 3X3 matrix of float)
+0:363      'inFM1' (temp 3X3 matrix of float)
+0:?     Sequence
+0:364      move second child to first child (temp float)
+0:364        'r0' (temp float)
+0:364        component-wise multiply (temp float)
+0:364          'inF0' (temp float)
+0:364          'inF1' (temp float)
+0:364      move second child to first child (temp 3-component vector of float)
+0:364        'r1' (temp 3-component vector of float)
+0:364        vector-scale (temp 3-component vector of float)
+0:364          'inFV0' (temp 3-component vector of float)
+0:364          'inF0' (temp float)
+0:364      move second child to first child (temp 3-component vector of float)
+0:364        'r2' (temp 3-component vector of float)
+0:364        vector-scale (temp 3-component vector of float)
+0:364          'inF0' (temp float)
+0:364          'inFV0' (temp 3-component vector of float)
+0:364      move second child to first child (temp float)
+0:364        'r3' (temp float)
+0:364        dot-product (global float)
+0:364          'inFV0' (temp 3-component vector of float)
+0:364          'inFV1' (temp 3-component vector of float)
+0:364      move second child to first child (temp 3-component vector of float)
+0:364        'r4' (temp 3-component vector of float)
+0:364        matrix-times-vector (temp 3-component vector of float)
+0:364          'inFM0' (temp 3X3 matrix of float)
+0:364          'inFV0' (temp 3-component vector of float)
+0:364      move second child to first child (temp 3-component vector of float)
+0:364        'r5' (temp 3-component vector of float)
+0:364        vector-times-matrix (temp 3-component vector of float)
+0:364          'inFV0' (temp 3-component vector of float)
+0:364          'inFM0' (temp 3X3 matrix of float)
+0:364      move second child to first child (temp 3X3 matrix of float)
+0:364        'r6' (temp 3X3 matrix of float)
+0:364        matrix-scale (temp 3X3 matrix of float)
+0:364          'inFM0' (temp 3X3 matrix of float)
+0:364          'inF0' (temp float)
+0:364      move second child to first child (temp 3X3 matrix of float)
+0:364        'r7' (temp 3X3 matrix of float)
+0:364        matrix-scale (temp 3X3 matrix of float)
+0:364          'inF0' (temp float)
+0:364          'inFM0' (temp 3X3 matrix of float)
+0:364      move second child to first child (temp 3X3 matrix of float)
+0:364        'r8' (temp 3X3 matrix of float)
+0:364        matrix-multiply (temp 3X3 matrix of float)
+0:364          'inFM0' (temp 3X3 matrix of float)
+0:364          'inFM1' (temp 3X3 matrix of float)
+0:373  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
+0:370    Function Parameters: 
+0:370      'inF0' (temp float)
+0:370      'inF1' (temp float)
+0:370      'inFV0' (temp 4-component vector of float)
+0:370      'inFV1' (temp 4-component vector of float)
+0:370      'inFM0' (temp 4X4 matrix of float)
+0:370      'inFM1' (temp 4X4 matrix of float)
+0:?     Sequence
+0:371      move second child to first child (temp float)
+0:371        'r0' (temp float)
+0:371        component-wise multiply (temp float)
+0:371          'inF0' (temp float)
+0:371          'inF1' (temp float)
+0:371      move second child to first child (temp 4-component vector of float)
+0:371        'r1' (temp 4-component vector of float)
+0:371        vector-scale (temp 4-component vector of float)
+0:371          'inFV0' (temp 4-component vector of float)
+0:371          'inF0' (temp float)
+0:371      move second child to first child (temp 4-component vector of float)
+0:371        'r2' (temp 4-component vector of float)
+0:371        vector-scale (temp 4-component vector of float)
+0:371          'inF0' (temp float)
+0:371          'inFV0' (temp 4-component vector of float)
+0:371      move second child to first child (temp float)
+0:371        'r3' (temp float)
+0:371        dot-product (global float)
+0:371          'inFV0' (temp 4-component vector of float)
+0:371          'inFV1' (temp 4-component vector of float)
+0:371      move second child to first child (temp 4-component vector of float)
+0:371        'r4' (temp 4-component vector of float)
+0:371        matrix-times-vector (temp 4-component vector of float)
+0:371          'inFM0' (temp 4X4 matrix of float)
+0:371          'inFV0' (temp 4-component vector of float)
+0:371      move second child to first child (temp 4-component vector of float)
+0:371        'r5' (temp 4-component vector of float)
+0:371        vector-times-matrix (temp 4-component vector of float)
+0:371          'inFV0' (temp 4-component vector of float)
+0:371          'inFM0' (temp 4X4 matrix of float)
+0:371      move second child to first child (temp 4X4 matrix of float)
+0:371        'r6' (temp 4X4 matrix of float)
+0:371        matrix-scale (temp 4X4 matrix of float)
+0:371          'inFM0' (temp 4X4 matrix of float)
+0:371          'inF0' (temp float)
+0:371      move second child to first child (temp 4X4 matrix of float)
+0:371        'r7' (temp 4X4 matrix of float)
+0:371        matrix-scale (temp 4X4 matrix of float)
+0:371          'inF0' (temp float)
+0:371          'inFM0' (temp 4X4 matrix of float)
+0:371      move second child to first child (temp 4X4 matrix of float)
+0:371        'r8' (temp 4X4 matrix of float)
+0:371        matrix-multiply (temp 4X4 matrix of float)
+0:371          'inFM0' (temp 4X4 matrix of float)
+0:371          'inFM1' (temp 4X4 matrix of float)
 0:?   Linker Objects
 
 
@@ -890,7 +1212,7 @@ Linked vertex stage:
 
 Shader version: 450
 0:? Sequence
-0:56  Function Definition: VertexShaderFunction(f1;f1;f1; (temp float)
+0:59  Function Definition: VertexShaderFunction(f1;f1;f1; (temp float)
 0:2    Function Parameters: 
 0:2      'inF0' (temp float)
 0:2      'inF1' (temp float)
@@ -938,7 +1260,7 @@ Shader version: 450
 0:22          7 (const int)
 0:23      Floor (global float)
 0:23        'inF0' (temp float)
-0:25      Function Call: fmod(f1;f1; (global float)
+0:25      mod (global float)
 0:25        'inF0' (temp float)
 0:25        'inF1' (temp float)
 0:26      Fraction (global float)
@@ -957,690 +1279,830 @@ Shader version: 450
 0:31        'inF1' (temp float)
 0:32      log (global float)
 0:32        'inF0' (temp float)
-0:33      log2 (global float)
-0:33        'inF0' (temp float)
-0:34      max (global float)
+0:33      component-wise multiply (temp float)
+0:33        log2 (temp float)
+0:33          'inF0' (temp float)
+0:33        Constant:
+0:33          0.301030
+0:34      log2 (global float)
 0:34        'inF0' (temp float)
-0:34        'inF1' (temp float)
-0:35      min (global float)
+0:35      max (global float)
 0:35        'inF0' (temp float)
 0:35        'inF1' (temp float)
-0:37      pow (global float)
-0:37        'inF0' (temp float)
-0:37        'inF1' (temp float)
-0:38      radians (global float)
+0:36      min (global float)
+0:36        'inF0' (temp float)
+0:36        'inF1' (temp float)
+0:38      pow (global float)
 0:38        'inF0' (temp float)
-0:39      bitFieldReverse (global uint)
-0:39        Constant:
-0:39          2 (const uint)
-0:40      roundEven (global float)
-0:40        'inF0' (temp float)
-0:41      inverse sqrt (global float)
+0:38        'inF1' (temp float)
+0:39      radians (global float)
+0:39        'inF0' (temp float)
+0:40      bitFieldReverse (global uint)
+0:40        Constant:
+0:40          2 (const uint)
+0:41      roundEven (global float)
 0:41        'inF0' (temp float)
-0:42      Sign (global float)
+0:42      inverse sqrt (global float)
 0:42        'inF0' (temp float)
-0:43      sine (global float)
+0:43      clamp (global float)
 0:43        'inF0' (temp float)
-0:44      hyp. sine (global float)
+0:43        Constant:
+0:43          0.000000
+0:43        Constant:
+0:43          1.000000
+0:44      Sign (global float)
 0:44        'inF0' (temp float)
-0:45      smoothstep (global float)
+0:45      sine (global float)
 0:45        'inF0' (temp float)
-0:45        'inF1' (temp float)
-0:45        'inF2' (temp float)
-0:46      sqrt (global float)
-0:46        'inF0' (temp float)
-0:47      step (global float)
+0:46      Sequence
+0:46        move second child to first child (temp float)
+0:46          'inF1' (temp float)
+0:46          sine (temp float)
+0:46            'inF0' (temp float)
+0:46        move second child to first child (temp float)
+0:46          'inF2' (temp float)
+0:46          cosine (temp float)
+0:46            'inF0' (temp float)
+0:47      hyp. sine (global float)
 0:47        'inF0' (temp float)
-0:47        'inF1' (temp float)
-0:48      tangent (global float)
+0:48      smoothstep (global float)
 0:48        'inF0' (temp float)
-0:49      hyp. tangent (global float)
+0:48        'inF1' (temp float)
+0:48        'inF2' (temp float)
+0:49      sqrt (global float)
 0:49        'inF0' (temp float)
-0:51      trunc (global float)
+0:50      step (global float)
+0:50        'inF0' (temp float)
+0:50        'inF1' (temp float)
+0:51      tangent (global float)
 0:51        'inF0' (temp float)
-0:53      Branch: Return with expression
-0:53        Constant:
-0:53          0.000000
-0:62  Function Definition: VertexShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
-0:57    Function Parameters: 
-0:57      'inF0' (temp 1-component vector of float)
-0:57      'inF1' (temp 1-component vector of float)
-0:57      'inF2' (temp 1-component vector of float)
+0:52      hyp. tangent (global float)
+0:52        'inF0' (temp float)
+0:54      trunc (global float)
+0:54        'inF0' (temp float)
+0:56      Branch: Return with expression
+0:56        Constant:
+0:56          0.000000
+0:65  Function Definition: VertexShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
+0:60    Function Parameters: 
+0:60      'inF0' (temp 1-component vector of float)
+0:60      'inF1' (temp 1-component vector of float)
+0:60      'inF2' (temp 1-component vector of float)
 0:?     Sequence
-0:59      Branch: Return with expression
-0:59        Constant:
-0:59          0.000000
-0:125  Function Definition: VertexShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
-0:63    Function Parameters: 
-0:63      'inF0' (temp 2-component vector of float)
-0:63      'inF1' (temp 2-component vector of float)
-0:63      'inF2' (temp 2-component vector of float)
+0:62      Branch: Return with expression
+0:62        Constant:
+0:62          0.000000
+0:131  Function Definition: VertexShaderFunction(vf2;vf2;vf2; (temp 2-component vector of float)
+0:66    Function Parameters: 
+0:66      'inF0' (temp 2-component vector of float)
+0:66      'inF1' (temp 2-component vector of float)
+0:66      'inF2' (temp 2-component vector of float)
 0:?     Sequence
-0:64      all (global bool)
-0:64        'inF0' (temp 2-component vector of float)
-0:65      Absolute value (global 2-component vector of float)
-0:65        'inF0' (temp 2-component vector of float)
-0:66      arc cosine (global 2-component vector of float)
-0:66        'inF0' (temp 2-component vector of float)
-0:67      any (global bool)
+0:67      all (global bool)
 0:67        'inF0' (temp 2-component vector of float)
-0:68      arc sine (global 2-component vector of float)
+0:68      Absolute value (global 2-component vector of float)
 0:68        'inF0' (temp 2-component vector of float)
-0:69      arc tangent (global 2-component vector of float)
+0:69      arc cosine (global 2-component vector of float)
 0:69        'inF0' (temp 2-component vector of float)
-0:70      arc tangent (global 2-component vector of float)
+0:70      any (global bool)
 0:70        'inF0' (temp 2-component vector of float)
-0:70        'inF1' (temp 2-component vector of float)
-0:71      Ceiling (global 2-component vector of float)
+0:71      arc sine (global 2-component vector of float)
 0:71        'inF0' (temp 2-component vector of float)
-0:72      clamp (global 2-component vector of float)
+0:72      arc tangent (global 2-component vector of float)
 0:72        'inF0' (temp 2-component vector of float)
-0:72        'inF1' (temp 2-component vector of float)
-0:72        'inF2' (temp 2-component vector of float)
-0:73      cosine (global 2-component vector of float)
+0:73      arc tangent (global 2-component vector of float)
 0:73        'inF0' (temp 2-component vector of float)
-0:74      hyp. cosine (global 2-component vector of float)
+0:73        'inF1' (temp 2-component vector of float)
+0:74      Ceiling (global 2-component vector of float)
 0:74        'inF0' (temp 2-component vector of float)
+0:75      clamp (global 2-component vector of float)
+0:75        'inF0' (temp 2-component vector of float)
+0:75        'inF1' (temp 2-component vector of float)
+0:75        'inF2' (temp 2-component vector of float)
+0:76      cosine (global 2-component vector of float)
+0:76        'inF0' (temp 2-component vector of float)
+0:77      hyp. cosine (global 2-component vector of float)
+0:77        'inF0' (temp 2-component vector of float)
 0:?       bitCount (global 2-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
-0:76      degrees (global 2-component vector of float)
-0:76        'inF0' (temp 2-component vector of float)
-0:77      distance (global float)
-0:77        'inF0' (temp 2-component vector of float)
-0:77        'inF1' (temp 2-component vector of float)
-0:78      dot-product (global float)
-0:78        'inF0' (temp 2-component vector of float)
-0:78        'inF1' (temp 2-component vector of float)
-0:82      exp (global 2-component vector of float)
-0:82        'inF0' (temp 2-component vector of float)
-0:83      exp2 (global 2-component vector of float)
-0:83        'inF0' (temp 2-component vector of float)
-0:84      face-forward (global 2-component vector of float)
-0:84        'inF0' (temp 2-component vector of float)
-0:84        'inF1' (temp 2-component vector of float)
-0:84        'inF2' (temp 2-component vector of float)
-0:85      findMSB (global int)
-0:85        Constant:
-0:85          7 (const int)
-0:86      findLSB (global int)
-0:86        Constant:
-0:86          7 (const int)
-0:87      Floor (global 2-component vector of float)
+0:79      degrees (global 2-component vector of float)
+0:79        'inF0' (temp 2-component vector of float)
+0:80      distance (global float)
+0:80        'inF0' (temp 2-component vector of float)
+0:80        'inF1' (temp 2-component vector of float)
+0:81      dot-product (global float)
+0:81        'inF0' (temp 2-component vector of float)
+0:81        'inF1' (temp 2-component vector of float)
+0:85      exp (global 2-component vector of float)
+0:85        'inF0' (temp 2-component vector of float)
+0:86      exp2 (global 2-component vector of float)
+0:86        'inF0' (temp 2-component vector of float)
+0:87      face-forward (global 2-component vector of float)
 0:87        'inF0' (temp 2-component vector of float)
-0:89      Function Call: fmod(vf2;vf2; (global 2-component vector of float)
-0:89        'inF0' (temp 2-component vector of float)
-0:89        'inF1' (temp 2-component vector of float)
-0:90      Fraction (global 2-component vector of float)
+0:87        'inF1' (temp 2-component vector of float)
+0:87        'inF2' (temp 2-component vector of float)
+0:88      findMSB (global int)
+0:88        Constant:
+0:88          7 (const int)
+0:89      findLSB (global int)
+0:89        Constant:
+0:89          7 (const int)
+0:90      Floor (global 2-component vector of float)
 0:90        'inF0' (temp 2-component vector of float)
-0:91      frexp (global 2-component vector of float)
-0:91        'inF0' (temp 2-component vector of float)
-0:91        'inF1' (temp 2-component vector of float)
-0:92      fwidth (global 2-component vector of float)
+0:92      mod (global 2-component vector of float)
 0:92        'inF0' (temp 2-component vector of float)
-0:93      isinf (global 2-component vector of bool)
+0:92        'inF1' (temp 2-component vector of float)
+0:93      Fraction (global 2-component vector of float)
 0:93        'inF0' (temp 2-component vector of float)
-0:94      isnan (global 2-component vector of bool)
+0:94      frexp (global 2-component vector of float)
 0:94        'inF0' (temp 2-component vector of float)
-0:95      ldexp (global 2-component vector of float)
+0:94        'inF1' (temp 2-component vector of float)
+0:95      fwidth (global 2-component vector of float)
 0:95        'inF0' (temp 2-component vector of float)
-0:95        'inF1' (temp 2-component vector of float)
-0:96      length (global float)
+0:96      isinf (global 2-component vector of bool)
 0:96        'inF0' (temp 2-component vector of float)
-0:97      log (global 2-component vector of float)
+0:97      isnan (global 2-component vector of bool)
 0:97        'inF0' (temp 2-component vector of float)
-0:98      log2 (global 2-component vector of float)
+0:98      ldexp (global 2-component vector of float)
 0:98        'inF0' (temp 2-component vector of float)
-0:99      max (global 2-component vector of float)
+0:98        'inF1' (temp 2-component vector of float)
+0:99      length (global float)
 0:99        'inF0' (temp 2-component vector of float)
-0:99        'inF1' (temp 2-component vector of float)
-0:100      min (global 2-component vector of float)
+0:100      log (global 2-component vector of float)
 0:100        'inF0' (temp 2-component vector of float)
-0:100        'inF1' (temp 2-component vector of float)
-0:102      normalize (global 2-component vector of float)
+0:101      vector-scale (temp 2-component vector of float)
+0:101        log2 (temp 2-component vector of float)
+0:101          'inF0' (temp 2-component vector of float)
+0:101        Constant:
+0:101          0.301030
+0:102      log2 (global 2-component vector of float)
 0:102        'inF0' (temp 2-component vector of float)
-0:103      pow (global 2-component vector of float)
+0:103      max (global 2-component vector of float)
 0:103        'inF0' (temp 2-component vector of float)
 0:103        'inF1' (temp 2-component vector of float)
-0:104      radians (global 2-component vector of float)
+0:104      min (global 2-component vector of float)
 0:104        'inF0' (temp 2-component vector of float)
-0:105      reflect (global 2-component vector of float)
-0:105        'inF0' (temp 2-component vector of float)
-0:105        'inF1' (temp 2-component vector of float)
-0:106      refract (global 2-component vector of float)
+0:104        'inF1' (temp 2-component vector of float)
+0:106      normalize (global 2-component vector of float)
 0:106        'inF0' (temp 2-component vector of float)
-0:106        'inF1' (temp 2-component vector of float)
-0:106        Constant:
-0:106          2.000000
+0:107      pow (global 2-component vector of float)
+0:107        'inF0' (temp 2-component vector of float)
+0:107        'inF1' (temp 2-component vector of float)
+0:108      radians (global 2-component vector of float)
+0:108        'inF0' (temp 2-component vector of float)
+0:109      reflect (global 2-component vector of float)
+0:109        'inF0' (temp 2-component vector of float)
+0:109        'inF1' (temp 2-component vector of float)
+0:110      refract (global 2-component vector of float)
+0:110        'inF0' (temp 2-component vector of float)
+0:110        'inF1' (temp 2-component vector of float)
+0:110        Constant:
+0:110          2.000000
 0:?       bitFieldReverse (global 2-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
-0:108      roundEven (global 2-component vector of float)
-0:108        'inF0' (temp 2-component vector of float)
-0:109      inverse sqrt (global 2-component vector of float)
-0:109        'inF0' (temp 2-component vector of float)
-0:110      Sign (global 2-component vector of float)
-0:110        'inF0' (temp 2-component vector of float)
-0:111      sine (global 2-component vector of float)
-0:111        'inF0' (temp 2-component vector of float)
-0:112      hyp. sine (global 2-component vector of float)
+0:112      roundEven (global 2-component vector of float)
 0:112        'inF0' (temp 2-component vector of float)
-0:113      smoothstep (global 2-component vector of float)
+0:113      inverse sqrt (global 2-component vector of float)
 0:113        'inF0' (temp 2-component vector of float)
-0:113        'inF1' (temp 2-component vector of float)
-0:113        'inF2' (temp 2-component vector of float)
-0:114      sqrt (global 2-component vector of float)
+0:114      clamp (global 2-component vector of float)
 0:114        'inF0' (temp 2-component vector of float)
-0:115      step (global 2-component vector of float)
+0:114        Constant:
+0:114          0.000000
+0:114        Constant:
+0:114          1.000000
+0:115      Sign (global 2-component vector of float)
 0:115        'inF0' (temp 2-component vector of float)
-0:115        'inF1' (temp 2-component vector of float)
-0:116      tangent (global 2-component vector of float)
+0:116      sine (global 2-component vector of float)
 0:116        'inF0' (temp 2-component vector of float)
-0:117      hyp. tangent (global 2-component vector of float)
-0:117        'inF0' (temp 2-component vector of float)
-0:119      trunc (global 2-component vector of float)
+0:117      Sequence
+0:117        move second child to first child (temp 2-component vector of float)
+0:117          'inF1' (temp 2-component vector of float)
+0:117          sine (temp 2-component vector of float)
+0:117            'inF0' (temp 2-component vector of float)
+0:117        move second child to first child (temp 2-component vector of float)
+0:117          'inF2' (temp 2-component vector of float)
+0:117          cosine (temp 2-component vector of float)
+0:117            'inF0' (temp 2-component vector of float)
+0:118      hyp. sine (global 2-component vector of float)
+0:118        'inF0' (temp 2-component vector of float)
+0:119      smoothstep (global 2-component vector of float)
 0:119        'inF0' (temp 2-component vector of float)
-0:122      Branch: Return with expression
+0:119        'inF1' (temp 2-component vector of float)
+0:119        'inF2' (temp 2-component vector of float)
+0:120      sqrt (global 2-component vector of float)
+0:120        'inF0' (temp 2-component vector of float)
+0:121      step (global 2-component vector of float)
+0:121        'inF0' (temp 2-component vector of float)
+0:121        'inF1' (temp 2-component vector of float)
+0:122      tangent (global 2-component vector of float)
+0:122        'inF0' (temp 2-component vector of float)
+0:123      hyp. tangent (global 2-component vector of float)
+0:123        'inF0' (temp 2-component vector of float)
+0:125      trunc (global 2-component vector of float)
+0:125        'inF0' (temp 2-component vector of float)
+0:128      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
-0:189  Function Definition: VertexShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
-0:126    Function Parameters: 
-0:126      'inF0' (temp 3-component vector of float)
-0:126      'inF1' (temp 3-component vector of float)
-0:126      'inF2' (temp 3-component vector of float)
+0:198  Function Definition: VertexShaderFunction(vf3;vf3;vf3; (temp 3-component vector of float)
+0:132    Function Parameters: 
+0:132      'inF0' (temp 3-component vector of float)
+0:132      'inF1' (temp 3-component vector of float)
+0:132      'inF2' (temp 3-component vector of float)
 0:?     Sequence
-0:127      all (global bool)
-0:127        'inF0' (temp 3-component vector of float)
-0:128      Absolute value (global 3-component vector of float)
-0:128        'inF0' (temp 3-component vector of float)
-0:129      arc cosine (global 3-component vector of float)
-0:129        'inF0' (temp 3-component vector of float)
-0:130      any (global bool)
-0:130        'inF0' (temp 3-component vector of float)
-0:131      arc sine (global 3-component vector of float)
-0:131        'inF0' (temp 3-component vector of float)
-0:132      arc tangent (global 3-component vector of float)
-0:132        'inF0' (temp 3-component vector of float)
-0:133      arc tangent (global 3-component vector of float)
+0:133      all (global bool)
 0:133        'inF0' (temp 3-component vector of float)
-0:133        'inF1' (temp 3-component vector of float)
-0:134      Ceiling (global 3-component vector of float)
+0:134      Absolute value (global 3-component vector of float)
 0:134        'inF0' (temp 3-component vector of float)
-0:135      clamp (global 3-component vector of float)
+0:135      arc cosine (global 3-component vector of float)
 0:135        'inF0' (temp 3-component vector of float)
-0:135        'inF1' (temp 3-component vector of float)
-0:135        'inF2' (temp 3-component vector of float)
-0:136      cosine (global 3-component vector of float)
+0:136      any (global bool)
 0:136        'inF0' (temp 3-component vector of float)
-0:137      hyp. cosine (global 3-component vector of float)
+0:137      arc sine (global 3-component vector of float)
 0:137        'inF0' (temp 3-component vector of float)
+0:138      arc tangent (global 3-component vector of float)
+0:138        'inF0' (temp 3-component vector of float)
+0:139      arc tangent (global 3-component vector of float)
+0:139        'inF0' (temp 3-component vector of float)
+0:139        'inF1' (temp 3-component vector of float)
+0:140      Ceiling (global 3-component vector of float)
+0:140        'inF0' (temp 3-component vector of float)
+0:141      clamp (global 3-component vector of float)
+0:141        'inF0' (temp 3-component vector of float)
+0:141        'inF1' (temp 3-component vector of float)
+0:141        'inF2' (temp 3-component vector of float)
+0:142      cosine (global 3-component vector of float)
+0:142        'inF0' (temp 3-component vector of float)
+0:143      hyp. cosine (global 3-component vector of float)
+0:143        'inF0' (temp 3-component vector of float)
 0:?       bitCount (global 3-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
-0:139      cross-product (global 3-component vector of float)
-0:139        'inF0' (temp 3-component vector of float)
-0:139        'inF1' (temp 3-component vector of float)
-0:140      degrees (global 3-component vector of float)
-0:140        'inF0' (temp 3-component vector of float)
-0:141      distance (global float)
-0:141        'inF0' (temp 3-component vector of float)
-0:141        'inF1' (temp 3-component vector of float)
-0:142      dot-product (global float)
-0:142        'inF0' (temp 3-component vector of float)
-0:142        'inF1' (temp 3-component vector of float)
-0:146      exp (global 3-component vector of float)
+0:145      cross-product (global 3-component vector of float)
+0:145        'inF0' (temp 3-component vector of float)
+0:145        'inF1' (temp 3-component vector of float)
+0:146      degrees (global 3-component vector of float)
 0:146        'inF0' (temp 3-component vector of float)
-0:147      exp2 (global 3-component vector of float)
+0:147      distance (global float)
 0:147        'inF0' (temp 3-component vector of float)
-0:148      face-forward (global 3-component vector of float)
+0:147        'inF1' (temp 3-component vector of float)
+0:148      dot-product (global float)
 0:148        'inF0' (temp 3-component vector of float)
 0:148        'inF1' (temp 3-component vector of float)
-0:148        'inF2' (temp 3-component vector of float)
-0:149      findMSB (global int)
-0:149        Constant:
-0:149          7 (const int)
-0:150      findLSB (global int)
-0:150        Constant:
-0:150          7 (const int)
-0:151      Floor (global 3-component vector of float)
-0:151        'inF0' (temp 3-component vector of float)
-0:153      Function Call: fmod(vf3;vf3; (global 3-component vector of float)
+0:152      exp (global 3-component vector of float)
+0:152        'inF0' (temp 3-component vector of float)
+0:153      exp2 (global 3-component vector of float)
 0:153        'inF0' (temp 3-component vector of float)
-0:153        'inF1' (temp 3-component vector of float)
-0:154      Fraction (global 3-component vector of float)
+0:154      face-forward (global 3-component vector of float)
 0:154        'inF0' (temp 3-component vector of float)
-0:155      frexp (global 3-component vector of float)
-0:155        'inF0' (temp 3-component vector of float)
-0:155        'inF1' (temp 3-component vector of float)
-0:156      fwidth (global 3-component vector of float)
-0:156        'inF0' (temp 3-component vector of float)
-0:157      isinf (global 3-component vector of bool)
+0:154        'inF1' (temp 3-component vector of float)
+0:154        'inF2' (temp 3-component vector of float)
+0:155      findMSB (global int)
+0:155        Constant:
+0:155          7 (const int)
+0:156      findLSB (global int)
+0:156        Constant:
+0:156          7 (const int)
+0:157      Floor (global 3-component vector of float)
 0:157        'inF0' (temp 3-component vector of float)
-0:158      isnan (global 3-component vector of bool)
-0:158        'inF0' (temp 3-component vector of float)
-0:159      ldexp (global 3-component vector of float)
+0:159      mod (global 3-component vector of float)
 0:159        'inF0' (temp 3-component vector of float)
 0:159        'inF1' (temp 3-component vector of float)
-0:160      length (global float)
+0:160      Fraction (global 3-component vector of float)
 0:160        'inF0' (temp 3-component vector of float)
-0:161      log (global 3-component vector of float)
+0:161      frexp (global 3-component vector of float)
 0:161        'inF0' (temp 3-component vector of float)
-0:162      log2 (global 3-component vector of float)
+0:161        'inF1' (temp 3-component vector of float)
+0:162      fwidth (global 3-component vector of float)
 0:162        'inF0' (temp 3-component vector of float)
-0:163      max (global 3-component vector of float)
+0:163      isinf (global 3-component vector of bool)
 0:163        'inF0' (temp 3-component vector of float)
-0:163        'inF1' (temp 3-component vector of float)
-0:164      min (global 3-component vector of float)
+0:164      isnan (global 3-component vector of bool)
 0:164        'inF0' (temp 3-component vector of float)
-0:164        'inF1' (temp 3-component vector of float)
-0:166      normalize (global 3-component vector of float)
+0:165      ldexp (global 3-component vector of float)
+0:165        'inF0' (temp 3-component vector of float)
+0:165        'inF1' (temp 3-component vector of float)
+0:166      length (global float)
 0:166        'inF0' (temp 3-component vector of float)
-0:167      pow (global 3-component vector of float)
+0:167      log (global 3-component vector of float)
 0:167        'inF0' (temp 3-component vector of float)
-0:167        'inF1' (temp 3-component vector of float)
-0:168      radians (global 3-component vector of float)
-0:168        'inF0' (temp 3-component vector of float)
-0:169      reflect (global 3-component vector of float)
+0:168      vector-scale (temp 3-component vector of float)
+0:168        log2 (temp 3-component vector of float)
+0:168          'inF0' (temp 3-component vector of float)
+0:168        Constant:
+0:168          0.301030
+0:169      log2 (global 3-component vector of float)
 0:169        'inF0' (temp 3-component vector of float)
-0:169        'inF1' (temp 3-component vector of float)
-0:170      refract (global 3-component vector of float)
+0:170      max (global 3-component vector of float)
 0:170        'inF0' (temp 3-component vector of float)
 0:170        'inF1' (temp 3-component vector of float)
-0:170        Constant:
-0:170          2.000000
+0:171      min (global 3-component vector of float)
+0:171        'inF0' (temp 3-component vector of float)
+0:171        'inF1' (temp 3-component vector of float)
+0:173      normalize (global 3-component vector of float)
+0:173        'inF0' (temp 3-component vector of float)
+0:174      pow (global 3-component vector of float)
+0:174        'inF0' (temp 3-component vector of float)
+0:174        'inF1' (temp 3-component vector of float)
+0:175      radians (global 3-component vector of float)
+0:175        'inF0' (temp 3-component vector of float)
+0:176      reflect (global 3-component vector of float)
+0:176        'inF0' (temp 3-component vector of float)
+0:176        'inF1' (temp 3-component vector of float)
+0:177      refract (global 3-component vector of float)
+0:177        'inF0' (temp 3-component vector of float)
+0:177        'inF1' (temp 3-component vector of float)
+0:177        Constant:
+0:177          2.000000
 0:?       bitFieldReverse (global 3-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
-0:172      roundEven (global 3-component vector of float)
-0:172        'inF0' (temp 3-component vector of float)
-0:173      inverse sqrt (global 3-component vector of float)
-0:173        'inF0' (temp 3-component vector of float)
-0:174      Sign (global 3-component vector of float)
-0:174        'inF0' (temp 3-component vector of float)
-0:175      sine (global 3-component vector of float)
-0:175        'inF0' (temp 3-component vector of float)
-0:176      hyp. sine (global 3-component vector of float)
-0:176        'inF0' (temp 3-component vector of float)
-0:177      smoothstep (global 3-component vector of float)
-0:177        'inF0' (temp 3-component vector of float)
-0:177        'inF1' (temp 3-component vector of float)
-0:177        'inF2' (temp 3-component vector of float)
-0:178      sqrt (global 3-component vector of float)
-0:178        'inF0' (temp 3-component vector of float)
-0:179      step (global 3-component vector of float)
+0:179      roundEven (global 3-component vector of float)
 0:179        'inF0' (temp 3-component vector of float)
-0:179        'inF1' (temp 3-component vector of float)
-0:180      tangent (global 3-component vector of float)
+0:180      inverse sqrt (global 3-component vector of float)
 0:180        'inF0' (temp 3-component vector of float)
-0:181      hyp. tangent (global 3-component vector of float)
+0:181      clamp (global 3-component vector of float)
 0:181        'inF0' (temp 3-component vector of float)
-0:183      trunc (global 3-component vector of float)
+0:181        Constant:
+0:181          0.000000
+0:181        Constant:
+0:181          1.000000
+0:182      Sign (global 3-component vector of float)
+0:182        'inF0' (temp 3-component vector of float)
+0:183      sine (global 3-component vector of float)
 0:183        'inF0' (temp 3-component vector of float)
-0:186      Branch: Return with expression
+0:184      Sequence
+0:184        move second child to first child (temp 3-component vector of float)
+0:184          'inF1' (temp 3-component vector of float)
+0:184          sine (temp 3-component vector of float)
+0:184            'inF0' (temp 3-component vector of float)
+0:184        move second child to first child (temp 3-component vector of float)
+0:184          'inF2' (temp 3-component vector of float)
+0:184          cosine (temp 3-component vector of float)
+0:184            'inF0' (temp 3-component vector of float)
+0:185      hyp. sine (global 3-component vector of float)
+0:185        'inF0' (temp 3-component vector of float)
+0:186      smoothstep (global 3-component vector of float)
+0:186        'inF0' (temp 3-component vector of float)
+0:186        'inF1' (temp 3-component vector of float)
+0:186        'inF2' (temp 3-component vector of float)
+0:187      sqrt (global 3-component vector of float)
+0:187        'inF0' (temp 3-component vector of float)
+0:188      step (global 3-component vector of float)
+0:188        'inF0' (temp 3-component vector of float)
+0:188        'inF1' (temp 3-component vector of float)
+0:189      tangent (global 3-component vector of float)
+0:189        'inF0' (temp 3-component vector of float)
+0:190      hyp. tangent (global 3-component vector of float)
+0:190        'inF0' (temp 3-component vector of float)
+0:192      trunc (global 3-component vector of float)
+0:192        'inF0' (temp 3-component vector of float)
+0:195      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
-0:298  Function Definition: VertexShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
-0:190    Function Parameters: 
-0:190      'inF0' (temp 4-component vector of float)
-0:190      'inF1' (temp 4-component vector of float)
-0:190      'inF2' (temp 4-component vector of float)
+0:314  Function Definition: VertexShaderFunction(vf4;vf4;vf4; (temp 4-component vector of float)
+0:199    Function Parameters: 
+0:199      'inF0' (temp 4-component vector of float)
+0:199      'inF1' (temp 4-component vector of float)
+0:199      'inF2' (temp 4-component vector of float)
 0:?     Sequence
-0:191      all (global bool)
-0:191        'inF0' (temp 4-component vector of float)
-0:192      Absolute value (global 4-component vector of float)
-0:192        'inF0' (temp 4-component vector of float)
-0:193      arc cosine (global 4-component vector of float)
-0:193        'inF0' (temp 4-component vector of float)
-0:194      any (global bool)
-0:194        'inF0' (temp 4-component vector of float)
-0:195      arc sine (global 4-component vector of float)
-0:195        'inF0' (temp 4-component vector of float)
-0:196      arc tangent (global 4-component vector of float)
-0:196        'inF0' (temp 4-component vector of float)
-0:197      arc tangent (global 4-component vector of float)
-0:197        'inF0' (temp 4-component vector of float)
-0:197        'inF1' (temp 4-component vector of float)
-0:198      Ceiling (global 4-component vector of float)
-0:198        'inF0' (temp 4-component vector of float)
-0:199      clamp (global 4-component vector of float)
-0:199        'inF0' (temp 4-component vector of float)
-0:199        'inF1' (temp 4-component vector of float)
-0:199        'inF2' (temp 4-component vector of float)
-0:200      cosine (global 4-component vector of float)
+0:200      all (global bool)
 0:200        'inF0' (temp 4-component vector of float)
-0:201      hyp. cosine (global 4-component vector of float)
+0:201      Absolute value (global 4-component vector of float)
 0:201        'inF0' (temp 4-component vector of float)
+0:202      arc cosine (global 4-component vector of float)
+0:202        'inF0' (temp 4-component vector of float)
+0:203      any (global bool)
+0:203        'inF0' (temp 4-component vector of float)
+0:204      arc sine (global 4-component vector of float)
+0:204        'inF0' (temp 4-component vector of float)
+0:205      arc tangent (global 4-component vector of float)
+0:205        'inF0' (temp 4-component vector of float)
+0:206      arc tangent (global 4-component vector of float)
+0:206        'inF0' (temp 4-component vector of float)
+0:206        'inF1' (temp 4-component vector of float)
+0:207      Ceiling (global 4-component vector of float)
+0:207        'inF0' (temp 4-component vector of float)
+0:208      clamp (global 4-component vector of float)
+0:208        'inF0' (temp 4-component vector of float)
+0:208        'inF1' (temp 4-component vector of float)
+0:208        'inF2' (temp 4-component vector of float)
+0:209      cosine (global 4-component vector of float)
+0:209        'inF0' (temp 4-component vector of float)
+0:210      hyp. cosine (global 4-component vector of float)
+0:210        'inF0' (temp 4-component vector of float)
 0:?       bitCount (global 4-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
 0:?           2 (const uint)
-0:203      degrees (global 4-component vector of float)
-0:203        'inF0' (temp 4-component vector of float)
-0:204      distance (global float)
-0:204        'inF0' (temp 4-component vector of float)
-0:204        'inF1' (temp 4-component vector of float)
-0:205      dot-product (global float)
-0:205        'inF0' (temp 4-component vector of float)
-0:205        'inF1' (temp 4-component vector of float)
-0:209      exp (global 4-component vector of float)
-0:209        'inF0' (temp 4-component vector of float)
-0:210      exp2 (global 4-component vector of float)
-0:210        'inF0' (temp 4-component vector of float)
-0:211      face-forward (global 4-component vector of float)
-0:211        'inF0' (temp 4-component vector of float)
-0:211        'inF1' (temp 4-component vector of float)
-0:211        'inF2' (temp 4-component vector of float)
-0:212      findMSB (global int)
-0:212        Constant:
-0:212          7 (const int)
-0:213      findLSB (global int)
-0:213        Constant:
-0:213          7 (const int)
-0:214      Floor (global 4-component vector of float)
+0:212      degrees (global 4-component vector of float)
+0:212        'inF0' (temp 4-component vector of float)
+0:213      distance (global float)
+0:213        'inF0' (temp 4-component vector of float)
+0:213        'inF1' (temp 4-component vector of float)
+0:214      dot-product (global float)
 0:214        'inF0' (temp 4-component vector of float)
-0:216      Function Call: fmod(vf4;vf4; (global 4-component vector of float)
-0:216        'inF0' (temp 4-component vector of float)
-0:216        'inF1' (temp 4-component vector of float)
-0:217      Fraction (global 4-component vector of float)
-0:217        'inF0' (temp 4-component vector of float)
-0:218      frexp (global 4-component vector of float)
-0:218        'inF0' (temp 4-component vector of float)
-0:218        'inF1' (temp 4-component vector of float)
-0:219      fwidth (global 4-component vector of float)
+0:214        'inF1' (temp 4-component vector of float)
+0:215      Construct vec4 (temp float)
+0:215        Constant:
+0:215          1.000000
+0:215        component-wise multiply (temp float)
+0:215          direct index (temp float)
+0:215            'inF0' (temp 4-component vector of float)
+0:215            Constant:
+0:215              1 (const int)
+0:215          direct index (temp float)
+0:215            'inF1' (temp 4-component vector of float)
+0:215            Constant:
+0:215              1 (const int)
+0:215        direct index (temp float)
+0:215          'inF0' (temp 4-component vector of float)
+0:215          Constant:
+0:215            2 (const int)
+0:215        direct index (temp float)
+0:215          'inF1' (temp 4-component vector of float)
+0:215          Constant:
+0:215            3 (const int)
+0:219      exp (global 4-component vector of float)
 0:219        'inF0' (temp 4-component vector of float)
-0:220      isinf (global 4-component vector of bool)
+0:220      exp2 (global 4-component vector of float)
 0:220        'inF0' (temp 4-component vector of float)
-0:221      isnan (global 4-component vector of bool)
+0:221      face-forward (global 4-component vector of float)
 0:221        'inF0' (temp 4-component vector of float)
-0:222      ldexp (global 4-component vector of float)
-0:222        'inF0' (temp 4-component vector of float)
-0:222        'inF1' (temp 4-component vector of float)
-0:223      length (global float)
-0:223        'inF0' (temp 4-component vector of float)
-0:224      log (global 4-component vector of float)
+0:221        'inF1' (temp 4-component vector of float)
+0:221        'inF2' (temp 4-component vector of float)
+0:222      findMSB (global int)
+0:222        Constant:
+0:222          7 (const int)
+0:223      findLSB (global int)
+0:223        Constant:
+0:223          7 (const int)
+0:224      Floor (global 4-component vector of float)
 0:224        'inF0' (temp 4-component vector of float)
-0:225      log2 (global 4-component vector of float)
-0:225        'inF0' (temp 4-component vector of float)
-0:226      max (global 4-component vector of float)
+0:226      mod (global 4-component vector of float)
 0:226        'inF0' (temp 4-component vector of float)
 0:226        'inF1' (temp 4-component vector of float)
-0:227      min (global 4-component vector of float)
+0:227      Fraction (global 4-component vector of float)
 0:227        'inF0' (temp 4-component vector of float)
-0:227        'inF1' (temp 4-component vector of float)
-0:229      normalize (global 4-component vector of float)
+0:228      frexp (global 4-component vector of float)
+0:228        'inF0' (temp 4-component vector of float)
+0:228        'inF1' (temp 4-component vector of float)
+0:229      fwidth (global 4-component vector of float)
 0:229        'inF0' (temp 4-component vector of float)
-0:230      pow (global 4-component vector of float)
+0:230      isinf (global 4-component vector of bool)
 0:230        'inF0' (temp 4-component vector of float)
-0:230        'inF1' (temp 4-component vector of float)
-0:231      radians (global 4-component vector of float)
+0:231      isnan (global 4-component vector of bool)
 0:231        'inF0' (temp 4-component vector of float)
-0:232      reflect (global 4-component vector of float)
+0:232      ldexp (global 4-component vector of float)
 0:232        'inF0' (temp 4-component vector of float)
 0:232        'inF1' (temp 4-component vector of float)
-0:233      refract (global 4-component vector of float)
+0:233      length (global float)
 0:233        'inF0' (temp 4-component vector of float)
-0:233        'inF1' (temp 4-component vector of float)
-0:233        Constant:
-0:233          2.000000
+0:234      log (global 4-component vector of float)
+0:234        'inF0' (temp 4-component vector of float)
+0:235      vector-scale (temp 4-component vector of float)
+0:235        log2 (temp 4-component vector of float)
+0:235          'inF0' (temp 4-component vector of float)
+0:235        Constant:
+0:235          0.301030
+0:236      log2 (global 4-component vector of float)
+0:236        'inF0' (temp 4-component vector of float)
+0:237      max (global 4-component vector of float)
+0:237        'inF0' (temp 4-component vector of float)
+0:237        'inF1' (temp 4-component vector of float)
+0:238      min (global 4-component vector of float)
+0:238        'inF0' (temp 4-component vector of float)
+0:238        'inF1' (temp 4-component vector of float)
+0:240      normalize (global 4-component vector of float)
+0:240        'inF0' (temp 4-component vector of float)
+0:241      pow (global 4-component vector of float)
+0:241        'inF0' (temp 4-component vector of float)
+0:241        'inF1' (temp 4-component vector of float)
+0:242      radians (global 4-component vector of float)
+0:242        'inF0' (temp 4-component vector of float)
+0:243      reflect (global 4-component vector of float)
+0:243        'inF0' (temp 4-component vector of float)
+0:243        'inF1' (temp 4-component vector of float)
+0:244      refract (global 4-component vector of float)
+0:244        'inF0' (temp 4-component vector of float)
+0:244        'inF1' (temp 4-component vector of float)
+0:244        Constant:
+0:244          2.000000
 0:?       bitFieldReverse (global 4-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
 0:?           4 (const uint)
-0:235      roundEven (global 4-component vector of float)
-0:235        'inF0' (temp 4-component vector of float)
-0:236      inverse sqrt (global 4-component vector of float)
-0:236        'inF0' (temp 4-component vector of float)
-0:237      Sign (global 4-component vector of float)
-0:237        'inF0' (temp 4-component vector of float)
-0:238      sine (global 4-component vector of float)
-0:238        'inF0' (temp 4-component vector of float)
-0:239      hyp. sine (global 4-component vector of float)
-0:239        'inF0' (temp 4-component vector of float)
-0:240      smoothstep (global 4-component vector of float)
-0:240        'inF0' (temp 4-component vector of float)
-0:240        'inF1' (temp 4-component vector of float)
-0:240        'inF2' (temp 4-component vector of float)
-0:241      sqrt (global 4-component vector of float)
-0:241        'inF0' (temp 4-component vector of float)
-0:242      step (global 4-component vector of float)
-0:242        'inF0' (temp 4-component vector of float)
-0:242        'inF1' (temp 4-component vector of float)
-0:243      tangent (global 4-component vector of float)
-0:243        'inF0' (temp 4-component vector of float)
-0:244      hyp. tangent (global 4-component vector of float)
-0:244        'inF0' (temp 4-component vector of float)
-0:246      trunc (global 4-component vector of float)
+0:246      roundEven (global 4-component vector of float)
 0:246        'inF0' (temp 4-component vector of float)
-0:249      Branch: Return with expression
+0:247      inverse sqrt (global 4-component vector of float)
+0:247        'inF0' (temp 4-component vector of float)
+0:248      clamp (global 4-component vector of float)
+0:248        'inF0' (temp 4-component vector of float)
+0:248        Constant:
+0:248          0.000000
+0:248        Constant:
+0:248          1.000000
+0:249      Sign (global 4-component vector of float)
+0:249        'inF0' (temp 4-component vector of float)
+0:250      sine (global 4-component vector of float)
+0:250        'inF0' (temp 4-component vector of float)
+0:251      Sequence
+0:251        move second child to first child (temp 4-component vector of float)
+0:251          'inF1' (temp 4-component vector of float)
+0:251          sine (temp 4-component vector of float)
+0:251            'inF0' (temp 4-component vector of float)
+0:251        move second child to first child (temp 4-component vector of float)
+0:251          'inF2' (temp 4-component vector of float)
+0:251          cosine (temp 4-component vector of float)
+0:251            'inF0' (temp 4-component vector of float)
+0:252      hyp. sine (global 4-component vector of float)
+0:252        'inF0' (temp 4-component vector of float)
+0:253      smoothstep (global 4-component vector of float)
+0:253        'inF0' (temp 4-component vector of float)
+0:253        'inF1' (temp 4-component vector of float)
+0:253        'inF2' (temp 4-component vector of float)
+0:254      sqrt (global 4-component vector of float)
+0:254        'inF0' (temp 4-component vector of float)
+0:255      step (global 4-component vector of float)
+0:255        'inF0' (temp 4-component vector of float)
+0:255        'inF1' (temp 4-component vector of float)
+0:256      tangent (global 4-component vector of float)
+0:256        'inF0' (temp 4-component vector of float)
+0:257      hyp. tangent (global 4-component vector of float)
+0:257        'inF0' (temp 4-component vector of float)
+0:259      trunc (global 4-component vector of float)
+0:259        'inF0' (temp 4-component vector of float)
+0:262      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
 0:?           4.000000
-0:307  Function Definition: VertexShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
-0:299    Function Parameters: 
-0:299      'inF0' (temp 2X2 matrix of float)
-0:299      'inF1' (temp 2X2 matrix of float)
-0:299      'inF2' (temp 2X2 matrix of float)
+0:323  Function Definition: VertexShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:315    Function Parameters: 
+0:315      'inF0' (temp 2X2 matrix of float)
+0:315      'inF1' (temp 2X2 matrix of float)
+0:315      'inF2' (temp 2X2 matrix of float)
 0:?     Sequence
-0:301      all (global bool)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      Absolute value (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc cosine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      any (global bool)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc sine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      arc tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      Ceiling (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      clamp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301        'inF2' (temp 2X2 matrix of float)
-0:301      cosine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      hyp. cosine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      degrees (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      determinant (global float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      exp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      exp2 (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      findMSB (global int)
-0:301        Constant:
-0:301          7 (const int)
-0:301      findLSB (global int)
-0:301        Constant:
-0:301          7 (const int)
-0:301      Floor (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      Function Call: fmod(mf22;mf22; (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      Fraction (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      frexp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      fwidth (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      ldexp (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      log (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      log2 (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      max (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      min (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      pow (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      radians (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      roundEven (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      inverse sqrt (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      Sign (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      sine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      hyp. sine (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      smoothstep (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301        'inF2' (temp 2X2 matrix of float)
-0:301      sqrt (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      step (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301        'inF1' (temp 2X2 matrix of float)
-0:301      tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      hyp. tangent (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      transpose (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:301      trunc (global 2X2 matrix of float)
-0:301        'inF0' (temp 2X2 matrix of float)
-0:304      Branch: Return with expression
+0:317      all (global bool)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      Absolute value (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      arc cosine (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      any (global bool)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      arc sine (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      arc tangent (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      arc tangent (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      Ceiling (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      clamp (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317        'inF2' (temp 2X2 matrix of float)
+0:317      cosine (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      hyp. cosine (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      degrees (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      determinant (global float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      exp (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      exp2 (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      findMSB (global int)
+0:317        Constant:
+0:317          7 (const int)
+0:317      findLSB (global int)
+0:317        Constant:
+0:317          7 (const int)
+0:317      Floor (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      mod (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      Fraction (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      frexp (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      fwidth (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      ldexp (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      log (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      matrix-scale (temp 2X2 matrix of float)
+0:317        log2 (temp 2X2 matrix of float)
+0:317          'inF0' (temp 2X2 matrix of float)
+0:317        Constant:
+0:317          0.301030
+0:317      log2 (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      max (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      min (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      pow (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      radians (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      roundEven (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      inverse sqrt (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      clamp (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        Constant:
+0:317          0.000000
+0:317        Constant:
+0:317          1.000000
+0:317      Sign (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      sine (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      Sequence
+0:317        move second child to first child (temp 2X2 matrix of float)
+0:317          'inF1' (temp 2X2 matrix of float)
+0:317          sine (temp 2X2 matrix of float)
+0:317            'inF0' (temp 2X2 matrix of float)
+0:317        move second child to first child (temp 2X2 matrix of float)
+0:317          'inF2' (temp 2X2 matrix of float)
+0:317          cosine (temp 2X2 matrix of float)
+0:317            'inF0' (temp 2X2 matrix of float)
+0:317      hyp. sine (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      smoothstep (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317        'inF2' (temp 2X2 matrix of float)
+0:317      sqrt (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      step (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317        'inF1' (temp 2X2 matrix of float)
+0:317      tangent (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      hyp. tangent (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      transpose (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:317      trunc (global 2X2 matrix of float)
+0:317        'inF0' (temp 2X2 matrix of float)
+0:320      Branch: Return with expression
 0:?         Constant:
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
-0:316  Function Definition: VertexShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
-0:308    Function Parameters: 
-0:308      'inF0' (temp 3X3 matrix of float)
-0:308      'inF1' (temp 3X3 matrix of float)
-0:308      'inF2' (temp 3X3 matrix of float)
+0:332  Function Definition: VertexShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:324    Function Parameters: 
+0:324      'inF0' (temp 3X3 matrix of float)
+0:324      'inF1' (temp 3X3 matrix of float)
+0:324      'inF2' (temp 3X3 matrix of float)
 0:?     Sequence
-0:310      all (global bool)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      Absolute value (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc cosine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      any (global bool)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc sine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      arc tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      Ceiling (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      clamp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310        'inF2' (temp 3X3 matrix of float)
-0:310      cosine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      hyp. cosine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      degrees (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      determinant (global float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      exp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      exp2 (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      findMSB (global int)
-0:310        Constant:
-0:310          7 (const int)
-0:310      findLSB (global int)
-0:310        Constant:
-0:310          7 (const int)
-0:310      Floor (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      Function Call: fmod(mf33;mf33; (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      Fraction (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      frexp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      fwidth (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      ldexp (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      log (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      log2 (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      max (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      min (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      pow (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      radians (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      roundEven (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      inverse sqrt (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      Sign (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      sine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      hyp. sine (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      smoothstep (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310        'inF2' (temp 3X3 matrix of float)
-0:310      sqrt (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      step (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310        'inF1' (temp 3X3 matrix of float)
-0:310      tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      hyp. tangent (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      transpose (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:310      trunc (global 3X3 matrix of float)
-0:310        'inF0' (temp 3X3 matrix of float)
-0:313      Branch: Return with expression
+0:326      all (global bool)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      Absolute value (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      arc cosine (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      any (global bool)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      arc sine (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      arc tangent (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      arc tangent (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      Ceiling (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      clamp (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326        'inF2' (temp 3X3 matrix of float)
+0:326      cosine (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      hyp. cosine (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      degrees (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      determinant (global float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      exp (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      exp2 (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      findMSB (global int)
+0:326        Constant:
+0:326          7 (const int)
+0:326      findLSB (global int)
+0:326        Constant:
+0:326          7 (const int)
+0:326      Floor (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      mod (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      Fraction (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      frexp (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      fwidth (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      ldexp (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      log (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      matrix-scale (temp 3X3 matrix of float)
+0:326        log2 (temp 3X3 matrix of float)
+0:326          'inF0' (temp 3X3 matrix of float)
+0:326        Constant:
+0:326          0.301030
+0:326      log2 (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      max (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      min (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      pow (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      radians (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      roundEven (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      inverse sqrt (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      clamp (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        Constant:
+0:326          0.000000
+0:326        Constant:
+0:326          1.000000
+0:326      Sign (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      sine (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      Sequence
+0:326        move second child to first child (temp 3X3 matrix of float)
+0:326          'inF1' (temp 3X3 matrix of float)
+0:326          sine (temp 3X3 matrix of float)
+0:326            'inF0' (temp 3X3 matrix of float)
+0:326        move second child to first child (temp 3X3 matrix of float)
+0:326          'inF2' (temp 3X3 matrix of float)
+0:326          cosine (temp 3X3 matrix of float)
+0:326            'inF0' (temp 3X3 matrix of float)
+0:326      hyp. sine (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      smoothstep (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326        'inF2' (temp 3X3 matrix of float)
+0:326      sqrt (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      step (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326        'inF1' (temp 3X3 matrix of float)
+0:326      tangent (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      hyp. tangent (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      transpose (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:326      trunc (global 3X3 matrix of float)
+0:326        'inF0' (temp 3X3 matrix of float)
+0:329      Branch: Return with expression
 0:?         Constant:
 0:?           3.000000
 0:?           3.000000
@@ -1651,109 +2113,129 @@ Shader version: 450
 0:?           3.000000
 0:?           3.000000
 0:?           3.000000
-0:324  Function Definition: VertexShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
-0:317    Function Parameters: 
-0:317      'inF0' (temp 4X4 matrix of float)
-0:317      'inF1' (temp 4X4 matrix of float)
-0:317      'inF2' (temp 4X4 matrix of float)
+0:353  Function Definition: VertexShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:333    Function Parameters: 
+0:333      'inF0' (temp 4X4 matrix of float)
+0:333      'inF1' (temp 4X4 matrix of float)
+0:333      'inF2' (temp 4X4 matrix of float)
 0:?     Sequence
-0:319      all (global bool)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      Absolute value (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc cosine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      any (global bool)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc sine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      arc tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      Ceiling (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      clamp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319        'inF2' (temp 4X4 matrix of float)
-0:319      cosine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      hyp. cosine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      degrees (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      determinant (global float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      exp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      exp2 (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      findMSB (global int)
-0:319        Constant:
-0:319          7 (const int)
-0:319      findLSB (global int)
-0:319        Constant:
-0:319          7 (const int)
-0:319      Floor (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      Function Call: fmod(mf44;mf44; (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      Fraction (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      frexp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      fwidth (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      ldexp (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      log (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      log2 (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      max (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      min (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      pow (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      radians (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      roundEven (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      inverse sqrt (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      Sign (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      sine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      hyp. sine (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      smoothstep (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319        'inF2' (temp 4X4 matrix of float)
-0:319      sqrt (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      step (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319        'inF1' (temp 4X4 matrix of float)
-0:319      tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      hyp. tangent (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      transpose (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:319      trunc (global 4X4 matrix of float)
-0:319        'inF0' (temp 4X4 matrix of float)
-0:322      Branch: Return with expression
+0:335      all (global bool)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      Absolute value (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      arc cosine (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      any (global bool)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      arc sine (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      arc tangent (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      arc tangent (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      Ceiling (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      clamp (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335        'inF2' (temp 4X4 matrix of float)
+0:335      cosine (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      hyp. cosine (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      degrees (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      determinant (global float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      exp (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      exp2 (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      findMSB (global int)
+0:335        Constant:
+0:335          7 (const int)
+0:335      findLSB (global int)
+0:335        Constant:
+0:335          7 (const int)
+0:335      Floor (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      mod (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      Fraction (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      frexp (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      fwidth (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      ldexp (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      log (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      matrix-scale (temp 4X4 matrix of float)
+0:335        log2 (temp 4X4 matrix of float)
+0:335          'inF0' (temp 4X4 matrix of float)
+0:335        Constant:
+0:335          0.301030
+0:335      log2 (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      max (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      min (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      pow (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      radians (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      roundEven (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      inverse sqrt (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      clamp (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        Constant:
+0:335          0.000000
+0:335        Constant:
+0:335          1.000000
+0:335      Sign (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      sine (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      Sequence
+0:335        move second child to first child (temp 4X4 matrix of float)
+0:335          'inF1' (temp 4X4 matrix of float)
+0:335          sine (temp 4X4 matrix of float)
+0:335            'inF0' (temp 4X4 matrix of float)
+0:335        move second child to first child (temp 4X4 matrix of float)
+0:335          'inF2' (temp 4X4 matrix of float)
+0:335          cosine (temp 4X4 matrix of float)
+0:335            'inF0' (temp 4X4 matrix of float)
+0:335      hyp. sine (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      smoothstep (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335        'inF2' (temp 4X4 matrix of float)
+0:335      sqrt (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      step (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335        'inF1' (temp 4X4 matrix of float)
+0:335      tangent (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      hyp. tangent (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      transpose (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:335      trunc (global 4X4 matrix of float)
+0:335        'inF0' (temp 4X4 matrix of float)
+0:338      Branch: Return with expression
 0:?         Constant:
 0:?           4.000000
 0:?           4.000000
@@ -1771,12 +2253,173 @@ Shader version: 450
 0:?           4.000000
 0:?           4.000000
 0:?           4.000000
+0:360  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
+0:356    Function Parameters: 
+0:356      'inF0' (temp float)
+0:356      'inF1' (temp float)
+0:356      'inFV0' (temp 2-component vector of float)
+0:356      'inFV1' (temp 2-component vector of float)
+0:356      'inFM0' (temp 2X2 matrix of float)
+0:356      'inFM1' (temp 2X2 matrix of float)
+0:?     Sequence
+0:357      move second child to first child (temp float)
+0:357        'r0' (temp float)
+0:357        component-wise multiply (temp float)
+0:357          'inF0' (temp float)
+0:357          'inF1' (temp float)
+0:357      move second child to first child (temp 2-component vector of float)
+0:357        'r1' (temp 2-component vector of float)
+0:357        vector-scale (temp 2-component vector of float)
+0:357          'inFV0' (temp 2-component vector of float)
+0:357          'inF0' (temp float)
+0:357      move second child to first child (temp 2-component vector of float)
+0:357        'r2' (temp 2-component vector of float)
+0:357        vector-scale (temp 2-component vector of float)
+0:357          'inF0' (temp float)
+0:357          'inFV0' (temp 2-component vector of float)
+0:357      move second child to first child (temp float)
+0:357        'r3' (temp float)
+0:357        dot-product (global float)
+0:357          'inFV0' (temp 2-component vector of float)
+0:357          'inFV1' (temp 2-component vector of float)
+0:357      move second child to first child (temp 2-component vector of float)
+0:357        'r4' (temp 2-component vector of float)
+0:357        matrix-times-vector (temp 2-component vector of float)
+0:357          'inFM0' (temp 2X2 matrix of float)
+0:357          'inFV0' (temp 2-component vector of float)
+0:357      move second child to first child (temp 2-component vector of float)
+0:357        'r5' (temp 2-component vector of float)
+0:357        vector-times-matrix (temp 2-component vector of float)
+0:357          'inFV0' (temp 2-component vector of float)
+0:357          'inFM0' (temp 2X2 matrix of float)
+0:357      move second child to first child (temp 2X2 matrix of float)
+0:357        'r6' (temp 2X2 matrix of float)
+0:357        matrix-scale (temp 2X2 matrix of float)
+0:357          'inFM0' (temp 2X2 matrix of float)
+0:357          'inF0' (temp float)
+0:357      move second child to first child (temp 2X2 matrix of float)
+0:357        'r7' (temp 2X2 matrix of float)
+0:357        matrix-scale (temp 2X2 matrix of float)
+0:357          'inF0' (temp float)
+0:357          'inFM0' (temp 2X2 matrix of float)
+0:357      move second child to first child (temp 2X2 matrix of float)
+0:357        'r8' (temp 2X2 matrix of float)
+0:357        matrix-multiply (temp 2X2 matrix of float)
+0:357          'inFM0' (temp 2X2 matrix of float)
+0:357          'inFM1' (temp 2X2 matrix of float)
+0:367  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
+0:363    Function Parameters: 
+0:363      'inF0' (temp float)
+0:363      'inF1' (temp float)
+0:363      'inFV0' (temp 3-component vector of float)
+0:363      'inFV1' (temp 3-component vector of float)
+0:363      'inFM0' (temp 3X3 matrix of float)
+0:363      'inFM1' (temp 3X3 matrix of float)
+0:?     Sequence
+0:364      move second child to first child (temp float)
+0:364        'r0' (temp float)
+0:364        component-wise multiply (temp float)
+0:364          'inF0' (temp float)
+0:364          'inF1' (temp float)
+0:364      move second child to first child (temp 3-component vector of float)
+0:364        'r1' (temp 3-component vector of float)
+0:364        vector-scale (temp 3-component vector of float)
+0:364          'inFV0' (temp 3-component vector of float)
+0:364          'inF0' (temp float)
+0:364      move second child to first child (temp 3-component vector of float)
+0:364        'r2' (temp 3-component vector of float)
+0:364        vector-scale (temp 3-component vector of float)
+0:364          'inF0' (temp float)
+0:364          'inFV0' (temp 3-component vector of float)
+0:364      move second child to first child (temp float)
+0:364        'r3' (temp float)
+0:364        dot-product (global float)
+0:364          'inFV0' (temp 3-component vector of float)
+0:364          'inFV1' (temp 3-component vector of float)
+0:364      move second child to first child (temp 3-component vector of float)
+0:364        'r4' (temp 3-component vector of float)
+0:364        matrix-times-vector (temp 3-component vector of float)
+0:364          'inFM0' (temp 3X3 matrix of float)
+0:364          'inFV0' (temp 3-component vector of float)
+0:364      move second child to first child (temp 3-component vector of float)
+0:364        'r5' (temp 3-component vector of float)
+0:364        vector-times-matrix (temp 3-component vector of float)
+0:364          'inFV0' (temp 3-component vector of float)
+0:364          'inFM0' (temp 3X3 matrix of float)
+0:364      move second child to first child (temp 3X3 matrix of float)
+0:364        'r6' (temp 3X3 matrix of float)
+0:364        matrix-scale (temp 3X3 matrix of float)
+0:364          'inFM0' (temp 3X3 matrix of float)
+0:364          'inF0' (temp float)
+0:364      move second child to first child (temp 3X3 matrix of float)
+0:364        'r7' (temp 3X3 matrix of float)
+0:364        matrix-scale (temp 3X3 matrix of float)
+0:364          'inF0' (temp float)
+0:364          'inFM0' (temp 3X3 matrix of float)
+0:364      move second child to first child (temp 3X3 matrix of float)
+0:364        'r8' (temp 3X3 matrix of float)
+0:364        matrix-multiply (temp 3X3 matrix of float)
+0:364          'inFM0' (temp 3X3 matrix of float)
+0:364          'inFM1' (temp 3X3 matrix of float)
+0:373  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
+0:370    Function Parameters: 
+0:370      'inF0' (temp float)
+0:370      'inF1' (temp float)
+0:370      'inFV0' (temp 4-component vector of float)
+0:370      'inFV1' (temp 4-component vector of float)
+0:370      'inFM0' (temp 4X4 matrix of float)
+0:370      'inFM1' (temp 4X4 matrix of float)
+0:?     Sequence
+0:371      move second child to first child (temp float)
+0:371        'r0' (temp float)
+0:371        component-wise multiply (temp float)
+0:371          'inF0' (temp float)
+0:371          'inF1' (temp float)
+0:371      move second child to first child (temp 4-component vector of float)
+0:371        'r1' (temp 4-component vector of float)
+0:371        vector-scale (temp 4-component vector of float)
+0:371          'inFV0' (temp 4-component vector of float)
+0:371          'inF0' (temp float)
+0:371      move second child to first child (temp 4-component vector of float)
+0:371        'r2' (temp 4-component vector of float)
+0:371        vector-scale (temp 4-component vector of float)
+0:371          'inF0' (temp float)
+0:371          'inFV0' (temp 4-component vector of float)
+0:371      move second child to first child (temp float)
+0:371        'r3' (temp float)
+0:371        dot-product (global float)
+0:371          'inFV0' (temp 4-component vector of float)
+0:371          'inFV1' (temp 4-component vector of float)
+0:371      move second child to first child (temp 4-component vector of float)
+0:371        'r4' (temp 4-component vector of float)
+0:371        matrix-times-vector (temp 4-component vector of float)
+0:371          'inFM0' (temp 4X4 matrix of float)
+0:371          'inFV0' (temp 4-component vector of float)
+0:371      move second child to first child (temp 4-component vector of float)
+0:371        'r5' (temp 4-component vector of float)
+0:371        vector-times-matrix (temp 4-component vector of float)
+0:371          'inFV0' (temp 4-component vector of float)
+0:371          'inFM0' (temp 4X4 matrix of float)
+0:371      move second child to first child (temp 4X4 matrix of float)
+0:371        'r6' (temp 4X4 matrix of float)
+0:371        matrix-scale (temp 4X4 matrix of float)
+0:371          'inFM0' (temp 4X4 matrix of float)
+0:371          'inF0' (temp float)
+0:371      move second child to first child (temp 4X4 matrix of float)
+0:371        'r7' (temp 4X4 matrix of float)
+0:371        matrix-scale (temp 4X4 matrix of float)
+0:371          'inF0' (temp float)
+0:371          'inFM0' (temp 4X4 matrix of float)
+0:371      move second child to first child (temp 4X4 matrix of float)
+0:371        'r8' (temp 4X4 matrix of float)
+0:371        matrix-multiply (temp 4X4 matrix of float)
+0:371          'inFM0' (temp 4X4 matrix of float)
+0:371          'inFM1' (temp 4X4 matrix of float)
 0:?   Linker Objects
 
-Missing functionality: missing user function; linker needs to catch that
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 796
+// Id's are bound by 1064
 
                               Capability Shader
                1:             ExtInstImport  "GLSL.std.450"
@@ -1784,211 +2427,442 @@ Missing functionality: missing user function; linker needs to catch that
                               EntryPoint Vertex 4  "VertexShaderFunction"
                               Source HLSL 450
                               Name 4  "VertexShaderFunction"
-                              Name 8  "inF0"
-                              Name 23  "inF1"
-                              Name 30  "inF2"
-                              Name 55  "ResType"
-                              Name 115  "inF0"
-                              Name 129  "inF1"
-                              Name 136  "inF2"
-                              Name 171  "ResType"
-                              Name 244  "inF0"
-                              Name 258  "inF1"
-                              Name 265  "inF2"
-                              Name 303  "ResType"
-                              Name 374  "inF0"
-                              Name 388  "inF1"
-                              Name 395  "inF2"
-                              Name 429  "ResType"
-                              Name 501  "inF0"
-                              Name 515  "inF1"
-                              Name 522  "inF2"
-                              Name 544  "ResType"
-                              Name 600  "inF0"
-                              Name 614  "inF1"
-                              Name 621  "inF2"
-                              Name 643  "ResType"
-                              Name 699  "inF0"
-                              Name 713  "inF1"
-                              Name 720  "inF2"
-                              Name 742  "ResType"
+                              Name 19  "TestGenMul(f1;f1;vf2;vf2;mf22;mf22;"
+                              Name 13  "inF0"
+                              Name 14  "inF1"
+                              Name 15  "inFV0"
+                              Name 16  "inFV1"
+                              Name 17  "inFM0"
+                              Name 18  "inFM1"
+                              Name 32  "TestGenMul(f1;f1;vf3;vf3;mf33;mf33;"
+                              Name 26  "inF0"
+                              Name 27  "inF1"
+                              Name 28  "inFV0"
+                              Name 29  "inFV1"
+                              Name 30  "inFM0"
+                              Name 31  "inFM1"
+                              Name 45  "TestGenMul(f1;f1;vf4;vf4;mf44;mf44;"
+                              Name 39  "inF0"
+                              Name 40  "inF1"
+                              Name 41  "inFV0"
+                              Name 42  "inFV1"
+                              Name 43  "inFM0"
+                              Name 44  "inFM1"
+                              Name 47  "inF0"
+                              Name 62  "inF1"
+                              Name 69  "inF2"
+                              Name 97  "ResType"
+                              Name 166  "inF0"
+                              Name 180  "inF1"
+                              Name 187  "inF2"
+                              Name 225  "ResType"
+                              Name 306  "inF0"
+                              Name 320  "inF1"
+                              Name 327  "inF2"
+                              Name 368  "ResType"
+                              Name 448  "inF0"
+                              Name 462  "inF1"
+                              Name 469  "inF2"
+                              Name 515  "ResType"
+                              Name 596  "inF0"
+                              Name 610  "inF1"
+                              Name 617  "inF2"
+                              Name 648  "ResType"
+                              Name 713  "inF0"
+                              Name 727  "inF1"
+                              Name 734  "inF2"
+                              Name 768  "ResType"
+                              Name 833  "inF0"
+                              Name 847  "inF1"
+                              Name 854  "inF2"
+                              Name 891  "ResType"
+                              Name 956  "r0"
+                              Name 960  "r1"
+                              Name 964  "r2"
+                              Name 968  "r3"
+                              Name 972  "r4"
+                              Name 976  "r5"
+                              Name 980  "r6"
+                              Name 984  "r7"
+                              Name 988  "r8"
+                              Name 992  "r0"
+                              Name 996  "r1"
+                              Name 1000  "r2"
+                              Name 1004  "r3"
+                              Name 1008  "r4"
+                              Name 1012  "r5"
+                              Name 1016  "r6"
+                              Name 1020  "r7"
+                              Name 1024  "r8"
+                              Name 1028  "r0"
+                              Name 1032  "r1"
+                              Name 1036  "r2"
+                              Name 1040  "r3"
+                              Name 1044  "r4"
+                              Name 1048  "r5"
+                              Name 1052  "r6"
+                              Name 1056  "r7"
+                              Name 1060  "r8"
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
                7:             TypePointer Function 6(float)
-              10:             TypeBool
-              37:             TypeInt 32 0
-              38:     37(int) Constant 7
-              46:             TypeInt 32 1
-              47:     46(int) Constant 7
-     55(ResType):             TypeStruct 6(float) 46(int)
-              83:     37(int) Constant 2
-             110:    6(float) Constant 0
-             113:             TypeVector 6(float) 2
-             114:             TypePointer Function 113(fvec2)
-             143:             TypeVector 37(int) 2
-             144:     37(int) Constant 3
-             145:  143(ivec2) ConstantComposite 38 144
-             170:             TypeVector 46(int) 2
-    171(ResType):             TypeStruct 113(fvec2) 170(ivec2)
-             178:             TypeVector 10(bool) 2
-             209:    6(float) Constant 1073741824
-             211:     37(int) Constant 1
-             212:  143(ivec2) ConstantComposite 211 83
-             239:    6(float) Constant 1065353216
-             240:  113(fvec2) ConstantComposite 239 209
-             242:             TypeVector 6(float) 3
-             243:             TypePointer Function 242(fvec3)
-             272:             TypeVector 37(int) 3
-             273:     37(int) Constant 5
-             274:  272(ivec3) ConstantComposite 38 144 273
-             302:             TypeVector 46(int) 3
-    303(ResType):             TypeStruct 242(fvec3) 302(ivec3)
-             310:             TypeVector 10(bool) 3
-             342:  272(ivec3) ConstantComposite 211 83 144
-             369:    6(float) Constant 1077936128
-             370:  242(fvec3) ConstantComposite 239 209 369
-             372:             TypeVector 6(float) 4
-             373:             TypePointer Function 372(fvec4)
-             402:             TypeVector 37(int) 4
-             403:  402(ivec4) ConstantComposite 38 144 273 83
-             428:             TypeVector 46(int) 4
-    429(ResType):             TypeStruct 372(fvec4) 428(ivec4)
-             436:             TypeVector 10(bool) 4
-             468:     37(int) Constant 4
-             469:  402(ivec4) ConstantComposite 211 83 144 468
-             496:    6(float) Constant 1082130432
-             497:  372(fvec4) ConstantComposite 239 209 369 496
-             499:             TypeMatrix 113(fvec2) 2
-             500:             TypePointer Function 499
-    544(ResType):             TypeStruct 499 170(ivec2)
-             595:  113(fvec2) ConstantComposite 209 209
-             596:         499 ConstantComposite 595 595
-             598:             TypeMatrix 242(fvec3) 3
-             599:             TypePointer Function 598
-    643(ResType):             TypeStruct 598 302(ivec3)
-             694:  242(fvec3) ConstantComposite 369 369 369
-             695:         598 ConstantComposite 694 694 694
-             697:             TypeMatrix 372(fvec4) 4
-             698:             TypePointer Function 697
-    742(ResType):             TypeStruct 697 428(ivec4)
-             793:  372(fvec4) ConstantComposite 496 496 496 496
-             794:         697 ConstantComposite 793 793 793 793
+               8:             TypeVector 6(float) 2
+               9:             TypePointer Function 8(fvec2)
+              10:             TypeMatrix 8(fvec2) 2
+              11:             TypePointer Function 10
+              12:             TypeFunction 2 7(ptr) 7(ptr) 9(ptr) 9(ptr) 11(ptr) 11(ptr)
+              21:             TypeVector 6(float) 3
+              22:             TypePointer Function 21(fvec3)
+              23:             TypeMatrix 21(fvec3) 3
+              24:             TypePointer Function 23
+              25:             TypeFunction 2 7(ptr) 7(ptr) 22(ptr) 22(ptr) 24(ptr) 24(ptr)
+              34:             TypeVector 6(float) 4
+              35:             TypePointer Function 34(fvec4)
+              36:             TypeMatrix 34(fvec4) 4
+              37:             TypePointer Function 36
+              38:             TypeFunction 2 7(ptr) 7(ptr) 35(ptr) 35(ptr) 37(ptr) 37(ptr)
+              49:             TypeBool
+              76:             TypeInt 32 0
+              77:     76(int) Constant 7
+              85:             TypeInt 32 1
+              86:     85(int) Constant 7
+     97(ResType):             TypeStruct 6(float) 85(int)
+             114:    6(float) Constant 1050288283
+             129:     76(int) Constant 2
+             136:    6(float) Constant 0
+             137:    6(float) Constant 1065353216
+             194:             TypeVector 76(int) 2
+             195:     76(int) Constant 3
+             196:  194(ivec2) ConstantComposite 77 195
+             224:             TypeVector 85(int) 2
+    225(ResType):             TypeStruct 8(fvec2) 224(ivec2)
+             232:             TypeVector 49(bool) 2
+             266:    6(float) Constant 1073741824
+             268:     76(int) Constant 1
+             269:  194(ivec2) ConstantComposite 268 129
+             304:    8(fvec2) ConstantComposite 137 266
+             334:             TypeVector 76(int) 3
+             335:     76(int) Constant 5
+             336:  334(ivec3) ConstantComposite 77 195 335
+             367:             TypeVector 85(int) 3
+    368(ResType):             TypeStruct 21(fvec3) 367(ivec3)
+             375:             TypeVector 49(bool) 3
+             410:  334(ivec3) ConstantComposite 268 129 195
+             445:    6(float) Constant 1077936128
+             446:   21(fvec3) ConstantComposite 137 266 445
+             476:             TypeVector 76(int) 4
+             477:  476(ivec4) ConstantComposite 77 195 335 129
+             514:             TypeVector 85(int) 4
+    515(ResType):             TypeStruct 34(fvec4) 514(ivec4)
+             522:             TypeVector 49(bool) 4
+             557:     76(int) Constant 4
+             558:  476(ivec4) ConstantComposite 268 129 195 557
+             593:    6(float) Constant 1082130432
+             594:   34(fvec4) ConstantComposite 137 266 445 593
+    648(ResType):             TypeStruct 10 224(ivec2)
+             710:    8(fvec2) ConstantComposite 266 266
+             711:          10 ConstantComposite 710 710
+    768(ResType):             TypeStruct 23 367(ivec3)
+             830:   21(fvec3) ConstantComposite 445 445 445
+             831:          23 ConstantComposite 830 830 830
+    891(ResType):             TypeStruct 36 514(ivec4)
+             953:   34(fvec4) ConstantComposite 593 593 593 593
+             954:          36 ConstantComposite 953 953 953 953
 4(VertexShaderFunction):           2 Function None 3
                5:             Label
-         8(inF0):      7(ptr) Variable Function
-        23(inF1):      7(ptr) Variable Function
-        30(inF2):      7(ptr) Variable Function
-       115(inF0):    114(ptr) Variable Function
-       129(inF1):    114(ptr) Variable Function
-       136(inF2):    114(ptr) Variable Function
-       244(inF0):    243(ptr) Variable Function
-       258(inF1):    243(ptr) Variable Function
-       265(inF2):    243(ptr) Variable Function
-       374(inF0):    373(ptr) Variable Function
-       388(inF1):    373(ptr) Variable Function
-       395(inF2):    373(ptr) Variable Function
-       501(inF0):    500(ptr) Variable Function
-       515(inF1):    500(ptr) Variable Function
-       522(inF2):    500(ptr) Variable Function
-       600(inF0):    599(ptr) Variable Function
-       614(inF1):    599(ptr) Variable Function
-       621(inF2):    599(ptr) Variable Function
-       699(inF0):    698(ptr) Variable Function
-       713(inF1):    698(ptr) Variable Function
-       720(inF2):    698(ptr) Variable Function
-               9:    6(float) Load 8(inF0)
-              11:    10(bool) All 9
-              12:    6(float) Load 8(inF0)
-              13:    6(float) ExtInst 1(GLSL.std.450) 4(FAbs) 12
-              14:    6(float) Load 8(inF0)
-              15:    6(float) ExtInst 1(GLSL.std.450) 17(Acos) 14
-              16:    6(float) Load 8(inF0)
-              17:    10(bool) Any 16
-              18:    6(float) Load 8(inF0)
-              19:    6(float) ExtInst 1(GLSL.std.450) 16(Asin) 18
-              20:    6(float) Load 8(inF0)
-              21:    6(float) ExtInst 1(GLSL.std.450) 18(Atan) 20
-              22:    6(float) Load 8(inF0)
-              24:    6(float) Load 23(inF1)
-              25:    6(float) ExtInst 1(GLSL.std.450) 25(Atan2) 22 24
-              26:    6(float) Load 8(inF0)
-              27:    6(float) ExtInst 1(GLSL.std.450) 9(Ceil) 26
-              28:    6(float) Load 8(inF0)
-              29:    6(float) Load 23(inF1)
-              31:    6(float) Load 30(inF2)
-              32:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 28 29 31
-              33:    6(float) Load 8(inF0)
-              34:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 33
-              35:    6(float) Load 8(inF0)
-              36:    6(float) ExtInst 1(GLSL.std.450) 20(Cosh) 35
-              39:     37(int) BitCount 38
-              40:    6(float) Load 8(inF0)
-              41:    6(float) ExtInst 1(GLSL.std.450) 12(Degrees) 40
-              42:    6(float) Load 8(inF0)
-              43:    6(float) ExtInst 1(GLSL.std.450) 27(Exp) 42
-              44:    6(float) Load 8(inF0)
-              45:    6(float) ExtInst 1(GLSL.std.450) 29(Exp2) 44
-              48:     46(int) ExtInst 1(GLSL.std.450) 74(FindSMsb) 47
-              49:     46(int) ExtInst 1(GLSL.std.450) 73(FindILsb) 47
-              50:    6(float) Load 8(inF0)
-              51:    6(float) ExtInst 1(GLSL.std.450) 8(Floor) 50
-              52:    6(float) Load 8(inF0)
-              53:    6(float) ExtInst 1(GLSL.std.450) 10(Fract) 52
-              54:    6(float) Load 8(inF0)
-              56: 55(ResType) ExtInst 1(GLSL.std.450) 52(FrexpStruct) 54
-              57:     46(int) CompositeExtract 56 1
-                              Store 23(inF1) 57
-              58:    6(float) CompositeExtract 56 0
-              59:    6(float) Load 8(inF0)
-              60:    6(float) Fwidth 59
-              61:    6(float) Load 8(inF0)
-              62:    10(bool) IsInf 61
-              63:    6(float) Load 8(inF0)
-              64:    10(bool) IsNan 63
-              65:    6(float) Load 8(inF0)
-              66:    6(float) Load 23(inF1)
-              67:    6(float) ExtInst 1(GLSL.std.450) 53(Ldexp) 65 66
-              68:    6(float) Load 8(inF0)
-              69:    6(float) ExtInst 1(GLSL.std.450) 28(Log) 68
-              70:    6(float) Load 8(inF0)
-              71:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 70
-              72:    6(float) Load 8(inF0)
-              73:    6(float) Load 23(inF1)
-              74:    6(float) ExtInst 1(GLSL.std.450) 40(FMax) 72 73
-              75:    6(float) Load 8(inF0)
-              76:    6(float) Load 23(inF1)
-              77:    6(float) ExtInst 1(GLSL.std.450) 37(FMin) 75 76
-              78:    6(float) Load 8(inF0)
-              79:    6(float) Load 23(inF1)
-              80:    6(float) ExtInst 1(GLSL.std.450) 26(Pow) 78 79
-              81:    6(float) Load 8(inF0)
-              82:    6(float) ExtInst 1(GLSL.std.450) 11(Radians) 81
-              84:     37(int) BitReverse 83
-              85:    6(float) Load 8(inF0)
-              86:    6(float) ExtInst 1(GLSL.std.450) 2(RoundEven) 85
-              87:    6(float) Load 8(inF0)
-              88:    6(float) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 87
-              89:    6(float) Load 8(inF0)
-              90:    6(float) ExtInst 1(GLSL.std.450) 6(FSign) 89
-              91:    6(float) Load 8(inF0)
-              92:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 91
-              93:    6(float) Load 8(inF0)
-              94:    6(float) ExtInst 1(GLSL.std.450) 19(Sinh) 93
-              95:    6(float) Load 8(inF0)
-              96:    6(float) Load 23(inF1)
-              97:    6(float) Load 30(inF2)
-              98:    6(float) ExtInst 1(GLSL.std.450) 49(SmoothStep) 95 96 97
-              99:    6(float) Load 8(inF0)
-             100:    6(float) ExtInst 1(GLSL.std.450) 31(Sqrt) 99
-             101:    6(float) Load 8(inF0)
-             102:    6(float) Load 23(inF1)
-             103:    6(float) ExtInst 1(GLSL.std.450) 48(Step) 101 102
-             104:    6(float) Load 8(inF0)
-             105:    6(float) ExtInst 1(GLSL.std.450) 15(Tan) 104
-             106:    6(float) Load 8(inF0)
-             107:    6(float) ExtInst 1(GLSL.std.450) 21(Tanh) 106
-             108:    6(float) Load 8(inF0)
-             109:    6(float) ExtInst 1(GLSL.std.450) 3(Trunc) 108
-                              ReturnValue 110
+        47(inF0):      7(ptr) Variable Function
+        62(inF1):      7(ptr) Variable Function
+        69(inF2):      7(ptr) Variable Function
+       166(inF0):      9(ptr) Variable Function
+       180(inF1):      9(ptr) Variable Function
+       187(inF2):      9(ptr) Variable Function
+       306(inF0):     22(ptr) Variable Function
+       320(inF1):     22(ptr) Variable Function
+       327(inF2):     22(ptr) Variable Function
+       448(inF0):     35(ptr) Variable Function
+       462(inF1):     35(ptr) Variable Function
+       469(inF2):     35(ptr) Variable Function
+       596(inF0):     11(ptr) Variable Function
+       610(inF1):     11(ptr) Variable Function
+       617(inF2):     11(ptr) Variable Function
+       713(inF0):     24(ptr) Variable Function
+       727(inF1):     24(ptr) Variable Function
+       734(inF2):     24(ptr) Variable Function
+       833(inF0):     37(ptr) Variable Function
+       847(inF1):     37(ptr) Variable Function
+       854(inF2):     37(ptr) Variable Function
+              48:    6(float) Load 47(inF0)
+              50:    49(bool) All 48
+              51:    6(float) Load 47(inF0)
+              52:    6(float) ExtInst 1(GLSL.std.450) 4(FAbs) 51
+              53:    6(float) Load 47(inF0)
+              54:    6(float) ExtInst 1(GLSL.std.450) 17(Acos) 53
+              55:    6(float) Load 47(inF0)
+              56:    49(bool) Any 55
+              57:    6(float) Load 47(inF0)
+              58:    6(float) ExtInst 1(GLSL.std.450) 16(Asin) 57
+              59:    6(float) Load 47(inF0)
+              60:    6(float) ExtInst 1(GLSL.std.450) 18(Atan) 59
+              61:    6(float) Load 47(inF0)
+              63:    6(float) Load 62(inF1)
+              64:    6(float) ExtInst 1(GLSL.std.450) 25(Atan2) 61 63
+              65:    6(float) Load 47(inF0)
+              66:    6(float) ExtInst 1(GLSL.std.450) 9(Ceil) 65
+              67:    6(float) Load 47(inF0)
+              68:    6(float) Load 62(inF1)
+              70:    6(float) Load 69(inF2)
+              71:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 67 68 70
+              72:    6(float) Load 47(inF0)
+              73:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 72
+              74:    6(float) Load 47(inF0)
+              75:    6(float) ExtInst 1(GLSL.std.450) 20(Cosh) 74
+              78:     76(int) BitCount 77
+              79:    6(float) Load 47(inF0)
+              80:    6(float) ExtInst 1(GLSL.std.450) 12(Degrees) 79
+              81:    6(float) Load 47(inF0)
+              82:    6(float) ExtInst 1(GLSL.std.450) 27(Exp) 81
+              83:    6(float) Load 47(inF0)
+              84:    6(float) ExtInst 1(GLSL.std.450) 29(Exp2) 83
+              87:     85(int) ExtInst 1(GLSL.std.450) 74(FindSMsb) 86
+              88:     85(int) ExtInst 1(GLSL.std.450) 73(FindILsb) 86
+              89:    6(float) Load 47(inF0)
+              90:    6(float) ExtInst 1(GLSL.std.450) 8(Floor) 89
+              91:    6(float) Load 47(inF0)
+              92:    6(float) Load 62(inF1)
+              93:    6(float) FMod 91 92
+              94:    6(float) Load 47(inF0)
+              95:    6(float) ExtInst 1(GLSL.std.450) 10(Fract) 94
+              96:    6(float) Load 47(inF0)
+              98: 97(ResType) ExtInst 1(GLSL.std.450) 52(FrexpStruct) 96
+              99:     85(int) CompositeExtract 98 1
+                              Store 62(inF1) 99
+             100:    6(float) CompositeExtract 98 0
+             101:    6(float) Load 47(inF0)
+             102:    6(float) Fwidth 101
+             103:    6(float) Load 47(inF0)
+             104:    49(bool) IsInf 103
+             105:    6(float) Load 47(inF0)
+             106:    49(bool) IsNan 105
+             107:    6(float) Load 47(inF0)
+             108:    6(float) Load 62(inF1)
+             109:    6(float) ExtInst 1(GLSL.std.450) 53(Ldexp) 107 108
+             110:    6(float) Load 47(inF0)
+             111:    6(float) ExtInst 1(GLSL.std.450) 28(Log) 110
+             112:    6(float) Load 47(inF0)
+             113:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 112
+             115:    6(float) FMul 113 114
+             116:    6(float) Load 47(inF0)
+             117:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 116
+             118:    6(float) Load 47(inF0)
+             119:    6(float) Load 62(inF1)
+             120:    6(float) ExtInst 1(GLSL.std.450) 40(FMax) 118 119
+             121:    6(float) Load 47(inF0)
+             122:    6(float) Load 62(inF1)
+             123:    6(float) ExtInst 1(GLSL.std.450) 37(FMin) 121 122
+             124:    6(float) Load 47(inF0)
+             125:    6(float) Load 62(inF1)
+             126:    6(float) ExtInst 1(GLSL.std.450) 26(Pow) 124 125
+             127:    6(float) Load 47(inF0)
+             128:    6(float) ExtInst 1(GLSL.std.450) 11(Radians) 127
+             130:     76(int) BitReverse 129
+             131:    6(float) Load 47(inF0)
+             132:    6(float) ExtInst 1(GLSL.std.450) 2(RoundEven) 131
+             133:    6(float) Load 47(inF0)
+             134:    6(float) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 133
+             135:    6(float) Load 47(inF0)
+             138:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 135 136 137
+             139:    6(float) Load 47(inF0)
+             140:    6(float) ExtInst 1(GLSL.std.450) 6(FSign) 139
+             141:    6(float) Load 47(inF0)
+             142:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 141
+             143:    6(float) Load 47(inF0)
+             144:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 143
+                              Store 62(inF1) 144
+             145:    6(float) Load 47(inF0)
+             146:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 145
+                              Store 69(inF2) 146
+             147:    6(float) Load 47(inF0)
+             148:    6(float) ExtInst 1(GLSL.std.450) 19(Sinh) 147
+             149:    6(float) Load 47(inF0)
+             150:    6(float) Load 62(inF1)
+             151:    6(float) Load 69(inF2)
+             152:    6(float) ExtInst 1(GLSL.std.450) 49(SmoothStep) 149 150 151
+             153:    6(float) Load 47(inF0)
+             154:    6(float) ExtInst 1(GLSL.std.450) 31(Sqrt) 153
+             155:    6(float) Load 47(inF0)
+             156:    6(float) Load 62(inF1)
+             157:    6(float) ExtInst 1(GLSL.std.450) 48(Step) 155 156
+             158:    6(float) Load 47(inF0)
+             159:    6(float) ExtInst 1(GLSL.std.450) 15(Tan) 158
+             160:    6(float) Load 47(inF0)
+             161:    6(float) ExtInst 1(GLSL.std.450) 21(Tanh) 160
+             162:    6(float) Load 47(inF0)
+             163:    6(float) ExtInst 1(GLSL.std.450) 3(Trunc) 162
+                              ReturnValue 136
+                              FunctionEnd
+19(TestGenMul(f1;f1;vf2;vf2;mf22;mf22;):           2 Function None 12
+        13(inF0):      7(ptr) FunctionParameter
+        14(inF1):      7(ptr) FunctionParameter
+       15(inFV0):      9(ptr) FunctionParameter
+       16(inFV1):      9(ptr) FunctionParameter
+       17(inFM0):     11(ptr) FunctionParameter
+       18(inFM1):     11(ptr) FunctionParameter
+              20:             Label
+         956(r0):      7(ptr) Variable Function
+         960(r1):      9(ptr) Variable Function
+         964(r2):      9(ptr) Variable Function
+         968(r3):      7(ptr) Variable Function
+         972(r4):      9(ptr) Variable Function
+         976(r5):      9(ptr) Variable Function
+         980(r6):     11(ptr) Variable Function
+         984(r7):     11(ptr) Variable Function
+         988(r8):     11(ptr) Variable Function
+             957:    6(float) Load 13(inF0)
+             958:    6(float) Load 14(inF1)
+             959:    6(float) FMul 957 958
+                              Store 956(r0) 959
+             961:    8(fvec2) Load 15(inFV0)
+             962:    6(float) Load 13(inF0)
+             963:    8(fvec2) VectorTimesScalar 961 962
+                              Store 960(r1) 963
+             965:    6(float) Load 13(inF0)
+             966:    8(fvec2) Load 15(inFV0)
+             967:    8(fvec2) VectorTimesScalar 966 965
+                              Store 964(r2) 967
+             969:    8(fvec2) Load 15(inFV0)
+             970:    8(fvec2) Load 16(inFV1)
+             971:    6(float) Dot 969 970
+                              Store 968(r3) 971
+             973:          10 Load 17(inFM0)
+             974:    8(fvec2) Load 15(inFV0)
+             975:    8(fvec2) MatrixTimesVector 973 974
+                              Store 972(r4) 975
+             977:    8(fvec2) Load 15(inFV0)
+             978:          10 Load 17(inFM0)
+             979:    8(fvec2) VectorTimesMatrix 977 978
+                              Store 976(r5) 979
+             981:          10 Load 17(inFM0)
+             982:    6(float) Load 13(inF0)
+             983:          10 MatrixTimesScalar 981 982
+                              Store 980(r6) 983
+             985:    6(float) Load 13(inF0)
+             986:          10 Load 17(inFM0)
+             987:          10 MatrixTimesScalar 986 985
+                              Store 984(r7) 987
+             989:          10 Load 17(inFM0)
+             990:          10 Load 18(inFM1)
+             991:          10 MatrixTimesMatrix 989 990
+                              Store 988(r8) 991
+                              Return
+                              FunctionEnd
+32(TestGenMul(f1;f1;vf3;vf3;mf33;mf33;):           2 Function None 25
+        26(inF0):      7(ptr) FunctionParameter
+        27(inF1):      7(ptr) FunctionParameter
+       28(inFV0):     22(ptr) FunctionParameter
+       29(inFV1):     22(ptr) FunctionParameter
+       30(inFM0):     24(ptr) FunctionParameter
+       31(inFM1):     24(ptr) FunctionParameter
+              33:             Label
+         992(r0):      7(ptr) Variable Function
+         996(r1):     22(ptr) Variable Function
+        1000(r2):     22(ptr) Variable Function
+        1004(r3):      7(ptr) Variable Function
+        1008(r4):     22(ptr) Variable Function
+        1012(r5):     22(ptr) Variable Function
+        1016(r6):     24(ptr) Variable Function
+        1020(r7):     24(ptr) Variable Function
+        1024(r8):     24(ptr) Variable Function
+             993:    6(float) Load 26(inF0)
+             994:    6(float) Load 27(inF1)
+             995:    6(float) FMul 993 994
+                              Store 992(r0) 995
+             997:   21(fvec3) Load 28(inFV0)
+             998:    6(float) Load 26(inF0)
+             999:   21(fvec3) VectorTimesScalar 997 998
+                              Store 996(r1) 999
+            1001:    6(float) Load 26(inF0)
+            1002:   21(fvec3) Load 28(inFV0)
+            1003:   21(fvec3) VectorTimesScalar 1002 1001
+                              Store 1000(r2) 1003
+            1005:   21(fvec3) Load 28(inFV0)
+            1006:   21(fvec3) Load 29(inFV1)
+            1007:    6(float) Dot 1005 1006
+                              Store 1004(r3) 1007
+            1009:          23 Load 30(inFM0)
+            1010:   21(fvec3) Load 28(inFV0)
+            1011:   21(fvec3) MatrixTimesVector 1009 1010
+                              Store 1008(r4) 1011
+            1013:   21(fvec3) Load 28(inFV0)
+            1014:          23 Load 30(inFM0)
+            1015:   21(fvec3) VectorTimesMatrix 1013 1014
+                              Store 1012(r5) 1015
+            1017:          23 Load 30(inFM0)
+            1018:    6(float) Load 26(inF0)
+            1019:          23 MatrixTimesScalar 1017 1018
+                              Store 1016(r6) 1019
+            1021:    6(float) Load 26(inF0)
+            1022:          23 Load 30(inFM0)
+            1023:          23 MatrixTimesScalar 1022 1021
+                              Store 1020(r7) 1023
+            1025:          23 Load 30(inFM0)
+            1026:          23 Load 31(inFM1)
+            1027:          23 MatrixTimesMatrix 1025 1026
+                              Store 1024(r8) 1027
+                              Return
+                              FunctionEnd
+45(TestGenMul(f1;f1;vf4;vf4;mf44;mf44;):           2 Function None 38
+        39(inF0):      7(ptr) FunctionParameter
+        40(inF1):      7(ptr) FunctionParameter
+       41(inFV0):     35(ptr) FunctionParameter
+       42(inFV1):     35(ptr) FunctionParameter
+       43(inFM0):     37(ptr) FunctionParameter
+       44(inFM1):     37(ptr) FunctionParameter
+              46:             Label
+        1028(r0):      7(ptr) Variable Function
+        1032(r1):     35(ptr) Variable Function
+        1036(r2):     35(ptr) Variable Function
+        1040(r3):      7(ptr) Variable Function
+        1044(r4):     35(ptr) Variable Function
+        1048(r5):     35(ptr) Variable Function
+        1052(r6):     37(ptr) Variable Function
+        1056(r7):     37(ptr) Variable Function
+        1060(r8):     37(ptr) Variable Function
+            1029:    6(float) Load 39(inF0)
+            1030:    6(float) Load 40(inF1)
+            1031:    6(float) FMul 1029 1030
+                              Store 1028(r0) 1031
+            1033:   34(fvec4) Load 41(inFV0)
+            1034:    6(float) Load 39(inF0)
+            1035:   34(fvec4) VectorTimesScalar 1033 1034
+                              Store 1032(r1) 1035
+            1037:    6(float) Load 39(inF0)
+            1038:   34(fvec4) Load 41(inFV0)
+            1039:   34(fvec4) VectorTimesScalar 1038 1037
+                              Store 1036(r2) 1039
+            1041:   34(fvec4) Load 41(inFV0)
+            1042:   34(fvec4) Load 42(inFV1)
+            1043:    6(float) Dot 1041 1042
+                              Store 1040(r3) 1043
+            1045:          36 Load 43(inFM0)
+            1046:   34(fvec4) Load 41(inFV0)
+            1047:   34(fvec4) MatrixTimesVector 1045 1046
+                              Store 1044(r4) 1047
+            1049:   34(fvec4) Load 41(inFV0)
+            1050:          36 Load 43(inFM0)
+            1051:   34(fvec4) VectorTimesMatrix 1049 1050
+                              Store 1048(r5) 1051
+            1053:          36 Load 43(inFM0)
+            1054:    6(float) Load 39(inF0)
+            1055:          36 MatrixTimesScalar 1053 1054
+                              Store 1052(r6) 1055
+            1057:    6(float) Load 39(inF0)
+            1058:          36 Load 43(inFM0)
+            1059:          36 MatrixTimesScalar 1058 1057
+                              Store 1056(r7) 1059
+            1061:          36 Load 43(inFM0)
+            1062:          36 Load 44(inFM1)
+            1063:          36 MatrixTimesMatrix 1061 1062
+                              Store 1060(r8) 1063
+                              Return
                               FunctionEnd

--- a/Test/hlsl.intrinsics.frag
+++ b/Test/hlsl.intrinsics.frag
@@ -9,6 +9,7 @@ float PixelShaderFunction(float inF0, float inF1, float inF2)
     atan2(inF0, inF1);
     ceil(inF0);
     clamp(inF0, inF1, inF2);
+    clip(inF0);
     cos(inF0);
     cosh(inF0);
     countbits(7);
@@ -36,17 +37,20 @@ float PixelShaderFunction(float inF0, float inF1, float inF2)
     isnan(inF0);
     ldexp(inF0, inF1);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
-    // TODO: mul(inF0, inF1);
     pow(inF0, inF1);
     radians(inF0);
+    rcp(inF0);
     reversebits(2);
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -76,6 +80,7 @@ float2 PixelShaderFunction(float2 inF0, float2 inF1, float2 inF2)
     atan2(inF0, inF1);
     ceil(inF0);
     clamp(inF0, inF1, inF2);
+    clip(inF0);
     cos(inF0);
     cosh(inF0);
     countbits(int2(7,3));
@@ -107,20 +112,23 @@ float2 PixelShaderFunction(float2 inF0, float2 inF1, float2 inF2)
     ldexp(inF0, inF1);
     length(inF0);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
-    // TODO: mul(inF0, inF1);
     normalize(inF0);
     pow(inF0, inF1);
     radians(inF0);
+    rcp(inF0);
     reflect(inF0, inF1);
     refract(inF0, inF1, 2.0);
     reversebits(int2(1,2));
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -145,6 +153,7 @@ float3 PixelShaderFunction(float3 inF0, float3 inF1, float3 inF2)
     atan2(inF0, inF1);
     ceil(inF0);
     clamp(inF0, inF1, inF2);
+    clip(inF0);
     cos(inF0);
     cosh(inF0);
     countbits(int3(7,3,5));
@@ -177,20 +186,23 @@ float3 PixelShaderFunction(float3 inF0, float3 inF1, float3 inF2)
     ldexp(inF0, inF1);
     length(inF0);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
-    // TODO: mul(inF0, inF1);
     normalize(inF0);
     pow(inF0, inF1);
     radians(inF0);
+    rcp(inF0);
     reflect(inF0, inF1);
     refract(inF0, inF1, 2.0);
     reversebits(int3(1,2,3));
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -215,6 +227,7 @@ float4 PixelShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     atan2(inF0, inF1);
     ceil(inF0);
     clamp(inF0, inF1, inF2);
+    clip(inF0);
     cos(inF0);
     cosh(inF0);
     countbits(int4(7,3,5,2));
@@ -227,6 +240,7 @@ float4 PixelShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     degrees(inF0);
     distance(inF0, inF1);
     dot(inF0, inF1);
+    dst(inF0, inF1);
     // EvaluateAttributeAtCentroid(inF0);
     // EvaluateAttributeAtSample(inF0, 0);
     // TODO: EvaluateAttributeSnapped(inF0, int2(1,2));
@@ -246,20 +260,23 @@ float4 PixelShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     ldexp(inF0, inF1);
     length(inF0);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
-    // TODO: mul(inF0, inF1);
     normalize(inF0);
     pow(inF0, inF1);
     radians(inF0);
+    rcp(inF0);
     reflect(inF0, inF1);
     refract(inF0, inF1, 2.0);
     reversebits(int4(1,2,3,4));
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -283,6 +300,7 @@ float4 PixelShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     atan(inF0); \
     atan2(inF0, inF1); \
     ceil(inF0); \
+    clip(inF0); \
     clamp(inF0, inF1, inF2); \
     cos(inF0); \
     cosh(inF0); \
@@ -305,15 +323,18 @@ float4 PixelShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     fwidth(inF0); \
     ldexp(inF0, inF1); \
     log(inF0); \
-    log2(inF0); \
+    log10(inF0); \
+    log2(inF0);      \
     max(inF0, inF1); \
     min(inF0, inF1); \
     pow(inF0, inF1); \
     radians(inF0); \
     round(inF0); \
     rsqrt(inF0); \
+    saturate(inF0); \
     sign(inF0); \
     sin(inF0); \
+    sincos(inF0, inF1, inF2); \
     sinh(inF0); \
     smoothstep(inF0, inF1, inF2); \
     sqrt(inF0); \
@@ -350,4 +371,37 @@ float4x4 PixelShaderFunction(float4x4 inF0, float4x4 inF1, float4x4 inF2)
 
     // TODO: ... add when float1 prototypes are generated
     return float4x4(4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4);
+}
+
+#define TESTGENMUL(ST, VT, MT) \
+    ST r0 = mul(inF0,  inF1);  \
+    VT r1 = mul(inFV0, inF0);  \
+    VT r2 = mul(inF0,  inFV0); \
+    ST r3 = mul(inFV0, inFV1); \
+    VT r4 = mul(inFM0, inFV0); \
+    VT r5 = mul(inFV0, inFM0); \
+    MT r6 = mul(inFM0, inF0);  \
+    MT r7 = mul(inF0, inFM0);  \
+    MT r8 = mul(inFM0, inFM1);
+
+
+void TestGenMul(float inF0, float inF1,
+                float2 inFV0, float2 inFV1,
+                float2x2 inFM0, float2x2 inFM1)
+{
+    TESTGENMUL(float, float2, float2x2);
+}
+
+void TestGenMul(float inF0, float inF1,
+                float3 inFV0, float3 inFV1,
+                float3x3 inFM0, float3x3 inFM1)
+{
+    TESTGENMUL(float, float3, float3x3);
+}
+
+void TestGenMul(float inF0, float inF1,
+                float4 inFV0, float4 inFV1,
+                float4x4 inFM0, float4x4 inFM1)
+{
+    TESTGENMUL(float, float4, float4x4);
 }

--- a/Test/hlsl.intrinsics.vert
+++ b/Test/hlsl.intrinsics.vert
@@ -30,6 +30,7 @@ float VertexShaderFunction(float inF0, float inF1, float inF2)
     isnan(inF0);
     ldexp(inF0, inF1);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
@@ -39,8 +40,10 @@ float VertexShaderFunction(float inF0, float inF1, float inF2)
     reversebits(2);
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -95,6 +98,7 @@ float2 VertexShaderFunction(float2 inF0, float2 inF1, float2 inF2)
     ldexp(inF0, inF1);
     length(inF0);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
@@ -107,8 +111,10 @@ float2 VertexShaderFunction(float2 inF0, float2 inF1, float2 inF2)
     reversebits(int2(1,2));
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -159,6 +165,7 @@ float3 VertexShaderFunction(float3 inF0, float3 inF1, float3 inF2)
     ldexp(inF0, inF1);
     length(inF0);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
@@ -171,8 +178,10 @@ float3 VertexShaderFunction(float3 inF0, float3 inF1, float3 inF2)
     reversebits(int3(1,2,3));
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -203,6 +212,7 @@ float4 VertexShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     degrees(inF0);
     distance(inF0, inF1);
     dot(inF0, inF1);
+    dst(inF0, inF1);
     // EvaluateAttributeAtCentroid(inF0);
     // EvaluateAttributeAtSample(inF0, 0);
     // TODO: EvaluateAttributeSnapped(inF0, int2(1,2));
@@ -222,6 +232,7 @@ float4 VertexShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     ldexp(inF0, inF1);
     length(inF0);
     log(inF0);
+    log10(inF0);
     log2(inF0);
     max(inF0, inF1);
     min(inF0, inF1);
@@ -234,8 +245,10 @@ float4 VertexShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     reversebits(int4(1,2,3,4));
     round(inF0);
     rsqrt(inF0);
+    saturate(inF0);
     sign(inF0);
     sin(inF0);
+    sincos(inF0, inF1, inF2);
     sinh(inF0);
     smoothstep(inF0, inF1, inF2);
     sqrt(inF0);
@@ -275,6 +288,7 @@ float4 VertexShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     fwidth(inF0); \
     ldexp(inF0, inF1); \
     log(inF0); \
+    log10(inF0); \
     log2(inF0); \
     max(inF0, inF1); \
     min(inF0, inF1); \
@@ -282,8 +296,10 @@ float4 VertexShaderFunction(float4 inF0, float4 inF1, float4 inF2)
     radians(inF0); \
     round(inF0); \
     rsqrt(inF0); \
+    saturate(inF0); \
     sign(inF0); \
     sin(inF0); \
+    sincos(inF0, inF1, inF2); \
     sinh(inF0); \
     smoothstep(inF0, inF1, inF2); \
     sqrt(inF0); \
@@ -320,4 +336,37 @@ float4x4 VertexShaderFunction(float4x4 inF0, float4x4 inF1, float4x4 inF2)
 
     // TODO: ... add when float1 prototypes are generated
     return float4x4(4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4);
+}
+
+#define TESTGENMUL(ST, VT, MT) \
+    ST r0 = mul(inF0,  inF1);  \
+    VT r1 = mul(inFV0, inF0);  \
+    VT r2 = mul(inF0,  inFV0); \
+    ST r3 = mul(inFV0, inFV1); \
+    VT r4 = mul(inFM0, inFV0); \
+    VT r5 = mul(inFV0, inFM0); \
+    MT r6 = mul(inFM0, inF0);  \
+    MT r7 = mul(inF0, inFM0);  \
+    MT r8 = mul(inFM0, inFM1);
+
+
+void TestGenMul(float inF0, float inF1,
+                float2 inFV0, float2 inFV1,
+                float2x2 inFM0, float2x2 inFM1)
+{
+    TESTGENMUL(float, float2, float2x2);
+}
+
+void TestGenMul(float inF0, float inF1,
+                float3 inFV0, float3 inFV1,
+                float3x3 inFM0, float3x3 inFM1)
+{
+    TESTGENMUL(float, float3, float3x3);
+}
+
+void TestGenMul(float inF0, float inF1,
+                float4 inFV0, float4 inFV1,
+                float4x4 inFM0, float4x4 inFM1)
+{
+    TESTGENMUL(float, float4, float4x4);
 }

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -1,6 +1,6 @@
 //
 //Copyright (C) 2002-2005  3Dlabs Inc. Ltd.
-//Copyright (C) 2012-2015 LunarG, Inc.
+//Copyright (C) 2012-2016 LunarG, Inc.
 //Copyright (C) 2015-2016 Google, Inc.
 //
 //All rights reserved.
@@ -1043,8 +1043,9 @@ public:
     POOL_ALLOCATOR_NEW_DELETE(GetThreadPoolAllocator())
 
     // for "empty" type (no args) or simple scalar/vector/matrix
-    explicit TType(TBasicType t = EbtVoid, TStorageQualifier q = EvqTemporary, int vs = 1, int mc = 0, int mr = 0) :
-                            basicType(t), vectorSize(vs), matrixCols(mc), matrixRows(mr), vector1(false),
+    explicit TType(TBasicType t = EbtVoid, TStorageQualifier q = EvqTemporary, int vs = 1, int mc = 0, int mr = 0,
+                   bool isVector = false) :
+                            basicType(t), vectorSize(vs), matrixCols(mc), matrixRows(mr), vector1(isVector && vs == 1),
                             arraySizes(nullptr), structure(nullptr), fieldName(nullptr), typeName(nullptr)
                             {
                                 sampler.clear();
@@ -1052,8 +1053,9 @@ public:
                                 qualifier.storage = q;
                             }
     // for explicit precision qualifier
-    TType(TBasicType t, TStorageQualifier q, TPrecisionQualifier p, int vs = 1, int mc = 0, int mr = 0) :
-                            basicType(t), vectorSize(vs), matrixCols(mc), matrixRows(mr), vector1(false),
+    TType(TBasicType t, TStorageQualifier q, TPrecisionQualifier p, int vs = 1, int mc = 0, int mr = 0, 
+          bool isVector = false) :
+                            basicType(t), vectorSize(vs), matrixCols(mc), matrixRows(mr), vector1(isVector && vs == 1),
                             arraySizes(nullptr), structure(nullptr), fieldName(nullptr), typeName(nullptr)
                             {
                                 sampler.clear();

--- a/glslang/Include/intermediate.h
+++ b/glslang/Include/intermediate.h
@@ -1,6 +1,6 @@
 //
 //Copyright (C) 2002-2005  3Dlabs Inc. Ltd.
-//Copyright (C) 2012-2013 LunarG, Inc.
+//Copyright (C) 2012-2016 LunarG, Inc.
 //
 //All rights reserved.
 //
@@ -493,6 +493,19 @@ enum TOperator {
     EOpBitCount,
     EOpFindLSB,
     EOpFindMSB,
+
+    //
+    // HLSL operations
+    //
+
+    EOpClip,
+    EOpIsFinite,
+    EOpLog10,
+    EOpRcp,
+    EOpSaturate,
+    EOpSinCos,
+    EOpGenMul,  // mul(x,y) on any of mat/vec/scalars
+    EOpDst,
 };
 
 class TIntermTraverser;

--- a/glslang/MachineIndependent/intermOut.cpp
+++ b/glslang/MachineIndependent/intermOut.cpp
@@ -1,6 +1,6 @@
 //
 //Copyright (C) 2002-2005  3Dlabs Inc. Ltd.
-//Copyright (C) 2012-2013 LunarG, Inc.
+//Copyright (C) 2012-2016 LunarG, Inc.
 //
 //All rights reserved.
 //
@@ -359,6 +359,12 @@ bool TOutputTraverser::visitUnary(TVisit /* visit */, TIntermUnary* node)
     case EOpAllInvocations:         out.debug << "allInvocations";        break;
     case EOpAllInvocationsEqual:    out.debug << "allInvocationsEqual";   break;
 
+    case EOpClip:                   out.debug << "clip";                  break;
+    case EOpIsFinite:               out.debug << "isfinite";              break;
+    case EOpLog10:                  out.debug << "log10";                 break;
+    case EOpRcp:                    out.debug << "rcp";                   break;
+    case EOpSaturate:               out.debug << "saturate";              break;
+
     default: out.debug.message(EPrefixError, "Bad unary op");
     }
 
@@ -533,6 +539,9 @@ bool TOutputTraverser::visitAggregate(TVisit /* visit */, TIntermAggregate* node
 
     case EOpInterpolateAtSample:   out.debug << "interpolateAtSample";    break;
     case EOpInterpolateAtOffset:   out.debug << "interpolateAtOffset";    break;
+
+    case EOpSinCos:                     out.debug << "sincos";                break;
+    case EOpGenMul:                     out.debug << "mul";                   break;
 
     default: out.debug.message(EPrefixError, "Bad aggregation op");
     }

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -1,5 +1,6 @@
 //
 //Copyright (C) 2016 Google, Inc.
+//Copyright (C) 2016 LunarG, Inc.
 //
 //All rights reserved.
 //
@@ -765,6 +766,184 @@ void HlslParseContext::handleFunctionArgument(TFunction* function, TIntermTyped*
         arguments = newArg;
 }
 
+// Optionally decompose intrinsics to AST opcodes.
+//
+void HlslParseContext::decomposeIntrinsic(const TSourceLoc& loc, TIntermTyped*& node, TIntermNode* arguments)
+{
+    // HLSL intrinsics can be pass through to native AST opcodes, or decomposed here to existing AST
+    // opcodes for compatibility with existing software stacks.
+    static const bool decomposeHlslIntrinsics = true;
+
+    if (!decomposeHlslIntrinsics || !node || !node->getAsOperator())
+        return;
+    
+    const TIntermAggregate* argAggregate = arguments ? arguments->getAsAggregate() : nullptr;
+    TIntermUnary* fnUnary = node->getAsUnaryNode();
+    const TOperator op  = node->getAsOperator()->getOp();
+
+    switch (op) {
+    case EOpGenMul:
+        {
+            // mul(a,b) -> MatrixTimesMatrix, MatrixTimesVector, MatrixTimesScalar, VectorTimesScalar, Dot, Mul
+            TIntermTyped* arg0 = argAggregate->getSequence()[0]->getAsTyped();
+            TIntermTyped* arg1 = argAggregate->getSequence()[1]->getAsTyped();
+
+            if (arg0->isVector() && arg1->isVector()) {  // vec * vec
+                node->getAsAggregate()->setOperator(EOpDot);
+            } else {
+                node = handleBinaryMath(loc, "mul", EOpMul, arg0, arg1);
+            }
+
+            break;
+        }
+
+    case EOpRcp:
+        {
+            // rcp(a) -> 1 / a
+            TIntermTyped* arg0 = fnUnary->getOperand();
+            TBasicType   type0 = arg0->getBasicType();
+            TIntermTyped* one  = intermediate.addConstantUnion(1, type0, loc, true);
+            node  = handleBinaryMath(loc, "rcp", EOpDiv, one, arg0);
+
+            break;
+        }
+
+    case EOpSaturate:
+        {
+            // saturate(a) -> clamp(a,0,1)
+            TIntermTyped* arg0 = fnUnary->getOperand();
+            TBasicType   type0 = arg0->getBasicType();
+            TIntermAggregate* clamp = new TIntermAggregate(EOpClamp);
+
+            clamp->getSequence().push_back(arg0);
+            clamp->getSequence().push_back(intermediate.addConstantUnion(0, type0, loc, true));
+            clamp->getSequence().push_back(intermediate.addConstantUnion(1, type0, loc, true));
+            clamp->setLoc(loc);
+            clamp->setType(node->getType());
+            node = clamp;
+
+            break;
+        }
+
+    case EOpSinCos:
+        {
+            // sincos(a,b,c) -> b = sin(a), c = cos(a)
+            TIntermTyped* arg0 = argAggregate->getSequence()[0]->getAsTyped();
+            TIntermTyped* arg1 = argAggregate->getSequence()[1]->getAsTyped();
+            TIntermTyped* arg2 = argAggregate->getSequence()[2]->getAsTyped();
+
+            TIntermTyped* sinStatement = handleUnaryMath(loc, "sin", EOpSin, arg0);
+            TIntermTyped* cosStatement = handleUnaryMath(loc, "cos", EOpCos, arg0);
+            TIntermTyped* sinAssign    = intermediate.addAssign(EOpAssign, arg1, sinStatement, loc);
+            TIntermTyped* cosAssign    = intermediate.addAssign(EOpAssign, arg2, cosStatement, loc);
+
+            TIntermAggregate* compoundStatement = intermediate.makeAggregate(sinAssign, loc);
+            compoundStatement = intermediate.growAggregate(compoundStatement, cosAssign);
+            compoundStatement->setOperator(EOpSequence);
+            compoundStatement->setLoc(loc);
+
+            node = compoundStatement;
+
+            break;
+        }
+
+    case EOpClip:
+        {
+            // clip(a) -> if (any(a<0)) discard;
+            TIntermTyped*  arg0 = fnUnary->getOperand();
+            TBasicType     type0 = arg0->getBasicType();
+            TIntermTyped*  compareNode = nullptr;
+
+            // For non-scalars: per experiment with FXC compiler, discard if any component < 0.
+            if (!arg0->isScalar()) {
+                // component-wise compare: a < 0
+                TIntermAggregate* less = new TIntermAggregate(EOpLessThan);
+                less->getSequence().push_back(arg0);
+                less->setLoc(loc);
+
+                // make vec or mat of bool matching dimensions of input
+                less->setType(TType(EbtBool, EvqTemporary,
+                                    arg0->getType().getVectorSize(),
+                                    arg0->getType().getMatrixCols(),
+                                    arg0->getType().getMatrixRows(),
+                                    arg0->getType().isVector()));
+
+                // calculate # of components for comparison const
+                const int constComponentCount = 
+                    std::max(arg0->getType().getVectorSize(), 1) *
+                    std::max(arg0->getType().getMatrixCols(), 1) *
+                    std::max(arg0->getType().getMatrixRows(), 1);
+
+                TConstUnion zero;
+                zero.setDConst(0.0);
+                TConstUnionArray zeros(constComponentCount, zero);
+
+                less->getSequence().push_back(intermediate.addConstantUnion(zeros, arg0->getType(), loc, true));
+
+                compareNode = intermediate.addBuiltInFunctionCall(loc, EOpAny, true, less, TType(EbtBool));
+            } else {
+                TIntermTyped* zero = intermediate.addConstantUnion(0, type0, loc, true);
+                compareNode = handleBinaryMath(loc, "clip", EOpLessThan, arg0, zero);
+            }
+            
+            TIntermBranch* killNode = intermediate.addBranch(EOpKill, loc);
+
+            node = new TIntermSelection(compareNode, killNode, nullptr);
+            node->setLoc(loc);
+            
+            break;
+        }
+
+    case EOpLog10:
+        {
+            // log10(a) -> log2(a) * 0.301029995663981  (== 1/log2(10))
+            TIntermTyped* arg0 = fnUnary->getOperand();
+            TIntermTyped* log2 = handleUnaryMath(loc, "log2", EOpLog2, arg0);
+            TIntermTyped* base = intermediate.addConstantUnion(0.301029995663981f, EbtFloat, loc, true);
+
+            node  = handleBinaryMath(loc, "mul", EOpMul, log2, base);
+
+            break;
+        }
+
+    case EOpDst:
+        {
+            // dest.x = 1;
+            // dest.y = src0.y * src1.y;
+            // dest.z = src0.z;
+            // dest.w = src1.w;
+
+            TIntermTyped* arg0 = argAggregate->getSequence()[0]->getAsTyped();
+            TIntermTyped* arg1 = argAggregate->getSequence()[1]->getAsTyped();
+            TBasicType    type0 = arg0->getBasicType();
+
+            TIntermTyped* x = intermediate.addConstantUnion(0, loc, true);
+            TIntermTyped* y = intermediate.addConstantUnion(1, loc, true);
+            TIntermTyped* z = intermediate.addConstantUnion(2, loc, true);
+            TIntermTyped* w = intermediate.addConstantUnion(3, loc, true);
+
+            TIntermTyped* src0y = intermediate.addIndex(EOpIndexDirect, arg0, y, loc);
+            TIntermTyped* src1y = intermediate.addIndex(EOpIndexDirect, arg1, y, loc);
+            TIntermTyped* src0z = intermediate.addIndex(EOpIndexDirect, arg0, z, loc);
+            TIntermTyped* src1w = intermediate.addIndex(EOpIndexDirect, arg1, w, loc);
+
+            TIntermAggregate* dst = new TIntermAggregate(EOpConstructVec4);
+
+            dst->getSequence().push_back(intermediate.addConstantUnion(1.0, EbtFloat, loc, true));
+            dst->getSequence().push_back(handleBinaryMath(loc, "mul", EOpMul, src0y, src1y));
+            dst->getSequence().push_back(src0z);
+            dst->getSequence().push_back(src1w);
+            dst->setLoc(loc);
+            node = dst;
+
+            break;
+        }
+
+    default:
+        break; // most pass through unchanged
+    }
+}
+
 //
 // Handle seeing function call syntax in the grammar, which could be any of
 //  - .length() method
@@ -867,6 +1046,8 @@ TIntermTyped* HlslParseContext::handleFunctionCall(const TSourceLoc& loc, TFunct
                 }
                 result = addOutputArgumentConversions(*fnCandidate, *result->getAsAggregate());
             }
+
+            decomposeIntrinsic(loc, result, arguments);
         }
     }
 

--- a/hlsl/hlslParseHelper.h
+++ b/hlsl/hlslParseHelper.h
@@ -1,5 +1,6 @@
 //
 //Copyright (C) 2016 Google, Inc.
+//Copyright (C) 2016 LunarG, Inc.
 //
 //All rights reserved.
 //
@@ -85,6 +86,7 @@ public:
     TIntermAggregate* handleFunctionDefinition(const TSourceLoc&, TFunction&);
     void handleFunctionArgument(TFunction*, TIntermTyped*& arguments, TIntermTyped* newArg);
     TIntermTyped* handleFunctionCall(const TSourceLoc&, TFunction*, TIntermNode*);
+    void decomposeIntrinsic(const TSourceLoc&, TIntermTyped*& node, TIntermNode* arguments);
     TIntermTyped* handleLengthMethod(const TSourceLoc&, TFunction*, TIntermNode*);
     void addInputArgumentConversions(const TFunction&, TIntermNode*&) const;
     TIntermTyped* addOutputArgumentConversions(const TFunction&, TIntermAggregate&) const;

--- a/hlsl/hlslParseables.cpp
+++ b/hlsl/hlslParseables.cpp
@@ -279,7 +279,7 @@ void TBuiltInParseablesHlsl::initialize(int version, EProfile profile, int spv, 
         { "DeviceMemoryBarrierWithGroupSync", nullptr, nullptr,   "-",          "-",      EShLangComputeMask },
         { "distance",                         "S",     "F",       "V,",         "F,",     EShLangAll },
         { "dot",                              "S",     nullptr,   "V,",         "FI,",    EShLangAll },
-        { "dst",                              nullptr, nullptr,   "V,",         "F,",     EShLangAll },
+        { "dst",                              nullptr, nullptr,   "V4,V4",      "F,",     EShLangAll },
         // { "errorf",                           "-",     "-",       "",         "",     EShLangAll }, TODO: varargs
         { "EvaluateAttributeAtCentroid",      nullptr, nullptr,   "SVM",        "F",      EShLangFragmentMask },
         { "EvaluateAttributeAtSample",        nullptr, nullptr,   "SVM,S",      "F,U",    EShLangFragmentMask },
@@ -324,6 +324,7 @@ void TBuiltInParseablesHlsl::initialize(int version, EProfile profile, int spv, 
         { "min",                              nullptr, nullptr,   "SVM,",       "FI,",    EShLangAll },
         { "modf",                             nullptr, nullptr,   "SVM,>",      "FI,",    EShLangAll },
         { "msad4",                            "V4",    "U",       "S,V2,V4",    "U,,",    EShLangAll },
+        // TODO: fix matrix return size for non-square mats used with mul opcode
         { "mul",                              "S",     nullptr,   "S,S",        "FI,",    EShLangAll },
         { "mul",                              "V",     nullptr,   "S,V",        "FI,",    EShLangAll },
         { "mul",                              "M",     nullptr,   "S,M",        "FI,",    EShLangAll },
@@ -508,7 +509,7 @@ void TBuiltInParseablesHlsl::initialize(const TBuiltInResource &resources, int v
 void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, int spv, int vulkan, EShLanguage language,
                                               TSymbolTable& symbolTable)
 {
-    // symbolTable.relateToOperator("abort");
+    // symbolTable.relateToOperator("abort",                       EOpAbort);
     symbolTable.relateToOperator("abs",                         EOpAbs);
     symbolTable.relateToOperator("acos",                        EOpAcos);
     symbolTable.relateToOperator("all",                         EOpAll);
@@ -525,12 +526,12 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, int
     symbolTable.relateToOperator("ceil",                        EOpCeil);
     // symbolTable.relateToOperator("CheckAccessFullyMapped");
     symbolTable.relateToOperator("clamp",                       EOpClamp);
-    // symbolTable.relateToOperator("clip");
+    symbolTable.relateToOperator("clip",                        EOpClip);
     symbolTable.relateToOperator("cos",                         EOpCos);
     symbolTable.relateToOperator("cosh",                        EOpCosh);
     symbolTable.relateToOperator("countbits",                   EOpBitCount);
     symbolTable.relateToOperator("cross",                       EOpCross);
-    // symbolTable.relateToOperator("D3DCOLORtoUBYTE4");
+    // symbolTable.relateToOperator("D3DCOLORtoUBYTE4",            EOpD3DCOLORtoUBYTE4);
     symbolTable.relateToOperator("ddx",                         EOpDPdx);
     symbolTable.relateToOperator("ddx_coarse",                  EOpDPdxCoarse);
     symbolTable.relateToOperator("ddx_fine",                    EOpDPdxFine);
@@ -543,7 +544,7 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, int
     // symbolTable.relateToOperator("DeviceMemoryBarrierWithGroupSync");
     symbolTable.relateToOperator("distance",                    EOpDistance);
     symbolTable.relateToOperator("dot",                         EOpDot);
-    // symbolTable.relateToOperator("dst");
+    symbolTable.relateToOperator("dst",                         EOpDst);
     // symbolTable.relateToOperator("errorf");
     symbolTable.relateToOperator("EvaluateAttributeAtCentroid", EOpInterpolateAtCentroid);
     symbolTable.relateToOperator("EvaluateAttributeAtSample",   EOpInterpolateAtSample);
@@ -557,7 +558,7 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, int
     symbolTable.relateToOperator("firstbitlow",                 EOpFindLSB);
     symbolTable.relateToOperator("floor",                       EOpFloor);
     symbolTable.relateToOperator("fma",                         EOpFma);
-    // symbolTable.relateToOperator("fmod");
+    symbolTable.relateToOperator("fmod",                        EOpMod);
     symbolTable.relateToOperator("frac",                        EOpFract);
     symbolTable.relateToOperator("frexp",                       EOpFrexp);
     symbolTable.relateToOperator("fwidth",                      EOpFwidth);
@@ -574,21 +575,21 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, int
     // symbolTable.relateToOperator("InterlockedMin");
     // symbolTable.relateToOperator("InterlockedOr");
     // symbolTable.relateToOperator("InterlockedXor");
-    // symbolTable.relateToOperator("isfinite");
+    symbolTable.relateToOperator("isfinite",                    EOpIsFinite);
     symbolTable.relateToOperator("isinf",                       EOpIsInf);
     symbolTable.relateToOperator("isnan",                       EOpIsNan);
     symbolTable.relateToOperator("ldexp",                       EOpLdexp);
     symbolTable.relateToOperator("length",                      EOpLength);
     // symbolTable.relateToOperator("lit");
     symbolTable.relateToOperator("log",                         EOpLog);
-    // symbolTable.relateToOperator("log10");
+    symbolTable.relateToOperator("log10",                       EOpLog10);
     symbolTable.relateToOperator("log2",                        EOpLog2);
     // symbolTable.relateToOperator("mad");
     symbolTable.relateToOperator("max",                         EOpMax);
     symbolTable.relateToOperator("min",                         EOpMin);
     symbolTable.relateToOperator("modf",                        EOpModf);
-    // symbolTable.relateToOperator("msad4");
-    // symbolTable.relateToOperator("mul");
+    // symbolTable.relateToOperator("msad4",                       EOpMsad4);
+    symbolTable.relateToOperator("mul",                         EOpGenMul);
     // symbolTable.relateToOperator("noise",                    EOpNoise); // TODO: check return type
     symbolTable.relateToOperator("normalize",                   EOpNormalize);
     symbolTable.relateToOperator("pow",                         EOpPow);
@@ -604,16 +605,16 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, int
     // symbolTable.relateToOperator("ProcessTriTessFactorsMax");
     // symbolTable.relateToOperator("ProcessTriTessFactorsMin");
     symbolTable.relateToOperator("radians",                     EOpRadians);
-    // symbolTable.relateToOperator("rcp");
+    symbolTable.relateToOperator("rcp",                         EOpRcp);
     symbolTable.relateToOperator("reflect",                     EOpReflect);
     symbolTable.relateToOperator("refract",                     EOpRefract);
     symbolTable.relateToOperator("reversebits",                 EOpBitFieldReverse);
     symbolTable.relateToOperator("round",                       EOpRoundEven);
     symbolTable.relateToOperator("rsqrt",                       EOpInverseSqrt);
-    // symbolTable.relateToOperator("saturate"); 
+    symbolTable.relateToOperator("saturate",                    EOpSaturate);
     symbolTable.relateToOperator("sign",                        EOpSign);
     symbolTable.relateToOperator("sin",                         EOpSin);
-    // symbolTable.relateToOperator("sincos");
+    symbolTable.relateToOperator("sincos",                      EOpSinCos);
     symbolTable.relateToOperator("sinh",                        EOpSinh);
     symbolTable.relateToOperator("smoothstep",                  EOpSmoothStep);
     symbolTable.relateToOperator("sqrt",                        EOpSqrt);


### PR DESCRIPTION
Connect some new HLSL intrinsics which require simple decompositions:

clip
dst
isfinite
log10
mul (generic mat/vec/scalar forms)
rcp
saturate
sincos

This PR adds decomposeIntrinsic(), which is either (A) a no-op to pass intrinsics through unmodified to AST opcodes for downstream native handling, or (B) a set of simple decompositions to current AST opcodes, for compatibility with existing downstream code. Only (B) is currently implemented.

* mul is turned into one of the MatrixTimesMatrix, MatrixTimesVector, MatrixTimesScalar, VectorTimesMatrix, VectorTimesScalar, Dot, or Mul opcodes. This is only available with square matrices presently.

* clip is turned into either a test for <0 and branch with pixel kill, or a component-wise test with any() followed by same. The HLSL docs don't specify the behavior on vectors, but experiments with FXC showed any() is what happens.

* log10 is turned into a log2 + a multiply to achieve base 10 log.

* sincos is turned into a separate sin and cos which assign to the output parameters.

* saturate is turned into a clamp to 0,1.

* rcp is turned into a divide.

* isfinite is passed through to an existing SPIR-V opcode via a new AST opcode.

* dst is turned into a construction of components from each input, per HLSL docs.
