### PR TITLE
Compilation fix (mingw64)

### DIFF
--- a/glslang/OSDependent/Windows/ossource.cpp
+++ b/glslang/OSDependent/Windows/ossource.cpp
@@ -134,7 +134,7 @@ unsigned int __stdcall EnterGenericThread (void* entry)
 
 void* OS_CreateThread(TThreadEntrypoint entry)
 {
-    return (void*)_beginthreadex(0, 0, EnterGenericThread, entry, 0, 0);
+    return (void*)_beginthreadex(0, 0, EnterGenericThread, (void*)entry, 0, 0);
 }
 
 void OS_WaitForAllThreads(void* threads, int numThreads)


### PR DESCRIPTION
AFAIK, `entry` cannot be implicitly converted to `void*`. This fails to compile with clang-3.8.