### PR TITLE
HLSL: Add lerp, fix sincos ret, add ret type tests, non-square mats, tx semantics

### DIFF
--- a/Test/baseResults/hlsl.intrinsics.frag.out
+++ b/Test/baseResults/hlsl.intrinsics.frag.out
@@ -2,7 +2,7 @@ hlsl.intrinsics.frag
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:87  Function Definition: PixelShaderFunction(f1;f1;f1;u1;u1; (temp float)
+0:88  Function Definition: PixelShaderFunction(f1;f1;f1;u1;u1; (temp float)
 0:17    Function Parameters: 
 0:17      'inF0' (in float)
 0:17      'inF1' (in float)
@@ -10,33 +10,57 @@ gl_FragCoord origin is upper left
 0:17      'inU0' (in uint)
 0:17      'inU1' (in uint)
 0:?     Sequence
-0:20      all (global bool)
-0:20        'inF0' (in float)
-0:21      Absolute value (global float)
-0:21        'inF0' (in float)
-0:22      arc cosine (global float)
-0:22        'inF0' (in float)
-0:23      any (global bool)
-0:23        'inF0' (in float)
-0:24      arc sine (global float)
-0:24        'inF0' (in float)
-0:25      floatBitsToInt (global int)
-0:25        'inF0' (in float)
-0:26      floatBitsToUint (global uint)
-0:26        'inF0' (in float)
-0:27      intBitsToFloat (global float)
-0:27        'inU0' (in uint)
-0:29      arc tangent (global float)
-0:29        'inF0' (in float)
-0:30      arc tangent (global float)
-0:30        'inF0' (in float)
-0:30        'inF1' (in float)
-0:31      Ceiling (global float)
-0:31        'inF0' (in float)
-0:32      clamp (global float)
-0:32        'inF0' (in float)
-0:32        'inF1' (in float)
-0:32        'inF2' (in float)
+0:20      move second child to first child (temp bool)
+0:20        'r000' (temp bool)
+0:20        all (global bool)
+0:20          'inF0' (in float)
+0:21      move second child to first child (temp float)
+0:21        'r001' (temp float)
+0:21        Absolute value (global float)
+0:21          'inF0' (in float)
+0:22      move second child to first child (temp float)
+0:22        'r002' (temp float)
+0:22        arc cosine (global float)
+0:22          'inF0' (in float)
+0:23      move second child to first child (temp bool)
+0:23        'r003' (temp bool)
+0:23        any (global bool)
+0:23          'inF0' (in float)
+0:24      move second child to first child (temp float)
+0:24        'r004' (temp float)
+0:24        arc sine (global float)
+0:24          'inF0' (in float)
+0:25      move second child to first child (temp int)
+0:25        'r005' (temp int)
+0:25        floatBitsToInt (global int)
+0:25          'inF0' (in float)
+0:26      move second child to first child (temp uint)
+0:26        'r006' (temp uint)
+0:26        floatBitsToUint (global uint)
+0:26          'inF0' (in float)
+0:27      move second child to first child (temp float)
+0:27        'r007' (temp float)
+0:27        intBitsToFloat (global float)
+0:27          'inU0' (in uint)
+0:29      move second child to first child (temp float)
+0:29        'r009' (temp float)
+0:29        arc tangent (global float)
+0:29          'inF0' (in float)
+0:30      move second child to first child (temp float)
+0:30        'r010' (temp float)
+0:30        arc tangent (global float)
+0:30          'inF0' (in float)
+0:30          'inF1' (in float)
+0:31      move second child to first child (temp float)
+0:31        'r011' (temp float)
+0:31        Ceiling (global float)
+0:31          'inF0' (in float)
+0:32      move second child to first child (temp float)
+0:32        'r012' (temp float)
+0:32        clamp (global float)
+0:32          'inF0' (in float)
+0:32          'inF1' (in float)
+0:32          'inF2' (in float)
 0:33      Test condition and select (temp void)
 0:33        Condition
 0:33        Compare Less Than (temp bool)
@@ -45,1044 +69,1724 @@ gl_FragCoord origin is upper left
 0:33            0.000000
 0:33        true case
 0:33        Branch: Kill
-0:34      cosine (global float)
-0:34        'inF0' (in float)
-0:35      hyp. cosine (global float)
-0:35        'inF0' (in float)
-0:36      bitCount (global uint)
-0:36        Constant:
-0:36          7 (const uint)
-0:37      dPdx (global float)
-0:37        'inF0' (in float)
-0:38      dPdxCoarse (global float)
-0:38        'inF0' (in float)
-0:39      dPdxFine (global float)
-0:39        'inF0' (in float)
-0:40      dPdy (global float)
-0:40        'inF0' (in float)
-0:41      dPdyCoarse (global float)
-0:41        'inF0' (in float)
-0:42      dPdyFine (global float)
-0:42        'inF0' (in float)
-0:43      degrees (global float)
-0:43        'inF0' (in float)
-0:47      exp (global float)
-0:47        'inF0' (in float)
-0:48      exp2 (global float)
-0:48        'inF0' (in float)
-0:49      findMSB (global int)
-0:49        Constant:
-0:49          7 (const int)
-0:50      findLSB (global int)
-0:50        Constant:
-0:50          7 (const int)
-0:51      Floor (global float)
-0:51        'inF0' (in float)
-0:53      mod (global float)
-0:53        'inF0' (in float)
-0:53        'inF1' (in float)
-0:54      Fraction (global float)
-0:54        'inF0' (in float)
-0:55      frexp (global float)
-0:55        'inF0' (in float)
-0:55        'inF1' (in float)
-0:56      fwidth (global float)
-0:56        'inF0' (in float)
-0:57      isinf (global bool)
-0:57        'inF0' (in float)
-0:58      isnan (global bool)
-0:58        'inF0' (in float)
-0:59      ldexp (global float)
-0:59        'inF0' (in float)
-0:59        'inF1' (in float)
-0:60      log (global float)
-0:60        'inF0' (in float)
-0:61      component-wise multiply (temp float)
-0:61        log2 (temp float)
+0:34      move second child to first child (temp float)
+0:34        'r014' (temp float)
+0:34        cosine (global float)
+0:34          'inF0' (in float)
+0:35      move second child to first child (temp float)
+0:35        'r015' (temp float)
+0:35        hyp. cosine (global float)
+0:35          'inF0' (in float)
+0:36      move second child to first child (temp uint)
+0:36        'r016' (temp uint)
+0:36        bitCount (global uint)
+0:36          Constant:
+0:36            7 (const uint)
+0:37      move second child to first child (temp float)
+0:37        'r017' (temp float)
+0:37        dPdx (global float)
+0:37          'inF0' (in float)
+0:38      move second child to first child (temp float)
+0:38        'r018' (temp float)
+0:38        dPdxCoarse (global float)
+0:38          'inF0' (in float)
+0:39      move second child to first child (temp float)
+0:39        'r019' (temp float)
+0:39        dPdxFine (global float)
+0:39          'inF0' (in float)
+0:40      move second child to first child (temp float)
+0:40        'r020' (temp float)
+0:40        dPdy (global float)
+0:40          'inF0' (in float)
+0:41      move second child to first child (temp float)
+0:41        'r021' (temp float)
+0:41        dPdyCoarse (global float)
+0:41          'inF0' (in float)
+0:42      move second child to first child (temp float)
+0:42        'r022' (temp float)
+0:42        dPdyFine (global float)
+0:42          'inF0' (in float)
+0:43      move second child to first child (temp float)
+0:43        'r023' (temp float)
+0:43        degrees (global float)
+0:43          'inF0' (in float)
+0:47      move second child to first child (temp float)
+0:47        'r027' (temp float)
+0:47        exp (global float)
+0:47          'inF0' (in float)
+0:48      move second child to first child (temp float)
+0:48        'r028' (temp float)
+0:48        exp2 (global float)
+0:48          'inF0' (in float)
+0:49      move second child to first child (temp uint)
+0:49        'r029' (temp uint)
+0:49        Convert int to uint (temp uint)
+0:49          findMSB (global int)
+0:49            Constant:
+0:49              7 (const int)
+0:50      move second child to first child (temp uint)
+0:50        'r030' (temp uint)
+0:50        Convert int to uint (temp uint)
+0:50          findLSB (global int)
+0:50            Constant:
+0:50              7 (const int)
+0:51      move second child to first child (temp float)
+0:51        'r031' (temp float)
+0:51        Floor (global float)
+0:51          'inF0' (in float)
+0:53      move second child to first child (temp float)
+0:53        'r033' (temp float)
+0:53        mod (global float)
+0:53          'inF0' (in float)
+0:53          'inF1' (in float)
+0:54      move second child to first child (temp float)
+0:54        'r034' (temp float)
+0:54        Fraction (global float)
+0:54          'inF0' (in float)
+0:55      move second child to first child (temp float)
+0:55        'r035' (temp float)
+0:55        frexp (global float)
+0:55          'inF0' (in float)
+0:55          'inF1' (in float)
+0:56      move second child to first child (temp float)
+0:56        'r036' (temp float)
+0:56        fwidth (global float)
+0:56          'inF0' (in float)
+0:57      move second child to first child (temp bool)
+0:57        'r037' (temp bool)
+0:57        isinf (global bool)
+0:57          'inF0' (in float)
+0:58      move second child to first child (temp bool)
+0:58        'r038' (temp bool)
+0:58        isnan (global bool)
+0:58          'inF0' (in float)
+0:59      move second child to first child (temp float)
+0:59        'r039' (temp float)
+0:59        ldexp (global float)
+0:59          'inF0' (in float)
+0:59          'inF1' (in float)
+0:60      move second child to first child (temp float)
+0:60        'r039a' (temp float)
+0:60        mix (global float)
+0:60          'inF0' (in float)
+0:60          'inF1' (in float)
+0:60          'inF2' (in float)
+0:61      move second child to first child (temp float)
+0:61        'r040' (temp float)
+0:61        log (global float)
 0:61          'inF0' (in float)
-0:61        Constant:
-0:61          0.301030
-0:62      log2 (global float)
-0:62        'inF0' (in float)
-0:63      max (global float)
-0:63        'inF0' (in float)
-0:63        'inF1' (in float)
-0:64      min (global float)
-0:64        'inF0' (in float)
-0:64        'inF1' (in float)
-0:65      pow (global float)
-0:65        'inF0' (in float)
-0:65        'inF1' (in float)
-0:66      radians (global float)
-0:66        'inF0' (in float)
-0:67      divide (temp float)
-0:67        Constant:
-0:67          1.000000
-0:67        'inF0' (in float)
-0:68      bitFieldReverse (global uint)
-0:68        Constant:
-0:68          2 (const uint)
-0:69      roundEven (global float)
-0:69        'inF0' (in float)
-0:70      inverse sqrt (global float)
-0:70        'inF0' (in float)
-0:71      clamp (temp float)
-0:71        'inF0' (in float)
-0:71        Constant:
-0:71          0.000000
-0:71        Constant:
-0:71          1.000000
-0:72      Sign (global float)
-0:72        'inF0' (in float)
-0:73      sine (global float)
-0:73        'inF0' (in float)
-0:74      Sequence
-0:74        move second child to first child (temp float)
-0:74          'inF1' (in float)
-0:74          sine (temp float)
-0:74            'inF0' (in float)
-0:74        move second child to first child (temp float)
-0:74          'inF2' (in float)
-0:74          cosine (temp float)
-0:74            'inF0' (in float)
-0:75      hyp. sine (global float)
-0:75        'inF0' (in float)
-0:76      smoothstep (global float)
-0:76        'inF0' (in float)
-0:76        'inF1' (in float)
-0:76        'inF2' (in float)
-0:77      sqrt (global float)
-0:77        'inF0' (in float)
-0:78      step (global float)
-0:78        'inF0' (in float)
-0:78        'inF1' (in float)
-0:79      tangent (global float)
-0:79        'inF0' (in float)
-0:80      hyp. tangent (global float)
-0:80        'inF0' (in float)
-0:82      trunc (global float)
-0:82        'inF0' (in float)
-0:84      Branch: Return with expression
-0:84        Constant:
-0:84          0.000000
-0:93  Function Definition: PixelShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
-0:88    Function Parameters: 
-0:88      'inF0' (in 1-component vector of float)
-0:88      'inF1' (in 1-component vector of float)
-0:88      'inF2' (in 1-component vector of float)
+0:62      move second child to first child (temp float)
+0:62        'r041' (temp float)
+0:62        component-wise multiply (temp float)
+0:62          log2 (temp float)
+0:62            'inF0' (in float)
+0:62          Constant:
+0:62            0.301030
+0:63      move second child to first child (temp float)
+0:63        'r042' (temp float)
+0:63        log2 (global float)
+0:63          'inF0' (in float)
+0:64      move second child to first child (temp float)
+0:64        'r043' (temp float)
+0:64        max (global float)
+0:64          'inF0' (in float)
+0:64          'inF1' (in float)
+0:65      move second child to first child (temp float)
+0:65        'r044' (temp float)
+0:65        min (global float)
+0:65          'inF0' (in float)
+0:65          'inF1' (in float)
+0:66      move second child to first child (temp float)
+0:66        'r045' (temp float)
+0:66        pow (global float)
+0:66          'inF0' (in float)
+0:66          'inF1' (in float)
+0:67      move second child to first child (temp float)
+0:67        'r046' (temp float)
+0:67        radians (global float)
+0:67          'inF0' (in float)
+0:68      move second child to first child (temp float)
+0:68        'r047' (temp float)
+0:68        divide (temp float)
+0:68          Constant:
+0:68            1.000000
+0:68          'inF0' (in float)
+0:69      move second child to first child (temp uint)
+0:69        'r048' (temp uint)
+0:69        bitFieldReverse (global uint)
+0:69          Constant:
+0:69            2 (const uint)
+0:70      move second child to first child (temp float)
+0:70        'r049' (temp float)
+0:70        roundEven (global float)
+0:70          'inF0' (in float)
+0:71      move second child to first child (temp float)
+0:71        'r050' (temp float)
+0:71        inverse sqrt (global float)
+0:71          'inF0' (in float)
+0:72      move second child to first child (temp float)
+0:72        'r051' (temp float)
+0:72        clamp (temp float)
+0:72          'inF0' (in float)
+0:72          Constant:
+0:72            0.000000
+0:72          Constant:
+0:72            1.000000
+0:73      move second child to first child (temp float)
+0:73        'r052' (temp float)
+0:73        Sign (global float)
+0:73          'inF0' (in float)
+0:74      move second child to first child (temp float)
+0:74        'r053' (temp float)
+0:74        sine (global float)
+0:74          'inF0' (in float)
+0:75      Sequence
+0:75        move second child to first child (temp float)
+0:75          'inF1' (in float)
+0:75          sine (temp float)
+0:75            'inF0' (in float)
+0:75        move second child to first child (temp float)
+0:75          'inF2' (in float)
+0:75          cosine (temp float)
+0:75            'inF0' (in float)
+0:76      move second child to first child (temp float)
+0:76        'r055' (temp float)
+0:76        hyp. sine (global float)
+0:76          'inF0' (in float)
+0:77      move second child to first child (temp float)
+0:77        'r056' (temp float)
+0:77        smoothstep (global float)
+0:77          'inF0' (in float)
+0:77          'inF1' (in float)
+0:77          'inF2' (in float)
+0:78      move second child to first child (temp float)
+0:78        'r057' (temp float)
+0:78        sqrt (global float)
+0:78          'inF0' (in float)
+0:79      move second child to first child (temp float)
+0:79        'r058' (temp float)
+0:79        step (global float)
+0:79          'inF0' (in float)
+0:79          'inF1' (in float)
+0:80      move second child to first child (temp float)
+0:80        'r059' (temp float)
+0:80        tangent (global float)
+0:80          'inF0' (in float)
+0:81      move second child to first child (temp float)
+0:81        'r060' (temp float)
+0:81        hyp. tangent (global float)
+0:81          'inF0' (in float)
+0:83      move second child to first child (temp float)
+0:83        'r061' (temp float)
+0:83        trunc (global float)
+0:83          'inF0' (in float)
+0:85      Branch: Return with expression
+0:85        Constant:
+0:85          0.000000
+0:94  Function Definition: PixelShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
+0:89    Function Parameters: 
+0:89      'inF0' (in 1-component vector of float)
+0:89      'inF1' (in 1-component vector of float)
+0:89      'inF2' (in 1-component vector of float)
 0:?     Sequence
-0:90      Branch: Return with expression
-0:90        Constant:
-0:90          0.000000
-0:172  Function Definition: PixelShaderFunction(vf2;vf2;vf2;vu2;vu2; (temp 2-component vector of float)
-0:94    Function Parameters: 
-0:94      'inF0' (in 2-component vector of float)
-0:94      'inF1' (in 2-component vector of float)
-0:94      'inF2' (in 2-component vector of float)
-0:94      'inU0' (in 2-component vector of uint)
-0:94      'inU1' (in 2-component vector of uint)
+0:91      Branch: Return with expression
+0:91        Constant:
+0:91          0.000000
+0:177  Function Definition: PixelShaderFunction(vf2;vf2;vf2;vu2;vu2; (temp 2-component vector of float)
+0:95    Function Parameters: 
+0:95      'inF0' (in 2-component vector of float)
+0:95      'inF1' (in 2-component vector of float)
+0:95      'inF2' (in 2-component vector of float)
+0:95      'inU0' (in 2-component vector of uint)
+0:95      'inU1' (in 2-component vector of uint)
 0:?     Sequence
-0:97      all (global bool)
-0:97        'inF0' (in 2-component vector of float)
-0:98      Absolute value (global 2-component vector of float)
-0:98        'inF0' (in 2-component vector of float)
-0:99      arc cosine (global 2-component vector of float)
-0:99        'inF0' (in 2-component vector of float)
-0:100      any (global bool)
-0:100        'inF0' (in 2-component vector of float)
-0:101      arc sine (global 2-component vector of float)
-0:101        'inF0' (in 2-component vector of float)
-0:102      floatBitsToInt (global 2-component vector of int)
-0:102        'inF0' (in 2-component vector of float)
-0:103      floatBitsToUint (global 2-component vector of uint)
-0:103        'inF0' (in 2-component vector of float)
-0:104      intBitsToFloat (global 2-component vector of float)
-0:104        'inU0' (in 2-component vector of uint)
-0:106      arc tangent (global 2-component vector of float)
-0:106        'inF0' (in 2-component vector of float)
-0:107      arc tangent (global 2-component vector of float)
-0:107        'inF0' (in 2-component vector of float)
-0:107        'inF1' (in 2-component vector of float)
-0:108      Ceiling (global 2-component vector of float)
-0:108        'inF0' (in 2-component vector of float)
-0:109      clamp (global 2-component vector of float)
-0:109        'inF0' (in 2-component vector of float)
-0:109        'inF1' (in 2-component vector of float)
-0:109        'inF2' (in 2-component vector of float)
-0:110      Test condition and select (temp void)
-0:110        Condition
-0:110        any (temp bool)
-0:110          Compare Less Than (temp 2-component vector of bool)
-0:110            'inF0' (in 2-component vector of float)
-0:110            Constant:
-0:110              0.000000
-0:110              0.000000
-0:110        true case
-0:110        Branch: Kill
-0:111      cosine (global 2-component vector of float)
-0:111        'inF0' (in 2-component vector of float)
-0:112      hyp. cosine (global 2-component vector of float)
-0:112        'inF0' (in 2-component vector of float)
-0:?       bitCount (global 2-component vector of uint)
-0:?         Constant:
-0:?           7 (const uint)
-0:?           3 (const uint)
-0:114      dPdx (global 2-component vector of float)
-0:114        'inF0' (in 2-component vector of float)
-0:115      dPdxCoarse (global 2-component vector of float)
-0:115        'inF0' (in 2-component vector of float)
-0:116      dPdxFine (global 2-component vector of float)
-0:116        'inF0' (in 2-component vector of float)
-0:117      dPdy (global 2-component vector of float)
-0:117        'inF0' (in 2-component vector of float)
-0:118      dPdyCoarse (global 2-component vector of float)
-0:118        'inF0' (in 2-component vector of float)
-0:119      dPdyFine (global 2-component vector of float)
-0:119        'inF0' (in 2-component vector of float)
-0:120      degrees (global 2-component vector of float)
-0:120        'inF0' (in 2-component vector of float)
-0:121      distance (global float)
-0:121        'inF0' (in 2-component vector of float)
-0:121        'inF1' (in 2-component vector of float)
-0:122      dot-product (global float)
-0:122        'inF0' (in 2-component vector of float)
-0:122        'inF1' (in 2-component vector of float)
-0:126      exp (global 2-component vector of float)
-0:126        'inF0' (in 2-component vector of float)
-0:127      exp2 (global 2-component vector of float)
-0:127        'inF0' (in 2-component vector of float)
-0:128      face-forward (global 2-component vector of float)
-0:128        'inF0' (in 2-component vector of float)
-0:128        'inF1' (in 2-component vector of float)
-0:128        'inF2' (in 2-component vector of float)
-0:129      findMSB (global int)
-0:129        Constant:
-0:129          7 (const int)
-0:130      findLSB (global int)
-0:130        Constant:
-0:130          7 (const int)
-0:131      Floor (global 2-component vector of float)
-0:131        'inF0' (in 2-component vector of float)
-0:133      mod (global 2-component vector of float)
-0:133        'inF0' (in 2-component vector of float)
-0:133        'inF1' (in 2-component vector of float)
-0:134      Fraction (global 2-component vector of float)
-0:134        'inF0' (in 2-component vector of float)
-0:135      frexp (global 2-component vector of float)
-0:135        'inF0' (in 2-component vector of float)
-0:135        'inF1' (in 2-component vector of float)
-0:136      fwidth (global 2-component vector of float)
-0:136        'inF0' (in 2-component vector of float)
-0:137      isinf (global 2-component vector of bool)
-0:137        'inF0' (in 2-component vector of float)
-0:138      isnan (global 2-component vector of bool)
-0:138        'inF0' (in 2-component vector of float)
-0:139      ldexp (global 2-component vector of float)
-0:139        'inF0' (in 2-component vector of float)
-0:139        'inF1' (in 2-component vector of float)
-0:140      length (global float)
-0:140        'inF0' (in 2-component vector of float)
-0:141      log (global 2-component vector of float)
-0:141        'inF0' (in 2-component vector of float)
-0:142      vector-scale (temp 2-component vector of float)
-0:142        log2 (temp 2-component vector of float)
+0:98      move second child to first child (temp bool)
+0:98        'r000' (temp bool)
+0:98        all (global bool)
+0:98          'inF0' (in 2-component vector of float)
+0:99      move second child to first child (temp 2-component vector of float)
+0:99        'r001' (temp 2-component vector of float)
+0:99        Absolute value (global 2-component vector of float)
+0:99          'inF0' (in 2-component vector of float)
+0:100      move second child to first child (temp 2-component vector of float)
+0:100        'r002' (temp 2-component vector of float)
+0:100        arc cosine (global 2-component vector of float)
+0:100          'inF0' (in 2-component vector of float)
+0:101      move second child to first child (temp bool)
+0:101        'r003' (temp bool)
+0:101        any (global bool)
+0:101          'inF0' (in 2-component vector of float)
+0:102      move second child to first child (temp 2-component vector of float)
+0:102        'r004' (temp 2-component vector of float)
+0:102        arc sine (global 2-component vector of float)
+0:102          'inF0' (in 2-component vector of float)
+0:103      move second child to first child (temp 2-component vector of int)
+0:103        'r005' (temp 2-component vector of int)
+0:103        floatBitsToInt (global 2-component vector of int)
+0:103          'inF0' (in 2-component vector of float)
+0:104      move second child to first child (temp 2-component vector of uint)
+0:104        'r006' (temp 2-component vector of uint)
+0:104        floatBitsToUint (global 2-component vector of uint)
+0:104          'inF0' (in 2-component vector of float)
+0:105      move second child to first child (temp 2-component vector of float)
+0:105        'r007' (temp 2-component vector of float)
+0:105        intBitsToFloat (global 2-component vector of float)
+0:105          'inU0' (in 2-component vector of uint)
+0:107      move second child to first child (temp 2-component vector of float)
+0:107        'r009' (temp 2-component vector of float)
+0:107        arc tangent (global 2-component vector of float)
+0:107          'inF0' (in 2-component vector of float)
+0:108      move second child to first child (temp 2-component vector of float)
+0:108        'r010' (temp 2-component vector of float)
+0:108        arc tangent (global 2-component vector of float)
+0:108          'inF0' (in 2-component vector of float)
+0:108          'inF1' (in 2-component vector of float)
+0:109      move second child to first child (temp 2-component vector of float)
+0:109        'r011' (temp 2-component vector of float)
+0:109        Ceiling (global 2-component vector of float)
+0:109          'inF0' (in 2-component vector of float)
+0:110      move second child to first child (temp 2-component vector of float)
+0:110        'r012' (temp 2-component vector of float)
+0:110        clamp (global 2-component vector of float)
+0:110          'inF0' (in 2-component vector of float)
+0:110          'inF1' (in 2-component vector of float)
+0:110          'inF2' (in 2-component vector of float)
+0:111      Test condition and select (temp void)
+0:111        Condition
+0:111        any (temp bool)
+0:111          Compare Less Than (temp 2-component vector of bool)
+0:111            'inF0' (in 2-component vector of float)
+0:111            Constant:
+0:111              0.000000
+0:111              0.000000
+0:111        true case
+0:111        Branch: Kill
+0:112      move second child to first child (temp 2-component vector of float)
+0:112        'r013' (temp 2-component vector of float)
+0:112        cosine (global 2-component vector of float)
+0:112          'inF0' (in 2-component vector of float)
+0:113      move second child to first child (temp 2-component vector of float)
+0:113        'r015' (temp 2-component vector of float)
+0:113        hyp. cosine (global 2-component vector of float)
+0:113          'inF0' (in 2-component vector of float)
+0:114      move second child to first child (temp 2-component vector of uint)
+0:114        'r016' (temp 2-component vector of uint)
+0:?         bitCount (global 2-component vector of uint)
+0:?           Constant:
+0:?             7 (const uint)
+0:?             3 (const uint)
+0:115      move second child to first child (temp 2-component vector of float)
+0:115        'r017' (temp 2-component vector of float)
+0:115        dPdx (global 2-component vector of float)
+0:115          'inF0' (in 2-component vector of float)
+0:116      move second child to first child (temp 2-component vector of float)
+0:116        'r018' (temp 2-component vector of float)
+0:116        dPdxCoarse (global 2-component vector of float)
+0:116          'inF0' (in 2-component vector of float)
+0:117      move second child to first child (temp 2-component vector of float)
+0:117        'r019' (temp 2-component vector of float)
+0:117        dPdxFine (global 2-component vector of float)
+0:117          'inF0' (in 2-component vector of float)
+0:118      move second child to first child (temp 2-component vector of float)
+0:118        'r020' (temp 2-component vector of float)
+0:118        dPdy (global 2-component vector of float)
+0:118          'inF0' (in 2-component vector of float)
+0:119      move second child to first child (temp 2-component vector of float)
+0:119        'r021' (temp 2-component vector of float)
+0:119        dPdyCoarse (global 2-component vector of float)
+0:119          'inF0' (in 2-component vector of float)
+0:120      move second child to first child (temp 2-component vector of float)
+0:120        'r022' (temp 2-component vector of float)
+0:120        dPdyFine (global 2-component vector of float)
+0:120          'inF0' (in 2-component vector of float)
+0:121      move second child to first child (temp 2-component vector of float)
+0:121        'r023' (temp 2-component vector of float)
+0:121        degrees (global 2-component vector of float)
+0:121          'inF0' (in 2-component vector of float)
+0:125      move second child to first child (temp float)
+0:125        'r026' (temp float)
+0:125        distance (global float)
+0:125          'inF0' (in 2-component vector of float)
+0:125          'inF1' (in 2-component vector of float)
+0:126      move second child to first child (temp float)
+0:126        'r027' (temp float)
+0:126        dot-product (global float)
+0:126          'inF0' (in 2-component vector of float)
+0:126          'inF1' (in 2-component vector of float)
+0:130      move second child to first child (temp 2-component vector of float)
+0:130        'r028' (temp 2-component vector of float)
+0:130        exp (global 2-component vector of float)
+0:130          'inF0' (in 2-component vector of float)
+0:131      move second child to first child (temp 2-component vector of float)
+0:131        'r029' (temp 2-component vector of float)
+0:131        exp2 (global 2-component vector of float)
+0:131          'inF0' (in 2-component vector of float)
+0:132      move second child to first child (temp 2-component vector of float)
+0:132        'r030' (temp 2-component vector of float)
+0:132        face-forward (global 2-component vector of float)
+0:132          'inF0' (in 2-component vector of float)
+0:132          'inF1' (in 2-component vector of float)
+0:132          'inF2' (in 2-component vector of float)
+0:133      move second child to first child (temp 2-component vector of uint)
+0:133        'r031' (temp 2-component vector of uint)
+0:?         findMSB (global 2-component vector of uint)
+0:?           Constant:
+0:?             7 (const uint)
+0:?             8 (const uint)
+0:134      move second child to first child (temp 2-component vector of uint)
+0:134        'r032' (temp 2-component vector of uint)
+0:?         findLSB (global 2-component vector of uint)
+0:?           Constant:
+0:?             7 (const uint)
+0:?             8 (const uint)
+0:135      move second child to first child (temp 2-component vector of float)
+0:135        'r033' (temp 2-component vector of float)
+0:135        Floor (global 2-component vector of float)
+0:135          'inF0' (in 2-component vector of float)
+0:137      move second child to first child (temp 2-component vector of float)
+0:137        'r035' (temp 2-component vector of float)
+0:137        mod (global 2-component vector of float)
+0:137          'inF0' (in 2-component vector of float)
+0:137          'inF1' (in 2-component vector of float)
+0:138      move second child to first child (temp 2-component vector of float)
+0:138        'r036' (temp 2-component vector of float)
+0:138        Fraction (global 2-component vector of float)
+0:138          'inF0' (in 2-component vector of float)
+0:139      move second child to first child (temp 2-component vector of float)
+0:139        'r037' (temp 2-component vector of float)
+0:139        frexp (global 2-component vector of float)
+0:139          'inF0' (in 2-component vector of float)
+0:139          'inF1' (in 2-component vector of float)
+0:140      move second child to first child (temp 2-component vector of float)
+0:140        'r038' (temp 2-component vector of float)
+0:140        fwidth (global 2-component vector of float)
+0:140          'inF0' (in 2-component vector of float)
+0:141      move second child to first child (temp 2-component vector of bool)
+0:141        'r039' (temp 2-component vector of bool)
+0:141        isinf (global 2-component vector of bool)
+0:141          'inF0' (in 2-component vector of float)
+0:142      move second child to first child (temp 2-component vector of bool)
+0:142        'r040' (temp 2-component vector of bool)
+0:142        isnan (global 2-component vector of bool)
 0:142          'inF0' (in 2-component vector of float)
-0:142        Constant:
-0:142          0.301030
-0:143      log2 (global 2-component vector of float)
-0:143        'inF0' (in 2-component vector of float)
-0:144      max (global 2-component vector of float)
-0:144        'inF0' (in 2-component vector of float)
-0:144        'inF1' (in 2-component vector of float)
-0:145      min (global 2-component vector of float)
-0:145        'inF0' (in 2-component vector of float)
-0:145        'inF1' (in 2-component vector of float)
-0:146      normalize (global 2-component vector of float)
-0:146        'inF0' (in 2-component vector of float)
-0:147      pow (global 2-component vector of float)
-0:147        'inF0' (in 2-component vector of float)
-0:147        'inF1' (in 2-component vector of float)
-0:148      radians (global 2-component vector of float)
-0:148        'inF0' (in 2-component vector of float)
-0:149      divide (temp 2-component vector of float)
-0:149        Constant:
-0:149          1.000000
-0:149        'inF0' (in 2-component vector of float)
-0:150      reflect (global 2-component vector of float)
-0:150        'inF0' (in 2-component vector of float)
-0:150        'inF1' (in 2-component vector of float)
-0:151      refract (global 2-component vector of float)
-0:151        'inF0' (in 2-component vector of float)
-0:151        'inF1' (in 2-component vector of float)
-0:151        Constant:
-0:151          2.000000
-0:?       bitFieldReverse (global 2-component vector of uint)
-0:?         Constant:
-0:?           1 (const uint)
-0:?           2 (const uint)
-0:153      roundEven (global 2-component vector of float)
-0:153        'inF0' (in 2-component vector of float)
-0:154      inverse sqrt (global 2-component vector of float)
-0:154        'inF0' (in 2-component vector of float)
-0:155      clamp (temp 2-component vector of float)
-0:155        'inF0' (in 2-component vector of float)
-0:155        Constant:
-0:155          0.000000
-0:155        Constant:
-0:155          1.000000
-0:156      Sign (global 2-component vector of float)
-0:156        'inF0' (in 2-component vector of float)
-0:157      sine (global 2-component vector of float)
-0:157        'inF0' (in 2-component vector of float)
-0:158      Sequence
-0:158        move second child to first child (temp 2-component vector of float)
-0:158          'inF1' (in 2-component vector of float)
-0:158          sine (temp 2-component vector of float)
-0:158            'inF0' (in 2-component vector of float)
-0:158        move second child to first child (temp 2-component vector of float)
-0:158          'inF2' (in 2-component vector of float)
-0:158          cosine (temp 2-component vector of float)
-0:158            'inF0' (in 2-component vector of float)
-0:159      hyp. sine (global 2-component vector of float)
-0:159        'inF0' (in 2-component vector of float)
-0:160      smoothstep (global 2-component vector of float)
-0:160        'inF0' (in 2-component vector of float)
-0:160        'inF1' (in 2-component vector of float)
-0:160        'inF2' (in 2-component vector of float)
-0:161      sqrt (global 2-component vector of float)
-0:161        'inF0' (in 2-component vector of float)
-0:162      step (global 2-component vector of float)
-0:162        'inF0' (in 2-component vector of float)
-0:162        'inF1' (in 2-component vector of float)
-0:163      tangent (global 2-component vector of float)
-0:163        'inF0' (in 2-component vector of float)
-0:164      hyp. tangent (global 2-component vector of float)
-0:164        'inF0' (in 2-component vector of float)
-0:166      trunc (global 2-component vector of float)
-0:166        'inF0' (in 2-component vector of float)
-0:169      Branch: Return with expression
+0:143      move second child to first child (temp 2-component vector of float)
+0:143        'r041' (temp 2-component vector of float)
+0:143        ldexp (global 2-component vector of float)
+0:143          'inF0' (in 2-component vector of float)
+0:143          'inF1' (in 2-component vector of float)
+0:144      move second child to first child (temp 2-component vector of float)
+0:144        'r039a' (temp 2-component vector of float)
+0:144        mix (global 2-component vector of float)
+0:144          'inF0' (in 2-component vector of float)
+0:144          'inF1' (in 2-component vector of float)
+0:144          'inF2' (in 2-component vector of float)
+0:145      move second child to first child (temp float)
+0:145        'r042' (temp float)
+0:145        length (global float)
+0:145          'inF0' (in 2-component vector of float)
+0:146      move second child to first child (temp 2-component vector of float)
+0:146        'r043' (temp 2-component vector of float)
+0:146        log (global 2-component vector of float)
+0:146          'inF0' (in 2-component vector of float)
+0:147      move second child to first child (temp 2-component vector of float)
+0:147        'r044' (temp 2-component vector of float)
+0:147        vector-scale (temp 2-component vector of float)
+0:147          log2 (temp 2-component vector of float)
+0:147            'inF0' (in 2-component vector of float)
+0:147          Constant:
+0:147            0.301030
+0:148      move second child to first child (temp 2-component vector of float)
+0:148        'r045' (temp 2-component vector of float)
+0:148        log2 (global 2-component vector of float)
+0:148          'inF0' (in 2-component vector of float)
+0:149      move second child to first child (temp 2-component vector of float)
+0:149        'r046' (temp 2-component vector of float)
+0:149        max (global 2-component vector of float)
+0:149          'inF0' (in 2-component vector of float)
+0:149          'inF1' (in 2-component vector of float)
+0:150      move second child to first child (temp 2-component vector of float)
+0:150        'r047' (temp 2-component vector of float)
+0:150        min (global 2-component vector of float)
+0:150          'inF0' (in 2-component vector of float)
+0:150          'inF1' (in 2-component vector of float)
+0:151      move second child to first child (temp 2-component vector of float)
+0:151        'r048' (temp 2-component vector of float)
+0:151        normalize (global 2-component vector of float)
+0:151          'inF0' (in 2-component vector of float)
+0:152      move second child to first child (temp 2-component vector of float)
+0:152        'r049' (temp 2-component vector of float)
+0:152        pow (global 2-component vector of float)
+0:152          'inF0' (in 2-component vector of float)
+0:152          'inF1' (in 2-component vector of float)
+0:153      move second child to first child (temp 2-component vector of float)
+0:153        'r050' (temp 2-component vector of float)
+0:153        radians (global 2-component vector of float)
+0:153          'inF0' (in 2-component vector of float)
+0:154      move second child to first child (temp 2-component vector of float)
+0:154        'r051' (temp 2-component vector of float)
+0:154        divide (temp 2-component vector of float)
+0:154          Constant:
+0:154            1.000000
+0:154          'inF0' (in 2-component vector of float)
+0:155      move second child to first child (temp 2-component vector of float)
+0:155        'r052' (temp 2-component vector of float)
+0:155        reflect (global 2-component vector of float)
+0:155          'inF0' (in 2-component vector of float)
+0:155          'inF1' (in 2-component vector of float)
+0:156      move second child to first child (temp 2-component vector of float)
+0:156        'r053' (temp 2-component vector of float)
+0:156        refract (global 2-component vector of float)
+0:156          'inF0' (in 2-component vector of float)
+0:156          'inF1' (in 2-component vector of float)
+0:156          Constant:
+0:156            2.000000
+0:157      move second child to first child (temp 2-component vector of uint)
+0:157        'r054' (temp 2-component vector of uint)
+0:?         bitFieldReverse (global 2-component vector of uint)
+0:?           Constant:
+0:?             1 (const uint)
+0:?             2 (const uint)
+0:158      move second child to first child (temp 2-component vector of float)
+0:158        'r055' (temp 2-component vector of float)
+0:158        roundEven (global 2-component vector of float)
+0:158          'inF0' (in 2-component vector of float)
+0:159      move second child to first child (temp 2-component vector of float)
+0:159        'r056' (temp 2-component vector of float)
+0:159        inverse sqrt (global 2-component vector of float)
+0:159          'inF0' (in 2-component vector of float)
+0:160      move second child to first child (temp 2-component vector of float)
+0:160        'r057' (temp 2-component vector of float)
+0:160        clamp (temp 2-component vector of float)
+0:160          'inF0' (in 2-component vector of float)
+0:160          Constant:
+0:160            0.000000
+0:160          Constant:
+0:160            1.000000
+0:161      move second child to first child (temp 2-component vector of float)
+0:161        'r058' (temp 2-component vector of float)
+0:161        Sign (global 2-component vector of float)
+0:161          'inF0' (in 2-component vector of float)
+0:162      move second child to first child (temp 2-component vector of float)
+0:162        'r059' (temp 2-component vector of float)
+0:162        sine (global 2-component vector of float)
+0:162          'inF0' (in 2-component vector of float)
+0:163      Sequence
+0:163        move second child to first child (temp 2-component vector of float)
+0:163          'inF1' (in 2-component vector of float)
+0:163          sine (temp 2-component vector of float)
+0:163            'inF0' (in 2-component vector of float)
+0:163        move second child to first child (temp 2-component vector of float)
+0:163          'inF2' (in 2-component vector of float)
+0:163          cosine (temp 2-component vector of float)
+0:163            'inF0' (in 2-component vector of float)
+0:164      move second child to first child (temp 2-component vector of float)
+0:164        'r060' (temp 2-component vector of float)
+0:164        hyp. sine (global 2-component vector of float)
+0:164          'inF0' (in 2-component vector of float)
+0:165      move second child to first child (temp 2-component vector of float)
+0:165        'r061' (temp 2-component vector of float)
+0:165        smoothstep (global 2-component vector of float)
+0:165          'inF0' (in 2-component vector of float)
+0:165          'inF1' (in 2-component vector of float)
+0:165          'inF2' (in 2-component vector of float)
+0:166      move second child to first child (temp 2-component vector of float)
+0:166        'r062' (temp 2-component vector of float)
+0:166        sqrt (global 2-component vector of float)
+0:166          'inF0' (in 2-component vector of float)
+0:167      move second child to first child (temp 2-component vector of float)
+0:167        'r063' (temp 2-component vector of float)
+0:167        step (global 2-component vector of float)
+0:167          'inF0' (in 2-component vector of float)
+0:167          'inF1' (in 2-component vector of float)
+0:168      move second child to first child (temp 2-component vector of float)
+0:168        'r064' (temp 2-component vector of float)
+0:168        tangent (global 2-component vector of float)
+0:168          'inF0' (in 2-component vector of float)
+0:169      move second child to first child (temp 2-component vector of float)
+0:169        'r065' (temp 2-component vector of float)
+0:169        hyp. tangent (global 2-component vector of float)
+0:169          'inF0' (in 2-component vector of float)
+0:171      move second child to first child (temp 2-component vector of float)
+0:171        'r066' (temp 2-component vector of float)
+0:171        trunc (global 2-component vector of float)
+0:171          'inF0' (in 2-component vector of float)
+0:174      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
-0:252  Function Definition: PixelShaderFunction(vf3;vf3;vf3;vu3;vu3; (temp 3-component vector of float)
-0:173    Function Parameters: 
-0:173      'inF0' (in 3-component vector of float)
-0:173      'inF1' (in 3-component vector of float)
-0:173      'inF2' (in 3-component vector of float)
-0:173      'inU0' (in 3-component vector of uint)
-0:173      'inU1' (in 3-component vector of uint)
+0:258  Function Definition: PixelShaderFunction(vf3;vf3;vf3;vu3;vu3; (temp 3-component vector of float)
+0:178    Function Parameters: 
+0:178      'inF0' (in 3-component vector of float)
+0:178      'inF1' (in 3-component vector of float)
+0:178      'inF2' (in 3-component vector of float)
+0:178      'inU0' (in 3-component vector of uint)
+0:178      'inU1' (in 3-component vector of uint)
 0:?     Sequence
-0:176      all (global bool)
-0:176        'inF0' (in 3-component vector of float)
-0:177      Absolute value (global 3-component vector of float)
-0:177        'inF0' (in 3-component vector of float)
-0:178      arc cosine (global 3-component vector of float)
-0:178        'inF0' (in 3-component vector of float)
-0:179      any (global bool)
-0:179        'inF0' (in 3-component vector of float)
-0:180      arc sine (global 3-component vector of float)
-0:180        'inF0' (in 3-component vector of float)
-0:181      floatBitsToInt (global 3-component vector of int)
-0:181        'inF0' (in 3-component vector of float)
-0:182      floatBitsToUint (global 3-component vector of uint)
-0:182        'inF0' (in 3-component vector of float)
-0:183      intBitsToFloat (global 3-component vector of float)
-0:183        'inU0' (in 3-component vector of uint)
-0:185      arc tangent (global 3-component vector of float)
-0:185        'inF0' (in 3-component vector of float)
-0:186      arc tangent (global 3-component vector of float)
-0:186        'inF0' (in 3-component vector of float)
-0:186        'inF1' (in 3-component vector of float)
-0:187      Ceiling (global 3-component vector of float)
-0:187        'inF0' (in 3-component vector of float)
-0:188      clamp (global 3-component vector of float)
-0:188        'inF0' (in 3-component vector of float)
-0:188        'inF1' (in 3-component vector of float)
-0:188        'inF2' (in 3-component vector of float)
-0:189      Test condition and select (temp void)
-0:189        Condition
-0:189        any (temp bool)
-0:189          Compare Less Than (temp 3-component vector of bool)
-0:189            'inF0' (in 3-component vector of float)
-0:189            Constant:
-0:189              0.000000
-0:189              0.000000
-0:189              0.000000
-0:189        true case
-0:189        Branch: Kill
-0:190      cosine (global 3-component vector of float)
-0:190        'inF0' (in 3-component vector of float)
-0:191      hyp. cosine (global 3-component vector of float)
-0:191        'inF0' (in 3-component vector of float)
-0:?       bitCount (global 3-component vector of uint)
-0:?         Constant:
-0:?           7 (const uint)
-0:?           3 (const uint)
-0:?           5 (const uint)
-0:193      cross-product (global 3-component vector of float)
-0:193        'inF0' (in 3-component vector of float)
-0:193        'inF1' (in 3-component vector of float)
-0:194      dPdx (global 3-component vector of float)
-0:194        'inF0' (in 3-component vector of float)
-0:195      dPdxCoarse (global 3-component vector of float)
-0:195        'inF0' (in 3-component vector of float)
-0:196      dPdxFine (global 3-component vector of float)
-0:196        'inF0' (in 3-component vector of float)
-0:197      dPdy (global 3-component vector of float)
-0:197        'inF0' (in 3-component vector of float)
-0:198      dPdyCoarse (global 3-component vector of float)
-0:198        'inF0' (in 3-component vector of float)
-0:199      dPdyFine (global 3-component vector of float)
-0:199        'inF0' (in 3-component vector of float)
-0:200      degrees (global 3-component vector of float)
-0:200        'inF0' (in 3-component vector of float)
-0:201      distance (global float)
-0:201        'inF0' (in 3-component vector of float)
-0:201        'inF1' (in 3-component vector of float)
-0:202      dot-product (global float)
-0:202        'inF0' (in 3-component vector of float)
-0:202        'inF1' (in 3-component vector of float)
-0:206      exp (global 3-component vector of float)
-0:206        'inF0' (in 3-component vector of float)
-0:207      exp2 (global 3-component vector of float)
-0:207        'inF0' (in 3-component vector of float)
-0:208      face-forward (global 3-component vector of float)
-0:208        'inF0' (in 3-component vector of float)
-0:208        'inF1' (in 3-component vector of float)
-0:208        'inF2' (in 3-component vector of float)
-0:209      findMSB (global int)
-0:209        Constant:
-0:209          7 (const int)
-0:210      findLSB (global int)
-0:210        Constant:
-0:210          7 (const int)
-0:211      Floor (global 3-component vector of float)
-0:211        'inF0' (in 3-component vector of float)
-0:213      mod (global 3-component vector of float)
-0:213        'inF0' (in 3-component vector of float)
-0:213        'inF1' (in 3-component vector of float)
-0:214      Fraction (global 3-component vector of float)
-0:214        'inF0' (in 3-component vector of float)
-0:215      frexp (global 3-component vector of float)
-0:215        'inF0' (in 3-component vector of float)
-0:215        'inF1' (in 3-component vector of float)
-0:216      fwidth (global 3-component vector of float)
-0:216        'inF0' (in 3-component vector of float)
-0:217      isinf (global 3-component vector of bool)
-0:217        'inF0' (in 3-component vector of float)
-0:218      isnan (global 3-component vector of bool)
-0:218        'inF0' (in 3-component vector of float)
-0:219      ldexp (global 3-component vector of float)
-0:219        'inF0' (in 3-component vector of float)
-0:219        'inF1' (in 3-component vector of float)
-0:220      length (global float)
-0:220        'inF0' (in 3-component vector of float)
-0:221      log (global 3-component vector of float)
-0:221        'inF0' (in 3-component vector of float)
-0:222      vector-scale (temp 3-component vector of float)
-0:222        log2 (temp 3-component vector of float)
+0:181      move second child to first child (temp bool)
+0:181        'r000' (temp bool)
+0:181        all (global bool)
+0:181          'inF0' (in 3-component vector of float)
+0:182      move second child to first child (temp 3-component vector of float)
+0:182        'r001' (temp 3-component vector of float)
+0:182        Absolute value (global 3-component vector of float)
+0:182          'inF0' (in 3-component vector of float)
+0:183      move second child to first child (temp 3-component vector of float)
+0:183        'r002' (temp 3-component vector of float)
+0:183        arc cosine (global 3-component vector of float)
+0:183          'inF0' (in 3-component vector of float)
+0:184      move second child to first child (temp bool)
+0:184        'r003' (temp bool)
+0:184        any (global bool)
+0:184          'inF0' (in 3-component vector of float)
+0:185      move second child to first child (temp 3-component vector of float)
+0:185        'r004' (temp 3-component vector of float)
+0:185        arc sine (global 3-component vector of float)
+0:185          'inF0' (in 3-component vector of float)
+0:186      move second child to first child (temp 3-component vector of int)
+0:186        'r005' (temp 3-component vector of int)
+0:186        floatBitsToInt (global 3-component vector of int)
+0:186          'inF0' (in 3-component vector of float)
+0:187      move second child to first child (temp 3-component vector of uint)
+0:187        'r006' (temp 3-component vector of uint)
+0:187        floatBitsToUint (global 3-component vector of uint)
+0:187          'inF0' (in 3-component vector of float)
+0:188      move second child to first child (temp 3-component vector of float)
+0:188        'r007' (temp 3-component vector of float)
+0:188        intBitsToFloat (global 3-component vector of float)
+0:188          'inU0' (in 3-component vector of uint)
+0:190      move second child to first child (temp 3-component vector of float)
+0:190        'r009' (temp 3-component vector of float)
+0:190        arc tangent (global 3-component vector of float)
+0:190          'inF0' (in 3-component vector of float)
+0:191      move second child to first child (temp 3-component vector of float)
+0:191        'r010' (temp 3-component vector of float)
+0:191        arc tangent (global 3-component vector of float)
+0:191          'inF0' (in 3-component vector of float)
+0:191          'inF1' (in 3-component vector of float)
+0:192      move second child to first child (temp 3-component vector of float)
+0:192        'r011' (temp 3-component vector of float)
+0:192        Ceiling (global 3-component vector of float)
+0:192          'inF0' (in 3-component vector of float)
+0:193      move second child to first child (temp 3-component vector of float)
+0:193        'r012' (temp 3-component vector of float)
+0:193        clamp (global 3-component vector of float)
+0:193          'inF0' (in 3-component vector of float)
+0:193          'inF1' (in 3-component vector of float)
+0:193          'inF2' (in 3-component vector of float)
+0:194      Test condition and select (temp void)
+0:194        Condition
+0:194        any (temp bool)
+0:194          Compare Less Than (temp 3-component vector of bool)
+0:194            'inF0' (in 3-component vector of float)
+0:194            Constant:
+0:194              0.000000
+0:194              0.000000
+0:194              0.000000
+0:194        true case
+0:194        Branch: Kill
+0:195      move second child to first child (temp 3-component vector of float)
+0:195        'r013' (temp 3-component vector of float)
+0:195        cosine (global 3-component vector of float)
+0:195          'inF0' (in 3-component vector of float)
+0:196      move second child to first child (temp 3-component vector of float)
+0:196        'r014' (temp 3-component vector of float)
+0:196        hyp. cosine (global 3-component vector of float)
+0:196          'inF0' (in 3-component vector of float)
+0:197      move second child to first child (temp 3-component vector of uint)
+0:197        'r015' (temp 3-component vector of uint)
+0:?         bitCount (global 3-component vector of uint)
+0:?           Constant:
+0:?             7 (const uint)
+0:?             3 (const uint)
+0:?             5 (const uint)
+0:198      move second child to first child (temp 3-component vector of float)
+0:198        'r016' (temp 3-component vector of float)
+0:198        cross-product (global 3-component vector of float)
+0:198          'inF0' (in 3-component vector of float)
+0:198          'inF1' (in 3-component vector of float)
+0:199      move second child to first child (temp 3-component vector of float)
+0:199        'r017' (temp 3-component vector of float)
+0:199        dPdx (global 3-component vector of float)
+0:199          'inF0' (in 3-component vector of float)
+0:200      move second child to first child (temp 3-component vector of float)
+0:200        'r018' (temp 3-component vector of float)
+0:200        dPdxCoarse (global 3-component vector of float)
+0:200          'inF0' (in 3-component vector of float)
+0:201      move second child to first child (temp 3-component vector of float)
+0:201        'r019' (temp 3-component vector of float)
+0:201        dPdxFine (global 3-component vector of float)
+0:201          'inF0' (in 3-component vector of float)
+0:202      move second child to first child (temp 3-component vector of float)
+0:202        'r020' (temp 3-component vector of float)
+0:202        dPdy (global 3-component vector of float)
+0:202          'inF0' (in 3-component vector of float)
+0:203      move second child to first child (temp 3-component vector of float)
+0:203        'r021' (temp 3-component vector of float)
+0:203        dPdyCoarse (global 3-component vector of float)
+0:203          'inF0' (in 3-component vector of float)
+0:204      move second child to first child (temp 3-component vector of float)
+0:204        'r022' (temp 3-component vector of float)
+0:204        dPdyFine (global 3-component vector of float)
+0:204          'inF0' (in 3-component vector of float)
+0:205      move second child to first child (temp 3-component vector of float)
+0:205        'r023' (temp 3-component vector of float)
+0:205        degrees (global 3-component vector of float)
+0:205          'inF0' (in 3-component vector of float)
+0:206      move second child to first child (temp float)
+0:206        'r024' (temp float)
+0:206        distance (global float)
+0:206          'inF0' (in 3-component vector of float)
+0:206          'inF1' (in 3-component vector of float)
+0:207      move second child to first child (temp float)
+0:207        'r025' (temp float)
+0:207        dot-product (global float)
+0:207          'inF0' (in 3-component vector of float)
+0:207          'inF1' (in 3-component vector of float)
+0:211      move second child to first child (temp 3-component vector of float)
+0:211        'r029' (temp 3-component vector of float)
+0:211        exp (global 3-component vector of float)
+0:211          'inF0' (in 3-component vector of float)
+0:212      move second child to first child (temp 3-component vector of float)
+0:212        'r030' (temp 3-component vector of float)
+0:212        exp2 (global 3-component vector of float)
+0:212          'inF0' (in 3-component vector of float)
+0:213      move second child to first child (temp 3-component vector of float)
+0:213        'r031' (temp 3-component vector of float)
+0:213        face-forward (global 3-component vector of float)
+0:213          'inF0' (in 3-component vector of float)
+0:213          'inF1' (in 3-component vector of float)
+0:213          'inF2' (in 3-component vector of float)
+0:214      move second child to first child (temp 3-component vector of uint)
+0:214        'r032' (temp 3-component vector of uint)
+0:?         findMSB (global 3-component vector of uint)
+0:?           Constant:
+0:?             2 (const uint)
+0:?             3 (const uint)
+0:?             4 (const uint)
+0:215      move second child to first child (temp 3-component vector of uint)
+0:215        'r033' (temp 3-component vector of uint)
+0:?         findLSB (global 3-component vector of uint)
+0:?           Constant:
+0:?             2 (const uint)
+0:?             3 (const uint)
+0:?             4 (const uint)
+0:216      move second child to first child (temp 3-component vector of float)
+0:216        'r034' (temp 3-component vector of float)
+0:216        Floor (global 3-component vector of float)
+0:216          'inF0' (in 3-component vector of float)
+0:218      move second child to first child (temp 3-component vector of float)
+0:218        'r036' (temp 3-component vector of float)
+0:218        mod (global 3-component vector of float)
+0:218          'inF0' (in 3-component vector of float)
+0:218          'inF1' (in 3-component vector of float)
+0:219      move second child to first child (temp 3-component vector of float)
+0:219        'r037' (temp 3-component vector of float)
+0:219        Fraction (global 3-component vector of float)
+0:219          'inF0' (in 3-component vector of float)
+0:220      move second child to first child (temp 3-component vector of float)
+0:220        'r038' (temp 3-component vector of float)
+0:220        frexp (global 3-component vector of float)
+0:220          'inF0' (in 3-component vector of float)
+0:220          'inF1' (in 3-component vector of float)
+0:221      move second child to first child (temp 3-component vector of float)
+0:221        'r039' (temp 3-component vector of float)
+0:221        fwidth (global 3-component vector of float)
+0:221          'inF0' (in 3-component vector of float)
+0:222      move second child to first child (temp 3-component vector of bool)
+0:222        'r040' (temp 3-component vector of bool)
+0:222        isinf (global 3-component vector of bool)
 0:222          'inF0' (in 3-component vector of float)
-0:222        Constant:
-0:222          0.301030
-0:223      log2 (global 3-component vector of float)
-0:223        'inF0' (in 3-component vector of float)
-0:224      max (global 3-component vector of float)
-0:224        'inF0' (in 3-component vector of float)
-0:224        'inF1' (in 3-component vector of float)
-0:225      min (global 3-component vector of float)
-0:225        'inF0' (in 3-component vector of float)
-0:225        'inF1' (in 3-component vector of float)
-0:226      normalize (global 3-component vector of float)
-0:226        'inF0' (in 3-component vector of float)
-0:227      pow (global 3-component vector of float)
-0:227        'inF0' (in 3-component vector of float)
-0:227        'inF1' (in 3-component vector of float)
-0:228      radians (global 3-component vector of float)
-0:228        'inF0' (in 3-component vector of float)
-0:229      divide (temp 3-component vector of float)
-0:229        Constant:
-0:229          1.000000
-0:229        'inF0' (in 3-component vector of float)
-0:230      reflect (global 3-component vector of float)
-0:230        'inF0' (in 3-component vector of float)
-0:230        'inF1' (in 3-component vector of float)
-0:231      refract (global 3-component vector of float)
-0:231        'inF0' (in 3-component vector of float)
-0:231        'inF1' (in 3-component vector of float)
-0:231        Constant:
-0:231          2.000000
-0:?       bitFieldReverse (global 3-component vector of uint)
-0:?         Constant:
-0:?           1 (const uint)
-0:?           2 (const uint)
-0:?           3 (const uint)
-0:233      roundEven (global 3-component vector of float)
-0:233        'inF0' (in 3-component vector of float)
-0:234      inverse sqrt (global 3-component vector of float)
-0:234        'inF0' (in 3-component vector of float)
-0:235      clamp (temp 3-component vector of float)
-0:235        'inF0' (in 3-component vector of float)
-0:235        Constant:
-0:235          0.000000
-0:235        Constant:
-0:235          1.000000
-0:236      Sign (global 3-component vector of float)
-0:236        'inF0' (in 3-component vector of float)
-0:237      sine (global 3-component vector of float)
-0:237        'inF0' (in 3-component vector of float)
-0:238      Sequence
-0:238        move second child to first child (temp 3-component vector of float)
-0:238          'inF1' (in 3-component vector of float)
-0:238          sine (temp 3-component vector of float)
-0:238            'inF0' (in 3-component vector of float)
-0:238        move second child to first child (temp 3-component vector of float)
-0:238          'inF2' (in 3-component vector of float)
-0:238          cosine (temp 3-component vector of float)
-0:238            'inF0' (in 3-component vector of float)
-0:239      hyp. sine (global 3-component vector of float)
-0:239        'inF0' (in 3-component vector of float)
-0:240      smoothstep (global 3-component vector of float)
-0:240        'inF0' (in 3-component vector of float)
-0:240        'inF1' (in 3-component vector of float)
-0:240        'inF2' (in 3-component vector of float)
-0:241      sqrt (global 3-component vector of float)
-0:241        'inF0' (in 3-component vector of float)
-0:242      step (global 3-component vector of float)
-0:242        'inF0' (in 3-component vector of float)
-0:242        'inF1' (in 3-component vector of float)
-0:243      tangent (global 3-component vector of float)
-0:243        'inF0' (in 3-component vector of float)
-0:244      hyp. tangent (global 3-component vector of float)
-0:244        'inF0' (in 3-component vector of float)
-0:246      trunc (global 3-component vector of float)
-0:246        'inF0' (in 3-component vector of float)
-0:249      Branch: Return with expression
+0:223      move second child to first child (temp 3-component vector of bool)
+0:223        'r041' (temp 3-component vector of bool)
+0:223        isnan (global 3-component vector of bool)
+0:223          'inF0' (in 3-component vector of float)
+0:224      move second child to first child (temp 3-component vector of float)
+0:224        'r042' (temp 3-component vector of float)
+0:224        ldexp (global 3-component vector of float)
+0:224          'inF0' (in 3-component vector of float)
+0:224          'inF1' (in 3-component vector of float)
+0:225      move second child to first child (temp 3-component vector of float)
+0:225        'r039a' (temp 3-component vector of float)
+0:225        mix (global 3-component vector of float)
+0:225          'inF0' (in 3-component vector of float)
+0:225          'inF1' (in 3-component vector of float)
+0:225          'inF2' (in 3-component vector of float)
+0:226      move second child to first child (temp float)
+0:226        'r043' (temp float)
+0:226        length (global float)
+0:226          'inF0' (in 3-component vector of float)
+0:227      move second child to first child (temp 3-component vector of float)
+0:227        'r044' (temp 3-component vector of float)
+0:227        log (global 3-component vector of float)
+0:227          'inF0' (in 3-component vector of float)
+0:228      move second child to first child (temp 3-component vector of float)
+0:228        'r045' (temp 3-component vector of float)
+0:228        vector-scale (temp 3-component vector of float)
+0:228          log2 (temp 3-component vector of float)
+0:228            'inF0' (in 3-component vector of float)
+0:228          Constant:
+0:228            0.301030
+0:229      move second child to first child (temp 3-component vector of float)
+0:229        'r046' (temp 3-component vector of float)
+0:229        log2 (global 3-component vector of float)
+0:229          'inF0' (in 3-component vector of float)
+0:230      move second child to first child (temp 3-component vector of float)
+0:230        'r047' (temp 3-component vector of float)
+0:230        max (global 3-component vector of float)
+0:230          'inF0' (in 3-component vector of float)
+0:230          'inF1' (in 3-component vector of float)
+0:231      move second child to first child (temp 3-component vector of float)
+0:231        'r048' (temp 3-component vector of float)
+0:231        min (global 3-component vector of float)
+0:231          'inF0' (in 3-component vector of float)
+0:231          'inF1' (in 3-component vector of float)
+0:232      move second child to first child (temp 3-component vector of float)
+0:232        'r049' (temp 3-component vector of float)
+0:232        normalize (global 3-component vector of float)
+0:232          'inF0' (in 3-component vector of float)
+0:233      move second child to first child (temp 3-component vector of float)
+0:233        'r050' (temp 3-component vector of float)
+0:233        pow (global 3-component vector of float)
+0:233          'inF0' (in 3-component vector of float)
+0:233          'inF1' (in 3-component vector of float)
+0:234      move second child to first child (temp 3-component vector of float)
+0:234        'r051' (temp 3-component vector of float)
+0:234        radians (global 3-component vector of float)
+0:234          'inF0' (in 3-component vector of float)
+0:235      move second child to first child (temp 3-component vector of float)
+0:235        'r052' (temp 3-component vector of float)
+0:235        divide (temp 3-component vector of float)
+0:235          Constant:
+0:235            1.000000
+0:235          'inF0' (in 3-component vector of float)
+0:236      move second child to first child (temp 3-component vector of float)
+0:236        'r053' (temp 3-component vector of float)
+0:236        reflect (global 3-component vector of float)
+0:236          'inF0' (in 3-component vector of float)
+0:236          'inF1' (in 3-component vector of float)
+0:237      move second child to first child (temp 3-component vector of float)
+0:237        'r054' (temp 3-component vector of float)
+0:237        refract (global 3-component vector of float)
+0:237          'inF0' (in 3-component vector of float)
+0:237          'inF1' (in 3-component vector of float)
+0:237          Constant:
+0:237            2.000000
+0:238      move second child to first child (temp 3-component vector of uint)
+0:238        'r055' (temp 3-component vector of uint)
+0:?         bitFieldReverse (global 3-component vector of uint)
+0:?           Constant:
+0:?             1 (const uint)
+0:?             2 (const uint)
+0:?             3 (const uint)
+0:239      move second child to first child (temp 3-component vector of float)
+0:239        'r056' (temp 3-component vector of float)
+0:239        roundEven (global 3-component vector of float)
+0:239          'inF0' (in 3-component vector of float)
+0:240      move second child to first child (temp 3-component vector of float)
+0:240        'r057' (temp 3-component vector of float)
+0:240        inverse sqrt (global 3-component vector of float)
+0:240          'inF0' (in 3-component vector of float)
+0:241      move second child to first child (temp 3-component vector of float)
+0:241        'r058' (temp 3-component vector of float)
+0:241        clamp (temp 3-component vector of float)
+0:241          'inF0' (in 3-component vector of float)
+0:241          Constant:
+0:241            0.000000
+0:241          Constant:
+0:241            1.000000
+0:242      move second child to first child (temp 3-component vector of float)
+0:242        'r059' (temp 3-component vector of float)
+0:242        Sign (global 3-component vector of float)
+0:242          'inF0' (in 3-component vector of float)
+0:243      move second child to first child (temp 3-component vector of float)
+0:243        'r060' (temp 3-component vector of float)
+0:243        sine (global 3-component vector of float)
+0:243          'inF0' (in 3-component vector of float)
+0:244      Sequence
+0:244        move second child to first child (temp 3-component vector of float)
+0:244          'inF1' (in 3-component vector of float)
+0:244          sine (temp 3-component vector of float)
+0:244            'inF0' (in 3-component vector of float)
+0:244        move second child to first child (temp 3-component vector of float)
+0:244          'inF2' (in 3-component vector of float)
+0:244          cosine (temp 3-component vector of float)
+0:244            'inF0' (in 3-component vector of float)
+0:245      move second child to first child (temp 3-component vector of float)
+0:245        'r061' (temp 3-component vector of float)
+0:245        hyp. sine (global 3-component vector of float)
+0:245          'inF0' (in 3-component vector of float)
+0:246      move second child to first child (temp 3-component vector of float)
+0:246        'r062' (temp 3-component vector of float)
+0:246        smoothstep (global 3-component vector of float)
+0:246          'inF0' (in 3-component vector of float)
+0:246          'inF1' (in 3-component vector of float)
+0:246          'inF2' (in 3-component vector of float)
+0:247      move second child to first child (temp 3-component vector of float)
+0:247        'r063' (temp 3-component vector of float)
+0:247        sqrt (global 3-component vector of float)
+0:247          'inF0' (in 3-component vector of float)
+0:248      move second child to first child (temp 3-component vector of float)
+0:248        'r064' (temp 3-component vector of float)
+0:248        step (global 3-component vector of float)
+0:248          'inF0' (in 3-component vector of float)
+0:248          'inF1' (in 3-component vector of float)
+0:249      move second child to first child (temp 3-component vector of float)
+0:249        'r065' (temp 3-component vector of float)
+0:249        tangent (global 3-component vector of float)
+0:249          'inF0' (in 3-component vector of float)
+0:250      move second child to first child (temp 3-component vector of float)
+0:250        'r066' (temp 3-component vector of float)
+0:250        hyp. tangent (global 3-component vector of float)
+0:250          'inF0' (in 3-component vector of float)
+0:252      move second child to first child (temp 3-component vector of float)
+0:252        'r067' (temp 3-component vector of float)
+0:252        trunc (global 3-component vector of float)
+0:252          'inF0' (in 3-component vector of float)
+0:255      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
-0:393  Function Definition: PixelShaderFunction(vf4;vf4;vf4;vu4;vu4; (temp 4-component vector of float)
-0:253    Function Parameters: 
-0:253      'inF0' (in 4-component vector of float)
-0:253      'inF1' (in 4-component vector of float)
-0:253      'inF2' (in 4-component vector of float)
-0:253      'inU0' (in 4-component vector of uint)
-0:253      'inU1' (in 4-component vector of uint)
+0:399  Function Definition: PixelShaderFunction(vf4;vf4;vf4;vu4;vu4; (temp 4-component vector of float)
+0:259    Function Parameters: 
+0:259      'inF0' (in 4-component vector of float)
+0:259      'inF1' (in 4-component vector of float)
+0:259      'inF2' (in 4-component vector of float)
+0:259      'inU0' (in 4-component vector of uint)
+0:259      'inU1' (in 4-component vector of uint)
 0:?     Sequence
-0:256      all (global bool)
-0:256        'inF0' (in 4-component vector of float)
-0:257      Absolute value (global 4-component vector of float)
-0:257        'inF0' (in 4-component vector of float)
-0:258      arc cosine (global 4-component vector of float)
-0:258        'inF0' (in 4-component vector of float)
-0:259      any (global bool)
-0:259        'inF0' (in 4-component vector of float)
-0:260      arc sine (global 4-component vector of float)
-0:260        'inF0' (in 4-component vector of float)
-0:261      floatBitsToInt (global 4-component vector of int)
-0:261        'inF0' (in 4-component vector of float)
-0:262      floatBitsToUint (global 4-component vector of uint)
-0:262        'inF0' (in 4-component vector of float)
-0:263      intBitsToFloat (global 4-component vector of float)
-0:263        'inU0' (in 4-component vector of uint)
-0:265      arc tangent (global 4-component vector of float)
-0:265        'inF0' (in 4-component vector of float)
-0:266      arc tangent (global 4-component vector of float)
-0:266        'inF0' (in 4-component vector of float)
-0:266        'inF1' (in 4-component vector of float)
-0:267      Ceiling (global 4-component vector of float)
-0:267        'inF0' (in 4-component vector of float)
-0:268      clamp (global 4-component vector of float)
-0:268        'inF0' (in 4-component vector of float)
-0:268        'inF1' (in 4-component vector of float)
-0:268        'inF2' (in 4-component vector of float)
-0:269      Test condition and select (temp void)
-0:269        Condition
-0:269        any (temp bool)
-0:269          Compare Less Than (temp 4-component vector of bool)
-0:269            'inF0' (in 4-component vector of float)
-0:269            Constant:
-0:269              0.000000
-0:269              0.000000
-0:269              0.000000
-0:269              0.000000
-0:269        true case
-0:269        Branch: Kill
-0:270      cosine (global 4-component vector of float)
-0:270        'inF0' (in 4-component vector of float)
-0:271      hyp. cosine (global 4-component vector of float)
-0:271        'inF0' (in 4-component vector of float)
-0:?       bitCount (global 4-component vector of uint)
-0:?         Constant:
-0:?           7 (const uint)
-0:?           3 (const uint)
-0:?           5 (const uint)
-0:?           2 (const uint)
-0:273      dPdx (global 4-component vector of float)
-0:273        'inF0' (in 4-component vector of float)
-0:274      dPdxCoarse (global 4-component vector of float)
-0:274        'inF0' (in 4-component vector of float)
-0:275      dPdxFine (global 4-component vector of float)
-0:275        'inF0' (in 4-component vector of float)
-0:276      dPdy (global 4-component vector of float)
-0:276        'inF0' (in 4-component vector of float)
-0:277      dPdyCoarse (global 4-component vector of float)
-0:277        'inF0' (in 4-component vector of float)
-0:278      dPdyFine (global 4-component vector of float)
-0:278        'inF0' (in 4-component vector of float)
-0:279      degrees (global 4-component vector of float)
-0:279        'inF0' (in 4-component vector of float)
-0:280      distance (global float)
-0:280        'inF0' (in 4-component vector of float)
-0:280        'inF1' (in 4-component vector of float)
-0:281      dot-product (global float)
-0:281        'inF0' (in 4-component vector of float)
-0:281        'inF1' (in 4-component vector of float)
-0:282      Construct vec4 (temp 4-component vector of float)
-0:282        Constant:
-0:282          1.000000
-0:282        component-wise multiply (temp float)
-0:282          direct index (temp float)
-0:282            'inF0' (in 4-component vector of float)
-0:282            Constant:
-0:282              1 (const int)
-0:282          direct index (temp float)
-0:282            'inF1' (in 4-component vector of float)
-0:282            Constant:
-0:282              1 (const int)
-0:282        direct index (temp float)
+0:262      move second child to first child (temp bool)
+0:262        'r000' (temp bool)
+0:262        all (global bool)
+0:262          'inF0' (in 4-component vector of float)
+0:263      move second child to first child (temp 4-component vector of float)
+0:263        'r001' (temp 4-component vector of float)
+0:263        Absolute value (global 4-component vector of float)
+0:263          'inF0' (in 4-component vector of float)
+0:264      move second child to first child (temp 4-component vector of float)
+0:264        'r002' (temp 4-component vector of float)
+0:264        arc cosine (global 4-component vector of float)
+0:264          'inF0' (in 4-component vector of float)
+0:265      move second child to first child (temp bool)
+0:265        'r003' (temp bool)
+0:265        any (global bool)
+0:265          'inF0' (in 4-component vector of float)
+0:266      move second child to first child (temp 4-component vector of float)
+0:266        'r004' (temp 4-component vector of float)
+0:266        arc sine (global 4-component vector of float)
+0:266          'inF0' (in 4-component vector of float)
+0:267      move second child to first child (temp 4-component vector of int)
+0:267        'r005' (temp 4-component vector of int)
+0:267        floatBitsToInt (global 4-component vector of int)
+0:267          'inF0' (in 4-component vector of float)
+0:268      move second child to first child (temp 4-component vector of uint)
+0:268        'r006' (temp 4-component vector of uint)
+0:268        floatBitsToUint (global 4-component vector of uint)
+0:268          'inF0' (in 4-component vector of float)
+0:269      move second child to first child (temp 4-component vector of float)
+0:269        'r007' (temp 4-component vector of float)
+0:269        intBitsToFloat (global 4-component vector of float)
+0:269          'inU0' (in 4-component vector of uint)
+0:271      move second child to first child (temp 4-component vector of float)
+0:271        'r009' (temp 4-component vector of float)
+0:271        arc tangent (global 4-component vector of float)
+0:271          'inF0' (in 4-component vector of float)
+0:272      move second child to first child (temp 4-component vector of float)
+0:272        'r010' (temp 4-component vector of float)
+0:272        arc tangent (global 4-component vector of float)
+0:272          'inF0' (in 4-component vector of float)
+0:272          'inF1' (in 4-component vector of float)
+0:273      move second child to first child (temp 4-component vector of float)
+0:273        'r011' (temp 4-component vector of float)
+0:273        Ceiling (global 4-component vector of float)
+0:273          'inF0' (in 4-component vector of float)
+0:274      move second child to first child (temp 4-component vector of float)
+0:274        'r012' (temp 4-component vector of float)
+0:274        clamp (global 4-component vector of float)
+0:274          'inF0' (in 4-component vector of float)
+0:274          'inF1' (in 4-component vector of float)
+0:274          'inF2' (in 4-component vector of float)
+0:275      Test condition and select (temp void)
+0:275        Condition
+0:275        any (temp bool)
+0:275          Compare Less Than (temp 4-component vector of bool)
+0:275            'inF0' (in 4-component vector of float)
+0:275            Constant:
+0:275              0.000000
+0:275              0.000000
+0:275              0.000000
+0:275              0.000000
+0:275        true case
+0:275        Branch: Kill
+0:276      move second child to first child (temp 4-component vector of float)
+0:276        'r013' (temp 4-component vector of float)
+0:276        cosine (global 4-component vector of float)
+0:276          'inF0' (in 4-component vector of float)
+0:277      move second child to first child (temp 4-component vector of float)
+0:277        'r014' (temp 4-component vector of float)
+0:277        hyp. cosine (global 4-component vector of float)
+0:277          'inF0' (in 4-component vector of float)
+0:278      move second child to first child (temp 4-component vector of uint)
+0:278        'r015' (temp 4-component vector of uint)
+0:?         bitCount (global 4-component vector of uint)
+0:?           Constant:
+0:?             7 (const uint)
+0:?             3 (const uint)
+0:?             5 (const uint)
+0:?             2 (const uint)
+0:279      move second child to first child (temp 4-component vector of float)
+0:279        'r016' (temp 4-component vector of float)
+0:279        dPdx (global 4-component vector of float)
+0:279          'inF0' (in 4-component vector of float)
+0:280      move second child to first child (temp 4-component vector of float)
+0:280        'r017' (temp 4-component vector of float)
+0:280        dPdxCoarse (global 4-component vector of float)
+0:280          'inF0' (in 4-component vector of float)
+0:281      move second child to first child (temp 4-component vector of float)
+0:281        'r018' (temp 4-component vector of float)
+0:281        dPdxFine (global 4-component vector of float)
+0:281          'inF0' (in 4-component vector of float)
+0:282      move second child to first child (temp 4-component vector of float)
+0:282        'r019' (temp 4-component vector of float)
+0:282        dPdy (global 4-component vector of float)
 0:282          'inF0' (in 4-component vector of float)
-0:282          Constant:
-0:282            2 (const int)
-0:282        direct index (temp float)
-0:282          'inF1' (in 4-component vector of float)
-0:282          Constant:
-0:282            3 (const int)
-0:286      exp (global 4-component vector of float)
-0:286        'inF0' (in 4-component vector of float)
-0:287      exp2 (global 4-component vector of float)
-0:287        'inF0' (in 4-component vector of float)
-0:288      face-forward (global 4-component vector of float)
-0:288        'inF0' (in 4-component vector of float)
-0:288        'inF1' (in 4-component vector of float)
-0:288        'inF2' (in 4-component vector of float)
-0:289      findMSB (global int)
-0:289        Constant:
-0:289          7 (const int)
-0:290      findLSB (global int)
-0:290        Constant:
-0:290          7 (const int)
-0:291      Floor (global 4-component vector of float)
-0:291        'inF0' (in 4-component vector of float)
-0:293      mod (global 4-component vector of float)
-0:293        'inF0' (in 4-component vector of float)
-0:293        'inF1' (in 4-component vector of float)
-0:294      Fraction (global 4-component vector of float)
-0:294        'inF0' (in 4-component vector of float)
-0:295      frexp (global 4-component vector of float)
-0:295        'inF0' (in 4-component vector of float)
-0:295        'inF1' (in 4-component vector of float)
-0:296      fwidth (global 4-component vector of float)
-0:296        'inF0' (in 4-component vector of float)
-0:297      isinf (global 4-component vector of bool)
-0:297        'inF0' (in 4-component vector of float)
-0:298      isnan (global 4-component vector of bool)
-0:298        'inF0' (in 4-component vector of float)
-0:299      ldexp (global 4-component vector of float)
-0:299        'inF0' (in 4-component vector of float)
-0:299        'inF1' (in 4-component vector of float)
-0:300      length (global float)
-0:300        'inF0' (in 4-component vector of float)
-0:301      log (global 4-component vector of float)
-0:301        'inF0' (in 4-component vector of float)
-0:302      vector-scale (temp 4-component vector of float)
-0:302        log2 (temp 4-component vector of float)
+0:283      move second child to first child (temp 4-component vector of float)
+0:283        'r020' (temp 4-component vector of float)
+0:283        dPdyCoarse (global 4-component vector of float)
+0:283          'inF0' (in 4-component vector of float)
+0:284      move second child to first child (temp 4-component vector of float)
+0:284        'r021' (temp 4-component vector of float)
+0:284        dPdyFine (global 4-component vector of float)
+0:284          'inF0' (in 4-component vector of float)
+0:285      move second child to first child (temp 4-component vector of float)
+0:285        'r022' (temp 4-component vector of float)
+0:285        degrees (global 4-component vector of float)
+0:285          'inF0' (in 4-component vector of float)
+0:286      move second child to first child (temp float)
+0:286        'r023' (temp float)
+0:286        distance (global float)
+0:286          'inF0' (in 4-component vector of float)
+0:286          'inF1' (in 4-component vector of float)
+0:287      move second child to first child (temp float)
+0:287        'r024' (temp float)
+0:287        dot-product (global float)
+0:287          'inF0' (in 4-component vector of float)
+0:287          'inF1' (in 4-component vector of float)
+0:288      move second child to first child (temp 4-component vector of float)
+0:288        'r025' (temp 4-component vector of float)
+0:288        Construct vec4 (temp 4-component vector of float)
+0:288          Constant:
+0:288            1.000000
+0:288          component-wise multiply (temp float)
+0:288            direct index (temp float)
+0:288              'inF0' (in 4-component vector of float)
+0:288              Constant:
+0:288                1 (const int)
+0:288            direct index (temp float)
+0:288              'inF1' (in 4-component vector of float)
+0:288              Constant:
+0:288                1 (const int)
+0:288          direct index (temp float)
+0:288            'inF0' (in 4-component vector of float)
+0:288            Constant:
+0:288              2 (const int)
+0:288          direct index (temp float)
+0:288            'inF1' (in 4-component vector of float)
+0:288            Constant:
+0:288              3 (const int)
+0:292      move second child to first child (temp 4-component vector of float)
+0:292        'r029' (temp 4-component vector of float)
+0:292        exp (global 4-component vector of float)
+0:292          'inF0' (in 4-component vector of float)
+0:293      move second child to first child (temp 4-component vector of float)
+0:293        'r030' (temp 4-component vector of float)
+0:293        exp2 (global 4-component vector of float)
+0:293          'inF0' (in 4-component vector of float)
+0:294      move second child to first child (temp 4-component vector of float)
+0:294        'r031' (temp 4-component vector of float)
+0:294        face-forward (global 4-component vector of float)
+0:294          'inF0' (in 4-component vector of float)
+0:294          'inF1' (in 4-component vector of float)
+0:294          'inF2' (in 4-component vector of float)
+0:295      move second child to first child (temp 4-component vector of uint)
+0:295        'r032' (temp 4-component vector of uint)
+0:?         findMSB (global 4-component vector of uint)
+0:?           Constant:
+0:?             7 (const uint)
+0:?             8 (const uint)
+0:?             9 (const uint)
+0:?             10 (const uint)
+0:296      move second child to first child (temp 4-component vector of uint)
+0:296        'r033' (temp 4-component vector of uint)
+0:?         findLSB (global 4-component vector of uint)
+0:?           Constant:
+0:?             7 (const uint)
+0:?             8 (const uint)
+0:?             9 (const uint)
+0:?             10 (const uint)
+0:297      move second child to first child (temp 4-component vector of float)
+0:297        'r034' (temp 4-component vector of float)
+0:297        Floor (global 4-component vector of float)
+0:297          'inF0' (in 4-component vector of float)
+0:299      move second child to first child (temp 4-component vector of float)
+0:299        'r036' (temp 4-component vector of float)
+0:299        mod (global 4-component vector of float)
+0:299          'inF0' (in 4-component vector of float)
+0:299          'inF1' (in 4-component vector of float)
+0:300      move second child to first child (temp 4-component vector of float)
+0:300        'r037' (temp 4-component vector of float)
+0:300        Fraction (global 4-component vector of float)
+0:300          'inF0' (in 4-component vector of float)
+0:301      move second child to first child (temp 4-component vector of float)
+0:301        'r038' (temp 4-component vector of float)
+0:301        frexp (global 4-component vector of float)
+0:301          'inF0' (in 4-component vector of float)
+0:301          'inF1' (in 4-component vector of float)
+0:302      move second child to first child (temp 4-component vector of float)
+0:302        'r039' (temp 4-component vector of float)
+0:302        fwidth (global 4-component vector of float)
 0:302          'inF0' (in 4-component vector of float)
-0:302        Constant:
-0:302          0.301030
-0:303      log2 (global 4-component vector of float)
-0:303        'inF0' (in 4-component vector of float)
-0:304      max (global 4-component vector of float)
-0:304        'inF0' (in 4-component vector of float)
-0:304        'inF1' (in 4-component vector of float)
-0:305      min (global 4-component vector of float)
-0:305        'inF0' (in 4-component vector of float)
-0:305        'inF1' (in 4-component vector of float)
-0:306      normalize (global 4-component vector of float)
-0:306        'inF0' (in 4-component vector of float)
-0:307      pow (global 4-component vector of float)
-0:307        'inF0' (in 4-component vector of float)
-0:307        'inF1' (in 4-component vector of float)
-0:308      radians (global 4-component vector of float)
-0:308        'inF0' (in 4-component vector of float)
-0:309      divide (temp 4-component vector of float)
-0:309        Constant:
-0:309          1.000000
-0:309        'inF0' (in 4-component vector of float)
-0:310      reflect (global 4-component vector of float)
-0:310        'inF0' (in 4-component vector of float)
-0:310        'inF1' (in 4-component vector of float)
-0:311      refract (global 4-component vector of float)
-0:311        'inF0' (in 4-component vector of float)
-0:311        'inF1' (in 4-component vector of float)
-0:311        Constant:
-0:311          2.000000
-0:?       bitFieldReverse (global 4-component vector of uint)
-0:?         Constant:
-0:?           1 (const uint)
-0:?           2 (const uint)
-0:?           3 (const uint)
-0:?           4 (const uint)
-0:313      roundEven (global 4-component vector of float)
-0:313        'inF0' (in 4-component vector of float)
-0:314      inverse sqrt (global 4-component vector of float)
-0:314        'inF0' (in 4-component vector of float)
-0:315      clamp (temp 4-component vector of float)
-0:315        'inF0' (in 4-component vector of float)
-0:315        Constant:
-0:315          0.000000
-0:315        Constant:
-0:315          1.000000
-0:316      Sign (global 4-component vector of float)
-0:316        'inF0' (in 4-component vector of float)
-0:317      sine (global 4-component vector of float)
-0:317        'inF0' (in 4-component vector of float)
-0:318      Sequence
-0:318        move second child to first child (temp 4-component vector of float)
+0:303      move second child to first child (temp 4-component vector of bool)
+0:303        'r040' (temp 4-component vector of bool)
+0:303        isinf (global 4-component vector of bool)
+0:303          'inF0' (in 4-component vector of float)
+0:304      move second child to first child (temp 4-component vector of bool)
+0:304        'r041' (temp 4-component vector of bool)
+0:304        isnan (global 4-component vector of bool)
+0:304          'inF0' (in 4-component vector of float)
+0:305      move second child to first child (temp 4-component vector of float)
+0:305        'r042' (temp 4-component vector of float)
+0:305        ldexp (global 4-component vector of float)
+0:305          'inF0' (in 4-component vector of float)
+0:305          'inF1' (in 4-component vector of float)
+0:306      move second child to first child (temp 4-component vector of float)
+0:306        'r039a' (temp 4-component vector of float)
+0:306        mix (global 4-component vector of float)
+0:306          'inF0' (in 4-component vector of float)
+0:306          'inF1' (in 4-component vector of float)
+0:306          'inF2' (in 4-component vector of float)
+0:307      move second child to first child (temp float)
+0:307        'r043' (temp float)
+0:307        length (global float)
+0:307          'inF0' (in 4-component vector of float)
+0:308      move second child to first child (temp 4-component vector of float)
+0:308        'r044' (temp 4-component vector of float)
+0:308        log (global 4-component vector of float)
+0:308          'inF0' (in 4-component vector of float)
+0:309      move second child to first child (temp 4-component vector of float)
+0:309        'r045' (temp 4-component vector of float)
+0:309        vector-scale (temp 4-component vector of float)
+0:309          log2 (temp 4-component vector of float)
+0:309            'inF0' (in 4-component vector of float)
+0:309          Constant:
+0:309            0.301030
+0:310      move second child to first child (temp 4-component vector of float)
+0:310        'r046' (temp 4-component vector of float)
+0:310        log2 (global 4-component vector of float)
+0:310          'inF0' (in 4-component vector of float)
+0:311      move second child to first child (temp 4-component vector of float)
+0:311        'r047' (temp 4-component vector of float)
+0:311        max (global 4-component vector of float)
+0:311          'inF0' (in 4-component vector of float)
+0:311          'inF1' (in 4-component vector of float)
+0:312      move second child to first child (temp 4-component vector of float)
+0:312        'r048' (temp 4-component vector of float)
+0:312        min (global 4-component vector of float)
+0:312          'inF0' (in 4-component vector of float)
+0:312          'inF1' (in 4-component vector of float)
+0:313      move second child to first child (temp 4-component vector of float)
+0:313        'r049' (temp 4-component vector of float)
+0:313        normalize (global 4-component vector of float)
+0:313          'inF0' (in 4-component vector of float)
+0:314      move second child to first child (temp 4-component vector of float)
+0:314        'r050' (temp 4-component vector of float)
+0:314        pow (global 4-component vector of float)
+0:314          'inF0' (in 4-component vector of float)
+0:314          'inF1' (in 4-component vector of float)
+0:315      move second child to first child (temp 4-component vector of float)
+0:315        'r051' (temp 4-component vector of float)
+0:315        radians (global 4-component vector of float)
+0:315          'inF0' (in 4-component vector of float)
+0:316      move second child to first child (temp 4-component vector of float)
+0:316        'r052' (temp 4-component vector of float)
+0:316        divide (temp 4-component vector of float)
+0:316          Constant:
+0:316            1.000000
+0:316          'inF0' (in 4-component vector of float)
+0:317      move second child to first child (temp 4-component vector of float)
+0:317        'r053' (temp 4-component vector of float)
+0:317        reflect (global 4-component vector of float)
+0:317          'inF0' (in 4-component vector of float)
+0:317          'inF1' (in 4-component vector of float)
+0:318      move second child to first child (temp 4-component vector of float)
+0:318        'r054' (temp 4-component vector of float)
+0:318        refract (global 4-component vector of float)
+0:318          'inF0' (in 4-component vector of float)
 0:318          'inF1' (in 4-component vector of float)
-0:318          sine (temp 4-component vector of float)
-0:318            'inF0' (in 4-component vector of float)
-0:318        move second child to first child (temp 4-component vector of float)
-0:318          'inF2' (in 4-component vector of float)
-0:318          cosine (temp 4-component vector of float)
-0:318            'inF0' (in 4-component vector of float)
-0:319      hyp. sine (global 4-component vector of float)
-0:319        'inF0' (in 4-component vector of float)
-0:320      smoothstep (global 4-component vector of float)
-0:320        'inF0' (in 4-component vector of float)
-0:320        'inF1' (in 4-component vector of float)
-0:320        'inF2' (in 4-component vector of float)
-0:321      sqrt (global 4-component vector of float)
-0:321        'inF0' (in 4-component vector of float)
-0:322      step (global 4-component vector of float)
-0:322        'inF0' (in 4-component vector of float)
-0:322        'inF1' (in 4-component vector of float)
-0:323      tangent (global 4-component vector of float)
-0:323        'inF0' (in 4-component vector of float)
-0:324      hyp. tangent (global 4-component vector of float)
-0:324        'inF0' (in 4-component vector of float)
-0:326      trunc (global 4-component vector of float)
-0:326        'inF0' (in 4-component vector of float)
-0:329      Branch: Return with expression
+0:318          Constant:
+0:318            2.000000
+0:319      move second child to first child (temp 4-component vector of uint)
+0:319        'r055' (temp 4-component vector of uint)
+0:?         bitFieldReverse (global 4-component vector of uint)
+0:?           Constant:
+0:?             1 (const uint)
+0:?             2 (const uint)
+0:?             3 (const uint)
+0:?             4 (const uint)
+0:320      move second child to first child (temp 4-component vector of float)
+0:320        'r056' (temp 4-component vector of float)
+0:320        roundEven (global 4-component vector of float)
+0:320          'inF0' (in 4-component vector of float)
+0:321      move second child to first child (temp 4-component vector of float)
+0:321        'r057' (temp 4-component vector of float)
+0:321        inverse sqrt (global 4-component vector of float)
+0:321          'inF0' (in 4-component vector of float)
+0:322      move second child to first child (temp 4-component vector of float)
+0:322        'r058' (temp 4-component vector of float)
+0:322        clamp (temp 4-component vector of float)
+0:322          'inF0' (in 4-component vector of float)
+0:322          Constant:
+0:322            0.000000
+0:322          Constant:
+0:322            1.000000
+0:323      move second child to first child (temp 4-component vector of float)
+0:323        'r059' (temp 4-component vector of float)
+0:323        Sign (global 4-component vector of float)
+0:323          'inF0' (in 4-component vector of float)
+0:324      move second child to first child (temp 4-component vector of float)
+0:324        'r060' (temp 4-component vector of float)
+0:324        sine (global 4-component vector of float)
+0:324          'inF0' (in 4-component vector of float)
+0:325      Sequence
+0:325        move second child to first child (temp 4-component vector of float)
+0:325          'inF1' (in 4-component vector of float)
+0:325          sine (temp 4-component vector of float)
+0:325            'inF0' (in 4-component vector of float)
+0:325        move second child to first child (temp 4-component vector of float)
+0:325          'inF2' (in 4-component vector of float)
+0:325          cosine (temp 4-component vector of float)
+0:325            'inF0' (in 4-component vector of float)
+0:326      move second child to first child (temp 4-component vector of float)
+0:326        'r061' (temp 4-component vector of float)
+0:326        hyp. sine (global 4-component vector of float)
+0:326          'inF0' (in 4-component vector of float)
+0:327      move second child to first child (temp 4-component vector of float)
+0:327        'r062' (temp 4-component vector of float)
+0:327        smoothstep (global 4-component vector of float)
+0:327          'inF0' (in 4-component vector of float)
+0:327          'inF1' (in 4-component vector of float)
+0:327          'inF2' (in 4-component vector of float)
+0:328      move second child to first child (temp 4-component vector of float)
+0:328        'r063' (temp 4-component vector of float)
+0:328        sqrt (global 4-component vector of float)
+0:328          'inF0' (in 4-component vector of float)
+0:329      move second child to first child (temp 4-component vector of float)
+0:329        'r064' (temp 4-component vector of float)
+0:329        step (global 4-component vector of float)
+0:329          'inF0' (in 4-component vector of float)
+0:329          'inF1' (in 4-component vector of float)
+0:330      move second child to first child (temp 4-component vector of float)
+0:330        'r065' (temp 4-component vector of float)
+0:330        tangent (global 4-component vector of float)
+0:330          'inF0' (in 4-component vector of float)
+0:331      move second child to first child (temp 4-component vector of float)
+0:331        'r066' (temp 4-component vector of float)
+0:331        hyp. tangent (global 4-component vector of float)
+0:331          'inF0' (in 4-component vector of float)
+0:333      move second child to first child (temp 4-component vector of float)
+0:333        'r067' (temp 4-component vector of float)
+0:333        trunc (global 4-component vector of float)
+0:333          'inF0' (in 4-component vector of float)
+0:336      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
 0:?           4.000000
-0:402  Function Definition: PixelShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
-0:394    Function Parameters: 
-0:394      'inF0' (in 2X2 matrix of float)
-0:394      'inF1' (in 2X2 matrix of float)
-0:394      'inF2' (in 2X2 matrix of float)
+0:408  Function Definition: PixelShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:400    Function Parameters: 
+0:400      'inF0' (in 2X2 matrix of float)
+0:400      'inF1' (in 2X2 matrix of float)
+0:400      'inF2' (in 2X2 matrix of float)
 0:?     Sequence
-0:396      all (global bool)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      Absolute value (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      arc cosine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      any (global bool)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      arc sine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      arc tangent (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      arc tangent (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      Ceiling (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      Test condition and select (temp void)
-0:396        Condition
-0:396        any (temp bool)
-0:396          Compare Less Than (temp 2X2 matrix of bool)
-0:396            'inF0' (in 2X2 matrix of float)
-0:396            Constant:
-0:396              0.000000
-0:396              0.000000
-0:396              0.000000
-0:396              0.000000
-0:396        true case
-0:396        Branch: Kill
-0:396      clamp (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396        'inF2' (in 2X2 matrix of float)
-0:396      cosine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      hyp. cosine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      dPdx (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      dPdxCoarse (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      dPdxFine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      dPdy (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      dPdyCoarse (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      dPdyFine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      degrees (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      determinant (global float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      exp (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      exp2 (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      findMSB (global int)
-0:396        Constant:
-0:396          7 (const int)
-0:396      findLSB (global int)
-0:396        Constant:
-0:396          7 (const int)
-0:396      Floor (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      mod (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      Fraction (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      frexp (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      fwidth (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      ldexp (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      log (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      matrix-scale (temp 2X2 matrix of float)
-0:396        log2 (temp 2X2 matrix of float)
-0:396          'inF0' (in 2X2 matrix of float)
-0:396        Constant:
-0:396          0.301030
-0:396      log2 (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      max (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      min (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      pow (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      radians (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      roundEven (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      inverse sqrt (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      clamp (temp 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        Constant:
-0:396          0.000000
-0:396        Constant:
-0:396          1.000000
-0:396      Sign (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      sine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      Sequence
-0:396        move second child to first child (temp 2X2 matrix of float)
-0:396          'inF1' (in 2X2 matrix of float)
-0:396          sine (temp 2X2 matrix of float)
-0:396            'inF0' (in 2X2 matrix of float)
-0:396        move second child to first child (temp 2X2 matrix of float)
-0:396          'inF2' (in 2X2 matrix of float)
-0:396          cosine (temp 2X2 matrix of float)
-0:396            'inF0' (in 2X2 matrix of float)
-0:396      hyp. sine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      smoothstep (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396        'inF2' (in 2X2 matrix of float)
-0:396      sqrt (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      step (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      tangent (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      hyp. tangent (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      transpose (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      trunc (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:399      Branch: Return with expression
+0:402      move second child to first child (temp bool)
+0:402        'r000' (temp bool)
+0:402        all (global bool)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r001' (temp 2X2 matrix of float)
+0:402        Absolute value (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      arc cosine (global 2X2 matrix of float)
+0:402        'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp bool)
+0:402        'r003' (temp bool)
+0:402        any (global bool)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r004' (temp 2X2 matrix of float)
+0:402        arc sine (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r005' (temp 2X2 matrix of float)
+0:402        arc tangent (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r006' (temp 2X2 matrix of float)
+0:402        arc tangent (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r007' (temp 2X2 matrix of float)
+0:402        Ceiling (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      Test condition and select (temp void)
+0:402        Condition
+0:402        any (temp bool)
+0:402          Compare Less Than (temp 2X2 matrix of bool)
+0:402            'inF0' (in 2X2 matrix of float)
+0:402            Constant:
+0:402              0.000000
+0:402              0.000000
+0:402              0.000000
+0:402              0.000000
+0:402        true case
+0:402        Branch: Kill
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r008' (temp 2X2 matrix of float)
+0:402        clamp (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402          'inF2' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r009' (temp 2X2 matrix of float)
+0:402        cosine (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r010' (temp 2X2 matrix of float)
+0:402        hyp. cosine (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r011' (temp 2X2 matrix of float)
+0:402        dPdx (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r012' (temp 2X2 matrix of float)
+0:402        dPdxCoarse (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r013' (temp 2X2 matrix of float)
+0:402        dPdxFine (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r014' (temp 2X2 matrix of float)
+0:402        dPdy (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r015' (temp 2X2 matrix of float)
+0:402        dPdyCoarse (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r016' (temp 2X2 matrix of float)
+0:402        dPdyFine (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r017' (temp 2X2 matrix of float)
+0:402        degrees (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp float)
+0:402        'r018' (temp float)
+0:402        determinant (global float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r019' (temp 2X2 matrix of float)
+0:402        exp (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'R020' (temp 2X2 matrix of float)
+0:402        exp2 (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r021' (temp 2X2 matrix of float)
+0:402        Floor (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r022' (temp 2X2 matrix of float)
+0:402        mod (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r023' (temp 2X2 matrix of float)
+0:402        Fraction (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r024' (temp 2X2 matrix of float)
+0:402        frexp (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r025' (temp 2X2 matrix of float)
+0:402        fwidth (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r026' (temp 2X2 matrix of float)
+0:402        ldexp (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r026a' (temp 2X2 matrix of float)
+0:402        mix (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402          'inF2' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r027' (temp 2X2 matrix of float)
+0:402        log (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r028' (temp 2X2 matrix of float)
+0:402        matrix-scale (temp 2X2 matrix of float)
+0:402          log2 (temp 2X2 matrix of float)
+0:402            'inF0' (in 2X2 matrix of float)
+0:402          Constant:
+0:402            0.301030
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r029' (temp 2X2 matrix of float)
+0:402        log2 (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r030' (temp 2X2 matrix of float)
+0:402        max (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r031' (temp 2X2 matrix of float)
+0:402        min (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r032' (temp 2X2 matrix of float)
+0:402        pow (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r033' (temp 2X2 matrix of float)
+0:402        radians (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r034' (temp 2X2 matrix of float)
+0:402        roundEven (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r035' (temp 2X2 matrix of float)
+0:402        inverse sqrt (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r036' (temp 2X2 matrix of float)
+0:402        clamp (temp 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          Constant:
+0:402            0.000000
+0:402          Constant:
+0:402            1.000000
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r037' (temp 2X2 matrix of float)
+0:402        Sign (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r038' (temp 2X2 matrix of float)
+0:402        sine (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      Sequence
+0:402        move second child to first child (temp 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402          sine (temp 2X2 matrix of float)
+0:402            'inF0' (in 2X2 matrix of float)
+0:402        move second child to first child (temp 2X2 matrix of float)
+0:402          'inF2' (in 2X2 matrix of float)
+0:402          cosine (temp 2X2 matrix of float)
+0:402            'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r039' (temp 2X2 matrix of float)
+0:402        hyp. sine (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r049' (temp 2X2 matrix of float)
+0:402        smoothstep (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402          'inF2' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r041' (temp 2X2 matrix of float)
+0:402        sqrt (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r042' (temp 2X2 matrix of float)
+0:402        step (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r043' (temp 2X2 matrix of float)
+0:402        tangent (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r044' (temp 2X2 matrix of float)
+0:402        hyp. tangent (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      transpose (global 2X2 matrix of float)
+0:402        'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r046' (temp 2X2 matrix of float)
+0:402        trunc (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:405      Branch: Return with expression
 0:?         Constant:
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
-0:411  Function Definition: PixelShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
-0:403    Function Parameters: 
-0:403      'inF0' (in 3X3 matrix of float)
-0:403      'inF1' (in 3X3 matrix of float)
-0:403      'inF2' (in 3X3 matrix of float)
+0:417  Function Definition: PixelShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:409    Function Parameters: 
+0:409      'inF0' (in 3X3 matrix of float)
+0:409      'inF1' (in 3X3 matrix of float)
+0:409      'inF2' (in 3X3 matrix of float)
 0:?     Sequence
-0:405      all (global bool)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      Absolute value (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      arc cosine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      any (global bool)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      arc sine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      arc tangent (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      arc tangent (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      Ceiling (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      Test condition and select (temp void)
-0:405        Condition
-0:405        any (temp bool)
-0:405          Compare Less Than (temp 3X3 matrix of bool)
-0:405            'inF0' (in 3X3 matrix of float)
-0:405            Constant:
-0:405              0.000000
-0:405              0.000000
-0:405              0.000000
-0:405              0.000000
-0:405              0.000000
-0:405              0.000000
-0:405              0.000000
-0:405              0.000000
-0:405              0.000000
-0:405        true case
-0:405        Branch: Kill
-0:405      clamp (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405        'inF2' (in 3X3 matrix of float)
-0:405      cosine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      hyp. cosine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      dPdx (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      dPdxCoarse (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      dPdxFine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      dPdy (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      dPdyCoarse (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      dPdyFine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      degrees (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      determinant (global float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      exp (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      exp2 (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      findMSB (global int)
-0:405        Constant:
-0:405          7 (const int)
-0:405      findLSB (global int)
-0:405        Constant:
-0:405          7 (const int)
-0:405      Floor (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      mod (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      Fraction (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      frexp (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      fwidth (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      ldexp (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      log (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      matrix-scale (temp 3X3 matrix of float)
-0:405        log2 (temp 3X3 matrix of float)
-0:405          'inF0' (in 3X3 matrix of float)
-0:405        Constant:
-0:405          0.301030
-0:405      log2 (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      max (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      min (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      pow (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      radians (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      roundEven (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      inverse sqrt (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      clamp (temp 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        Constant:
-0:405          0.000000
-0:405        Constant:
-0:405          1.000000
-0:405      Sign (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      sine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      Sequence
-0:405        move second child to first child (temp 3X3 matrix of float)
-0:405          'inF1' (in 3X3 matrix of float)
-0:405          sine (temp 3X3 matrix of float)
-0:405            'inF0' (in 3X3 matrix of float)
-0:405        move second child to first child (temp 3X3 matrix of float)
-0:405          'inF2' (in 3X3 matrix of float)
-0:405          cosine (temp 3X3 matrix of float)
-0:405            'inF0' (in 3X3 matrix of float)
-0:405      hyp. sine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      smoothstep (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405        'inF2' (in 3X3 matrix of float)
-0:405      sqrt (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      step (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      tangent (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      hyp. tangent (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      transpose (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      trunc (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:408      Branch: Return with expression
+0:411      move second child to first child (temp bool)
+0:411        'r000' (temp bool)
+0:411        all (global bool)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r001' (temp 3X3 matrix of float)
+0:411        Absolute value (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      arc cosine (global 3X3 matrix of float)
+0:411        'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp bool)
+0:411        'r003' (temp bool)
+0:411        any (global bool)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r004' (temp 3X3 matrix of float)
+0:411        arc sine (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r005' (temp 3X3 matrix of float)
+0:411        arc tangent (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r006' (temp 3X3 matrix of float)
+0:411        arc tangent (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r007' (temp 3X3 matrix of float)
+0:411        Ceiling (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      Test condition and select (temp void)
+0:411        Condition
+0:411        any (temp bool)
+0:411          Compare Less Than (temp 3X3 matrix of bool)
+0:411            'inF0' (in 3X3 matrix of float)
+0:411            Constant:
+0:411              0.000000
+0:411              0.000000
+0:411              0.000000
+0:411              0.000000
+0:411              0.000000
+0:411              0.000000
+0:411              0.000000
+0:411              0.000000
+0:411              0.000000
+0:411        true case
+0:411        Branch: Kill
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r008' (temp 3X3 matrix of float)
+0:411        clamp (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411          'inF2' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r009' (temp 3X3 matrix of float)
+0:411        cosine (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r010' (temp 3X3 matrix of float)
+0:411        hyp. cosine (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r011' (temp 3X3 matrix of float)
+0:411        dPdx (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r012' (temp 3X3 matrix of float)
+0:411        dPdxCoarse (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r013' (temp 3X3 matrix of float)
+0:411        dPdxFine (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r014' (temp 3X3 matrix of float)
+0:411        dPdy (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r015' (temp 3X3 matrix of float)
+0:411        dPdyCoarse (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r016' (temp 3X3 matrix of float)
+0:411        dPdyFine (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r017' (temp 3X3 matrix of float)
+0:411        degrees (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp float)
+0:411        'r018' (temp float)
+0:411        determinant (global float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r019' (temp 3X3 matrix of float)
+0:411        exp (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'R020' (temp 3X3 matrix of float)
+0:411        exp2 (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r021' (temp 3X3 matrix of float)
+0:411        Floor (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r022' (temp 3X3 matrix of float)
+0:411        mod (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r023' (temp 3X3 matrix of float)
+0:411        Fraction (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r024' (temp 3X3 matrix of float)
+0:411        frexp (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r025' (temp 3X3 matrix of float)
+0:411        fwidth (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r026' (temp 3X3 matrix of float)
+0:411        ldexp (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r026a' (temp 3X3 matrix of float)
+0:411        mix (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411          'inF2' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r027' (temp 3X3 matrix of float)
+0:411        log (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r028' (temp 3X3 matrix of float)
+0:411        matrix-scale (temp 3X3 matrix of float)
+0:411          log2 (temp 3X3 matrix of float)
+0:411            'inF0' (in 3X3 matrix of float)
+0:411          Constant:
+0:411            0.301030
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r029' (temp 3X3 matrix of float)
+0:411        log2 (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r030' (temp 3X3 matrix of float)
+0:411        max (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r031' (temp 3X3 matrix of float)
+0:411        min (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r032' (temp 3X3 matrix of float)
+0:411        pow (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r033' (temp 3X3 matrix of float)
+0:411        radians (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r034' (temp 3X3 matrix of float)
+0:411        roundEven (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r035' (temp 3X3 matrix of float)
+0:411        inverse sqrt (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r036' (temp 3X3 matrix of float)
+0:411        clamp (temp 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          Constant:
+0:411            0.000000
+0:411          Constant:
+0:411            1.000000
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r037' (temp 3X3 matrix of float)
+0:411        Sign (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r038' (temp 3X3 matrix of float)
+0:411        sine (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      Sequence
+0:411        move second child to first child (temp 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411          sine (temp 3X3 matrix of float)
+0:411            'inF0' (in 3X3 matrix of float)
+0:411        move second child to first child (temp 3X3 matrix of float)
+0:411          'inF2' (in 3X3 matrix of float)
+0:411          cosine (temp 3X3 matrix of float)
+0:411            'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r039' (temp 3X3 matrix of float)
+0:411        hyp. sine (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r049' (temp 3X3 matrix of float)
+0:411        smoothstep (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411          'inF2' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r041' (temp 3X3 matrix of float)
+0:411        sqrt (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r042' (temp 3X3 matrix of float)
+0:411        step (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r043' (temp 3X3 matrix of float)
+0:411        tangent (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r044' (temp 3X3 matrix of float)
+0:411        hyp. tangent (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      transpose (global 3X3 matrix of float)
+0:411        'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r046' (temp 3X3 matrix of float)
+0:411        trunc (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:414      Branch: Return with expression
 0:?         Constant:
 0:?           3.000000
 0:?           3.000000
@@ -1093,165 +1797,255 @@ gl_FragCoord origin is upper left
 0:?           3.000000
 0:?           3.000000
 0:?           3.000000
-0:432  Function Definition: PixelShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
-0:412    Function Parameters: 
-0:412      'inF0' (in 4X4 matrix of float)
-0:412      'inF1' (in 4X4 matrix of float)
-0:412      'inF2' (in 4X4 matrix of float)
+0:438  Function Definition: PixelShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:418    Function Parameters: 
+0:418      'inF0' (in 4X4 matrix of float)
+0:418      'inF1' (in 4X4 matrix of float)
+0:418      'inF2' (in 4X4 matrix of float)
 0:?     Sequence
-0:414      all (global bool)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      Absolute value (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      arc cosine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      any (global bool)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      arc sine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      arc tangent (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      arc tangent (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      Ceiling (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      Test condition and select (temp void)
-0:414        Condition
-0:414        any (temp bool)
-0:414          Compare Less Than (temp 4X4 matrix of bool)
-0:414            'inF0' (in 4X4 matrix of float)
-0:414            Constant:
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414        true case
-0:414        Branch: Kill
-0:414      clamp (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414        'inF2' (in 4X4 matrix of float)
-0:414      cosine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      hyp. cosine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      dPdx (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      dPdxCoarse (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      dPdxFine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      dPdy (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      dPdyCoarse (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      dPdyFine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      degrees (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      determinant (global float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      exp (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      exp2 (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      findMSB (global int)
-0:414        Constant:
-0:414          7 (const int)
-0:414      findLSB (global int)
-0:414        Constant:
-0:414          7 (const int)
-0:414      Floor (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      mod (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      Fraction (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      frexp (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      fwidth (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      ldexp (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      log (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      matrix-scale (temp 4X4 matrix of float)
-0:414        log2 (temp 4X4 matrix of float)
-0:414          'inF0' (in 4X4 matrix of float)
-0:414        Constant:
-0:414          0.301030
-0:414      log2 (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      max (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      min (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      pow (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      radians (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      roundEven (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      inverse sqrt (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      clamp (temp 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        Constant:
-0:414          0.000000
-0:414        Constant:
-0:414          1.000000
-0:414      Sign (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      sine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      Sequence
-0:414        move second child to first child (temp 4X4 matrix of float)
-0:414          'inF1' (in 4X4 matrix of float)
-0:414          sine (temp 4X4 matrix of float)
-0:414            'inF0' (in 4X4 matrix of float)
-0:414        move second child to first child (temp 4X4 matrix of float)
-0:414          'inF2' (in 4X4 matrix of float)
-0:414          cosine (temp 4X4 matrix of float)
-0:414            'inF0' (in 4X4 matrix of float)
-0:414      hyp. sine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      smoothstep (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414        'inF2' (in 4X4 matrix of float)
-0:414      sqrt (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      step (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      tangent (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      hyp. tangent (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      transpose (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      trunc (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:417      Branch: Return with expression
+0:420      move second child to first child (temp bool)
+0:420        'r000' (temp bool)
+0:420        all (global bool)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r001' (temp 4X4 matrix of float)
+0:420        Absolute value (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      arc cosine (global 4X4 matrix of float)
+0:420        'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp bool)
+0:420        'r003' (temp bool)
+0:420        any (global bool)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r004' (temp 4X4 matrix of float)
+0:420        arc sine (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r005' (temp 4X4 matrix of float)
+0:420        arc tangent (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r006' (temp 4X4 matrix of float)
+0:420        arc tangent (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r007' (temp 4X4 matrix of float)
+0:420        Ceiling (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      Test condition and select (temp void)
+0:420        Condition
+0:420        any (temp bool)
+0:420          Compare Less Than (temp 4X4 matrix of bool)
+0:420            'inF0' (in 4X4 matrix of float)
+0:420            Constant:
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420        true case
+0:420        Branch: Kill
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r008' (temp 4X4 matrix of float)
+0:420        clamp (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420          'inF2' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r009' (temp 4X4 matrix of float)
+0:420        cosine (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r010' (temp 4X4 matrix of float)
+0:420        hyp. cosine (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r011' (temp 4X4 matrix of float)
+0:420        dPdx (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r012' (temp 4X4 matrix of float)
+0:420        dPdxCoarse (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r013' (temp 4X4 matrix of float)
+0:420        dPdxFine (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r014' (temp 4X4 matrix of float)
+0:420        dPdy (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r015' (temp 4X4 matrix of float)
+0:420        dPdyCoarse (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r016' (temp 4X4 matrix of float)
+0:420        dPdyFine (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r017' (temp 4X4 matrix of float)
+0:420        degrees (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp float)
+0:420        'r018' (temp float)
+0:420        determinant (global float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r019' (temp 4X4 matrix of float)
+0:420        exp (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'R020' (temp 4X4 matrix of float)
+0:420        exp2 (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r021' (temp 4X4 matrix of float)
+0:420        Floor (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r022' (temp 4X4 matrix of float)
+0:420        mod (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r023' (temp 4X4 matrix of float)
+0:420        Fraction (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r024' (temp 4X4 matrix of float)
+0:420        frexp (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r025' (temp 4X4 matrix of float)
+0:420        fwidth (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r026' (temp 4X4 matrix of float)
+0:420        ldexp (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r026a' (temp 4X4 matrix of float)
+0:420        mix (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420          'inF2' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r027' (temp 4X4 matrix of float)
+0:420        log (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r028' (temp 4X4 matrix of float)
+0:420        matrix-scale (temp 4X4 matrix of float)
+0:420          log2 (temp 4X4 matrix of float)
+0:420            'inF0' (in 4X4 matrix of float)
+0:420          Constant:
+0:420            0.301030
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r029' (temp 4X4 matrix of float)
+0:420        log2 (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r030' (temp 4X4 matrix of float)
+0:420        max (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r031' (temp 4X4 matrix of float)
+0:420        min (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r032' (temp 4X4 matrix of float)
+0:420        pow (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r033' (temp 4X4 matrix of float)
+0:420        radians (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r034' (temp 4X4 matrix of float)
+0:420        roundEven (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r035' (temp 4X4 matrix of float)
+0:420        inverse sqrt (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r036' (temp 4X4 matrix of float)
+0:420        clamp (temp 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          Constant:
+0:420            0.000000
+0:420          Constant:
+0:420            1.000000
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r037' (temp 4X4 matrix of float)
+0:420        Sign (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r038' (temp 4X4 matrix of float)
+0:420        sine (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      Sequence
+0:420        move second child to first child (temp 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420          sine (temp 4X4 matrix of float)
+0:420            'inF0' (in 4X4 matrix of float)
+0:420        move second child to first child (temp 4X4 matrix of float)
+0:420          'inF2' (in 4X4 matrix of float)
+0:420          cosine (temp 4X4 matrix of float)
+0:420            'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r039' (temp 4X4 matrix of float)
+0:420        hyp. sine (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r049' (temp 4X4 matrix of float)
+0:420        smoothstep (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420          'inF2' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r041' (temp 4X4 matrix of float)
+0:420        sqrt (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r042' (temp 4X4 matrix of float)
+0:420        step (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r043' (temp 4X4 matrix of float)
+0:420        tangent (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r044' (temp 4X4 matrix of float)
+0:420        hyp. tangent (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      transpose (global 4X4 matrix of float)
+0:420        'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r046' (temp 4X4 matrix of float)
+0:420        trunc (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:423      Branch: Return with expression
 0:?         Constant:
 0:?           4.000000
 0:?           4.000000
@@ -1269,168 +2063,265 @@ gl_FragCoord origin is upper left
 0:?           4.000000
 0:?           4.000000
 0:?           4.000000
-0:439  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
-0:435    Function Parameters: 
-0:435      'inF0' (in float)
-0:435      'inF1' (in float)
-0:435      'inFV0' (in 2-component vector of float)
-0:435      'inFV1' (in 2-component vector of float)
-0:435      'inFM0' (in 2X2 matrix of float)
-0:435      'inFM1' (in 2X2 matrix of float)
+0:445  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
+0:441    Function Parameters: 
+0:441      'inF0' (in float)
+0:441      'inF1' (in float)
+0:441      'inFV0' (in 2-component vector of float)
+0:441      'inFV1' (in 2-component vector of float)
+0:441      'inFM0' (in 2X2 matrix of float)
+0:441      'inFM1' (in 2X2 matrix of float)
 0:?     Sequence
-0:436      move second child to first child (temp float)
-0:436        'r0' (temp float)
-0:436        component-wise multiply (temp float)
-0:436          'inF0' (in float)
-0:436          'inF1' (in float)
-0:436      move second child to first child (temp 2-component vector of float)
-0:436        'r1' (temp 2-component vector of float)
-0:436        vector-scale (temp 2-component vector of float)
-0:436          'inFV0' (in 2-component vector of float)
-0:436          'inF0' (in float)
-0:436      move second child to first child (temp 2-component vector of float)
-0:436        'r2' (temp 2-component vector of float)
-0:436        vector-scale (temp 2-component vector of float)
-0:436          'inF0' (in float)
-0:436          'inFV0' (in 2-component vector of float)
-0:436      move second child to first child (temp float)
-0:436        'r3' (temp float)
-0:436        dot-product (global float)
-0:436          'inFV0' (in 2-component vector of float)
-0:436          'inFV1' (in 2-component vector of float)
-0:436      move second child to first child (temp 2-component vector of float)
-0:436        'r4' (temp 2-component vector of float)
-0:436        matrix-times-vector (temp 2-component vector of float)
-0:436          'inFM0' (in 2X2 matrix of float)
-0:436          'inFV0' (in 2-component vector of float)
-0:436      move second child to first child (temp 2-component vector of float)
-0:436        'r5' (temp 2-component vector of float)
-0:436        vector-times-matrix (temp 2-component vector of float)
-0:436          'inFV0' (in 2-component vector of float)
-0:436          'inFM0' (in 2X2 matrix of float)
-0:436      move second child to first child (temp 2X2 matrix of float)
-0:436        'r6' (temp 2X2 matrix of float)
-0:436        matrix-scale (temp 2X2 matrix of float)
-0:436          'inFM0' (in 2X2 matrix of float)
-0:436          'inF0' (in float)
-0:436      move second child to first child (temp 2X2 matrix of float)
-0:436        'r7' (temp 2X2 matrix of float)
-0:436        matrix-scale (temp 2X2 matrix of float)
-0:436          'inF0' (in float)
-0:436          'inFM0' (in 2X2 matrix of float)
-0:436      move second child to first child (temp 2X2 matrix of float)
-0:436        'r8' (temp 2X2 matrix of float)
-0:436        matrix-multiply (temp 2X2 matrix of float)
-0:436          'inFM0' (in 2X2 matrix of float)
-0:436          'inFM1' (in 2X2 matrix of float)
-0:446  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
-0:442    Function Parameters: 
-0:442      'inF0' (in float)
-0:442      'inF1' (in float)
-0:442      'inFV0' (in 3-component vector of float)
-0:442      'inFV1' (in 3-component vector of float)
-0:442      'inFM0' (in 3X3 matrix of float)
-0:442      'inFM1' (in 3X3 matrix of float)
+0:442      move second child to first child (temp float)
+0:442        'r0' (temp float)
+0:442        component-wise multiply (temp float)
+0:442          'inF0' (in float)
+0:442          'inF1' (in float)
+0:442      move second child to first child (temp 2-component vector of float)
+0:442        'r1' (temp 2-component vector of float)
+0:442        vector-scale (temp 2-component vector of float)
+0:442          'inFV0' (in 2-component vector of float)
+0:442          'inF0' (in float)
+0:442      move second child to first child (temp 2-component vector of float)
+0:442        'r2' (temp 2-component vector of float)
+0:442        vector-scale (temp 2-component vector of float)
+0:442          'inF0' (in float)
+0:442          'inFV0' (in 2-component vector of float)
+0:442      move second child to first child (temp float)
+0:442        'r3' (temp float)
+0:442        dot-product (global float)
+0:442          'inFV0' (in 2-component vector of float)
+0:442          'inFV1' (in 2-component vector of float)
+0:442      move second child to first child (temp 2-component vector of float)
+0:442        'r4' (temp 2-component vector of float)
+0:442        matrix-times-vector (temp 2-component vector of float)
+0:442          'inFM0' (in 2X2 matrix of float)
+0:442          'inFV0' (in 2-component vector of float)
+0:442      move second child to first child (temp 2-component vector of float)
+0:442        'r5' (temp 2-component vector of float)
+0:442        vector-times-matrix (temp 2-component vector of float)
+0:442          'inFV0' (in 2-component vector of float)
+0:442          'inFM0' (in 2X2 matrix of float)
+0:442      move second child to first child (temp 2X2 matrix of float)
+0:442        'r6' (temp 2X2 matrix of float)
+0:442        matrix-scale (temp 2X2 matrix of float)
+0:442          'inFM0' (in 2X2 matrix of float)
+0:442          'inF0' (in float)
+0:442      move second child to first child (temp 2X2 matrix of float)
+0:442        'r7' (temp 2X2 matrix of float)
+0:442        matrix-scale (temp 2X2 matrix of float)
+0:442          'inF0' (in float)
+0:442          'inFM0' (in 2X2 matrix of float)
+0:442      move second child to first child (temp 2X2 matrix of float)
+0:442        'r8' (temp 2X2 matrix of float)
+0:442        matrix-multiply (temp 2X2 matrix of float)
+0:442          'inFM0' (in 2X2 matrix of float)
+0:442          'inFM1' (in 2X2 matrix of float)
+0:452  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
+0:448    Function Parameters: 
+0:448      'inF0' (in float)
+0:448      'inF1' (in float)
+0:448      'inFV0' (in 3-component vector of float)
+0:448      'inFV1' (in 3-component vector of float)
+0:448      'inFM0' (in 3X3 matrix of float)
+0:448      'inFM1' (in 3X3 matrix of float)
 0:?     Sequence
-0:443      move second child to first child (temp float)
-0:443        'r0' (temp float)
-0:443        component-wise multiply (temp float)
-0:443          'inF0' (in float)
-0:443          'inF1' (in float)
-0:443      move second child to first child (temp 3-component vector of float)
-0:443        'r1' (temp 3-component vector of float)
-0:443        vector-scale (temp 3-component vector of float)
-0:443          'inFV0' (in 3-component vector of float)
-0:443          'inF0' (in float)
-0:443      move second child to first child (temp 3-component vector of float)
-0:443        'r2' (temp 3-component vector of float)
-0:443        vector-scale (temp 3-component vector of float)
-0:443          'inF0' (in float)
-0:443          'inFV0' (in 3-component vector of float)
-0:443      move second child to first child (temp float)
-0:443        'r3' (temp float)
-0:443        dot-product (global float)
-0:443          'inFV0' (in 3-component vector of float)
-0:443          'inFV1' (in 3-component vector of float)
-0:443      move second child to first child (temp 3-component vector of float)
-0:443        'r4' (temp 3-component vector of float)
-0:443        matrix-times-vector (temp 3-component vector of float)
-0:443          'inFM0' (in 3X3 matrix of float)
-0:443          'inFV0' (in 3-component vector of float)
-0:443      move second child to first child (temp 3-component vector of float)
-0:443        'r5' (temp 3-component vector of float)
-0:443        vector-times-matrix (temp 3-component vector of float)
-0:443          'inFV0' (in 3-component vector of float)
-0:443          'inFM0' (in 3X3 matrix of float)
-0:443      move second child to first child (temp 3X3 matrix of float)
-0:443        'r6' (temp 3X3 matrix of float)
-0:443        matrix-scale (temp 3X3 matrix of float)
-0:443          'inFM0' (in 3X3 matrix of float)
-0:443          'inF0' (in float)
-0:443      move second child to first child (temp 3X3 matrix of float)
-0:443        'r7' (temp 3X3 matrix of float)
-0:443        matrix-scale (temp 3X3 matrix of float)
-0:443          'inF0' (in float)
-0:443          'inFM0' (in 3X3 matrix of float)
-0:443      move second child to first child (temp 3X3 matrix of float)
-0:443        'r8' (temp 3X3 matrix of float)
-0:443        matrix-multiply (temp 3X3 matrix of float)
-0:443          'inFM0' (in 3X3 matrix of float)
-0:443          'inFM1' (in 3X3 matrix of float)
-0:452  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
-0:449    Function Parameters: 
-0:449      'inF0' (in float)
-0:449      'inF1' (in float)
-0:449      'inFV0' (in 4-component vector of float)
-0:449      'inFV1' (in 4-component vector of float)
-0:449      'inFM0' (in 4X4 matrix of float)
-0:449      'inFM1' (in 4X4 matrix of float)
+0:449      move second child to first child (temp float)
+0:449        'r0' (temp float)
+0:449        component-wise multiply (temp float)
+0:449          'inF0' (in float)
+0:449          'inF1' (in float)
+0:449      move second child to first child (temp 3-component vector of float)
+0:449        'r1' (temp 3-component vector of float)
+0:449        vector-scale (temp 3-component vector of float)
+0:449          'inFV0' (in 3-component vector of float)
+0:449          'inF0' (in float)
+0:449      move second child to first child (temp 3-component vector of float)
+0:449        'r2' (temp 3-component vector of float)
+0:449        vector-scale (temp 3-component vector of float)
+0:449          'inF0' (in float)
+0:449          'inFV0' (in 3-component vector of float)
+0:449      move second child to first child (temp float)
+0:449        'r3' (temp float)
+0:449        dot-product (global float)
+0:449          'inFV0' (in 3-component vector of float)
+0:449          'inFV1' (in 3-component vector of float)
+0:449      move second child to first child (temp 3-component vector of float)
+0:449        'r4' (temp 3-component vector of float)
+0:449        matrix-times-vector (temp 3-component vector of float)
+0:449          'inFM0' (in 3X3 matrix of float)
+0:449          'inFV0' (in 3-component vector of float)
+0:449      move second child to first child (temp 3-component vector of float)
+0:449        'r5' (temp 3-component vector of float)
+0:449        vector-times-matrix (temp 3-component vector of float)
+0:449          'inFV0' (in 3-component vector of float)
+0:449          'inFM0' (in 3X3 matrix of float)
+0:449      move second child to first child (temp 3X3 matrix of float)
+0:449        'r6' (temp 3X3 matrix of float)
+0:449        matrix-scale (temp 3X3 matrix of float)
+0:449          'inFM0' (in 3X3 matrix of float)
+0:449          'inF0' (in float)
+0:449      move second child to first child (temp 3X3 matrix of float)
+0:449        'r7' (temp 3X3 matrix of float)
+0:449        matrix-scale (temp 3X3 matrix of float)
+0:449          'inF0' (in float)
+0:449          'inFM0' (in 3X3 matrix of float)
+0:449      move second child to first child (temp 3X3 matrix of float)
+0:449        'r8' (temp 3X3 matrix of float)
+0:449        matrix-multiply (temp 3X3 matrix of float)
+0:449          'inFM0' (in 3X3 matrix of float)
+0:449          'inFM1' (in 3X3 matrix of float)
+0:460  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
+0:455    Function Parameters: 
+0:455      'inF0' (in float)
+0:455      'inF1' (in float)
+0:455      'inFV0' (in 4-component vector of float)
+0:455      'inFV1' (in 4-component vector of float)
+0:455      'inFM0' (in 4X4 matrix of float)
+0:455      'inFM1' (in 4X4 matrix of float)
 0:?     Sequence
-0:450      move second child to first child (temp float)
-0:450        'r0' (temp float)
-0:450        component-wise multiply (temp float)
-0:450          'inF0' (in float)
-0:450          'inF1' (in float)
-0:450      move second child to first child (temp 4-component vector of float)
-0:450        'r1' (temp 4-component vector of float)
-0:450        vector-scale (temp 4-component vector of float)
-0:450          'inFV0' (in 4-component vector of float)
-0:450          'inF0' (in float)
-0:450      move second child to first child (temp 4-component vector of float)
-0:450        'r2' (temp 4-component vector of float)
-0:450        vector-scale (temp 4-component vector of float)
-0:450          'inF0' (in float)
-0:450          'inFV0' (in 4-component vector of float)
-0:450      move second child to first child (temp float)
-0:450        'r3' (temp float)
-0:450        dot-product (global float)
-0:450          'inFV0' (in 4-component vector of float)
-0:450          'inFV1' (in 4-component vector of float)
-0:450      move second child to first child (temp 4-component vector of float)
-0:450        'r4' (temp 4-component vector of float)
-0:450        matrix-times-vector (temp 4-component vector of float)
-0:450          'inFM0' (in 4X4 matrix of float)
-0:450          'inFV0' (in 4-component vector of float)
-0:450      move second child to first child (temp 4-component vector of float)
-0:450        'r5' (temp 4-component vector of float)
-0:450        vector-times-matrix (temp 4-component vector of float)
-0:450          'inFV0' (in 4-component vector of float)
-0:450          'inFM0' (in 4X4 matrix of float)
-0:450      move second child to first child (temp 4X4 matrix of float)
-0:450        'r6' (temp 4X4 matrix of float)
-0:450        matrix-scale (temp 4X4 matrix of float)
-0:450          'inFM0' (in 4X4 matrix of float)
-0:450          'inF0' (in float)
-0:450      move second child to first child (temp 4X4 matrix of float)
-0:450        'r7' (temp 4X4 matrix of float)
-0:450        matrix-scale (temp 4X4 matrix of float)
-0:450          'inF0' (in float)
-0:450          'inFM0' (in 4X4 matrix of float)
-0:450      move second child to first child (temp 4X4 matrix of float)
-0:450        'r8' (temp 4X4 matrix of float)
-0:450        matrix-multiply (temp 4X4 matrix of float)
-0:450          'inFM0' (in 4X4 matrix of float)
-0:450          'inFM1' (in 4X4 matrix of float)
+0:456      move second child to first child (temp float)
+0:456        'r0' (temp float)
+0:456        component-wise multiply (temp float)
+0:456          'inF0' (in float)
+0:456          'inF1' (in float)
+0:456      move second child to first child (temp 4-component vector of float)
+0:456        'r1' (temp 4-component vector of float)
+0:456        vector-scale (temp 4-component vector of float)
+0:456          'inFV0' (in 4-component vector of float)
+0:456          'inF0' (in float)
+0:456      move second child to first child (temp 4-component vector of float)
+0:456        'r2' (temp 4-component vector of float)
+0:456        vector-scale (temp 4-component vector of float)
+0:456          'inF0' (in float)
+0:456          'inFV0' (in 4-component vector of float)
+0:456      move second child to first child (temp float)
+0:456        'r3' (temp float)
+0:456        dot-product (global float)
+0:456          'inFV0' (in 4-component vector of float)
+0:456          'inFV1' (in 4-component vector of float)
+0:456      move second child to first child (temp 4-component vector of float)
+0:456        'r4' (temp 4-component vector of float)
+0:456        matrix-times-vector (temp 4-component vector of float)
+0:456          'inFM0' (in 4X4 matrix of float)
+0:456          'inFV0' (in 4-component vector of float)
+0:456      move second child to first child (temp 4-component vector of float)
+0:456        'r5' (temp 4-component vector of float)
+0:456        vector-times-matrix (temp 4-component vector of float)
+0:456          'inFV0' (in 4-component vector of float)
+0:456          'inFM0' (in 4X4 matrix of float)
+0:456      move second child to first child (temp 4X4 matrix of float)
+0:456        'r6' (temp 4X4 matrix of float)
+0:456        matrix-scale (temp 4X4 matrix of float)
+0:456          'inFM0' (in 4X4 matrix of float)
+0:456          'inF0' (in float)
+0:456      move second child to first child (temp 4X4 matrix of float)
+0:456        'r7' (temp 4X4 matrix of float)
+0:456        matrix-scale (temp 4X4 matrix of float)
+0:456          'inF0' (in float)
+0:456          'inFM0' (in 4X4 matrix of float)
+0:456      move second child to first child (temp 4X4 matrix of float)
+0:456        'r8' (temp 4X4 matrix of float)
+0:456        matrix-multiply (temp 4X4 matrix of float)
+0:456          'inFM0' (in 4X4 matrix of float)
+0:456          'inFM1' (in 4X4 matrix of float)
+0:484  Function Definition: TestGenMul(f1;f1;vf2;vf3;mf32;mf23;mf33;mf43;mf42; (temp void)
+0:465    Function Parameters: 
+0:465      'inF0' (in float)
+0:465      'inF1' (in float)
+0:465      'inFV2' (in 2-component vector of float)
+0:465      'inFV3' (in 3-component vector of float)
+0:465      'inFM2x3' (in 3X2 matrix of float)
+0:465      'inFM3x2' (in 2X3 matrix of float)
+0:465      'inFM3x3' (in 3X3 matrix of float)
+0:465      'inFM3x4' (in 4X3 matrix of float)
+0:465      'inFM2x4' (in 4X2 matrix of float)
+0:?     Sequence
+0:466      move second child to first child (temp float)
+0:466        'r00' (temp float)
+0:466        component-wise multiply (temp float)
+0:466          'inF0' (in float)
+0:466          'inF1' (in float)
+0:467      move second child to first child (temp 2-component vector of float)
+0:467        'r01' (temp 2-component vector of float)
+0:467        vector-scale (temp 2-component vector of float)
+0:467          'inFV2' (in 2-component vector of float)
+0:467          'inF0' (in float)
+0:468      move second child to first child (temp 3-component vector of float)
+0:468        'r02' (temp 3-component vector of float)
+0:468        vector-scale (temp 3-component vector of float)
+0:468          'inFV3' (in 3-component vector of float)
+0:468          'inF0' (in float)
+0:469      move second child to first child (temp 2-component vector of float)
+0:469        'r03' (temp 2-component vector of float)
+0:469        vector-scale (temp 2-component vector of float)
+0:469          'inF0' (in float)
+0:469          'inFV2' (in 2-component vector of float)
+0:470      move second child to first child (temp 3-component vector of float)
+0:470        'r04' (temp 3-component vector of float)
+0:470        vector-scale (temp 3-component vector of float)
+0:470          'inF0' (in float)
+0:470          'inFV3' (in 3-component vector of float)
+0:471      move second child to first child (temp float)
+0:471        'r05' (temp float)
+0:471        dot-product (global float)
+0:471          'inFV2' (in 2-component vector of float)
+0:471          'inFV2' (in 2-component vector of float)
+0:472      move second child to first child (temp float)
+0:472        'r06' (temp float)
+0:472        dot-product (global float)
+0:472          'inFV3' (in 3-component vector of float)
+0:472          'inFV3' (in 3-component vector of float)
+0:473      move second child to first child (temp 3-component vector of float)
+0:473        'r07' (temp 3-component vector of float)
+0:473        vector-times-matrix (temp 3-component vector of float)
+0:473          'inFV2' (in 2-component vector of float)
+0:473          'inFM2x3' (in 3X2 matrix of float)
+0:474      move second child to first child (temp 2-component vector of float)
+0:474        'r08' (temp 2-component vector of float)
+0:474        vector-times-matrix (temp 2-component vector of float)
+0:474          'inFV3' (in 3-component vector of float)
+0:474          'inFM3x2' (in 2X3 matrix of float)
+0:475      move second child to first child (temp 2-component vector of float)
+0:475        'r09' (temp 2-component vector of float)
+0:475        matrix-times-vector (temp 2-component vector of float)
+0:475          'inFM2x3' (in 3X2 matrix of float)
+0:475          'inFV3' (in 3-component vector of float)
+0:476      move second child to first child (temp 3-component vector of float)
+0:476        'r10' (temp 3-component vector of float)
+0:476        matrix-times-vector (temp 3-component vector of float)
+0:476          'inFM3x2' (in 2X3 matrix of float)
+0:476          'inFV2' (in 2-component vector of float)
+0:477      move second child to first child (temp 3X2 matrix of float)
+0:477        'r11' (temp 3X2 matrix of float)
+0:477        matrix-scale (temp 3X2 matrix of float)
+0:477          'inFM2x3' (in 3X2 matrix of float)
+0:477          'inF0' (in float)
+0:478      move second child to first child (temp 2X3 matrix of float)
+0:478        'r12' (temp 2X3 matrix of float)
+0:478        matrix-scale (temp 2X3 matrix of float)
+0:478          'inFM3x2' (in 2X3 matrix of float)
+0:478          'inF0' (in float)
+0:479      move second child to first child (temp 2X2 matrix of float)
+0:479        'r13' (temp 2X2 matrix of float)
+0:479        matrix-multiply (temp 2X2 matrix of float)
+0:479          'inFM2x3' (in 3X2 matrix of float)
+0:479          'inFM3x2' (in 2X3 matrix of float)
+0:480      move second child to first child (temp 3X2 matrix of float)
+0:480        'r14' (temp 3X2 matrix of float)
+0:480        matrix-multiply (temp 3X2 matrix of float)
+0:480          'inFM2x3' (in 3X2 matrix of float)
+0:480          'inFM3x3' (in 3X3 matrix of float)
+0:481      move second child to first child (temp 4X2 matrix of float)
+0:481        'r15' (temp 4X2 matrix of float)
+0:481        matrix-multiply (temp 4X2 matrix of float)
+0:481          'inFM2x3' (in 3X2 matrix of float)
+0:481          'inFM3x4' (in 4X3 matrix of float)
+0:482      move second child to first child (temp 4X3 matrix of float)
+0:482        'r16' (temp 4X3 matrix of float)
+0:482        matrix-multiply (temp 4X3 matrix of float)
+0:482          'inFM3x2' (in 2X3 matrix of float)
+0:482          'inFM2x4' (in 4X2 matrix of float)
 0:?   Linker Objects
 0:?     'gs_ua' (temp uint)
 0:?     'gs_ub' (temp uint)
@@ -1452,7 +2343,7 @@ Linked fragment stage:
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:87  Function Definition: PixelShaderFunction(f1;f1;f1;u1;u1; (temp float)
+0:88  Function Definition: PixelShaderFunction(f1;f1;f1;u1;u1; (temp float)
 0:17    Function Parameters: 
 0:17      'inF0' (in float)
 0:17      'inF1' (in float)
@@ -1460,33 +2351,57 @@ gl_FragCoord origin is upper left
 0:17      'inU0' (in uint)
 0:17      'inU1' (in uint)
 0:?     Sequence
-0:20      all (global bool)
-0:20        'inF0' (in float)
-0:21      Absolute value (global float)
-0:21        'inF0' (in float)
-0:22      arc cosine (global float)
-0:22        'inF0' (in float)
-0:23      any (global bool)
-0:23        'inF0' (in float)
-0:24      arc sine (global float)
-0:24        'inF0' (in float)
-0:25      floatBitsToInt (global int)
-0:25        'inF0' (in float)
-0:26      floatBitsToUint (global uint)
-0:26        'inF0' (in float)
-0:27      intBitsToFloat (global float)
-0:27        'inU0' (in uint)
-0:29      arc tangent (global float)
-0:29        'inF0' (in float)
-0:30      arc tangent (global float)
-0:30        'inF0' (in float)
-0:30        'inF1' (in float)
-0:31      Ceiling (global float)
-0:31        'inF0' (in float)
-0:32      clamp (global float)
-0:32        'inF0' (in float)
-0:32        'inF1' (in float)
-0:32        'inF2' (in float)
+0:20      move second child to first child (temp bool)
+0:20        'r000' (temp bool)
+0:20        all (global bool)
+0:20          'inF0' (in float)
+0:21      move second child to first child (temp float)
+0:21        'r001' (temp float)
+0:21        Absolute value (global float)
+0:21          'inF0' (in float)
+0:22      move second child to first child (temp float)
+0:22        'r002' (temp float)
+0:22        arc cosine (global float)
+0:22          'inF0' (in float)
+0:23      move second child to first child (temp bool)
+0:23        'r003' (temp bool)
+0:23        any (global bool)
+0:23          'inF0' (in float)
+0:24      move second child to first child (temp float)
+0:24        'r004' (temp float)
+0:24        arc sine (global float)
+0:24          'inF0' (in float)
+0:25      move second child to first child (temp int)
+0:25        'r005' (temp int)
+0:25        floatBitsToInt (global int)
+0:25          'inF0' (in float)
+0:26      move second child to first child (temp uint)
+0:26        'r006' (temp uint)
+0:26        floatBitsToUint (global uint)
+0:26          'inF0' (in float)
+0:27      move second child to first child (temp float)
+0:27        'r007' (temp float)
+0:27        intBitsToFloat (global float)
+0:27          'inU0' (in uint)
+0:29      move second child to first child (temp float)
+0:29        'r009' (temp float)
+0:29        arc tangent (global float)
+0:29          'inF0' (in float)
+0:30      move second child to first child (temp float)
+0:30        'r010' (temp float)
+0:30        arc tangent (global float)
+0:30          'inF0' (in float)
+0:30          'inF1' (in float)
+0:31      move second child to first child (temp float)
+0:31        'r011' (temp float)
+0:31        Ceiling (global float)
+0:31          'inF0' (in float)
+0:32      move second child to first child (temp float)
+0:32        'r012' (temp float)
+0:32        clamp (global float)
+0:32          'inF0' (in float)
+0:32          'inF1' (in float)
+0:32          'inF2' (in float)
 0:33      Test condition and select (temp void)
 0:33        Condition
 0:33        Compare Less Than (temp bool)
@@ -1495,1044 +2410,1724 @@ gl_FragCoord origin is upper left
 0:33            0.000000
 0:33        true case
 0:33        Branch: Kill
-0:34      cosine (global float)
-0:34        'inF0' (in float)
-0:35      hyp. cosine (global float)
-0:35        'inF0' (in float)
-0:36      bitCount (global uint)
-0:36        Constant:
-0:36          7 (const uint)
-0:37      dPdx (global float)
-0:37        'inF0' (in float)
-0:38      dPdxCoarse (global float)
-0:38        'inF0' (in float)
-0:39      dPdxFine (global float)
-0:39        'inF0' (in float)
-0:40      dPdy (global float)
-0:40        'inF0' (in float)
-0:41      dPdyCoarse (global float)
-0:41        'inF0' (in float)
-0:42      dPdyFine (global float)
-0:42        'inF0' (in float)
-0:43      degrees (global float)
-0:43        'inF0' (in float)
-0:47      exp (global float)
-0:47        'inF0' (in float)
-0:48      exp2 (global float)
-0:48        'inF0' (in float)
-0:49      findMSB (global int)
-0:49        Constant:
-0:49          7 (const int)
-0:50      findLSB (global int)
-0:50        Constant:
-0:50          7 (const int)
-0:51      Floor (global float)
-0:51        'inF0' (in float)
-0:53      mod (global float)
-0:53        'inF0' (in float)
-0:53        'inF1' (in float)
-0:54      Fraction (global float)
-0:54        'inF0' (in float)
-0:55      frexp (global float)
-0:55        'inF0' (in float)
-0:55        'inF1' (in float)
-0:56      fwidth (global float)
-0:56        'inF0' (in float)
-0:57      isinf (global bool)
-0:57        'inF0' (in float)
-0:58      isnan (global bool)
-0:58        'inF0' (in float)
-0:59      ldexp (global float)
-0:59        'inF0' (in float)
-0:59        'inF1' (in float)
-0:60      log (global float)
-0:60        'inF0' (in float)
-0:61      component-wise multiply (temp float)
-0:61        log2 (temp float)
+0:34      move second child to first child (temp float)
+0:34        'r014' (temp float)
+0:34        cosine (global float)
+0:34          'inF0' (in float)
+0:35      move second child to first child (temp float)
+0:35        'r015' (temp float)
+0:35        hyp. cosine (global float)
+0:35          'inF0' (in float)
+0:36      move second child to first child (temp uint)
+0:36        'r016' (temp uint)
+0:36        bitCount (global uint)
+0:36          Constant:
+0:36            7 (const uint)
+0:37      move second child to first child (temp float)
+0:37        'r017' (temp float)
+0:37        dPdx (global float)
+0:37          'inF0' (in float)
+0:38      move second child to first child (temp float)
+0:38        'r018' (temp float)
+0:38        dPdxCoarse (global float)
+0:38          'inF0' (in float)
+0:39      move second child to first child (temp float)
+0:39        'r019' (temp float)
+0:39        dPdxFine (global float)
+0:39          'inF0' (in float)
+0:40      move second child to first child (temp float)
+0:40        'r020' (temp float)
+0:40        dPdy (global float)
+0:40          'inF0' (in float)
+0:41      move second child to first child (temp float)
+0:41        'r021' (temp float)
+0:41        dPdyCoarse (global float)
+0:41          'inF0' (in float)
+0:42      move second child to first child (temp float)
+0:42        'r022' (temp float)
+0:42        dPdyFine (global float)
+0:42          'inF0' (in float)
+0:43      move second child to first child (temp float)
+0:43        'r023' (temp float)
+0:43        degrees (global float)
+0:43          'inF0' (in float)
+0:47      move second child to first child (temp float)
+0:47        'r027' (temp float)
+0:47        exp (global float)
+0:47          'inF0' (in float)
+0:48      move second child to first child (temp float)
+0:48        'r028' (temp float)
+0:48        exp2 (global float)
+0:48          'inF0' (in float)
+0:49      move second child to first child (temp uint)
+0:49        'r029' (temp uint)
+0:49        Convert int to uint (temp uint)
+0:49          findMSB (global int)
+0:49            Constant:
+0:49              7 (const int)
+0:50      move second child to first child (temp uint)
+0:50        'r030' (temp uint)
+0:50        Convert int to uint (temp uint)
+0:50          findLSB (global int)
+0:50            Constant:
+0:50              7 (const int)
+0:51      move second child to first child (temp float)
+0:51        'r031' (temp float)
+0:51        Floor (global float)
+0:51          'inF0' (in float)
+0:53      move second child to first child (temp float)
+0:53        'r033' (temp float)
+0:53        mod (global float)
+0:53          'inF0' (in float)
+0:53          'inF1' (in float)
+0:54      move second child to first child (temp float)
+0:54        'r034' (temp float)
+0:54        Fraction (global float)
+0:54          'inF0' (in float)
+0:55      move second child to first child (temp float)
+0:55        'r035' (temp float)
+0:55        frexp (global float)
+0:55          'inF0' (in float)
+0:55          'inF1' (in float)
+0:56      move second child to first child (temp float)
+0:56        'r036' (temp float)
+0:56        fwidth (global float)
+0:56          'inF0' (in float)
+0:57      move second child to first child (temp bool)
+0:57        'r037' (temp bool)
+0:57        isinf (global bool)
+0:57          'inF0' (in float)
+0:58      move second child to first child (temp bool)
+0:58        'r038' (temp bool)
+0:58        isnan (global bool)
+0:58          'inF0' (in float)
+0:59      move second child to first child (temp float)
+0:59        'r039' (temp float)
+0:59        ldexp (global float)
+0:59          'inF0' (in float)
+0:59          'inF1' (in float)
+0:60      move second child to first child (temp float)
+0:60        'r039a' (temp float)
+0:60        mix (global float)
+0:60          'inF0' (in float)
+0:60          'inF1' (in float)
+0:60          'inF2' (in float)
+0:61      move second child to first child (temp float)
+0:61        'r040' (temp float)
+0:61        log (global float)
 0:61          'inF0' (in float)
-0:61        Constant:
-0:61          0.301030
-0:62      log2 (global float)
-0:62        'inF0' (in float)
-0:63      max (global float)
-0:63        'inF0' (in float)
-0:63        'inF1' (in float)
-0:64      min (global float)
-0:64        'inF0' (in float)
-0:64        'inF1' (in float)
-0:65      pow (global float)
-0:65        'inF0' (in float)
-0:65        'inF1' (in float)
-0:66      radians (global float)
-0:66        'inF0' (in float)
-0:67      divide (temp float)
-0:67        Constant:
-0:67          1.000000
-0:67        'inF0' (in float)
-0:68      bitFieldReverse (global uint)
-0:68        Constant:
-0:68          2 (const uint)
-0:69      roundEven (global float)
-0:69        'inF0' (in float)
-0:70      inverse sqrt (global float)
-0:70        'inF0' (in float)
-0:71      clamp (temp float)
-0:71        'inF0' (in float)
-0:71        Constant:
-0:71          0.000000
-0:71        Constant:
-0:71          1.000000
-0:72      Sign (global float)
-0:72        'inF0' (in float)
-0:73      sine (global float)
-0:73        'inF0' (in float)
-0:74      Sequence
-0:74        move second child to first child (temp float)
-0:74          'inF1' (in float)
-0:74          sine (temp float)
-0:74            'inF0' (in float)
-0:74        move second child to first child (temp float)
-0:74          'inF2' (in float)
-0:74          cosine (temp float)
-0:74            'inF0' (in float)
-0:75      hyp. sine (global float)
-0:75        'inF0' (in float)
-0:76      smoothstep (global float)
-0:76        'inF0' (in float)
-0:76        'inF1' (in float)
-0:76        'inF2' (in float)
-0:77      sqrt (global float)
-0:77        'inF0' (in float)
-0:78      step (global float)
-0:78        'inF0' (in float)
-0:78        'inF1' (in float)
-0:79      tangent (global float)
-0:79        'inF0' (in float)
-0:80      hyp. tangent (global float)
-0:80        'inF0' (in float)
-0:82      trunc (global float)
-0:82        'inF0' (in float)
-0:84      Branch: Return with expression
-0:84        Constant:
-0:84          0.000000
-0:93  Function Definition: PixelShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
-0:88    Function Parameters: 
-0:88      'inF0' (in 1-component vector of float)
-0:88      'inF1' (in 1-component vector of float)
-0:88      'inF2' (in 1-component vector of float)
+0:62      move second child to first child (temp float)
+0:62        'r041' (temp float)
+0:62        component-wise multiply (temp float)
+0:62          log2 (temp float)
+0:62            'inF0' (in float)
+0:62          Constant:
+0:62            0.301030
+0:63      move second child to first child (temp float)
+0:63        'r042' (temp float)
+0:63        log2 (global float)
+0:63          'inF0' (in float)
+0:64      move second child to first child (temp float)
+0:64        'r043' (temp float)
+0:64        max (global float)
+0:64          'inF0' (in float)
+0:64          'inF1' (in float)
+0:65      move second child to first child (temp float)
+0:65        'r044' (temp float)
+0:65        min (global float)
+0:65          'inF0' (in float)
+0:65          'inF1' (in float)
+0:66      move second child to first child (temp float)
+0:66        'r045' (temp float)
+0:66        pow (global float)
+0:66          'inF0' (in float)
+0:66          'inF1' (in float)
+0:67      move second child to first child (temp float)
+0:67        'r046' (temp float)
+0:67        radians (global float)
+0:67          'inF0' (in float)
+0:68      move second child to first child (temp float)
+0:68        'r047' (temp float)
+0:68        divide (temp float)
+0:68          Constant:
+0:68            1.000000
+0:68          'inF0' (in float)
+0:69      move second child to first child (temp uint)
+0:69        'r048' (temp uint)
+0:69        bitFieldReverse (global uint)
+0:69          Constant:
+0:69            2 (const uint)
+0:70      move second child to first child (temp float)
+0:70        'r049' (temp float)
+0:70        roundEven (global float)
+0:70          'inF0' (in float)
+0:71      move second child to first child (temp float)
+0:71        'r050' (temp float)
+0:71        inverse sqrt (global float)
+0:71          'inF0' (in float)
+0:72      move second child to first child (temp float)
+0:72        'r051' (temp float)
+0:72        clamp (temp float)
+0:72          'inF0' (in float)
+0:72          Constant:
+0:72            0.000000
+0:72          Constant:
+0:72            1.000000
+0:73      move second child to first child (temp float)
+0:73        'r052' (temp float)
+0:73        Sign (global float)
+0:73          'inF0' (in float)
+0:74      move second child to first child (temp float)
+0:74        'r053' (temp float)
+0:74        sine (global float)
+0:74          'inF0' (in float)
+0:75      Sequence
+0:75        move second child to first child (temp float)
+0:75          'inF1' (in float)
+0:75          sine (temp float)
+0:75            'inF0' (in float)
+0:75        move second child to first child (temp float)
+0:75          'inF2' (in float)
+0:75          cosine (temp float)
+0:75            'inF0' (in float)
+0:76      move second child to first child (temp float)
+0:76        'r055' (temp float)
+0:76        hyp. sine (global float)
+0:76          'inF0' (in float)
+0:77      move second child to first child (temp float)
+0:77        'r056' (temp float)
+0:77        smoothstep (global float)
+0:77          'inF0' (in float)
+0:77          'inF1' (in float)
+0:77          'inF2' (in float)
+0:78      move second child to first child (temp float)
+0:78        'r057' (temp float)
+0:78        sqrt (global float)
+0:78          'inF0' (in float)
+0:79      move second child to first child (temp float)
+0:79        'r058' (temp float)
+0:79        step (global float)
+0:79          'inF0' (in float)
+0:79          'inF1' (in float)
+0:80      move second child to first child (temp float)
+0:80        'r059' (temp float)
+0:80        tangent (global float)
+0:80          'inF0' (in float)
+0:81      move second child to first child (temp float)
+0:81        'r060' (temp float)
+0:81        hyp. tangent (global float)
+0:81          'inF0' (in float)
+0:83      move second child to first child (temp float)
+0:83        'r061' (temp float)
+0:83        trunc (global float)
+0:83          'inF0' (in float)
+0:85      Branch: Return with expression
+0:85        Constant:
+0:85          0.000000
+0:94  Function Definition: PixelShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
+0:89    Function Parameters: 
+0:89      'inF0' (in 1-component vector of float)
+0:89      'inF1' (in 1-component vector of float)
+0:89      'inF2' (in 1-component vector of float)
 0:?     Sequence
-0:90      Branch: Return with expression
-0:90        Constant:
-0:90          0.000000
-0:172  Function Definition: PixelShaderFunction(vf2;vf2;vf2;vu2;vu2; (temp 2-component vector of float)
-0:94    Function Parameters: 
-0:94      'inF0' (in 2-component vector of float)
-0:94      'inF1' (in 2-component vector of float)
-0:94      'inF2' (in 2-component vector of float)
-0:94      'inU0' (in 2-component vector of uint)
-0:94      'inU1' (in 2-component vector of uint)
+0:91      Branch: Return with expression
+0:91        Constant:
+0:91          0.000000
+0:177  Function Definition: PixelShaderFunction(vf2;vf2;vf2;vu2;vu2; (temp 2-component vector of float)
+0:95    Function Parameters: 
+0:95      'inF0' (in 2-component vector of float)
+0:95      'inF1' (in 2-component vector of float)
+0:95      'inF2' (in 2-component vector of float)
+0:95      'inU0' (in 2-component vector of uint)
+0:95      'inU1' (in 2-component vector of uint)
 0:?     Sequence
-0:97      all (global bool)
-0:97        'inF0' (in 2-component vector of float)
-0:98      Absolute value (global 2-component vector of float)
-0:98        'inF0' (in 2-component vector of float)
-0:99      arc cosine (global 2-component vector of float)
-0:99        'inF0' (in 2-component vector of float)
-0:100      any (global bool)
-0:100        'inF0' (in 2-component vector of float)
-0:101      arc sine (global 2-component vector of float)
-0:101        'inF0' (in 2-component vector of float)
-0:102      floatBitsToInt (global 2-component vector of int)
-0:102        'inF0' (in 2-component vector of float)
-0:103      floatBitsToUint (global 2-component vector of uint)
-0:103        'inF0' (in 2-component vector of float)
-0:104      intBitsToFloat (global 2-component vector of float)
-0:104        'inU0' (in 2-component vector of uint)
-0:106      arc tangent (global 2-component vector of float)
-0:106        'inF0' (in 2-component vector of float)
-0:107      arc tangent (global 2-component vector of float)
-0:107        'inF0' (in 2-component vector of float)
-0:107        'inF1' (in 2-component vector of float)
-0:108      Ceiling (global 2-component vector of float)
-0:108        'inF0' (in 2-component vector of float)
-0:109      clamp (global 2-component vector of float)
-0:109        'inF0' (in 2-component vector of float)
-0:109        'inF1' (in 2-component vector of float)
-0:109        'inF2' (in 2-component vector of float)
-0:110      Test condition and select (temp void)
-0:110        Condition
-0:110        any (temp bool)
-0:110          Compare Less Than (temp 2-component vector of bool)
-0:110            'inF0' (in 2-component vector of float)
-0:110            Constant:
-0:110              0.000000
-0:110              0.000000
-0:110        true case
-0:110        Branch: Kill
-0:111      cosine (global 2-component vector of float)
-0:111        'inF0' (in 2-component vector of float)
-0:112      hyp. cosine (global 2-component vector of float)
-0:112        'inF0' (in 2-component vector of float)
-0:?       bitCount (global 2-component vector of uint)
-0:?         Constant:
-0:?           7 (const uint)
-0:?           3 (const uint)
-0:114      dPdx (global 2-component vector of float)
-0:114        'inF0' (in 2-component vector of float)
-0:115      dPdxCoarse (global 2-component vector of float)
-0:115        'inF0' (in 2-component vector of float)
-0:116      dPdxFine (global 2-component vector of float)
-0:116        'inF0' (in 2-component vector of float)
-0:117      dPdy (global 2-component vector of float)
-0:117        'inF0' (in 2-component vector of float)
-0:118      dPdyCoarse (global 2-component vector of float)
-0:118        'inF0' (in 2-component vector of float)
-0:119      dPdyFine (global 2-component vector of float)
-0:119        'inF0' (in 2-component vector of float)
-0:120      degrees (global 2-component vector of float)
-0:120        'inF0' (in 2-component vector of float)
-0:121      distance (global float)
-0:121        'inF0' (in 2-component vector of float)
-0:121        'inF1' (in 2-component vector of float)
-0:122      dot-product (global float)
-0:122        'inF0' (in 2-component vector of float)
-0:122        'inF1' (in 2-component vector of float)
-0:126      exp (global 2-component vector of float)
-0:126        'inF0' (in 2-component vector of float)
-0:127      exp2 (global 2-component vector of float)
-0:127        'inF0' (in 2-component vector of float)
-0:128      face-forward (global 2-component vector of float)
-0:128        'inF0' (in 2-component vector of float)
-0:128        'inF1' (in 2-component vector of float)
-0:128        'inF2' (in 2-component vector of float)
-0:129      findMSB (global int)
-0:129        Constant:
-0:129          7 (const int)
-0:130      findLSB (global int)
-0:130        Constant:
-0:130          7 (const int)
-0:131      Floor (global 2-component vector of float)
-0:131        'inF0' (in 2-component vector of float)
-0:133      mod (global 2-component vector of float)
-0:133        'inF0' (in 2-component vector of float)
-0:133        'inF1' (in 2-component vector of float)
-0:134      Fraction (global 2-component vector of float)
-0:134        'inF0' (in 2-component vector of float)
-0:135      frexp (global 2-component vector of float)
-0:135        'inF0' (in 2-component vector of float)
-0:135        'inF1' (in 2-component vector of float)
-0:136      fwidth (global 2-component vector of float)
-0:136        'inF0' (in 2-component vector of float)
-0:137      isinf (global 2-component vector of bool)
-0:137        'inF0' (in 2-component vector of float)
-0:138      isnan (global 2-component vector of bool)
-0:138        'inF0' (in 2-component vector of float)
-0:139      ldexp (global 2-component vector of float)
-0:139        'inF0' (in 2-component vector of float)
-0:139        'inF1' (in 2-component vector of float)
-0:140      length (global float)
-0:140        'inF0' (in 2-component vector of float)
-0:141      log (global 2-component vector of float)
-0:141        'inF0' (in 2-component vector of float)
-0:142      vector-scale (temp 2-component vector of float)
-0:142        log2 (temp 2-component vector of float)
+0:98      move second child to first child (temp bool)
+0:98        'r000' (temp bool)
+0:98        all (global bool)
+0:98          'inF0' (in 2-component vector of float)
+0:99      move second child to first child (temp 2-component vector of float)
+0:99        'r001' (temp 2-component vector of float)
+0:99        Absolute value (global 2-component vector of float)
+0:99          'inF0' (in 2-component vector of float)
+0:100      move second child to first child (temp 2-component vector of float)
+0:100        'r002' (temp 2-component vector of float)
+0:100        arc cosine (global 2-component vector of float)
+0:100          'inF0' (in 2-component vector of float)
+0:101      move second child to first child (temp bool)
+0:101        'r003' (temp bool)
+0:101        any (global bool)
+0:101          'inF0' (in 2-component vector of float)
+0:102      move second child to first child (temp 2-component vector of float)
+0:102        'r004' (temp 2-component vector of float)
+0:102        arc sine (global 2-component vector of float)
+0:102          'inF0' (in 2-component vector of float)
+0:103      move second child to first child (temp 2-component vector of int)
+0:103        'r005' (temp 2-component vector of int)
+0:103        floatBitsToInt (global 2-component vector of int)
+0:103          'inF0' (in 2-component vector of float)
+0:104      move second child to first child (temp 2-component vector of uint)
+0:104        'r006' (temp 2-component vector of uint)
+0:104        floatBitsToUint (global 2-component vector of uint)
+0:104          'inF0' (in 2-component vector of float)
+0:105      move second child to first child (temp 2-component vector of float)
+0:105        'r007' (temp 2-component vector of float)
+0:105        intBitsToFloat (global 2-component vector of float)
+0:105          'inU0' (in 2-component vector of uint)
+0:107      move second child to first child (temp 2-component vector of float)
+0:107        'r009' (temp 2-component vector of float)
+0:107        arc tangent (global 2-component vector of float)
+0:107          'inF0' (in 2-component vector of float)
+0:108      move second child to first child (temp 2-component vector of float)
+0:108        'r010' (temp 2-component vector of float)
+0:108        arc tangent (global 2-component vector of float)
+0:108          'inF0' (in 2-component vector of float)
+0:108          'inF1' (in 2-component vector of float)
+0:109      move second child to first child (temp 2-component vector of float)
+0:109        'r011' (temp 2-component vector of float)
+0:109        Ceiling (global 2-component vector of float)
+0:109          'inF0' (in 2-component vector of float)
+0:110      move second child to first child (temp 2-component vector of float)
+0:110        'r012' (temp 2-component vector of float)
+0:110        clamp (global 2-component vector of float)
+0:110          'inF0' (in 2-component vector of float)
+0:110          'inF1' (in 2-component vector of float)
+0:110          'inF2' (in 2-component vector of float)
+0:111      Test condition and select (temp void)
+0:111        Condition
+0:111        any (temp bool)
+0:111          Compare Less Than (temp 2-component vector of bool)
+0:111            'inF0' (in 2-component vector of float)
+0:111            Constant:
+0:111              0.000000
+0:111              0.000000
+0:111        true case
+0:111        Branch: Kill
+0:112      move second child to first child (temp 2-component vector of float)
+0:112        'r013' (temp 2-component vector of float)
+0:112        cosine (global 2-component vector of float)
+0:112          'inF0' (in 2-component vector of float)
+0:113      move second child to first child (temp 2-component vector of float)
+0:113        'r015' (temp 2-component vector of float)
+0:113        hyp. cosine (global 2-component vector of float)
+0:113          'inF0' (in 2-component vector of float)
+0:114      move second child to first child (temp 2-component vector of uint)
+0:114        'r016' (temp 2-component vector of uint)
+0:?         bitCount (global 2-component vector of uint)
+0:?           Constant:
+0:?             7 (const uint)
+0:?             3 (const uint)
+0:115      move second child to first child (temp 2-component vector of float)
+0:115        'r017' (temp 2-component vector of float)
+0:115        dPdx (global 2-component vector of float)
+0:115          'inF0' (in 2-component vector of float)
+0:116      move second child to first child (temp 2-component vector of float)
+0:116        'r018' (temp 2-component vector of float)
+0:116        dPdxCoarse (global 2-component vector of float)
+0:116          'inF0' (in 2-component vector of float)
+0:117      move second child to first child (temp 2-component vector of float)
+0:117        'r019' (temp 2-component vector of float)
+0:117        dPdxFine (global 2-component vector of float)
+0:117          'inF0' (in 2-component vector of float)
+0:118      move second child to first child (temp 2-component vector of float)
+0:118        'r020' (temp 2-component vector of float)
+0:118        dPdy (global 2-component vector of float)
+0:118          'inF0' (in 2-component vector of float)
+0:119      move second child to first child (temp 2-component vector of float)
+0:119        'r021' (temp 2-component vector of float)
+0:119        dPdyCoarse (global 2-component vector of float)
+0:119          'inF0' (in 2-component vector of float)
+0:120      move second child to first child (temp 2-component vector of float)
+0:120        'r022' (temp 2-component vector of float)
+0:120        dPdyFine (global 2-component vector of float)
+0:120          'inF0' (in 2-component vector of float)
+0:121      move second child to first child (temp 2-component vector of float)
+0:121        'r023' (temp 2-component vector of float)
+0:121        degrees (global 2-component vector of float)
+0:121          'inF0' (in 2-component vector of float)
+0:125      move second child to first child (temp float)
+0:125        'r026' (temp float)
+0:125        distance (global float)
+0:125          'inF0' (in 2-component vector of float)
+0:125          'inF1' (in 2-component vector of float)
+0:126      move second child to first child (temp float)
+0:126        'r027' (temp float)
+0:126        dot-product (global float)
+0:126          'inF0' (in 2-component vector of float)
+0:126          'inF1' (in 2-component vector of float)
+0:130      move second child to first child (temp 2-component vector of float)
+0:130        'r028' (temp 2-component vector of float)
+0:130        exp (global 2-component vector of float)
+0:130          'inF0' (in 2-component vector of float)
+0:131      move second child to first child (temp 2-component vector of float)
+0:131        'r029' (temp 2-component vector of float)
+0:131        exp2 (global 2-component vector of float)
+0:131          'inF0' (in 2-component vector of float)
+0:132      move second child to first child (temp 2-component vector of float)
+0:132        'r030' (temp 2-component vector of float)
+0:132        face-forward (global 2-component vector of float)
+0:132          'inF0' (in 2-component vector of float)
+0:132          'inF1' (in 2-component vector of float)
+0:132          'inF2' (in 2-component vector of float)
+0:133      move second child to first child (temp 2-component vector of uint)
+0:133        'r031' (temp 2-component vector of uint)
+0:?         findMSB (global 2-component vector of uint)
+0:?           Constant:
+0:?             7 (const uint)
+0:?             8 (const uint)
+0:134      move second child to first child (temp 2-component vector of uint)
+0:134        'r032' (temp 2-component vector of uint)
+0:?         findLSB (global 2-component vector of uint)
+0:?           Constant:
+0:?             7 (const uint)
+0:?             8 (const uint)
+0:135      move second child to first child (temp 2-component vector of float)
+0:135        'r033' (temp 2-component vector of float)
+0:135        Floor (global 2-component vector of float)
+0:135          'inF0' (in 2-component vector of float)
+0:137      move second child to first child (temp 2-component vector of float)
+0:137        'r035' (temp 2-component vector of float)
+0:137        mod (global 2-component vector of float)
+0:137          'inF0' (in 2-component vector of float)
+0:137          'inF1' (in 2-component vector of float)
+0:138      move second child to first child (temp 2-component vector of float)
+0:138        'r036' (temp 2-component vector of float)
+0:138        Fraction (global 2-component vector of float)
+0:138          'inF0' (in 2-component vector of float)
+0:139      move second child to first child (temp 2-component vector of float)
+0:139        'r037' (temp 2-component vector of float)
+0:139        frexp (global 2-component vector of float)
+0:139          'inF0' (in 2-component vector of float)
+0:139          'inF1' (in 2-component vector of float)
+0:140      move second child to first child (temp 2-component vector of float)
+0:140        'r038' (temp 2-component vector of float)
+0:140        fwidth (global 2-component vector of float)
+0:140          'inF0' (in 2-component vector of float)
+0:141      move second child to first child (temp 2-component vector of bool)
+0:141        'r039' (temp 2-component vector of bool)
+0:141        isinf (global 2-component vector of bool)
+0:141          'inF0' (in 2-component vector of float)
+0:142      move second child to first child (temp 2-component vector of bool)
+0:142        'r040' (temp 2-component vector of bool)
+0:142        isnan (global 2-component vector of bool)
 0:142          'inF0' (in 2-component vector of float)
-0:142        Constant:
-0:142          0.301030
-0:143      log2 (global 2-component vector of float)
-0:143        'inF0' (in 2-component vector of float)
-0:144      max (global 2-component vector of float)
-0:144        'inF0' (in 2-component vector of float)
-0:144        'inF1' (in 2-component vector of float)
-0:145      min (global 2-component vector of float)
-0:145        'inF0' (in 2-component vector of float)
-0:145        'inF1' (in 2-component vector of float)
-0:146      normalize (global 2-component vector of float)
-0:146        'inF0' (in 2-component vector of float)
-0:147      pow (global 2-component vector of float)
-0:147        'inF0' (in 2-component vector of float)
-0:147        'inF1' (in 2-component vector of float)
-0:148      radians (global 2-component vector of float)
-0:148        'inF0' (in 2-component vector of float)
-0:149      divide (temp 2-component vector of float)
-0:149        Constant:
-0:149          1.000000
-0:149        'inF0' (in 2-component vector of float)
-0:150      reflect (global 2-component vector of float)
-0:150        'inF0' (in 2-component vector of float)
-0:150        'inF1' (in 2-component vector of float)
-0:151      refract (global 2-component vector of float)
-0:151        'inF0' (in 2-component vector of float)
-0:151        'inF1' (in 2-component vector of float)
-0:151        Constant:
-0:151          2.000000
-0:?       bitFieldReverse (global 2-component vector of uint)
-0:?         Constant:
-0:?           1 (const uint)
-0:?           2 (const uint)
-0:153      roundEven (global 2-component vector of float)
-0:153        'inF0' (in 2-component vector of float)
-0:154      inverse sqrt (global 2-component vector of float)
-0:154        'inF0' (in 2-component vector of float)
-0:155      clamp (temp 2-component vector of float)
-0:155        'inF0' (in 2-component vector of float)
-0:155        Constant:
-0:155          0.000000
-0:155        Constant:
-0:155          1.000000
-0:156      Sign (global 2-component vector of float)
-0:156        'inF0' (in 2-component vector of float)
-0:157      sine (global 2-component vector of float)
-0:157        'inF0' (in 2-component vector of float)
-0:158      Sequence
-0:158        move second child to first child (temp 2-component vector of float)
-0:158          'inF1' (in 2-component vector of float)
-0:158          sine (temp 2-component vector of float)
-0:158            'inF0' (in 2-component vector of float)
-0:158        move second child to first child (temp 2-component vector of float)
-0:158          'inF2' (in 2-component vector of float)
-0:158          cosine (temp 2-component vector of float)
-0:158            'inF0' (in 2-component vector of float)
-0:159      hyp. sine (global 2-component vector of float)
-0:159        'inF0' (in 2-component vector of float)
-0:160      smoothstep (global 2-component vector of float)
-0:160        'inF0' (in 2-component vector of float)
-0:160        'inF1' (in 2-component vector of float)
-0:160        'inF2' (in 2-component vector of float)
-0:161      sqrt (global 2-component vector of float)
-0:161        'inF0' (in 2-component vector of float)
-0:162      step (global 2-component vector of float)
-0:162        'inF0' (in 2-component vector of float)
-0:162        'inF1' (in 2-component vector of float)
-0:163      tangent (global 2-component vector of float)
-0:163        'inF0' (in 2-component vector of float)
-0:164      hyp. tangent (global 2-component vector of float)
-0:164        'inF0' (in 2-component vector of float)
-0:166      trunc (global 2-component vector of float)
-0:166        'inF0' (in 2-component vector of float)
-0:169      Branch: Return with expression
+0:143      move second child to first child (temp 2-component vector of float)
+0:143        'r041' (temp 2-component vector of float)
+0:143        ldexp (global 2-component vector of float)
+0:143          'inF0' (in 2-component vector of float)
+0:143          'inF1' (in 2-component vector of float)
+0:144      move second child to first child (temp 2-component vector of float)
+0:144        'r039a' (temp 2-component vector of float)
+0:144        mix (global 2-component vector of float)
+0:144          'inF0' (in 2-component vector of float)
+0:144          'inF1' (in 2-component vector of float)
+0:144          'inF2' (in 2-component vector of float)
+0:145      move second child to first child (temp float)
+0:145        'r042' (temp float)
+0:145        length (global float)
+0:145          'inF0' (in 2-component vector of float)
+0:146      move second child to first child (temp 2-component vector of float)
+0:146        'r043' (temp 2-component vector of float)
+0:146        log (global 2-component vector of float)
+0:146          'inF0' (in 2-component vector of float)
+0:147      move second child to first child (temp 2-component vector of float)
+0:147        'r044' (temp 2-component vector of float)
+0:147        vector-scale (temp 2-component vector of float)
+0:147          log2 (temp 2-component vector of float)
+0:147            'inF0' (in 2-component vector of float)
+0:147          Constant:
+0:147            0.301030
+0:148      move second child to first child (temp 2-component vector of float)
+0:148        'r045' (temp 2-component vector of float)
+0:148        log2 (global 2-component vector of float)
+0:148          'inF0' (in 2-component vector of float)
+0:149      move second child to first child (temp 2-component vector of float)
+0:149        'r046' (temp 2-component vector of float)
+0:149        max (global 2-component vector of float)
+0:149          'inF0' (in 2-component vector of float)
+0:149          'inF1' (in 2-component vector of float)
+0:150      move second child to first child (temp 2-component vector of float)
+0:150        'r047' (temp 2-component vector of float)
+0:150        min (global 2-component vector of float)
+0:150          'inF0' (in 2-component vector of float)
+0:150          'inF1' (in 2-component vector of float)
+0:151      move second child to first child (temp 2-component vector of float)
+0:151        'r048' (temp 2-component vector of float)
+0:151        normalize (global 2-component vector of float)
+0:151          'inF0' (in 2-component vector of float)
+0:152      move second child to first child (temp 2-component vector of float)
+0:152        'r049' (temp 2-component vector of float)
+0:152        pow (global 2-component vector of float)
+0:152          'inF0' (in 2-component vector of float)
+0:152          'inF1' (in 2-component vector of float)
+0:153      move second child to first child (temp 2-component vector of float)
+0:153        'r050' (temp 2-component vector of float)
+0:153        radians (global 2-component vector of float)
+0:153          'inF0' (in 2-component vector of float)
+0:154      move second child to first child (temp 2-component vector of float)
+0:154        'r051' (temp 2-component vector of float)
+0:154        divide (temp 2-component vector of float)
+0:154          Constant:
+0:154            1.000000
+0:154          'inF0' (in 2-component vector of float)
+0:155      move second child to first child (temp 2-component vector of float)
+0:155        'r052' (temp 2-component vector of float)
+0:155        reflect (global 2-component vector of float)
+0:155          'inF0' (in 2-component vector of float)
+0:155          'inF1' (in 2-component vector of float)
+0:156      move second child to first child (temp 2-component vector of float)
+0:156        'r053' (temp 2-component vector of float)
+0:156        refract (global 2-component vector of float)
+0:156          'inF0' (in 2-component vector of float)
+0:156          'inF1' (in 2-component vector of float)
+0:156          Constant:
+0:156            2.000000
+0:157      move second child to first child (temp 2-component vector of uint)
+0:157        'r054' (temp 2-component vector of uint)
+0:?         bitFieldReverse (global 2-component vector of uint)
+0:?           Constant:
+0:?             1 (const uint)
+0:?             2 (const uint)
+0:158      move second child to first child (temp 2-component vector of float)
+0:158        'r055' (temp 2-component vector of float)
+0:158        roundEven (global 2-component vector of float)
+0:158          'inF0' (in 2-component vector of float)
+0:159      move second child to first child (temp 2-component vector of float)
+0:159        'r056' (temp 2-component vector of float)
+0:159        inverse sqrt (global 2-component vector of float)
+0:159          'inF0' (in 2-component vector of float)
+0:160      move second child to first child (temp 2-component vector of float)
+0:160        'r057' (temp 2-component vector of float)
+0:160        clamp (temp 2-component vector of float)
+0:160          'inF0' (in 2-component vector of float)
+0:160          Constant:
+0:160            0.000000
+0:160          Constant:
+0:160            1.000000
+0:161      move second child to first child (temp 2-component vector of float)
+0:161        'r058' (temp 2-component vector of float)
+0:161        Sign (global 2-component vector of float)
+0:161          'inF0' (in 2-component vector of float)
+0:162      move second child to first child (temp 2-component vector of float)
+0:162        'r059' (temp 2-component vector of float)
+0:162        sine (global 2-component vector of float)
+0:162          'inF0' (in 2-component vector of float)
+0:163      Sequence
+0:163        move second child to first child (temp 2-component vector of float)
+0:163          'inF1' (in 2-component vector of float)
+0:163          sine (temp 2-component vector of float)
+0:163            'inF0' (in 2-component vector of float)
+0:163        move second child to first child (temp 2-component vector of float)
+0:163          'inF2' (in 2-component vector of float)
+0:163          cosine (temp 2-component vector of float)
+0:163            'inF0' (in 2-component vector of float)
+0:164      move second child to first child (temp 2-component vector of float)
+0:164        'r060' (temp 2-component vector of float)
+0:164        hyp. sine (global 2-component vector of float)
+0:164          'inF0' (in 2-component vector of float)
+0:165      move second child to first child (temp 2-component vector of float)
+0:165        'r061' (temp 2-component vector of float)
+0:165        smoothstep (global 2-component vector of float)
+0:165          'inF0' (in 2-component vector of float)
+0:165          'inF1' (in 2-component vector of float)
+0:165          'inF2' (in 2-component vector of float)
+0:166      move second child to first child (temp 2-component vector of float)
+0:166        'r062' (temp 2-component vector of float)
+0:166        sqrt (global 2-component vector of float)
+0:166          'inF0' (in 2-component vector of float)
+0:167      move second child to first child (temp 2-component vector of float)
+0:167        'r063' (temp 2-component vector of float)
+0:167        step (global 2-component vector of float)
+0:167          'inF0' (in 2-component vector of float)
+0:167          'inF1' (in 2-component vector of float)
+0:168      move second child to first child (temp 2-component vector of float)
+0:168        'r064' (temp 2-component vector of float)
+0:168        tangent (global 2-component vector of float)
+0:168          'inF0' (in 2-component vector of float)
+0:169      move second child to first child (temp 2-component vector of float)
+0:169        'r065' (temp 2-component vector of float)
+0:169        hyp. tangent (global 2-component vector of float)
+0:169          'inF0' (in 2-component vector of float)
+0:171      move second child to first child (temp 2-component vector of float)
+0:171        'r066' (temp 2-component vector of float)
+0:171        trunc (global 2-component vector of float)
+0:171          'inF0' (in 2-component vector of float)
+0:174      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
-0:252  Function Definition: PixelShaderFunction(vf3;vf3;vf3;vu3;vu3; (temp 3-component vector of float)
-0:173    Function Parameters: 
-0:173      'inF0' (in 3-component vector of float)
-0:173      'inF1' (in 3-component vector of float)
-0:173      'inF2' (in 3-component vector of float)
-0:173      'inU0' (in 3-component vector of uint)
-0:173      'inU1' (in 3-component vector of uint)
+0:258  Function Definition: PixelShaderFunction(vf3;vf3;vf3;vu3;vu3; (temp 3-component vector of float)
+0:178    Function Parameters: 
+0:178      'inF0' (in 3-component vector of float)
+0:178      'inF1' (in 3-component vector of float)
+0:178      'inF2' (in 3-component vector of float)
+0:178      'inU0' (in 3-component vector of uint)
+0:178      'inU1' (in 3-component vector of uint)
 0:?     Sequence
-0:176      all (global bool)
-0:176        'inF0' (in 3-component vector of float)
-0:177      Absolute value (global 3-component vector of float)
-0:177        'inF0' (in 3-component vector of float)
-0:178      arc cosine (global 3-component vector of float)
-0:178        'inF0' (in 3-component vector of float)
-0:179      any (global bool)
-0:179        'inF0' (in 3-component vector of float)
-0:180      arc sine (global 3-component vector of float)
-0:180        'inF0' (in 3-component vector of float)
-0:181      floatBitsToInt (global 3-component vector of int)
-0:181        'inF0' (in 3-component vector of float)
-0:182      floatBitsToUint (global 3-component vector of uint)
-0:182        'inF0' (in 3-component vector of float)
-0:183      intBitsToFloat (global 3-component vector of float)
-0:183        'inU0' (in 3-component vector of uint)
-0:185      arc tangent (global 3-component vector of float)
-0:185        'inF0' (in 3-component vector of float)
-0:186      arc tangent (global 3-component vector of float)
-0:186        'inF0' (in 3-component vector of float)
-0:186        'inF1' (in 3-component vector of float)
-0:187      Ceiling (global 3-component vector of float)
-0:187        'inF0' (in 3-component vector of float)
-0:188      clamp (global 3-component vector of float)
-0:188        'inF0' (in 3-component vector of float)
-0:188        'inF1' (in 3-component vector of float)
-0:188        'inF2' (in 3-component vector of float)
-0:189      Test condition and select (temp void)
-0:189        Condition
-0:189        any (temp bool)
-0:189          Compare Less Than (temp 3-component vector of bool)
-0:189            'inF0' (in 3-component vector of float)
-0:189            Constant:
-0:189              0.000000
-0:189              0.000000
-0:189              0.000000
-0:189        true case
-0:189        Branch: Kill
-0:190      cosine (global 3-component vector of float)
-0:190        'inF0' (in 3-component vector of float)
-0:191      hyp. cosine (global 3-component vector of float)
-0:191        'inF0' (in 3-component vector of float)
-0:?       bitCount (global 3-component vector of uint)
-0:?         Constant:
-0:?           7 (const uint)
-0:?           3 (const uint)
-0:?           5 (const uint)
-0:193      cross-product (global 3-component vector of float)
-0:193        'inF0' (in 3-component vector of float)
-0:193        'inF1' (in 3-component vector of float)
-0:194      dPdx (global 3-component vector of float)
-0:194        'inF0' (in 3-component vector of float)
-0:195      dPdxCoarse (global 3-component vector of float)
-0:195        'inF0' (in 3-component vector of float)
-0:196      dPdxFine (global 3-component vector of float)
-0:196        'inF0' (in 3-component vector of float)
-0:197      dPdy (global 3-component vector of float)
-0:197        'inF0' (in 3-component vector of float)
-0:198      dPdyCoarse (global 3-component vector of float)
-0:198        'inF0' (in 3-component vector of float)
-0:199      dPdyFine (global 3-component vector of float)
-0:199        'inF0' (in 3-component vector of float)
-0:200      degrees (global 3-component vector of float)
-0:200        'inF0' (in 3-component vector of float)
-0:201      distance (global float)
-0:201        'inF0' (in 3-component vector of float)
-0:201        'inF1' (in 3-component vector of float)
-0:202      dot-product (global float)
-0:202        'inF0' (in 3-component vector of float)
-0:202        'inF1' (in 3-component vector of float)
-0:206      exp (global 3-component vector of float)
-0:206        'inF0' (in 3-component vector of float)
-0:207      exp2 (global 3-component vector of float)
-0:207        'inF0' (in 3-component vector of float)
-0:208      face-forward (global 3-component vector of float)
-0:208        'inF0' (in 3-component vector of float)
-0:208        'inF1' (in 3-component vector of float)
-0:208        'inF2' (in 3-component vector of float)
-0:209      findMSB (global int)
-0:209        Constant:
-0:209          7 (const int)
-0:210      findLSB (global int)
-0:210        Constant:
-0:210          7 (const int)
-0:211      Floor (global 3-component vector of float)
-0:211        'inF0' (in 3-component vector of float)
-0:213      mod (global 3-component vector of float)
-0:213        'inF0' (in 3-component vector of float)
-0:213        'inF1' (in 3-component vector of float)
-0:214      Fraction (global 3-component vector of float)
-0:214        'inF0' (in 3-component vector of float)
-0:215      frexp (global 3-component vector of float)
-0:215        'inF0' (in 3-component vector of float)
-0:215        'inF1' (in 3-component vector of float)
-0:216      fwidth (global 3-component vector of float)
-0:216        'inF0' (in 3-component vector of float)
-0:217      isinf (global 3-component vector of bool)
-0:217        'inF0' (in 3-component vector of float)
-0:218      isnan (global 3-component vector of bool)
-0:218        'inF0' (in 3-component vector of float)
-0:219      ldexp (global 3-component vector of float)
-0:219        'inF0' (in 3-component vector of float)
-0:219        'inF1' (in 3-component vector of float)
-0:220      length (global float)
-0:220        'inF0' (in 3-component vector of float)
-0:221      log (global 3-component vector of float)
-0:221        'inF0' (in 3-component vector of float)
-0:222      vector-scale (temp 3-component vector of float)
-0:222        log2 (temp 3-component vector of float)
+0:181      move second child to first child (temp bool)
+0:181        'r000' (temp bool)
+0:181        all (global bool)
+0:181          'inF0' (in 3-component vector of float)
+0:182      move second child to first child (temp 3-component vector of float)
+0:182        'r001' (temp 3-component vector of float)
+0:182        Absolute value (global 3-component vector of float)
+0:182          'inF0' (in 3-component vector of float)
+0:183      move second child to first child (temp 3-component vector of float)
+0:183        'r002' (temp 3-component vector of float)
+0:183        arc cosine (global 3-component vector of float)
+0:183          'inF0' (in 3-component vector of float)
+0:184      move second child to first child (temp bool)
+0:184        'r003' (temp bool)
+0:184        any (global bool)
+0:184          'inF0' (in 3-component vector of float)
+0:185      move second child to first child (temp 3-component vector of float)
+0:185        'r004' (temp 3-component vector of float)
+0:185        arc sine (global 3-component vector of float)
+0:185          'inF0' (in 3-component vector of float)
+0:186      move second child to first child (temp 3-component vector of int)
+0:186        'r005' (temp 3-component vector of int)
+0:186        floatBitsToInt (global 3-component vector of int)
+0:186          'inF0' (in 3-component vector of float)
+0:187      move second child to first child (temp 3-component vector of uint)
+0:187        'r006' (temp 3-component vector of uint)
+0:187        floatBitsToUint (global 3-component vector of uint)
+0:187          'inF0' (in 3-component vector of float)
+0:188      move second child to first child (temp 3-component vector of float)
+0:188        'r007' (temp 3-component vector of float)
+0:188        intBitsToFloat (global 3-component vector of float)
+0:188          'inU0' (in 3-component vector of uint)
+0:190      move second child to first child (temp 3-component vector of float)
+0:190        'r009' (temp 3-component vector of float)
+0:190        arc tangent (global 3-component vector of float)
+0:190          'inF0' (in 3-component vector of float)
+0:191      move second child to first child (temp 3-component vector of float)
+0:191        'r010' (temp 3-component vector of float)
+0:191        arc tangent (global 3-component vector of float)
+0:191          'inF0' (in 3-component vector of float)
+0:191          'inF1' (in 3-component vector of float)
+0:192      move second child to first child (temp 3-component vector of float)
+0:192        'r011' (temp 3-component vector of float)
+0:192        Ceiling (global 3-component vector of float)
+0:192          'inF0' (in 3-component vector of float)
+0:193      move second child to first child (temp 3-component vector of float)
+0:193        'r012' (temp 3-component vector of float)
+0:193        clamp (global 3-component vector of float)
+0:193          'inF0' (in 3-component vector of float)
+0:193          'inF1' (in 3-component vector of float)
+0:193          'inF2' (in 3-component vector of float)
+0:194      Test condition and select (temp void)
+0:194        Condition
+0:194        any (temp bool)
+0:194          Compare Less Than (temp 3-component vector of bool)
+0:194            'inF0' (in 3-component vector of float)
+0:194            Constant:
+0:194              0.000000
+0:194              0.000000
+0:194              0.000000
+0:194        true case
+0:194        Branch: Kill
+0:195      move second child to first child (temp 3-component vector of float)
+0:195        'r013' (temp 3-component vector of float)
+0:195        cosine (global 3-component vector of float)
+0:195          'inF0' (in 3-component vector of float)
+0:196      move second child to first child (temp 3-component vector of float)
+0:196        'r014' (temp 3-component vector of float)
+0:196        hyp. cosine (global 3-component vector of float)
+0:196          'inF0' (in 3-component vector of float)
+0:197      move second child to first child (temp 3-component vector of uint)
+0:197        'r015' (temp 3-component vector of uint)
+0:?         bitCount (global 3-component vector of uint)
+0:?           Constant:
+0:?             7 (const uint)
+0:?             3 (const uint)
+0:?             5 (const uint)
+0:198      move second child to first child (temp 3-component vector of float)
+0:198        'r016' (temp 3-component vector of float)
+0:198        cross-product (global 3-component vector of float)
+0:198          'inF0' (in 3-component vector of float)
+0:198          'inF1' (in 3-component vector of float)
+0:199      move second child to first child (temp 3-component vector of float)
+0:199        'r017' (temp 3-component vector of float)
+0:199        dPdx (global 3-component vector of float)
+0:199          'inF0' (in 3-component vector of float)
+0:200      move second child to first child (temp 3-component vector of float)
+0:200        'r018' (temp 3-component vector of float)
+0:200        dPdxCoarse (global 3-component vector of float)
+0:200          'inF0' (in 3-component vector of float)
+0:201      move second child to first child (temp 3-component vector of float)
+0:201        'r019' (temp 3-component vector of float)
+0:201        dPdxFine (global 3-component vector of float)
+0:201          'inF0' (in 3-component vector of float)
+0:202      move second child to first child (temp 3-component vector of float)
+0:202        'r020' (temp 3-component vector of float)
+0:202        dPdy (global 3-component vector of float)
+0:202          'inF0' (in 3-component vector of float)
+0:203      move second child to first child (temp 3-component vector of float)
+0:203        'r021' (temp 3-component vector of float)
+0:203        dPdyCoarse (global 3-component vector of float)
+0:203          'inF0' (in 3-component vector of float)
+0:204      move second child to first child (temp 3-component vector of float)
+0:204        'r022' (temp 3-component vector of float)
+0:204        dPdyFine (global 3-component vector of float)
+0:204          'inF0' (in 3-component vector of float)
+0:205      move second child to first child (temp 3-component vector of float)
+0:205        'r023' (temp 3-component vector of float)
+0:205        degrees (global 3-component vector of float)
+0:205          'inF0' (in 3-component vector of float)
+0:206      move second child to first child (temp float)
+0:206        'r024' (temp float)
+0:206        distance (global float)
+0:206          'inF0' (in 3-component vector of float)
+0:206          'inF1' (in 3-component vector of float)
+0:207      move second child to first child (temp float)
+0:207        'r025' (temp float)
+0:207        dot-product (global float)
+0:207          'inF0' (in 3-component vector of float)
+0:207          'inF1' (in 3-component vector of float)
+0:211      move second child to first child (temp 3-component vector of float)
+0:211        'r029' (temp 3-component vector of float)
+0:211        exp (global 3-component vector of float)
+0:211          'inF0' (in 3-component vector of float)
+0:212      move second child to first child (temp 3-component vector of float)
+0:212        'r030' (temp 3-component vector of float)
+0:212        exp2 (global 3-component vector of float)
+0:212          'inF0' (in 3-component vector of float)
+0:213      move second child to first child (temp 3-component vector of float)
+0:213        'r031' (temp 3-component vector of float)
+0:213        face-forward (global 3-component vector of float)
+0:213          'inF0' (in 3-component vector of float)
+0:213          'inF1' (in 3-component vector of float)
+0:213          'inF2' (in 3-component vector of float)
+0:214      move second child to first child (temp 3-component vector of uint)
+0:214        'r032' (temp 3-component vector of uint)
+0:?         findMSB (global 3-component vector of uint)
+0:?           Constant:
+0:?             2 (const uint)
+0:?             3 (const uint)
+0:?             4 (const uint)
+0:215      move second child to first child (temp 3-component vector of uint)
+0:215        'r033' (temp 3-component vector of uint)
+0:?         findLSB (global 3-component vector of uint)
+0:?           Constant:
+0:?             2 (const uint)
+0:?             3 (const uint)
+0:?             4 (const uint)
+0:216      move second child to first child (temp 3-component vector of float)
+0:216        'r034' (temp 3-component vector of float)
+0:216        Floor (global 3-component vector of float)
+0:216          'inF0' (in 3-component vector of float)
+0:218      move second child to first child (temp 3-component vector of float)
+0:218        'r036' (temp 3-component vector of float)
+0:218        mod (global 3-component vector of float)
+0:218          'inF0' (in 3-component vector of float)
+0:218          'inF1' (in 3-component vector of float)
+0:219      move second child to first child (temp 3-component vector of float)
+0:219        'r037' (temp 3-component vector of float)
+0:219        Fraction (global 3-component vector of float)
+0:219          'inF0' (in 3-component vector of float)
+0:220      move second child to first child (temp 3-component vector of float)
+0:220        'r038' (temp 3-component vector of float)
+0:220        frexp (global 3-component vector of float)
+0:220          'inF0' (in 3-component vector of float)
+0:220          'inF1' (in 3-component vector of float)
+0:221      move second child to first child (temp 3-component vector of float)
+0:221        'r039' (temp 3-component vector of float)
+0:221        fwidth (global 3-component vector of float)
+0:221          'inF0' (in 3-component vector of float)
+0:222      move second child to first child (temp 3-component vector of bool)
+0:222        'r040' (temp 3-component vector of bool)
+0:222        isinf (global 3-component vector of bool)
 0:222          'inF0' (in 3-component vector of float)
-0:222        Constant:
-0:222          0.301030
-0:223      log2 (global 3-component vector of float)
-0:223        'inF0' (in 3-component vector of float)
-0:224      max (global 3-component vector of float)
-0:224        'inF0' (in 3-component vector of float)
-0:224        'inF1' (in 3-component vector of float)
-0:225      min (global 3-component vector of float)
-0:225        'inF0' (in 3-component vector of float)
-0:225        'inF1' (in 3-component vector of float)
-0:226      normalize (global 3-component vector of float)
-0:226        'inF0' (in 3-component vector of float)
-0:227      pow (global 3-component vector of float)
-0:227        'inF0' (in 3-component vector of float)
-0:227        'inF1' (in 3-component vector of float)
-0:228      radians (global 3-component vector of float)
-0:228        'inF0' (in 3-component vector of float)
-0:229      divide (temp 3-component vector of float)
-0:229        Constant:
-0:229          1.000000
-0:229        'inF0' (in 3-component vector of float)
-0:230      reflect (global 3-component vector of float)
-0:230        'inF0' (in 3-component vector of float)
-0:230        'inF1' (in 3-component vector of float)
-0:231      refract (global 3-component vector of float)
-0:231        'inF0' (in 3-component vector of float)
-0:231        'inF1' (in 3-component vector of float)
-0:231        Constant:
-0:231          2.000000
-0:?       bitFieldReverse (global 3-component vector of uint)
-0:?         Constant:
-0:?           1 (const uint)
-0:?           2 (const uint)
-0:?           3 (const uint)
-0:233      roundEven (global 3-component vector of float)
-0:233        'inF0' (in 3-component vector of float)
-0:234      inverse sqrt (global 3-component vector of float)
-0:234        'inF0' (in 3-component vector of float)
-0:235      clamp (temp 3-component vector of float)
-0:235        'inF0' (in 3-component vector of float)
-0:235        Constant:
-0:235          0.000000
-0:235        Constant:
-0:235          1.000000
-0:236      Sign (global 3-component vector of float)
-0:236        'inF0' (in 3-component vector of float)
-0:237      sine (global 3-component vector of float)
-0:237        'inF0' (in 3-component vector of float)
-0:238      Sequence
-0:238        move second child to first child (temp 3-component vector of float)
-0:238          'inF1' (in 3-component vector of float)
-0:238          sine (temp 3-component vector of float)
-0:238            'inF0' (in 3-component vector of float)
-0:238        move second child to first child (temp 3-component vector of float)
-0:238          'inF2' (in 3-component vector of float)
-0:238          cosine (temp 3-component vector of float)
-0:238            'inF0' (in 3-component vector of float)
-0:239      hyp. sine (global 3-component vector of float)
-0:239        'inF0' (in 3-component vector of float)
-0:240      smoothstep (global 3-component vector of float)
-0:240        'inF0' (in 3-component vector of float)
-0:240        'inF1' (in 3-component vector of float)
-0:240        'inF2' (in 3-component vector of float)
-0:241      sqrt (global 3-component vector of float)
-0:241        'inF0' (in 3-component vector of float)
-0:242      step (global 3-component vector of float)
-0:242        'inF0' (in 3-component vector of float)
-0:242        'inF1' (in 3-component vector of float)
-0:243      tangent (global 3-component vector of float)
-0:243        'inF0' (in 3-component vector of float)
-0:244      hyp. tangent (global 3-component vector of float)
-0:244        'inF0' (in 3-component vector of float)
-0:246      trunc (global 3-component vector of float)
-0:246        'inF0' (in 3-component vector of float)
-0:249      Branch: Return with expression
+0:223      move second child to first child (temp 3-component vector of bool)
+0:223        'r041' (temp 3-component vector of bool)
+0:223        isnan (global 3-component vector of bool)
+0:223          'inF0' (in 3-component vector of float)
+0:224      move second child to first child (temp 3-component vector of float)
+0:224        'r042' (temp 3-component vector of float)
+0:224        ldexp (global 3-component vector of float)
+0:224          'inF0' (in 3-component vector of float)
+0:224          'inF1' (in 3-component vector of float)
+0:225      move second child to first child (temp 3-component vector of float)
+0:225        'r039a' (temp 3-component vector of float)
+0:225        mix (global 3-component vector of float)
+0:225          'inF0' (in 3-component vector of float)
+0:225          'inF1' (in 3-component vector of float)
+0:225          'inF2' (in 3-component vector of float)
+0:226      move second child to first child (temp float)
+0:226        'r043' (temp float)
+0:226        length (global float)
+0:226          'inF0' (in 3-component vector of float)
+0:227      move second child to first child (temp 3-component vector of float)
+0:227        'r044' (temp 3-component vector of float)
+0:227        log (global 3-component vector of float)
+0:227          'inF0' (in 3-component vector of float)
+0:228      move second child to first child (temp 3-component vector of float)
+0:228        'r045' (temp 3-component vector of float)
+0:228        vector-scale (temp 3-component vector of float)
+0:228          log2 (temp 3-component vector of float)
+0:228            'inF0' (in 3-component vector of float)
+0:228          Constant:
+0:228            0.301030
+0:229      move second child to first child (temp 3-component vector of float)
+0:229        'r046' (temp 3-component vector of float)
+0:229        log2 (global 3-component vector of float)
+0:229          'inF0' (in 3-component vector of float)
+0:230      move second child to first child (temp 3-component vector of float)
+0:230        'r047' (temp 3-component vector of float)
+0:230        max (global 3-component vector of float)
+0:230          'inF0' (in 3-component vector of float)
+0:230          'inF1' (in 3-component vector of float)
+0:231      move second child to first child (temp 3-component vector of float)
+0:231        'r048' (temp 3-component vector of float)
+0:231        min (global 3-component vector of float)
+0:231          'inF0' (in 3-component vector of float)
+0:231          'inF1' (in 3-component vector of float)
+0:232      move second child to first child (temp 3-component vector of float)
+0:232        'r049' (temp 3-component vector of float)
+0:232        normalize (global 3-component vector of float)
+0:232          'inF0' (in 3-component vector of float)
+0:233      move second child to first child (temp 3-component vector of float)
+0:233        'r050' (temp 3-component vector of float)
+0:233        pow (global 3-component vector of float)
+0:233          'inF0' (in 3-component vector of float)
+0:233          'inF1' (in 3-component vector of float)
+0:234      move second child to first child (temp 3-component vector of float)
+0:234        'r051' (temp 3-component vector of float)
+0:234        radians (global 3-component vector of float)
+0:234          'inF0' (in 3-component vector of float)
+0:235      move second child to first child (temp 3-component vector of float)
+0:235        'r052' (temp 3-component vector of float)
+0:235        divide (temp 3-component vector of float)
+0:235          Constant:
+0:235            1.000000
+0:235          'inF0' (in 3-component vector of float)
+0:236      move second child to first child (temp 3-component vector of float)
+0:236        'r053' (temp 3-component vector of float)
+0:236        reflect (global 3-component vector of float)
+0:236          'inF0' (in 3-component vector of float)
+0:236          'inF1' (in 3-component vector of float)
+0:237      move second child to first child (temp 3-component vector of float)
+0:237        'r054' (temp 3-component vector of float)
+0:237        refract (global 3-component vector of float)
+0:237          'inF0' (in 3-component vector of float)
+0:237          'inF1' (in 3-component vector of float)
+0:237          Constant:
+0:237            2.000000
+0:238      move second child to first child (temp 3-component vector of uint)
+0:238        'r055' (temp 3-component vector of uint)
+0:?         bitFieldReverse (global 3-component vector of uint)
+0:?           Constant:
+0:?             1 (const uint)
+0:?             2 (const uint)
+0:?             3 (const uint)
+0:239      move second child to first child (temp 3-component vector of float)
+0:239        'r056' (temp 3-component vector of float)
+0:239        roundEven (global 3-component vector of float)
+0:239          'inF0' (in 3-component vector of float)
+0:240      move second child to first child (temp 3-component vector of float)
+0:240        'r057' (temp 3-component vector of float)
+0:240        inverse sqrt (global 3-component vector of float)
+0:240          'inF0' (in 3-component vector of float)
+0:241      move second child to first child (temp 3-component vector of float)
+0:241        'r058' (temp 3-component vector of float)
+0:241        clamp (temp 3-component vector of float)
+0:241          'inF0' (in 3-component vector of float)
+0:241          Constant:
+0:241            0.000000
+0:241          Constant:
+0:241            1.000000
+0:242      move second child to first child (temp 3-component vector of float)
+0:242        'r059' (temp 3-component vector of float)
+0:242        Sign (global 3-component vector of float)
+0:242          'inF0' (in 3-component vector of float)
+0:243      move second child to first child (temp 3-component vector of float)
+0:243        'r060' (temp 3-component vector of float)
+0:243        sine (global 3-component vector of float)
+0:243          'inF0' (in 3-component vector of float)
+0:244      Sequence
+0:244        move second child to first child (temp 3-component vector of float)
+0:244          'inF1' (in 3-component vector of float)
+0:244          sine (temp 3-component vector of float)
+0:244            'inF0' (in 3-component vector of float)
+0:244        move second child to first child (temp 3-component vector of float)
+0:244          'inF2' (in 3-component vector of float)
+0:244          cosine (temp 3-component vector of float)
+0:244            'inF0' (in 3-component vector of float)
+0:245      move second child to first child (temp 3-component vector of float)
+0:245        'r061' (temp 3-component vector of float)
+0:245        hyp. sine (global 3-component vector of float)
+0:245          'inF0' (in 3-component vector of float)
+0:246      move second child to first child (temp 3-component vector of float)
+0:246        'r062' (temp 3-component vector of float)
+0:246        smoothstep (global 3-component vector of float)
+0:246          'inF0' (in 3-component vector of float)
+0:246          'inF1' (in 3-component vector of float)
+0:246          'inF2' (in 3-component vector of float)
+0:247      move second child to first child (temp 3-component vector of float)
+0:247        'r063' (temp 3-component vector of float)
+0:247        sqrt (global 3-component vector of float)
+0:247          'inF0' (in 3-component vector of float)
+0:248      move second child to first child (temp 3-component vector of float)
+0:248        'r064' (temp 3-component vector of float)
+0:248        step (global 3-component vector of float)
+0:248          'inF0' (in 3-component vector of float)
+0:248          'inF1' (in 3-component vector of float)
+0:249      move second child to first child (temp 3-component vector of float)
+0:249        'r065' (temp 3-component vector of float)
+0:249        tangent (global 3-component vector of float)
+0:249          'inF0' (in 3-component vector of float)
+0:250      move second child to first child (temp 3-component vector of float)
+0:250        'r066' (temp 3-component vector of float)
+0:250        hyp. tangent (global 3-component vector of float)
+0:250          'inF0' (in 3-component vector of float)
+0:252      move second child to first child (temp 3-component vector of float)
+0:252        'r067' (temp 3-component vector of float)
+0:252        trunc (global 3-component vector of float)
+0:252          'inF0' (in 3-component vector of float)
+0:255      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
-0:393  Function Definition: PixelShaderFunction(vf4;vf4;vf4;vu4;vu4; (temp 4-component vector of float)
-0:253    Function Parameters: 
-0:253      'inF0' (in 4-component vector of float)
-0:253      'inF1' (in 4-component vector of float)
-0:253      'inF2' (in 4-component vector of float)
-0:253      'inU0' (in 4-component vector of uint)
-0:253      'inU1' (in 4-component vector of uint)
+0:399  Function Definition: PixelShaderFunction(vf4;vf4;vf4;vu4;vu4; (temp 4-component vector of float)
+0:259    Function Parameters: 
+0:259      'inF0' (in 4-component vector of float)
+0:259      'inF1' (in 4-component vector of float)
+0:259      'inF2' (in 4-component vector of float)
+0:259      'inU0' (in 4-component vector of uint)
+0:259      'inU1' (in 4-component vector of uint)
 0:?     Sequence
-0:256      all (global bool)
-0:256        'inF0' (in 4-component vector of float)
-0:257      Absolute value (global 4-component vector of float)
-0:257        'inF0' (in 4-component vector of float)
-0:258      arc cosine (global 4-component vector of float)
-0:258        'inF0' (in 4-component vector of float)
-0:259      any (global bool)
-0:259        'inF0' (in 4-component vector of float)
-0:260      arc sine (global 4-component vector of float)
-0:260        'inF0' (in 4-component vector of float)
-0:261      floatBitsToInt (global 4-component vector of int)
-0:261        'inF0' (in 4-component vector of float)
-0:262      floatBitsToUint (global 4-component vector of uint)
-0:262        'inF0' (in 4-component vector of float)
-0:263      intBitsToFloat (global 4-component vector of float)
-0:263        'inU0' (in 4-component vector of uint)
-0:265      arc tangent (global 4-component vector of float)
-0:265        'inF0' (in 4-component vector of float)
-0:266      arc tangent (global 4-component vector of float)
-0:266        'inF0' (in 4-component vector of float)
-0:266        'inF1' (in 4-component vector of float)
-0:267      Ceiling (global 4-component vector of float)
-0:267        'inF0' (in 4-component vector of float)
-0:268      clamp (global 4-component vector of float)
-0:268        'inF0' (in 4-component vector of float)
-0:268        'inF1' (in 4-component vector of float)
-0:268        'inF2' (in 4-component vector of float)
-0:269      Test condition and select (temp void)
-0:269        Condition
-0:269        any (temp bool)
-0:269          Compare Less Than (temp 4-component vector of bool)
-0:269            'inF0' (in 4-component vector of float)
-0:269            Constant:
-0:269              0.000000
-0:269              0.000000
-0:269              0.000000
-0:269              0.000000
-0:269        true case
-0:269        Branch: Kill
-0:270      cosine (global 4-component vector of float)
-0:270        'inF0' (in 4-component vector of float)
-0:271      hyp. cosine (global 4-component vector of float)
-0:271        'inF0' (in 4-component vector of float)
-0:?       bitCount (global 4-component vector of uint)
-0:?         Constant:
-0:?           7 (const uint)
-0:?           3 (const uint)
-0:?           5 (const uint)
-0:?           2 (const uint)
-0:273      dPdx (global 4-component vector of float)
-0:273        'inF0' (in 4-component vector of float)
-0:274      dPdxCoarse (global 4-component vector of float)
-0:274        'inF0' (in 4-component vector of float)
-0:275      dPdxFine (global 4-component vector of float)
-0:275        'inF0' (in 4-component vector of float)
-0:276      dPdy (global 4-component vector of float)
-0:276        'inF0' (in 4-component vector of float)
-0:277      dPdyCoarse (global 4-component vector of float)
-0:277        'inF0' (in 4-component vector of float)
-0:278      dPdyFine (global 4-component vector of float)
-0:278        'inF0' (in 4-component vector of float)
-0:279      degrees (global 4-component vector of float)
-0:279        'inF0' (in 4-component vector of float)
-0:280      distance (global float)
-0:280        'inF0' (in 4-component vector of float)
-0:280        'inF1' (in 4-component vector of float)
-0:281      dot-product (global float)
-0:281        'inF0' (in 4-component vector of float)
-0:281        'inF1' (in 4-component vector of float)
-0:282      Construct vec4 (temp 4-component vector of float)
-0:282        Constant:
-0:282          1.000000
-0:282        component-wise multiply (temp float)
-0:282          direct index (temp float)
-0:282            'inF0' (in 4-component vector of float)
-0:282            Constant:
-0:282              1 (const int)
-0:282          direct index (temp float)
-0:282            'inF1' (in 4-component vector of float)
-0:282            Constant:
-0:282              1 (const int)
-0:282        direct index (temp float)
+0:262      move second child to first child (temp bool)
+0:262        'r000' (temp bool)
+0:262        all (global bool)
+0:262          'inF0' (in 4-component vector of float)
+0:263      move second child to first child (temp 4-component vector of float)
+0:263        'r001' (temp 4-component vector of float)
+0:263        Absolute value (global 4-component vector of float)
+0:263          'inF0' (in 4-component vector of float)
+0:264      move second child to first child (temp 4-component vector of float)
+0:264        'r002' (temp 4-component vector of float)
+0:264        arc cosine (global 4-component vector of float)
+0:264          'inF0' (in 4-component vector of float)
+0:265      move second child to first child (temp bool)
+0:265        'r003' (temp bool)
+0:265        any (global bool)
+0:265          'inF0' (in 4-component vector of float)
+0:266      move second child to first child (temp 4-component vector of float)
+0:266        'r004' (temp 4-component vector of float)
+0:266        arc sine (global 4-component vector of float)
+0:266          'inF0' (in 4-component vector of float)
+0:267      move second child to first child (temp 4-component vector of int)
+0:267        'r005' (temp 4-component vector of int)
+0:267        floatBitsToInt (global 4-component vector of int)
+0:267          'inF0' (in 4-component vector of float)
+0:268      move second child to first child (temp 4-component vector of uint)
+0:268        'r006' (temp 4-component vector of uint)
+0:268        floatBitsToUint (global 4-component vector of uint)
+0:268          'inF0' (in 4-component vector of float)
+0:269      move second child to first child (temp 4-component vector of float)
+0:269        'r007' (temp 4-component vector of float)
+0:269        intBitsToFloat (global 4-component vector of float)
+0:269          'inU0' (in 4-component vector of uint)
+0:271      move second child to first child (temp 4-component vector of float)
+0:271        'r009' (temp 4-component vector of float)
+0:271        arc tangent (global 4-component vector of float)
+0:271          'inF0' (in 4-component vector of float)
+0:272      move second child to first child (temp 4-component vector of float)
+0:272        'r010' (temp 4-component vector of float)
+0:272        arc tangent (global 4-component vector of float)
+0:272          'inF0' (in 4-component vector of float)
+0:272          'inF1' (in 4-component vector of float)
+0:273      move second child to first child (temp 4-component vector of float)
+0:273        'r011' (temp 4-component vector of float)
+0:273        Ceiling (global 4-component vector of float)
+0:273          'inF0' (in 4-component vector of float)
+0:274      move second child to first child (temp 4-component vector of float)
+0:274        'r012' (temp 4-component vector of float)
+0:274        clamp (global 4-component vector of float)
+0:274          'inF0' (in 4-component vector of float)
+0:274          'inF1' (in 4-component vector of float)
+0:274          'inF2' (in 4-component vector of float)
+0:275      Test condition and select (temp void)
+0:275        Condition
+0:275        any (temp bool)
+0:275          Compare Less Than (temp 4-component vector of bool)
+0:275            'inF0' (in 4-component vector of float)
+0:275            Constant:
+0:275              0.000000
+0:275              0.000000
+0:275              0.000000
+0:275              0.000000
+0:275        true case
+0:275        Branch: Kill
+0:276      move second child to first child (temp 4-component vector of float)
+0:276        'r013' (temp 4-component vector of float)
+0:276        cosine (global 4-component vector of float)
+0:276          'inF0' (in 4-component vector of float)
+0:277      move second child to first child (temp 4-component vector of float)
+0:277        'r014' (temp 4-component vector of float)
+0:277        hyp. cosine (global 4-component vector of float)
+0:277          'inF0' (in 4-component vector of float)
+0:278      move second child to first child (temp 4-component vector of uint)
+0:278        'r015' (temp 4-component vector of uint)
+0:?         bitCount (global 4-component vector of uint)
+0:?           Constant:
+0:?             7 (const uint)
+0:?             3 (const uint)
+0:?             5 (const uint)
+0:?             2 (const uint)
+0:279      move second child to first child (temp 4-component vector of float)
+0:279        'r016' (temp 4-component vector of float)
+0:279        dPdx (global 4-component vector of float)
+0:279          'inF0' (in 4-component vector of float)
+0:280      move second child to first child (temp 4-component vector of float)
+0:280        'r017' (temp 4-component vector of float)
+0:280        dPdxCoarse (global 4-component vector of float)
+0:280          'inF0' (in 4-component vector of float)
+0:281      move second child to first child (temp 4-component vector of float)
+0:281        'r018' (temp 4-component vector of float)
+0:281        dPdxFine (global 4-component vector of float)
+0:281          'inF0' (in 4-component vector of float)
+0:282      move second child to first child (temp 4-component vector of float)
+0:282        'r019' (temp 4-component vector of float)
+0:282        dPdy (global 4-component vector of float)
 0:282          'inF0' (in 4-component vector of float)
-0:282          Constant:
-0:282            2 (const int)
-0:282        direct index (temp float)
-0:282          'inF1' (in 4-component vector of float)
-0:282          Constant:
-0:282            3 (const int)
-0:286      exp (global 4-component vector of float)
-0:286        'inF0' (in 4-component vector of float)
-0:287      exp2 (global 4-component vector of float)
-0:287        'inF0' (in 4-component vector of float)
-0:288      face-forward (global 4-component vector of float)
-0:288        'inF0' (in 4-component vector of float)
-0:288        'inF1' (in 4-component vector of float)
-0:288        'inF2' (in 4-component vector of float)
-0:289      findMSB (global int)
-0:289        Constant:
-0:289          7 (const int)
-0:290      findLSB (global int)
-0:290        Constant:
-0:290          7 (const int)
-0:291      Floor (global 4-component vector of float)
-0:291        'inF0' (in 4-component vector of float)
-0:293      mod (global 4-component vector of float)
-0:293        'inF0' (in 4-component vector of float)
-0:293        'inF1' (in 4-component vector of float)
-0:294      Fraction (global 4-component vector of float)
-0:294        'inF0' (in 4-component vector of float)
-0:295      frexp (global 4-component vector of float)
-0:295        'inF0' (in 4-component vector of float)
-0:295        'inF1' (in 4-component vector of float)
-0:296      fwidth (global 4-component vector of float)
-0:296        'inF0' (in 4-component vector of float)
-0:297      isinf (global 4-component vector of bool)
-0:297        'inF0' (in 4-component vector of float)
-0:298      isnan (global 4-component vector of bool)
-0:298        'inF0' (in 4-component vector of float)
-0:299      ldexp (global 4-component vector of float)
-0:299        'inF0' (in 4-component vector of float)
-0:299        'inF1' (in 4-component vector of float)
-0:300      length (global float)
-0:300        'inF0' (in 4-component vector of float)
-0:301      log (global 4-component vector of float)
-0:301        'inF0' (in 4-component vector of float)
-0:302      vector-scale (temp 4-component vector of float)
-0:302        log2 (temp 4-component vector of float)
+0:283      move second child to first child (temp 4-component vector of float)
+0:283        'r020' (temp 4-component vector of float)
+0:283        dPdyCoarse (global 4-component vector of float)
+0:283          'inF0' (in 4-component vector of float)
+0:284      move second child to first child (temp 4-component vector of float)
+0:284        'r021' (temp 4-component vector of float)
+0:284        dPdyFine (global 4-component vector of float)
+0:284          'inF0' (in 4-component vector of float)
+0:285      move second child to first child (temp 4-component vector of float)
+0:285        'r022' (temp 4-component vector of float)
+0:285        degrees (global 4-component vector of float)
+0:285          'inF0' (in 4-component vector of float)
+0:286      move second child to first child (temp float)
+0:286        'r023' (temp float)
+0:286        distance (global float)
+0:286          'inF0' (in 4-component vector of float)
+0:286          'inF1' (in 4-component vector of float)
+0:287      move second child to first child (temp float)
+0:287        'r024' (temp float)
+0:287        dot-product (global float)
+0:287          'inF0' (in 4-component vector of float)
+0:287          'inF1' (in 4-component vector of float)
+0:288      move second child to first child (temp 4-component vector of float)
+0:288        'r025' (temp 4-component vector of float)
+0:288        Construct vec4 (temp 4-component vector of float)
+0:288          Constant:
+0:288            1.000000
+0:288          component-wise multiply (temp float)
+0:288            direct index (temp float)
+0:288              'inF0' (in 4-component vector of float)
+0:288              Constant:
+0:288                1 (const int)
+0:288            direct index (temp float)
+0:288              'inF1' (in 4-component vector of float)
+0:288              Constant:
+0:288                1 (const int)
+0:288          direct index (temp float)
+0:288            'inF0' (in 4-component vector of float)
+0:288            Constant:
+0:288              2 (const int)
+0:288          direct index (temp float)
+0:288            'inF1' (in 4-component vector of float)
+0:288            Constant:
+0:288              3 (const int)
+0:292      move second child to first child (temp 4-component vector of float)
+0:292        'r029' (temp 4-component vector of float)
+0:292        exp (global 4-component vector of float)
+0:292          'inF0' (in 4-component vector of float)
+0:293      move second child to first child (temp 4-component vector of float)
+0:293        'r030' (temp 4-component vector of float)
+0:293        exp2 (global 4-component vector of float)
+0:293          'inF0' (in 4-component vector of float)
+0:294      move second child to first child (temp 4-component vector of float)
+0:294        'r031' (temp 4-component vector of float)
+0:294        face-forward (global 4-component vector of float)
+0:294          'inF0' (in 4-component vector of float)
+0:294          'inF1' (in 4-component vector of float)
+0:294          'inF2' (in 4-component vector of float)
+0:295      move second child to first child (temp 4-component vector of uint)
+0:295        'r032' (temp 4-component vector of uint)
+0:?         findMSB (global 4-component vector of uint)
+0:?           Constant:
+0:?             7 (const uint)
+0:?             8 (const uint)
+0:?             9 (const uint)
+0:?             10 (const uint)
+0:296      move second child to first child (temp 4-component vector of uint)
+0:296        'r033' (temp 4-component vector of uint)
+0:?         findLSB (global 4-component vector of uint)
+0:?           Constant:
+0:?             7 (const uint)
+0:?             8 (const uint)
+0:?             9 (const uint)
+0:?             10 (const uint)
+0:297      move second child to first child (temp 4-component vector of float)
+0:297        'r034' (temp 4-component vector of float)
+0:297        Floor (global 4-component vector of float)
+0:297          'inF0' (in 4-component vector of float)
+0:299      move second child to first child (temp 4-component vector of float)
+0:299        'r036' (temp 4-component vector of float)
+0:299        mod (global 4-component vector of float)
+0:299          'inF0' (in 4-component vector of float)
+0:299          'inF1' (in 4-component vector of float)
+0:300      move second child to first child (temp 4-component vector of float)
+0:300        'r037' (temp 4-component vector of float)
+0:300        Fraction (global 4-component vector of float)
+0:300          'inF0' (in 4-component vector of float)
+0:301      move second child to first child (temp 4-component vector of float)
+0:301        'r038' (temp 4-component vector of float)
+0:301        frexp (global 4-component vector of float)
+0:301          'inF0' (in 4-component vector of float)
+0:301          'inF1' (in 4-component vector of float)
+0:302      move second child to first child (temp 4-component vector of float)
+0:302        'r039' (temp 4-component vector of float)
+0:302        fwidth (global 4-component vector of float)
 0:302          'inF0' (in 4-component vector of float)
-0:302        Constant:
-0:302          0.301030
-0:303      log2 (global 4-component vector of float)
-0:303        'inF0' (in 4-component vector of float)
-0:304      max (global 4-component vector of float)
-0:304        'inF0' (in 4-component vector of float)
-0:304        'inF1' (in 4-component vector of float)
-0:305      min (global 4-component vector of float)
-0:305        'inF0' (in 4-component vector of float)
-0:305        'inF1' (in 4-component vector of float)
-0:306      normalize (global 4-component vector of float)
-0:306        'inF0' (in 4-component vector of float)
-0:307      pow (global 4-component vector of float)
-0:307        'inF0' (in 4-component vector of float)
-0:307        'inF1' (in 4-component vector of float)
-0:308      radians (global 4-component vector of float)
-0:308        'inF0' (in 4-component vector of float)
-0:309      divide (temp 4-component vector of float)
-0:309        Constant:
-0:309          1.000000
-0:309        'inF0' (in 4-component vector of float)
-0:310      reflect (global 4-component vector of float)
-0:310        'inF0' (in 4-component vector of float)
-0:310        'inF1' (in 4-component vector of float)
-0:311      refract (global 4-component vector of float)
-0:311        'inF0' (in 4-component vector of float)
-0:311        'inF1' (in 4-component vector of float)
-0:311        Constant:
-0:311          2.000000
-0:?       bitFieldReverse (global 4-component vector of uint)
-0:?         Constant:
-0:?           1 (const uint)
-0:?           2 (const uint)
-0:?           3 (const uint)
-0:?           4 (const uint)
-0:313      roundEven (global 4-component vector of float)
-0:313        'inF0' (in 4-component vector of float)
-0:314      inverse sqrt (global 4-component vector of float)
-0:314        'inF0' (in 4-component vector of float)
-0:315      clamp (temp 4-component vector of float)
-0:315        'inF0' (in 4-component vector of float)
-0:315        Constant:
-0:315          0.000000
-0:315        Constant:
-0:315          1.000000
-0:316      Sign (global 4-component vector of float)
-0:316        'inF0' (in 4-component vector of float)
-0:317      sine (global 4-component vector of float)
-0:317        'inF0' (in 4-component vector of float)
-0:318      Sequence
-0:318        move second child to first child (temp 4-component vector of float)
+0:303      move second child to first child (temp 4-component vector of bool)
+0:303        'r040' (temp 4-component vector of bool)
+0:303        isinf (global 4-component vector of bool)
+0:303          'inF0' (in 4-component vector of float)
+0:304      move second child to first child (temp 4-component vector of bool)
+0:304        'r041' (temp 4-component vector of bool)
+0:304        isnan (global 4-component vector of bool)
+0:304          'inF0' (in 4-component vector of float)
+0:305      move second child to first child (temp 4-component vector of float)
+0:305        'r042' (temp 4-component vector of float)
+0:305        ldexp (global 4-component vector of float)
+0:305          'inF0' (in 4-component vector of float)
+0:305          'inF1' (in 4-component vector of float)
+0:306      move second child to first child (temp 4-component vector of float)
+0:306        'r039a' (temp 4-component vector of float)
+0:306        mix (global 4-component vector of float)
+0:306          'inF0' (in 4-component vector of float)
+0:306          'inF1' (in 4-component vector of float)
+0:306          'inF2' (in 4-component vector of float)
+0:307      move second child to first child (temp float)
+0:307        'r043' (temp float)
+0:307        length (global float)
+0:307          'inF0' (in 4-component vector of float)
+0:308      move second child to first child (temp 4-component vector of float)
+0:308        'r044' (temp 4-component vector of float)
+0:308        log (global 4-component vector of float)
+0:308          'inF0' (in 4-component vector of float)
+0:309      move second child to first child (temp 4-component vector of float)
+0:309        'r045' (temp 4-component vector of float)
+0:309        vector-scale (temp 4-component vector of float)
+0:309          log2 (temp 4-component vector of float)
+0:309            'inF0' (in 4-component vector of float)
+0:309          Constant:
+0:309            0.301030
+0:310      move second child to first child (temp 4-component vector of float)
+0:310        'r046' (temp 4-component vector of float)
+0:310        log2 (global 4-component vector of float)
+0:310          'inF0' (in 4-component vector of float)
+0:311      move second child to first child (temp 4-component vector of float)
+0:311        'r047' (temp 4-component vector of float)
+0:311        max (global 4-component vector of float)
+0:311          'inF0' (in 4-component vector of float)
+0:311          'inF1' (in 4-component vector of float)
+0:312      move second child to first child (temp 4-component vector of float)
+0:312        'r048' (temp 4-component vector of float)
+0:312        min (global 4-component vector of float)
+0:312          'inF0' (in 4-component vector of float)
+0:312          'inF1' (in 4-component vector of float)
+0:313      move second child to first child (temp 4-component vector of float)
+0:313        'r049' (temp 4-component vector of float)
+0:313        normalize (global 4-component vector of float)
+0:313          'inF0' (in 4-component vector of float)
+0:314      move second child to first child (temp 4-component vector of float)
+0:314        'r050' (temp 4-component vector of float)
+0:314        pow (global 4-component vector of float)
+0:314          'inF0' (in 4-component vector of float)
+0:314          'inF1' (in 4-component vector of float)
+0:315      move second child to first child (temp 4-component vector of float)
+0:315        'r051' (temp 4-component vector of float)
+0:315        radians (global 4-component vector of float)
+0:315          'inF0' (in 4-component vector of float)
+0:316      move second child to first child (temp 4-component vector of float)
+0:316        'r052' (temp 4-component vector of float)
+0:316        divide (temp 4-component vector of float)
+0:316          Constant:
+0:316            1.000000
+0:316          'inF0' (in 4-component vector of float)
+0:317      move second child to first child (temp 4-component vector of float)
+0:317        'r053' (temp 4-component vector of float)
+0:317        reflect (global 4-component vector of float)
+0:317          'inF0' (in 4-component vector of float)
+0:317          'inF1' (in 4-component vector of float)
+0:318      move second child to first child (temp 4-component vector of float)
+0:318        'r054' (temp 4-component vector of float)
+0:318        refract (global 4-component vector of float)
+0:318          'inF0' (in 4-component vector of float)
 0:318          'inF1' (in 4-component vector of float)
-0:318          sine (temp 4-component vector of float)
-0:318            'inF0' (in 4-component vector of float)
-0:318        move second child to first child (temp 4-component vector of float)
-0:318          'inF2' (in 4-component vector of float)
-0:318          cosine (temp 4-component vector of float)
-0:318            'inF0' (in 4-component vector of float)
-0:319      hyp. sine (global 4-component vector of float)
-0:319        'inF0' (in 4-component vector of float)
-0:320      smoothstep (global 4-component vector of float)
-0:320        'inF0' (in 4-component vector of float)
-0:320        'inF1' (in 4-component vector of float)
-0:320        'inF2' (in 4-component vector of float)
-0:321      sqrt (global 4-component vector of float)
-0:321        'inF0' (in 4-component vector of float)
-0:322      step (global 4-component vector of float)
-0:322        'inF0' (in 4-component vector of float)
-0:322        'inF1' (in 4-component vector of float)
-0:323      tangent (global 4-component vector of float)
-0:323        'inF0' (in 4-component vector of float)
-0:324      hyp. tangent (global 4-component vector of float)
-0:324        'inF0' (in 4-component vector of float)
-0:326      trunc (global 4-component vector of float)
-0:326        'inF0' (in 4-component vector of float)
-0:329      Branch: Return with expression
+0:318          Constant:
+0:318            2.000000
+0:319      move second child to first child (temp 4-component vector of uint)
+0:319        'r055' (temp 4-component vector of uint)
+0:?         bitFieldReverse (global 4-component vector of uint)
+0:?           Constant:
+0:?             1 (const uint)
+0:?             2 (const uint)
+0:?             3 (const uint)
+0:?             4 (const uint)
+0:320      move second child to first child (temp 4-component vector of float)
+0:320        'r056' (temp 4-component vector of float)
+0:320        roundEven (global 4-component vector of float)
+0:320          'inF0' (in 4-component vector of float)
+0:321      move second child to first child (temp 4-component vector of float)
+0:321        'r057' (temp 4-component vector of float)
+0:321        inverse sqrt (global 4-component vector of float)
+0:321          'inF0' (in 4-component vector of float)
+0:322      move second child to first child (temp 4-component vector of float)
+0:322        'r058' (temp 4-component vector of float)
+0:322        clamp (temp 4-component vector of float)
+0:322          'inF0' (in 4-component vector of float)
+0:322          Constant:
+0:322            0.000000
+0:322          Constant:
+0:322            1.000000
+0:323      move second child to first child (temp 4-component vector of float)
+0:323        'r059' (temp 4-component vector of float)
+0:323        Sign (global 4-component vector of float)
+0:323          'inF0' (in 4-component vector of float)
+0:324      move second child to first child (temp 4-component vector of float)
+0:324        'r060' (temp 4-component vector of float)
+0:324        sine (global 4-component vector of float)
+0:324          'inF0' (in 4-component vector of float)
+0:325      Sequence
+0:325        move second child to first child (temp 4-component vector of float)
+0:325          'inF1' (in 4-component vector of float)
+0:325          sine (temp 4-component vector of float)
+0:325            'inF0' (in 4-component vector of float)
+0:325        move second child to first child (temp 4-component vector of float)
+0:325          'inF2' (in 4-component vector of float)
+0:325          cosine (temp 4-component vector of float)
+0:325            'inF0' (in 4-component vector of float)
+0:326      move second child to first child (temp 4-component vector of float)
+0:326        'r061' (temp 4-component vector of float)
+0:326        hyp. sine (global 4-component vector of float)
+0:326          'inF0' (in 4-component vector of float)
+0:327      move second child to first child (temp 4-component vector of float)
+0:327        'r062' (temp 4-component vector of float)
+0:327        smoothstep (global 4-component vector of float)
+0:327          'inF0' (in 4-component vector of float)
+0:327          'inF1' (in 4-component vector of float)
+0:327          'inF2' (in 4-component vector of float)
+0:328      move second child to first child (temp 4-component vector of float)
+0:328        'r063' (temp 4-component vector of float)
+0:328        sqrt (global 4-component vector of float)
+0:328          'inF0' (in 4-component vector of float)
+0:329      move second child to first child (temp 4-component vector of float)
+0:329        'r064' (temp 4-component vector of float)
+0:329        step (global 4-component vector of float)
+0:329          'inF0' (in 4-component vector of float)
+0:329          'inF1' (in 4-component vector of float)
+0:330      move second child to first child (temp 4-component vector of float)
+0:330        'r065' (temp 4-component vector of float)
+0:330        tangent (global 4-component vector of float)
+0:330          'inF0' (in 4-component vector of float)
+0:331      move second child to first child (temp 4-component vector of float)
+0:331        'r066' (temp 4-component vector of float)
+0:331        hyp. tangent (global 4-component vector of float)
+0:331          'inF0' (in 4-component vector of float)
+0:333      move second child to first child (temp 4-component vector of float)
+0:333        'r067' (temp 4-component vector of float)
+0:333        trunc (global 4-component vector of float)
+0:333          'inF0' (in 4-component vector of float)
+0:336      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
 0:?           4.000000
-0:402  Function Definition: PixelShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
-0:394    Function Parameters: 
-0:394      'inF0' (in 2X2 matrix of float)
-0:394      'inF1' (in 2X2 matrix of float)
-0:394      'inF2' (in 2X2 matrix of float)
+0:408  Function Definition: PixelShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:400    Function Parameters: 
+0:400      'inF0' (in 2X2 matrix of float)
+0:400      'inF1' (in 2X2 matrix of float)
+0:400      'inF2' (in 2X2 matrix of float)
 0:?     Sequence
-0:396      all (global bool)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      Absolute value (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      arc cosine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      any (global bool)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      arc sine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      arc tangent (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      arc tangent (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      Ceiling (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      Test condition and select (temp void)
-0:396        Condition
-0:396        any (temp bool)
-0:396          Compare Less Than (temp 2X2 matrix of bool)
-0:396            'inF0' (in 2X2 matrix of float)
-0:396            Constant:
-0:396              0.000000
-0:396              0.000000
-0:396              0.000000
-0:396              0.000000
-0:396        true case
-0:396        Branch: Kill
-0:396      clamp (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396        'inF2' (in 2X2 matrix of float)
-0:396      cosine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      hyp. cosine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      dPdx (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      dPdxCoarse (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      dPdxFine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      dPdy (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      dPdyCoarse (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      dPdyFine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      degrees (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      determinant (global float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      exp (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      exp2 (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      findMSB (global int)
-0:396        Constant:
-0:396          7 (const int)
-0:396      findLSB (global int)
-0:396        Constant:
-0:396          7 (const int)
-0:396      Floor (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      mod (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      Fraction (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      frexp (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      fwidth (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      ldexp (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      log (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      matrix-scale (temp 2X2 matrix of float)
-0:396        log2 (temp 2X2 matrix of float)
-0:396          'inF0' (in 2X2 matrix of float)
-0:396        Constant:
-0:396          0.301030
-0:396      log2 (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      max (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      min (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      pow (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      radians (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      roundEven (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      inverse sqrt (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      clamp (temp 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        Constant:
-0:396          0.000000
-0:396        Constant:
-0:396          1.000000
-0:396      Sign (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      sine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      Sequence
-0:396        move second child to first child (temp 2X2 matrix of float)
-0:396          'inF1' (in 2X2 matrix of float)
-0:396          sine (temp 2X2 matrix of float)
-0:396            'inF0' (in 2X2 matrix of float)
-0:396        move second child to first child (temp 2X2 matrix of float)
-0:396          'inF2' (in 2X2 matrix of float)
-0:396          cosine (temp 2X2 matrix of float)
-0:396            'inF0' (in 2X2 matrix of float)
-0:396      hyp. sine (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      smoothstep (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396        'inF2' (in 2X2 matrix of float)
-0:396      sqrt (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      step (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396        'inF1' (in 2X2 matrix of float)
-0:396      tangent (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      hyp. tangent (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      transpose (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:396      trunc (global 2X2 matrix of float)
-0:396        'inF0' (in 2X2 matrix of float)
-0:399      Branch: Return with expression
+0:402      move second child to first child (temp bool)
+0:402        'r000' (temp bool)
+0:402        all (global bool)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r001' (temp 2X2 matrix of float)
+0:402        Absolute value (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      arc cosine (global 2X2 matrix of float)
+0:402        'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp bool)
+0:402        'r003' (temp bool)
+0:402        any (global bool)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r004' (temp 2X2 matrix of float)
+0:402        arc sine (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r005' (temp 2X2 matrix of float)
+0:402        arc tangent (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r006' (temp 2X2 matrix of float)
+0:402        arc tangent (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r007' (temp 2X2 matrix of float)
+0:402        Ceiling (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      Test condition and select (temp void)
+0:402        Condition
+0:402        any (temp bool)
+0:402          Compare Less Than (temp 2X2 matrix of bool)
+0:402            'inF0' (in 2X2 matrix of float)
+0:402            Constant:
+0:402              0.000000
+0:402              0.000000
+0:402              0.000000
+0:402              0.000000
+0:402        true case
+0:402        Branch: Kill
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r008' (temp 2X2 matrix of float)
+0:402        clamp (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402          'inF2' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r009' (temp 2X2 matrix of float)
+0:402        cosine (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r010' (temp 2X2 matrix of float)
+0:402        hyp. cosine (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r011' (temp 2X2 matrix of float)
+0:402        dPdx (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r012' (temp 2X2 matrix of float)
+0:402        dPdxCoarse (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r013' (temp 2X2 matrix of float)
+0:402        dPdxFine (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r014' (temp 2X2 matrix of float)
+0:402        dPdy (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r015' (temp 2X2 matrix of float)
+0:402        dPdyCoarse (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r016' (temp 2X2 matrix of float)
+0:402        dPdyFine (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r017' (temp 2X2 matrix of float)
+0:402        degrees (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp float)
+0:402        'r018' (temp float)
+0:402        determinant (global float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r019' (temp 2X2 matrix of float)
+0:402        exp (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'R020' (temp 2X2 matrix of float)
+0:402        exp2 (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r021' (temp 2X2 matrix of float)
+0:402        Floor (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r022' (temp 2X2 matrix of float)
+0:402        mod (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r023' (temp 2X2 matrix of float)
+0:402        Fraction (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r024' (temp 2X2 matrix of float)
+0:402        frexp (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r025' (temp 2X2 matrix of float)
+0:402        fwidth (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r026' (temp 2X2 matrix of float)
+0:402        ldexp (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r026a' (temp 2X2 matrix of float)
+0:402        mix (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402          'inF2' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r027' (temp 2X2 matrix of float)
+0:402        log (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r028' (temp 2X2 matrix of float)
+0:402        matrix-scale (temp 2X2 matrix of float)
+0:402          log2 (temp 2X2 matrix of float)
+0:402            'inF0' (in 2X2 matrix of float)
+0:402          Constant:
+0:402            0.301030
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r029' (temp 2X2 matrix of float)
+0:402        log2 (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r030' (temp 2X2 matrix of float)
+0:402        max (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r031' (temp 2X2 matrix of float)
+0:402        min (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r032' (temp 2X2 matrix of float)
+0:402        pow (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r033' (temp 2X2 matrix of float)
+0:402        radians (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r034' (temp 2X2 matrix of float)
+0:402        roundEven (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r035' (temp 2X2 matrix of float)
+0:402        inverse sqrt (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r036' (temp 2X2 matrix of float)
+0:402        clamp (temp 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          Constant:
+0:402            0.000000
+0:402          Constant:
+0:402            1.000000
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r037' (temp 2X2 matrix of float)
+0:402        Sign (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r038' (temp 2X2 matrix of float)
+0:402        sine (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      Sequence
+0:402        move second child to first child (temp 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402          sine (temp 2X2 matrix of float)
+0:402            'inF0' (in 2X2 matrix of float)
+0:402        move second child to first child (temp 2X2 matrix of float)
+0:402          'inF2' (in 2X2 matrix of float)
+0:402          cosine (temp 2X2 matrix of float)
+0:402            'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r039' (temp 2X2 matrix of float)
+0:402        hyp. sine (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r049' (temp 2X2 matrix of float)
+0:402        smoothstep (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402          'inF2' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r041' (temp 2X2 matrix of float)
+0:402        sqrt (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r042' (temp 2X2 matrix of float)
+0:402        step (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402          'inF1' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r043' (temp 2X2 matrix of float)
+0:402        tangent (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r044' (temp 2X2 matrix of float)
+0:402        hyp. tangent (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:402      transpose (global 2X2 matrix of float)
+0:402        'inF0' (in 2X2 matrix of float)
+0:402      move second child to first child (temp 2X2 matrix of float)
+0:402        'r046' (temp 2X2 matrix of float)
+0:402        trunc (global 2X2 matrix of float)
+0:402          'inF0' (in 2X2 matrix of float)
+0:405      Branch: Return with expression
 0:?         Constant:
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
-0:411  Function Definition: PixelShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
-0:403    Function Parameters: 
-0:403      'inF0' (in 3X3 matrix of float)
-0:403      'inF1' (in 3X3 matrix of float)
-0:403      'inF2' (in 3X3 matrix of float)
+0:417  Function Definition: PixelShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:409    Function Parameters: 
+0:409      'inF0' (in 3X3 matrix of float)
+0:409      'inF1' (in 3X3 matrix of float)
+0:409      'inF2' (in 3X3 matrix of float)
 0:?     Sequence
-0:405      all (global bool)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      Absolute value (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      arc cosine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      any (global bool)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      arc sine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      arc tangent (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      arc tangent (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      Ceiling (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      Test condition and select (temp void)
-0:405        Condition
-0:405        any (temp bool)
-0:405          Compare Less Than (temp 3X3 matrix of bool)
-0:405            'inF0' (in 3X3 matrix of float)
-0:405            Constant:
-0:405              0.000000
-0:405              0.000000
-0:405              0.000000
-0:405              0.000000
-0:405              0.000000
-0:405              0.000000
-0:405              0.000000
-0:405              0.000000
-0:405              0.000000
-0:405        true case
-0:405        Branch: Kill
-0:405      clamp (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405        'inF2' (in 3X3 matrix of float)
-0:405      cosine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      hyp. cosine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      dPdx (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      dPdxCoarse (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      dPdxFine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      dPdy (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      dPdyCoarse (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      dPdyFine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      degrees (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      determinant (global float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      exp (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      exp2 (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      findMSB (global int)
-0:405        Constant:
-0:405          7 (const int)
-0:405      findLSB (global int)
-0:405        Constant:
-0:405          7 (const int)
-0:405      Floor (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      mod (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      Fraction (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      frexp (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      fwidth (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      ldexp (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      log (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      matrix-scale (temp 3X3 matrix of float)
-0:405        log2 (temp 3X3 matrix of float)
-0:405          'inF0' (in 3X3 matrix of float)
-0:405        Constant:
-0:405          0.301030
-0:405      log2 (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      max (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      min (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      pow (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      radians (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      roundEven (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      inverse sqrt (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      clamp (temp 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        Constant:
-0:405          0.000000
-0:405        Constant:
-0:405          1.000000
-0:405      Sign (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      sine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      Sequence
-0:405        move second child to first child (temp 3X3 matrix of float)
-0:405          'inF1' (in 3X3 matrix of float)
-0:405          sine (temp 3X3 matrix of float)
-0:405            'inF0' (in 3X3 matrix of float)
-0:405        move second child to first child (temp 3X3 matrix of float)
-0:405          'inF2' (in 3X3 matrix of float)
-0:405          cosine (temp 3X3 matrix of float)
-0:405            'inF0' (in 3X3 matrix of float)
-0:405      hyp. sine (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      smoothstep (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405        'inF2' (in 3X3 matrix of float)
-0:405      sqrt (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      step (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405        'inF1' (in 3X3 matrix of float)
-0:405      tangent (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      hyp. tangent (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      transpose (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:405      trunc (global 3X3 matrix of float)
-0:405        'inF0' (in 3X3 matrix of float)
-0:408      Branch: Return with expression
+0:411      move second child to first child (temp bool)
+0:411        'r000' (temp bool)
+0:411        all (global bool)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r001' (temp 3X3 matrix of float)
+0:411        Absolute value (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      arc cosine (global 3X3 matrix of float)
+0:411        'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp bool)
+0:411        'r003' (temp bool)
+0:411        any (global bool)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r004' (temp 3X3 matrix of float)
+0:411        arc sine (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r005' (temp 3X3 matrix of float)
+0:411        arc tangent (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r006' (temp 3X3 matrix of float)
+0:411        arc tangent (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r007' (temp 3X3 matrix of float)
+0:411        Ceiling (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      Test condition and select (temp void)
+0:411        Condition
+0:411        any (temp bool)
+0:411          Compare Less Than (temp 3X3 matrix of bool)
+0:411            'inF0' (in 3X3 matrix of float)
+0:411            Constant:
+0:411              0.000000
+0:411              0.000000
+0:411              0.000000
+0:411              0.000000
+0:411              0.000000
+0:411              0.000000
+0:411              0.000000
+0:411              0.000000
+0:411              0.000000
+0:411        true case
+0:411        Branch: Kill
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r008' (temp 3X3 matrix of float)
+0:411        clamp (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411          'inF2' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r009' (temp 3X3 matrix of float)
+0:411        cosine (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r010' (temp 3X3 matrix of float)
+0:411        hyp. cosine (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r011' (temp 3X3 matrix of float)
+0:411        dPdx (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r012' (temp 3X3 matrix of float)
+0:411        dPdxCoarse (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r013' (temp 3X3 matrix of float)
+0:411        dPdxFine (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r014' (temp 3X3 matrix of float)
+0:411        dPdy (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r015' (temp 3X3 matrix of float)
+0:411        dPdyCoarse (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r016' (temp 3X3 matrix of float)
+0:411        dPdyFine (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r017' (temp 3X3 matrix of float)
+0:411        degrees (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp float)
+0:411        'r018' (temp float)
+0:411        determinant (global float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r019' (temp 3X3 matrix of float)
+0:411        exp (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'R020' (temp 3X3 matrix of float)
+0:411        exp2 (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r021' (temp 3X3 matrix of float)
+0:411        Floor (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r022' (temp 3X3 matrix of float)
+0:411        mod (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r023' (temp 3X3 matrix of float)
+0:411        Fraction (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r024' (temp 3X3 matrix of float)
+0:411        frexp (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r025' (temp 3X3 matrix of float)
+0:411        fwidth (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r026' (temp 3X3 matrix of float)
+0:411        ldexp (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r026a' (temp 3X3 matrix of float)
+0:411        mix (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411          'inF2' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r027' (temp 3X3 matrix of float)
+0:411        log (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r028' (temp 3X3 matrix of float)
+0:411        matrix-scale (temp 3X3 matrix of float)
+0:411          log2 (temp 3X3 matrix of float)
+0:411            'inF0' (in 3X3 matrix of float)
+0:411          Constant:
+0:411            0.301030
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r029' (temp 3X3 matrix of float)
+0:411        log2 (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r030' (temp 3X3 matrix of float)
+0:411        max (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r031' (temp 3X3 matrix of float)
+0:411        min (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r032' (temp 3X3 matrix of float)
+0:411        pow (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r033' (temp 3X3 matrix of float)
+0:411        radians (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r034' (temp 3X3 matrix of float)
+0:411        roundEven (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r035' (temp 3X3 matrix of float)
+0:411        inverse sqrt (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r036' (temp 3X3 matrix of float)
+0:411        clamp (temp 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          Constant:
+0:411            0.000000
+0:411          Constant:
+0:411            1.000000
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r037' (temp 3X3 matrix of float)
+0:411        Sign (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r038' (temp 3X3 matrix of float)
+0:411        sine (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      Sequence
+0:411        move second child to first child (temp 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411          sine (temp 3X3 matrix of float)
+0:411            'inF0' (in 3X3 matrix of float)
+0:411        move second child to first child (temp 3X3 matrix of float)
+0:411          'inF2' (in 3X3 matrix of float)
+0:411          cosine (temp 3X3 matrix of float)
+0:411            'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r039' (temp 3X3 matrix of float)
+0:411        hyp. sine (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r049' (temp 3X3 matrix of float)
+0:411        smoothstep (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411          'inF2' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r041' (temp 3X3 matrix of float)
+0:411        sqrt (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r042' (temp 3X3 matrix of float)
+0:411        step (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411          'inF1' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r043' (temp 3X3 matrix of float)
+0:411        tangent (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r044' (temp 3X3 matrix of float)
+0:411        hyp. tangent (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:411      transpose (global 3X3 matrix of float)
+0:411        'inF0' (in 3X3 matrix of float)
+0:411      move second child to first child (temp 3X3 matrix of float)
+0:411        'r046' (temp 3X3 matrix of float)
+0:411        trunc (global 3X3 matrix of float)
+0:411          'inF0' (in 3X3 matrix of float)
+0:414      Branch: Return with expression
 0:?         Constant:
 0:?           3.000000
 0:?           3.000000
@@ -2543,165 +4138,255 @@ gl_FragCoord origin is upper left
 0:?           3.000000
 0:?           3.000000
 0:?           3.000000
-0:432  Function Definition: PixelShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
-0:412    Function Parameters: 
-0:412      'inF0' (in 4X4 matrix of float)
-0:412      'inF1' (in 4X4 matrix of float)
-0:412      'inF2' (in 4X4 matrix of float)
+0:438  Function Definition: PixelShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:418    Function Parameters: 
+0:418      'inF0' (in 4X4 matrix of float)
+0:418      'inF1' (in 4X4 matrix of float)
+0:418      'inF2' (in 4X4 matrix of float)
 0:?     Sequence
-0:414      all (global bool)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      Absolute value (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      arc cosine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      any (global bool)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      arc sine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      arc tangent (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      arc tangent (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      Ceiling (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      Test condition and select (temp void)
-0:414        Condition
-0:414        any (temp bool)
-0:414          Compare Less Than (temp 4X4 matrix of bool)
-0:414            'inF0' (in 4X4 matrix of float)
-0:414            Constant:
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414              0.000000
-0:414        true case
-0:414        Branch: Kill
-0:414      clamp (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414        'inF2' (in 4X4 matrix of float)
-0:414      cosine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      hyp. cosine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      dPdx (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      dPdxCoarse (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      dPdxFine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      dPdy (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      dPdyCoarse (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      dPdyFine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      degrees (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      determinant (global float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      exp (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      exp2 (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      findMSB (global int)
-0:414        Constant:
-0:414          7 (const int)
-0:414      findLSB (global int)
-0:414        Constant:
-0:414          7 (const int)
-0:414      Floor (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      mod (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      Fraction (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      frexp (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      fwidth (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      ldexp (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      log (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      matrix-scale (temp 4X4 matrix of float)
-0:414        log2 (temp 4X4 matrix of float)
-0:414          'inF0' (in 4X4 matrix of float)
-0:414        Constant:
-0:414          0.301030
-0:414      log2 (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      max (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      min (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      pow (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      radians (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      roundEven (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      inverse sqrt (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      clamp (temp 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        Constant:
-0:414          0.000000
-0:414        Constant:
-0:414          1.000000
-0:414      Sign (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      sine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      Sequence
-0:414        move second child to first child (temp 4X4 matrix of float)
-0:414          'inF1' (in 4X4 matrix of float)
-0:414          sine (temp 4X4 matrix of float)
-0:414            'inF0' (in 4X4 matrix of float)
-0:414        move second child to first child (temp 4X4 matrix of float)
-0:414          'inF2' (in 4X4 matrix of float)
-0:414          cosine (temp 4X4 matrix of float)
-0:414            'inF0' (in 4X4 matrix of float)
-0:414      hyp. sine (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      smoothstep (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414        'inF2' (in 4X4 matrix of float)
-0:414      sqrt (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      step (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414        'inF1' (in 4X4 matrix of float)
-0:414      tangent (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      hyp. tangent (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      transpose (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:414      trunc (global 4X4 matrix of float)
-0:414        'inF0' (in 4X4 matrix of float)
-0:417      Branch: Return with expression
+0:420      move second child to first child (temp bool)
+0:420        'r000' (temp bool)
+0:420        all (global bool)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r001' (temp 4X4 matrix of float)
+0:420        Absolute value (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      arc cosine (global 4X4 matrix of float)
+0:420        'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp bool)
+0:420        'r003' (temp bool)
+0:420        any (global bool)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r004' (temp 4X4 matrix of float)
+0:420        arc sine (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r005' (temp 4X4 matrix of float)
+0:420        arc tangent (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r006' (temp 4X4 matrix of float)
+0:420        arc tangent (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r007' (temp 4X4 matrix of float)
+0:420        Ceiling (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      Test condition and select (temp void)
+0:420        Condition
+0:420        any (temp bool)
+0:420          Compare Less Than (temp 4X4 matrix of bool)
+0:420            'inF0' (in 4X4 matrix of float)
+0:420            Constant:
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420              0.000000
+0:420        true case
+0:420        Branch: Kill
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r008' (temp 4X4 matrix of float)
+0:420        clamp (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420          'inF2' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r009' (temp 4X4 matrix of float)
+0:420        cosine (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r010' (temp 4X4 matrix of float)
+0:420        hyp. cosine (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r011' (temp 4X4 matrix of float)
+0:420        dPdx (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r012' (temp 4X4 matrix of float)
+0:420        dPdxCoarse (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r013' (temp 4X4 matrix of float)
+0:420        dPdxFine (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r014' (temp 4X4 matrix of float)
+0:420        dPdy (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r015' (temp 4X4 matrix of float)
+0:420        dPdyCoarse (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r016' (temp 4X4 matrix of float)
+0:420        dPdyFine (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r017' (temp 4X4 matrix of float)
+0:420        degrees (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp float)
+0:420        'r018' (temp float)
+0:420        determinant (global float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r019' (temp 4X4 matrix of float)
+0:420        exp (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'R020' (temp 4X4 matrix of float)
+0:420        exp2 (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r021' (temp 4X4 matrix of float)
+0:420        Floor (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r022' (temp 4X4 matrix of float)
+0:420        mod (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r023' (temp 4X4 matrix of float)
+0:420        Fraction (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r024' (temp 4X4 matrix of float)
+0:420        frexp (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r025' (temp 4X4 matrix of float)
+0:420        fwidth (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r026' (temp 4X4 matrix of float)
+0:420        ldexp (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r026a' (temp 4X4 matrix of float)
+0:420        mix (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420          'inF2' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r027' (temp 4X4 matrix of float)
+0:420        log (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r028' (temp 4X4 matrix of float)
+0:420        matrix-scale (temp 4X4 matrix of float)
+0:420          log2 (temp 4X4 matrix of float)
+0:420            'inF0' (in 4X4 matrix of float)
+0:420          Constant:
+0:420            0.301030
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r029' (temp 4X4 matrix of float)
+0:420        log2 (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r030' (temp 4X4 matrix of float)
+0:420        max (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r031' (temp 4X4 matrix of float)
+0:420        min (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r032' (temp 4X4 matrix of float)
+0:420        pow (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r033' (temp 4X4 matrix of float)
+0:420        radians (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r034' (temp 4X4 matrix of float)
+0:420        roundEven (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r035' (temp 4X4 matrix of float)
+0:420        inverse sqrt (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r036' (temp 4X4 matrix of float)
+0:420        clamp (temp 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          Constant:
+0:420            0.000000
+0:420          Constant:
+0:420            1.000000
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r037' (temp 4X4 matrix of float)
+0:420        Sign (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r038' (temp 4X4 matrix of float)
+0:420        sine (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      Sequence
+0:420        move second child to first child (temp 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420          sine (temp 4X4 matrix of float)
+0:420            'inF0' (in 4X4 matrix of float)
+0:420        move second child to first child (temp 4X4 matrix of float)
+0:420          'inF2' (in 4X4 matrix of float)
+0:420          cosine (temp 4X4 matrix of float)
+0:420            'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r039' (temp 4X4 matrix of float)
+0:420        hyp. sine (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r049' (temp 4X4 matrix of float)
+0:420        smoothstep (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420          'inF2' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r041' (temp 4X4 matrix of float)
+0:420        sqrt (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r042' (temp 4X4 matrix of float)
+0:420        step (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420          'inF1' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r043' (temp 4X4 matrix of float)
+0:420        tangent (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r044' (temp 4X4 matrix of float)
+0:420        hyp. tangent (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:420      transpose (global 4X4 matrix of float)
+0:420        'inF0' (in 4X4 matrix of float)
+0:420      move second child to first child (temp 4X4 matrix of float)
+0:420        'r046' (temp 4X4 matrix of float)
+0:420        trunc (global 4X4 matrix of float)
+0:420          'inF0' (in 4X4 matrix of float)
+0:423      Branch: Return with expression
 0:?         Constant:
 0:?           4.000000
 0:?           4.000000
@@ -2719,168 +4404,265 @@ gl_FragCoord origin is upper left
 0:?           4.000000
 0:?           4.000000
 0:?           4.000000
-0:439  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
-0:435    Function Parameters: 
-0:435      'inF0' (in float)
-0:435      'inF1' (in float)
-0:435      'inFV0' (in 2-component vector of float)
-0:435      'inFV1' (in 2-component vector of float)
-0:435      'inFM0' (in 2X2 matrix of float)
-0:435      'inFM1' (in 2X2 matrix of float)
+0:445  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
+0:441    Function Parameters: 
+0:441      'inF0' (in float)
+0:441      'inF1' (in float)
+0:441      'inFV0' (in 2-component vector of float)
+0:441      'inFV1' (in 2-component vector of float)
+0:441      'inFM0' (in 2X2 matrix of float)
+0:441      'inFM1' (in 2X2 matrix of float)
 0:?     Sequence
-0:436      move second child to first child (temp float)
-0:436        'r0' (temp float)
-0:436        component-wise multiply (temp float)
-0:436          'inF0' (in float)
-0:436          'inF1' (in float)
-0:436      move second child to first child (temp 2-component vector of float)
-0:436        'r1' (temp 2-component vector of float)
-0:436        vector-scale (temp 2-component vector of float)
-0:436          'inFV0' (in 2-component vector of float)
-0:436          'inF0' (in float)
-0:436      move second child to first child (temp 2-component vector of float)
-0:436        'r2' (temp 2-component vector of float)
-0:436        vector-scale (temp 2-component vector of float)
-0:436          'inF0' (in float)
-0:436          'inFV0' (in 2-component vector of float)
-0:436      move second child to first child (temp float)
-0:436        'r3' (temp float)
-0:436        dot-product (global float)
-0:436          'inFV0' (in 2-component vector of float)
-0:436          'inFV1' (in 2-component vector of float)
-0:436      move second child to first child (temp 2-component vector of float)
-0:436        'r4' (temp 2-component vector of float)
-0:436        matrix-times-vector (temp 2-component vector of float)
-0:436          'inFM0' (in 2X2 matrix of float)
-0:436          'inFV0' (in 2-component vector of float)
-0:436      move second child to first child (temp 2-component vector of float)
-0:436        'r5' (temp 2-component vector of float)
-0:436        vector-times-matrix (temp 2-component vector of float)
-0:436          'inFV0' (in 2-component vector of float)
-0:436          'inFM0' (in 2X2 matrix of float)
-0:436      move second child to first child (temp 2X2 matrix of float)
-0:436        'r6' (temp 2X2 matrix of float)
-0:436        matrix-scale (temp 2X2 matrix of float)
-0:436          'inFM0' (in 2X2 matrix of float)
-0:436          'inF0' (in float)
-0:436      move second child to first child (temp 2X2 matrix of float)
-0:436        'r7' (temp 2X2 matrix of float)
-0:436        matrix-scale (temp 2X2 matrix of float)
-0:436          'inF0' (in float)
-0:436          'inFM0' (in 2X2 matrix of float)
-0:436      move second child to first child (temp 2X2 matrix of float)
-0:436        'r8' (temp 2X2 matrix of float)
-0:436        matrix-multiply (temp 2X2 matrix of float)
-0:436          'inFM0' (in 2X2 matrix of float)
-0:436          'inFM1' (in 2X2 matrix of float)
-0:446  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
-0:442    Function Parameters: 
-0:442      'inF0' (in float)
-0:442      'inF1' (in float)
-0:442      'inFV0' (in 3-component vector of float)
-0:442      'inFV1' (in 3-component vector of float)
-0:442      'inFM0' (in 3X3 matrix of float)
-0:442      'inFM1' (in 3X3 matrix of float)
+0:442      move second child to first child (temp float)
+0:442        'r0' (temp float)
+0:442        component-wise multiply (temp float)
+0:442          'inF0' (in float)
+0:442          'inF1' (in float)
+0:442      move second child to first child (temp 2-component vector of float)
+0:442        'r1' (temp 2-component vector of float)
+0:442        vector-scale (temp 2-component vector of float)
+0:442          'inFV0' (in 2-component vector of float)
+0:442          'inF0' (in float)
+0:442      move second child to first child (temp 2-component vector of float)
+0:442        'r2' (temp 2-component vector of float)
+0:442        vector-scale (temp 2-component vector of float)
+0:442          'inF0' (in float)
+0:442          'inFV0' (in 2-component vector of float)
+0:442      move second child to first child (temp float)
+0:442        'r3' (temp float)
+0:442        dot-product (global float)
+0:442          'inFV0' (in 2-component vector of float)
+0:442          'inFV1' (in 2-component vector of float)
+0:442      move second child to first child (temp 2-component vector of float)
+0:442        'r4' (temp 2-component vector of float)
+0:442        matrix-times-vector (temp 2-component vector of float)
+0:442          'inFM0' (in 2X2 matrix of float)
+0:442          'inFV0' (in 2-component vector of float)
+0:442      move second child to first child (temp 2-component vector of float)
+0:442        'r5' (temp 2-component vector of float)
+0:442        vector-times-matrix (temp 2-component vector of float)
+0:442          'inFV0' (in 2-component vector of float)
+0:442          'inFM0' (in 2X2 matrix of float)
+0:442      move second child to first child (temp 2X2 matrix of float)
+0:442        'r6' (temp 2X2 matrix of float)
+0:442        matrix-scale (temp 2X2 matrix of float)
+0:442          'inFM0' (in 2X2 matrix of float)
+0:442          'inF0' (in float)
+0:442      move second child to first child (temp 2X2 matrix of float)
+0:442        'r7' (temp 2X2 matrix of float)
+0:442        matrix-scale (temp 2X2 matrix of float)
+0:442          'inF0' (in float)
+0:442          'inFM0' (in 2X2 matrix of float)
+0:442      move second child to first child (temp 2X2 matrix of float)
+0:442        'r8' (temp 2X2 matrix of float)
+0:442        matrix-multiply (temp 2X2 matrix of float)
+0:442          'inFM0' (in 2X2 matrix of float)
+0:442          'inFM1' (in 2X2 matrix of float)
+0:452  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
+0:448    Function Parameters: 
+0:448      'inF0' (in float)
+0:448      'inF1' (in float)
+0:448      'inFV0' (in 3-component vector of float)
+0:448      'inFV1' (in 3-component vector of float)
+0:448      'inFM0' (in 3X3 matrix of float)
+0:448      'inFM1' (in 3X3 matrix of float)
 0:?     Sequence
-0:443      move second child to first child (temp float)
-0:443        'r0' (temp float)
-0:443        component-wise multiply (temp float)
-0:443          'inF0' (in float)
-0:443          'inF1' (in float)
-0:443      move second child to first child (temp 3-component vector of float)
-0:443        'r1' (temp 3-component vector of float)
-0:443        vector-scale (temp 3-component vector of float)
-0:443          'inFV0' (in 3-component vector of float)
-0:443          'inF0' (in float)
-0:443      move second child to first child (temp 3-component vector of float)
-0:443        'r2' (temp 3-component vector of float)
-0:443        vector-scale (temp 3-component vector of float)
-0:443          'inF0' (in float)
-0:443          'inFV0' (in 3-component vector of float)
-0:443      move second child to first child (temp float)
-0:443        'r3' (temp float)
-0:443        dot-product (global float)
-0:443          'inFV0' (in 3-component vector of float)
-0:443          'inFV1' (in 3-component vector of float)
-0:443      move second child to first child (temp 3-component vector of float)
-0:443        'r4' (temp 3-component vector of float)
-0:443        matrix-times-vector (temp 3-component vector of float)
-0:443          'inFM0' (in 3X3 matrix of float)
-0:443          'inFV0' (in 3-component vector of float)
-0:443      move second child to first child (temp 3-component vector of float)
-0:443        'r5' (temp 3-component vector of float)
-0:443        vector-times-matrix (temp 3-component vector of float)
-0:443          'inFV0' (in 3-component vector of float)
-0:443          'inFM0' (in 3X3 matrix of float)
-0:443      move second child to first child (temp 3X3 matrix of float)
-0:443        'r6' (temp 3X3 matrix of float)
-0:443        matrix-scale (temp 3X3 matrix of float)
-0:443          'inFM0' (in 3X3 matrix of float)
-0:443          'inF0' (in float)
-0:443      move second child to first child (temp 3X3 matrix of float)
-0:443        'r7' (temp 3X3 matrix of float)
-0:443        matrix-scale (temp 3X3 matrix of float)
-0:443          'inF0' (in float)
-0:443          'inFM0' (in 3X3 matrix of float)
-0:443      move second child to first child (temp 3X3 matrix of float)
-0:443        'r8' (temp 3X3 matrix of float)
-0:443        matrix-multiply (temp 3X3 matrix of float)
-0:443          'inFM0' (in 3X3 matrix of float)
-0:443          'inFM1' (in 3X3 matrix of float)
-0:452  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
-0:449    Function Parameters: 
-0:449      'inF0' (in float)
-0:449      'inF1' (in float)
-0:449      'inFV0' (in 4-component vector of float)
-0:449      'inFV1' (in 4-component vector of float)
-0:449      'inFM0' (in 4X4 matrix of float)
-0:449      'inFM1' (in 4X4 matrix of float)
+0:449      move second child to first child (temp float)
+0:449        'r0' (temp float)
+0:449        component-wise multiply (temp float)
+0:449          'inF0' (in float)
+0:449          'inF1' (in float)
+0:449      move second child to first child (temp 3-component vector of float)
+0:449        'r1' (temp 3-component vector of float)
+0:449        vector-scale (temp 3-component vector of float)
+0:449          'inFV0' (in 3-component vector of float)
+0:449          'inF0' (in float)
+0:449      move second child to first child (temp 3-component vector of float)
+0:449        'r2' (temp 3-component vector of float)
+0:449        vector-scale (temp 3-component vector of float)
+0:449          'inF0' (in float)
+0:449          'inFV0' (in 3-component vector of float)
+0:449      move second child to first child (temp float)
+0:449        'r3' (temp float)
+0:449        dot-product (global float)
+0:449          'inFV0' (in 3-component vector of float)
+0:449          'inFV1' (in 3-component vector of float)
+0:449      move second child to first child (temp 3-component vector of float)
+0:449        'r4' (temp 3-component vector of float)
+0:449        matrix-times-vector (temp 3-component vector of float)
+0:449          'inFM0' (in 3X3 matrix of float)
+0:449          'inFV0' (in 3-component vector of float)
+0:449      move second child to first child (temp 3-component vector of float)
+0:449        'r5' (temp 3-component vector of float)
+0:449        vector-times-matrix (temp 3-component vector of float)
+0:449          'inFV0' (in 3-component vector of float)
+0:449          'inFM0' (in 3X3 matrix of float)
+0:449      move second child to first child (temp 3X3 matrix of float)
+0:449        'r6' (temp 3X3 matrix of float)
+0:449        matrix-scale (temp 3X3 matrix of float)
+0:449          'inFM0' (in 3X3 matrix of float)
+0:449          'inF0' (in float)
+0:449      move second child to first child (temp 3X3 matrix of float)
+0:449        'r7' (temp 3X3 matrix of float)
+0:449        matrix-scale (temp 3X3 matrix of float)
+0:449          'inF0' (in float)
+0:449          'inFM0' (in 3X3 matrix of float)
+0:449      move second child to first child (temp 3X3 matrix of float)
+0:449        'r8' (temp 3X3 matrix of float)
+0:449        matrix-multiply (temp 3X3 matrix of float)
+0:449          'inFM0' (in 3X3 matrix of float)
+0:449          'inFM1' (in 3X3 matrix of float)
+0:460  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
+0:455    Function Parameters: 
+0:455      'inF0' (in float)
+0:455      'inF1' (in float)
+0:455      'inFV0' (in 4-component vector of float)
+0:455      'inFV1' (in 4-component vector of float)
+0:455      'inFM0' (in 4X4 matrix of float)
+0:455      'inFM1' (in 4X4 matrix of float)
 0:?     Sequence
-0:450      move second child to first child (temp float)
-0:450        'r0' (temp float)
-0:450        component-wise multiply (temp float)
-0:450          'inF0' (in float)
-0:450          'inF1' (in float)
-0:450      move second child to first child (temp 4-component vector of float)
-0:450        'r1' (temp 4-component vector of float)
-0:450        vector-scale (temp 4-component vector of float)
-0:450          'inFV0' (in 4-component vector of float)
-0:450          'inF0' (in float)
-0:450      move second child to first child (temp 4-component vector of float)
-0:450        'r2' (temp 4-component vector of float)
-0:450        vector-scale (temp 4-component vector of float)
-0:450          'inF0' (in float)
-0:450          'inFV0' (in 4-component vector of float)
-0:450      move second child to first child (temp float)
-0:450        'r3' (temp float)
-0:450        dot-product (global float)
-0:450          'inFV0' (in 4-component vector of float)
-0:450          'inFV1' (in 4-component vector of float)
-0:450      move second child to first child (temp 4-component vector of float)
-0:450        'r4' (temp 4-component vector of float)
-0:450        matrix-times-vector (temp 4-component vector of float)
-0:450          'inFM0' (in 4X4 matrix of float)
-0:450          'inFV0' (in 4-component vector of float)
-0:450      move second child to first child (temp 4-component vector of float)
-0:450        'r5' (temp 4-component vector of float)
-0:450        vector-times-matrix (temp 4-component vector of float)
-0:450          'inFV0' (in 4-component vector of float)
-0:450          'inFM0' (in 4X4 matrix of float)
-0:450      move second child to first child (temp 4X4 matrix of float)
-0:450        'r6' (temp 4X4 matrix of float)
-0:450        matrix-scale (temp 4X4 matrix of float)
-0:450          'inFM0' (in 4X4 matrix of float)
-0:450          'inF0' (in float)
-0:450      move second child to first child (temp 4X4 matrix of float)
-0:450        'r7' (temp 4X4 matrix of float)
-0:450        matrix-scale (temp 4X4 matrix of float)
-0:450          'inF0' (in float)
-0:450          'inFM0' (in 4X4 matrix of float)
-0:450      move second child to first child (temp 4X4 matrix of float)
-0:450        'r8' (temp 4X4 matrix of float)
-0:450        matrix-multiply (temp 4X4 matrix of float)
-0:450          'inFM0' (in 4X4 matrix of float)
-0:450          'inFM1' (in 4X4 matrix of float)
+0:456      move second child to first child (temp float)
+0:456        'r0' (temp float)
+0:456        component-wise multiply (temp float)
+0:456          'inF0' (in float)
+0:456          'inF1' (in float)
+0:456      move second child to first child (temp 4-component vector of float)
+0:456        'r1' (temp 4-component vector of float)
+0:456        vector-scale (temp 4-component vector of float)
+0:456          'inFV0' (in 4-component vector of float)
+0:456          'inF0' (in float)
+0:456      move second child to first child (temp 4-component vector of float)
+0:456        'r2' (temp 4-component vector of float)
+0:456        vector-scale (temp 4-component vector of float)
+0:456          'inF0' (in float)
+0:456          'inFV0' (in 4-component vector of float)
+0:456      move second child to first child (temp float)
+0:456        'r3' (temp float)
+0:456        dot-product (global float)
+0:456          'inFV0' (in 4-component vector of float)
+0:456          'inFV1' (in 4-component vector of float)
+0:456      move second child to first child (temp 4-component vector of float)
+0:456        'r4' (temp 4-component vector of float)
+0:456        matrix-times-vector (temp 4-component vector of float)
+0:456          'inFM0' (in 4X4 matrix of float)
+0:456          'inFV0' (in 4-component vector of float)
+0:456      move second child to first child (temp 4-component vector of float)
+0:456        'r5' (temp 4-component vector of float)
+0:456        vector-times-matrix (temp 4-component vector of float)
+0:456          'inFV0' (in 4-component vector of float)
+0:456          'inFM0' (in 4X4 matrix of float)
+0:456      move second child to first child (temp 4X4 matrix of float)
+0:456        'r6' (temp 4X4 matrix of float)
+0:456        matrix-scale (temp 4X4 matrix of float)
+0:456          'inFM0' (in 4X4 matrix of float)
+0:456          'inF0' (in float)
+0:456      move second child to first child (temp 4X4 matrix of float)
+0:456        'r7' (temp 4X4 matrix of float)
+0:456        matrix-scale (temp 4X4 matrix of float)
+0:456          'inF0' (in float)
+0:456          'inFM0' (in 4X4 matrix of float)
+0:456      move second child to first child (temp 4X4 matrix of float)
+0:456        'r8' (temp 4X4 matrix of float)
+0:456        matrix-multiply (temp 4X4 matrix of float)
+0:456          'inFM0' (in 4X4 matrix of float)
+0:456          'inFM1' (in 4X4 matrix of float)
+0:484  Function Definition: TestGenMul(f1;f1;vf2;vf3;mf32;mf23;mf33;mf43;mf42; (temp void)
+0:465    Function Parameters: 
+0:465      'inF0' (in float)
+0:465      'inF1' (in float)
+0:465      'inFV2' (in 2-component vector of float)
+0:465      'inFV3' (in 3-component vector of float)
+0:465      'inFM2x3' (in 3X2 matrix of float)
+0:465      'inFM3x2' (in 2X3 matrix of float)
+0:465      'inFM3x3' (in 3X3 matrix of float)
+0:465      'inFM3x4' (in 4X3 matrix of float)
+0:465      'inFM2x4' (in 4X2 matrix of float)
+0:?     Sequence
+0:466      move second child to first child (temp float)
+0:466        'r00' (temp float)
+0:466        component-wise multiply (temp float)
+0:466          'inF0' (in float)
+0:466          'inF1' (in float)
+0:467      move second child to first child (temp 2-component vector of float)
+0:467        'r01' (temp 2-component vector of float)
+0:467        vector-scale (temp 2-component vector of float)
+0:467          'inFV2' (in 2-component vector of float)
+0:467          'inF0' (in float)
+0:468      move second child to first child (temp 3-component vector of float)
+0:468        'r02' (temp 3-component vector of float)
+0:468        vector-scale (temp 3-component vector of float)
+0:468          'inFV3' (in 3-component vector of float)
+0:468          'inF0' (in float)
+0:469      move second child to first child (temp 2-component vector of float)
+0:469        'r03' (temp 2-component vector of float)
+0:469        vector-scale (temp 2-component vector of float)
+0:469          'inF0' (in float)
+0:469          'inFV2' (in 2-component vector of float)
+0:470      move second child to first child (temp 3-component vector of float)
+0:470        'r04' (temp 3-component vector of float)
+0:470        vector-scale (temp 3-component vector of float)
+0:470          'inF0' (in float)
+0:470          'inFV3' (in 3-component vector of float)
+0:471      move second child to first child (temp float)
+0:471        'r05' (temp float)
+0:471        dot-product (global float)
+0:471          'inFV2' (in 2-component vector of float)
+0:471          'inFV2' (in 2-component vector of float)
+0:472      move second child to first child (temp float)
+0:472        'r06' (temp float)
+0:472        dot-product (global float)
+0:472          'inFV3' (in 3-component vector of float)
+0:472          'inFV3' (in 3-component vector of float)
+0:473      move second child to first child (temp 3-component vector of float)
+0:473        'r07' (temp 3-component vector of float)
+0:473        vector-times-matrix (temp 3-component vector of float)
+0:473          'inFV2' (in 2-component vector of float)
+0:473          'inFM2x3' (in 3X2 matrix of float)
+0:474      move second child to first child (temp 2-component vector of float)
+0:474        'r08' (temp 2-component vector of float)
+0:474        vector-times-matrix (temp 2-component vector of float)
+0:474          'inFV3' (in 3-component vector of float)
+0:474          'inFM3x2' (in 2X3 matrix of float)
+0:475      move second child to first child (temp 2-component vector of float)
+0:475        'r09' (temp 2-component vector of float)
+0:475        matrix-times-vector (temp 2-component vector of float)
+0:475          'inFM2x3' (in 3X2 matrix of float)
+0:475          'inFV3' (in 3-component vector of float)
+0:476      move second child to first child (temp 3-component vector of float)
+0:476        'r10' (temp 3-component vector of float)
+0:476        matrix-times-vector (temp 3-component vector of float)
+0:476          'inFM3x2' (in 2X3 matrix of float)
+0:476          'inFV2' (in 2-component vector of float)
+0:477      move second child to first child (temp 3X2 matrix of float)
+0:477        'r11' (temp 3X2 matrix of float)
+0:477        matrix-scale (temp 3X2 matrix of float)
+0:477          'inFM2x3' (in 3X2 matrix of float)
+0:477          'inF0' (in float)
+0:478      move second child to first child (temp 2X3 matrix of float)
+0:478        'r12' (temp 2X3 matrix of float)
+0:478        matrix-scale (temp 2X3 matrix of float)
+0:478          'inFM3x2' (in 2X3 matrix of float)
+0:478          'inF0' (in float)
+0:479      move second child to first child (temp 2X2 matrix of float)
+0:479        'r13' (temp 2X2 matrix of float)
+0:479        matrix-multiply (temp 2X2 matrix of float)
+0:479          'inFM2x3' (in 3X2 matrix of float)
+0:479          'inFM3x2' (in 2X3 matrix of float)
+0:480      move second child to first child (temp 3X2 matrix of float)
+0:480        'r14' (temp 3X2 matrix of float)
+0:480        matrix-multiply (temp 3X2 matrix of float)
+0:480          'inFM2x3' (in 3X2 matrix of float)
+0:480          'inFM3x3' (in 3X3 matrix of float)
+0:481      move second child to first child (temp 4X2 matrix of float)
+0:481        'r15' (temp 4X2 matrix of float)
+0:481        matrix-multiply (temp 4X2 matrix of float)
+0:481          'inFM2x3' (in 3X2 matrix of float)
+0:481          'inFM3x4' (in 4X3 matrix of float)
+0:482      move second child to first child (temp 4X3 matrix of float)
+0:482        'r16' (temp 4X3 matrix of float)
+0:482        matrix-multiply (temp 4X3 matrix of float)
+0:482          'inFM3x2' (in 2X3 matrix of float)
+0:482          'inFM2x4' (in 4X2 matrix of float)
 0:?   Linker Objects
 0:?     'gs_ua' (temp uint)
 0:?     'gs_ub' (temp uint)
@@ -2897,13 +4679,13 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 1265
+// Id's are bound by 1776
 
                               Capability Shader
                               Capability DerivativeControl
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "PixelShaderFunction" 48 67 73 80 195 213 219 226 366 384 390 397 539 557 563 570 719 733 748 857 871 886 998 1012 1027
+                              EntryPoint Fragment 4  "PixelShaderFunction" 71 98 106 115 281 308 316 325 524 551 559 568 770 797 805 814 1023 1042 1059 1209 1228 1245 1398 1417 1434
                               ExecutionMode 4 OriginUpperLeft
                               Source HLSL 450
                               Name 4  "PixelShaderFunction"
@@ -2928,77 +4710,489 @@ gl_FragCoord origin is upper left
                               Name 42  "inFV1"
                               Name 43  "inFM0"
                               Name 44  "inFM1"
-                              Name 48  "inF0"
-                              Name 67  "inU0"
-                              Name 73  "inF1"
-                              Name 80  "inF2"
-                              Name 124  "ResType"
-                              Name 195  "inF0"
-                              Name 213  "inU0"
-                              Name 219  "inF1"
-                              Name 226  "inF2"
-                              Name 282  "ResType"
-                              Name 366  "inF0"
-                              Name 384  "inU0"
-                              Name 390  "inF1"
-                              Name 397  "inF2"
-                              Name 456  "ResType"
-                              Name 539  "inF0"
-                              Name 557  "inU0"
-                              Name 563  "inF1"
-                              Name 570  "inF2"
-                              Name 635  "ResType"
-                              Name 719  "inF0"
-                              Name 733  "inF1"
-                              Name 748  "inF2"
-                              Name 791  "ResType"
-                              Name 857  "inF0"
-                              Name 871  "inF1"
-                              Name 886  "inF2"
-                              Name 932  "ResType"
-                              Name 998  "inF0"
-                              Name 1012  "inF1"
-                              Name 1027  "inF2"
-                              Name 1076  "ResType"
-                              Name 1141  "r0"
-                              Name 1145  "r1"
-                              Name 1149  "r2"
-                              Name 1153  "r3"
-                              Name 1157  "r4"
-                              Name 1161  "r5"
-                              Name 1165  "r6"
-                              Name 1169  "r7"
-                              Name 1173  "r8"
-                              Name 1177  "r0"
-                              Name 1181  "r1"
-                              Name 1185  "r2"
-                              Name 1189  "r3"
-                              Name 1193  "r4"
-                              Name 1197  "r5"
-                              Name 1201  "r6"
-                              Name 1205  "r7"
-                              Name 1209  "r8"
-                              Name 1213  "r0"
-                              Name 1217  "r1"
-                              Name 1221  "r2"
-                              Name 1225  "r3"
-                              Name 1229  "r4"
-                              Name 1233  "r5"
-                              Name 1237  "r6"
-                              Name 1241  "r7"
-                              Name 1245  "r8"
-                              Name 1250  "gs_ua"
-                              Name 1251  "gs_ub"
-                              Name 1252  "gs_uc"
-                              Name 1254  "gs_ua2"
-                              Name 1255  "gs_ub2"
-                              Name 1256  "gs_uc2"
-                              Name 1258  "gs_ua3"
-                              Name 1259  "gs_ub3"
-                              Name 1260  "gs_uc3"
-                              Name 1262  "gs_ua4"
-                              Name 1263  "gs_ub4"
-                              Name 1264  "gs_uc4"
+                              Name 65  "TestGenMul(f1;f1;vf2;vf3;mf32;mf23;mf33;mf43;mf42;"
+                              Name 56  "inF0"
+                              Name 57  "inF1"
+                              Name 58  "inFV2"
+                              Name 59  "inFV3"
+                              Name 60  "inFM2x3"
+                              Name 61  "inFM3x2"
+                              Name 62  "inFM3x3"
+                              Name 63  "inFM3x4"
+                              Name 64  "inFM2x4"
+                              Name 69  "r000"
+                              Name 71  "inF0"
+                              Name 74  "r001"
+                              Name 77  "r002"
+                              Name 80  "r003"
+                              Name 83  "r004"
+                              Name 88  "r005"
+                              Name 93  "r006"
+                              Name 96  "r007"
+                              Name 98  "inU0"
+                              Name 101  "r009"
+                              Name 104  "r010"
+                              Name 106  "inF1"
+                              Name 109  "r011"
+                              Name 112  "r012"
+                              Name 115  "inF2"
+                              Name 124  "r014"
+                              Name 127  "r015"
+                              Name 130  "r016"
+                              Name 133  "r017"
+                              Name 136  "r018"
+                              Name 139  "r019"
+                              Name 142  "r020"
+                              Name 145  "r021"
+                              Name 148  "r022"
+                              Name 151  "r023"
+                              Name 154  "r027"
+                              Name 157  "r028"
+                              Name 160  "r029"
+                              Name 164  "r030"
+                              Name 167  "r031"
+                              Name 170  "r033"
+                              Name 174  "r034"
+                              Name 177  "r035"
+                              Name 179  "ResType"
+                              Name 183  "r036"
+                              Name 186  "r037"
+                              Name 189  "r038"
+                              Name 192  "r039"
+                              Name 196  "r039a"
+                              Name 201  "r040"
+                              Name 204  "r041"
+                              Name 209  "r042"
+                              Name 212  "r043"
+                              Name 216  "r044"
+                              Name 220  "r045"
+                              Name 224  "r046"
+                              Name 227  "r047"
+                              Name 231  "r048"
+                              Name 234  "r049"
+                              Name 237  "r050"
+                              Name 240  "r051"
+                              Name 243  "r052"
+                              Name 246  "r053"
+                              Name 253  "r055"
+                              Name 256  "r056"
+                              Name 261  "r057"
+                              Name 264  "r058"
+                              Name 268  "r059"
+                              Name 271  "r060"
+                              Name 274  "r061"
+                              Name 279  "r000"
+                              Name 281  "inF0"
+                              Name 284  "r001"
+                              Name 287  "r002"
+                              Name 290  "r003"
+                              Name 293  "r004"
+                              Name 298  "r005"
+                              Name 303  "r006"
+                              Name 306  "r007"
+                              Name 308  "inU0"
+                              Name 311  "r009"
+                              Name 314  "r010"
+                              Name 316  "inF1"
+                              Name 319  "r011"
+                              Name 322  "r012"
+                              Name 325  "inF2"
+                              Name 336  "r013"
+                              Name 339  "r015"
+                              Name 342  "r016"
+                              Name 346  "r017"
+                              Name 349  "r018"
+                              Name 352  "r019"
+                              Name 355  "r020"
+                              Name 358  "r021"
+                              Name 361  "r022"
+                              Name 364  "r023"
+                              Name 367  "r026"
+                              Name 371  "r027"
+                              Name 375  "r028"
+                              Name 378  "r029"
+                              Name 381  "r030"
+                              Name 386  "r031"
+                              Name 390  "r032"
+                              Name 392  "r033"
+                              Name 395  "r035"
+                              Name 399  "r036"
+                              Name 402  "r037"
+                              Name 404  "ResType"
+                              Name 408  "r038"
+                              Name 412  "r039"
+                              Name 415  "r040"
+                              Name 418  "r041"
+                              Name 422  "r039a"
+                              Name 427  "r042"
+                              Name 430  "r043"
+                              Name 433  "r044"
+                              Name 437  "r045"
+                              Name 440  "r046"
+                              Name 444  "r047"
+                              Name 448  "r048"
+                              Name 451  "r049"
+                              Name 455  "r050"
+                              Name 458  "r051"
+                              Name 462  "r052"
+                              Name 466  "r053"
+                              Name 471  "r054"
+                              Name 475  "r055"
+                              Name 478  "r056"
+                              Name 481  "r057"
+                              Name 486  "r058"
+                              Name 489  "r059"
+                              Name 496  "r060"
+                              Name 499  "r061"
+                              Name 504  "r062"
+                              Name 507  "r063"
+                              Name 511  "r064"
+                              Name 514  "r065"
+                              Name 517  "r066"
+                              Name 522  "r000"
+                              Name 524  "inF0"
+                              Name 527  "r001"
+                              Name 530  "r002"
+                              Name 533  "r003"
+                              Name 536  "r004"
+                              Name 541  "r005"
+                              Name 546  "r006"
+                              Name 549  "r007"
+                              Name 551  "inU0"
+                              Name 554  "r009"
+                              Name 557  "r010"
+                              Name 559  "inF1"
+                              Name 562  "r011"
+                              Name 565  "r012"
+                              Name 568  "inF2"
+                              Name 579  "r013"
+                              Name 582  "r014"
+                              Name 585  "r015"
+                              Name 589  "r016"
+                              Name 593  "r017"
+                              Name 596  "r018"
+                              Name 599  "r019"
+                              Name 602  "r020"
+                              Name 605  "r021"
+                              Name 608  "r022"
+                              Name 611  "r023"
+                              Name 614  "r024"
+                              Name 618  "r025"
+                              Name 622  "r029"
+                              Name 625  "r030"
+                              Name 628  "r031"
+                              Name 633  "r032"
+                              Name 637  "r033"
+                              Name 639  "r034"
+                              Name 642  "r036"
+                              Name 646  "r037"
+                              Name 649  "r038"
+                              Name 651  "ResType"
+                              Name 655  "r039"
+                              Name 659  "r040"
+                              Name 662  "r041"
+                              Name 665  "r042"
+                              Name 669  "r039a"
+                              Name 674  "r043"
+                              Name 677  "r044"
+                              Name 680  "r045"
+                              Name 684  "r046"
+                              Name 687  "r047"
+                              Name 691  "r048"
+                              Name 695  "r049"
+                              Name 698  "r050"
+                              Name 702  "r051"
+                              Name 705  "r052"
+                              Name 709  "r053"
+                              Name 713  "r054"
+                              Name 717  "r055"
+                              Name 720  "r056"
+                              Name 723  "r057"
+                              Name 726  "r058"
+                              Name 731  "r059"
+                              Name 734  "r060"
+                              Name 741  "r061"
+                              Name 744  "r062"
+                              Name 749  "r063"
+                              Name 752  "r064"
+                              Name 756  "r065"
+                              Name 759  "r066"
+                              Name 762  "r067"
+                              Name 768  "r000"
+                              Name 770  "inF0"
+                              Name 773  "r001"
+                              Name 776  "r002"
+                              Name 779  "r003"
+                              Name 782  "r004"
+                              Name 787  "r005"
+                              Name 792  "r006"
+                              Name 795  "r007"
+                              Name 797  "inU0"
+                              Name 800  "r009"
+                              Name 803  "r010"
+                              Name 805  "inF1"
+                              Name 808  "r011"
+                              Name 811  "r012"
+                              Name 814  "inF2"
+                              Name 825  "r013"
+                              Name 828  "r014"
+                              Name 831  "r015"
+                              Name 834  "r016"
+                              Name 837  "r017"
+                              Name 840  "r018"
+                              Name 843  "r019"
+                              Name 846  "r020"
+                              Name 849  "r021"
+                              Name 852  "r022"
+                              Name 855  "r023"
+                              Name 859  "r024"
+                              Name 863  "r025"
+                              Name 874  "r029"
+                              Name 877  "r030"
+                              Name 880  "r031"
+                              Name 885  "r032"
+                              Name 890  "r033"
+                              Name 892  "r034"
+                              Name 895  "r036"
+                              Name 899  "r037"
+                              Name 902  "r038"
+                              Name 904  "ResType"
+                              Name 908  "r039"
+                              Name 912  "r040"
+                              Name 915  "r041"
+                              Name 918  "r042"
+                              Name 922  "r039a"
+                              Name 927  "r043"
+                              Name 930  "r044"
+                              Name 933  "r045"
+                              Name 937  "r046"
+                              Name 940  "r047"
+                              Name 944  "r048"
+                              Name 948  "r049"
+                              Name 951  "r050"
+                              Name 955  "r051"
+                              Name 958  "r052"
+                              Name 962  "r053"
+                              Name 966  "r054"
+                              Name 970  "r055"
+                              Name 973  "r056"
+                              Name 976  "r057"
+                              Name 979  "r058"
+                              Name 984  "r059"
+                              Name 987  "r060"
+                              Name 994  "r061"
+                              Name 997  "r062"
+                              Name 1002  "r063"
+                              Name 1005  "r064"
+                              Name 1009  "r065"
+                              Name 1012  "r066"
+                              Name 1015  "r067"
+                              Name 1021  "r000"
+                              Name 1023  "inF0"
+                              Name 1026  "r001"
+                              Name 1031  "r003"
+                              Name 1034  "r004"
+                              Name 1037  "r005"
+                              Name 1040  "r006"
+                              Name 1042  "inF1"
+                              Name 1045  "r007"
+                              Name 1056  "r008"
+                              Name 1059  "inF2"
+                              Name 1062  "r009"
+                              Name 1065  "r010"
+                              Name 1068  "r011"
+                              Name 1071  "r012"
+                              Name 1074  "r013"
+                              Name 1077  "r014"
+                              Name 1080  "r015"
+                              Name 1083  "r016"
+                              Name 1086  "r017"
+                              Name 1089  "r018"
+                              Name 1092  "r019"
+                              Name 1095  "R020"
+                              Name 1098  "r021"
+                              Name 1101  "r022"
+                              Name 1111  "r023"
+                              Name 1114  "r024"
+                              Name 1116  "ResType"
+                              Name 1120  "r025"
+                              Name 1123  "r026"
+                              Name 1127  "r026a"
+                              Name 1132  "r027"
+                              Name 1135  "r028"
+                              Name 1139  "r029"
+                              Name 1142  "r030"
+                              Name 1146  "r031"
+                              Name 1150  "r032"
+                              Name 1154  "r033"
+                              Name 1157  "r034"
+                              Name 1160  "r035"
+                              Name 1163  "r036"
+                              Name 1168  "r037"
+                              Name 1171  "r038"
+                              Name 1178  "r039"
+                              Name 1181  "r049"
+                              Name 1186  "r041"
+                              Name 1189  "r042"
+                              Name 1193  "r043"
+                              Name 1196  "r044"
+                              Name 1201  "r046"
+                              Name 1207  "r000"
+                              Name 1209  "inF0"
+                              Name 1212  "r001"
+                              Name 1217  "r003"
+                              Name 1220  "r004"
+                              Name 1223  "r005"
+                              Name 1226  "r006"
+                              Name 1228  "inF1"
+                              Name 1231  "r007"
+                              Name 1242  "r008"
+                              Name 1245  "inF2"
+                              Name 1248  "r009"
+                              Name 1251  "r010"
+                              Name 1254  "r011"
+                              Name 1257  "r012"
+                              Name 1260  "r013"
+                              Name 1263  "r014"
+                              Name 1266  "r015"
+                              Name 1269  "r016"
+                              Name 1272  "r017"
+                              Name 1275  "r018"
+                              Name 1278  "r019"
+                              Name 1281  "R020"
+                              Name 1284  "r021"
+                              Name 1287  "r022"
+                              Name 1300  "r023"
+                              Name 1303  "r024"
+                              Name 1305  "ResType"
+                              Name 1309  "r025"
+                              Name 1312  "r026"
+                              Name 1316  "r026a"
+                              Name 1321  "r027"
+                              Name 1324  "r028"
+                              Name 1328  "r029"
+                              Name 1331  "r030"
+                              Name 1335  "r031"
+                              Name 1339  "r032"
+                              Name 1343  "r033"
+                              Name 1346  "r034"
+                              Name 1349  "r035"
+                              Name 1352  "r036"
+                              Name 1357  "r037"
+                              Name 1360  "r038"
+                              Name 1367  "r039"
+                              Name 1370  "r049"
+                              Name 1375  "r041"
+                              Name 1378  "r042"
+                              Name 1382  "r043"
+                              Name 1385  "r044"
+                              Name 1390  "r046"
+                              Name 1396  "r000"
+                              Name 1398  "inF0"
+                              Name 1401  "r001"
+                              Name 1406  "r003"
+                              Name 1409  "r004"
+                              Name 1412  "r005"
+                              Name 1415  "r006"
+                              Name 1417  "inF1"
+                              Name 1420  "r007"
+                              Name 1431  "r008"
+                              Name 1434  "inF2"
+                              Name 1437  "r009"
+                              Name 1440  "r010"
+                              Name 1443  "r011"
+                              Name 1446  "r012"
+                              Name 1449  "r013"
+                              Name 1452  "r014"
+                              Name 1455  "r015"
+                              Name 1458  "r016"
+                              Name 1461  "r017"
+                              Name 1464  "r018"
+                              Name 1467  "r019"
+                              Name 1470  "R020"
+                              Name 1473  "r021"
+                              Name 1476  "r022"
+                              Name 1492  "r023"
+                              Name 1495  "r024"
+                              Name 1497  "ResType"
+                              Name 1501  "r025"
+                              Name 1504  "r026"
+                              Name 1508  "r026a"
+                              Name 1513  "r027"
+                              Name 1516  "r028"
+                              Name 1520  "r029"
+                              Name 1523  "r030"
+                              Name 1527  "r031"
+                              Name 1531  "r032"
+                              Name 1535  "r033"
+                              Name 1538  "r034"
+                              Name 1541  "r035"
+                              Name 1544  "r036"
+                              Name 1549  "r037"
+                              Name 1552  "r038"
+                              Name 1559  "r039"
+                              Name 1562  "r049"
+                              Name 1567  "r041"
+                              Name 1570  "r042"
+                              Name 1574  "r043"
+                              Name 1577  "r044"
+                              Name 1582  "r046"
+                              Name 1588  "r0"
+                              Name 1592  "r1"
+                              Name 1596  "r2"
+                              Name 1600  "r3"
+                              Name 1604  "r4"
+                              Name 1608  "r5"
+                              Name 1612  "r6"
+                              Name 1616  "r7"
+                              Name 1620  "r8"
+                              Name 1624  "r0"
+                              Name 1628  "r1"
+                              Name 1632  "r2"
+                              Name 1636  "r3"
+                              Name 1640  "r4"
+                              Name 1644  "r5"
+                              Name 1648  "r6"
+                              Name 1652  "r7"
+                              Name 1656  "r8"
+                              Name 1660  "r0"
+                              Name 1664  "r1"
+                              Name 1668  "r2"
+                              Name 1672  "r3"
+                              Name 1676  "r4"
+                              Name 1680  "r5"
+                              Name 1684  "r6"
+                              Name 1688  "r7"
+                              Name 1692  "r8"
+                              Name 1696  "r00"
+                              Name 1700  "r01"
+                              Name 1704  "r02"
+                              Name 1708  "r03"
+                              Name 1712  "r04"
+                              Name 1716  "r05"
+                              Name 1720  "r06"
+                              Name 1724  "r07"
+                              Name 1728  "r08"
+                              Name 1732  "r09"
+                              Name 1736  "r10"
+                              Name 1740  "r11"
+                              Name 1744  "r12"
+                              Name 1748  "r13"
+                              Name 1752  "r14"
+                              Name 1756  "r15"
+                              Name 1760  "r16"
+                              Name 1764  "gs_ua"
+                              Name 1765  "gs_ub"
+                              Name 1766  "gs_uc"
+                              Name 1767  "gs_ua2"
+                              Name 1768  "gs_ub2"
+                              Name 1769  "gs_uc2"
+                              Name 1770  "gs_ua3"
+                              Name 1771  "gs_ub3"
+                              Name 1772  "gs_uc3"
+                              Name 1773  "gs_ua4"
+                              Name 1774  "gs_ub4"
+                              Name 1775  "gs_uc4"
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -3018,239 +5212,709 @@ gl_FragCoord origin is upper left
               36:             TypeMatrix 34(fvec4) 4
               37:             TypePointer Function 36
               38:             TypeFunction 2 7(ptr) 7(ptr) 35(ptr) 35(ptr) 37(ptr) 37(ptr)
-              47:             TypePointer Input 6(float)
-        48(inF0):     47(ptr) Variable Input
-              50:             TypeBool
-              61:             TypeInt 32 1
-              64:             TypeInt 32 0
-              66:             TypePointer Input 64(int)
-        67(inU0):     66(ptr) Variable Input
-        73(inF1):     47(ptr) Variable Input
-        80(inF2):     47(ptr) Variable Input
-              84:    6(float) Constant 0
-              93:     64(int) Constant 7
-             113:     61(int) Constant 7
-    124(ResType):             TypeStruct 6(float) 61(int)
-             141:    6(float) Constant 1050288283
-             156:    6(float) Constant 1065353216
-             159:     64(int) Constant 2
-             194:             TypePointer Input 8(fvec2)
-       195(inF0):    194(ptr) Variable Input
-             207:             TypeVector 61(int) 2
-             210:             TypeVector 64(int) 2
-             212:             TypePointer Input 210(ivec2)
-       213(inU0):    212(ptr) Variable Input
-       219(inF1):    194(ptr) Variable Input
-       226(inF2):    194(ptr) Variable Input
-             230:    8(fvec2) ConstantComposite 84 84
-             231:             TypeVector 50(bool) 2
-             241:     64(int) Constant 3
-             242:  210(ivec2) ConstantComposite 93 241
-    282(ResType):             TypeStruct 8(fvec2) 207(ivec2)
-             325:    6(float) Constant 1073741824
-             327:     64(int) Constant 1
-             328:  210(ivec2) ConstantComposite 327 159
-             363:    8(fvec2) ConstantComposite 156 325
-             365:             TypePointer Input 21(fvec3)
-       366(inF0):    365(ptr) Variable Input
-             378:             TypeVector 61(int) 3
-             381:             TypeVector 64(int) 3
-             383:             TypePointer Input 381(ivec3)
-       384(inU0):    383(ptr) Variable Input
-       390(inF1):    365(ptr) Variable Input
-       397(inF2):    365(ptr) Variable Input
-             401:   21(fvec3) ConstantComposite 84 84 84
-             402:             TypeVector 50(bool) 3
-             412:     64(int) Constant 5
-             413:  381(ivec3) ConstantComposite 93 241 412
-    456(ResType):             TypeStruct 21(fvec3) 378(ivec3)
-             500:  381(ivec3) ConstantComposite 327 159 241
-             535:    6(float) Constant 1077936128
-             536:   21(fvec3) ConstantComposite 156 325 535
-             538:             TypePointer Input 34(fvec4)
-       539(inF0):    538(ptr) Variable Input
-             551:             TypeVector 61(int) 4
-             554:             TypeVector 64(int) 4
-             556:             TypePointer Input 554(ivec4)
-       557(inU0):    556(ptr) Variable Input
-       563(inF1):    538(ptr) Variable Input
-       570(inF2):    538(ptr) Variable Input
-             574:   34(fvec4) ConstantComposite 84 84 84 84
-             575:             TypeVector 50(bool) 4
-             585:  554(ivec4) ConstantComposite 93 241 412 159
-    635(ResType):             TypeStruct 34(fvec4) 551(ivec4)
-             679:     64(int) Constant 4
-             680:  554(ivec4) ConstantComposite 327 159 241 679
-             715:    6(float) Constant 1082130432
-             716:   34(fvec4) ConstantComposite 156 325 535 715
-             718:             TypePointer Input 10
-       719(inF0):    718(ptr) Variable Input
-       733(inF1):    718(ptr) Variable Input
-             739:          10 ConstantComposite 230 230
-             740:             TypeMatrix 231(bvec2) 2
-       748(inF2):    718(ptr) Variable Input
-    791(ResType):             TypeStruct 10 207(ivec2)
-             853:    8(fvec2) ConstantComposite 325 325
-             854:          10 ConstantComposite 853 853
-             856:             TypePointer Input 23
-       857(inF0):    856(ptr) Variable Input
-       871(inF1):    856(ptr) Variable Input
-             877:          23 ConstantComposite 401 401 401
-             878:             TypeMatrix 402(bvec3) 3
-       886(inF2):    856(ptr) Variable Input
-    932(ResType):             TypeStruct 23 378(ivec3)
-             994:   21(fvec3) ConstantComposite 535 535 535
-             995:          23 ConstantComposite 994 994 994
-             997:             TypePointer Input 36
-       998(inF0):    997(ptr) Variable Input
-      1012(inF1):    997(ptr) Variable Input
-            1018:          36 ConstantComposite 574 574 574 574
-            1019:             TypeMatrix 575(bvec4) 4
-      1027(inF2):    997(ptr) Variable Input
-   1076(ResType):             TypeStruct 36 551(ivec4)
-            1138:   34(fvec4) ConstantComposite 715 715 715 715
-            1139:          36 ConstantComposite 1138 1138 1138 1138
-            1249:             TypePointer Function 64(int)
-            1253:             TypePointer Function 210(ivec2)
-            1257:             TypePointer Function 381(ivec3)
-            1261:             TypePointer Function 554(ivec4)
+              47:             TypeMatrix 8(fvec2) 3
+              48:             TypePointer Function 47
+              49:             TypeMatrix 21(fvec3) 2
+              50:             TypePointer Function 49
+              51:             TypeMatrix 21(fvec3) 4
+              52:             TypePointer Function 51
+              53:             TypeMatrix 8(fvec2) 4
+              54:             TypePointer Function 53
+              55:             TypeFunction 2 7(ptr) 7(ptr) 9(ptr) 22(ptr) 48(ptr) 50(ptr) 24(ptr) 52(ptr) 54(ptr)
+              67:             TypeBool
+              68:             TypePointer Function 67(bool)
+              70:             TypePointer Input 6(float)
+        71(inF0):     70(ptr) Variable Input
+              86:             TypeInt 32 1
+              87:             TypePointer Function 86(int)
+              91:             TypeInt 32 0
+              92:             TypePointer Function 91(int)
+              97:             TypePointer Input 91(int)
+        98(inU0):     97(ptr) Variable Input
+       106(inF1):     70(ptr) Variable Input
+       115(inF2):     70(ptr) Variable Input
+             119:    6(float) Constant 0
+             131:     91(int) Constant 7
+             161:     86(int) Constant 7
+    179(ResType):             TypeStruct 6(float) 86(int)
+             207:    6(float) Constant 1050288283
+             228:    6(float) Constant 1065353216
+             232:     91(int) Constant 2
+             280:             TypePointer Input 8(fvec2)
+       281(inF0):    280(ptr) Variable Input
+             296:             TypeVector 86(int) 2
+             297:             TypePointer Function 296(ivec2)
+             301:             TypeVector 91(int) 2
+             302:             TypePointer Function 301(ivec2)
+             307:             TypePointer Input 301(ivec2)
+       308(inU0):    307(ptr) Variable Input
+       316(inF1):    280(ptr) Variable Input
+       325(inF2):    280(ptr) Variable Input
+             329:    8(fvec2) ConstantComposite 119 119
+             330:             TypeVector 67(bool) 2
+             343:     91(int) Constant 3
+             344:  301(ivec2) ConstantComposite 131 343
+             387:     91(int) Constant 8
+             388:  301(ivec2) ConstantComposite 131 387
+    404(ResType):             TypeStruct 8(fvec2) 296(ivec2)
+             411:             TypePointer Function 330(bvec2)
+             469:    6(float) Constant 1073741824
+             472:     91(int) Constant 1
+             473:  301(ivec2) ConstantComposite 472 232
+             520:    8(fvec2) ConstantComposite 228 469
+             523:             TypePointer Input 21(fvec3)
+       524(inF0):    523(ptr) Variable Input
+             539:             TypeVector 86(int) 3
+             540:             TypePointer Function 539(ivec3)
+             544:             TypeVector 91(int) 3
+             545:             TypePointer Function 544(ivec3)
+             550:             TypePointer Input 544(ivec3)
+       551(inU0):    550(ptr) Variable Input
+       559(inF1):    523(ptr) Variable Input
+       568(inF2):    523(ptr) Variable Input
+             572:   21(fvec3) ConstantComposite 119 119 119
+             573:             TypeVector 67(bool) 3
+             586:     91(int) Constant 5
+             587:  544(ivec3) ConstantComposite 131 343 586
+             634:     91(int) Constant 4
+             635:  544(ivec3) ConstantComposite 232 343 634
+    651(ResType):             TypeStruct 21(fvec3) 539(ivec3)
+             658:             TypePointer Function 573(bvec3)
+             718:  544(ivec3) ConstantComposite 472 232 343
+             765:    6(float) Constant 1077936128
+             766:   21(fvec3) ConstantComposite 228 469 765
+             769:             TypePointer Input 34(fvec4)
+       770(inF0):    769(ptr) Variable Input
+             785:             TypeVector 86(int) 4
+             786:             TypePointer Function 785(ivec4)
+             790:             TypeVector 91(int) 4
+             791:             TypePointer Function 790(ivec4)
+             796:             TypePointer Input 790(ivec4)
+       797(inU0):    796(ptr) Variable Input
+       805(inF1):    769(ptr) Variable Input
+       814(inF2):    769(ptr) Variable Input
+             818:   34(fvec4) ConstantComposite 119 119 119 119
+             819:             TypeVector 67(bool) 4
+             832:  790(ivec4) ConstantComposite 131 343 586 232
+             886:     91(int) Constant 9
+             887:     91(int) Constant 10
+             888:  790(ivec4) ConstantComposite 131 387 886 887
+    904(ResType):             TypeStruct 34(fvec4) 785(ivec4)
+             911:             TypePointer Function 819(bvec4)
+             971:  790(ivec4) ConstantComposite 472 232 343 634
+            1018:    6(float) Constant 1082130432
+            1019:   34(fvec4) ConstantComposite 228 469 765 1018
+            1022:             TypePointer Input 10
+      1023(inF0):   1022(ptr) Variable Input
+      1042(inF1):   1022(ptr) Variable Input
+            1049:          10 ConstantComposite 329 329
+            1050:             TypeMatrix 330(bvec2) 2
+      1059(inF2):   1022(ptr) Variable Input
+   1116(ResType):             TypeStruct 10 296(ivec2)
+            1204:    8(fvec2) ConstantComposite 469 469
+            1205:          10 ConstantComposite 1204 1204
+            1208:             TypePointer Input 23
+      1209(inF0):   1208(ptr) Variable Input
+      1228(inF1):   1208(ptr) Variable Input
+            1235:          23 ConstantComposite 572 572 572
+            1236:             TypeMatrix 573(bvec3) 3
+      1245(inF2):   1208(ptr) Variable Input
+   1305(ResType):             TypeStruct 23 539(ivec3)
+            1393:   21(fvec3) ConstantComposite 765 765 765
+            1394:          23 ConstantComposite 1393 1393 1393
+            1397:             TypePointer Input 36
+      1398(inF0):   1397(ptr) Variable Input
+      1417(inF1):   1397(ptr) Variable Input
+            1424:          36 ConstantComposite 818 818 818 818
+            1425:             TypeMatrix 819(bvec4) 4
+      1434(inF2):   1397(ptr) Variable Input
+   1497(ResType):             TypeStruct 36 785(ivec4)
+            1585:   34(fvec4) ConstantComposite 1018 1018 1018 1018
+            1586:          36 ConstantComposite 1585 1585 1585 1585
 4(PixelShaderFunction):           2 Function None 3
                5:             Label
-              49:    6(float) Load 48(inF0)
-              51:    50(bool) All 49
-              52:    6(float) Load 48(inF0)
-              53:    6(float) ExtInst 1(GLSL.std.450) 4(FAbs) 52
-              54:    6(float) Load 48(inF0)
-              55:    6(float) ExtInst 1(GLSL.std.450) 17(Acos) 54
-              56:    6(float) Load 48(inF0)
-              57:    50(bool) Any 56
-              58:    6(float) Load 48(inF0)
-              59:    6(float) ExtInst 1(GLSL.std.450) 16(Asin) 58
-              60:    6(float) Load 48(inF0)
-              62:     61(int) Bitcast 60
-              63:    6(float) Load 48(inF0)
-              65:     64(int) Bitcast 63
-              68:     64(int) Load 67(inU0)
-              69:    6(float) Bitcast 68
-              70:    6(float) Load 48(inF0)
-              71:    6(float) ExtInst 1(GLSL.std.450) 18(Atan) 70
-              72:    6(float) Load 48(inF0)
-              74:    6(float) Load 73(inF1)
-              75:    6(float) ExtInst 1(GLSL.std.450) 25(Atan2) 72 74
-              76:    6(float) Load 48(inF0)
-              77:    6(float) ExtInst 1(GLSL.std.450) 9(Ceil) 76
-              78:    6(float) Load 48(inF0)
-              79:    6(float) Load 73(inF1)
-              81:    6(float) Load 80(inF2)
-              82:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 78 79 81
-              83:    6(float) Load 48(inF0)
-              85:    50(bool) FOrdLessThan 83 84
-                              SelectionMerge 87 None
-                              BranchConditional 85 86 87
-              86:               Label
+        69(r000):     68(ptr) Variable Function
+        74(r001):      7(ptr) Variable Function
+        77(r002):      7(ptr) Variable Function
+        80(r003):     68(ptr) Variable Function
+        83(r004):      7(ptr) Variable Function
+        88(r005):     87(ptr) Variable Function
+        93(r006):     92(ptr) Variable Function
+        96(r007):      7(ptr) Variable Function
+       101(r009):      7(ptr) Variable Function
+       104(r010):      7(ptr) Variable Function
+       109(r011):      7(ptr) Variable Function
+       112(r012):      7(ptr) Variable Function
+       124(r014):      7(ptr) Variable Function
+       127(r015):      7(ptr) Variable Function
+       130(r016):     92(ptr) Variable Function
+       133(r017):      7(ptr) Variable Function
+       136(r018):      7(ptr) Variable Function
+       139(r019):      7(ptr) Variable Function
+       142(r020):      7(ptr) Variable Function
+       145(r021):      7(ptr) Variable Function
+       148(r022):      7(ptr) Variable Function
+       151(r023):      7(ptr) Variable Function
+       154(r027):      7(ptr) Variable Function
+       157(r028):      7(ptr) Variable Function
+       160(r029):     92(ptr) Variable Function
+       164(r030):     92(ptr) Variable Function
+       167(r031):      7(ptr) Variable Function
+       170(r033):      7(ptr) Variable Function
+       174(r034):      7(ptr) Variable Function
+       177(r035):      7(ptr) Variable Function
+       183(r036):      7(ptr) Variable Function
+       186(r037):     68(ptr) Variable Function
+       189(r038):     68(ptr) Variable Function
+       192(r039):      7(ptr) Variable Function
+      196(r039a):      7(ptr) Variable Function
+       201(r040):      7(ptr) Variable Function
+       204(r041):      7(ptr) Variable Function
+       209(r042):      7(ptr) Variable Function
+       212(r043):      7(ptr) Variable Function
+       216(r044):      7(ptr) Variable Function
+       220(r045):      7(ptr) Variable Function
+       224(r046):      7(ptr) Variable Function
+       227(r047):      7(ptr) Variable Function
+       231(r048):     92(ptr) Variable Function
+       234(r049):      7(ptr) Variable Function
+       237(r050):      7(ptr) Variable Function
+       240(r051):      7(ptr) Variable Function
+       243(r052):      7(ptr) Variable Function
+       246(r053):      7(ptr) Variable Function
+       253(r055):      7(ptr) Variable Function
+       256(r056):      7(ptr) Variable Function
+       261(r057):      7(ptr) Variable Function
+       264(r058):      7(ptr) Variable Function
+       268(r059):      7(ptr) Variable Function
+       271(r060):      7(ptr) Variable Function
+       274(r061):      7(ptr) Variable Function
+       279(r000):     68(ptr) Variable Function
+       284(r001):      9(ptr) Variable Function
+       287(r002):      9(ptr) Variable Function
+       290(r003):     68(ptr) Variable Function
+       293(r004):      9(ptr) Variable Function
+       298(r005):    297(ptr) Variable Function
+       303(r006):    302(ptr) Variable Function
+       306(r007):      9(ptr) Variable Function
+       311(r009):      9(ptr) Variable Function
+       314(r010):      9(ptr) Variable Function
+       319(r011):      9(ptr) Variable Function
+       322(r012):      9(ptr) Variable Function
+       336(r013):      9(ptr) Variable Function
+       339(r015):      9(ptr) Variable Function
+       342(r016):    302(ptr) Variable Function
+       346(r017):      9(ptr) Variable Function
+       349(r018):      9(ptr) Variable Function
+       352(r019):      9(ptr) Variable Function
+       355(r020):      9(ptr) Variable Function
+       358(r021):      9(ptr) Variable Function
+       361(r022):      9(ptr) Variable Function
+       364(r023):      9(ptr) Variable Function
+       367(r026):      7(ptr) Variable Function
+       371(r027):      7(ptr) Variable Function
+       375(r028):      9(ptr) Variable Function
+       378(r029):      9(ptr) Variable Function
+       381(r030):      9(ptr) Variable Function
+       386(r031):    302(ptr) Variable Function
+       390(r032):    302(ptr) Variable Function
+       392(r033):      9(ptr) Variable Function
+       395(r035):      9(ptr) Variable Function
+       399(r036):      9(ptr) Variable Function
+       402(r037):      9(ptr) Variable Function
+       408(r038):      9(ptr) Variable Function
+       412(r039):    411(ptr) Variable Function
+       415(r040):    411(ptr) Variable Function
+       418(r041):      9(ptr) Variable Function
+      422(r039a):      9(ptr) Variable Function
+       427(r042):      7(ptr) Variable Function
+       430(r043):      9(ptr) Variable Function
+       433(r044):      9(ptr) Variable Function
+       437(r045):      9(ptr) Variable Function
+       440(r046):      9(ptr) Variable Function
+       444(r047):      9(ptr) Variable Function
+       448(r048):      9(ptr) Variable Function
+       451(r049):      9(ptr) Variable Function
+       455(r050):      9(ptr) Variable Function
+       458(r051):      9(ptr) Variable Function
+       462(r052):      9(ptr) Variable Function
+       466(r053):      9(ptr) Variable Function
+       471(r054):    302(ptr) Variable Function
+       475(r055):      9(ptr) Variable Function
+       478(r056):      9(ptr) Variable Function
+       481(r057):      9(ptr) Variable Function
+       486(r058):      9(ptr) Variable Function
+       489(r059):      9(ptr) Variable Function
+       496(r060):      9(ptr) Variable Function
+       499(r061):      9(ptr) Variable Function
+       504(r062):      9(ptr) Variable Function
+       507(r063):      9(ptr) Variable Function
+       511(r064):      9(ptr) Variable Function
+       514(r065):      9(ptr) Variable Function
+       517(r066):      9(ptr) Variable Function
+       522(r000):     68(ptr) Variable Function
+       527(r001):     22(ptr) Variable Function
+       530(r002):     22(ptr) Variable Function
+       533(r003):     68(ptr) Variable Function
+       536(r004):     22(ptr) Variable Function
+       541(r005):    540(ptr) Variable Function
+       546(r006):    545(ptr) Variable Function
+       549(r007):     22(ptr) Variable Function
+       554(r009):     22(ptr) Variable Function
+       557(r010):     22(ptr) Variable Function
+       562(r011):     22(ptr) Variable Function
+       565(r012):     22(ptr) Variable Function
+       579(r013):     22(ptr) Variable Function
+       582(r014):     22(ptr) Variable Function
+       585(r015):    545(ptr) Variable Function
+       589(r016):     22(ptr) Variable Function
+       593(r017):     22(ptr) Variable Function
+       596(r018):     22(ptr) Variable Function
+       599(r019):     22(ptr) Variable Function
+       602(r020):     22(ptr) Variable Function
+       605(r021):     22(ptr) Variable Function
+       608(r022):     22(ptr) Variable Function
+       611(r023):     22(ptr) Variable Function
+       614(r024):      7(ptr) Variable Function
+       618(r025):      7(ptr) Variable Function
+       622(r029):     22(ptr) Variable Function
+       625(r030):     22(ptr) Variable Function
+       628(r031):     22(ptr) Variable Function
+       633(r032):    545(ptr) Variable Function
+       637(r033):    545(ptr) Variable Function
+       639(r034):     22(ptr) Variable Function
+       642(r036):     22(ptr) Variable Function
+       646(r037):     22(ptr) Variable Function
+       649(r038):     22(ptr) Variable Function
+       655(r039):     22(ptr) Variable Function
+       659(r040):    658(ptr) Variable Function
+       662(r041):    658(ptr) Variable Function
+       665(r042):     22(ptr) Variable Function
+      669(r039a):     22(ptr) Variable Function
+       674(r043):      7(ptr) Variable Function
+       677(r044):     22(ptr) Variable Function
+       680(r045):     22(ptr) Variable Function
+       684(r046):     22(ptr) Variable Function
+       687(r047):     22(ptr) Variable Function
+       691(r048):     22(ptr) Variable Function
+       695(r049):     22(ptr) Variable Function
+       698(r050):     22(ptr) Variable Function
+       702(r051):     22(ptr) Variable Function
+       705(r052):     22(ptr) Variable Function
+       709(r053):     22(ptr) Variable Function
+       713(r054):     22(ptr) Variable Function
+       717(r055):    545(ptr) Variable Function
+       720(r056):     22(ptr) Variable Function
+       723(r057):     22(ptr) Variable Function
+       726(r058):     22(ptr) Variable Function
+       731(r059):     22(ptr) Variable Function
+       734(r060):     22(ptr) Variable Function
+       741(r061):     22(ptr) Variable Function
+       744(r062):     22(ptr) Variable Function
+       749(r063):     22(ptr) Variable Function
+       752(r064):     22(ptr) Variable Function
+       756(r065):     22(ptr) Variable Function
+       759(r066):     22(ptr) Variable Function
+       762(r067):     22(ptr) Variable Function
+       768(r000):     68(ptr) Variable Function
+       773(r001):     35(ptr) Variable Function
+       776(r002):     35(ptr) Variable Function
+       779(r003):     68(ptr) Variable Function
+       782(r004):     35(ptr) Variable Function
+       787(r005):    786(ptr) Variable Function
+       792(r006):    791(ptr) Variable Function
+       795(r007):     35(ptr) Variable Function
+       800(r009):     35(ptr) Variable Function
+       803(r010):     35(ptr) Variable Function
+       808(r011):     35(ptr) Variable Function
+       811(r012):     35(ptr) Variable Function
+       825(r013):     35(ptr) Variable Function
+       828(r014):     35(ptr) Variable Function
+       831(r015):    791(ptr) Variable Function
+       834(r016):     35(ptr) Variable Function
+       837(r017):     35(ptr) Variable Function
+       840(r018):     35(ptr) Variable Function
+       843(r019):     35(ptr) Variable Function
+       846(r020):     35(ptr) Variable Function
+       849(r021):     35(ptr) Variable Function
+       852(r022):     35(ptr) Variable Function
+       855(r023):      7(ptr) Variable Function
+       859(r024):      7(ptr) Variable Function
+       863(r025):     35(ptr) Variable Function
+       874(r029):     35(ptr) Variable Function
+       877(r030):     35(ptr) Variable Function
+       880(r031):     35(ptr) Variable Function
+       885(r032):    791(ptr) Variable Function
+       890(r033):    791(ptr) Variable Function
+       892(r034):     35(ptr) Variable Function
+       895(r036):     35(ptr) Variable Function
+       899(r037):     35(ptr) Variable Function
+       902(r038):     35(ptr) Variable Function
+       908(r039):     35(ptr) Variable Function
+       912(r040):    911(ptr) Variable Function
+       915(r041):    911(ptr) Variable Function
+       918(r042):     35(ptr) Variable Function
+      922(r039a):     35(ptr) Variable Function
+       927(r043):      7(ptr) Variable Function
+       930(r044):     35(ptr) Variable Function
+       933(r045):     35(ptr) Variable Function
+       937(r046):     35(ptr) Variable Function
+       940(r047):     35(ptr) Variable Function
+       944(r048):     35(ptr) Variable Function
+       948(r049):     35(ptr) Variable Function
+       951(r050):     35(ptr) Variable Function
+       955(r051):     35(ptr) Variable Function
+       958(r052):     35(ptr) Variable Function
+       962(r053):     35(ptr) Variable Function
+       966(r054):     35(ptr) Variable Function
+       970(r055):    791(ptr) Variable Function
+       973(r056):     35(ptr) Variable Function
+       976(r057):     35(ptr) Variable Function
+       979(r058):     35(ptr) Variable Function
+       984(r059):     35(ptr) Variable Function
+       987(r060):     35(ptr) Variable Function
+       994(r061):     35(ptr) Variable Function
+       997(r062):     35(ptr) Variable Function
+      1002(r063):     35(ptr) Variable Function
+      1005(r064):     35(ptr) Variable Function
+      1009(r065):     35(ptr) Variable Function
+      1012(r066):     35(ptr) Variable Function
+      1015(r067):     35(ptr) Variable Function
+      1021(r000):     68(ptr) Variable Function
+      1026(r001):     11(ptr) Variable Function
+      1031(r003):     68(ptr) Variable Function
+      1034(r004):     11(ptr) Variable Function
+      1037(r005):     11(ptr) Variable Function
+      1040(r006):     11(ptr) Variable Function
+      1045(r007):     11(ptr) Variable Function
+      1056(r008):     11(ptr) Variable Function
+      1062(r009):     11(ptr) Variable Function
+      1065(r010):     11(ptr) Variable Function
+      1068(r011):     11(ptr) Variable Function
+      1071(r012):     11(ptr) Variable Function
+      1074(r013):     11(ptr) Variable Function
+      1077(r014):     11(ptr) Variable Function
+      1080(r015):     11(ptr) Variable Function
+      1083(r016):     11(ptr) Variable Function
+      1086(r017):     11(ptr) Variable Function
+      1089(r018):      7(ptr) Variable Function
+      1092(r019):     11(ptr) Variable Function
+      1095(R020):     11(ptr) Variable Function
+      1098(r021):     11(ptr) Variable Function
+      1101(r022):     11(ptr) Variable Function
+      1111(r023):     11(ptr) Variable Function
+      1114(r024):     11(ptr) Variable Function
+      1120(r025):     11(ptr) Variable Function
+      1123(r026):     11(ptr) Variable Function
+     1127(r026a):     11(ptr) Variable Function
+      1132(r027):     11(ptr) Variable Function
+      1135(r028):     11(ptr) Variable Function
+      1139(r029):     11(ptr) Variable Function
+      1142(r030):     11(ptr) Variable Function
+      1146(r031):     11(ptr) Variable Function
+      1150(r032):     11(ptr) Variable Function
+      1154(r033):     11(ptr) Variable Function
+      1157(r034):     11(ptr) Variable Function
+      1160(r035):     11(ptr) Variable Function
+      1163(r036):     11(ptr) Variable Function
+      1168(r037):     11(ptr) Variable Function
+      1171(r038):     11(ptr) Variable Function
+      1178(r039):     11(ptr) Variable Function
+      1181(r049):     11(ptr) Variable Function
+      1186(r041):     11(ptr) Variable Function
+      1189(r042):     11(ptr) Variable Function
+      1193(r043):     11(ptr) Variable Function
+      1196(r044):     11(ptr) Variable Function
+      1201(r046):     11(ptr) Variable Function
+      1207(r000):     68(ptr) Variable Function
+      1212(r001):     24(ptr) Variable Function
+      1217(r003):     68(ptr) Variable Function
+      1220(r004):     24(ptr) Variable Function
+      1223(r005):     24(ptr) Variable Function
+      1226(r006):     24(ptr) Variable Function
+      1231(r007):     24(ptr) Variable Function
+      1242(r008):     24(ptr) Variable Function
+      1248(r009):     24(ptr) Variable Function
+      1251(r010):     24(ptr) Variable Function
+      1254(r011):     24(ptr) Variable Function
+      1257(r012):     24(ptr) Variable Function
+      1260(r013):     24(ptr) Variable Function
+      1263(r014):     24(ptr) Variable Function
+      1266(r015):     24(ptr) Variable Function
+      1269(r016):     24(ptr) Variable Function
+      1272(r017):     24(ptr) Variable Function
+      1275(r018):      7(ptr) Variable Function
+      1278(r019):     24(ptr) Variable Function
+      1281(R020):     24(ptr) Variable Function
+      1284(r021):     24(ptr) Variable Function
+      1287(r022):     24(ptr) Variable Function
+      1300(r023):     24(ptr) Variable Function
+      1303(r024):     24(ptr) Variable Function
+      1309(r025):     24(ptr) Variable Function
+      1312(r026):     24(ptr) Variable Function
+     1316(r026a):     24(ptr) Variable Function
+      1321(r027):     24(ptr) Variable Function
+      1324(r028):     24(ptr) Variable Function
+      1328(r029):     24(ptr) Variable Function
+      1331(r030):     24(ptr) Variable Function
+      1335(r031):     24(ptr) Variable Function
+      1339(r032):     24(ptr) Variable Function
+      1343(r033):     24(ptr) Variable Function
+      1346(r034):     24(ptr) Variable Function
+      1349(r035):     24(ptr) Variable Function
+      1352(r036):     24(ptr) Variable Function
+      1357(r037):     24(ptr) Variable Function
+      1360(r038):     24(ptr) Variable Function
+      1367(r039):     24(ptr) Variable Function
+      1370(r049):     24(ptr) Variable Function
+      1375(r041):     24(ptr) Variable Function
+      1378(r042):     24(ptr) Variable Function
+      1382(r043):     24(ptr) Variable Function
+      1385(r044):     24(ptr) Variable Function
+      1390(r046):     24(ptr) Variable Function
+      1396(r000):     68(ptr) Variable Function
+      1401(r001):     37(ptr) Variable Function
+      1406(r003):     68(ptr) Variable Function
+      1409(r004):     37(ptr) Variable Function
+      1412(r005):     37(ptr) Variable Function
+      1415(r006):     37(ptr) Variable Function
+      1420(r007):     37(ptr) Variable Function
+      1431(r008):     37(ptr) Variable Function
+      1437(r009):     37(ptr) Variable Function
+      1440(r010):     37(ptr) Variable Function
+      1443(r011):     37(ptr) Variable Function
+      1446(r012):     37(ptr) Variable Function
+      1449(r013):     37(ptr) Variable Function
+      1452(r014):     37(ptr) Variable Function
+      1455(r015):     37(ptr) Variable Function
+      1458(r016):     37(ptr) Variable Function
+      1461(r017):     37(ptr) Variable Function
+      1464(r018):      7(ptr) Variable Function
+      1467(r019):     37(ptr) Variable Function
+      1470(R020):     37(ptr) Variable Function
+      1473(r021):     37(ptr) Variable Function
+      1476(r022):     37(ptr) Variable Function
+      1492(r023):     37(ptr) Variable Function
+      1495(r024):     37(ptr) Variable Function
+      1501(r025):     37(ptr) Variable Function
+      1504(r026):     37(ptr) Variable Function
+     1508(r026a):     37(ptr) Variable Function
+      1513(r027):     37(ptr) Variable Function
+      1516(r028):     37(ptr) Variable Function
+      1520(r029):     37(ptr) Variable Function
+      1523(r030):     37(ptr) Variable Function
+      1527(r031):     37(ptr) Variable Function
+      1531(r032):     37(ptr) Variable Function
+      1535(r033):     37(ptr) Variable Function
+      1538(r034):     37(ptr) Variable Function
+      1541(r035):     37(ptr) Variable Function
+      1544(r036):     37(ptr) Variable Function
+      1549(r037):     37(ptr) Variable Function
+      1552(r038):     37(ptr) Variable Function
+      1559(r039):     37(ptr) Variable Function
+      1562(r049):     37(ptr) Variable Function
+      1567(r041):     37(ptr) Variable Function
+      1570(r042):     37(ptr) Variable Function
+      1574(r043):     37(ptr) Variable Function
+      1577(r044):     37(ptr) Variable Function
+      1582(r046):     37(ptr) Variable Function
+              72:    6(float) Load 71(inF0)
+              73:    67(bool) All 72
+                              Store 69(r000) 73
+              75:    6(float) Load 71(inF0)
+              76:    6(float) ExtInst 1(GLSL.std.450) 4(FAbs) 75
+                              Store 74(r001) 76
+              78:    6(float) Load 71(inF0)
+              79:    6(float) ExtInst 1(GLSL.std.450) 17(Acos) 78
+                              Store 77(r002) 79
+              81:    6(float) Load 71(inF0)
+              82:    67(bool) Any 81
+                              Store 80(r003) 82
+              84:    6(float) Load 71(inF0)
+              85:    6(float) ExtInst 1(GLSL.std.450) 16(Asin) 84
+                              Store 83(r004) 85
+              89:    6(float) Load 71(inF0)
+              90:     86(int) Bitcast 89
+                              Store 88(r005) 90
+              94:    6(float) Load 71(inF0)
+              95:     91(int) Bitcast 94
+                              Store 93(r006) 95
+              99:     91(int) Load 98(inU0)
+             100:    6(float) Bitcast 99
+                              Store 96(r007) 100
+             102:    6(float) Load 71(inF0)
+             103:    6(float) ExtInst 1(GLSL.std.450) 18(Atan) 102
+                              Store 101(r009) 103
+             105:    6(float) Load 71(inF0)
+             107:    6(float) Load 106(inF1)
+             108:    6(float) ExtInst 1(GLSL.std.450) 25(Atan2) 105 107
+                              Store 104(r010) 108
+             110:    6(float) Load 71(inF0)
+             111:    6(float) ExtInst 1(GLSL.std.450) 9(Ceil) 110
+                              Store 109(r011) 111
+             113:    6(float) Load 71(inF0)
+             114:    6(float) Load 106(inF1)
+             116:    6(float) Load 115(inF2)
+             117:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 113 114 116
+                              Store 112(r012) 117
+             118:    6(float) Load 71(inF0)
+             120:    67(bool) FOrdLessThan 118 119
+                              SelectionMerge 122 None
+                              BranchConditional 120 121 122
+             121:               Label
                                 Kill
-              87:             Label
-              89:    6(float) Load 48(inF0)
-              90:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 89
-              91:    6(float) Load 48(inF0)
-              92:    6(float) ExtInst 1(GLSL.std.450) 20(Cosh) 91
-              94:     64(int) BitCount 93
-              95:    6(float) Load 48(inF0)
-              96:    6(float) DPdx 95
-              97:    6(float) Load 48(inF0)
-              98:    6(float) DPdxCoarse 97
-              99:    6(float) Load 48(inF0)
-             100:    6(float) DPdxFine 99
-             101:    6(float) Load 48(inF0)
-             102:    6(float) DPdy 101
-             103:    6(float) Load 48(inF0)
-             104:    6(float) DPdyCoarse 103
-             105:    6(float) Load 48(inF0)
-             106:    6(float) DPdyFine 105
-             107:    6(float) Load 48(inF0)
-             108:    6(float) ExtInst 1(GLSL.std.450) 12(Degrees) 107
-             109:    6(float) Load 48(inF0)
-             110:    6(float) ExtInst 1(GLSL.std.450) 27(Exp) 109
-             111:    6(float) Load 48(inF0)
-             112:    6(float) ExtInst 1(GLSL.std.450) 29(Exp2) 111
-             114:     61(int) ExtInst 1(GLSL.std.450) 74(FindSMsb) 113
-             115:     61(int) ExtInst 1(GLSL.std.450) 73(FindILsb) 113
-             116:    6(float) Load 48(inF0)
-             117:    6(float) ExtInst 1(GLSL.std.450) 8(Floor) 116
-             118:    6(float) Load 48(inF0)
-             119:    6(float) Load 73(inF1)
-             120:    6(float) FMod 118 119
-             121:    6(float) Load 48(inF0)
-             122:    6(float) ExtInst 1(GLSL.std.450) 10(Fract) 121
-             123:    6(float) Load 48(inF0)
-             125:124(ResType) ExtInst 1(GLSL.std.450) 52(FrexpStruct) 123
-             126:     61(int) CompositeExtract 125 1
-                              Store 73(inF1) 126
-             127:    6(float) CompositeExtract 125 0
-             128:    6(float) Load 48(inF0)
-             129:    6(float) Fwidth 128
-             130:    6(float) Load 48(inF0)
-             131:    50(bool) IsInf 130
-             132:    6(float) Load 48(inF0)
-             133:    50(bool) IsNan 132
-             134:    6(float) Load 48(inF0)
-             135:    6(float) Load 73(inF1)
-             136:    6(float) ExtInst 1(GLSL.std.450) 53(Ldexp) 134 135
-             137:    6(float) Load 48(inF0)
-             138:    6(float) ExtInst 1(GLSL.std.450) 28(Log) 137
-             139:    6(float) Load 48(inF0)
-             140:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 139
-             142:    6(float) FMul 140 141
-             143:    6(float) Load 48(inF0)
-             144:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 143
-             145:    6(float) Load 48(inF0)
-             146:    6(float) Load 73(inF1)
-             147:    6(float) ExtInst 1(GLSL.std.450) 40(FMax) 145 146
-             148:    6(float) Load 48(inF0)
-             149:    6(float) Load 73(inF1)
-             150:    6(float) ExtInst 1(GLSL.std.450) 37(FMin) 148 149
-             151:    6(float) Load 48(inF0)
-             152:    6(float) Load 73(inF1)
-             153:    6(float) ExtInst 1(GLSL.std.450) 26(Pow) 151 152
-             154:    6(float) Load 48(inF0)
-             155:    6(float) ExtInst 1(GLSL.std.450) 11(Radians) 154
-             157:    6(float) Load 48(inF0)
-             158:    6(float) FDiv 156 157
-             160:     64(int) BitReverse 159
-             161:    6(float) Load 48(inF0)
-             162:    6(float) ExtInst 1(GLSL.std.450) 2(RoundEven) 161
-             163:    6(float) Load 48(inF0)
-             164:    6(float) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 163
-             165:    6(float) Load 48(inF0)
-             166:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 165 84 156
-             167:    6(float) Load 48(inF0)
-             168:    6(float) ExtInst 1(GLSL.std.450) 6(FSign) 167
-             169:    6(float) Load 48(inF0)
-             170:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 169
-             171:    6(float) Load 48(inF0)
-             172:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 171
-                              Store 73(inF1) 172
-             173:    6(float) Load 48(inF0)
-             174:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 173
-                              Store 80(inF2) 174
-             175:    6(float) Load 48(inF0)
-             176:    6(float) ExtInst 1(GLSL.std.450) 19(Sinh) 175
-             177:    6(float) Load 48(inF0)
-             178:    6(float) Load 73(inF1)
-             179:    6(float) Load 80(inF2)
-             180:    6(float) ExtInst 1(GLSL.std.450) 49(SmoothStep) 177 178 179
-             181:    6(float) Load 48(inF0)
-             182:    6(float) ExtInst 1(GLSL.std.450) 31(Sqrt) 181
-             183:    6(float) Load 48(inF0)
-             184:    6(float) Load 73(inF1)
-             185:    6(float) ExtInst 1(GLSL.std.450) 48(Step) 183 184
-             186:    6(float) Load 48(inF0)
-             187:    6(float) ExtInst 1(GLSL.std.450) 15(Tan) 186
-             188:    6(float) Load 48(inF0)
-             189:    6(float) ExtInst 1(GLSL.std.450) 21(Tanh) 188
-             190:    6(float) Load 48(inF0)
-             191:    6(float) ExtInst 1(GLSL.std.450) 3(Trunc) 190
-                              ReturnValue 84
+             122:             Label
+             125:    6(float) Load 71(inF0)
+             126:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 125
+                              Store 124(r014) 126
+             128:    6(float) Load 71(inF0)
+             129:    6(float) ExtInst 1(GLSL.std.450) 20(Cosh) 128
+                              Store 127(r015) 129
+             132:     91(int) BitCount 131
+                              Store 130(r016) 132
+             134:    6(float) Load 71(inF0)
+             135:    6(float) DPdx 134
+                              Store 133(r017) 135
+             137:    6(float) Load 71(inF0)
+             138:    6(float) DPdxCoarse 137
+                              Store 136(r018) 138
+             140:    6(float) Load 71(inF0)
+             141:    6(float) DPdxFine 140
+                              Store 139(r019) 141
+             143:    6(float) Load 71(inF0)
+             144:    6(float) DPdy 143
+                              Store 142(r020) 144
+             146:    6(float) Load 71(inF0)
+             147:    6(float) DPdyCoarse 146
+                              Store 145(r021) 147
+             149:    6(float) Load 71(inF0)
+             150:    6(float) DPdyFine 149
+                              Store 148(r022) 150
+             152:    6(float) Load 71(inF0)
+             153:    6(float) ExtInst 1(GLSL.std.450) 12(Degrees) 152
+                              Store 151(r023) 153
+             155:    6(float) Load 71(inF0)
+             156:    6(float) ExtInst 1(GLSL.std.450) 27(Exp) 155
+                              Store 154(r027) 156
+             158:    6(float) Load 71(inF0)
+             159:    6(float) ExtInst 1(GLSL.std.450) 29(Exp2) 158
+                              Store 157(r028) 159
+             162:     86(int) ExtInst 1(GLSL.std.450) 74(FindSMsb) 161
+             163:     91(int) Bitcast 162
+                              Store 160(r029) 163
+             165:     86(int) ExtInst 1(GLSL.std.450) 73(FindILsb) 161
+             166:     91(int) Bitcast 165
+                              Store 164(r030) 166
+             168:    6(float) Load 71(inF0)
+             169:    6(float) ExtInst 1(GLSL.std.450) 8(Floor) 168
+                              Store 167(r031) 169
+             171:    6(float) Load 71(inF0)
+             172:    6(float) Load 106(inF1)
+             173:    6(float) FMod 171 172
+                              Store 170(r033) 173
+             175:    6(float) Load 71(inF0)
+             176:    6(float) ExtInst 1(GLSL.std.450) 10(Fract) 175
+                              Store 174(r034) 176
+             178:    6(float) Load 71(inF0)
+             180:179(ResType) ExtInst 1(GLSL.std.450) 52(FrexpStruct) 178
+             181:     86(int) CompositeExtract 180 1
+                              Store 106(inF1) 181
+             182:    6(float) CompositeExtract 180 0
+                              Store 177(r035) 182
+             184:    6(float) Load 71(inF0)
+             185:    6(float) Fwidth 184
+                              Store 183(r036) 185
+             187:    6(float) Load 71(inF0)
+             188:    67(bool) IsInf 187
+                              Store 186(r037) 188
+             190:    6(float) Load 71(inF0)
+             191:    67(bool) IsNan 190
+                              Store 189(r038) 191
+             193:    6(float) Load 71(inF0)
+             194:    6(float) Load 106(inF1)
+             195:    6(float) ExtInst 1(GLSL.std.450) 53(Ldexp) 193 194
+                              Store 192(r039) 195
+             197:    6(float) Load 71(inF0)
+             198:    6(float) Load 106(inF1)
+             199:    6(float) Load 115(inF2)
+             200:    6(float) ExtInst 1(GLSL.std.450) 46(FMix) 197 198 199
+                              Store 196(r039a) 200
+             202:    6(float) Load 71(inF0)
+             203:    6(float) ExtInst 1(GLSL.std.450) 28(Log) 202
+                              Store 201(r040) 203
+             205:    6(float) Load 71(inF0)
+             206:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 205
+             208:    6(float) FMul 206 207
+                              Store 204(r041) 208
+             210:    6(float) Load 71(inF0)
+             211:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 210
+                              Store 209(r042) 211
+             213:    6(float) Load 71(inF0)
+             214:    6(float) Load 106(inF1)
+             215:    6(float) ExtInst 1(GLSL.std.450) 40(FMax) 213 214
+                              Store 212(r043) 215
+             217:    6(float) Load 71(inF0)
+             218:    6(float) Load 106(inF1)
+             219:    6(float) ExtInst 1(GLSL.std.450) 37(FMin) 217 218
+                              Store 216(r044) 219
+             221:    6(float) Load 71(inF0)
+             222:    6(float) Load 106(inF1)
+             223:    6(float) ExtInst 1(GLSL.std.450) 26(Pow) 221 222
+                              Store 220(r045) 223
+             225:    6(float) Load 71(inF0)
+             226:    6(float) ExtInst 1(GLSL.std.450) 11(Radians) 225
+                              Store 224(r046) 226
+             229:    6(float) Load 71(inF0)
+             230:    6(float) FDiv 228 229
+                              Store 227(r047) 230
+             233:     91(int) BitReverse 232
+                              Store 231(r048) 233
+             235:    6(float) Load 71(inF0)
+             236:    6(float) ExtInst 1(GLSL.std.450) 2(RoundEven) 235
+                              Store 234(r049) 236
+             238:    6(float) Load 71(inF0)
+             239:    6(float) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 238
+                              Store 237(r050) 239
+             241:    6(float) Load 71(inF0)
+             242:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 241 119 228
+                              Store 240(r051) 242
+             244:    6(float) Load 71(inF0)
+             245:    6(float) ExtInst 1(GLSL.std.450) 6(FSign) 244
+                              Store 243(r052) 245
+             247:    6(float) Load 71(inF0)
+             248:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 247
+                              Store 246(r053) 248
+             249:    6(float) Load 71(inF0)
+             250:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 249
+                              Store 106(inF1) 250
+             251:    6(float) Load 71(inF0)
+             252:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 251
+                              Store 115(inF2) 252
+             254:    6(float) Load 71(inF0)
+             255:    6(float) ExtInst 1(GLSL.std.450) 19(Sinh) 254
+                              Store 253(r055) 255
+             257:    6(float) Load 71(inF0)
+             258:    6(float) Load 106(inF1)
+             259:    6(float) Load 115(inF2)
+             260:    6(float) ExtInst 1(GLSL.std.450) 49(SmoothStep) 257 258 259
+                              Store 256(r056) 260
+             262:    6(float) Load 71(inF0)
+             263:    6(float) ExtInst 1(GLSL.std.450) 31(Sqrt) 262
+                              Store 261(r057) 263
+             265:    6(float) Load 71(inF0)
+             266:    6(float) Load 106(inF1)
+             267:    6(float) ExtInst 1(GLSL.std.450) 48(Step) 265 266
+                              Store 264(r058) 267
+             269:    6(float) Load 71(inF0)
+             270:    6(float) ExtInst 1(GLSL.std.450) 15(Tan) 269
+                              Store 268(r059) 270
+             272:    6(float) Load 71(inF0)
+             273:    6(float) ExtInst 1(GLSL.std.450) 21(Tanh) 272
+                              Store 271(r060) 273
+             275:    6(float) Load 71(inF0)
+             276:    6(float) ExtInst 1(GLSL.std.450) 3(Trunc) 275
+                              Store 274(r061) 276
+                              ReturnValue 119
                               FunctionEnd
 19(TestGenMul(f1;f1;vf2;vf2;mf22;mf22;):           2 Function None 12
         13(inF0):      7(ptr) FunctionParameter
@@ -3260,51 +5924,51 @@ gl_FragCoord origin is upper left
        17(inFM0):     11(ptr) FunctionParameter
        18(inFM1):     11(ptr) FunctionParameter
               20:             Label
-        1141(r0):      7(ptr) Variable Function
-        1145(r1):      9(ptr) Variable Function
-        1149(r2):      9(ptr) Variable Function
-        1153(r3):      7(ptr) Variable Function
-        1157(r4):      9(ptr) Variable Function
-        1161(r5):      9(ptr) Variable Function
-        1165(r6):     11(ptr) Variable Function
-        1169(r7):     11(ptr) Variable Function
-        1173(r8):     11(ptr) Variable Function
-            1142:    6(float) Load 13(inF0)
-            1143:    6(float) Load 14(inF1)
-            1144:    6(float) FMul 1142 1143
-                              Store 1141(r0) 1144
-            1146:    8(fvec2) Load 15(inFV0)
-            1147:    6(float) Load 13(inF0)
-            1148:    8(fvec2) VectorTimesScalar 1146 1147
-                              Store 1145(r1) 1148
-            1150:    6(float) Load 13(inF0)
-            1151:    8(fvec2) Load 15(inFV0)
-            1152:    8(fvec2) VectorTimesScalar 1151 1150
-                              Store 1149(r2) 1152
-            1154:    8(fvec2) Load 15(inFV0)
-            1155:    8(fvec2) Load 16(inFV1)
-            1156:    6(float) Dot 1154 1155
-                              Store 1153(r3) 1156
-            1158:          10 Load 17(inFM0)
-            1159:    8(fvec2) Load 15(inFV0)
-            1160:    8(fvec2) MatrixTimesVector 1158 1159
-                              Store 1157(r4) 1160
-            1162:    8(fvec2) Load 15(inFV0)
-            1163:          10 Load 17(inFM0)
-            1164:    8(fvec2) VectorTimesMatrix 1162 1163
-                              Store 1161(r5) 1164
-            1166:          10 Load 17(inFM0)
-            1167:    6(float) Load 13(inF0)
-            1168:          10 MatrixTimesScalar 1166 1167
-                              Store 1165(r6) 1168
-            1170:    6(float) Load 13(inF0)
-            1171:          10 Load 17(inFM0)
-            1172:          10 MatrixTimesScalar 1171 1170
-                              Store 1169(r7) 1172
-            1174:          10 Load 17(inFM0)
-            1175:          10 Load 18(inFM1)
-            1176:          10 MatrixTimesMatrix 1174 1175
-                              Store 1173(r8) 1176
+        1588(r0):      7(ptr) Variable Function
+        1592(r1):      9(ptr) Variable Function
+        1596(r2):      9(ptr) Variable Function
+        1600(r3):      7(ptr) Variable Function
+        1604(r4):      9(ptr) Variable Function
+        1608(r5):      9(ptr) Variable Function
+        1612(r6):     11(ptr) Variable Function
+        1616(r7):     11(ptr) Variable Function
+        1620(r8):     11(ptr) Variable Function
+            1589:    6(float) Load 13(inF0)
+            1590:    6(float) Load 14(inF1)
+            1591:    6(float) FMul 1589 1590
+                              Store 1588(r0) 1591
+            1593:    8(fvec2) Load 15(inFV0)
+            1594:    6(float) Load 13(inF0)
+            1595:    8(fvec2) VectorTimesScalar 1593 1594
+                              Store 1592(r1) 1595
+            1597:    6(float) Load 13(inF0)
+            1598:    8(fvec2) Load 15(inFV0)
+            1599:    8(fvec2) VectorTimesScalar 1598 1597
+                              Store 1596(r2) 1599
+            1601:    8(fvec2) Load 15(inFV0)
+            1602:    8(fvec2) Load 16(inFV1)
+            1603:    6(float) Dot 1601 1602
+                              Store 1600(r3) 1603
+            1605:          10 Load 17(inFM0)
+            1606:    8(fvec2) Load 15(inFV0)
+            1607:    8(fvec2) MatrixTimesVector 1605 1606
+                              Store 1604(r4) 1607
+            1609:    8(fvec2) Load 15(inFV0)
+            1610:          10 Load 17(inFM0)
+            1611:    8(fvec2) VectorTimesMatrix 1609 1610
+                              Store 1608(r5) 1611
+            1613:          10 Load 17(inFM0)
+            1614:    6(float) Load 13(inF0)
+            1615:          10 MatrixTimesScalar 1613 1614
+                              Store 1612(r6) 1615
+            1617:    6(float) Load 13(inF0)
+            1618:          10 Load 17(inFM0)
+            1619:          10 MatrixTimesScalar 1618 1617
+                              Store 1616(r7) 1619
+            1621:          10 Load 17(inFM0)
+            1622:          10 Load 18(inFM1)
+            1623:          10 MatrixTimesMatrix 1621 1622
+                              Store 1620(r8) 1623
                               Return
                               FunctionEnd
 32(TestGenMul(f1;f1;vf3;vf3;mf33;mf33;):           2 Function None 25
@@ -3315,51 +5979,51 @@ gl_FragCoord origin is upper left
        30(inFM0):     24(ptr) FunctionParameter
        31(inFM1):     24(ptr) FunctionParameter
               33:             Label
-        1177(r0):      7(ptr) Variable Function
-        1181(r1):     22(ptr) Variable Function
-        1185(r2):     22(ptr) Variable Function
-        1189(r3):      7(ptr) Variable Function
-        1193(r4):     22(ptr) Variable Function
-        1197(r5):     22(ptr) Variable Function
-        1201(r6):     24(ptr) Variable Function
-        1205(r7):     24(ptr) Variable Function
-        1209(r8):     24(ptr) Variable Function
-            1178:    6(float) Load 26(inF0)
-            1179:    6(float) Load 27(inF1)
-            1180:    6(float) FMul 1178 1179
-                              Store 1177(r0) 1180
-            1182:   21(fvec3) Load 28(inFV0)
-            1183:    6(float) Load 26(inF0)
-            1184:   21(fvec3) VectorTimesScalar 1182 1183
-                              Store 1181(r1) 1184
-            1186:    6(float) Load 26(inF0)
-            1187:   21(fvec3) Load 28(inFV0)
-            1188:   21(fvec3) VectorTimesScalar 1187 1186
-                              Store 1185(r2) 1188
-            1190:   21(fvec3) Load 28(inFV0)
-            1191:   21(fvec3) Load 29(inFV1)
-            1192:    6(float) Dot 1190 1191
-                              Store 1189(r3) 1192
-            1194:          23 Load 30(inFM0)
-            1195:   21(fvec3) Load 28(inFV0)
-            1196:   21(fvec3) MatrixTimesVector 1194 1195
-                              Store 1193(r4) 1196
-            1198:   21(fvec3) Load 28(inFV0)
-            1199:          23 Load 30(inFM0)
-            1200:   21(fvec3) VectorTimesMatrix 1198 1199
-                              Store 1197(r5) 1200
-            1202:          23 Load 30(inFM0)
-            1203:    6(float) Load 26(inF0)
-            1204:          23 MatrixTimesScalar 1202 1203
-                              Store 1201(r6) 1204
-            1206:    6(float) Load 26(inF0)
-            1207:          23 Load 30(inFM0)
-            1208:          23 MatrixTimesScalar 1207 1206
-                              Store 1205(r7) 1208
-            1210:          23 Load 30(inFM0)
-            1211:          23 Load 31(inFM1)
-            1212:          23 MatrixTimesMatrix 1210 1211
-                              Store 1209(r8) 1212
+        1624(r0):      7(ptr) Variable Function
+        1628(r1):     22(ptr) Variable Function
+        1632(r2):     22(ptr) Variable Function
+        1636(r3):      7(ptr) Variable Function
+        1640(r4):     22(ptr) Variable Function
+        1644(r5):     22(ptr) Variable Function
+        1648(r6):     24(ptr) Variable Function
+        1652(r7):     24(ptr) Variable Function
+        1656(r8):     24(ptr) Variable Function
+            1625:    6(float) Load 26(inF0)
+            1626:    6(float) Load 27(inF1)
+            1627:    6(float) FMul 1625 1626
+                              Store 1624(r0) 1627
+            1629:   21(fvec3) Load 28(inFV0)
+            1630:    6(float) Load 26(inF0)
+            1631:   21(fvec3) VectorTimesScalar 1629 1630
+                              Store 1628(r1) 1631
+            1633:    6(float) Load 26(inF0)
+            1634:   21(fvec3) Load 28(inFV0)
+            1635:   21(fvec3) VectorTimesScalar 1634 1633
+                              Store 1632(r2) 1635
+            1637:   21(fvec3) Load 28(inFV0)
+            1638:   21(fvec3) Load 29(inFV1)
+            1639:    6(float) Dot 1637 1638
+                              Store 1636(r3) 1639
+            1641:          23 Load 30(inFM0)
+            1642:   21(fvec3) Load 28(inFV0)
+            1643:   21(fvec3) MatrixTimesVector 1641 1642
+                              Store 1640(r4) 1643
+            1645:   21(fvec3) Load 28(inFV0)
+            1646:          23 Load 30(inFM0)
+            1647:   21(fvec3) VectorTimesMatrix 1645 1646
+                              Store 1644(r5) 1647
+            1649:          23 Load 30(inFM0)
+            1650:    6(float) Load 26(inF0)
+            1651:          23 MatrixTimesScalar 1649 1650
+                              Store 1648(r6) 1651
+            1653:    6(float) Load 26(inF0)
+            1654:          23 Load 30(inFM0)
+            1655:          23 MatrixTimesScalar 1654 1653
+                              Store 1652(r7) 1655
+            1657:          23 Load 30(inFM0)
+            1658:          23 Load 31(inFM1)
+            1659:          23 MatrixTimesMatrix 1657 1658
+                              Store 1656(r8) 1659
                               Return
                               FunctionEnd
 45(TestGenMul(f1;f1;vf4;vf4;mf44;mf44;):           2 Function None 38
@@ -3370,62 +6034,160 @@ gl_FragCoord origin is upper left
        43(inFM0):     37(ptr) FunctionParameter
        44(inFM1):     37(ptr) FunctionParameter
               46:             Label
-        1213(r0):      7(ptr) Variable Function
-        1217(r1):     35(ptr) Variable Function
-        1221(r2):     35(ptr) Variable Function
-        1225(r3):      7(ptr) Variable Function
-        1229(r4):     35(ptr) Variable Function
-        1233(r5):     35(ptr) Variable Function
-        1237(r6):     37(ptr) Variable Function
-        1241(r7):     37(ptr) Variable Function
-        1245(r8):     37(ptr) Variable Function
-     1250(gs_ua):   1249(ptr) Variable Function
-     1251(gs_ub):   1249(ptr) Variable Function
-     1252(gs_uc):   1249(ptr) Variable Function
-    1254(gs_ua2):   1253(ptr) Variable Function
-    1255(gs_ub2):   1253(ptr) Variable Function
-    1256(gs_uc2):   1253(ptr) Variable Function
-    1258(gs_ua3):   1257(ptr) Variable Function
-    1259(gs_ub3):   1257(ptr) Variable Function
-    1260(gs_uc3):   1257(ptr) Variable Function
-    1262(gs_ua4):   1261(ptr) Variable Function
-    1263(gs_ub4):   1261(ptr) Variable Function
-    1264(gs_uc4):   1261(ptr) Variable Function
-            1214:    6(float) Load 39(inF0)
-            1215:    6(float) Load 40(inF1)
-            1216:    6(float) FMul 1214 1215
-                              Store 1213(r0) 1216
-            1218:   34(fvec4) Load 41(inFV0)
-            1219:    6(float) Load 39(inF0)
-            1220:   34(fvec4) VectorTimesScalar 1218 1219
-                              Store 1217(r1) 1220
-            1222:    6(float) Load 39(inF0)
-            1223:   34(fvec4) Load 41(inFV0)
-            1224:   34(fvec4) VectorTimesScalar 1223 1222
-                              Store 1221(r2) 1224
-            1226:   34(fvec4) Load 41(inFV0)
-            1227:   34(fvec4) Load 42(inFV1)
-            1228:    6(float) Dot 1226 1227
-                              Store 1225(r3) 1228
-            1230:          36 Load 43(inFM0)
-            1231:   34(fvec4) Load 41(inFV0)
-            1232:   34(fvec4) MatrixTimesVector 1230 1231
-                              Store 1229(r4) 1232
-            1234:   34(fvec4) Load 41(inFV0)
-            1235:          36 Load 43(inFM0)
-            1236:   34(fvec4) VectorTimesMatrix 1234 1235
-                              Store 1233(r5) 1236
-            1238:          36 Load 43(inFM0)
-            1239:    6(float) Load 39(inF0)
-            1240:          36 MatrixTimesScalar 1238 1239
-                              Store 1237(r6) 1240
-            1242:    6(float) Load 39(inF0)
-            1243:          36 Load 43(inFM0)
-            1244:          36 MatrixTimesScalar 1243 1242
-                              Store 1241(r7) 1244
-            1246:          36 Load 43(inFM0)
-            1247:          36 Load 44(inFM1)
-            1248:          36 MatrixTimesMatrix 1246 1247
-                              Store 1245(r8) 1248
+        1660(r0):      7(ptr) Variable Function
+        1664(r1):     35(ptr) Variable Function
+        1668(r2):     35(ptr) Variable Function
+        1672(r3):      7(ptr) Variable Function
+        1676(r4):     35(ptr) Variable Function
+        1680(r5):     35(ptr) Variable Function
+        1684(r6):     37(ptr) Variable Function
+        1688(r7):     37(ptr) Variable Function
+        1692(r8):     37(ptr) Variable Function
+            1661:    6(float) Load 39(inF0)
+            1662:    6(float) Load 40(inF1)
+            1663:    6(float) FMul 1661 1662
+                              Store 1660(r0) 1663
+            1665:   34(fvec4) Load 41(inFV0)
+            1666:    6(float) Load 39(inF0)
+            1667:   34(fvec4) VectorTimesScalar 1665 1666
+                              Store 1664(r1) 1667
+            1669:    6(float) Load 39(inF0)
+            1670:   34(fvec4) Load 41(inFV0)
+            1671:   34(fvec4) VectorTimesScalar 1670 1669
+                              Store 1668(r2) 1671
+            1673:   34(fvec4) Load 41(inFV0)
+            1674:   34(fvec4) Load 42(inFV1)
+            1675:    6(float) Dot 1673 1674
+                              Store 1672(r3) 1675
+            1677:          36 Load 43(inFM0)
+            1678:   34(fvec4) Load 41(inFV0)
+            1679:   34(fvec4) MatrixTimesVector 1677 1678
+                              Store 1676(r4) 1679
+            1681:   34(fvec4) Load 41(inFV0)
+            1682:          36 Load 43(inFM0)
+            1683:   34(fvec4) VectorTimesMatrix 1681 1682
+                              Store 1680(r5) 1683
+            1685:          36 Load 43(inFM0)
+            1686:    6(float) Load 39(inF0)
+            1687:          36 MatrixTimesScalar 1685 1686
+                              Store 1684(r6) 1687
+            1689:    6(float) Load 39(inF0)
+            1690:          36 Load 43(inFM0)
+            1691:          36 MatrixTimesScalar 1690 1689
+                              Store 1688(r7) 1691
+            1693:          36 Load 43(inFM0)
+            1694:          36 Load 44(inFM1)
+            1695:          36 MatrixTimesMatrix 1693 1694
+                              Store 1692(r8) 1695
+                              Return
+                              FunctionEnd
+65(TestGenMul(f1;f1;vf2;vf3;mf32;mf23;mf33;mf43;mf42;):           2 Function None 55
+        56(inF0):      7(ptr) FunctionParameter
+        57(inF1):      7(ptr) FunctionParameter
+       58(inFV2):      9(ptr) FunctionParameter
+       59(inFV3):     22(ptr) FunctionParameter
+     60(inFM2x3):     48(ptr) FunctionParameter
+     61(inFM3x2):     50(ptr) FunctionParameter
+     62(inFM3x3):     24(ptr) FunctionParameter
+     63(inFM3x4):     52(ptr) FunctionParameter
+     64(inFM2x4):     54(ptr) FunctionParameter
+              66:             Label
+       1696(r00):      7(ptr) Variable Function
+       1700(r01):      9(ptr) Variable Function
+       1704(r02):     22(ptr) Variable Function
+       1708(r03):      9(ptr) Variable Function
+       1712(r04):     22(ptr) Variable Function
+       1716(r05):      7(ptr) Variable Function
+       1720(r06):      7(ptr) Variable Function
+       1724(r07):     22(ptr) Variable Function
+       1728(r08):      9(ptr) Variable Function
+       1732(r09):      9(ptr) Variable Function
+       1736(r10):     22(ptr) Variable Function
+       1740(r11):     48(ptr) Variable Function
+       1744(r12):     50(ptr) Variable Function
+       1748(r13):     11(ptr) Variable Function
+       1752(r14):     48(ptr) Variable Function
+       1756(r15):     54(ptr) Variable Function
+       1760(r16):     52(ptr) Variable Function
+     1764(gs_ua):     92(ptr) Variable Function
+     1765(gs_ub):     92(ptr) Variable Function
+     1766(gs_uc):     92(ptr) Variable Function
+    1767(gs_ua2):    302(ptr) Variable Function
+    1768(gs_ub2):    302(ptr) Variable Function
+    1769(gs_uc2):    302(ptr) Variable Function
+    1770(gs_ua3):    545(ptr) Variable Function
+    1771(gs_ub3):    545(ptr) Variable Function
+    1772(gs_uc3):    545(ptr) Variable Function
+    1773(gs_ua4):    791(ptr) Variable Function
+    1774(gs_ub4):    791(ptr) Variable Function
+    1775(gs_uc4):    791(ptr) Variable Function
+            1697:    6(float) Load 56(inF0)
+            1698:    6(float) Load 57(inF1)
+            1699:    6(float) FMul 1697 1698
+                              Store 1696(r00) 1699
+            1701:    8(fvec2) Load 58(inFV2)
+            1702:    6(float) Load 56(inF0)
+            1703:    8(fvec2) VectorTimesScalar 1701 1702
+                              Store 1700(r01) 1703
+            1705:   21(fvec3) Load 59(inFV3)
+            1706:    6(float) Load 56(inF0)
+            1707:   21(fvec3) VectorTimesScalar 1705 1706
+                              Store 1704(r02) 1707
+            1709:    6(float) Load 56(inF0)
+            1710:    8(fvec2) Load 58(inFV2)
+            1711:    8(fvec2) VectorTimesScalar 1710 1709
+                              Store 1708(r03) 1711
+            1713:    6(float) Load 56(inF0)
+            1714:   21(fvec3) Load 59(inFV3)
+            1715:   21(fvec3) VectorTimesScalar 1714 1713
+                              Store 1712(r04) 1715
+            1717:    8(fvec2) Load 58(inFV2)
+            1718:    8(fvec2) Load 58(inFV2)
+            1719:    6(float) Dot 1717 1718
+                              Store 1716(r05) 1719
+            1721:   21(fvec3) Load 59(inFV3)
+            1722:   21(fvec3) Load 59(inFV3)
+            1723:    6(float) Dot 1721 1722
+                              Store 1720(r06) 1723
+            1725:    8(fvec2) Load 58(inFV2)
+            1726:          47 Load 60(inFM2x3)
+            1727:   21(fvec3) VectorTimesMatrix 1725 1726
+                              Store 1724(r07) 1727
+            1729:   21(fvec3) Load 59(inFV3)
+            1730:          49 Load 61(inFM3x2)
+            1731:    8(fvec2) VectorTimesMatrix 1729 1730
+                              Store 1728(r08) 1731
+            1733:          47 Load 60(inFM2x3)
+            1734:   21(fvec3) Load 59(inFV3)
+            1735:    8(fvec2) MatrixTimesVector 1733 1734
+                              Store 1732(r09) 1735
+            1737:          49 Load 61(inFM3x2)
+            1738:    8(fvec2) Load 58(inFV2)
+            1739:   21(fvec3) MatrixTimesVector 1737 1738
+                              Store 1736(r10) 1739
+            1741:          47 Load 60(inFM2x3)
+            1742:    6(float) Load 56(inF0)
+            1743:          47 MatrixTimesScalar 1741 1742
+                              Store 1740(r11) 1743
+            1745:          49 Load 61(inFM3x2)
+            1746:    6(float) Load 56(inF0)
+            1747:          49 MatrixTimesScalar 1745 1746
+                              Store 1744(r12) 1747
+            1749:          47 Load 60(inFM2x3)
+            1750:          49 Load 61(inFM3x2)
+            1751:          10 MatrixTimesMatrix 1749 1750
+                              Store 1748(r13) 1751
+            1753:          47 Load 60(inFM2x3)
+            1754:          23 Load 62(inFM3x3)
+            1755:          47 MatrixTimesMatrix 1753 1754
+                              Store 1752(r14) 1755
+            1757:          47 Load 60(inFM2x3)
+            1758:          51 Load 63(inFM3x4)
+            1759:          53 MatrixTimesMatrix 1757 1758
+                              Store 1756(r15) 1759
+            1761:          49 Load 61(inFM3x2)
+            1762:          53 Load 64(inFM2x4)
+            1763:          51 MatrixTimesMatrix 1761 1762
+                              Store 1760(r16) 1763
                               Return
                               FunctionEnd

--- a/Test/baseResults/hlsl.intrinsics.vert.out
+++ b/Test/baseResults/hlsl.intrinsics.vert.out
@@ -1,7 +1,7 @@
 hlsl.intrinsics.vert
 Shader version: 450
 0:? Sequence
-0:62  Function Definition: VertexShaderFunction(f1;f1;f1;u1;u1; (temp float)
+0:63  Function Definition: VertexShaderFunction(f1;f1;f1;u1;u1; (temp float)
 0:2    Function Parameters: 
 0:2      'inF0' (in float)
 0:2      'inF1' (in float)
@@ -72,846 +72,870 @@ Shader version: 450
 0:34      ldexp (global float)
 0:34        'inF0' (in float)
 0:34        'inF1' (in float)
-0:35      log (global float)
+0:35      mix (global float)
 0:35        'inF0' (in float)
-0:36      component-wise multiply (temp float)
-0:36        log2 (temp float)
-0:36          'inF0' (in float)
-0:36        Constant:
-0:36          0.301030
-0:37      log2 (global float)
-0:37        'inF0' (in float)
-0:38      max (global float)
+0:35        'inF1' (in float)
+0:35        'inF2' (in float)
+0:36      log (global float)
+0:36        'inF0' (in float)
+0:37      component-wise multiply (temp float)
+0:37        log2 (temp float)
+0:37          'inF0' (in float)
+0:37        Constant:
+0:37          0.301030
+0:38      log2 (global float)
 0:38        'inF0' (in float)
-0:38        'inF1' (in float)
-0:39      min (global float)
+0:39      max (global float)
 0:39        'inF0' (in float)
 0:39        'inF1' (in float)
-0:41      pow (global float)
-0:41        'inF0' (in float)
-0:41        'inF1' (in float)
-0:42      radians (global float)
+0:40      min (global float)
+0:40        'inF0' (in float)
+0:40        'inF1' (in float)
+0:42      pow (global float)
 0:42        'inF0' (in float)
-0:43      bitFieldReverse (global uint)
-0:43        Constant:
-0:43          2 (const uint)
-0:44      roundEven (global float)
-0:44        'inF0' (in float)
-0:45      inverse sqrt (global float)
+0:42        'inF1' (in float)
+0:43      radians (global float)
+0:43        'inF0' (in float)
+0:44      bitFieldReverse (global uint)
+0:44        Constant:
+0:44          2 (const uint)
+0:45      roundEven (global float)
 0:45        'inF0' (in float)
-0:46      clamp (temp float)
+0:46      inverse sqrt (global float)
 0:46        'inF0' (in float)
-0:46        Constant:
-0:46          0.000000
-0:46        Constant:
-0:46          1.000000
-0:47      Sign (global float)
+0:47      clamp (temp float)
 0:47        'inF0' (in float)
-0:48      sine (global float)
+0:47        Constant:
+0:47          0.000000
+0:47        Constant:
+0:47          1.000000
+0:48      Sign (global float)
 0:48        'inF0' (in float)
-0:49      Sequence
-0:49        move second child to first child (temp float)
-0:49          'inF1' (in float)
-0:49          sine (temp float)
-0:49            'inF0' (in float)
-0:49        move second child to first child (temp float)
-0:49          'inF2' (in float)
-0:49          cosine (temp float)
-0:49            'inF0' (in float)
-0:50      hyp. sine (global float)
-0:50        'inF0' (in float)
-0:51      smoothstep (global float)
+0:49      sine (global float)
+0:49        'inF0' (in float)
+0:50      Sequence
+0:50        move second child to first child (temp float)
+0:50          'inF1' (in float)
+0:50          sine (temp float)
+0:50            'inF0' (in float)
+0:50        move second child to first child (temp float)
+0:50          'inF2' (in float)
+0:50          cosine (temp float)
+0:50            'inF0' (in float)
+0:51      hyp. sine (global float)
 0:51        'inF0' (in float)
-0:51        'inF1' (in float)
-0:51        'inF2' (in float)
-0:52      sqrt (global float)
+0:52      smoothstep (global float)
 0:52        'inF0' (in float)
-0:53      step (global float)
+0:52        'inF1' (in float)
+0:52        'inF2' (in float)
+0:53      sqrt (global float)
 0:53        'inF0' (in float)
-0:53        'inF1' (in float)
-0:54      tangent (global float)
+0:54      step (global float)
 0:54        'inF0' (in float)
-0:55      hyp. tangent (global float)
+0:54        'inF1' (in float)
+0:55      tangent (global float)
 0:55        'inF0' (in float)
-0:57      trunc (global float)
-0:57        'inF0' (in float)
-0:59      Branch: Return with expression
-0:59        Constant:
-0:59          0.000000
-0:68  Function Definition: VertexShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
-0:63    Function Parameters: 
-0:63      'inF0' (in 1-component vector of float)
-0:63      'inF1' (in 1-component vector of float)
-0:63      'inF2' (in 1-component vector of float)
+0:56      hyp. tangent (global float)
+0:56        'inF0' (in float)
+0:58      trunc (global float)
+0:58        'inF0' (in float)
+0:60      Branch: Return with expression
+0:60        Constant:
+0:60          0.000000
+0:69  Function Definition: VertexShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
+0:64    Function Parameters: 
+0:64      'inF0' (in 1-component vector of float)
+0:64      'inF1' (in 1-component vector of float)
+0:64      'inF2' (in 1-component vector of float)
 0:?     Sequence
-0:65      Branch: Return with expression
-0:65        Constant:
-0:65          0.000000
-0:137  Function Definition: VertexShaderFunction(vf2;vf2;vf2;vu2;vu2; (temp 2-component vector of float)
-0:69    Function Parameters: 
-0:69      'inF0' (in 2-component vector of float)
-0:69      'inF1' (in 2-component vector of float)
-0:69      'inF2' (in 2-component vector of float)
-0:69      'inU0' (in 2-component vector of uint)
-0:69      'inU1' (in 2-component vector of uint)
+0:66      Branch: Return with expression
+0:66        Constant:
+0:66          0.000000
+0:139  Function Definition: VertexShaderFunction(vf2;vf2;vf2;vu2;vu2; (temp 2-component vector of float)
+0:70    Function Parameters: 
+0:70      'inF0' (in 2-component vector of float)
+0:70      'inF1' (in 2-component vector of float)
+0:70      'inF2' (in 2-component vector of float)
+0:70      'inU0' (in 2-component vector of uint)
+0:70      'inU1' (in 2-component vector of uint)
 0:?     Sequence
-0:70      all (global bool)
-0:70        'inF0' (in 2-component vector of float)
-0:71      Absolute value (global 2-component vector of float)
+0:71      all (global bool)
 0:71        'inF0' (in 2-component vector of float)
-0:72      arc cosine (global 2-component vector of float)
+0:72      Absolute value (global 2-component vector of float)
 0:72        'inF0' (in 2-component vector of float)
-0:73      any (global bool)
+0:73      arc cosine (global 2-component vector of float)
 0:73        'inF0' (in 2-component vector of float)
-0:74      arc sine (global 2-component vector of float)
+0:74      any (global bool)
 0:74        'inF0' (in 2-component vector of float)
-0:75      floatBitsToInt (global 2-component vector of int)
+0:75      arc sine (global 2-component vector of float)
 0:75        'inF0' (in 2-component vector of float)
-0:76      floatBitsToUint (global 2-component vector of uint)
+0:76      floatBitsToInt (global 2-component vector of int)
 0:76        'inF0' (in 2-component vector of float)
-0:77      intBitsToFloat (global 2-component vector of float)
-0:77        'inU0' (in 2-component vector of uint)
-0:79      arc tangent (global 2-component vector of float)
-0:79        'inF0' (in 2-component vector of float)
+0:77      floatBitsToUint (global 2-component vector of uint)
+0:77        'inF0' (in 2-component vector of float)
+0:78      intBitsToFloat (global 2-component vector of float)
+0:78        'inU0' (in 2-component vector of uint)
 0:80      arc tangent (global 2-component vector of float)
 0:80        'inF0' (in 2-component vector of float)
-0:80        'inF1' (in 2-component vector of float)
-0:81      Ceiling (global 2-component vector of float)
+0:81      arc tangent (global 2-component vector of float)
 0:81        'inF0' (in 2-component vector of float)
-0:82      clamp (global 2-component vector of float)
+0:81        'inF1' (in 2-component vector of float)
+0:82      Ceiling (global 2-component vector of float)
 0:82        'inF0' (in 2-component vector of float)
-0:82        'inF1' (in 2-component vector of float)
-0:82        'inF2' (in 2-component vector of float)
-0:83      cosine (global 2-component vector of float)
+0:83      clamp (global 2-component vector of float)
 0:83        'inF0' (in 2-component vector of float)
-0:84      hyp. cosine (global 2-component vector of float)
+0:83        'inF1' (in 2-component vector of float)
+0:83        'inF2' (in 2-component vector of float)
+0:84      cosine (global 2-component vector of float)
 0:84        'inF0' (in 2-component vector of float)
+0:85      hyp. cosine (global 2-component vector of float)
+0:85        'inF0' (in 2-component vector of float)
 0:?       bitCount (global 2-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
-0:86      degrees (global 2-component vector of float)
-0:86        'inF0' (in 2-component vector of float)
-0:87      distance (global float)
+0:87      degrees (global 2-component vector of float)
 0:87        'inF0' (in 2-component vector of float)
-0:87        'inF1' (in 2-component vector of float)
-0:88      dot-product (global float)
+0:88      distance (global float)
 0:88        'inF0' (in 2-component vector of float)
 0:88        'inF1' (in 2-component vector of float)
-0:92      exp (global 2-component vector of float)
-0:92        'inF0' (in 2-component vector of float)
-0:93      exp2 (global 2-component vector of float)
+0:89      dot-product (global float)
+0:89        'inF0' (in 2-component vector of float)
+0:89        'inF1' (in 2-component vector of float)
+0:93      exp (global 2-component vector of float)
 0:93        'inF0' (in 2-component vector of float)
-0:94      face-forward (global 2-component vector of float)
+0:94      exp2 (global 2-component vector of float)
 0:94        'inF0' (in 2-component vector of float)
-0:94        'inF1' (in 2-component vector of float)
-0:94        'inF2' (in 2-component vector of float)
-0:95      findMSB (global int)
-0:95        Constant:
-0:95          7 (const int)
-0:96      findLSB (global int)
+0:95      face-forward (global 2-component vector of float)
+0:95        'inF0' (in 2-component vector of float)
+0:95        'inF1' (in 2-component vector of float)
+0:95        'inF2' (in 2-component vector of float)
+0:96      findMSB (global int)
 0:96        Constant:
 0:96          7 (const int)
-0:97      Floor (global 2-component vector of float)
-0:97        'inF0' (in 2-component vector of float)
-0:99      mod (global 2-component vector of float)
-0:99        'inF0' (in 2-component vector of float)
-0:99        'inF1' (in 2-component vector of float)
-0:100      Fraction (global 2-component vector of float)
+0:97      findLSB (global int)
+0:97        Constant:
+0:97          7 (const int)
+0:98      Floor (global 2-component vector of float)
+0:98        'inF0' (in 2-component vector of float)
+0:100      mod (global 2-component vector of float)
 0:100        'inF0' (in 2-component vector of float)
-0:101      frexp (global 2-component vector of float)
+0:100        'inF1' (in 2-component vector of float)
+0:101      Fraction (global 2-component vector of float)
 0:101        'inF0' (in 2-component vector of float)
-0:101        'inF1' (in 2-component vector of float)
-0:102      isinf (global 2-component vector of bool)
+0:102      frexp (global 2-component vector of float)
 0:102        'inF0' (in 2-component vector of float)
-0:103      isnan (global 2-component vector of bool)
+0:102        'inF1' (in 2-component vector of float)
+0:103      isinf (global 2-component vector of bool)
 0:103        'inF0' (in 2-component vector of float)
-0:104      ldexp (global 2-component vector of float)
+0:104      isnan (global 2-component vector of bool)
 0:104        'inF0' (in 2-component vector of float)
-0:104        'inF1' (in 2-component vector of float)
-0:105      length (global float)
+0:105      ldexp (global 2-component vector of float)
 0:105        'inF0' (in 2-component vector of float)
-0:106      log (global 2-component vector of float)
+0:105        'inF1' (in 2-component vector of float)
+0:106      mix (global 2-component vector of float)
 0:106        'inF0' (in 2-component vector of float)
-0:107      vector-scale (temp 2-component vector of float)
-0:107        log2 (temp 2-component vector of float)
-0:107          'inF0' (in 2-component vector of float)
-0:107        Constant:
-0:107          0.301030
-0:108      log2 (global 2-component vector of float)
+0:106        'inF1' (in 2-component vector of float)
+0:106        'inF2' (in 2-component vector of float)
+0:107      length (global float)
+0:107        'inF0' (in 2-component vector of float)
+0:108      log (global 2-component vector of float)
 0:108        'inF0' (in 2-component vector of float)
-0:109      max (global 2-component vector of float)
-0:109        'inF0' (in 2-component vector of float)
-0:109        'inF1' (in 2-component vector of float)
-0:110      min (global 2-component vector of float)
+0:109      vector-scale (temp 2-component vector of float)
+0:109        log2 (temp 2-component vector of float)
+0:109          'inF0' (in 2-component vector of float)
+0:109        Constant:
+0:109          0.301030
+0:110      log2 (global 2-component vector of float)
 0:110        'inF0' (in 2-component vector of float)
-0:110        'inF1' (in 2-component vector of float)
-0:112      normalize (global 2-component vector of float)
+0:111      max (global 2-component vector of float)
+0:111        'inF0' (in 2-component vector of float)
+0:111        'inF1' (in 2-component vector of float)
+0:112      min (global 2-component vector of float)
 0:112        'inF0' (in 2-component vector of float)
-0:113      pow (global 2-component vector of float)
-0:113        'inF0' (in 2-component vector of float)
-0:113        'inF1' (in 2-component vector of float)
-0:114      radians (global 2-component vector of float)
+0:112        'inF1' (in 2-component vector of float)
+0:114      normalize (global 2-component vector of float)
 0:114        'inF0' (in 2-component vector of float)
-0:115      reflect (global 2-component vector of float)
+0:115      pow (global 2-component vector of float)
 0:115        'inF0' (in 2-component vector of float)
 0:115        'inF1' (in 2-component vector of float)
-0:116      refract (global 2-component vector of float)
+0:116      radians (global 2-component vector of float)
 0:116        'inF0' (in 2-component vector of float)
-0:116        'inF1' (in 2-component vector of float)
-0:116        Constant:
-0:116          2.000000
+0:117      reflect (global 2-component vector of float)
+0:117        'inF0' (in 2-component vector of float)
+0:117        'inF1' (in 2-component vector of float)
+0:118      refract (global 2-component vector of float)
+0:118        'inF0' (in 2-component vector of float)
+0:118        'inF1' (in 2-component vector of float)
+0:118        Constant:
+0:118          2.000000
 0:?       bitFieldReverse (global 2-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
-0:118      roundEven (global 2-component vector of float)
-0:118        'inF0' (in 2-component vector of float)
-0:119      inverse sqrt (global 2-component vector of float)
-0:119        'inF0' (in 2-component vector of float)
-0:120      clamp (temp 2-component vector of float)
+0:120      roundEven (global 2-component vector of float)
 0:120        'inF0' (in 2-component vector of float)
-0:120        Constant:
-0:120          0.000000
-0:120        Constant:
-0:120          1.000000
-0:121      Sign (global 2-component vector of float)
+0:121      inverse sqrt (global 2-component vector of float)
 0:121        'inF0' (in 2-component vector of float)
-0:122      sine (global 2-component vector of float)
+0:122      clamp (temp 2-component vector of float)
 0:122        'inF0' (in 2-component vector of float)
-0:123      Sequence
-0:123        move second child to first child (temp 2-component vector of float)
-0:123          'inF1' (in 2-component vector of float)
-0:123          sine (temp 2-component vector of float)
-0:123            'inF0' (in 2-component vector of float)
-0:123        move second child to first child (temp 2-component vector of float)
-0:123          'inF2' (in 2-component vector of float)
-0:123          cosine (temp 2-component vector of float)
-0:123            'inF0' (in 2-component vector of float)
-0:124      hyp. sine (global 2-component vector of float)
+0:122        Constant:
+0:122          0.000000
+0:122        Constant:
+0:122          1.000000
+0:123      Sign (global 2-component vector of float)
+0:123        'inF0' (in 2-component vector of float)
+0:124      sine (global 2-component vector of float)
 0:124        'inF0' (in 2-component vector of float)
-0:125      smoothstep (global 2-component vector of float)
-0:125        'inF0' (in 2-component vector of float)
-0:125        'inF1' (in 2-component vector of float)
-0:125        'inF2' (in 2-component vector of float)
-0:126      sqrt (global 2-component vector of float)
+0:125      Sequence
+0:125        move second child to first child (temp 2-component vector of float)
+0:125          'inF1' (in 2-component vector of float)
+0:125          sine (temp 2-component vector of float)
+0:125            'inF0' (in 2-component vector of float)
+0:125        move second child to first child (temp 2-component vector of float)
+0:125          'inF2' (in 2-component vector of float)
+0:125          cosine (temp 2-component vector of float)
+0:125            'inF0' (in 2-component vector of float)
+0:126      hyp. sine (global 2-component vector of float)
 0:126        'inF0' (in 2-component vector of float)
-0:127      step (global 2-component vector of float)
+0:127      smoothstep (global 2-component vector of float)
 0:127        'inF0' (in 2-component vector of float)
 0:127        'inF1' (in 2-component vector of float)
-0:128      tangent (global 2-component vector of float)
+0:127        'inF2' (in 2-component vector of float)
+0:128      sqrt (global 2-component vector of float)
 0:128        'inF0' (in 2-component vector of float)
-0:129      hyp. tangent (global 2-component vector of float)
+0:129      step (global 2-component vector of float)
 0:129        'inF0' (in 2-component vector of float)
-0:131      trunc (global 2-component vector of float)
+0:129        'inF1' (in 2-component vector of float)
+0:130      tangent (global 2-component vector of float)
+0:130        'inF0' (in 2-component vector of float)
+0:131      hyp. tangent (global 2-component vector of float)
 0:131        'inF0' (in 2-component vector of float)
-0:134      Branch: Return with expression
+0:133      trunc (global 2-component vector of float)
+0:133        'inF0' (in 2-component vector of float)
+0:136      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
-0:207  Function Definition: VertexShaderFunction(vf3;vf3;vf3;vu3;vu3; (temp 3-component vector of float)
-0:138    Function Parameters: 
-0:138      'inF0' (in 3-component vector of float)
-0:138      'inF1' (in 3-component vector of float)
-0:138      'inF2' (in 3-component vector of float)
-0:138      'inU0' (in 3-component vector of uint)
-0:138      'inU1' (in 3-component vector of uint)
+0:210  Function Definition: VertexShaderFunction(vf3;vf3;vf3;vu3;vu3; (temp 3-component vector of float)
+0:140    Function Parameters: 
+0:140      'inF0' (in 3-component vector of float)
+0:140      'inF1' (in 3-component vector of float)
+0:140      'inF2' (in 3-component vector of float)
+0:140      'inU0' (in 3-component vector of uint)
+0:140      'inU1' (in 3-component vector of uint)
 0:?     Sequence
-0:139      all (global bool)
-0:139        'inF0' (in 3-component vector of float)
-0:140      Absolute value (global 3-component vector of float)
-0:140        'inF0' (in 3-component vector of float)
-0:141      arc cosine (global 3-component vector of float)
+0:141      all (global bool)
 0:141        'inF0' (in 3-component vector of float)
-0:142      any (global bool)
+0:142      Absolute value (global 3-component vector of float)
 0:142        'inF0' (in 3-component vector of float)
-0:143      arc sine (global 3-component vector of float)
+0:143      arc cosine (global 3-component vector of float)
 0:143        'inF0' (in 3-component vector of float)
-0:144      floatBitsToInt (global 3-component vector of int)
+0:144      any (global bool)
 0:144        'inF0' (in 3-component vector of float)
-0:145      floatBitsToUint (global 3-component vector of uint)
+0:145      arc sine (global 3-component vector of float)
 0:145        'inF0' (in 3-component vector of float)
-0:146      intBitsToFloat (global 3-component vector of float)
-0:146        'inU0' (in 3-component vector of uint)
-0:148      arc tangent (global 3-component vector of float)
-0:148        'inF0' (in 3-component vector of float)
-0:149      arc tangent (global 3-component vector of float)
-0:149        'inF0' (in 3-component vector of float)
-0:149        'inF1' (in 3-component vector of float)
-0:150      Ceiling (global 3-component vector of float)
+0:146      floatBitsToInt (global 3-component vector of int)
+0:146        'inF0' (in 3-component vector of float)
+0:147      floatBitsToUint (global 3-component vector of uint)
+0:147        'inF0' (in 3-component vector of float)
+0:148      intBitsToFloat (global 3-component vector of float)
+0:148        'inU0' (in 3-component vector of uint)
+0:150      arc tangent (global 3-component vector of float)
 0:150        'inF0' (in 3-component vector of float)
-0:151      clamp (global 3-component vector of float)
+0:151      arc tangent (global 3-component vector of float)
 0:151        'inF0' (in 3-component vector of float)
 0:151        'inF1' (in 3-component vector of float)
-0:151        'inF2' (in 3-component vector of float)
-0:152      cosine (global 3-component vector of float)
+0:152      Ceiling (global 3-component vector of float)
 0:152        'inF0' (in 3-component vector of float)
-0:153      hyp. cosine (global 3-component vector of float)
+0:153      clamp (global 3-component vector of float)
 0:153        'inF0' (in 3-component vector of float)
+0:153        'inF1' (in 3-component vector of float)
+0:153        'inF2' (in 3-component vector of float)
+0:154      cosine (global 3-component vector of float)
+0:154        'inF0' (in 3-component vector of float)
+0:155      hyp. cosine (global 3-component vector of float)
+0:155        'inF0' (in 3-component vector of float)
 0:?       bitCount (global 3-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
-0:155      cross-product (global 3-component vector of float)
-0:155        'inF0' (in 3-component vector of float)
-0:155        'inF1' (in 3-component vector of float)
-0:156      degrees (global 3-component vector of float)
-0:156        'inF0' (in 3-component vector of float)
-0:157      distance (global float)
+0:157      cross-product (global 3-component vector of float)
 0:157        'inF0' (in 3-component vector of float)
 0:157        'inF1' (in 3-component vector of float)
-0:158      dot-product (global float)
+0:158      degrees (global 3-component vector of float)
 0:158        'inF0' (in 3-component vector of float)
-0:158        'inF1' (in 3-component vector of float)
-0:162      exp (global 3-component vector of float)
-0:162        'inF0' (in 3-component vector of float)
-0:163      exp2 (global 3-component vector of float)
-0:163        'inF0' (in 3-component vector of float)
-0:164      face-forward (global 3-component vector of float)
+0:159      distance (global float)
+0:159        'inF0' (in 3-component vector of float)
+0:159        'inF1' (in 3-component vector of float)
+0:160      dot-product (global float)
+0:160        'inF0' (in 3-component vector of float)
+0:160        'inF1' (in 3-component vector of float)
+0:164      exp (global 3-component vector of float)
 0:164        'inF0' (in 3-component vector of float)
-0:164        'inF1' (in 3-component vector of float)
-0:164        'inF2' (in 3-component vector of float)
-0:165      findMSB (global int)
-0:165        Constant:
-0:165          7 (const int)
-0:166      findLSB (global int)
-0:166        Constant:
-0:166          7 (const int)
-0:167      Floor (global 3-component vector of float)
-0:167        'inF0' (in 3-component vector of float)
-0:169      mod (global 3-component vector of float)
+0:165      exp2 (global 3-component vector of float)
+0:165        'inF0' (in 3-component vector of float)
+0:166      face-forward (global 3-component vector of float)
+0:166        'inF0' (in 3-component vector of float)
+0:166        'inF1' (in 3-component vector of float)
+0:166        'inF2' (in 3-component vector of float)
+0:167      findMSB (global int)
+0:167        Constant:
+0:167          7 (const int)
+0:168      findLSB (global int)
+0:168        Constant:
+0:168          7 (const int)
+0:169      Floor (global 3-component vector of float)
 0:169        'inF0' (in 3-component vector of float)
-0:169        'inF1' (in 3-component vector of float)
-0:170      Fraction (global 3-component vector of float)
-0:170        'inF0' (in 3-component vector of float)
-0:171      frexp (global 3-component vector of float)
+0:171      mod (global 3-component vector of float)
 0:171        'inF0' (in 3-component vector of float)
 0:171        'inF1' (in 3-component vector of float)
-0:172      isinf (global 3-component vector of bool)
+0:172      Fraction (global 3-component vector of float)
 0:172        'inF0' (in 3-component vector of float)
-0:173      isnan (global 3-component vector of bool)
+0:173      frexp (global 3-component vector of float)
 0:173        'inF0' (in 3-component vector of float)
-0:174      ldexp (global 3-component vector of float)
+0:173        'inF1' (in 3-component vector of float)
+0:174      isinf (global 3-component vector of bool)
 0:174        'inF0' (in 3-component vector of float)
-0:174        'inF1' (in 3-component vector of float)
-0:175      length (global float)
+0:175      isnan (global 3-component vector of bool)
 0:175        'inF0' (in 3-component vector of float)
-0:176      log (global 3-component vector of float)
+0:176      ldexp (global 3-component vector of float)
 0:176        'inF0' (in 3-component vector of float)
-0:177      vector-scale (temp 3-component vector of float)
-0:177        log2 (temp 3-component vector of float)
-0:177          'inF0' (in 3-component vector of float)
-0:177        Constant:
-0:177          0.301030
-0:178      log2 (global 3-component vector of float)
+0:176        'inF1' (in 3-component vector of float)
+0:177      mix (global 3-component vector of float)
+0:177        'inF0' (in 3-component vector of float)
+0:177        'inF1' (in 3-component vector of float)
+0:177        'inF2' (in 3-component vector of float)
+0:178      length (global float)
 0:178        'inF0' (in 3-component vector of float)
-0:179      max (global 3-component vector of float)
+0:179      log (global 3-component vector of float)
 0:179        'inF0' (in 3-component vector of float)
-0:179        'inF1' (in 3-component vector of float)
-0:180      min (global 3-component vector of float)
-0:180        'inF0' (in 3-component vector of float)
-0:180        'inF1' (in 3-component vector of float)
-0:182      normalize (global 3-component vector of float)
+0:180      vector-scale (temp 3-component vector of float)
+0:180        log2 (temp 3-component vector of float)
+0:180          'inF0' (in 3-component vector of float)
+0:180        Constant:
+0:180          0.301030
+0:181      log2 (global 3-component vector of float)
+0:181        'inF0' (in 3-component vector of float)
+0:182      max (global 3-component vector of float)
 0:182        'inF0' (in 3-component vector of float)
-0:183      pow (global 3-component vector of float)
+0:182        'inF1' (in 3-component vector of float)
+0:183      min (global 3-component vector of float)
 0:183        'inF0' (in 3-component vector of float)
 0:183        'inF1' (in 3-component vector of float)
-0:184      radians (global 3-component vector of float)
-0:184        'inF0' (in 3-component vector of float)
-0:185      reflect (global 3-component vector of float)
+0:185      normalize (global 3-component vector of float)
 0:185        'inF0' (in 3-component vector of float)
-0:185        'inF1' (in 3-component vector of float)
-0:186      refract (global 3-component vector of float)
+0:186      pow (global 3-component vector of float)
 0:186        'inF0' (in 3-component vector of float)
 0:186        'inF1' (in 3-component vector of float)
-0:186        Constant:
-0:186          2.000000
+0:187      radians (global 3-component vector of float)
+0:187        'inF0' (in 3-component vector of float)
+0:188      reflect (global 3-component vector of float)
+0:188        'inF0' (in 3-component vector of float)
+0:188        'inF1' (in 3-component vector of float)
+0:189      refract (global 3-component vector of float)
+0:189        'inF0' (in 3-component vector of float)
+0:189        'inF1' (in 3-component vector of float)
+0:189        Constant:
+0:189          2.000000
 0:?       bitFieldReverse (global 3-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
-0:188      roundEven (global 3-component vector of float)
-0:188        'inF0' (in 3-component vector of float)
-0:189      inverse sqrt (global 3-component vector of float)
-0:189        'inF0' (in 3-component vector of float)
-0:190      clamp (temp 3-component vector of float)
-0:190        'inF0' (in 3-component vector of float)
-0:190        Constant:
-0:190          0.000000
-0:190        Constant:
-0:190          1.000000
-0:191      Sign (global 3-component vector of float)
+0:191      roundEven (global 3-component vector of float)
 0:191        'inF0' (in 3-component vector of float)
-0:192      sine (global 3-component vector of float)
+0:192      inverse sqrt (global 3-component vector of float)
 0:192        'inF0' (in 3-component vector of float)
-0:193      Sequence
-0:193        move second child to first child (temp 3-component vector of float)
-0:193          'inF1' (in 3-component vector of float)
-0:193          sine (temp 3-component vector of float)
-0:193            'inF0' (in 3-component vector of float)
-0:193        move second child to first child (temp 3-component vector of float)
-0:193          'inF2' (in 3-component vector of float)
-0:193          cosine (temp 3-component vector of float)
-0:193            'inF0' (in 3-component vector of float)
-0:194      hyp. sine (global 3-component vector of float)
+0:193      clamp (temp 3-component vector of float)
+0:193        'inF0' (in 3-component vector of float)
+0:193        Constant:
+0:193          0.000000
+0:193        Constant:
+0:193          1.000000
+0:194      Sign (global 3-component vector of float)
 0:194        'inF0' (in 3-component vector of float)
-0:195      smoothstep (global 3-component vector of float)
+0:195      sine (global 3-component vector of float)
 0:195        'inF0' (in 3-component vector of float)
-0:195        'inF1' (in 3-component vector of float)
-0:195        'inF2' (in 3-component vector of float)
-0:196      sqrt (global 3-component vector of float)
-0:196        'inF0' (in 3-component vector of float)
-0:197      step (global 3-component vector of float)
+0:196      Sequence
+0:196        move second child to first child (temp 3-component vector of float)
+0:196          'inF1' (in 3-component vector of float)
+0:196          sine (temp 3-component vector of float)
+0:196            'inF0' (in 3-component vector of float)
+0:196        move second child to first child (temp 3-component vector of float)
+0:196          'inF2' (in 3-component vector of float)
+0:196          cosine (temp 3-component vector of float)
+0:196            'inF0' (in 3-component vector of float)
+0:197      hyp. sine (global 3-component vector of float)
 0:197        'inF0' (in 3-component vector of float)
-0:197        'inF1' (in 3-component vector of float)
-0:198      tangent (global 3-component vector of float)
+0:198      smoothstep (global 3-component vector of float)
 0:198        'inF0' (in 3-component vector of float)
-0:199      hyp. tangent (global 3-component vector of float)
+0:198        'inF1' (in 3-component vector of float)
+0:198        'inF2' (in 3-component vector of float)
+0:199      sqrt (global 3-component vector of float)
 0:199        'inF0' (in 3-component vector of float)
-0:201      trunc (global 3-component vector of float)
+0:200      step (global 3-component vector of float)
+0:200        'inF0' (in 3-component vector of float)
+0:200        'inF1' (in 3-component vector of float)
+0:201      tangent (global 3-component vector of float)
 0:201        'inF0' (in 3-component vector of float)
-0:204      Branch: Return with expression
+0:202      hyp. tangent (global 3-component vector of float)
+0:202        'inF0' (in 3-component vector of float)
+0:204      trunc (global 3-component vector of float)
+0:204        'inF0' (in 3-component vector of float)
+0:207      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
-0:330  Function Definition: VertexShaderFunction(vf4;vf4;vf4;vu4;vu4; (temp 4-component vector of float)
-0:208    Function Parameters: 
-0:208      'inF0' (in 4-component vector of float)
-0:208      'inF1' (in 4-component vector of float)
-0:208      'inF2' (in 4-component vector of float)
-0:208      'inU0' (in 4-component vector of uint)
-0:208      'inU1' (in 4-component vector of uint)
+0:335  Function Definition: VertexShaderFunction(vf4;vf4;vf4;vu4;vu4; (temp 4-component vector of float)
+0:211    Function Parameters: 
+0:211      'inF0' (in 4-component vector of float)
+0:211      'inF1' (in 4-component vector of float)
+0:211      'inF2' (in 4-component vector of float)
+0:211      'inU0' (in 4-component vector of uint)
+0:211      'inU1' (in 4-component vector of uint)
 0:?     Sequence
-0:209      all (global bool)
-0:209        'inF0' (in 4-component vector of float)
-0:210      Absolute value (global 4-component vector of float)
-0:210        'inF0' (in 4-component vector of float)
-0:211      arc cosine (global 4-component vector of float)
-0:211        'inF0' (in 4-component vector of float)
-0:212      any (global bool)
+0:212      all (global bool)
 0:212        'inF0' (in 4-component vector of float)
-0:213      arc sine (global 4-component vector of float)
+0:213      Absolute value (global 4-component vector of float)
 0:213        'inF0' (in 4-component vector of float)
-0:214      floatBitsToInt (global 4-component vector of int)
+0:214      arc cosine (global 4-component vector of float)
 0:214        'inF0' (in 4-component vector of float)
-0:215      floatBitsToUint (global 4-component vector of uint)
+0:215      any (global bool)
 0:215        'inF0' (in 4-component vector of float)
-0:216      intBitsToFloat (global 4-component vector of float)
-0:216        'inU0' (in 4-component vector of uint)
-0:218      arc tangent (global 4-component vector of float)
+0:216      arc sine (global 4-component vector of float)
+0:216        'inF0' (in 4-component vector of float)
+0:217      floatBitsToInt (global 4-component vector of int)
+0:217        'inF0' (in 4-component vector of float)
+0:218      floatBitsToUint (global 4-component vector of uint)
 0:218        'inF0' (in 4-component vector of float)
-0:219      arc tangent (global 4-component vector of float)
-0:219        'inF0' (in 4-component vector of float)
-0:219        'inF1' (in 4-component vector of float)
-0:220      Ceiling (global 4-component vector of float)
-0:220        'inF0' (in 4-component vector of float)
-0:221      clamp (global 4-component vector of float)
+0:219      intBitsToFloat (global 4-component vector of float)
+0:219        'inU0' (in 4-component vector of uint)
+0:221      arc tangent (global 4-component vector of float)
 0:221        'inF0' (in 4-component vector of float)
-0:221        'inF1' (in 4-component vector of float)
-0:221        'inF2' (in 4-component vector of float)
-0:222      cosine (global 4-component vector of float)
+0:222      arc tangent (global 4-component vector of float)
 0:222        'inF0' (in 4-component vector of float)
-0:223      hyp. cosine (global 4-component vector of float)
+0:222        'inF1' (in 4-component vector of float)
+0:223      Ceiling (global 4-component vector of float)
 0:223        'inF0' (in 4-component vector of float)
+0:224      clamp (global 4-component vector of float)
+0:224        'inF0' (in 4-component vector of float)
+0:224        'inF1' (in 4-component vector of float)
+0:224        'inF2' (in 4-component vector of float)
+0:225      cosine (global 4-component vector of float)
+0:225        'inF0' (in 4-component vector of float)
+0:226      hyp. cosine (global 4-component vector of float)
+0:226        'inF0' (in 4-component vector of float)
 0:?       bitCount (global 4-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
 0:?           2 (const uint)
-0:225      degrees (global 4-component vector of float)
-0:225        'inF0' (in 4-component vector of float)
-0:226      distance (global float)
-0:226        'inF0' (in 4-component vector of float)
-0:226        'inF1' (in 4-component vector of float)
-0:227      dot-product (global float)
-0:227        'inF0' (in 4-component vector of float)
-0:227        'inF1' (in 4-component vector of float)
-0:228      Construct vec4 (temp 4-component vector of float)
-0:228        Constant:
-0:228          1.000000
-0:228        component-wise multiply (temp float)
-0:228          direct index (temp float)
-0:228            'inF0' (in 4-component vector of float)
-0:228            Constant:
-0:228              1 (const int)
-0:228          direct index (temp float)
-0:228            'inF1' (in 4-component vector of float)
-0:228            Constant:
-0:228              1 (const int)
-0:228        direct index (temp float)
-0:228          'inF0' (in 4-component vector of float)
-0:228          Constant:
-0:228            2 (const int)
-0:228        direct index (temp float)
-0:228          'inF1' (in 4-component vector of float)
-0:228          Constant:
-0:228            3 (const int)
-0:232      exp (global 4-component vector of float)
-0:232        'inF0' (in 4-component vector of float)
-0:233      exp2 (global 4-component vector of float)
-0:233        'inF0' (in 4-component vector of float)
-0:234      face-forward (global 4-component vector of float)
-0:234        'inF0' (in 4-component vector of float)
-0:234        'inF1' (in 4-component vector of float)
-0:234        'inF2' (in 4-component vector of float)
-0:235      findMSB (global int)
-0:235        Constant:
-0:235          7 (const int)
-0:236      findLSB (global int)
-0:236        Constant:
-0:236          7 (const int)
-0:237      Floor (global 4-component vector of float)
+0:228      degrees (global 4-component vector of float)
+0:228        'inF0' (in 4-component vector of float)
+0:229      distance (global float)
+0:229        'inF0' (in 4-component vector of float)
+0:229        'inF1' (in 4-component vector of float)
+0:230      dot-product (global float)
+0:230        'inF0' (in 4-component vector of float)
+0:230        'inF1' (in 4-component vector of float)
+0:231      Construct vec4 (temp 4-component vector of float)
+0:231        Constant:
+0:231          1.000000
+0:231        component-wise multiply (temp float)
+0:231          direct index (temp float)
+0:231            'inF0' (in 4-component vector of float)
+0:231            Constant:
+0:231              1 (const int)
+0:231          direct index (temp float)
+0:231            'inF1' (in 4-component vector of float)
+0:231            Constant:
+0:231              1 (const int)
+0:231        direct index (temp float)
+0:231          'inF0' (in 4-component vector of float)
+0:231          Constant:
+0:231            2 (const int)
+0:231        direct index (temp float)
+0:231          'inF1' (in 4-component vector of float)
+0:231          Constant:
+0:231            3 (const int)
+0:235      exp (global 4-component vector of float)
+0:235        'inF0' (in 4-component vector of float)
+0:236      exp2 (global 4-component vector of float)
+0:236        'inF0' (in 4-component vector of float)
+0:237      face-forward (global 4-component vector of float)
 0:237        'inF0' (in 4-component vector of float)
-0:239      mod (global 4-component vector of float)
-0:239        'inF0' (in 4-component vector of float)
-0:239        'inF1' (in 4-component vector of float)
-0:240      Fraction (global 4-component vector of float)
+0:237        'inF1' (in 4-component vector of float)
+0:237        'inF2' (in 4-component vector of float)
+0:238      findMSB (global int)
+0:238        Constant:
+0:238          7 (const int)
+0:239      findLSB (global int)
+0:239        Constant:
+0:239          7 (const int)
+0:240      Floor (global 4-component vector of float)
 0:240        'inF0' (in 4-component vector of float)
-0:241      frexp (global 4-component vector of float)
-0:241        'inF0' (in 4-component vector of float)
-0:241        'inF1' (in 4-component vector of float)
-0:242      isinf (global 4-component vector of bool)
+0:242      mod (global 4-component vector of float)
 0:242        'inF0' (in 4-component vector of float)
-0:243      isnan (global 4-component vector of bool)
+0:242        'inF1' (in 4-component vector of float)
+0:243      Fraction (global 4-component vector of float)
 0:243        'inF0' (in 4-component vector of float)
-0:244      ldexp (global 4-component vector of float)
+0:244      frexp (global 4-component vector of float)
 0:244        'inF0' (in 4-component vector of float)
 0:244        'inF1' (in 4-component vector of float)
-0:245      length (global float)
+0:245      isinf (global 4-component vector of bool)
 0:245        'inF0' (in 4-component vector of float)
-0:246      log (global 4-component vector of float)
+0:246      isnan (global 4-component vector of bool)
 0:246        'inF0' (in 4-component vector of float)
-0:247      vector-scale (temp 4-component vector of float)
-0:247        log2 (temp 4-component vector of float)
-0:247          'inF0' (in 4-component vector of float)
-0:247        Constant:
-0:247          0.301030
-0:248      log2 (global 4-component vector of float)
+0:247      ldexp (global 4-component vector of float)
+0:247        'inF0' (in 4-component vector of float)
+0:247        'inF1' (in 4-component vector of float)
+0:248      mix (global 4-component vector of float)
 0:248        'inF0' (in 4-component vector of float)
-0:249      max (global 4-component vector of float)
+0:248        'inF1' (in 4-component vector of float)
+0:248        'inF2' (in 4-component vector of float)
+0:249      length (global float)
 0:249        'inF0' (in 4-component vector of float)
-0:249        'inF1' (in 4-component vector of float)
-0:250      min (global 4-component vector of float)
+0:250      log (global 4-component vector of float)
 0:250        'inF0' (in 4-component vector of float)
-0:250        'inF1' (in 4-component vector of float)
-0:252      normalize (global 4-component vector of float)
+0:251      vector-scale (temp 4-component vector of float)
+0:251        log2 (temp 4-component vector of float)
+0:251          'inF0' (in 4-component vector of float)
+0:251        Constant:
+0:251          0.301030
+0:252      log2 (global 4-component vector of float)
 0:252        'inF0' (in 4-component vector of float)
-0:253      pow (global 4-component vector of float)
+0:253      max (global 4-component vector of float)
 0:253        'inF0' (in 4-component vector of float)
 0:253        'inF1' (in 4-component vector of float)
-0:254      radians (global 4-component vector of float)
+0:254      min (global 4-component vector of float)
 0:254        'inF0' (in 4-component vector of float)
-0:255      reflect (global 4-component vector of float)
-0:255        'inF0' (in 4-component vector of float)
-0:255        'inF1' (in 4-component vector of float)
-0:256      refract (global 4-component vector of float)
+0:254        'inF1' (in 4-component vector of float)
+0:256      normalize (global 4-component vector of float)
 0:256        'inF0' (in 4-component vector of float)
-0:256        'inF1' (in 4-component vector of float)
-0:256        Constant:
-0:256          2.000000
+0:257      pow (global 4-component vector of float)
+0:257        'inF0' (in 4-component vector of float)
+0:257        'inF1' (in 4-component vector of float)
+0:258      radians (global 4-component vector of float)
+0:258        'inF0' (in 4-component vector of float)
+0:259      reflect (global 4-component vector of float)
+0:259        'inF0' (in 4-component vector of float)
+0:259        'inF1' (in 4-component vector of float)
+0:260      refract (global 4-component vector of float)
+0:260        'inF0' (in 4-component vector of float)
+0:260        'inF1' (in 4-component vector of float)
+0:260        Constant:
+0:260          2.000000
 0:?       bitFieldReverse (global 4-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
 0:?           4 (const uint)
-0:258      roundEven (global 4-component vector of float)
-0:258        'inF0' (in 4-component vector of float)
-0:259      inverse sqrt (global 4-component vector of float)
-0:259        'inF0' (in 4-component vector of float)
-0:260      clamp (temp 4-component vector of float)
-0:260        'inF0' (in 4-component vector of float)
-0:260        Constant:
-0:260          0.000000
-0:260        Constant:
-0:260          1.000000
-0:261      Sign (global 4-component vector of float)
-0:261        'inF0' (in 4-component vector of float)
-0:262      sine (global 4-component vector of float)
+0:262      roundEven (global 4-component vector of float)
 0:262        'inF0' (in 4-component vector of float)
-0:263      Sequence
-0:263        move second child to first child (temp 4-component vector of float)
-0:263          'inF1' (in 4-component vector of float)
-0:263          sine (temp 4-component vector of float)
-0:263            'inF0' (in 4-component vector of float)
-0:263        move second child to first child (temp 4-component vector of float)
-0:263          'inF2' (in 4-component vector of float)
-0:263          cosine (temp 4-component vector of float)
-0:263            'inF0' (in 4-component vector of float)
-0:264      hyp. sine (global 4-component vector of float)
+0:263      inverse sqrt (global 4-component vector of float)
+0:263        'inF0' (in 4-component vector of float)
+0:264      clamp (temp 4-component vector of float)
 0:264        'inF0' (in 4-component vector of float)
-0:265      smoothstep (global 4-component vector of float)
+0:264        Constant:
+0:264          0.000000
+0:264        Constant:
+0:264          1.000000
+0:265      Sign (global 4-component vector of float)
 0:265        'inF0' (in 4-component vector of float)
-0:265        'inF1' (in 4-component vector of float)
-0:265        'inF2' (in 4-component vector of float)
-0:266      sqrt (global 4-component vector of float)
+0:266      sine (global 4-component vector of float)
 0:266        'inF0' (in 4-component vector of float)
-0:267      step (global 4-component vector of float)
-0:267        'inF0' (in 4-component vector of float)
-0:267        'inF1' (in 4-component vector of float)
-0:268      tangent (global 4-component vector of float)
+0:267      Sequence
+0:267        move second child to first child (temp 4-component vector of float)
+0:267          'inF1' (in 4-component vector of float)
+0:267          sine (temp 4-component vector of float)
+0:267            'inF0' (in 4-component vector of float)
+0:267        move second child to first child (temp 4-component vector of float)
+0:267          'inF2' (in 4-component vector of float)
+0:267          cosine (temp 4-component vector of float)
+0:267            'inF0' (in 4-component vector of float)
+0:268      hyp. sine (global 4-component vector of float)
 0:268        'inF0' (in 4-component vector of float)
-0:269      hyp. tangent (global 4-component vector of float)
+0:269      smoothstep (global 4-component vector of float)
 0:269        'inF0' (in 4-component vector of float)
-0:271      trunc (global 4-component vector of float)
+0:269        'inF1' (in 4-component vector of float)
+0:269        'inF2' (in 4-component vector of float)
+0:270      sqrt (global 4-component vector of float)
+0:270        'inF0' (in 4-component vector of float)
+0:271      step (global 4-component vector of float)
 0:271        'inF0' (in 4-component vector of float)
-0:274      Branch: Return with expression
+0:271        'inF1' (in 4-component vector of float)
+0:272      tangent (global 4-component vector of float)
+0:272        'inF0' (in 4-component vector of float)
+0:273      hyp. tangent (global 4-component vector of float)
+0:273        'inF0' (in 4-component vector of float)
+0:275      trunc (global 4-component vector of float)
+0:275        'inF0' (in 4-component vector of float)
+0:278      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
 0:?           4.000000
-0:339  Function Definition: VertexShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
-0:331    Function Parameters: 
-0:331      'inF0' (in 2X2 matrix of float)
-0:331      'inF1' (in 2X2 matrix of float)
-0:331      'inF2' (in 2X2 matrix of float)
+0:344  Function Definition: VertexShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:336    Function Parameters: 
+0:336      'inF0' (in 2X2 matrix of float)
+0:336      'inF1' (in 2X2 matrix of float)
+0:336      'inF2' (in 2X2 matrix of float)
 0:?     Sequence
-0:333      all (global bool)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      Absolute value (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      arc cosine (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      any (global bool)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      arc sine (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      arc tangent (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      arc tangent (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      Ceiling (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      clamp (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333        'inF2' (in 2X2 matrix of float)
-0:333      cosine (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      hyp. cosine (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      degrees (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      determinant (global float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      exp (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      exp2 (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      findMSB (global int)
-0:333        Constant:
-0:333          7 (const int)
-0:333      findLSB (global int)
-0:333        Constant:
-0:333          7 (const int)
-0:333      Floor (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      mod (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      Fraction (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      frexp (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      ldexp (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      log (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      matrix-scale (temp 2X2 matrix of float)
-0:333        log2 (temp 2X2 matrix of float)
-0:333          'inF0' (in 2X2 matrix of float)
-0:333        Constant:
-0:333          0.301030
-0:333      log2 (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      max (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      min (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      pow (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      radians (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      roundEven (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      inverse sqrt (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      clamp (temp 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        Constant:
-0:333          0.000000
-0:333        Constant:
-0:333          1.000000
-0:333      Sign (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      sine (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      Sequence
-0:333        move second child to first child (temp 2X2 matrix of float)
-0:333          'inF1' (in 2X2 matrix of float)
-0:333          sine (temp 2X2 matrix of float)
-0:333            'inF0' (in 2X2 matrix of float)
-0:333        move second child to first child (temp 2X2 matrix of float)
-0:333          'inF2' (in 2X2 matrix of float)
-0:333          cosine (temp 2X2 matrix of float)
-0:333            'inF0' (in 2X2 matrix of float)
-0:333      hyp. sine (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      smoothstep (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333        'inF2' (in 2X2 matrix of float)
-0:333      sqrt (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      step (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      tangent (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      hyp. tangent (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      transpose (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      trunc (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:336      Branch: Return with expression
+0:338      all (global bool)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      Absolute value (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      arc cosine (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      any (global bool)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      arc sine (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      arc tangent (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      arc tangent (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      Ceiling (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      clamp (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338        'inF2' (in 2X2 matrix of float)
+0:338      cosine (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      hyp. cosine (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      degrees (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      determinant (global float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      exp (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      exp2 (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      findMSB (global int)
+0:338        Constant:
+0:338          7 (const int)
+0:338      findLSB (global int)
+0:338        Constant:
+0:338          7 (const int)
+0:338      Floor (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      mod (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      Fraction (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      frexp (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      ldexp (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      mix (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338        'inF2' (in 2X2 matrix of float)
+0:338      log (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      matrix-scale (temp 2X2 matrix of float)
+0:338        log2 (temp 2X2 matrix of float)
+0:338          'inF0' (in 2X2 matrix of float)
+0:338        Constant:
+0:338          0.301030
+0:338      log2 (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      max (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      min (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      pow (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      radians (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      roundEven (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      inverse sqrt (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      clamp (temp 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        Constant:
+0:338          0.000000
+0:338        Constant:
+0:338          1.000000
+0:338      Sign (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      sine (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      Sequence
+0:338        move second child to first child (temp 2X2 matrix of float)
+0:338          'inF1' (in 2X2 matrix of float)
+0:338          sine (temp 2X2 matrix of float)
+0:338            'inF0' (in 2X2 matrix of float)
+0:338        move second child to first child (temp 2X2 matrix of float)
+0:338          'inF2' (in 2X2 matrix of float)
+0:338          cosine (temp 2X2 matrix of float)
+0:338            'inF0' (in 2X2 matrix of float)
+0:338      hyp. sine (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      smoothstep (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338        'inF2' (in 2X2 matrix of float)
+0:338      sqrt (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      step (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      tangent (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      hyp. tangent (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      transpose (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      trunc (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:341      Branch: Return with expression
 0:?         Constant:
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
-0:348  Function Definition: VertexShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
-0:340    Function Parameters: 
-0:340      'inF0' (in 3X3 matrix of float)
-0:340      'inF1' (in 3X3 matrix of float)
-0:340      'inF2' (in 3X3 matrix of float)
+0:353  Function Definition: VertexShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:345    Function Parameters: 
+0:345      'inF0' (in 3X3 matrix of float)
+0:345      'inF1' (in 3X3 matrix of float)
+0:345      'inF2' (in 3X3 matrix of float)
 0:?     Sequence
-0:342      all (global bool)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      Absolute value (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      arc cosine (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      any (global bool)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      arc sine (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      arc tangent (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      arc tangent (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      Ceiling (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      clamp (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342        'inF2' (in 3X3 matrix of float)
-0:342      cosine (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      hyp. cosine (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      degrees (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      determinant (global float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      exp (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      exp2 (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      findMSB (global int)
-0:342        Constant:
-0:342          7 (const int)
-0:342      findLSB (global int)
-0:342        Constant:
-0:342          7 (const int)
-0:342      Floor (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      mod (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      Fraction (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      frexp (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      ldexp (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      log (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      matrix-scale (temp 3X3 matrix of float)
-0:342        log2 (temp 3X3 matrix of float)
-0:342          'inF0' (in 3X3 matrix of float)
-0:342        Constant:
-0:342          0.301030
-0:342      log2 (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      max (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      min (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      pow (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      radians (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      roundEven (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      inverse sqrt (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      clamp (temp 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        Constant:
-0:342          0.000000
-0:342        Constant:
-0:342          1.000000
-0:342      Sign (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      sine (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      Sequence
-0:342        move second child to first child (temp 3X3 matrix of float)
-0:342          'inF1' (in 3X3 matrix of float)
-0:342          sine (temp 3X3 matrix of float)
-0:342            'inF0' (in 3X3 matrix of float)
-0:342        move second child to first child (temp 3X3 matrix of float)
-0:342          'inF2' (in 3X3 matrix of float)
-0:342          cosine (temp 3X3 matrix of float)
-0:342            'inF0' (in 3X3 matrix of float)
-0:342      hyp. sine (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      smoothstep (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342        'inF2' (in 3X3 matrix of float)
-0:342      sqrt (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      step (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      tangent (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      hyp. tangent (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      transpose (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      trunc (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:345      Branch: Return with expression
+0:347      all (global bool)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      Absolute value (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      arc cosine (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      any (global bool)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      arc sine (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      arc tangent (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      arc tangent (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      Ceiling (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      clamp (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347        'inF2' (in 3X3 matrix of float)
+0:347      cosine (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      hyp. cosine (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      degrees (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      determinant (global float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      exp (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      exp2 (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      findMSB (global int)
+0:347        Constant:
+0:347          7 (const int)
+0:347      findLSB (global int)
+0:347        Constant:
+0:347          7 (const int)
+0:347      Floor (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      mod (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      Fraction (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      frexp (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      ldexp (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      mix (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347        'inF2' (in 3X3 matrix of float)
+0:347      log (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      matrix-scale (temp 3X3 matrix of float)
+0:347        log2 (temp 3X3 matrix of float)
+0:347          'inF0' (in 3X3 matrix of float)
+0:347        Constant:
+0:347          0.301030
+0:347      log2 (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      max (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      min (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      pow (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      radians (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      roundEven (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      inverse sqrt (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      clamp (temp 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        Constant:
+0:347          0.000000
+0:347        Constant:
+0:347          1.000000
+0:347      Sign (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      sine (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      Sequence
+0:347        move second child to first child (temp 3X3 matrix of float)
+0:347          'inF1' (in 3X3 matrix of float)
+0:347          sine (temp 3X3 matrix of float)
+0:347            'inF0' (in 3X3 matrix of float)
+0:347        move second child to first child (temp 3X3 matrix of float)
+0:347          'inF2' (in 3X3 matrix of float)
+0:347          cosine (temp 3X3 matrix of float)
+0:347            'inF0' (in 3X3 matrix of float)
+0:347      hyp. sine (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      smoothstep (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347        'inF2' (in 3X3 matrix of float)
+0:347      sqrt (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      step (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      tangent (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      hyp. tangent (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      transpose (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      trunc (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:350      Branch: Return with expression
 0:?         Constant:
 0:?           3.000000
 0:?           3.000000
@@ -922,127 +946,131 @@ Shader version: 450
 0:?           3.000000
 0:?           3.000000
 0:?           3.000000
-0:369  Function Definition: VertexShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
-0:349    Function Parameters: 
-0:349      'inF0' (in 4X4 matrix of float)
-0:349      'inF1' (in 4X4 matrix of float)
-0:349      'inF2' (in 4X4 matrix of float)
+0:374  Function Definition: VertexShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:354    Function Parameters: 
+0:354      'inF0' (in 4X4 matrix of float)
+0:354      'inF1' (in 4X4 matrix of float)
+0:354      'inF2' (in 4X4 matrix of float)
 0:?     Sequence
-0:351      all (global bool)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      Absolute value (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      arc cosine (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      any (global bool)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      arc sine (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      arc tangent (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      arc tangent (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      Ceiling (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      clamp (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351        'inF2' (in 4X4 matrix of float)
-0:351      cosine (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      hyp. cosine (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      degrees (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      determinant (global float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      exp (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      exp2 (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      findMSB (global int)
-0:351        Constant:
-0:351          7 (const int)
-0:351      findLSB (global int)
-0:351        Constant:
-0:351          7 (const int)
-0:351      Floor (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      mod (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      Fraction (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      frexp (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      ldexp (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      log (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      matrix-scale (temp 4X4 matrix of float)
-0:351        log2 (temp 4X4 matrix of float)
-0:351          'inF0' (in 4X4 matrix of float)
-0:351        Constant:
-0:351          0.301030
-0:351      log2 (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      max (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      min (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      pow (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      radians (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      roundEven (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      inverse sqrt (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      clamp (temp 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        Constant:
-0:351          0.000000
-0:351        Constant:
-0:351          1.000000
-0:351      Sign (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      sine (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      Sequence
-0:351        move second child to first child (temp 4X4 matrix of float)
-0:351          'inF1' (in 4X4 matrix of float)
-0:351          sine (temp 4X4 matrix of float)
-0:351            'inF0' (in 4X4 matrix of float)
-0:351        move second child to first child (temp 4X4 matrix of float)
-0:351          'inF2' (in 4X4 matrix of float)
-0:351          cosine (temp 4X4 matrix of float)
-0:351            'inF0' (in 4X4 matrix of float)
-0:351      hyp. sine (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      smoothstep (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351        'inF2' (in 4X4 matrix of float)
-0:351      sqrt (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      step (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      tangent (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      hyp. tangent (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      transpose (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      trunc (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:354      Branch: Return with expression
+0:356      all (global bool)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      Absolute value (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      arc cosine (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      any (global bool)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      arc sine (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      arc tangent (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      arc tangent (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      Ceiling (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      clamp (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356        'inF2' (in 4X4 matrix of float)
+0:356      cosine (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      hyp. cosine (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      degrees (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      determinant (global float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      exp (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      exp2 (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      findMSB (global int)
+0:356        Constant:
+0:356          7 (const int)
+0:356      findLSB (global int)
+0:356        Constant:
+0:356          7 (const int)
+0:356      Floor (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      mod (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      Fraction (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      frexp (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      ldexp (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      mix (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356        'inF2' (in 4X4 matrix of float)
+0:356      log (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      matrix-scale (temp 4X4 matrix of float)
+0:356        log2 (temp 4X4 matrix of float)
+0:356          'inF0' (in 4X4 matrix of float)
+0:356        Constant:
+0:356          0.301030
+0:356      log2 (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      max (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      min (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      pow (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      radians (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      roundEven (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      inverse sqrt (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      clamp (temp 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        Constant:
+0:356          0.000000
+0:356        Constant:
+0:356          1.000000
+0:356      Sign (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      sine (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      Sequence
+0:356        move second child to first child (temp 4X4 matrix of float)
+0:356          'inF1' (in 4X4 matrix of float)
+0:356          sine (temp 4X4 matrix of float)
+0:356            'inF0' (in 4X4 matrix of float)
+0:356        move second child to first child (temp 4X4 matrix of float)
+0:356          'inF2' (in 4X4 matrix of float)
+0:356          cosine (temp 4X4 matrix of float)
+0:356            'inF0' (in 4X4 matrix of float)
+0:356      hyp. sine (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      smoothstep (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356        'inF2' (in 4X4 matrix of float)
+0:356      sqrt (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      step (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      tangent (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      hyp. tangent (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      transpose (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      trunc (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:359      Branch: Return with expression
 0:?         Constant:
 0:?           4.000000
 0:?           4.000000
@@ -1060,168 +1088,265 @@ Shader version: 450
 0:?           4.000000
 0:?           4.000000
 0:?           4.000000
-0:376  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
-0:372    Function Parameters: 
-0:372      'inF0' (in float)
-0:372      'inF1' (in float)
-0:372      'inFV0' (in 2-component vector of float)
-0:372      'inFV1' (in 2-component vector of float)
-0:372      'inFM0' (in 2X2 matrix of float)
-0:372      'inFM1' (in 2X2 matrix of float)
+0:381  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
+0:377    Function Parameters: 
+0:377      'inF0' (in float)
+0:377      'inF1' (in float)
+0:377      'inFV0' (in 2-component vector of float)
+0:377      'inFV1' (in 2-component vector of float)
+0:377      'inFM0' (in 2X2 matrix of float)
+0:377      'inFM1' (in 2X2 matrix of float)
 0:?     Sequence
-0:373      move second child to first child (temp float)
-0:373        'r0' (temp float)
-0:373        component-wise multiply (temp float)
-0:373          'inF0' (in float)
-0:373          'inF1' (in float)
-0:373      move second child to first child (temp 2-component vector of float)
-0:373        'r1' (temp 2-component vector of float)
-0:373        vector-scale (temp 2-component vector of float)
-0:373          'inFV0' (in 2-component vector of float)
-0:373          'inF0' (in float)
-0:373      move second child to first child (temp 2-component vector of float)
-0:373        'r2' (temp 2-component vector of float)
-0:373        vector-scale (temp 2-component vector of float)
-0:373          'inF0' (in float)
-0:373          'inFV0' (in 2-component vector of float)
-0:373      move second child to first child (temp float)
-0:373        'r3' (temp float)
-0:373        dot-product (global float)
-0:373          'inFV0' (in 2-component vector of float)
-0:373          'inFV1' (in 2-component vector of float)
-0:373      move second child to first child (temp 2-component vector of float)
-0:373        'r4' (temp 2-component vector of float)
-0:373        matrix-times-vector (temp 2-component vector of float)
-0:373          'inFM0' (in 2X2 matrix of float)
-0:373          'inFV0' (in 2-component vector of float)
-0:373      move second child to first child (temp 2-component vector of float)
-0:373        'r5' (temp 2-component vector of float)
-0:373        vector-times-matrix (temp 2-component vector of float)
-0:373          'inFV0' (in 2-component vector of float)
-0:373          'inFM0' (in 2X2 matrix of float)
-0:373      move second child to first child (temp 2X2 matrix of float)
-0:373        'r6' (temp 2X2 matrix of float)
-0:373        matrix-scale (temp 2X2 matrix of float)
-0:373          'inFM0' (in 2X2 matrix of float)
-0:373          'inF0' (in float)
-0:373      move second child to first child (temp 2X2 matrix of float)
-0:373        'r7' (temp 2X2 matrix of float)
-0:373        matrix-scale (temp 2X2 matrix of float)
-0:373          'inF0' (in float)
-0:373          'inFM0' (in 2X2 matrix of float)
-0:373      move second child to first child (temp 2X2 matrix of float)
-0:373        'r8' (temp 2X2 matrix of float)
-0:373        matrix-multiply (temp 2X2 matrix of float)
-0:373          'inFM0' (in 2X2 matrix of float)
-0:373          'inFM1' (in 2X2 matrix of float)
-0:383  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
-0:379    Function Parameters: 
-0:379      'inF0' (in float)
-0:379      'inF1' (in float)
-0:379      'inFV0' (in 3-component vector of float)
-0:379      'inFV1' (in 3-component vector of float)
-0:379      'inFM0' (in 3X3 matrix of float)
-0:379      'inFM1' (in 3X3 matrix of float)
+0:378      move second child to first child (temp float)
+0:378        'r0' (temp float)
+0:378        component-wise multiply (temp float)
+0:378          'inF0' (in float)
+0:378          'inF1' (in float)
+0:378      move second child to first child (temp 2-component vector of float)
+0:378        'r1' (temp 2-component vector of float)
+0:378        vector-scale (temp 2-component vector of float)
+0:378          'inFV0' (in 2-component vector of float)
+0:378          'inF0' (in float)
+0:378      move second child to first child (temp 2-component vector of float)
+0:378        'r2' (temp 2-component vector of float)
+0:378        vector-scale (temp 2-component vector of float)
+0:378          'inF0' (in float)
+0:378          'inFV0' (in 2-component vector of float)
+0:378      move second child to first child (temp float)
+0:378        'r3' (temp float)
+0:378        dot-product (global float)
+0:378          'inFV0' (in 2-component vector of float)
+0:378          'inFV1' (in 2-component vector of float)
+0:378      move second child to first child (temp 2-component vector of float)
+0:378        'r4' (temp 2-component vector of float)
+0:378        matrix-times-vector (temp 2-component vector of float)
+0:378          'inFM0' (in 2X2 matrix of float)
+0:378          'inFV0' (in 2-component vector of float)
+0:378      move second child to first child (temp 2-component vector of float)
+0:378        'r5' (temp 2-component vector of float)
+0:378        vector-times-matrix (temp 2-component vector of float)
+0:378          'inFV0' (in 2-component vector of float)
+0:378          'inFM0' (in 2X2 matrix of float)
+0:378      move second child to first child (temp 2X2 matrix of float)
+0:378        'r6' (temp 2X2 matrix of float)
+0:378        matrix-scale (temp 2X2 matrix of float)
+0:378          'inFM0' (in 2X2 matrix of float)
+0:378          'inF0' (in float)
+0:378      move second child to first child (temp 2X2 matrix of float)
+0:378        'r7' (temp 2X2 matrix of float)
+0:378        matrix-scale (temp 2X2 matrix of float)
+0:378          'inF0' (in float)
+0:378          'inFM0' (in 2X2 matrix of float)
+0:378      move second child to first child (temp 2X2 matrix of float)
+0:378        'r8' (temp 2X2 matrix of float)
+0:378        matrix-multiply (temp 2X2 matrix of float)
+0:378          'inFM0' (in 2X2 matrix of float)
+0:378          'inFM1' (in 2X2 matrix of float)
+0:388  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
+0:384    Function Parameters: 
+0:384      'inF0' (in float)
+0:384      'inF1' (in float)
+0:384      'inFV0' (in 3-component vector of float)
+0:384      'inFV1' (in 3-component vector of float)
+0:384      'inFM0' (in 3X3 matrix of float)
+0:384      'inFM1' (in 3X3 matrix of float)
 0:?     Sequence
-0:380      move second child to first child (temp float)
-0:380        'r0' (temp float)
-0:380        component-wise multiply (temp float)
-0:380          'inF0' (in float)
-0:380          'inF1' (in float)
-0:380      move second child to first child (temp 3-component vector of float)
-0:380        'r1' (temp 3-component vector of float)
-0:380        vector-scale (temp 3-component vector of float)
-0:380          'inFV0' (in 3-component vector of float)
-0:380          'inF0' (in float)
-0:380      move second child to first child (temp 3-component vector of float)
-0:380        'r2' (temp 3-component vector of float)
-0:380        vector-scale (temp 3-component vector of float)
-0:380          'inF0' (in float)
-0:380          'inFV0' (in 3-component vector of float)
-0:380      move second child to first child (temp float)
-0:380        'r3' (temp float)
-0:380        dot-product (global float)
-0:380          'inFV0' (in 3-component vector of float)
-0:380          'inFV1' (in 3-component vector of float)
-0:380      move second child to first child (temp 3-component vector of float)
-0:380        'r4' (temp 3-component vector of float)
-0:380        matrix-times-vector (temp 3-component vector of float)
-0:380          'inFM0' (in 3X3 matrix of float)
-0:380          'inFV0' (in 3-component vector of float)
-0:380      move second child to first child (temp 3-component vector of float)
-0:380        'r5' (temp 3-component vector of float)
-0:380        vector-times-matrix (temp 3-component vector of float)
-0:380          'inFV0' (in 3-component vector of float)
-0:380          'inFM0' (in 3X3 matrix of float)
-0:380      move second child to first child (temp 3X3 matrix of float)
-0:380        'r6' (temp 3X3 matrix of float)
-0:380        matrix-scale (temp 3X3 matrix of float)
-0:380          'inFM0' (in 3X3 matrix of float)
-0:380          'inF0' (in float)
-0:380      move second child to first child (temp 3X3 matrix of float)
-0:380        'r7' (temp 3X3 matrix of float)
-0:380        matrix-scale (temp 3X3 matrix of float)
-0:380          'inF0' (in float)
-0:380          'inFM0' (in 3X3 matrix of float)
-0:380      move second child to first child (temp 3X3 matrix of float)
-0:380        'r8' (temp 3X3 matrix of float)
-0:380        matrix-multiply (temp 3X3 matrix of float)
-0:380          'inFM0' (in 3X3 matrix of float)
-0:380          'inFM1' (in 3X3 matrix of float)
-0:389  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
-0:386    Function Parameters: 
-0:386      'inF0' (in float)
-0:386      'inF1' (in float)
-0:386      'inFV0' (in 4-component vector of float)
-0:386      'inFV1' (in 4-component vector of float)
-0:386      'inFM0' (in 4X4 matrix of float)
-0:386      'inFM1' (in 4X4 matrix of float)
+0:385      move second child to first child (temp float)
+0:385        'r0' (temp float)
+0:385        component-wise multiply (temp float)
+0:385          'inF0' (in float)
+0:385          'inF1' (in float)
+0:385      move second child to first child (temp 3-component vector of float)
+0:385        'r1' (temp 3-component vector of float)
+0:385        vector-scale (temp 3-component vector of float)
+0:385          'inFV0' (in 3-component vector of float)
+0:385          'inF0' (in float)
+0:385      move second child to first child (temp 3-component vector of float)
+0:385        'r2' (temp 3-component vector of float)
+0:385        vector-scale (temp 3-component vector of float)
+0:385          'inF0' (in float)
+0:385          'inFV0' (in 3-component vector of float)
+0:385      move second child to first child (temp float)
+0:385        'r3' (temp float)
+0:385        dot-product (global float)
+0:385          'inFV0' (in 3-component vector of float)
+0:385          'inFV1' (in 3-component vector of float)
+0:385      move second child to first child (temp 3-component vector of float)
+0:385        'r4' (temp 3-component vector of float)
+0:385        matrix-times-vector (temp 3-component vector of float)
+0:385          'inFM0' (in 3X3 matrix of float)
+0:385          'inFV0' (in 3-component vector of float)
+0:385      move second child to first child (temp 3-component vector of float)
+0:385        'r5' (temp 3-component vector of float)
+0:385        vector-times-matrix (temp 3-component vector of float)
+0:385          'inFV0' (in 3-component vector of float)
+0:385          'inFM0' (in 3X3 matrix of float)
+0:385      move second child to first child (temp 3X3 matrix of float)
+0:385        'r6' (temp 3X3 matrix of float)
+0:385        matrix-scale (temp 3X3 matrix of float)
+0:385          'inFM0' (in 3X3 matrix of float)
+0:385          'inF0' (in float)
+0:385      move second child to first child (temp 3X3 matrix of float)
+0:385        'r7' (temp 3X3 matrix of float)
+0:385        matrix-scale (temp 3X3 matrix of float)
+0:385          'inF0' (in float)
+0:385          'inFM0' (in 3X3 matrix of float)
+0:385      move second child to first child (temp 3X3 matrix of float)
+0:385        'r8' (temp 3X3 matrix of float)
+0:385        matrix-multiply (temp 3X3 matrix of float)
+0:385          'inFM0' (in 3X3 matrix of float)
+0:385          'inFM1' (in 3X3 matrix of float)
+0:396  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
+0:391    Function Parameters: 
+0:391      'inF0' (in float)
+0:391      'inF1' (in float)
+0:391      'inFV0' (in 4-component vector of float)
+0:391      'inFV1' (in 4-component vector of float)
+0:391      'inFM0' (in 4X4 matrix of float)
+0:391      'inFM1' (in 4X4 matrix of float)
 0:?     Sequence
-0:387      move second child to first child (temp float)
-0:387        'r0' (temp float)
-0:387        component-wise multiply (temp float)
-0:387          'inF0' (in float)
-0:387          'inF1' (in float)
-0:387      move second child to first child (temp 4-component vector of float)
-0:387        'r1' (temp 4-component vector of float)
-0:387        vector-scale (temp 4-component vector of float)
-0:387          'inFV0' (in 4-component vector of float)
-0:387          'inF0' (in float)
-0:387      move second child to first child (temp 4-component vector of float)
-0:387        'r2' (temp 4-component vector of float)
-0:387        vector-scale (temp 4-component vector of float)
-0:387          'inF0' (in float)
-0:387          'inFV0' (in 4-component vector of float)
-0:387      move second child to first child (temp float)
-0:387        'r3' (temp float)
-0:387        dot-product (global float)
-0:387          'inFV0' (in 4-component vector of float)
-0:387          'inFV1' (in 4-component vector of float)
-0:387      move second child to first child (temp 4-component vector of float)
-0:387        'r4' (temp 4-component vector of float)
-0:387        matrix-times-vector (temp 4-component vector of float)
-0:387          'inFM0' (in 4X4 matrix of float)
-0:387          'inFV0' (in 4-component vector of float)
-0:387      move second child to first child (temp 4-component vector of float)
-0:387        'r5' (temp 4-component vector of float)
-0:387        vector-times-matrix (temp 4-component vector of float)
-0:387          'inFV0' (in 4-component vector of float)
-0:387          'inFM0' (in 4X4 matrix of float)
-0:387      move second child to first child (temp 4X4 matrix of float)
-0:387        'r6' (temp 4X4 matrix of float)
-0:387        matrix-scale (temp 4X4 matrix of float)
-0:387          'inFM0' (in 4X4 matrix of float)
-0:387          'inF0' (in float)
-0:387      move second child to first child (temp 4X4 matrix of float)
-0:387        'r7' (temp 4X4 matrix of float)
-0:387        matrix-scale (temp 4X4 matrix of float)
-0:387          'inF0' (in float)
-0:387          'inFM0' (in 4X4 matrix of float)
-0:387      move second child to first child (temp 4X4 matrix of float)
-0:387        'r8' (temp 4X4 matrix of float)
-0:387        matrix-multiply (temp 4X4 matrix of float)
-0:387          'inFM0' (in 4X4 matrix of float)
-0:387          'inFM1' (in 4X4 matrix of float)
+0:392      move second child to first child (temp float)
+0:392        'r0' (temp float)
+0:392        component-wise multiply (temp float)
+0:392          'inF0' (in float)
+0:392          'inF1' (in float)
+0:392      move second child to first child (temp 4-component vector of float)
+0:392        'r1' (temp 4-component vector of float)
+0:392        vector-scale (temp 4-component vector of float)
+0:392          'inFV0' (in 4-component vector of float)
+0:392          'inF0' (in float)
+0:392      move second child to first child (temp 4-component vector of float)
+0:392        'r2' (temp 4-component vector of float)
+0:392        vector-scale (temp 4-component vector of float)
+0:392          'inF0' (in float)
+0:392          'inFV0' (in 4-component vector of float)
+0:392      move second child to first child (temp float)
+0:392        'r3' (temp float)
+0:392        dot-product (global float)
+0:392          'inFV0' (in 4-component vector of float)
+0:392          'inFV1' (in 4-component vector of float)
+0:392      move second child to first child (temp 4-component vector of float)
+0:392        'r4' (temp 4-component vector of float)
+0:392        matrix-times-vector (temp 4-component vector of float)
+0:392          'inFM0' (in 4X4 matrix of float)
+0:392          'inFV0' (in 4-component vector of float)
+0:392      move second child to first child (temp 4-component vector of float)
+0:392        'r5' (temp 4-component vector of float)
+0:392        vector-times-matrix (temp 4-component vector of float)
+0:392          'inFV0' (in 4-component vector of float)
+0:392          'inFM0' (in 4X4 matrix of float)
+0:392      move second child to first child (temp 4X4 matrix of float)
+0:392        'r6' (temp 4X4 matrix of float)
+0:392        matrix-scale (temp 4X4 matrix of float)
+0:392          'inFM0' (in 4X4 matrix of float)
+0:392          'inF0' (in float)
+0:392      move second child to first child (temp 4X4 matrix of float)
+0:392        'r7' (temp 4X4 matrix of float)
+0:392        matrix-scale (temp 4X4 matrix of float)
+0:392          'inF0' (in float)
+0:392          'inFM0' (in 4X4 matrix of float)
+0:392      move second child to first child (temp 4X4 matrix of float)
+0:392        'r8' (temp 4X4 matrix of float)
+0:392        matrix-multiply (temp 4X4 matrix of float)
+0:392          'inFM0' (in 4X4 matrix of float)
+0:392          'inFM1' (in 4X4 matrix of float)
+0:420  Function Definition: TestGenMul(f1;f1;vf2;vf3;mf32;mf23;mf33;mf43;mf42; (temp void)
+0:401    Function Parameters: 
+0:401      'inF0' (in float)
+0:401      'inF1' (in float)
+0:401      'inFV2' (in 2-component vector of float)
+0:401      'inFV3' (in 3-component vector of float)
+0:401      'inFM2x3' (in 3X2 matrix of float)
+0:401      'inFM3x2' (in 2X3 matrix of float)
+0:401      'inFM3x3' (in 3X3 matrix of float)
+0:401      'inFM3x4' (in 4X3 matrix of float)
+0:401      'inFM2x4' (in 4X2 matrix of float)
+0:?     Sequence
+0:402      move second child to first child (temp float)
+0:402        'r00' (temp float)
+0:402        component-wise multiply (temp float)
+0:402          'inF0' (in float)
+0:402          'inF1' (in float)
+0:403      move second child to first child (temp 2-component vector of float)
+0:403        'r01' (temp 2-component vector of float)
+0:403        vector-scale (temp 2-component vector of float)
+0:403          'inFV2' (in 2-component vector of float)
+0:403          'inF0' (in float)
+0:404      move second child to first child (temp 3-component vector of float)
+0:404        'r02' (temp 3-component vector of float)
+0:404        vector-scale (temp 3-component vector of float)
+0:404          'inFV3' (in 3-component vector of float)
+0:404          'inF0' (in float)
+0:405      move second child to first child (temp 2-component vector of float)
+0:405        'r03' (temp 2-component vector of float)
+0:405        vector-scale (temp 2-component vector of float)
+0:405          'inF0' (in float)
+0:405          'inFV2' (in 2-component vector of float)
+0:406      move second child to first child (temp 3-component vector of float)
+0:406        'r04' (temp 3-component vector of float)
+0:406        vector-scale (temp 3-component vector of float)
+0:406          'inF0' (in float)
+0:406          'inFV3' (in 3-component vector of float)
+0:407      move second child to first child (temp float)
+0:407        'r05' (temp float)
+0:407        dot-product (global float)
+0:407          'inFV2' (in 2-component vector of float)
+0:407          'inFV2' (in 2-component vector of float)
+0:408      move second child to first child (temp float)
+0:408        'r06' (temp float)
+0:408        dot-product (global float)
+0:408          'inFV3' (in 3-component vector of float)
+0:408          'inFV3' (in 3-component vector of float)
+0:409      move second child to first child (temp 3-component vector of float)
+0:409        'r07' (temp 3-component vector of float)
+0:409        vector-times-matrix (temp 3-component vector of float)
+0:409          'inFV2' (in 2-component vector of float)
+0:409          'inFM2x3' (in 3X2 matrix of float)
+0:410      move second child to first child (temp 2-component vector of float)
+0:410        'r08' (temp 2-component vector of float)
+0:410        vector-times-matrix (temp 2-component vector of float)
+0:410          'inFV3' (in 3-component vector of float)
+0:410          'inFM3x2' (in 2X3 matrix of float)
+0:411      move second child to first child (temp 2-component vector of float)
+0:411        'r09' (temp 2-component vector of float)
+0:411        matrix-times-vector (temp 2-component vector of float)
+0:411          'inFM2x3' (in 3X2 matrix of float)
+0:411          'inFV3' (in 3-component vector of float)
+0:412      move second child to first child (temp 3-component vector of float)
+0:412        'r10' (temp 3-component vector of float)
+0:412        matrix-times-vector (temp 3-component vector of float)
+0:412          'inFM3x2' (in 2X3 matrix of float)
+0:412          'inFV2' (in 2-component vector of float)
+0:413      move second child to first child (temp 3X2 matrix of float)
+0:413        'r11' (temp 3X2 matrix of float)
+0:413        matrix-scale (temp 3X2 matrix of float)
+0:413          'inFM2x3' (in 3X2 matrix of float)
+0:413          'inF0' (in float)
+0:414      move second child to first child (temp 2X3 matrix of float)
+0:414        'r12' (temp 2X3 matrix of float)
+0:414        matrix-scale (temp 2X3 matrix of float)
+0:414          'inFM3x2' (in 2X3 matrix of float)
+0:414          'inF0' (in float)
+0:415      move second child to first child (temp 2X2 matrix of float)
+0:415        'r13' (temp 2X2 matrix of float)
+0:415        matrix-multiply (temp 2X2 matrix of float)
+0:415          'inFM2x3' (in 3X2 matrix of float)
+0:415          'inFM3x2' (in 2X3 matrix of float)
+0:416      move second child to first child (temp 3X2 matrix of float)
+0:416        'r14' (temp 3X2 matrix of float)
+0:416        matrix-multiply (temp 3X2 matrix of float)
+0:416          'inFM2x3' (in 3X2 matrix of float)
+0:416          'inFM3x3' (in 3X3 matrix of float)
+0:417      move second child to first child (temp 4X2 matrix of float)
+0:417        'r15' (temp 4X2 matrix of float)
+0:417        matrix-multiply (temp 4X2 matrix of float)
+0:417          'inFM2x3' (in 3X2 matrix of float)
+0:417          'inFM3x4' (in 4X3 matrix of float)
+0:418      move second child to first child (temp 4X3 matrix of float)
+0:418        'r16' (temp 4X3 matrix of float)
+0:418        matrix-multiply (temp 4X3 matrix of float)
+0:418          'inFM3x2' (in 2X3 matrix of float)
+0:418          'inFM2x4' (in 4X2 matrix of float)
 0:?   Linker Objects
 
 
@@ -1230,7 +1355,7 @@ Linked vertex stage:
 
 Shader version: 450
 0:? Sequence
-0:62  Function Definition: VertexShaderFunction(f1;f1;f1;u1;u1; (temp float)
+0:63  Function Definition: VertexShaderFunction(f1;f1;f1;u1;u1; (temp float)
 0:2    Function Parameters: 
 0:2      'inF0' (in float)
 0:2      'inF1' (in float)
@@ -1301,846 +1426,870 @@ Shader version: 450
 0:34      ldexp (global float)
 0:34        'inF0' (in float)
 0:34        'inF1' (in float)
-0:35      log (global float)
+0:35      mix (global float)
 0:35        'inF0' (in float)
-0:36      component-wise multiply (temp float)
-0:36        log2 (temp float)
-0:36          'inF0' (in float)
-0:36        Constant:
-0:36          0.301030
-0:37      log2 (global float)
-0:37        'inF0' (in float)
-0:38      max (global float)
+0:35        'inF1' (in float)
+0:35        'inF2' (in float)
+0:36      log (global float)
+0:36        'inF0' (in float)
+0:37      component-wise multiply (temp float)
+0:37        log2 (temp float)
+0:37          'inF0' (in float)
+0:37        Constant:
+0:37          0.301030
+0:38      log2 (global float)
 0:38        'inF0' (in float)
-0:38        'inF1' (in float)
-0:39      min (global float)
+0:39      max (global float)
 0:39        'inF0' (in float)
 0:39        'inF1' (in float)
-0:41      pow (global float)
-0:41        'inF0' (in float)
-0:41        'inF1' (in float)
-0:42      radians (global float)
+0:40      min (global float)
+0:40        'inF0' (in float)
+0:40        'inF1' (in float)
+0:42      pow (global float)
 0:42        'inF0' (in float)
-0:43      bitFieldReverse (global uint)
-0:43        Constant:
-0:43          2 (const uint)
-0:44      roundEven (global float)
-0:44        'inF0' (in float)
-0:45      inverse sqrt (global float)
+0:42        'inF1' (in float)
+0:43      radians (global float)
+0:43        'inF0' (in float)
+0:44      bitFieldReverse (global uint)
+0:44        Constant:
+0:44          2 (const uint)
+0:45      roundEven (global float)
 0:45        'inF0' (in float)
-0:46      clamp (temp float)
+0:46      inverse sqrt (global float)
 0:46        'inF0' (in float)
-0:46        Constant:
-0:46          0.000000
-0:46        Constant:
-0:46          1.000000
-0:47      Sign (global float)
+0:47      clamp (temp float)
 0:47        'inF0' (in float)
-0:48      sine (global float)
+0:47        Constant:
+0:47          0.000000
+0:47        Constant:
+0:47          1.000000
+0:48      Sign (global float)
 0:48        'inF0' (in float)
-0:49      Sequence
-0:49        move second child to first child (temp float)
-0:49          'inF1' (in float)
-0:49          sine (temp float)
-0:49            'inF0' (in float)
-0:49        move second child to first child (temp float)
-0:49          'inF2' (in float)
-0:49          cosine (temp float)
-0:49            'inF0' (in float)
-0:50      hyp. sine (global float)
-0:50        'inF0' (in float)
-0:51      smoothstep (global float)
+0:49      sine (global float)
+0:49        'inF0' (in float)
+0:50      Sequence
+0:50        move second child to first child (temp float)
+0:50          'inF1' (in float)
+0:50          sine (temp float)
+0:50            'inF0' (in float)
+0:50        move second child to first child (temp float)
+0:50          'inF2' (in float)
+0:50          cosine (temp float)
+0:50            'inF0' (in float)
+0:51      hyp. sine (global float)
 0:51        'inF0' (in float)
-0:51        'inF1' (in float)
-0:51        'inF2' (in float)
-0:52      sqrt (global float)
+0:52      smoothstep (global float)
 0:52        'inF0' (in float)
-0:53      step (global float)
+0:52        'inF1' (in float)
+0:52        'inF2' (in float)
+0:53      sqrt (global float)
 0:53        'inF0' (in float)
-0:53        'inF1' (in float)
-0:54      tangent (global float)
+0:54      step (global float)
 0:54        'inF0' (in float)
-0:55      hyp. tangent (global float)
+0:54        'inF1' (in float)
+0:55      tangent (global float)
 0:55        'inF0' (in float)
-0:57      trunc (global float)
-0:57        'inF0' (in float)
-0:59      Branch: Return with expression
-0:59        Constant:
-0:59          0.000000
-0:68  Function Definition: VertexShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
-0:63    Function Parameters: 
-0:63      'inF0' (in 1-component vector of float)
-0:63      'inF1' (in 1-component vector of float)
-0:63      'inF2' (in 1-component vector of float)
+0:56      hyp. tangent (global float)
+0:56        'inF0' (in float)
+0:58      trunc (global float)
+0:58        'inF0' (in float)
+0:60      Branch: Return with expression
+0:60        Constant:
+0:60          0.000000
+0:69  Function Definition: VertexShaderFunction(vf1;vf1;vf1; (temp 1-component vector of float)
+0:64    Function Parameters: 
+0:64      'inF0' (in 1-component vector of float)
+0:64      'inF1' (in 1-component vector of float)
+0:64      'inF2' (in 1-component vector of float)
 0:?     Sequence
-0:65      Branch: Return with expression
-0:65        Constant:
-0:65          0.000000
-0:137  Function Definition: VertexShaderFunction(vf2;vf2;vf2;vu2;vu2; (temp 2-component vector of float)
-0:69    Function Parameters: 
-0:69      'inF0' (in 2-component vector of float)
-0:69      'inF1' (in 2-component vector of float)
-0:69      'inF2' (in 2-component vector of float)
-0:69      'inU0' (in 2-component vector of uint)
-0:69      'inU1' (in 2-component vector of uint)
+0:66      Branch: Return with expression
+0:66        Constant:
+0:66          0.000000
+0:139  Function Definition: VertexShaderFunction(vf2;vf2;vf2;vu2;vu2; (temp 2-component vector of float)
+0:70    Function Parameters: 
+0:70      'inF0' (in 2-component vector of float)
+0:70      'inF1' (in 2-component vector of float)
+0:70      'inF2' (in 2-component vector of float)
+0:70      'inU0' (in 2-component vector of uint)
+0:70      'inU1' (in 2-component vector of uint)
 0:?     Sequence
-0:70      all (global bool)
-0:70        'inF0' (in 2-component vector of float)
-0:71      Absolute value (global 2-component vector of float)
+0:71      all (global bool)
 0:71        'inF0' (in 2-component vector of float)
-0:72      arc cosine (global 2-component vector of float)
+0:72      Absolute value (global 2-component vector of float)
 0:72        'inF0' (in 2-component vector of float)
-0:73      any (global bool)
+0:73      arc cosine (global 2-component vector of float)
 0:73        'inF0' (in 2-component vector of float)
-0:74      arc sine (global 2-component vector of float)
+0:74      any (global bool)
 0:74        'inF0' (in 2-component vector of float)
-0:75      floatBitsToInt (global 2-component vector of int)
+0:75      arc sine (global 2-component vector of float)
 0:75        'inF0' (in 2-component vector of float)
-0:76      floatBitsToUint (global 2-component vector of uint)
+0:76      floatBitsToInt (global 2-component vector of int)
 0:76        'inF0' (in 2-component vector of float)
-0:77      intBitsToFloat (global 2-component vector of float)
-0:77        'inU0' (in 2-component vector of uint)
-0:79      arc tangent (global 2-component vector of float)
-0:79        'inF0' (in 2-component vector of float)
+0:77      floatBitsToUint (global 2-component vector of uint)
+0:77        'inF0' (in 2-component vector of float)
+0:78      intBitsToFloat (global 2-component vector of float)
+0:78        'inU0' (in 2-component vector of uint)
 0:80      arc tangent (global 2-component vector of float)
 0:80        'inF0' (in 2-component vector of float)
-0:80        'inF1' (in 2-component vector of float)
-0:81      Ceiling (global 2-component vector of float)
+0:81      arc tangent (global 2-component vector of float)
 0:81        'inF0' (in 2-component vector of float)
-0:82      clamp (global 2-component vector of float)
+0:81        'inF1' (in 2-component vector of float)
+0:82      Ceiling (global 2-component vector of float)
 0:82        'inF0' (in 2-component vector of float)
-0:82        'inF1' (in 2-component vector of float)
-0:82        'inF2' (in 2-component vector of float)
-0:83      cosine (global 2-component vector of float)
+0:83      clamp (global 2-component vector of float)
 0:83        'inF0' (in 2-component vector of float)
-0:84      hyp. cosine (global 2-component vector of float)
+0:83        'inF1' (in 2-component vector of float)
+0:83        'inF2' (in 2-component vector of float)
+0:84      cosine (global 2-component vector of float)
 0:84        'inF0' (in 2-component vector of float)
+0:85      hyp. cosine (global 2-component vector of float)
+0:85        'inF0' (in 2-component vector of float)
 0:?       bitCount (global 2-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
-0:86      degrees (global 2-component vector of float)
-0:86        'inF0' (in 2-component vector of float)
-0:87      distance (global float)
+0:87      degrees (global 2-component vector of float)
 0:87        'inF0' (in 2-component vector of float)
-0:87        'inF1' (in 2-component vector of float)
-0:88      dot-product (global float)
+0:88      distance (global float)
 0:88        'inF0' (in 2-component vector of float)
 0:88        'inF1' (in 2-component vector of float)
-0:92      exp (global 2-component vector of float)
-0:92        'inF0' (in 2-component vector of float)
-0:93      exp2 (global 2-component vector of float)
+0:89      dot-product (global float)
+0:89        'inF0' (in 2-component vector of float)
+0:89        'inF1' (in 2-component vector of float)
+0:93      exp (global 2-component vector of float)
 0:93        'inF0' (in 2-component vector of float)
-0:94      face-forward (global 2-component vector of float)
+0:94      exp2 (global 2-component vector of float)
 0:94        'inF0' (in 2-component vector of float)
-0:94        'inF1' (in 2-component vector of float)
-0:94        'inF2' (in 2-component vector of float)
-0:95      findMSB (global int)
-0:95        Constant:
-0:95          7 (const int)
-0:96      findLSB (global int)
+0:95      face-forward (global 2-component vector of float)
+0:95        'inF0' (in 2-component vector of float)
+0:95        'inF1' (in 2-component vector of float)
+0:95        'inF2' (in 2-component vector of float)
+0:96      findMSB (global int)
 0:96        Constant:
 0:96          7 (const int)
-0:97      Floor (global 2-component vector of float)
-0:97        'inF0' (in 2-component vector of float)
-0:99      mod (global 2-component vector of float)
-0:99        'inF0' (in 2-component vector of float)
-0:99        'inF1' (in 2-component vector of float)
-0:100      Fraction (global 2-component vector of float)
+0:97      findLSB (global int)
+0:97        Constant:
+0:97          7 (const int)
+0:98      Floor (global 2-component vector of float)
+0:98        'inF0' (in 2-component vector of float)
+0:100      mod (global 2-component vector of float)
 0:100        'inF0' (in 2-component vector of float)
-0:101      frexp (global 2-component vector of float)
+0:100        'inF1' (in 2-component vector of float)
+0:101      Fraction (global 2-component vector of float)
 0:101        'inF0' (in 2-component vector of float)
-0:101        'inF1' (in 2-component vector of float)
-0:102      isinf (global 2-component vector of bool)
+0:102      frexp (global 2-component vector of float)
 0:102        'inF0' (in 2-component vector of float)
-0:103      isnan (global 2-component vector of bool)
+0:102        'inF1' (in 2-component vector of float)
+0:103      isinf (global 2-component vector of bool)
 0:103        'inF0' (in 2-component vector of float)
-0:104      ldexp (global 2-component vector of float)
+0:104      isnan (global 2-component vector of bool)
 0:104        'inF0' (in 2-component vector of float)
-0:104        'inF1' (in 2-component vector of float)
-0:105      length (global float)
+0:105      ldexp (global 2-component vector of float)
 0:105        'inF0' (in 2-component vector of float)
-0:106      log (global 2-component vector of float)
+0:105        'inF1' (in 2-component vector of float)
+0:106      mix (global 2-component vector of float)
 0:106        'inF0' (in 2-component vector of float)
-0:107      vector-scale (temp 2-component vector of float)
-0:107        log2 (temp 2-component vector of float)
-0:107          'inF0' (in 2-component vector of float)
-0:107        Constant:
-0:107          0.301030
-0:108      log2 (global 2-component vector of float)
+0:106        'inF1' (in 2-component vector of float)
+0:106        'inF2' (in 2-component vector of float)
+0:107      length (global float)
+0:107        'inF0' (in 2-component vector of float)
+0:108      log (global 2-component vector of float)
 0:108        'inF0' (in 2-component vector of float)
-0:109      max (global 2-component vector of float)
-0:109        'inF0' (in 2-component vector of float)
-0:109        'inF1' (in 2-component vector of float)
-0:110      min (global 2-component vector of float)
+0:109      vector-scale (temp 2-component vector of float)
+0:109        log2 (temp 2-component vector of float)
+0:109          'inF0' (in 2-component vector of float)
+0:109        Constant:
+0:109          0.301030
+0:110      log2 (global 2-component vector of float)
 0:110        'inF0' (in 2-component vector of float)
-0:110        'inF1' (in 2-component vector of float)
-0:112      normalize (global 2-component vector of float)
+0:111      max (global 2-component vector of float)
+0:111        'inF0' (in 2-component vector of float)
+0:111        'inF1' (in 2-component vector of float)
+0:112      min (global 2-component vector of float)
 0:112        'inF0' (in 2-component vector of float)
-0:113      pow (global 2-component vector of float)
-0:113        'inF0' (in 2-component vector of float)
-0:113        'inF1' (in 2-component vector of float)
-0:114      radians (global 2-component vector of float)
+0:112        'inF1' (in 2-component vector of float)
+0:114      normalize (global 2-component vector of float)
 0:114        'inF0' (in 2-component vector of float)
-0:115      reflect (global 2-component vector of float)
+0:115      pow (global 2-component vector of float)
 0:115        'inF0' (in 2-component vector of float)
 0:115        'inF1' (in 2-component vector of float)
-0:116      refract (global 2-component vector of float)
+0:116      radians (global 2-component vector of float)
 0:116        'inF0' (in 2-component vector of float)
-0:116        'inF1' (in 2-component vector of float)
-0:116        Constant:
-0:116          2.000000
+0:117      reflect (global 2-component vector of float)
+0:117        'inF0' (in 2-component vector of float)
+0:117        'inF1' (in 2-component vector of float)
+0:118      refract (global 2-component vector of float)
+0:118        'inF0' (in 2-component vector of float)
+0:118        'inF1' (in 2-component vector of float)
+0:118        Constant:
+0:118          2.000000
 0:?       bitFieldReverse (global 2-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
-0:118      roundEven (global 2-component vector of float)
-0:118        'inF0' (in 2-component vector of float)
-0:119      inverse sqrt (global 2-component vector of float)
-0:119        'inF0' (in 2-component vector of float)
-0:120      clamp (temp 2-component vector of float)
+0:120      roundEven (global 2-component vector of float)
 0:120        'inF0' (in 2-component vector of float)
-0:120        Constant:
-0:120          0.000000
-0:120        Constant:
-0:120          1.000000
-0:121      Sign (global 2-component vector of float)
+0:121      inverse sqrt (global 2-component vector of float)
 0:121        'inF0' (in 2-component vector of float)
-0:122      sine (global 2-component vector of float)
+0:122      clamp (temp 2-component vector of float)
 0:122        'inF0' (in 2-component vector of float)
-0:123      Sequence
-0:123        move second child to first child (temp 2-component vector of float)
-0:123          'inF1' (in 2-component vector of float)
-0:123          sine (temp 2-component vector of float)
-0:123            'inF0' (in 2-component vector of float)
-0:123        move second child to first child (temp 2-component vector of float)
-0:123          'inF2' (in 2-component vector of float)
-0:123          cosine (temp 2-component vector of float)
-0:123            'inF0' (in 2-component vector of float)
-0:124      hyp. sine (global 2-component vector of float)
+0:122        Constant:
+0:122          0.000000
+0:122        Constant:
+0:122          1.000000
+0:123      Sign (global 2-component vector of float)
+0:123        'inF0' (in 2-component vector of float)
+0:124      sine (global 2-component vector of float)
 0:124        'inF0' (in 2-component vector of float)
-0:125      smoothstep (global 2-component vector of float)
-0:125        'inF0' (in 2-component vector of float)
-0:125        'inF1' (in 2-component vector of float)
-0:125        'inF2' (in 2-component vector of float)
-0:126      sqrt (global 2-component vector of float)
+0:125      Sequence
+0:125        move second child to first child (temp 2-component vector of float)
+0:125          'inF1' (in 2-component vector of float)
+0:125          sine (temp 2-component vector of float)
+0:125            'inF0' (in 2-component vector of float)
+0:125        move second child to first child (temp 2-component vector of float)
+0:125          'inF2' (in 2-component vector of float)
+0:125          cosine (temp 2-component vector of float)
+0:125            'inF0' (in 2-component vector of float)
+0:126      hyp. sine (global 2-component vector of float)
 0:126        'inF0' (in 2-component vector of float)
-0:127      step (global 2-component vector of float)
+0:127      smoothstep (global 2-component vector of float)
 0:127        'inF0' (in 2-component vector of float)
 0:127        'inF1' (in 2-component vector of float)
-0:128      tangent (global 2-component vector of float)
+0:127        'inF2' (in 2-component vector of float)
+0:128      sqrt (global 2-component vector of float)
 0:128        'inF0' (in 2-component vector of float)
-0:129      hyp. tangent (global 2-component vector of float)
+0:129      step (global 2-component vector of float)
 0:129        'inF0' (in 2-component vector of float)
-0:131      trunc (global 2-component vector of float)
+0:129        'inF1' (in 2-component vector of float)
+0:130      tangent (global 2-component vector of float)
+0:130        'inF0' (in 2-component vector of float)
+0:131      hyp. tangent (global 2-component vector of float)
 0:131        'inF0' (in 2-component vector of float)
-0:134      Branch: Return with expression
+0:133      trunc (global 2-component vector of float)
+0:133        'inF0' (in 2-component vector of float)
+0:136      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
-0:207  Function Definition: VertexShaderFunction(vf3;vf3;vf3;vu3;vu3; (temp 3-component vector of float)
-0:138    Function Parameters: 
-0:138      'inF0' (in 3-component vector of float)
-0:138      'inF1' (in 3-component vector of float)
-0:138      'inF2' (in 3-component vector of float)
-0:138      'inU0' (in 3-component vector of uint)
-0:138      'inU1' (in 3-component vector of uint)
+0:210  Function Definition: VertexShaderFunction(vf3;vf3;vf3;vu3;vu3; (temp 3-component vector of float)
+0:140    Function Parameters: 
+0:140      'inF0' (in 3-component vector of float)
+0:140      'inF1' (in 3-component vector of float)
+0:140      'inF2' (in 3-component vector of float)
+0:140      'inU0' (in 3-component vector of uint)
+0:140      'inU1' (in 3-component vector of uint)
 0:?     Sequence
-0:139      all (global bool)
-0:139        'inF0' (in 3-component vector of float)
-0:140      Absolute value (global 3-component vector of float)
-0:140        'inF0' (in 3-component vector of float)
-0:141      arc cosine (global 3-component vector of float)
+0:141      all (global bool)
 0:141        'inF0' (in 3-component vector of float)
-0:142      any (global bool)
+0:142      Absolute value (global 3-component vector of float)
 0:142        'inF0' (in 3-component vector of float)
-0:143      arc sine (global 3-component vector of float)
+0:143      arc cosine (global 3-component vector of float)
 0:143        'inF0' (in 3-component vector of float)
-0:144      floatBitsToInt (global 3-component vector of int)
+0:144      any (global bool)
 0:144        'inF0' (in 3-component vector of float)
-0:145      floatBitsToUint (global 3-component vector of uint)
+0:145      arc sine (global 3-component vector of float)
 0:145        'inF0' (in 3-component vector of float)
-0:146      intBitsToFloat (global 3-component vector of float)
-0:146        'inU0' (in 3-component vector of uint)
-0:148      arc tangent (global 3-component vector of float)
-0:148        'inF0' (in 3-component vector of float)
-0:149      arc tangent (global 3-component vector of float)
-0:149        'inF0' (in 3-component vector of float)
-0:149        'inF1' (in 3-component vector of float)
-0:150      Ceiling (global 3-component vector of float)
+0:146      floatBitsToInt (global 3-component vector of int)
+0:146        'inF0' (in 3-component vector of float)
+0:147      floatBitsToUint (global 3-component vector of uint)
+0:147        'inF0' (in 3-component vector of float)
+0:148      intBitsToFloat (global 3-component vector of float)
+0:148        'inU0' (in 3-component vector of uint)
+0:150      arc tangent (global 3-component vector of float)
 0:150        'inF0' (in 3-component vector of float)
-0:151      clamp (global 3-component vector of float)
+0:151      arc tangent (global 3-component vector of float)
 0:151        'inF0' (in 3-component vector of float)
 0:151        'inF1' (in 3-component vector of float)
-0:151        'inF2' (in 3-component vector of float)
-0:152      cosine (global 3-component vector of float)
+0:152      Ceiling (global 3-component vector of float)
 0:152        'inF0' (in 3-component vector of float)
-0:153      hyp. cosine (global 3-component vector of float)
+0:153      clamp (global 3-component vector of float)
 0:153        'inF0' (in 3-component vector of float)
+0:153        'inF1' (in 3-component vector of float)
+0:153        'inF2' (in 3-component vector of float)
+0:154      cosine (global 3-component vector of float)
+0:154        'inF0' (in 3-component vector of float)
+0:155      hyp. cosine (global 3-component vector of float)
+0:155        'inF0' (in 3-component vector of float)
 0:?       bitCount (global 3-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
-0:155      cross-product (global 3-component vector of float)
-0:155        'inF0' (in 3-component vector of float)
-0:155        'inF1' (in 3-component vector of float)
-0:156      degrees (global 3-component vector of float)
-0:156        'inF0' (in 3-component vector of float)
-0:157      distance (global float)
+0:157      cross-product (global 3-component vector of float)
 0:157        'inF0' (in 3-component vector of float)
 0:157        'inF1' (in 3-component vector of float)
-0:158      dot-product (global float)
+0:158      degrees (global 3-component vector of float)
 0:158        'inF0' (in 3-component vector of float)
-0:158        'inF1' (in 3-component vector of float)
-0:162      exp (global 3-component vector of float)
-0:162        'inF0' (in 3-component vector of float)
-0:163      exp2 (global 3-component vector of float)
-0:163        'inF0' (in 3-component vector of float)
-0:164      face-forward (global 3-component vector of float)
+0:159      distance (global float)
+0:159        'inF0' (in 3-component vector of float)
+0:159        'inF1' (in 3-component vector of float)
+0:160      dot-product (global float)
+0:160        'inF0' (in 3-component vector of float)
+0:160        'inF1' (in 3-component vector of float)
+0:164      exp (global 3-component vector of float)
 0:164        'inF0' (in 3-component vector of float)
-0:164        'inF1' (in 3-component vector of float)
-0:164        'inF2' (in 3-component vector of float)
-0:165      findMSB (global int)
-0:165        Constant:
-0:165          7 (const int)
-0:166      findLSB (global int)
-0:166        Constant:
-0:166          7 (const int)
-0:167      Floor (global 3-component vector of float)
-0:167        'inF0' (in 3-component vector of float)
-0:169      mod (global 3-component vector of float)
+0:165      exp2 (global 3-component vector of float)
+0:165        'inF0' (in 3-component vector of float)
+0:166      face-forward (global 3-component vector of float)
+0:166        'inF0' (in 3-component vector of float)
+0:166        'inF1' (in 3-component vector of float)
+0:166        'inF2' (in 3-component vector of float)
+0:167      findMSB (global int)
+0:167        Constant:
+0:167          7 (const int)
+0:168      findLSB (global int)
+0:168        Constant:
+0:168          7 (const int)
+0:169      Floor (global 3-component vector of float)
 0:169        'inF0' (in 3-component vector of float)
-0:169        'inF1' (in 3-component vector of float)
-0:170      Fraction (global 3-component vector of float)
-0:170        'inF0' (in 3-component vector of float)
-0:171      frexp (global 3-component vector of float)
+0:171      mod (global 3-component vector of float)
 0:171        'inF0' (in 3-component vector of float)
 0:171        'inF1' (in 3-component vector of float)
-0:172      isinf (global 3-component vector of bool)
+0:172      Fraction (global 3-component vector of float)
 0:172        'inF0' (in 3-component vector of float)
-0:173      isnan (global 3-component vector of bool)
+0:173      frexp (global 3-component vector of float)
 0:173        'inF0' (in 3-component vector of float)
-0:174      ldexp (global 3-component vector of float)
+0:173        'inF1' (in 3-component vector of float)
+0:174      isinf (global 3-component vector of bool)
 0:174        'inF0' (in 3-component vector of float)
-0:174        'inF1' (in 3-component vector of float)
-0:175      length (global float)
+0:175      isnan (global 3-component vector of bool)
 0:175        'inF0' (in 3-component vector of float)
-0:176      log (global 3-component vector of float)
+0:176      ldexp (global 3-component vector of float)
 0:176        'inF0' (in 3-component vector of float)
-0:177      vector-scale (temp 3-component vector of float)
-0:177        log2 (temp 3-component vector of float)
-0:177          'inF0' (in 3-component vector of float)
-0:177        Constant:
-0:177          0.301030
-0:178      log2 (global 3-component vector of float)
+0:176        'inF1' (in 3-component vector of float)
+0:177      mix (global 3-component vector of float)
+0:177        'inF0' (in 3-component vector of float)
+0:177        'inF1' (in 3-component vector of float)
+0:177        'inF2' (in 3-component vector of float)
+0:178      length (global float)
 0:178        'inF0' (in 3-component vector of float)
-0:179      max (global 3-component vector of float)
+0:179      log (global 3-component vector of float)
 0:179        'inF0' (in 3-component vector of float)
-0:179        'inF1' (in 3-component vector of float)
-0:180      min (global 3-component vector of float)
-0:180        'inF0' (in 3-component vector of float)
-0:180        'inF1' (in 3-component vector of float)
-0:182      normalize (global 3-component vector of float)
+0:180      vector-scale (temp 3-component vector of float)
+0:180        log2 (temp 3-component vector of float)
+0:180          'inF0' (in 3-component vector of float)
+0:180        Constant:
+0:180          0.301030
+0:181      log2 (global 3-component vector of float)
+0:181        'inF0' (in 3-component vector of float)
+0:182      max (global 3-component vector of float)
 0:182        'inF0' (in 3-component vector of float)
-0:183      pow (global 3-component vector of float)
+0:182        'inF1' (in 3-component vector of float)
+0:183      min (global 3-component vector of float)
 0:183        'inF0' (in 3-component vector of float)
 0:183        'inF1' (in 3-component vector of float)
-0:184      radians (global 3-component vector of float)
-0:184        'inF0' (in 3-component vector of float)
-0:185      reflect (global 3-component vector of float)
+0:185      normalize (global 3-component vector of float)
 0:185        'inF0' (in 3-component vector of float)
-0:185        'inF1' (in 3-component vector of float)
-0:186      refract (global 3-component vector of float)
+0:186      pow (global 3-component vector of float)
 0:186        'inF0' (in 3-component vector of float)
 0:186        'inF1' (in 3-component vector of float)
-0:186        Constant:
-0:186          2.000000
+0:187      radians (global 3-component vector of float)
+0:187        'inF0' (in 3-component vector of float)
+0:188      reflect (global 3-component vector of float)
+0:188        'inF0' (in 3-component vector of float)
+0:188        'inF1' (in 3-component vector of float)
+0:189      refract (global 3-component vector of float)
+0:189        'inF0' (in 3-component vector of float)
+0:189        'inF1' (in 3-component vector of float)
+0:189        Constant:
+0:189          2.000000
 0:?       bitFieldReverse (global 3-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
-0:188      roundEven (global 3-component vector of float)
-0:188        'inF0' (in 3-component vector of float)
-0:189      inverse sqrt (global 3-component vector of float)
-0:189        'inF0' (in 3-component vector of float)
-0:190      clamp (temp 3-component vector of float)
-0:190        'inF0' (in 3-component vector of float)
-0:190        Constant:
-0:190          0.000000
-0:190        Constant:
-0:190          1.000000
-0:191      Sign (global 3-component vector of float)
+0:191      roundEven (global 3-component vector of float)
 0:191        'inF0' (in 3-component vector of float)
-0:192      sine (global 3-component vector of float)
+0:192      inverse sqrt (global 3-component vector of float)
 0:192        'inF0' (in 3-component vector of float)
-0:193      Sequence
-0:193        move second child to first child (temp 3-component vector of float)
-0:193          'inF1' (in 3-component vector of float)
-0:193          sine (temp 3-component vector of float)
-0:193            'inF0' (in 3-component vector of float)
-0:193        move second child to first child (temp 3-component vector of float)
-0:193          'inF2' (in 3-component vector of float)
-0:193          cosine (temp 3-component vector of float)
-0:193            'inF0' (in 3-component vector of float)
-0:194      hyp. sine (global 3-component vector of float)
+0:193      clamp (temp 3-component vector of float)
+0:193        'inF0' (in 3-component vector of float)
+0:193        Constant:
+0:193          0.000000
+0:193        Constant:
+0:193          1.000000
+0:194      Sign (global 3-component vector of float)
 0:194        'inF0' (in 3-component vector of float)
-0:195      smoothstep (global 3-component vector of float)
+0:195      sine (global 3-component vector of float)
 0:195        'inF0' (in 3-component vector of float)
-0:195        'inF1' (in 3-component vector of float)
-0:195        'inF2' (in 3-component vector of float)
-0:196      sqrt (global 3-component vector of float)
-0:196        'inF0' (in 3-component vector of float)
-0:197      step (global 3-component vector of float)
+0:196      Sequence
+0:196        move second child to first child (temp 3-component vector of float)
+0:196          'inF1' (in 3-component vector of float)
+0:196          sine (temp 3-component vector of float)
+0:196            'inF0' (in 3-component vector of float)
+0:196        move second child to first child (temp 3-component vector of float)
+0:196          'inF2' (in 3-component vector of float)
+0:196          cosine (temp 3-component vector of float)
+0:196            'inF0' (in 3-component vector of float)
+0:197      hyp. sine (global 3-component vector of float)
 0:197        'inF0' (in 3-component vector of float)
-0:197        'inF1' (in 3-component vector of float)
-0:198      tangent (global 3-component vector of float)
+0:198      smoothstep (global 3-component vector of float)
 0:198        'inF0' (in 3-component vector of float)
-0:199      hyp. tangent (global 3-component vector of float)
+0:198        'inF1' (in 3-component vector of float)
+0:198        'inF2' (in 3-component vector of float)
+0:199      sqrt (global 3-component vector of float)
 0:199        'inF0' (in 3-component vector of float)
-0:201      trunc (global 3-component vector of float)
+0:200      step (global 3-component vector of float)
+0:200        'inF0' (in 3-component vector of float)
+0:200        'inF1' (in 3-component vector of float)
+0:201      tangent (global 3-component vector of float)
 0:201        'inF0' (in 3-component vector of float)
-0:204      Branch: Return with expression
+0:202      hyp. tangent (global 3-component vector of float)
+0:202        'inF0' (in 3-component vector of float)
+0:204      trunc (global 3-component vector of float)
+0:204        'inF0' (in 3-component vector of float)
+0:207      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
-0:330  Function Definition: VertexShaderFunction(vf4;vf4;vf4;vu4;vu4; (temp 4-component vector of float)
-0:208    Function Parameters: 
-0:208      'inF0' (in 4-component vector of float)
-0:208      'inF1' (in 4-component vector of float)
-0:208      'inF2' (in 4-component vector of float)
-0:208      'inU0' (in 4-component vector of uint)
-0:208      'inU1' (in 4-component vector of uint)
+0:335  Function Definition: VertexShaderFunction(vf4;vf4;vf4;vu4;vu4; (temp 4-component vector of float)
+0:211    Function Parameters: 
+0:211      'inF0' (in 4-component vector of float)
+0:211      'inF1' (in 4-component vector of float)
+0:211      'inF2' (in 4-component vector of float)
+0:211      'inU0' (in 4-component vector of uint)
+0:211      'inU1' (in 4-component vector of uint)
 0:?     Sequence
-0:209      all (global bool)
-0:209        'inF0' (in 4-component vector of float)
-0:210      Absolute value (global 4-component vector of float)
-0:210        'inF0' (in 4-component vector of float)
-0:211      arc cosine (global 4-component vector of float)
-0:211        'inF0' (in 4-component vector of float)
-0:212      any (global bool)
+0:212      all (global bool)
 0:212        'inF0' (in 4-component vector of float)
-0:213      arc sine (global 4-component vector of float)
+0:213      Absolute value (global 4-component vector of float)
 0:213        'inF0' (in 4-component vector of float)
-0:214      floatBitsToInt (global 4-component vector of int)
+0:214      arc cosine (global 4-component vector of float)
 0:214        'inF0' (in 4-component vector of float)
-0:215      floatBitsToUint (global 4-component vector of uint)
+0:215      any (global bool)
 0:215        'inF0' (in 4-component vector of float)
-0:216      intBitsToFloat (global 4-component vector of float)
-0:216        'inU0' (in 4-component vector of uint)
-0:218      arc tangent (global 4-component vector of float)
+0:216      arc sine (global 4-component vector of float)
+0:216        'inF0' (in 4-component vector of float)
+0:217      floatBitsToInt (global 4-component vector of int)
+0:217        'inF0' (in 4-component vector of float)
+0:218      floatBitsToUint (global 4-component vector of uint)
 0:218        'inF0' (in 4-component vector of float)
-0:219      arc tangent (global 4-component vector of float)
-0:219        'inF0' (in 4-component vector of float)
-0:219        'inF1' (in 4-component vector of float)
-0:220      Ceiling (global 4-component vector of float)
-0:220        'inF0' (in 4-component vector of float)
-0:221      clamp (global 4-component vector of float)
+0:219      intBitsToFloat (global 4-component vector of float)
+0:219        'inU0' (in 4-component vector of uint)
+0:221      arc tangent (global 4-component vector of float)
 0:221        'inF0' (in 4-component vector of float)
-0:221        'inF1' (in 4-component vector of float)
-0:221        'inF2' (in 4-component vector of float)
-0:222      cosine (global 4-component vector of float)
+0:222      arc tangent (global 4-component vector of float)
 0:222        'inF0' (in 4-component vector of float)
-0:223      hyp. cosine (global 4-component vector of float)
+0:222        'inF1' (in 4-component vector of float)
+0:223      Ceiling (global 4-component vector of float)
 0:223        'inF0' (in 4-component vector of float)
+0:224      clamp (global 4-component vector of float)
+0:224        'inF0' (in 4-component vector of float)
+0:224        'inF1' (in 4-component vector of float)
+0:224        'inF2' (in 4-component vector of float)
+0:225      cosine (global 4-component vector of float)
+0:225        'inF0' (in 4-component vector of float)
+0:226      hyp. cosine (global 4-component vector of float)
+0:226        'inF0' (in 4-component vector of float)
 0:?       bitCount (global 4-component vector of uint)
 0:?         Constant:
 0:?           7 (const uint)
 0:?           3 (const uint)
 0:?           5 (const uint)
 0:?           2 (const uint)
-0:225      degrees (global 4-component vector of float)
-0:225        'inF0' (in 4-component vector of float)
-0:226      distance (global float)
-0:226        'inF0' (in 4-component vector of float)
-0:226        'inF1' (in 4-component vector of float)
-0:227      dot-product (global float)
-0:227        'inF0' (in 4-component vector of float)
-0:227        'inF1' (in 4-component vector of float)
-0:228      Construct vec4 (temp 4-component vector of float)
-0:228        Constant:
-0:228          1.000000
-0:228        component-wise multiply (temp float)
-0:228          direct index (temp float)
-0:228            'inF0' (in 4-component vector of float)
-0:228            Constant:
-0:228              1 (const int)
-0:228          direct index (temp float)
-0:228            'inF1' (in 4-component vector of float)
-0:228            Constant:
-0:228              1 (const int)
-0:228        direct index (temp float)
-0:228          'inF0' (in 4-component vector of float)
-0:228          Constant:
-0:228            2 (const int)
-0:228        direct index (temp float)
-0:228          'inF1' (in 4-component vector of float)
-0:228          Constant:
-0:228            3 (const int)
-0:232      exp (global 4-component vector of float)
-0:232        'inF0' (in 4-component vector of float)
-0:233      exp2 (global 4-component vector of float)
-0:233        'inF0' (in 4-component vector of float)
-0:234      face-forward (global 4-component vector of float)
-0:234        'inF0' (in 4-component vector of float)
-0:234        'inF1' (in 4-component vector of float)
-0:234        'inF2' (in 4-component vector of float)
-0:235      findMSB (global int)
-0:235        Constant:
-0:235          7 (const int)
-0:236      findLSB (global int)
-0:236        Constant:
-0:236          7 (const int)
-0:237      Floor (global 4-component vector of float)
+0:228      degrees (global 4-component vector of float)
+0:228        'inF0' (in 4-component vector of float)
+0:229      distance (global float)
+0:229        'inF0' (in 4-component vector of float)
+0:229        'inF1' (in 4-component vector of float)
+0:230      dot-product (global float)
+0:230        'inF0' (in 4-component vector of float)
+0:230        'inF1' (in 4-component vector of float)
+0:231      Construct vec4 (temp 4-component vector of float)
+0:231        Constant:
+0:231          1.000000
+0:231        component-wise multiply (temp float)
+0:231          direct index (temp float)
+0:231            'inF0' (in 4-component vector of float)
+0:231            Constant:
+0:231              1 (const int)
+0:231          direct index (temp float)
+0:231            'inF1' (in 4-component vector of float)
+0:231            Constant:
+0:231              1 (const int)
+0:231        direct index (temp float)
+0:231          'inF0' (in 4-component vector of float)
+0:231          Constant:
+0:231            2 (const int)
+0:231        direct index (temp float)
+0:231          'inF1' (in 4-component vector of float)
+0:231          Constant:
+0:231            3 (const int)
+0:235      exp (global 4-component vector of float)
+0:235        'inF0' (in 4-component vector of float)
+0:236      exp2 (global 4-component vector of float)
+0:236        'inF0' (in 4-component vector of float)
+0:237      face-forward (global 4-component vector of float)
 0:237        'inF0' (in 4-component vector of float)
-0:239      mod (global 4-component vector of float)
-0:239        'inF0' (in 4-component vector of float)
-0:239        'inF1' (in 4-component vector of float)
-0:240      Fraction (global 4-component vector of float)
+0:237        'inF1' (in 4-component vector of float)
+0:237        'inF2' (in 4-component vector of float)
+0:238      findMSB (global int)
+0:238        Constant:
+0:238          7 (const int)
+0:239      findLSB (global int)
+0:239        Constant:
+0:239          7 (const int)
+0:240      Floor (global 4-component vector of float)
 0:240        'inF0' (in 4-component vector of float)
-0:241      frexp (global 4-component vector of float)
-0:241        'inF0' (in 4-component vector of float)
-0:241        'inF1' (in 4-component vector of float)
-0:242      isinf (global 4-component vector of bool)
+0:242      mod (global 4-component vector of float)
 0:242        'inF0' (in 4-component vector of float)
-0:243      isnan (global 4-component vector of bool)
+0:242        'inF1' (in 4-component vector of float)
+0:243      Fraction (global 4-component vector of float)
 0:243        'inF0' (in 4-component vector of float)
-0:244      ldexp (global 4-component vector of float)
+0:244      frexp (global 4-component vector of float)
 0:244        'inF0' (in 4-component vector of float)
 0:244        'inF1' (in 4-component vector of float)
-0:245      length (global float)
+0:245      isinf (global 4-component vector of bool)
 0:245        'inF0' (in 4-component vector of float)
-0:246      log (global 4-component vector of float)
+0:246      isnan (global 4-component vector of bool)
 0:246        'inF0' (in 4-component vector of float)
-0:247      vector-scale (temp 4-component vector of float)
-0:247        log2 (temp 4-component vector of float)
-0:247          'inF0' (in 4-component vector of float)
-0:247        Constant:
-0:247          0.301030
-0:248      log2 (global 4-component vector of float)
+0:247      ldexp (global 4-component vector of float)
+0:247        'inF0' (in 4-component vector of float)
+0:247        'inF1' (in 4-component vector of float)
+0:248      mix (global 4-component vector of float)
 0:248        'inF0' (in 4-component vector of float)
-0:249      max (global 4-component vector of float)
+0:248        'inF1' (in 4-component vector of float)
+0:248        'inF2' (in 4-component vector of float)
+0:249      length (global float)
 0:249        'inF0' (in 4-component vector of float)
-0:249        'inF1' (in 4-component vector of float)
-0:250      min (global 4-component vector of float)
+0:250      log (global 4-component vector of float)
 0:250        'inF0' (in 4-component vector of float)
-0:250        'inF1' (in 4-component vector of float)
-0:252      normalize (global 4-component vector of float)
+0:251      vector-scale (temp 4-component vector of float)
+0:251        log2 (temp 4-component vector of float)
+0:251          'inF0' (in 4-component vector of float)
+0:251        Constant:
+0:251          0.301030
+0:252      log2 (global 4-component vector of float)
 0:252        'inF0' (in 4-component vector of float)
-0:253      pow (global 4-component vector of float)
+0:253      max (global 4-component vector of float)
 0:253        'inF0' (in 4-component vector of float)
 0:253        'inF1' (in 4-component vector of float)
-0:254      radians (global 4-component vector of float)
+0:254      min (global 4-component vector of float)
 0:254        'inF0' (in 4-component vector of float)
-0:255      reflect (global 4-component vector of float)
-0:255        'inF0' (in 4-component vector of float)
-0:255        'inF1' (in 4-component vector of float)
-0:256      refract (global 4-component vector of float)
+0:254        'inF1' (in 4-component vector of float)
+0:256      normalize (global 4-component vector of float)
 0:256        'inF0' (in 4-component vector of float)
-0:256        'inF1' (in 4-component vector of float)
-0:256        Constant:
-0:256          2.000000
+0:257      pow (global 4-component vector of float)
+0:257        'inF0' (in 4-component vector of float)
+0:257        'inF1' (in 4-component vector of float)
+0:258      radians (global 4-component vector of float)
+0:258        'inF0' (in 4-component vector of float)
+0:259      reflect (global 4-component vector of float)
+0:259        'inF0' (in 4-component vector of float)
+0:259        'inF1' (in 4-component vector of float)
+0:260      refract (global 4-component vector of float)
+0:260        'inF0' (in 4-component vector of float)
+0:260        'inF1' (in 4-component vector of float)
+0:260        Constant:
+0:260          2.000000
 0:?       bitFieldReverse (global 4-component vector of uint)
 0:?         Constant:
 0:?           1 (const uint)
 0:?           2 (const uint)
 0:?           3 (const uint)
 0:?           4 (const uint)
-0:258      roundEven (global 4-component vector of float)
-0:258        'inF0' (in 4-component vector of float)
-0:259      inverse sqrt (global 4-component vector of float)
-0:259        'inF0' (in 4-component vector of float)
-0:260      clamp (temp 4-component vector of float)
-0:260        'inF0' (in 4-component vector of float)
-0:260        Constant:
-0:260          0.000000
-0:260        Constant:
-0:260          1.000000
-0:261      Sign (global 4-component vector of float)
-0:261        'inF0' (in 4-component vector of float)
-0:262      sine (global 4-component vector of float)
+0:262      roundEven (global 4-component vector of float)
 0:262        'inF0' (in 4-component vector of float)
-0:263      Sequence
-0:263        move second child to first child (temp 4-component vector of float)
-0:263          'inF1' (in 4-component vector of float)
-0:263          sine (temp 4-component vector of float)
-0:263            'inF0' (in 4-component vector of float)
-0:263        move second child to first child (temp 4-component vector of float)
-0:263          'inF2' (in 4-component vector of float)
-0:263          cosine (temp 4-component vector of float)
-0:263            'inF0' (in 4-component vector of float)
-0:264      hyp. sine (global 4-component vector of float)
+0:263      inverse sqrt (global 4-component vector of float)
+0:263        'inF0' (in 4-component vector of float)
+0:264      clamp (temp 4-component vector of float)
 0:264        'inF0' (in 4-component vector of float)
-0:265      smoothstep (global 4-component vector of float)
+0:264        Constant:
+0:264          0.000000
+0:264        Constant:
+0:264          1.000000
+0:265      Sign (global 4-component vector of float)
 0:265        'inF0' (in 4-component vector of float)
-0:265        'inF1' (in 4-component vector of float)
-0:265        'inF2' (in 4-component vector of float)
-0:266      sqrt (global 4-component vector of float)
+0:266      sine (global 4-component vector of float)
 0:266        'inF0' (in 4-component vector of float)
-0:267      step (global 4-component vector of float)
-0:267        'inF0' (in 4-component vector of float)
-0:267        'inF1' (in 4-component vector of float)
-0:268      tangent (global 4-component vector of float)
+0:267      Sequence
+0:267        move second child to first child (temp 4-component vector of float)
+0:267          'inF1' (in 4-component vector of float)
+0:267          sine (temp 4-component vector of float)
+0:267            'inF0' (in 4-component vector of float)
+0:267        move second child to first child (temp 4-component vector of float)
+0:267          'inF2' (in 4-component vector of float)
+0:267          cosine (temp 4-component vector of float)
+0:267            'inF0' (in 4-component vector of float)
+0:268      hyp. sine (global 4-component vector of float)
 0:268        'inF0' (in 4-component vector of float)
-0:269      hyp. tangent (global 4-component vector of float)
+0:269      smoothstep (global 4-component vector of float)
 0:269        'inF0' (in 4-component vector of float)
-0:271      trunc (global 4-component vector of float)
+0:269        'inF1' (in 4-component vector of float)
+0:269        'inF2' (in 4-component vector of float)
+0:270      sqrt (global 4-component vector of float)
+0:270        'inF0' (in 4-component vector of float)
+0:271      step (global 4-component vector of float)
 0:271        'inF0' (in 4-component vector of float)
-0:274      Branch: Return with expression
+0:271        'inF1' (in 4-component vector of float)
+0:272      tangent (global 4-component vector of float)
+0:272        'inF0' (in 4-component vector of float)
+0:273      hyp. tangent (global 4-component vector of float)
+0:273        'inF0' (in 4-component vector of float)
+0:275      trunc (global 4-component vector of float)
+0:275        'inF0' (in 4-component vector of float)
+0:278      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
 0:?           4.000000
-0:339  Function Definition: VertexShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
-0:331    Function Parameters: 
-0:331      'inF0' (in 2X2 matrix of float)
-0:331      'inF1' (in 2X2 matrix of float)
-0:331      'inF2' (in 2X2 matrix of float)
+0:344  Function Definition: VertexShaderFunction(mf22;mf22;mf22; (temp 2X2 matrix of float)
+0:336    Function Parameters: 
+0:336      'inF0' (in 2X2 matrix of float)
+0:336      'inF1' (in 2X2 matrix of float)
+0:336      'inF2' (in 2X2 matrix of float)
 0:?     Sequence
-0:333      all (global bool)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      Absolute value (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      arc cosine (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      any (global bool)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      arc sine (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      arc tangent (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      arc tangent (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      Ceiling (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      clamp (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333        'inF2' (in 2X2 matrix of float)
-0:333      cosine (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      hyp. cosine (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      degrees (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      determinant (global float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      exp (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      exp2 (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      findMSB (global int)
-0:333        Constant:
-0:333          7 (const int)
-0:333      findLSB (global int)
-0:333        Constant:
-0:333          7 (const int)
-0:333      Floor (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      mod (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      Fraction (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      frexp (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      ldexp (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      log (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      matrix-scale (temp 2X2 matrix of float)
-0:333        log2 (temp 2X2 matrix of float)
-0:333          'inF0' (in 2X2 matrix of float)
-0:333        Constant:
-0:333          0.301030
-0:333      log2 (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      max (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      min (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      pow (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      radians (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      roundEven (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      inverse sqrt (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      clamp (temp 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        Constant:
-0:333          0.000000
-0:333        Constant:
-0:333          1.000000
-0:333      Sign (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      sine (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      Sequence
-0:333        move second child to first child (temp 2X2 matrix of float)
-0:333          'inF1' (in 2X2 matrix of float)
-0:333          sine (temp 2X2 matrix of float)
-0:333            'inF0' (in 2X2 matrix of float)
-0:333        move second child to first child (temp 2X2 matrix of float)
-0:333          'inF2' (in 2X2 matrix of float)
-0:333          cosine (temp 2X2 matrix of float)
-0:333            'inF0' (in 2X2 matrix of float)
-0:333      hyp. sine (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      smoothstep (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333        'inF2' (in 2X2 matrix of float)
-0:333      sqrt (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      step (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333        'inF1' (in 2X2 matrix of float)
-0:333      tangent (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      hyp. tangent (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      transpose (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:333      trunc (global 2X2 matrix of float)
-0:333        'inF0' (in 2X2 matrix of float)
-0:336      Branch: Return with expression
+0:338      all (global bool)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      Absolute value (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      arc cosine (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      any (global bool)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      arc sine (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      arc tangent (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      arc tangent (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      Ceiling (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      clamp (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338        'inF2' (in 2X2 matrix of float)
+0:338      cosine (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      hyp. cosine (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      degrees (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      determinant (global float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      exp (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      exp2 (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      findMSB (global int)
+0:338        Constant:
+0:338          7 (const int)
+0:338      findLSB (global int)
+0:338        Constant:
+0:338          7 (const int)
+0:338      Floor (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      mod (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      Fraction (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      frexp (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      ldexp (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      mix (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338        'inF2' (in 2X2 matrix of float)
+0:338      log (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      matrix-scale (temp 2X2 matrix of float)
+0:338        log2 (temp 2X2 matrix of float)
+0:338          'inF0' (in 2X2 matrix of float)
+0:338        Constant:
+0:338          0.301030
+0:338      log2 (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      max (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      min (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      pow (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      radians (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      roundEven (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      inverse sqrt (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      clamp (temp 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        Constant:
+0:338          0.000000
+0:338        Constant:
+0:338          1.000000
+0:338      Sign (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      sine (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      Sequence
+0:338        move second child to first child (temp 2X2 matrix of float)
+0:338          'inF1' (in 2X2 matrix of float)
+0:338          sine (temp 2X2 matrix of float)
+0:338            'inF0' (in 2X2 matrix of float)
+0:338        move second child to first child (temp 2X2 matrix of float)
+0:338          'inF2' (in 2X2 matrix of float)
+0:338          cosine (temp 2X2 matrix of float)
+0:338            'inF0' (in 2X2 matrix of float)
+0:338      hyp. sine (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      smoothstep (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338        'inF2' (in 2X2 matrix of float)
+0:338      sqrt (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      step (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338        'inF1' (in 2X2 matrix of float)
+0:338      tangent (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      hyp. tangent (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      transpose (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:338      trunc (global 2X2 matrix of float)
+0:338        'inF0' (in 2X2 matrix of float)
+0:341      Branch: Return with expression
 0:?         Constant:
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
-0:348  Function Definition: VertexShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
-0:340    Function Parameters: 
-0:340      'inF0' (in 3X3 matrix of float)
-0:340      'inF1' (in 3X3 matrix of float)
-0:340      'inF2' (in 3X3 matrix of float)
+0:353  Function Definition: VertexShaderFunction(mf33;mf33;mf33; (temp 3X3 matrix of float)
+0:345    Function Parameters: 
+0:345      'inF0' (in 3X3 matrix of float)
+0:345      'inF1' (in 3X3 matrix of float)
+0:345      'inF2' (in 3X3 matrix of float)
 0:?     Sequence
-0:342      all (global bool)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      Absolute value (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      arc cosine (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      any (global bool)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      arc sine (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      arc tangent (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      arc tangent (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      Ceiling (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      clamp (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342        'inF2' (in 3X3 matrix of float)
-0:342      cosine (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      hyp. cosine (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      degrees (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      determinant (global float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      exp (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      exp2 (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      findMSB (global int)
-0:342        Constant:
-0:342          7 (const int)
-0:342      findLSB (global int)
-0:342        Constant:
-0:342          7 (const int)
-0:342      Floor (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      mod (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      Fraction (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      frexp (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      ldexp (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      log (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      matrix-scale (temp 3X3 matrix of float)
-0:342        log2 (temp 3X3 matrix of float)
-0:342          'inF0' (in 3X3 matrix of float)
-0:342        Constant:
-0:342          0.301030
-0:342      log2 (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      max (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      min (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      pow (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      radians (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      roundEven (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      inverse sqrt (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      clamp (temp 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        Constant:
-0:342          0.000000
-0:342        Constant:
-0:342          1.000000
-0:342      Sign (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      sine (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      Sequence
-0:342        move second child to first child (temp 3X3 matrix of float)
-0:342          'inF1' (in 3X3 matrix of float)
-0:342          sine (temp 3X3 matrix of float)
-0:342            'inF0' (in 3X3 matrix of float)
-0:342        move second child to first child (temp 3X3 matrix of float)
-0:342          'inF2' (in 3X3 matrix of float)
-0:342          cosine (temp 3X3 matrix of float)
-0:342            'inF0' (in 3X3 matrix of float)
-0:342      hyp. sine (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      smoothstep (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342        'inF2' (in 3X3 matrix of float)
-0:342      sqrt (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      step (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342        'inF1' (in 3X3 matrix of float)
-0:342      tangent (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      hyp. tangent (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      transpose (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:342      trunc (global 3X3 matrix of float)
-0:342        'inF0' (in 3X3 matrix of float)
-0:345      Branch: Return with expression
+0:347      all (global bool)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      Absolute value (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      arc cosine (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      any (global bool)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      arc sine (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      arc tangent (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      arc tangent (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      Ceiling (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      clamp (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347        'inF2' (in 3X3 matrix of float)
+0:347      cosine (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      hyp. cosine (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      degrees (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      determinant (global float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      exp (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      exp2 (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      findMSB (global int)
+0:347        Constant:
+0:347          7 (const int)
+0:347      findLSB (global int)
+0:347        Constant:
+0:347          7 (const int)
+0:347      Floor (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      mod (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      Fraction (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      frexp (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      ldexp (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      mix (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347        'inF2' (in 3X3 matrix of float)
+0:347      log (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      matrix-scale (temp 3X3 matrix of float)
+0:347        log2 (temp 3X3 matrix of float)
+0:347          'inF0' (in 3X3 matrix of float)
+0:347        Constant:
+0:347          0.301030
+0:347      log2 (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      max (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      min (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      pow (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      radians (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      roundEven (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      inverse sqrt (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      clamp (temp 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        Constant:
+0:347          0.000000
+0:347        Constant:
+0:347          1.000000
+0:347      Sign (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      sine (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      Sequence
+0:347        move second child to first child (temp 3X3 matrix of float)
+0:347          'inF1' (in 3X3 matrix of float)
+0:347          sine (temp 3X3 matrix of float)
+0:347            'inF0' (in 3X3 matrix of float)
+0:347        move second child to first child (temp 3X3 matrix of float)
+0:347          'inF2' (in 3X3 matrix of float)
+0:347          cosine (temp 3X3 matrix of float)
+0:347            'inF0' (in 3X3 matrix of float)
+0:347      hyp. sine (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      smoothstep (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347        'inF2' (in 3X3 matrix of float)
+0:347      sqrt (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      step (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347        'inF1' (in 3X3 matrix of float)
+0:347      tangent (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      hyp. tangent (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      transpose (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:347      trunc (global 3X3 matrix of float)
+0:347        'inF0' (in 3X3 matrix of float)
+0:350      Branch: Return with expression
 0:?         Constant:
 0:?           3.000000
 0:?           3.000000
@@ -2151,127 +2300,131 @@ Shader version: 450
 0:?           3.000000
 0:?           3.000000
 0:?           3.000000
-0:369  Function Definition: VertexShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
-0:349    Function Parameters: 
-0:349      'inF0' (in 4X4 matrix of float)
-0:349      'inF1' (in 4X4 matrix of float)
-0:349      'inF2' (in 4X4 matrix of float)
+0:374  Function Definition: VertexShaderFunction(mf44;mf44;mf44; (temp 4X4 matrix of float)
+0:354    Function Parameters: 
+0:354      'inF0' (in 4X4 matrix of float)
+0:354      'inF1' (in 4X4 matrix of float)
+0:354      'inF2' (in 4X4 matrix of float)
 0:?     Sequence
-0:351      all (global bool)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      Absolute value (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      arc cosine (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      any (global bool)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      arc sine (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      arc tangent (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      arc tangent (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      Ceiling (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      clamp (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351        'inF2' (in 4X4 matrix of float)
-0:351      cosine (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      hyp. cosine (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      degrees (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      determinant (global float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      exp (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      exp2 (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      findMSB (global int)
-0:351        Constant:
-0:351          7 (const int)
-0:351      findLSB (global int)
-0:351        Constant:
-0:351          7 (const int)
-0:351      Floor (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      mod (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      Fraction (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      frexp (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      ldexp (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      log (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      matrix-scale (temp 4X4 matrix of float)
-0:351        log2 (temp 4X4 matrix of float)
-0:351          'inF0' (in 4X4 matrix of float)
-0:351        Constant:
-0:351          0.301030
-0:351      log2 (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      max (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      min (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      pow (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      radians (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      roundEven (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      inverse sqrt (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      clamp (temp 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        Constant:
-0:351          0.000000
-0:351        Constant:
-0:351          1.000000
-0:351      Sign (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      sine (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      Sequence
-0:351        move second child to first child (temp 4X4 matrix of float)
-0:351          'inF1' (in 4X4 matrix of float)
-0:351          sine (temp 4X4 matrix of float)
-0:351            'inF0' (in 4X4 matrix of float)
-0:351        move second child to first child (temp 4X4 matrix of float)
-0:351          'inF2' (in 4X4 matrix of float)
-0:351          cosine (temp 4X4 matrix of float)
-0:351            'inF0' (in 4X4 matrix of float)
-0:351      hyp. sine (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      smoothstep (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351        'inF2' (in 4X4 matrix of float)
-0:351      sqrt (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      step (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351        'inF1' (in 4X4 matrix of float)
-0:351      tangent (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      hyp. tangent (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      transpose (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:351      trunc (global 4X4 matrix of float)
-0:351        'inF0' (in 4X4 matrix of float)
-0:354      Branch: Return with expression
+0:356      all (global bool)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      Absolute value (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      arc cosine (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      any (global bool)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      arc sine (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      arc tangent (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      arc tangent (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      Ceiling (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      clamp (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356        'inF2' (in 4X4 matrix of float)
+0:356      cosine (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      hyp. cosine (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      degrees (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      determinant (global float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      exp (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      exp2 (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      findMSB (global int)
+0:356        Constant:
+0:356          7 (const int)
+0:356      findLSB (global int)
+0:356        Constant:
+0:356          7 (const int)
+0:356      Floor (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      mod (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      Fraction (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      frexp (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      ldexp (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      mix (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356        'inF2' (in 4X4 matrix of float)
+0:356      log (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      matrix-scale (temp 4X4 matrix of float)
+0:356        log2 (temp 4X4 matrix of float)
+0:356          'inF0' (in 4X4 matrix of float)
+0:356        Constant:
+0:356          0.301030
+0:356      log2 (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      max (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      min (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      pow (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      radians (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      roundEven (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      inverse sqrt (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      clamp (temp 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        Constant:
+0:356          0.000000
+0:356        Constant:
+0:356          1.000000
+0:356      Sign (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      sine (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      Sequence
+0:356        move second child to first child (temp 4X4 matrix of float)
+0:356          'inF1' (in 4X4 matrix of float)
+0:356          sine (temp 4X4 matrix of float)
+0:356            'inF0' (in 4X4 matrix of float)
+0:356        move second child to first child (temp 4X4 matrix of float)
+0:356          'inF2' (in 4X4 matrix of float)
+0:356          cosine (temp 4X4 matrix of float)
+0:356            'inF0' (in 4X4 matrix of float)
+0:356      hyp. sine (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      smoothstep (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356        'inF2' (in 4X4 matrix of float)
+0:356      sqrt (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      step (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356        'inF1' (in 4X4 matrix of float)
+0:356      tangent (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      hyp. tangent (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      transpose (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:356      trunc (global 4X4 matrix of float)
+0:356        'inF0' (in 4X4 matrix of float)
+0:359      Branch: Return with expression
 0:?         Constant:
 0:?           4.000000
 0:?           4.000000
@@ -2289,178 +2442,275 @@ Shader version: 450
 0:?           4.000000
 0:?           4.000000
 0:?           4.000000
-0:376  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
-0:372    Function Parameters: 
-0:372      'inF0' (in float)
-0:372      'inF1' (in float)
-0:372      'inFV0' (in 2-component vector of float)
-0:372      'inFV1' (in 2-component vector of float)
-0:372      'inFM0' (in 2X2 matrix of float)
-0:372      'inFM1' (in 2X2 matrix of float)
+0:381  Function Definition: TestGenMul(f1;f1;vf2;vf2;mf22;mf22; (temp void)
+0:377    Function Parameters: 
+0:377      'inF0' (in float)
+0:377      'inF1' (in float)
+0:377      'inFV0' (in 2-component vector of float)
+0:377      'inFV1' (in 2-component vector of float)
+0:377      'inFM0' (in 2X2 matrix of float)
+0:377      'inFM1' (in 2X2 matrix of float)
 0:?     Sequence
-0:373      move second child to first child (temp float)
-0:373        'r0' (temp float)
-0:373        component-wise multiply (temp float)
-0:373          'inF0' (in float)
-0:373          'inF1' (in float)
-0:373      move second child to first child (temp 2-component vector of float)
-0:373        'r1' (temp 2-component vector of float)
-0:373        vector-scale (temp 2-component vector of float)
-0:373          'inFV0' (in 2-component vector of float)
-0:373          'inF0' (in float)
-0:373      move second child to first child (temp 2-component vector of float)
-0:373        'r2' (temp 2-component vector of float)
-0:373        vector-scale (temp 2-component vector of float)
-0:373          'inF0' (in float)
-0:373          'inFV0' (in 2-component vector of float)
-0:373      move second child to first child (temp float)
-0:373        'r3' (temp float)
-0:373        dot-product (global float)
-0:373          'inFV0' (in 2-component vector of float)
-0:373          'inFV1' (in 2-component vector of float)
-0:373      move second child to first child (temp 2-component vector of float)
-0:373        'r4' (temp 2-component vector of float)
-0:373        matrix-times-vector (temp 2-component vector of float)
-0:373          'inFM0' (in 2X2 matrix of float)
-0:373          'inFV0' (in 2-component vector of float)
-0:373      move second child to first child (temp 2-component vector of float)
-0:373        'r5' (temp 2-component vector of float)
-0:373        vector-times-matrix (temp 2-component vector of float)
-0:373          'inFV0' (in 2-component vector of float)
-0:373          'inFM0' (in 2X2 matrix of float)
-0:373      move second child to first child (temp 2X2 matrix of float)
-0:373        'r6' (temp 2X2 matrix of float)
-0:373        matrix-scale (temp 2X2 matrix of float)
-0:373          'inFM0' (in 2X2 matrix of float)
-0:373          'inF0' (in float)
-0:373      move second child to first child (temp 2X2 matrix of float)
-0:373        'r7' (temp 2X2 matrix of float)
-0:373        matrix-scale (temp 2X2 matrix of float)
-0:373          'inF0' (in float)
-0:373          'inFM0' (in 2X2 matrix of float)
-0:373      move second child to first child (temp 2X2 matrix of float)
-0:373        'r8' (temp 2X2 matrix of float)
-0:373        matrix-multiply (temp 2X2 matrix of float)
-0:373          'inFM0' (in 2X2 matrix of float)
-0:373          'inFM1' (in 2X2 matrix of float)
-0:383  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
-0:379    Function Parameters: 
-0:379      'inF0' (in float)
-0:379      'inF1' (in float)
-0:379      'inFV0' (in 3-component vector of float)
-0:379      'inFV1' (in 3-component vector of float)
-0:379      'inFM0' (in 3X3 matrix of float)
-0:379      'inFM1' (in 3X3 matrix of float)
+0:378      move second child to first child (temp float)
+0:378        'r0' (temp float)
+0:378        component-wise multiply (temp float)
+0:378          'inF0' (in float)
+0:378          'inF1' (in float)
+0:378      move second child to first child (temp 2-component vector of float)
+0:378        'r1' (temp 2-component vector of float)
+0:378        vector-scale (temp 2-component vector of float)
+0:378          'inFV0' (in 2-component vector of float)
+0:378          'inF0' (in float)
+0:378      move second child to first child (temp 2-component vector of float)
+0:378        'r2' (temp 2-component vector of float)
+0:378        vector-scale (temp 2-component vector of float)
+0:378          'inF0' (in float)
+0:378          'inFV0' (in 2-component vector of float)
+0:378      move second child to first child (temp float)
+0:378        'r3' (temp float)
+0:378        dot-product (global float)
+0:378          'inFV0' (in 2-component vector of float)
+0:378          'inFV1' (in 2-component vector of float)
+0:378      move second child to first child (temp 2-component vector of float)
+0:378        'r4' (temp 2-component vector of float)
+0:378        matrix-times-vector (temp 2-component vector of float)
+0:378          'inFM0' (in 2X2 matrix of float)
+0:378          'inFV0' (in 2-component vector of float)
+0:378      move second child to first child (temp 2-component vector of float)
+0:378        'r5' (temp 2-component vector of float)
+0:378        vector-times-matrix (temp 2-component vector of float)
+0:378          'inFV0' (in 2-component vector of float)
+0:378          'inFM0' (in 2X2 matrix of float)
+0:378      move second child to first child (temp 2X2 matrix of float)
+0:378        'r6' (temp 2X2 matrix of float)
+0:378        matrix-scale (temp 2X2 matrix of float)
+0:378          'inFM0' (in 2X2 matrix of float)
+0:378          'inF0' (in float)
+0:378      move second child to first child (temp 2X2 matrix of float)
+0:378        'r7' (temp 2X2 matrix of float)
+0:378        matrix-scale (temp 2X2 matrix of float)
+0:378          'inF0' (in float)
+0:378          'inFM0' (in 2X2 matrix of float)
+0:378      move second child to first child (temp 2X2 matrix of float)
+0:378        'r8' (temp 2X2 matrix of float)
+0:378        matrix-multiply (temp 2X2 matrix of float)
+0:378          'inFM0' (in 2X2 matrix of float)
+0:378          'inFM1' (in 2X2 matrix of float)
+0:388  Function Definition: TestGenMul(f1;f1;vf3;vf3;mf33;mf33; (temp void)
+0:384    Function Parameters: 
+0:384      'inF0' (in float)
+0:384      'inF1' (in float)
+0:384      'inFV0' (in 3-component vector of float)
+0:384      'inFV1' (in 3-component vector of float)
+0:384      'inFM0' (in 3X3 matrix of float)
+0:384      'inFM1' (in 3X3 matrix of float)
 0:?     Sequence
-0:380      move second child to first child (temp float)
-0:380        'r0' (temp float)
-0:380        component-wise multiply (temp float)
-0:380          'inF0' (in float)
-0:380          'inF1' (in float)
-0:380      move second child to first child (temp 3-component vector of float)
-0:380        'r1' (temp 3-component vector of float)
-0:380        vector-scale (temp 3-component vector of float)
-0:380          'inFV0' (in 3-component vector of float)
-0:380          'inF0' (in float)
-0:380      move second child to first child (temp 3-component vector of float)
-0:380        'r2' (temp 3-component vector of float)
-0:380        vector-scale (temp 3-component vector of float)
-0:380          'inF0' (in float)
-0:380          'inFV0' (in 3-component vector of float)
-0:380      move second child to first child (temp float)
-0:380        'r3' (temp float)
-0:380        dot-product (global float)
-0:380          'inFV0' (in 3-component vector of float)
-0:380          'inFV1' (in 3-component vector of float)
-0:380      move second child to first child (temp 3-component vector of float)
-0:380        'r4' (temp 3-component vector of float)
-0:380        matrix-times-vector (temp 3-component vector of float)
-0:380          'inFM0' (in 3X3 matrix of float)
-0:380          'inFV0' (in 3-component vector of float)
-0:380      move second child to first child (temp 3-component vector of float)
-0:380        'r5' (temp 3-component vector of float)
-0:380        vector-times-matrix (temp 3-component vector of float)
-0:380          'inFV0' (in 3-component vector of float)
-0:380          'inFM0' (in 3X3 matrix of float)
-0:380      move second child to first child (temp 3X3 matrix of float)
-0:380        'r6' (temp 3X3 matrix of float)
-0:380        matrix-scale (temp 3X3 matrix of float)
-0:380          'inFM0' (in 3X3 matrix of float)
-0:380          'inF0' (in float)
-0:380      move second child to first child (temp 3X3 matrix of float)
-0:380        'r7' (temp 3X3 matrix of float)
-0:380        matrix-scale (temp 3X3 matrix of float)
-0:380          'inF0' (in float)
-0:380          'inFM0' (in 3X3 matrix of float)
-0:380      move second child to first child (temp 3X3 matrix of float)
-0:380        'r8' (temp 3X3 matrix of float)
-0:380        matrix-multiply (temp 3X3 matrix of float)
-0:380          'inFM0' (in 3X3 matrix of float)
-0:380          'inFM1' (in 3X3 matrix of float)
-0:389  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
-0:386    Function Parameters: 
-0:386      'inF0' (in float)
-0:386      'inF1' (in float)
-0:386      'inFV0' (in 4-component vector of float)
-0:386      'inFV1' (in 4-component vector of float)
-0:386      'inFM0' (in 4X4 matrix of float)
-0:386      'inFM1' (in 4X4 matrix of float)
+0:385      move second child to first child (temp float)
+0:385        'r0' (temp float)
+0:385        component-wise multiply (temp float)
+0:385          'inF0' (in float)
+0:385          'inF1' (in float)
+0:385      move second child to first child (temp 3-component vector of float)
+0:385        'r1' (temp 3-component vector of float)
+0:385        vector-scale (temp 3-component vector of float)
+0:385          'inFV0' (in 3-component vector of float)
+0:385          'inF0' (in float)
+0:385      move second child to first child (temp 3-component vector of float)
+0:385        'r2' (temp 3-component vector of float)
+0:385        vector-scale (temp 3-component vector of float)
+0:385          'inF0' (in float)
+0:385          'inFV0' (in 3-component vector of float)
+0:385      move second child to first child (temp float)
+0:385        'r3' (temp float)
+0:385        dot-product (global float)
+0:385          'inFV0' (in 3-component vector of float)
+0:385          'inFV1' (in 3-component vector of float)
+0:385      move second child to first child (temp 3-component vector of float)
+0:385        'r4' (temp 3-component vector of float)
+0:385        matrix-times-vector (temp 3-component vector of float)
+0:385          'inFM0' (in 3X3 matrix of float)
+0:385          'inFV0' (in 3-component vector of float)
+0:385      move second child to first child (temp 3-component vector of float)
+0:385        'r5' (temp 3-component vector of float)
+0:385        vector-times-matrix (temp 3-component vector of float)
+0:385          'inFV0' (in 3-component vector of float)
+0:385          'inFM0' (in 3X3 matrix of float)
+0:385      move second child to first child (temp 3X3 matrix of float)
+0:385        'r6' (temp 3X3 matrix of float)
+0:385        matrix-scale (temp 3X3 matrix of float)
+0:385          'inFM0' (in 3X3 matrix of float)
+0:385          'inF0' (in float)
+0:385      move second child to first child (temp 3X3 matrix of float)
+0:385        'r7' (temp 3X3 matrix of float)
+0:385        matrix-scale (temp 3X3 matrix of float)
+0:385          'inF0' (in float)
+0:385          'inFM0' (in 3X3 matrix of float)
+0:385      move second child to first child (temp 3X3 matrix of float)
+0:385        'r8' (temp 3X3 matrix of float)
+0:385        matrix-multiply (temp 3X3 matrix of float)
+0:385          'inFM0' (in 3X3 matrix of float)
+0:385          'inFM1' (in 3X3 matrix of float)
+0:396  Function Definition: TestGenMul(f1;f1;vf4;vf4;mf44;mf44; (temp void)
+0:391    Function Parameters: 
+0:391      'inF0' (in float)
+0:391      'inF1' (in float)
+0:391      'inFV0' (in 4-component vector of float)
+0:391      'inFV1' (in 4-component vector of float)
+0:391      'inFM0' (in 4X4 matrix of float)
+0:391      'inFM1' (in 4X4 matrix of float)
 0:?     Sequence
-0:387      move second child to first child (temp float)
-0:387        'r0' (temp float)
-0:387        component-wise multiply (temp float)
-0:387          'inF0' (in float)
-0:387          'inF1' (in float)
-0:387      move second child to first child (temp 4-component vector of float)
-0:387        'r1' (temp 4-component vector of float)
-0:387        vector-scale (temp 4-component vector of float)
-0:387          'inFV0' (in 4-component vector of float)
-0:387          'inF0' (in float)
-0:387      move second child to first child (temp 4-component vector of float)
-0:387        'r2' (temp 4-component vector of float)
-0:387        vector-scale (temp 4-component vector of float)
-0:387          'inF0' (in float)
-0:387          'inFV0' (in 4-component vector of float)
-0:387      move second child to first child (temp float)
-0:387        'r3' (temp float)
-0:387        dot-product (global float)
-0:387          'inFV0' (in 4-component vector of float)
-0:387          'inFV1' (in 4-component vector of float)
-0:387      move second child to first child (temp 4-component vector of float)
-0:387        'r4' (temp 4-component vector of float)
-0:387        matrix-times-vector (temp 4-component vector of float)
-0:387          'inFM0' (in 4X4 matrix of float)
-0:387          'inFV0' (in 4-component vector of float)
-0:387      move second child to first child (temp 4-component vector of float)
-0:387        'r5' (temp 4-component vector of float)
-0:387        vector-times-matrix (temp 4-component vector of float)
-0:387          'inFV0' (in 4-component vector of float)
-0:387          'inFM0' (in 4X4 matrix of float)
-0:387      move second child to first child (temp 4X4 matrix of float)
-0:387        'r6' (temp 4X4 matrix of float)
-0:387        matrix-scale (temp 4X4 matrix of float)
-0:387          'inFM0' (in 4X4 matrix of float)
-0:387          'inF0' (in float)
-0:387      move second child to first child (temp 4X4 matrix of float)
-0:387        'r7' (temp 4X4 matrix of float)
-0:387        matrix-scale (temp 4X4 matrix of float)
-0:387          'inF0' (in float)
-0:387          'inFM0' (in 4X4 matrix of float)
-0:387      move second child to first child (temp 4X4 matrix of float)
-0:387        'r8' (temp 4X4 matrix of float)
-0:387        matrix-multiply (temp 4X4 matrix of float)
-0:387          'inFM0' (in 4X4 matrix of float)
-0:387          'inFM1' (in 4X4 matrix of float)
+0:392      move second child to first child (temp float)
+0:392        'r0' (temp float)
+0:392        component-wise multiply (temp float)
+0:392          'inF0' (in float)
+0:392          'inF1' (in float)
+0:392      move second child to first child (temp 4-component vector of float)
+0:392        'r1' (temp 4-component vector of float)
+0:392        vector-scale (temp 4-component vector of float)
+0:392          'inFV0' (in 4-component vector of float)
+0:392          'inF0' (in float)
+0:392      move second child to first child (temp 4-component vector of float)
+0:392        'r2' (temp 4-component vector of float)
+0:392        vector-scale (temp 4-component vector of float)
+0:392          'inF0' (in float)
+0:392          'inFV0' (in 4-component vector of float)
+0:392      move second child to first child (temp float)
+0:392        'r3' (temp float)
+0:392        dot-product (global float)
+0:392          'inFV0' (in 4-component vector of float)
+0:392          'inFV1' (in 4-component vector of float)
+0:392      move second child to first child (temp 4-component vector of float)
+0:392        'r4' (temp 4-component vector of float)
+0:392        matrix-times-vector (temp 4-component vector of float)
+0:392          'inFM0' (in 4X4 matrix of float)
+0:392          'inFV0' (in 4-component vector of float)
+0:392      move second child to first child (temp 4-component vector of float)
+0:392        'r5' (temp 4-component vector of float)
+0:392        vector-times-matrix (temp 4-component vector of float)
+0:392          'inFV0' (in 4-component vector of float)
+0:392          'inFM0' (in 4X4 matrix of float)
+0:392      move second child to first child (temp 4X4 matrix of float)
+0:392        'r6' (temp 4X4 matrix of float)
+0:392        matrix-scale (temp 4X4 matrix of float)
+0:392          'inFM0' (in 4X4 matrix of float)
+0:392          'inF0' (in float)
+0:392      move second child to first child (temp 4X4 matrix of float)
+0:392        'r7' (temp 4X4 matrix of float)
+0:392        matrix-scale (temp 4X4 matrix of float)
+0:392          'inF0' (in float)
+0:392          'inFM0' (in 4X4 matrix of float)
+0:392      move second child to first child (temp 4X4 matrix of float)
+0:392        'r8' (temp 4X4 matrix of float)
+0:392        matrix-multiply (temp 4X4 matrix of float)
+0:392          'inFM0' (in 4X4 matrix of float)
+0:392          'inFM1' (in 4X4 matrix of float)
+0:420  Function Definition: TestGenMul(f1;f1;vf2;vf3;mf32;mf23;mf33;mf43;mf42; (temp void)
+0:401    Function Parameters: 
+0:401      'inF0' (in float)
+0:401      'inF1' (in float)
+0:401      'inFV2' (in 2-component vector of float)
+0:401      'inFV3' (in 3-component vector of float)
+0:401      'inFM2x3' (in 3X2 matrix of float)
+0:401      'inFM3x2' (in 2X3 matrix of float)
+0:401      'inFM3x3' (in 3X3 matrix of float)
+0:401      'inFM3x4' (in 4X3 matrix of float)
+0:401      'inFM2x4' (in 4X2 matrix of float)
+0:?     Sequence
+0:402      move second child to first child (temp float)
+0:402        'r00' (temp float)
+0:402        component-wise multiply (temp float)
+0:402          'inF0' (in float)
+0:402          'inF1' (in float)
+0:403      move second child to first child (temp 2-component vector of float)
+0:403        'r01' (temp 2-component vector of float)
+0:403        vector-scale (temp 2-component vector of float)
+0:403          'inFV2' (in 2-component vector of float)
+0:403          'inF0' (in float)
+0:404      move second child to first child (temp 3-component vector of float)
+0:404        'r02' (temp 3-component vector of float)
+0:404        vector-scale (temp 3-component vector of float)
+0:404          'inFV3' (in 3-component vector of float)
+0:404          'inF0' (in float)
+0:405      move second child to first child (temp 2-component vector of float)
+0:405        'r03' (temp 2-component vector of float)
+0:405        vector-scale (temp 2-component vector of float)
+0:405          'inF0' (in float)
+0:405          'inFV2' (in 2-component vector of float)
+0:406      move second child to first child (temp 3-component vector of float)
+0:406        'r04' (temp 3-component vector of float)
+0:406        vector-scale (temp 3-component vector of float)
+0:406          'inF0' (in float)
+0:406          'inFV3' (in 3-component vector of float)
+0:407      move second child to first child (temp float)
+0:407        'r05' (temp float)
+0:407        dot-product (global float)
+0:407          'inFV2' (in 2-component vector of float)
+0:407          'inFV2' (in 2-component vector of float)
+0:408      move second child to first child (temp float)
+0:408        'r06' (temp float)
+0:408        dot-product (global float)
+0:408          'inFV3' (in 3-component vector of float)
+0:408          'inFV3' (in 3-component vector of float)
+0:409      move second child to first child (temp 3-component vector of float)
+0:409        'r07' (temp 3-component vector of float)
+0:409        vector-times-matrix (temp 3-component vector of float)
+0:409          'inFV2' (in 2-component vector of float)
+0:409          'inFM2x3' (in 3X2 matrix of float)
+0:410      move second child to first child (temp 2-component vector of float)
+0:410        'r08' (temp 2-component vector of float)
+0:410        vector-times-matrix (temp 2-component vector of float)
+0:410          'inFV3' (in 3-component vector of float)
+0:410          'inFM3x2' (in 2X3 matrix of float)
+0:411      move second child to first child (temp 2-component vector of float)
+0:411        'r09' (temp 2-component vector of float)
+0:411        matrix-times-vector (temp 2-component vector of float)
+0:411          'inFM2x3' (in 3X2 matrix of float)
+0:411          'inFV3' (in 3-component vector of float)
+0:412      move second child to first child (temp 3-component vector of float)
+0:412        'r10' (temp 3-component vector of float)
+0:412        matrix-times-vector (temp 3-component vector of float)
+0:412          'inFM3x2' (in 2X3 matrix of float)
+0:412          'inFV2' (in 2-component vector of float)
+0:413      move second child to first child (temp 3X2 matrix of float)
+0:413        'r11' (temp 3X2 matrix of float)
+0:413        matrix-scale (temp 3X2 matrix of float)
+0:413          'inFM2x3' (in 3X2 matrix of float)
+0:413          'inF0' (in float)
+0:414      move second child to first child (temp 2X3 matrix of float)
+0:414        'r12' (temp 2X3 matrix of float)
+0:414        matrix-scale (temp 2X3 matrix of float)
+0:414          'inFM3x2' (in 2X3 matrix of float)
+0:414          'inF0' (in float)
+0:415      move second child to first child (temp 2X2 matrix of float)
+0:415        'r13' (temp 2X2 matrix of float)
+0:415        matrix-multiply (temp 2X2 matrix of float)
+0:415          'inFM2x3' (in 3X2 matrix of float)
+0:415          'inFM3x2' (in 2X3 matrix of float)
+0:416      move second child to first child (temp 3X2 matrix of float)
+0:416        'r14' (temp 3X2 matrix of float)
+0:416        matrix-multiply (temp 3X2 matrix of float)
+0:416          'inFM2x3' (in 3X2 matrix of float)
+0:416          'inFM3x3' (in 3X3 matrix of float)
+0:417      move second child to first child (temp 4X2 matrix of float)
+0:417        'r15' (temp 4X2 matrix of float)
+0:417        matrix-multiply (temp 4X2 matrix of float)
+0:417          'inFM2x3' (in 3X2 matrix of float)
+0:417          'inFM3x4' (in 4X3 matrix of float)
+0:418      move second child to first child (temp 4X3 matrix of float)
+0:418        'r16' (temp 4X3 matrix of float)
+0:418        matrix-multiply (temp 4X3 matrix of float)
+0:418          'inFM3x2' (in 2X3 matrix of float)
+0:418          'inFM2x4' (in 4X2 matrix of float)
 0:?   Linker Objects
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 1090
+// Id's are bound by 1206
 
                               Capability Shader
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Vertex 4  "VertexShaderFunction" 48 67 73 80 174 192 198 205 321 339 345 352 470 488 494 501 626 640 647 742 756 763 861 875 882
+                              EntryPoint Vertex 4  "VertexShaderFunction" 68 87 93 100 198 216 222 229 349 367 373 380 502 520 526 533 662 676 683 782 796 803 905 919 926
                               Source HLSL 450
                               Name 4  "VertexShaderFunction"
                               Name 19  "TestGenMul(f1;f1;vf2;vf2;mf22;mf22;"
@@ -2484,65 +2734,92 @@ Shader version: 450
                               Name 42  "inFV1"
                               Name 43  "inFM0"
                               Name 44  "inFM1"
-                              Name 48  "inF0"
-                              Name 67  "inU0"
-                              Name 73  "inF1"
-                              Name 80  "inF2"
-                              Name 106  "ResType"
-                              Name 174  "inF0"
-                              Name 192  "inU0"
-                              Name 198  "inF1"
-                              Name 205  "inF2"
-                              Name 241  "ResType"
-                              Name 321  "inF0"
-                              Name 339  "inU0"
-                              Name 345  "inF1"
-                              Name 352  "inF2"
-                              Name 391  "ResType"
-                              Name 470  "inF0"
-                              Name 488  "inU0"
-                              Name 494  "inF1"
-                              Name 501  "inF2"
-                              Name 546  "ResType"
-                              Name 626  "inF0"
-                              Name 640  "inF1"
-                              Name 647  "inF2"
-                              Name 678  "ResType"
-                              Name 742  "inF0"
-                              Name 756  "inF1"
-                              Name 763  "inF2"
-                              Name 797  "ResType"
-                              Name 861  "inF0"
-                              Name 875  "inF1"
-                              Name 882  "inF2"
-                              Name 919  "ResType"
-                              Name 982  "r0"
-                              Name 986  "r1"
-                              Name 990  "r2"
-                              Name 994  "r3"
-                              Name 998  "r4"
-                              Name 1002  "r5"
-                              Name 1006  "r6"
-                              Name 1010  "r7"
-                              Name 1014  "r8"
-                              Name 1018  "r0"
-                              Name 1022  "r1"
-                              Name 1026  "r2"
-                              Name 1030  "r3"
-                              Name 1034  "r4"
-                              Name 1038  "r5"
-                              Name 1042  "r6"
-                              Name 1046  "r7"
-                              Name 1050  "r8"
-                              Name 1054  "r0"
-                              Name 1058  "r1"
-                              Name 1062  "r2"
-                              Name 1066  "r3"
-                              Name 1070  "r4"
-                              Name 1074  "r5"
-                              Name 1078  "r6"
-                              Name 1082  "r7"
-                              Name 1086  "r8"
+                              Name 65  "TestGenMul(f1;f1;vf2;vf3;mf32;mf23;mf33;mf43;mf42;"
+                              Name 56  "inF0"
+                              Name 57  "inF1"
+                              Name 58  "inFV2"
+                              Name 59  "inFV3"
+                              Name 60  "inFM2x3"
+                              Name 61  "inFM3x2"
+                              Name 62  "inFM3x3"
+                              Name 63  "inFM3x4"
+                              Name 64  "inFM2x4"
+                              Name 68  "inF0"
+                              Name 87  "inU0"
+                              Name 93  "inF1"
+                              Name 100  "inF2"
+                              Name 126  "ResType"
+                              Name 198  "inF0"
+                              Name 216  "inU0"
+                              Name 222  "inF1"
+                              Name 229  "inF2"
+                              Name 265  "ResType"
+                              Name 349  "inF0"
+                              Name 367  "inU0"
+                              Name 373  "inF1"
+                              Name 380  "inF2"
+                              Name 419  "ResType"
+                              Name 502  "inF0"
+                              Name 520  "inU0"
+                              Name 526  "inF1"
+                              Name 533  "inF2"
+                              Name 578  "ResType"
+                              Name 662  "inF0"
+                              Name 676  "inF1"
+                              Name 683  "inF2"
+                              Name 714  "ResType"
+                              Name 782  "inF0"
+                              Name 796  "inF1"
+                              Name 803  "inF2"
+                              Name 837  "ResType"
+                              Name 905  "inF0"
+                              Name 919  "inF1"
+                              Name 926  "inF2"
+                              Name 963  "ResType"
+                              Name 1030  "r0"
+                              Name 1034  "r1"
+                              Name 1038  "r2"
+                              Name 1042  "r3"
+                              Name 1046  "r4"
+                              Name 1050  "r5"
+                              Name 1054  "r6"
+                              Name 1058  "r7"
+                              Name 1062  "r8"
+                              Name 1066  "r0"
+                              Name 1070  "r1"
+                              Name 1074  "r2"
+                              Name 1078  "r3"
+                              Name 1082  "r4"
+                              Name 1086  "r5"
+                              Name 1090  "r6"
+                              Name 1094  "r7"
+                              Name 1098  "r8"
+                              Name 1102  "r0"
+                              Name 1106  "r1"
+                              Name 1110  "r2"
+                              Name 1114  "r3"
+                              Name 1118  "r4"
+                              Name 1122  "r5"
+                              Name 1126  "r6"
+                              Name 1130  "r7"
+                              Name 1134  "r8"
+                              Name 1138  "r00"
+                              Name 1142  "r01"
+                              Name 1146  "r02"
+                              Name 1150  "r03"
+                              Name 1154  "r04"
+                              Name 1158  "r05"
+                              Name 1162  "r06"
+                              Name 1166  "r07"
+                              Name 1170  "r08"
+                              Name 1174  "r09"
+                              Name 1178  "r10"
+                              Name 1182  "r11"
+                              Name 1186  "r12"
+                              Name 1190  "r13"
+                              Name 1194  "r14"
+                              Name 1198  "r15"
+                              Name 1202  "r16"
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -2562,203 +2839,216 @@ Shader version: 450
               36:             TypeMatrix 34(fvec4) 4
               37:             TypePointer Function 36
               38:             TypeFunction 2 7(ptr) 7(ptr) 35(ptr) 35(ptr) 37(ptr) 37(ptr)
-              47:             TypePointer Input 6(float)
-        48(inF0):     47(ptr) Variable Input
-              50:             TypeBool
-              61:             TypeInt 32 1
-              64:             TypeInt 32 0
-              66:             TypePointer Input 64(int)
-        67(inU0):     66(ptr) Variable Input
-        73(inF1):     47(ptr) Variable Input
-        80(inF2):     47(ptr) Variable Input
-              87:     64(int) Constant 7
-              95:     61(int) Constant 7
-    106(ResType):             TypeStruct 6(float) 61(int)
-             121:    6(float) Constant 1050288283
-             136:     64(int) Constant 2
-             143:    6(float) Constant 0
-             144:    6(float) Constant 1065353216
-             173:             TypePointer Input 8(fvec2)
-       174(inF0):    173(ptr) Variable Input
-             186:             TypeVector 61(int) 2
-             189:             TypeVector 64(int) 2
-             191:             TypePointer Input 189(ivec2)
-       192(inU0):    191(ptr) Variable Input
-       198(inF1):    173(ptr) Variable Input
-       205(inF2):    173(ptr) Variable Input
-             212:     64(int) Constant 3
-             213:  189(ivec2) ConstantComposite 87 212
-    241(ResType):             TypeStruct 8(fvec2) 186(ivec2)
-             246:             TypeVector 50(bool) 2
-             280:    6(float) Constant 1073741824
-             282:     64(int) Constant 1
-             283:  189(ivec2) ConstantComposite 282 136
-             318:    8(fvec2) ConstantComposite 144 280
-             320:             TypePointer Input 21(fvec3)
-       321(inF0):    320(ptr) Variable Input
-             333:             TypeVector 61(int) 3
-             336:             TypeVector 64(int) 3
-             338:             TypePointer Input 336(ivec3)
-       339(inU0):    338(ptr) Variable Input
-       345(inF1):    320(ptr) Variable Input
-       352(inF2):    320(ptr) Variable Input
-             359:     64(int) Constant 5
-             360:  336(ivec3) ConstantComposite 87 212 359
-    391(ResType):             TypeStruct 21(fvec3) 333(ivec3)
-             396:             TypeVector 50(bool) 3
-             431:  336(ivec3) ConstantComposite 282 136 212
-             466:    6(float) Constant 1077936128
-             467:   21(fvec3) ConstantComposite 144 280 466
-             469:             TypePointer Input 34(fvec4)
-       470(inF0):    469(ptr) Variable Input
-             482:             TypeVector 61(int) 4
-             485:             TypeVector 64(int) 4
-             487:             TypePointer Input 485(ivec4)
-       488(inU0):    487(ptr) Variable Input
-       494(inF1):    469(ptr) Variable Input
-       501(inF2):    469(ptr) Variable Input
-             508:  485(ivec4) ConstantComposite 87 212 359 136
-    546(ResType):             TypeStruct 34(fvec4) 482(ivec4)
-             551:             TypeVector 50(bool) 4
-             586:     64(int) Constant 4
-             587:  485(ivec4) ConstantComposite 282 136 212 586
-             622:    6(float) Constant 1082130432
-             623:   34(fvec4) ConstantComposite 144 280 466 622
-             625:             TypePointer Input 10
-       626(inF0):    625(ptr) Variable Input
-       640(inF1):    625(ptr) Variable Input
-       647(inF2):    625(ptr) Variable Input
-    678(ResType):             TypeStruct 10 186(ivec2)
-             738:    8(fvec2) ConstantComposite 280 280
-             739:          10 ConstantComposite 738 738
-             741:             TypePointer Input 23
-       742(inF0):    741(ptr) Variable Input
-       756(inF1):    741(ptr) Variable Input
-       763(inF2):    741(ptr) Variable Input
-    797(ResType):             TypeStruct 23 333(ivec3)
-             857:   21(fvec3) ConstantComposite 466 466 466
-             858:          23 ConstantComposite 857 857 857
-             860:             TypePointer Input 36
-       861(inF0):    860(ptr) Variable Input
-       875(inF1):    860(ptr) Variable Input
-       882(inF2):    860(ptr) Variable Input
-    919(ResType):             TypeStruct 36 482(ivec4)
-             979:   34(fvec4) ConstantComposite 622 622 622 622
-             980:          36 ConstantComposite 979 979 979 979
+              47:             TypeMatrix 8(fvec2) 3
+              48:             TypePointer Function 47
+              49:             TypeMatrix 21(fvec3) 2
+              50:             TypePointer Function 49
+              51:             TypeMatrix 21(fvec3) 4
+              52:             TypePointer Function 51
+              53:             TypeMatrix 8(fvec2) 4
+              54:             TypePointer Function 53
+              55:             TypeFunction 2 7(ptr) 7(ptr) 9(ptr) 22(ptr) 48(ptr) 50(ptr) 24(ptr) 52(ptr) 54(ptr)
+              67:             TypePointer Input 6(float)
+        68(inF0):     67(ptr) Variable Input
+              70:             TypeBool
+              81:             TypeInt 32 1
+              84:             TypeInt 32 0
+              86:             TypePointer Input 84(int)
+        87(inU0):     86(ptr) Variable Input
+        93(inF1):     67(ptr) Variable Input
+       100(inF2):     67(ptr) Variable Input
+             107:     84(int) Constant 7
+             115:     81(int) Constant 7
+    126(ResType):             TypeStruct 6(float) 81(int)
+             145:    6(float) Constant 1050288283
+             160:     84(int) Constant 2
+             167:    6(float) Constant 0
+             168:    6(float) Constant 1065353216
+             197:             TypePointer Input 8(fvec2)
+       198(inF0):    197(ptr) Variable Input
+             210:             TypeVector 81(int) 2
+             213:             TypeVector 84(int) 2
+             215:             TypePointer Input 213(ivec2)
+       216(inU0):    215(ptr) Variable Input
+       222(inF1):    197(ptr) Variable Input
+       229(inF2):    197(ptr) Variable Input
+             236:     84(int) Constant 3
+             237:  213(ivec2) ConstantComposite 107 236
+    265(ResType):             TypeStruct 8(fvec2) 210(ivec2)
+             270:             TypeVector 70(bool) 2
+             308:    6(float) Constant 1073741824
+             310:     84(int) Constant 1
+             311:  213(ivec2) ConstantComposite 310 160
+             346:    8(fvec2) ConstantComposite 168 308
+             348:             TypePointer Input 21(fvec3)
+       349(inF0):    348(ptr) Variable Input
+             361:             TypeVector 81(int) 3
+             364:             TypeVector 84(int) 3
+             366:             TypePointer Input 364(ivec3)
+       367(inU0):    366(ptr) Variable Input
+       373(inF1):    348(ptr) Variable Input
+       380(inF2):    348(ptr) Variable Input
+             387:     84(int) Constant 5
+             388:  364(ivec3) ConstantComposite 107 236 387
+    419(ResType):             TypeStruct 21(fvec3) 361(ivec3)
+             424:             TypeVector 70(bool) 3
+             463:  364(ivec3) ConstantComposite 310 160 236
+             498:    6(float) Constant 1077936128
+             499:   21(fvec3) ConstantComposite 168 308 498
+             501:             TypePointer Input 34(fvec4)
+       502(inF0):    501(ptr) Variable Input
+             514:             TypeVector 81(int) 4
+             517:             TypeVector 84(int) 4
+             519:             TypePointer Input 517(ivec4)
+       520(inU0):    519(ptr) Variable Input
+       526(inF1):    501(ptr) Variable Input
+       533(inF2):    501(ptr) Variable Input
+             540:  517(ivec4) ConstantComposite 107 236 387 160
+    578(ResType):             TypeStruct 34(fvec4) 514(ivec4)
+             583:             TypeVector 70(bool) 4
+             622:     84(int) Constant 4
+             623:  517(ivec4) ConstantComposite 310 160 236 622
+             658:    6(float) Constant 1082130432
+             659:   34(fvec4) ConstantComposite 168 308 498 658
+             661:             TypePointer Input 10
+       662(inF0):    661(ptr) Variable Input
+       676(inF1):    661(ptr) Variable Input
+       683(inF2):    661(ptr) Variable Input
+    714(ResType):             TypeStruct 10 210(ivec2)
+             778:    8(fvec2) ConstantComposite 308 308
+             779:          10 ConstantComposite 778 778
+             781:             TypePointer Input 23
+       782(inF0):    781(ptr) Variable Input
+       796(inF1):    781(ptr) Variable Input
+       803(inF2):    781(ptr) Variable Input
+    837(ResType):             TypeStruct 23 361(ivec3)
+             901:   21(fvec3) ConstantComposite 498 498 498
+             902:          23 ConstantComposite 901 901 901
+             904:             TypePointer Input 36
+       905(inF0):    904(ptr) Variable Input
+       919(inF1):    904(ptr) Variable Input
+       926(inF2):    904(ptr) Variable Input
+    963(ResType):             TypeStruct 36 514(ivec4)
+            1027:   34(fvec4) ConstantComposite 658 658 658 658
+            1028:          36 ConstantComposite 1027 1027 1027 1027
 4(VertexShaderFunction):           2 Function None 3
                5:             Label
-              49:    6(float) Load 48(inF0)
-              51:    50(bool) All 49
-              52:    6(float) Load 48(inF0)
-              53:    6(float) ExtInst 1(GLSL.std.450) 4(FAbs) 52
-              54:    6(float) Load 48(inF0)
-              55:    6(float) ExtInst 1(GLSL.std.450) 17(Acos) 54
-              56:    6(float) Load 48(inF0)
-              57:    50(bool) Any 56
-              58:    6(float) Load 48(inF0)
-              59:    6(float) ExtInst 1(GLSL.std.450) 16(Asin) 58
-              60:    6(float) Load 48(inF0)
-              62:     61(int) Bitcast 60
-              63:    6(float) Load 48(inF0)
-              65:     64(int) Bitcast 63
-              68:     64(int) Load 67(inU0)
-              69:    6(float) Bitcast 68
-              70:    6(float) Load 48(inF0)
-              71:    6(float) ExtInst 1(GLSL.std.450) 18(Atan) 70
-              72:    6(float) Load 48(inF0)
-              74:    6(float) Load 73(inF1)
-              75:    6(float) ExtInst 1(GLSL.std.450) 25(Atan2) 72 74
-              76:    6(float) Load 48(inF0)
-              77:    6(float) ExtInst 1(GLSL.std.450) 9(Ceil) 76
-              78:    6(float) Load 48(inF0)
-              79:    6(float) Load 73(inF1)
-              81:    6(float) Load 80(inF2)
-              82:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 78 79 81
-              83:    6(float) Load 48(inF0)
-              84:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 83
-              85:    6(float) Load 48(inF0)
-              86:    6(float) ExtInst 1(GLSL.std.450) 20(Cosh) 85
-              88:     64(int) BitCount 87
-              89:    6(float) Load 48(inF0)
-              90:    6(float) ExtInst 1(GLSL.std.450) 12(Degrees) 89
-              91:    6(float) Load 48(inF0)
-              92:    6(float) ExtInst 1(GLSL.std.450) 27(Exp) 91
-              93:    6(float) Load 48(inF0)
-              94:    6(float) ExtInst 1(GLSL.std.450) 29(Exp2) 93
-              96:     61(int) ExtInst 1(GLSL.std.450) 74(FindSMsb) 95
-              97:     61(int) ExtInst 1(GLSL.std.450) 73(FindILsb) 95
-              98:    6(float) Load 48(inF0)
-              99:    6(float) ExtInst 1(GLSL.std.450) 8(Floor) 98
-             100:    6(float) Load 48(inF0)
-             101:    6(float) Load 73(inF1)
-             102:    6(float) FMod 100 101
-             103:    6(float) Load 48(inF0)
-             104:    6(float) ExtInst 1(GLSL.std.450) 10(Fract) 103
-             105:    6(float) Load 48(inF0)
-             107:106(ResType) ExtInst 1(GLSL.std.450) 52(FrexpStruct) 105
-             108:     61(int) CompositeExtract 107 1
-                              Store 73(inF1) 108
-             109:    6(float) CompositeExtract 107 0
-             110:    6(float) Load 48(inF0)
-             111:    50(bool) IsInf 110
-             112:    6(float) Load 48(inF0)
-             113:    50(bool) IsNan 112
-             114:    6(float) Load 48(inF0)
-             115:    6(float) Load 73(inF1)
-             116:    6(float) ExtInst 1(GLSL.std.450) 53(Ldexp) 114 115
-             117:    6(float) Load 48(inF0)
-             118:    6(float) ExtInst 1(GLSL.std.450) 28(Log) 117
-             119:    6(float) Load 48(inF0)
-             120:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 119
-             122:    6(float) FMul 120 121
-             123:    6(float) Load 48(inF0)
-             124:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 123
-             125:    6(float) Load 48(inF0)
-             126:    6(float) Load 73(inF1)
-             127:    6(float) ExtInst 1(GLSL.std.450) 40(FMax) 125 126
-             128:    6(float) Load 48(inF0)
-             129:    6(float) Load 73(inF1)
-             130:    6(float) ExtInst 1(GLSL.std.450) 37(FMin) 128 129
-             131:    6(float) Load 48(inF0)
-             132:    6(float) Load 73(inF1)
-             133:    6(float) ExtInst 1(GLSL.std.450) 26(Pow) 131 132
-             134:    6(float) Load 48(inF0)
-             135:    6(float) ExtInst 1(GLSL.std.450) 11(Radians) 134
-             137:     64(int) BitReverse 136
-             138:    6(float) Load 48(inF0)
-             139:    6(float) ExtInst 1(GLSL.std.450) 2(RoundEven) 138
-             140:    6(float) Load 48(inF0)
-             141:    6(float) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 140
-             142:    6(float) Load 48(inF0)
-             145:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 142 143 144
-             146:    6(float) Load 48(inF0)
-             147:    6(float) ExtInst 1(GLSL.std.450) 6(FSign) 146
-             148:    6(float) Load 48(inF0)
-             149:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 148
-             150:    6(float) Load 48(inF0)
-             151:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 150
-                              Store 73(inF1) 151
-             152:    6(float) Load 48(inF0)
-             153:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 152
-                              Store 80(inF2) 153
-             154:    6(float) Load 48(inF0)
-             155:    6(float) ExtInst 1(GLSL.std.450) 19(Sinh) 154
-             156:    6(float) Load 48(inF0)
-             157:    6(float) Load 73(inF1)
-             158:    6(float) Load 80(inF2)
-             159:    6(float) ExtInst 1(GLSL.std.450) 49(SmoothStep) 156 157 158
-             160:    6(float) Load 48(inF0)
-             161:    6(float) ExtInst 1(GLSL.std.450) 31(Sqrt) 160
-             162:    6(float) Load 48(inF0)
-             163:    6(float) Load 73(inF1)
-             164:    6(float) ExtInst 1(GLSL.std.450) 48(Step) 162 163
-             165:    6(float) Load 48(inF0)
-             166:    6(float) ExtInst 1(GLSL.std.450) 15(Tan) 165
-             167:    6(float) Load 48(inF0)
-             168:    6(float) ExtInst 1(GLSL.std.450) 21(Tanh) 167
-             169:    6(float) Load 48(inF0)
-             170:    6(float) ExtInst 1(GLSL.std.450) 3(Trunc) 169
-                              ReturnValue 143
+              69:    6(float) Load 68(inF0)
+              71:    70(bool) All 69
+              72:    6(float) Load 68(inF0)
+              73:    6(float) ExtInst 1(GLSL.std.450) 4(FAbs) 72
+              74:    6(float) Load 68(inF0)
+              75:    6(float) ExtInst 1(GLSL.std.450) 17(Acos) 74
+              76:    6(float) Load 68(inF0)
+              77:    70(bool) Any 76
+              78:    6(float) Load 68(inF0)
+              79:    6(float) ExtInst 1(GLSL.std.450) 16(Asin) 78
+              80:    6(float) Load 68(inF0)
+              82:     81(int) Bitcast 80
+              83:    6(float) Load 68(inF0)
+              85:     84(int) Bitcast 83
+              88:     84(int) Load 87(inU0)
+              89:    6(float) Bitcast 88
+              90:    6(float) Load 68(inF0)
+              91:    6(float) ExtInst 1(GLSL.std.450) 18(Atan) 90
+              92:    6(float) Load 68(inF0)
+              94:    6(float) Load 93(inF1)
+              95:    6(float) ExtInst 1(GLSL.std.450) 25(Atan2) 92 94
+              96:    6(float) Load 68(inF0)
+              97:    6(float) ExtInst 1(GLSL.std.450) 9(Ceil) 96
+              98:    6(float) Load 68(inF0)
+              99:    6(float) Load 93(inF1)
+             101:    6(float) Load 100(inF2)
+             102:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 98 99 101
+             103:    6(float) Load 68(inF0)
+             104:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 103
+             105:    6(float) Load 68(inF0)
+             106:    6(float) ExtInst 1(GLSL.std.450) 20(Cosh) 105
+             108:     84(int) BitCount 107
+             109:    6(float) Load 68(inF0)
+             110:    6(float) ExtInst 1(GLSL.std.450) 12(Degrees) 109
+             111:    6(float) Load 68(inF0)
+             112:    6(float) ExtInst 1(GLSL.std.450) 27(Exp) 111
+             113:    6(float) Load 68(inF0)
+             114:    6(float) ExtInst 1(GLSL.std.450) 29(Exp2) 113
+             116:     81(int) ExtInst 1(GLSL.std.450) 74(FindSMsb) 115
+             117:     81(int) ExtInst 1(GLSL.std.450) 73(FindILsb) 115
+             118:    6(float) Load 68(inF0)
+             119:    6(float) ExtInst 1(GLSL.std.450) 8(Floor) 118
+             120:    6(float) Load 68(inF0)
+             121:    6(float) Load 93(inF1)
+             122:    6(float) FMod 120 121
+             123:    6(float) Load 68(inF0)
+             124:    6(float) ExtInst 1(GLSL.std.450) 10(Fract) 123
+             125:    6(float) Load 68(inF0)
+             127:126(ResType) ExtInst 1(GLSL.std.450) 52(FrexpStruct) 125
+             128:     81(int) CompositeExtract 127 1
+                              Store 93(inF1) 128
+             129:    6(float) CompositeExtract 127 0
+             130:    6(float) Load 68(inF0)
+             131:    70(bool) IsInf 130
+             132:    6(float) Load 68(inF0)
+             133:    70(bool) IsNan 132
+             134:    6(float) Load 68(inF0)
+             135:    6(float) Load 93(inF1)
+             136:    6(float) ExtInst 1(GLSL.std.450) 53(Ldexp) 134 135
+             137:    6(float) Load 68(inF0)
+             138:    6(float) Load 93(inF1)
+             139:    6(float) Load 100(inF2)
+             140:    6(float) ExtInst 1(GLSL.std.450) 46(FMix) 137 138 139
+             141:    6(float) Load 68(inF0)
+             142:    6(float) ExtInst 1(GLSL.std.450) 28(Log) 141
+             143:    6(float) Load 68(inF0)
+             144:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 143
+             146:    6(float) FMul 144 145
+             147:    6(float) Load 68(inF0)
+             148:    6(float) ExtInst 1(GLSL.std.450) 30(Log2) 147
+             149:    6(float) Load 68(inF0)
+             150:    6(float) Load 93(inF1)
+             151:    6(float) ExtInst 1(GLSL.std.450) 40(FMax) 149 150
+             152:    6(float) Load 68(inF0)
+             153:    6(float) Load 93(inF1)
+             154:    6(float) ExtInst 1(GLSL.std.450) 37(FMin) 152 153
+             155:    6(float) Load 68(inF0)
+             156:    6(float) Load 93(inF1)
+             157:    6(float) ExtInst 1(GLSL.std.450) 26(Pow) 155 156
+             158:    6(float) Load 68(inF0)
+             159:    6(float) ExtInst 1(GLSL.std.450) 11(Radians) 158
+             161:     84(int) BitReverse 160
+             162:    6(float) Load 68(inF0)
+             163:    6(float) ExtInst 1(GLSL.std.450) 2(RoundEven) 162
+             164:    6(float) Load 68(inF0)
+             165:    6(float) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 164
+             166:    6(float) Load 68(inF0)
+             169:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 166 167 168
+             170:    6(float) Load 68(inF0)
+             171:    6(float) ExtInst 1(GLSL.std.450) 6(FSign) 170
+             172:    6(float) Load 68(inF0)
+             173:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 172
+             174:    6(float) Load 68(inF0)
+             175:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 174
+                              Store 93(inF1) 175
+             176:    6(float) Load 68(inF0)
+             177:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 176
+                              Store 100(inF2) 177
+             178:    6(float) Load 68(inF0)
+             179:    6(float) ExtInst 1(GLSL.std.450) 19(Sinh) 178
+             180:    6(float) Load 68(inF0)
+             181:    6(float) Load 93(inF1)
+             182:    6(float) Load 100(inF2)
+             183:    6(float) ExtInst 1(GLSL.std.450) 49(SmoothStep) 180 181 182
+             184:    6(float) Load 68(inF0)
+             185:    6(float) ExtInst 1(GLSL.std.450) 31(Sqrt) 184
+             186:    6(float) Load 68(inF0)
+             187:    6(float) Load 93(inF1)
+             188:    6(float) ExtInst 1(GLSL.std.450) 48(Step) 186 187
+             189:    6(float) Load 68(inF0)
+             190:    6(float) ExtInst 1(GLSL.std.450) 15(Tan) 189
+             191:    6(float) Load 68(inF0)
+             192:    6(float) ExtInst 1(GLSL.std.450) 21(Tanh) 191
+             193:    6(float) Load 68(inF0)
+             194:    6(float) ExtInst 1(GLSL.std.450) 3(Trunc) 193
+                              ReturnValue 167
                               FunctionEnd
 19(TestGenMul(f1;f1;vf2;vf2;mf22;mf22;):           2 Function None 12
         13(inF0):      7(ptr) FunctionParameter
@@ -2768,51 +3058,51 @@ Shader version: 450
        17(inFM0):     11(ptr) FunctionParameter
        18(inFM1):     11(ptr) FunctionParameter
               20:             Label
-         982(r0):      7(ptr) Variable Function
-         986(r1):      9(ptr) Variable Function
-         990(r2):      9(ptr) Variable Function
-         994(r3):      7(ptr) Variable Function
-         998(r4):      9(ptr) Variable Function
-        1002(r5):      9(ptr) Variable Function
-        1006(r6):     11(ptr) Variable Function
-        1010(r7):     11(ptr) Variable Function
-        1014(r8):     11(ptr) Variable Function
-             983:    6(float) Load 13(inF0)
-             984:    6(float) Load 14(inF1)
-             985:    6(float) FMul 983 984
-                              Store 982(r0) 985
-             987:    8(fvec2) Load 15(inFV0)
-             988:    6(float) Load 13(inF0)
-             989:    8(fvec2) VectorTimesScalar 987 988
-                              Store 986(r1) 989
-             991:    6(float) Load 13(inF0)
-             992:    8(fvec2) Load 15(inFV0)
-             993:    8(fvec2) VectorTimesScalar 992 991
-                              Store 990(r2) 993
-             995:    8(fvec2) Load 15(inFV0)
-             996:    8(fvec2) Load 16(inFV1)
-             997:    6(float) Dot 995 996
-                              Store 994(r3) 997
-             999:          10 Load 17(inFM0)
-            1000:    8(fvec2) Load 15(inFV0)
-            1001:    8(fvec2) MatrixTimesVector 999 1000
-                              Store 998(r4) 1001
-            1003:    8(fvec2) Load 15(inFV0)
-            1004:          10 Load 17(inFM0)
-            1005:    8(fvec2) VectorTimesMatrix 1003 1004
-                              Store 1002(r5) 1005
-            1007:          10 Load 17(inFM0)
-            1008:    6(float) Load 13(inF0)
-            1009:          10 MatrixTimesScalar 1007 1008
-                              Store 1006(r6) 1009
-            1011:    6(float) Load 13(inF0)
-            1012:          10 Load 17(inFM0)
-            1013:          10 MatrixTimesScalar 1012 1011
-                              Store 1010(r7) 1013
-            1015:          10 Load 17(inFM0)
-            1016:          10 Load 18(inFM1)
-            1017:          10 MatrixTimesMatrix 1015 1016
-                              Store 1014(r8) 1017
+        1030(r0):      7(ptr) Variable Function
+        1034(r1):      9(ptr) Variable Function
+        1038(r2):      9(ptr) Variable Function
+        1042(r3):      7(ptr) Variable Function
+        1046(r4):      9(ptr) Variable Function
+        1050(r5):      9(ptr) Variable Function
+        1054(r6):     11(ptr) Variable Function
+        1058(r7):     11(ptr) Variable Function
+        1062(r8):     11(ptr) Variable Function
+            1031:    6(float) Load 13(inF0)
+            1032:    6(float) Load 14(inF1)
+            1033:    6(float) FMul 1031 1032
+                              Store 1030(r0) 1033
+            1035:    8(fvec2) Load 15(inFV0)
+            1036:    6(float) Load 13(inF0)
+            1037:    8(fvec2) VectorTimesScalar 1035 1036
+                              Store 1034(r1) 1037
+            1039:    6(float) Load 13(inF0)
+            1040:    8(fvec2) Load 15(inFV0)
+            1041:    8(fvec2) VectorTimesScalar 1040 1039
+                              Store 1038(r2) 1041
+            1043:    8(fvec2) Load 15(inFV0)
+            1044:    8(fvec2) Load 16(inFV1)
+            1045:    6(float) Dot 1043 1044
+                              Store 1042(r3) 1045
+            1047:          10 Load 17(inFM0)
+            1048:    8(fvec2) Load 15(inFV0)
+            1049:    8(fvec2) MatrixTimesVector 1047 1048
+                              Store 1046(r4) 1049
+            1051:    8(fvec2) Load 15(inFV0)
+            1052:          10 Load 17(inFM0)
+            1053:    8(fvec2) VectorTimesMatrix 1051 1052
+                              Store 1050(r5) 1053
+            1055:          10 Load 17(inFM0)
+            1056:    6(float) Load 13(inF0)
+            1057:          10 MatrixTimesScalar 1055 1056
+                              Store 1054(r6) 1057
+            1059:    6(float) Load 13(inF0)
+            1060:          10 Load 17(inFM0)
+            1061:          10 MatrixTimesScalar 1060 1059
+                              Store 1058(r7) 1061
+            1063:          10 Load 17(inFM0)
+            1064:          10 Load 18(inFM1)
+            1065:          10 MatrixTimesMatrix 1063 1064
+                              Store 1062(r8) 1065
                               Return
                               FunctionEnd
 32(TestGenMul(f1;f1;vf3;vf3;mf33;mf33;):           2 Function None 25
@@ -2823,51 +3113,51 @@ Shader version: 450
        30(inFM0):     24(ptr) FunctionParameter
        31(inFM1):     24(ptr) FunctionParameter
               33:             Label
-        1018(r0):      7(ptr) Variable Function
-        1022(r1):     22(ptr) Variable Function
-        1026(r2):     22(ptr) Variable Function
-        1030(r3):      7(ptr) Variable Function
-        1034(r4):     22(ptr) Variable Function
-        1038(r5):     22(ptr) Variable Function
-        1042(r6):     24(ptr) Variable Function
-        1046(r7):     24(ptr) Variable Function
-        1050(r8):     24(ptr) Variable Function
-            1019:    6(float) Load 26(inF0)
-            1020:    6(float) Load 27(inF1)
-            1021:    6(float) FMul 1019 1020
-                              Store 1018(r0) 1021
-            1023:   21(fvec3) Load 28(inFV0)
-            1024:    6(float) Load 26(inF0)
-            1025:   21(fvec3) VectorTimesScalar 1023 1024
-                              Store 1022(r1) 1025
-            1027:    6(float) Load 26(inF0)
-            1028:   21(fvec3) Load 28(inFV0)
-            1029:   21(fvec3) VectorTimesScalar 1028 1027
-                              Store 1026(r2) 1029
-            1031:   21(fvec3) Load 28(inFV0)
-            1032:   21(fvec3) Load 29(inFV1)
-            1033:    6(float) Dot 1031 1032
-                              Store 1030(r3) 1033
-            1035:          23 Load 30(inFM0)
-            1036:   21(fvec3) Load 28(inFV0)
-            1037:   21(fvec3) MatrixTimesVector 1035 1036
-                              Store 1034(r4) 1037
-            1039:   21(fvec3) Load 28(inFV0)
-            1040:          23 Load 30(inFM0)
-            1041:   21(fvec3) VectorTimesMatrix 1039 1040
-                              Store 1038(r5) 1041
-            1043:          23 Load 30(inFM0)
-            1044:    6(float) Load 26(inF0)
-            1045:          23 MatrixTimesScalar 1043 1044
-                              Store 1042(r6) 1045
-            1047:    6(float) Load 26(inF0)
-            1048:          23 Load 30(inFM0)
-            1049:          23 MatrixTimesScalar 1048 1047
-                              Store 1046(r7) 1049
-            1051:          23 Load 30(inFM0)
-            1052:          23 Load 31(inFM1)
-            1053:          23 MatrixTimesMatrix 1051 1052
-                              Store 1050(r8) 1053
+        1066(r0):      7(ptr) Variable Function
+        1070(r1):     22(ptr) Variable Function
+        1074(r2):     22(ptr) Variable Function
+        1078(r3):      7(ptr) Variable Function
+        1082(r4):     22(ptr) Variable Function
+        1086(r5):     22(ptr) Variable Function
+        1090(r6):     24(ptr) Variable Function
+        1094(r7):     24(ptr) Variable Function
+        1098(r8):     24(ptr) Variable Function
+            1067:    6(float) Load 26(inF0)
+            1068:    6(float) Load 27(inF1)
+            1069:    6(float) FMul 1067 1068
+                              Store 1066(r0) 1069
+            1071:   21(fvec3) Load 28(inFV0)
+            1072:    6(float) Load 26(inF0)
+            1073:   21(fvec3) VectorTimesScalar 1071 1072
+                              Store 1070(r1) 1073
+            1075:    6(float) Load 26(inF0)
+            1076:   21(fvec3) Load 28(inFV0)
+            1077:   21(fvec3) VectorTimesScalar 1076 1075
+                              Store 1074(r2) 1077
+            1079:   21(fvec3) Load 28(inFV0)
+            1080:   21(fvec3) Load 29(inFV1)
+            1081:    6(float) Dot 1079 1080
+                              Store 1078(r3) 1081
+            1083:          23 Load 30(inFM0)
+            1084:   21(fvec3) Load 28(inFV0)
+            1085:   21(fvec3) MatrixTimesVector 1083 1084
+                              Store 1082(r4) 1085
+            1087:   21(fvec3) Load 28(inFV0)
+            1088:          23 Load 30(inFM0)
+            1089:   21(fvec3) VectorTimesMatrix 1087 1088
+                              Store 1086(r5) 1089
+            1091:          23 Load 30(inFM0)
+            1092:    6(float) Load 26(inF0)
+            1093:          23 MatrixTimesScalar 1091 1092
+                              Store 1090(r6) 1093
+            1095:    6(float) Load 26(inF0)
+            1096:          23 Load 30(inFM0)
+            1097:          23 MatrixTimesScalar 1096 1095
+                              Store 1094(r7) 1097
+            1099:          23 Load 30(inFM0)
+            1100:          23 Load 31(inFM1)
+            1101:          23 MatrixTimesMatrix 1099 1100
+                              Store 1098(r8) 1101
                               Return
                               FunctionEnd
 45(TestGenMul(f1;f1;vf4;vf4;mf44;mf44;):           2 Function None 38
@@ -2878,50 +3168,148 @@ Shader version: 450
        43(inFM0):     37(ptr) FunctionParameter
        44(inFM1):     37(ptr) FunctionParameter
               46:             Label
-        1054(r0):      7(ptr) Variable Function
-        1058(r1):     35(ptr) Variable Function
-        1062(r2):     35(ptr) Variable Function
-        1066(r3):      7(ptr) Variable Function
-        1070(r4):     35(ptr) Variable Function
-        1074(r5):     35(ptr) Variable Function
-        1078(r6):     37(ptr) Variable Function
-        1082(r7):     37(ptr) Variable Function
-        1086(r8):     37(ptr) Variable Function
-            1055:    6(float) Load 39(inF0)
-            1056:    6(float) Load 40(inF1)
-            1057:    6(float) FMul 1055 1056
-                              Store 1054(r0) 1057
-            1059:   34(fvec4) Load 41(inFV0)
-            1060:    6(float) Load 39(inF0)
-            1061:   34(fvec4) VectorTimesScalar 1059 1060
-                              Store 1058(r1) 1061
-            1063:    6(float) Load 39(inF0)
-            1064:   34(fvec4) Load 41(inFV0)
-            1065:   34(fvec4) VectorTimesScalar 1064 1063
-                              Store 1062(r2) 1065
-            1067:   34(fvec4) Load 41(inFV0)
-            1068:   34(fvec4) Load 42(inFV1)
-            1069:    6(float) Dot 1067 1068
-                              Store 1066(r3) 1069
-            1071:          36 Load 43(inFM0)
-            1072:   34(fvec4) Load 41(inFV0)
-            1073:   34(fvec4) MatrixTimesVector 1071 1072
-                              Store 1070(r4) 1073
-            1075:   34(fvec4) Load 41(inFV0)
-            1076:          36 Load 43(inFM0)
-            1077:   34(fvec4) VectorTimesMatrix 1075 1076
-                              Store 1074(r5) 1077
-            1079:          36 Load 43(inFM0)
-            1080:    6(float) Load 39(inF0)
-            1081:          36 MatrixTimesScalar 1079 1080
-                              Store 1078(r6) 1081
-            1083:    6(float) Load 39(inF0)
-            1084:          36 Load 43(inFM0)
-            1085:          36 MatrixTimesScalar 1084 1083
-                              Store 1082(r7) 1085
-            1087:          36 Load 43(inFM0)
-            1088:          36 Load 44(inFM1)
-            1089:          36 MatrixTimesMatrix 1087 1088
-                              Store 1086(r8) 1089
+        1102(r0):      7(ptr) Variable Function
+        1106(r1):     35(ptr) Variable Function
+        1110(r2):     35(ptr) Variable Function
+        1114(r3):      7(ptr) Variable Function
+        1118(r4):     35(ptr) Variable Function
+        1122(r5):     35(ptr) Variable Function
+        1126(r6):     37(ptr) Variable Function
+        1130(r7):     37(ptr) Variable Function
+        1134(r8):     37(ptr) Variable Function
+            1103:    6(float) Load 39(inF0)
+            1104:    6(float) Load 40(inF1)
+            1105:    6(float) FMul 1103 1104
+                              Store 1102(r0) 1105
+            1107:   34(fvec4) Load 41(inFV0)
+            1108:    6(float) Load 39(inF0)
+            1109:   34(fvec4) VectorTimesScalar 1107 1108
+                              Store 1106(r1) 1109
+            1111:    6(float) Load 39(inF0)
+            1112:   34(fvec4) Load 41(inFV0)
+            1113:   34(fvec4) VectorTimesScalar 1112 1111
+                              Store 1110(r2) 1113
+            1115:   34(fvec4) Load 41(inFV0)
+            1116:   34(fvec4) Load 42(inFV1)
+            1117:    6(float) Dot 1115 1116
+                              Store 1114(r3) 1117
+            1119:          36 Load 43(inFM0)
+            1120:   34(fvec4) Load 41(inFV0)
+            1121:   34(fvec4) MatrixTimesVector 1119 1120
+                              Store 1118(r4) 1121
+            1123:   34(fvec4) Load 41(inFV0)
+            1124:          36 Load 43(inFM0)
+            1125:   34(fvec4) VectorTimesMatrix 1123 1124
+                              Store 1122(r5) 1125
+            1127:          36 Load 43(inFM0)
+            1128:    6(float) Load 39(inF0)
+            1129:          36 MatrixTimesScalar 1127 1128
+                              Store 1126(r6) 1129
+            1131:    6(float) Load 39(inF0)
+            1132:          36 Load 43(inFM0)
+            1133:          36 MatrixTimesScalar 1132 1131
+                              Store 1130(r7) 1133
+            1135:          36 Load 43(inFM0)
+            1136:          36 Load 44(inFM1)
+            1137:          36 MatrixTimesMatrix 1135 1136
+                              Store 1134(r8) 1137
+                              Return
+                              FunctionEnd
+65(TestGenMul(f1;f1;vf2;vf3;mf32;mf23;mf33;mf43;mf42;):           2 Function None 55
+        56(inF0):      7(ptr) FunctionParameter
+        57(inF1):      7(ptr) FunctionParameter
+       58(inFV2):      9(ptr) FunctionParameter
+       59(inFV3):     22(ptr) FunctionParameter
+     60(inFM2x3):     48(ptr) FunctionParameter
+     61(inFM3x2):     50(ptr) FunctionParameter
+     62(inFM3x3):     24(ptr) FunctionParameter
+     63(inFM3x4):     52(ptr) FunctionParameter
+     64(inFM2x4):     54(ptr) FunctionParameter
+              66:             Label
+       1138(r00):      7(ptr) Variable Function
+       1142(r01):      9(ptr) Variable Function
+       1146(r02):     22(ptr) Variable Function
+       1150(r03):      9(ptr) Variable Function
+       1154(r04):     22(ptr) Variable Function
+       1158(r05):      7(ptr) Variable Function
+       1162(r06):      7(ptr) Variable Function
+       1166(r07):     22(ptr) Variable Function
+       1170(r08):      9(ptr) Variable Function
+       1174(r09):      9(ptr) Variable Function
+       1178(r10):     22(ptr) Variable Function
+       1182(r11):     48(ptr) Variable Function
+       1186(r12):     50(ptr) Variable Function
+       1190(r13):     11(ptr) Variable Function
+       1194(r14):     48(ptr) Variable Function
+       1198(r15):     54(ptr) Variable Function
+       1202(r16):     52(ptr) Variable Function
+            1139:    6(float) Load 56(inF0)
+            1140:    6(float) Load 57(inF1)
+            1141:    6(float) FMul 1139 1140
+                              Store 1138(r00) 1141
+            1143:    8(fvec2) Load 58(inFV2)
+            1144:    6(float) Load 56(inF0)
+            1145:    8(fvec2) VectorTimesScalar 1143 1144
+                              Store 1142(r01) 1145
+            1147:   21(fvec3) Load 59(inFV3)
+            1148:    6(float) Load 56(inF0)
+            1149:   21(fvec3) VectorTimesScalar 1147 1148
+                              Store 1146(r02) 1149
+            1151:    6(float) Load 56(inF0)
+            1152:    8(fvec2) Load 58(inFV2)
+            1153:    8(fvec2) VectorTimesScalar 1152 1151
+                              Store 1150(r03) 1153
+            1155:    6(float) Load 56(inF0)
+            1156:   21(fvec3) Load 59(inFV3)
+            1157:   21(fvec3) VectorTimesScalar 1156 1155
+                              Store 1154(r04) 1157
+            1159:    8(fvec2) Load 58(inFV2)
+            1160:    8(fvec2) Load 58(inFV2)
+            1161:    6(float) Dot 1159 1160
+                              Store 1158(r05) 1161
+            1163:   21(fvec3) Load 59(inFV3)
+            1164:   21(fvec3) Load 59(inFV3)
+            1165:    6(float) Dot 1163 1164
+                              Store 1162(r06) 1165
+            1167:    8(fvec2) Load 58(inFV2)
+            1168:          47 Load 60(inFM2x3)
+            1169:   21(fvec3) VectorTimesMatrix 1167 1168
+                              Store 1166(r07) 1169
+            1171:   21(fvec3) Load 59(inFV3)
+            1172:          49 Load 61(inFM3x2)
+            1173:    8(fvec2) VectorTimesMatrix 1171 1172
+                              Store 1170(r08) 1173
+            1175:          47 Load 60(inFM2x3)
+            1176:   21(fvec3) Load 59(inFV3)
+            1177:    8(fvec2) MatrixTimesVector 1175 1176
+                              Store 1174(r09) 1177
+            1179:          49 Load 61(inFM3x2)
+            1180:    8(fvec2) Load 58(inFV2)
+            1181:   21(fvec3) MatrixTimesVector 1179 1180
+                              Store 1178(r10) 1181
+            1183:          47 Load 60(inFM2x3)
+            1184:    6(float) Load 56(inF0)
+            1185:          47 MatrixTimesScalar 1183 1184
+                              Store 1182(r11) 1185
+            1187:          49 Load 61(inFM3x2)
+            1188:    6(float) Load 56(inF0)
+            1189:          49 MatrixTimesScalar 1187 1188
+                              Store 1186(r12) 1189
+            1191:          47 Load 60(inFM2x3)
+            1192:          49 Load 61(inFM3x2)
+            1193:          10 MatrixTimesMatrix 1191 1192
+                              Store 1190(r13) 1193
+            1195:          47 Load 60(inFM2x3)
+            1196:          23 Load 62(inFM3x3)
+            1197:          47 MatrixTimesMatrix 1195 1196
+                              Store 1194(r14) 1197
+            1199:          47 Load 60(inFM2x3)
+            1200:          51 Load 63(inFM3x4)
+            1201:          53 MatrixTimesMatrix 1199 1200
+                              Store 1198(r15) 1201
+            1203:          49 Load 61(inFM3x2)
+            1204:          53 Load 64(inFM2x4)
+            1205:          51 MatrixTimesMatrix 1203 1204
+                              Store 1202(r16) 1205
                               Return
                               FunctionEnd

--- a/Test/hlsl.intrinsics.frag
+++ b/Test/hlsl.intrinsics.frag
@@ -17,69 +17,70 @@ float PixelShaderFunction(float inF0, float inF1, float inF2, uint inU0, uint in
 {
     uint out_u1;
 
-    all(inF0);
-    abs(inF0);
-    acos(inF0);
-    any(inF0);
-    asin(inF0);
-    asint(inF0);
-    asuint(inF0);
-    asfloat(inU0);
+    bool r000 = all(inF0);
+    float r001 = abs(inF0);
+    float r002 = acos(inF0);
+    bool r003 = any(inF0);
+    float r004 = asin(inF0);
+    int r005 = asint(inF0);
+    uint r006 = asuint(inF0);
+    float r007 = asfloat(inU0);
     // asdouble(inU0, inU1);  // TODO: enable when HLSL parser used for intrinsics
-    atan(inF0);
-    atan2(inF0, inF1);
-    ceil(inF0);
-    clamp(inF0, inF1, inF2);
+    float r009 = atan(inF0);
+    float r010 = atan2(inF0, inF1);
+    float r011 = ceil(inF0);
+    float r012 = clamp(inF0, inF1, inF2);
     clip(inF0);
-    cos(inF0);
-    cosh(inF0);
-    countbits(7);
-    ddx(inF0);
-    ddx_coarse(inF0);
-    ddx_fine(inF0);
-    ddy(inF0);
-    ddy_coarse(inF0);
-    ddy_fine(inF0);
-    degrees(inF0);
+    float r014 = cos(inF0);
+    float r015 = cosh(inF0);
+    uint r016 = countbits(7);
+    float r017 = ddx(inF0);
+    float r018 = ddx_coarse(inF0);
+    float r019 = ddx_fine(inF0);
+    float r020 = ddy(inF0);
+    float r021 = ddy_coarse(inF0);
+    float r022 = ddy_fine(inF0);
+    float r023 = degrees(inF0);
     // EvaluateAttributeAtCentroid(inF0);
     // EvaluateAttributeAtSample(inF0, 0);
     // TODO: EvaluateAttributeSnapped(inF0, int2(1,2));
-    exp(inF0);
-    exp2(inF0);
-    firstbithigh(7);
-    firstbitlow(7);
-    floor(inF0);
+    float r027 = exp(inF0);
+    float r028 = exp2(inF0);
+    uint r029 = firstbithigh(7);
+    uint r030 = firstbitlow(7);
+    float r031 = floor(inF0);
     // TODO: fma(inD0, inD1, inD2);
-    fmod(inF0, inF1);
-    frac(inF0);
-    frexp(inF0, inF1);
-    fwidth(inF0);
-    isinf(inF0);
-    isnan(inF0);
-    ldexp(inF0, inF1);
-    log(inF0);
-    log10(inF0);
-    log2(inF0);
-    max(inF0, inF1);
-    min(inF0, inF1);
-    pow(inF0, inF1);
-    radians(inF0);
-    rcp(inF0);
-    reversebits(2);
-    round(inF0);
-    rsqrt(inF0);
-    saturate(inF0);
-    sign(inF0);
-    sin(inF0);
+    float r033 = fmod(inF0, inF1);
+    float r034 = frac(inF0);
+    float r035 = frexp(inF0, inF1);
+    float r036 = fwidth(inF0);
+    bool r037 = isinf(inF0);
+    bool r038 = isnan(inF0);
+    float r039 = ldexp(inF0, inF1);
+    float r039a = lerp(inF0, inF1, inF2);
+    float r040 = log(inF0);
+    float r041 = log10(inF0);
+    float r042 = log2(inF0);
+    float r043 = max(inF0, inF1);
+    float r044 = min(inF0, inF1);
+    float r045 = pow(inF0, inF1);
+    float r046 = radians(inF0);
+    float r047 = rcp(inF0);
+    uint r048 = reversebits(2);
+    float r049 = round(inF0);
+    float r050 = rsqrt(inF0);
+    float r051 = saturate(inF0);
+    float r052 = sign(inF0);
+    float r053 = sin(inF0);
     sincos(inF0, inF1, inF2);
-    sinh(inF0);
-    smoothstep(inF0, inF1, inF2);
-    sqrt(inF0);
-    step(inF0, inF1);
-    tan(inF0);
-    tanh(inF0);
+    float r055 = sinh(inF0);
+    float r056 = smoothstep(inF0, inF1, inF2);
+    float r057 = sqrt(inF0);
+    float r058 = step(inF0, inF1);
+    float r059 = tan(inF0);
+    float r060 = tanh(inF0);
     // TODO: sampler intrinsics, when we can declare the types.
-    trunc(inF0);
+    float r061 = trunc(inF0);
 
     return 0.0;
 }
@@ -94,76 +95,80 @@ float2 PixelShaderFunction(float2 inF0, float2 inF1, float2 inF2, uint2 inU0, ui
 {
     uint2 out_u2;
 
-    all(inF0);
-    abs(inF0);
-    acos(inF0);
-    any(inF0);
-    asin(inF0);
-    asint(inF0);
-    asuint(inF0);
-    asfloat(inU0);
+    bool r000 = all(inF0);
+    float2 r001 = abs(inF0);
+    float2 r002 = acos(inF0);
+    bool r003 = any(inF0);
+    float2 r004 = asin(inF0);
+    int2 r005 = asint(inF0);
+    uint2 r006 = asuint(inF0);
+    float2 r007 = asfloat(inU0);
     // asdouble(inU0, inU1);  // TODO: enable when HLSL parser used for intrinsics
-    atan(inF0);
-    atan2(inF0, inF1);
-    ceil(inF0);
-    clamp(inF0, inF1, inF2);
+    float2 r009 = atan(inF0);
+    float2 r010 = atan2(inF0, inF1);
+    float2 r011 = ceil(inF0);
+    float2 r012 = clamp(inF0, inF1, inF2);
     clip(inF0);
-    cos(inF0);
-    cosh(inF0);
-    countbits(int2(7,3));
-    ddx(inF0);
-    ddx_coarse(inF0);
-    ddx_fine(inF0);
-    ddy(inF0);
-    ddy_coarse(inF0);
-    ddy_fine(inF0);
-    degrees(inF0);
-    distance(inF0, inF1);
-    dot(inF0, inF1);
+    float2 r013 = cos(inF0);
+    float2 r015 = cosh(inF0);
+    uint2 r016 = countbits(int2(7,3));
+    float2 r017 = ddx(inF0);
+    float2 r018 = ddx_coarse(inF0);
+    float2 r019 = ddx_fine(inF0);
+    float2 r020 = ddy(inF0);
+    float2 r021 = ddy_coarse(inF0);
+    float2 r022 = ddy_fine(inF0);
+    float2 r023 = degrees(inF0);
     // EvaluateAttributeAtCentroid(inF0);
     // EvaluateAttributeAtSample(inF0, 0);
     // TODO: EvaluateAttributeSnapped(inF0, int2(1,2));
-    exp(inF0);
-    exp2(inF0);
-    faceforward(inF0, inF1, inF2);
-    firstbithigh(7);
-    firstbitlow(7);
-    floor(inF0);
+    float r026 = distance(inF0, inF1);
+    float r027 = dot(inF0, inF1);
+    // EvaluateAttributeAtCentroid(inF0);
+    // EvaluateAttributeAtSample(inF0, 0);
+    // TODO: EvaluateAttributeSnapped(inF0, int2(1,2));
+    float2 r028 = exp(inF0);
+    float2 r029 = exp2(inF0);
+    float2 r030 = faceforward(inF0, inF1, inF2);
+    uint2 r031 = firstbithigh(uint2(7,8));
+    uint2 r032 = firstbitlow(uint2(7,8));
+    float2 r033 = floor(inF0);
     // TODO: fma(inD0, inD1, inD2);
-    fmod(inF0, inF1);
-    frac(inF0);
-    frexp(inF0, inF1);
-    fwidth(inF0);
-    isinf(inF0);
-    isnan(inF0);
-    ldexp(inF0, inF1);
-    length(inF0);
-    log(inF0);
-    log10(inF0);
-    log2(inF0);
-    max(inF0, inF1);
-    min(inF0, inF1);
-    normalize(inF0);
-    pow(inF0, inF1);
-    radians(inF0);
-    rcp(inF0);
-    reflect(inF0, inF1);
-    refract(inF0, inF1, 2.0);
-    reversebits(int2(1,2));
-    round(inF0);
-    rsqrt(inF0);
-    saturate(inF0);
-    sign(inF0);
-    sin(inF0);
+    float2 r035 = fmod(inF0, inF1);
+    float2 r036 = frac(inF0);
+    float2 r037 = frexp(inF0, inF1);
+    float2 r038 = fwidth(inF0);
+    bool2 r039 = isinf(inF0);
+    bool2 r040 = isnan(inF0);
+    float2 r041 = ldexp(inF0, inF1);
+    float2 r039a = lerp(inF0, inF1, inF2);
+    float r042 = length(inF0);
+    float2 r043 = log(inF0);
+    float2 r044 = log10(inF0);
+    float2 r045 = log2(inF0);
+    float2 r046 = max(inF0, inF1);
+    float2 r047 = min(inF0, inF1);
+    float2 r048 = normalize(inF0);
+    float2 r049 = pow(inF0, inF1);
+    float2 r050 = radians(inF0);
+    float2 r051 = rcp(inF0);
+    float2 r052 = reflect(inF0, inF1);
+    float2 r053 = refract(inF0, inF1, 2.0);
+    uint2 r054 = reversebits(uint2(1,2));
+    float2 r055 = round(inF0);
+    float2 r056 = rsqrt(inF0);
+    float2 r057 = saturate(inF0);
+    float2 r058 = sign(inF0);
+    float2 r059 = sin(inF0);
     sincos(inF0, inF1, inF2);
-    sinh(inF0);
-    smoothstep(inF0, inF1, inF2);
-    sqrt(inF0);
-    step(inF0, inF1);
-    tan(inF0);
-    tanh(inF0);
+    float2 r060 = sinh(inF0);
+    float2 r061 = smoothstep(inF0, inF1, inF2);
+    float2 r062 = sqrt(inF0);
+    float2 r063 = step(inF0, inF1);
+    float2 r064 = tan(inF0);
+    float2 r065 = tanh(inF0);
     // TODO: sampler intrinsics, when we can declare the types.
-    trunc(inF0);
+    float2 r066 = trunc(inF0);
 
     // TODO: ... add when float1 prototypes are generated
     return float2(1,2);
@@ -173,77 +178,78 @@ float3 PixelShaderFunction(float3 inF0, float3 inF1, float3 inF2, uint3 inU0, ui
 {
     uint3 out_u3;
     
-    all(inF0);
-    abs(inF0);
-    acos(inF0);
-    any(inF0);
-    asin(inF0);
-    asint(inF0);
-    asuint(inF0);
-    asfloat(inU0);
+    bool r000 = all(inF0);
+    float3 r001 = abs(inF0);
+    float3 r002 = acos(inF0);
+    bool r003 = any(inF0);
+    float3 r004 = asin(inF0);
+    int3 r005 = asint(inF0);
+    uint3 r006 = asuint(inF0);
+    float3 r007 = asfloat(inU0);
     // asdouble(inU0, inU1);  // TODO: enable when HLSL parser used for intrinsics
-    atan(inF0);
-    atan2(inF0, inF1);
-    ceil(inF0);
-    clamp(inF0, inF1, inF2);
+    float3 r009 = atan(inF0);
+    float3 r010 = atan2(inF0, inF1);
+    float3 r011 = ceil(inF0);
+    float3 r012 = clamp(inF0, inF1, inF2);
     clip(inF0);
-    cos(inF0);
-    cosh(inF0);
-    countbits(int3(7,3,5));
-    cross(inF0, inF1);
-    ddx(inF0);
-    ddx_coarse(inF0);
-    ddx_fine(inF0);
-    ddy(inF0);
-    ddy_coarse(inF0);
-    ddy_fine(inF0);
-    degrees(inF0);
-    distance(inF0, inF1);
-    dot(inF0, inF1);
+    float3 r013 = cos(inF0);
+    float3 r014 = cosh(inF0);
+    uint3 r015 = countbits(uint3(7,3,5));
+    float3 r016 = cross(inF0, inF1);
+    float3 r017 = ddx(inF0);
+    float3 r018 = ddx_coarse(inF0);
+    float3 r019 = ddx_fine(inF0);
+    float3 r020 = ddy(inF0);
+    float3 r021 = ddy_coarse(inF0);
+    float3 r022 = ddy_fine(inF0);
+    float3 r023 = degrees(inF0);
+    float r024 = distance(inF0, inF1);
+    float r025 = dot(inF0, inF1);
     // EvaluateAttributeAtCentroid(inF0);
     // EvaluateAttributeAtSample(inF0, 0);
     // TODO: EvaluateAttributeSnapped(inF0, int2(1,2));
-    exp(inF0);
-    exp2(inF0);
-    faceforward(inF0, inF1, inF2);
-    firstbithigh(7);
-    firstbitlow(7);
-    floor(inF0);
+    float3 r029 = exp(inF0);
+    float3 r030 = exp2(inF0);
+    float3 r031 = faceforward(inF0, inF1, inF2);
+    uint3 r032 = firstbithigh(uint3(2,3,4));
+    uint3 r033 = firstbitlow(uint3(2,3,4));
+    float3 r034 = floor(inF0);
     // TODO: fma(inD0, inD1, inD2);
-    fmod(inF0, inF1);
-    frac(inF0);
-    frexp(inF0, inF1);
-    fwidth(inF0);
-    isinf(inF0);
-    isnan(inF0);
-    ldexp(inF0, inF1);
-    length(inF0);
-    log(inF0);
-    log10(inF0);
-    log2(inF0);
-    max(inF0, inF1);
-    min(inF0, inF1);
-    normalize(inF0);
-    pow(inF0, inF1);
-    radians(inF0);
-    rcp(inF0);
-    reflect(inF0, inF1);
-    refract(inF0, inF1, 2.0);
-    reversebits(int3(1,2,3));
-    round(inF0);
-    rsqrt(inF0);
-    saturate(inF0);
-    sign(inF0);
-    sin(inF0);
+    float3 r036 = fmod(inF0, inF1);
+    float3 r037 = frac(inF0);
+    float3 r038 = frexp(inF0, inF1);
+    float3 r039 = fwidth(inF0);
+    bool3 r040 = isinf(inF0);
+    bool3 r041 = isnan(inF0);
+    float3 r042 = ldexp(inF0, inF1);
+    float3 r039a = lerp(inF0, inF1, inF2);
+    float r043 = length(inF0);
+    float3 r044 = log(inF0);
+    float3 r045 = log10(inF0);
+    float3 r046 = log2(inF0);
+    float3 r047 = max(inF0, inF1);
+    float3 r048 = min(inF0, inF1);
+    float3 r049 = normalize(inF0);
+    float3 r050 = pow(inF0, inF1);
+    float3 r051 = radians(inF0);
+    float3 r052 = rcp(inF0);
+    float3 r053 = reflect(inF0, inF1);
+    float3 r054 = refract(inF0, inF1, 2.0);
+    uint3 r055 = reversebits(uint3(1,2,3));
+    float3 r056 = round(inF0);
+    float3 r057 = rsqrt(inF0);
+    float3 r058 = saturate(inF0);
+    float3 r059 = sign(inF0);
+    float3 r060 = sin(inF0);
     sincos(inF0, inF1, inF2);
-    sinh(inF0);
-    smoothstep(inF0, inF1, inF2);
-    sqrt(inF0);
-    step(inF0, inF1);
-    tan(inF0);
-    tanh(inF0);
+    float3 r061 = sinh(inF0);
+    float3 r062 = smoothstep(inF0, inF1, inF2);
+    float3 r063 = sqrt(inF0);
+    float3 r064 = step(inF0, inF1);
+    float3 r065 = tan(inF0);
+    float3 r066 = tanh(inF0);
     // TODO: sampler intrinsics, when we can declare the types.
-    trunc(inF0);
+    float3 r067 = trunc(inF0);
 
     // TODO: ... add when float1 prototypes are generated
     return float3(1,2,3);
@@ -253,77 +259,78 @@ float4 PixelShaderFunction(float4 inF0, float4 inF1, float4 inF2, uint4 inU0, ui
 {
     uint4 out_u4;
 
-    all(inF0);
-    abs(inF0);
-    acos(inF0);
-    any(inF0);
-    asin(inF0);
-    asint(inF0);
-    asuint(inF0);
-    asfloat(inU0);
+    bool r000 = all(inF0);
+    float4 r001 = abs(inF0);
+    float4 r002 = acos(inF0);
+    bool r003 = any(inF0);
+    float4 r004 = asin(inF0);
+    int4 r005 = asint(inF0);
+    uint4 r006 = asuint(inF0);
+    float4 r007 = asfloat(inU0);
     // asdouble(inU0, inU1);  // TODO: enable when HLSL parser used for intrinsics
-    atan(inF0);
-    atan2(inF0, inF1);
-    ceil(inF0);
-    clamp(inF0, inF1, inF2);
+    float4 r009 = atan(inF0);
+    float4 r010 = atan2(inF0, inF1);
+    float4 r011 = ceil(inF0);
+    float4 r012 = clamp(inF0, inF1, inF2);
     clip(inF0);
-    cos(inF0);
-    cosh(inF0);
-    countbits(int4(7,3,5,2));
-    ddx(inF0);
-    ddx_coarse(inF0);
-    ddx_fine(inF0);
-    ddy(inF0);
-    ddy_coarse(inF0);
-    ddy_fine(inF0);
-    degrees(inF0);
-    distance(inF0, inF1);
-    dot(inF0, inF1);
-    dst(inF0, inF1);
+    float4 r013 = cos(inF0);
+    float4 r014 = cosh(inF0);
+    uint4 r015 = countbits(uint4(7,3,5,2));
+    float4 r016 = ddx(inF0);
+    float4 r017 = ddx_coarse(inF0);
+    float4 r018 = ddx_fine(inF0);
+    float4 r019 = ddy(inF0);
+    float4 r020 = ddy_coarse(inF0);
+    float4 r021 = ddy_fine(inF0);
+    float4 r022 = degrees(inF0);
+    float r023 = distance(inF0, inF1);
+    float r024 = dot(inF0, inF1);
+    float4 r025 = dst(inF0, inF1);
     // EvaluateAttributeAtCentroid(inF0);
     // EvaluateAttributeAtSample(inF0, 0);
     // TODO: EvaluateAttributeSnapped(inF0, int2(1,2));
-    exp(inF0);
-    exp2(inF0);
-    faceforward(inF0, inF1, inF2);
-    firstbithigh(7);
-    firstbitlow(7);
-    floor(inF0);
+    float4 r029 = exp(inF0);
+    float4 r030 = exp2(inF0);
+    float4 r031 = faceforward(inF0, inF1, inF2);
+    uint4 r032 = firstbithigh(uint4(7,8,9,10));
+    uint4 r033 = firstbitlow(uint4(7,8,9,10));
+    float4 r034 = floor(inF0);
     // TODO: fma(inD0, inD1, inD2);
-    fmod(inF0, inF1);
-    frac(inF0);
-    frexp(inF0, inF1);
-    fwidth(inF0);
-    isinf(inF0);
-    isnan(inF0);
-    ldexp(inF0, inF1);
-    length(inF0);
-    log(inF0);
-    log10(inF0);
-    log2(inF0);
-    max(inF0, inF1);
-    min(inF0, inF1);
-    normalize(inF0);
-    pow(inF0, inF1);
-    radians(inF0);
-    rcp(inF0);
-    reflect(inF0, inF1);
-    refract(inF0, inF1, 2.0);
-    reversebits(int4(1,2,3,4));
-    round(inF0);
-    rsqrt(inF0);
-    saturate(inF0);
-    sign(inF0);
-    sin(inF0);
+    float4 r036 = fmod(inF0, inF1);
+    float4 r037 = frac(inF0);
+    float4 r038 = frexp(inF0, inF1);
+    float4 r039 = fwidth(inF0);
+    bool4 r040 = isinf(inF0);
+    bool4 r041 = isnan(inF0);
+    float4 r042 = ldexp(inF0, inF1);
+    float4 r039a = lerp(inF0, inF1, inF2);
+    float r043 = length(inF0);
+    float4 r044 = log(inF0);
+    float4 r045 = log10(inF0);
+    float4 r046 = log2(inF0);
+    float4 r047 = max(inF0, inF1);
+    float4 r048 = min(inF0, inF1);
+    float4 r049 = normalize(inF0);
+    float4 r050 = pow(inF0, inF1);
+    float4 r051 = radians(inF0);
+    float4 r052 = rcp(inF0);
+    float4 r053 = reflect(inF0, inF1);
+    float4 r054 = refract(inF0, inF1, 2.0);
+    uint4 r055 = reversebits(uint4(1,2,3,4));
+    float4 r056 = round(inF0);
+    float4 r057 = rsqrt(inF0);
+    float4 r058 = saturate(inF0);
+    float4 r059 = sign(inF0);
+    float4 r060 = sin(inF0);
     sincos(inF0, inF1, inF2);
-    sinh(inF0);
-    smoothstep(inF0, inF1, inF2);
-    sqrt(inF0);
-    step(inF0, inF1);
-    tan(inF0);
-    tanh(inF0);
+    float4 r061 = sinh(inF0);
+    float4 r062 = smoothstep(inF0, inF1, inF2);
+    float4 r063 = sqrt(inF0);
+    float4 r064 = step(inF0, inF1);
+    float4 r065 = tan(inF0);
+    float4 r066 = tanh(inF0);
     // TODO: sampler intrinsics, when we can declare the types.
-    trunc(inF0);
+    float4 r067 = trunc(inF0);
 
     // TODO: ... add when float1 prototypes are generated
     return float4(1,2,3,4);
@@ -335,65 +342,64 @@ float4 PixelShaderFunction(float4 inF0, float4 inF1, float4 inF2, uint4 inU0, ui
 //    asuint(inF0); \
 
 // TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
-#define MATFNS() \
-    all(inF0); \
-    abs(inF0); \
-    acos(inF0); \
-    any(inF0); \
-    asin(inF0); \
-    atan(inF0); \
-    atan2(inF0, inF1); \
-    ceil(inF0); \
-    clip(inF0); \
-    clamp(inF0, inF1, inF2); \
-    cos(inF0); \
-    cosh(inF0); \
-    ddx(inF0); \
-    ddx_coarse(inF0); \
-    ddx_fine(inF0); \
-    ddy(inF0); \
-    ddy_coarse(inF0); \
-    ddy_fine(inF0); \
-    degrees(inF0); \
-    determinant(inF0); \
-    exp(inF0); \
-    exp2(inF0); \
-    firstbithigh(7); \
-    firstbitlow(7); \
-    floor(inF0); \
-    fmod(inF0, inF1); \
-    frac(inF0); \
-    frexp(inF0, inF1); \
-    fwidth(inF0); \
-    ldexp(inF0, inF1); \
-    log(inF0); \
-    log10(inF0); \
-    log2(inF0);      \
-    max(inF0, inF1); \
-    min(inF0, inF1); \
-    pow(inF0, inF1); \
-    radians(inF0); \
-    round(inF0); \
-    rsqrt(inF0); \
-    saturate(inF0); \
-    sign(inF0); \
-    sin(inF0); \
-    sincos(inF0, inF1, inF2); \
-    sinh(inF0); \
-    smoothstep(inF0, inF1, inF2); \
-    sqrt(inF0); \
-    step(inF0, inF1); \
-    tan(inF0); \
-    tanh(inF0); \
-    transpose(inF0); \
-    trunc(inF0);
+#define MATFNS(MT)                          \
+    bool r000 = all(inF0);                  \
+    MT r001 = abs(inF0);                    \
+    acos(inF0);                             \
+    bool r003 = any(inF0);                  \
+    MT r004 = asin(inF0);                   \
+    MT r005 = atan(inF0);                   \
+    MT r006 = atan2(inF0, inF1);            \
+    MT r007 = ceil(inF0);                   \
+    clip(inF0);                             \
+    MT r008 = clamp(inF0, inF1, inF2);      \
+    MT r009 = cos(inF0);                    \
+    MT r010 = cosh(inF0);                   \
+    MT r011 = ddx(inF0);                    \
+    MT r012 = ddx_coarse(inF0);             \
+    MT r013 = ddx_fine(inF0);               \
+    MT r014 = ddy(inF0);                    \
+    MT r015 = ddy_coarse(inF0);             \
+    MT r016 = ddy_fine(inF0);               \
+    MT r017 = degrees(inF0);                \
+    float r018 = determinant(inF0);         \
+    MT r019 = exp(inF0);                    \
+    MT R020 = exp2(inF0);                   \
+    MT r021 = floor(inF0);                  \
+    MT r022 = fmod(inF0, inF1);             \
+    MT r023 = frac(inF0);                   \
+    MT r024 = frexp(inF0, inF1);            \
+    MT r025 = fwidth(inF0);                 \
+    MT r026 = ldexp(inF0, inF1);            \
+    MT r026a = lerp(inF0, inF1, inF2);      \
+    MT r027 = log(inF0);                    \
+    MT r028 = log10(inF0);                  \
+    MT r029 = log2(inF0);                   \
+    MT r030 = max(inF0, inF1);              \
+    MT r031 = min(inF0, inF1);              \
+    MT r032 = pow(inF0, inF1);              \
+    MT r033 = radians(inF0);                \
+    MT r034 = round(inF0);                  \
+    MT r035 = rsqrt(inF0);                  \
+    MT r036 = saturate(inF0);               \
+    MT r037 = sign(inF0);                   \
+    MT r038 = sin(inF0);                    \
+    sincos(inF0, inF1, inF2);               \
+    MT r039 = sinh(inF0);                   \
+    MT r049 = smoothstep(inF0, inF1, inF2); \
+    MT r041 = sqrt(inF0);                   \
+    MT r042 = step(inF0, inF1);             \
+    MT r043 = tan(inF0);                    \
+    MT r044 = tanh(inF0);                   \
+    transpose(inF0);                        \
+    MT r046 = trunc(inF0);
 
 // TODO: turn on non-square matrix tests when protos are available.
 
 float2x2 PixelShaderFunction(float2x2 inF0, float2x2 inF1, float2x2 inF2)
 {
     // TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
-    MATFNS()
+    MATFNS(float2x2);
 
     // TODO: ... add when float1 prototypes are generated
     return float2x2(2,2,2,2);
@@ -402,7 +408,7 @@ float2x2 PixelShaderFunction(float2x2 inF0, float2x2 inF1, float2x2 inF2)
 float3x3 PixelShaderFunction(float3x3 inF0, float3x3 inF1, float3x3 inF2)
 {
     // TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
-    MATFNS()
+    MATFNS(float3x3);
 
     // TODO: ... add when float1 prototypes are generated
     return float3x3(3,3,3,3,3,3,3,3,3);
@@ -411,7 +417,7 @@ float3x3 PixelShaderFunction(float3x3 inF0, float3x3 inF1, float3x3 inF2)
 float4x4 PixelShaderFunction(float4x4 inF0, float4x4 inF1, float4x4 inF2)
 {
     // TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
-    MATFNS()
+    MATFNS(float4x4);
 
     // TODO: ... add when float1 prototypes are generated
     return float4x4(4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4);
@@ -448,4 +454,30 @@ void TestGenMul(float inF0, float inF1,
                 float4x4 inFM0, float4x4 inFM1)
 {
     TESTGENMUL(float, float4, float4x4);
+}
+
+// Test some non-square mats
+void TestGenMul(float inF0, float inF1,
+                float2 inFV2, float3 inFV3,
+                float2x3 inFM2x3, float3x2 inFM3x2,
+                float3x3 inFM3x3, float3x4 inFM3x4,
+                float2x4 inFM2x4)
+{
+    float  r00 = mul(inF0,  inF1);  // S=S*S
+    float2 r01 = mul(inFV2, inF0);  // V=V*S
+    float3 r02 = mul(inFV3, inF0);  // V=V*S
+    float2 r03 = mul(inF0,  inFV2); // V=S*V
+    float3 r04 = mul(inF0,  inFV3); // V=S*V
+    float  r05 = mul(inFV2, inFV2); // S=V*V
+    float  r06 = mul(inFV3, inFV3); // S=V*V
+    float3 r07 = mul(inFV2, inFM2x3); // V=V*M (return V dim is Mcols)
+    float2 r08 = mul(inFV3, inFM3x2); // V=V*M (return V dim is Mcols)
+    float2 r09 = mul(inFM2x3, inFV3); // V=M*V (return V dim is Mrows)
+    float3 r10 = mul(inFM3x2, inFV2); // V=M*V (return V dim is Mrows)
+    float2x3 r11 = mul(inFM2x3, inF0);
+    float3x2 r12 = mul(inFM3x2, inF0);
+    float2x2 r13 = mul(inFM2x3, inFM3x2);
+    float2x3 r14 = mul(inFM2x3, inFM3x3);
+    float2x4 r15 = mul(inFM2x3, inFM3x4);
+    float3x4 r16 = mul(inFM3x2, inFM2x4);
 }

--- a/Test/hlsl.intrinsics.vert
+++ b/Test/hlsl.intrinsics.vert
@@ -32,6 +32,7 @@ float VertexShaderFunction(float inF0, float inF1, float inF2, uint inU0, uint i
     isinf(inF0);
     isnan(inF0);
     ldexp(inF0, inF1);
+    lerp(inF0, inF1, inF2);
     log(inF0);
     log10(inF0);
     log2(inF0);
@@ -102,6 +103,7 @@ float2 VertexShaderFunction(float2 inF0, float2 inF1, float2 inF2, uint2 inU0, u
     isinf(inF0);
     isnan(inF0);
     ldexp(inF0, inF1);
+    lerp(inF0, inF1, inF2);
     length(inF0);
     log(inF0);
     log10(inF0);
@@ -172,6 +174,7 @@ float3 VertexShaderFunction(float3 inF0, float3 inF1, float3 inF2, uint3 inU0, u
     isinf(inF0);
     isnan(inF0);
     ldexp(inF0, inF1);
+    lerp(inF0, inF1, inF2);
     length(inF0);
     log(inF0);
     log10(inF0);
@@ -242,6 +245,7 @@ float4 VertexShaderFunction(float4 inF0, float4 inF1, float4 inF2, uint4 inU0, u
     isinf(inF0);
     isnan(inF0);
     ldexp(inF0, inF1);
+    lerp(inF0, inF1, inF2);
     length(inF0);
     log(inF0);
     log10(inF0);
@@ -303,6 +307,7 @@ float4 VertexShaderFunction(float4 inF0, float4 inF1, float4 inF2, uint4 inU0, u
     frac(inF0); \
     frexp(inF0, inF1); \
     ldexp(inF0, inF1); \
+    lerp(inF0, inF1, inF2); \
     log(inF0); \
     log10(inF0); \
     log2(inF0); \
@@ -385,4 +390,30 @@ void TestGenMul(float inF0, float inF1,
                 float4x4 inFM0, float4x4 inFM1)
 {
     TESTGENMUL(float, float4, float4x4);
+}
+
+// Test some non-square mats
+void TestGenMul(float inF0, float inF1,
+                float2 inFV2, float3 inFV3,
+                float2x3 inFM2x3, float3x2 inFM3x2,
+                float3x3 inFM3x3, float3x4 inFM3x4,
+                float2x4 inFM2x4)
+{
+    float  r00 = mul(inF0,  inF1);  // S=S*S
+    float2 r01 = mul(inFV2, inF0);  // V=V*S
+    float3 r02 = mul(inFV3, inF0);  // V=V*S
+    float2 r03 = mul(inF0,  inFV2); // V=S*V
+    float3 r04 = mul(inF0,  inFV3); // V=S*V
+    float  r05 = mul(inFV2, inFV2); // S=V*V
+    float  r06 = mul(inFV3, inFV3); // S=V*V
+    float3 r07 = mul(inFV2, inFM2x3); // V=V*M (return V dim is Mcols)
+    float2 r08 = mul(inFV3, inFM3x2); // V=V*M (return V dim is Mcols)
+    float2 r09 = mul(inFM2x3, inFV3); // V=M*V (return V dim is Mrows)
+    float3 r10 = mul(inFM3x2, inFV2); // V=M*V (return V dim is Mrows)
+    float2x3 r11 = mul(inFM2x3, inF0);
+    float3x2 r12 = mul(inFM3x2, inF0);
+    float2x2 r13 = mul(inFM2x3, inFM3x2);
+    float2x3 r14 = mul(inFM2x3, inFM3x3);
+    float2x4 r15 = mul(inFM2x3, inFM3x4);
+    float3x4 r16 = mul(inFM3x2, inFM2x4);
 }

--- a/glslang/Include/intermediate.h
+++ b/glslang/Include/intermediate.h
@@ -523,6 +523,7 @@ enum TOperator {
     EOpF32tof16,                         // HLSL conversion: half of a PackHalf2x16
     EOpF16tof32,                         // HLSL conversion: half of an UnpackHalf2x16
     EOpLit,                              // HLSL lighting coefficient vector
+    EOpTextureBias,                      // HLSL texture bias: will be lowered to EOpTexture
 };
 
 class TIntermTraverser;

--- a/hlsl/hlslParseHelper.h
+++ b/hlsl/hlslParseHelper.h
@@ -87,6 +87,7 @@ public:
     void handleFunctionArgument(TFunction*, TIntermTyped*& arguments, TIntermTyped* newArg);
     TIntermTyped* handleFunctionCall(const TSourceLoc&, TFunction*, TIntermNode*);
     void decomposeIntrinsic(const TSourceLoc&, TIntermTyped*& node, TIntermNode* arguments);
+    void textureParameters(const TSourceLoc&, TIntermTyped*& node, TIntermNode* arguments);
     TIntermTyped* handleLengthMethod(const TSourceLoc&, TFunction*, TIntermNode*);
     void addInputArgumentConversions(const TFunction&, TIntermNode*&) const;
     TIntermTyped* addOutputArgumentConversions(const TFunction&, TIntermAggregate&) const;

--- a/hlsl/hlslParseables.cpp
+++ b/hlsl/hlslParseables.cpp
@@ -54,6 +54,8 @@
 
 namespace {  // anonymous namespace functions
 
+const bool UseHlslTypes = false;
+
 const char* BaseTypeName(const char* argOrder, const char* scalarName, const char* vecName, const char* matName)
 {
     switch (*argOrder) {
@@ -74,22 +76,38 @@ const char* BaseTypeName(const char* argOrder, const char* scalarName, const cha
 glslang::TString& AppendTypeName(glslang::TString& s, const char* argOrder, const char* argType, int dim0, int dim1)
 {
     const bool transpose = (argOrder[0] == '^');
+    const bool matMul    = (argOrder[0] == '#');
 
-    // Take transpose of matrix dimensions
-    if (transpose) {
-        std::swap(dim0, dim1);
+    if (transpose) {  // Take transpose of matrix dimensions
+        std::swap(dim0, dim1); 
+        ++argOrder;
+    } else if (matMul) {
+        dim0 = dim1;  // set vector dimension to mat col
         ++argOrder;
     }
 
-    switch (*argType) {
-    case '-': s += "void"; break;
-    case 'F': s += BaseTypeName(argOrder, "float",   "vec",     "mat");  break;
-    case 'D': s += BaseTypeName(argOrder, "double",  "dvec",    "dmat"); break;
-    case 'I': s += BaseTypeName(argOrder, "int",     "ivec",    "imat"); break;
-    case 'U': s += BaseTypeName(argOrder, "uint",    "uvec",    "umat"); break;
-    case 'B': s += BaseTypeName(argOrder, "bool",    "bvec",    "bmat"); break;
-    case 'S': s += BaseTypeName(argOrder, "sampler", "sampler", "sampler"); break; // TODO: 
-    default:  s += "UNKNOWN_TYPE"; break;
+    if (UseHlslTypes) {
+        switch (*argType) {
+        case '-': s += "void";    break;
+        case 'F': s += "float";   break;
+        case 'D': s += "double";  break;
+        case 'I': s += "int";     break;
+        case 'U': s += "uint";    break;
+        case 'B': s += "bool";    break;
+        case 'S': s += "sampler"; break;
+        default:  s += "UNKNOWN_TYPE"; break;
+        }
+    } else {
+        switch (*argType) {
+        case '-': s += "void"; break;
+        case 'F': s += BaseTypeName(argOrder, "float",   "vec",     "mat");  break;
+        case 'D': s += BaseTypeName(argOrder, "double",  "dvec",    "dmat"); break;
+        case 'I': s += BaseTypeName(argOrder, "int",     "ivec",    "imat"); break;
+        case 'U': s += BaseTypeName(argOrder, "uint",    "uvec",    "umat"); break;
+        case 'B': s += BaseTypeName(argOrder, "bool",    "bvec",    "bmat"); break;
+        case 'S': s += BaseTypeName(argOrder, "sampler", "sampler", "sampler"); break; // TODO: 
+        default:  s += "UNKNOWN_TYPE"; break;
+        }
     }
 
     // handle fixed vector sizes, such as float3, and only ever 3.
@@ -119,7 +137,13 @@ glslang::TString& AppendTypeName(glslang::TString& s, const char* argOrder, cons
     case '-': break;  // no dimensions for voids
     case 'S': break;  // no dimensions on scalars
     case 'V': s += ('0' + dim0); break;
-    case 'M': s += ('0' + dim0); s += 'x'; s += ('0' + dim1); break;
+    case 'M': 
+        {
+            if (!UseHlslTypes)  // GLSL has column first for mat types
+                std::swap(dim0, dim1);
+            s += ('0' + dim0); s += 'x'; s += ('0' + dim1);
+            break;
+        }
     }
 
     return s;
@@ -142,7 +166,7 @@ inline bool IsValidGlsl(const char* cname, char retOrder, char retType, char arg
 
     const std::string name(cname);  // for ease of comparison. slow, but temporary, until HLSL parser is online.
                                 
-    if (isMat && dim0 != dim1)  // TODO: avoid mats until we find the right GLSL profile
+    if (isMat && dim1 == 1)  // TODO: avoid mat Nx1 until we find the right GLSL profile
         return false;
 
     if (isMat && (argType == 'I' || argType == 'U' || argType == 'B') ||
@@ -210,6 +234,39 @@ TBuiltInParseablesHlsl::TBuiltInParseablesHlsl()
 {
 }
 
+
+//
+// Handle creation of mat*mat specially, since it doesn't fall conveniently out of
+// the generic prototype creation code below.
+//
+void TBuiltInParseablesHlsl::createMatTimesMat()
+{
+    TString& s = commonBuiltins;
+
+    const int first = (UseHlslTypes ? 1 : 2);
+
+    for (int xRows = first; xRows <=4; xRows++) {
+        for (int xCols = first; xCols <=4; xCols++) {
+            const int yRows = xCols;
+            for (int yCols = first; yCols <=4; yCols++) {
+                const int retRows = xRows;
+                const int retCols = yCols;
+
+                AppendTypeName(s, "M", "F", retRows, retCols);  // add return type
+                s.append(" ");                                  // space between type and name
+                s.append("mul");                                // intrinsic name
+                s.append("(");                                  // open paren
+
+                AppendTypeName(s, "M", "F", xRows, xCols);      // add X input
+                s.append(", ");
+                AppendTypeName(s, "M", "F", yRows, yCols);      // add Y input
+
+                s.append(");\n");                               // close paren
+            }
+        }
+    }
+}
+
 //
 // Add all context-independent built-in functions and variables that are present
 // for the given version and profile.  Share common ones across stages, otherwise
@@ -232,6 +289,7 @@ void TBuiltInParseablesHlsl::initialize(int version, EProfile profile, const Spv
     // '>' as first letter of order creates an output parameter
     // '<' as first letter of order creates an input parameter
     // '^' as first letter of order takes transpose dimensions
+    // '#' as first letter of order sets rows=cols for mats
 
     static const struct {
         const char*   name;      // intrinsic name
@@ -321,6 +379,7 @@ void TBuiltInParseablesHlsl::initialize(int version, EProfile profile, const Spv
         { "isnan",                            nullptr, "B" ,      "SVM",        "F",      EShLangAll },
         { "ldexp",                            nullptr, nullptr,   "SVM,",       "F,",     EShLangAll },
         { "length",                           "S",     "F",       "V",          "F",      EShLangAll },
+        { "lerp",                             nullptr, nullptr,   "SVM,,",      "F,,",    EShLangAll },
         { "lit",                              "V4",    "F",       "S,,",        "F,,",    EShLangAll },
         { "log",                              nullptr, nullptr,   "SVM",        "F",      EShLangAll },
         { "log10",                            nullptr, nullptr,   "SVM",        "F",      EShLangAll },
@@ -330,16 +389,15 @@ void TBuiltInParseablesHlsl::initialize(int version, EProfile profile, const Spv
         { "min",                              nullptr, nullptr,   "SVM,",       "FI,",    EShLangAll },
         { "modf",                             nullptr, nullptr,   "SVM,>",      "FI,",    EShLangAll },
         { "msad4",                            "V4",    "U",       "S,V2,V4",    "U,,",    EShLangAll },
-        // TODO: fix matrix return size for non-square mats used with mul opcode
         { "mul",                              "S",     nullptr,   "S,S",        "FI,",    EShLangAll },
         { "mul",                              "V",     nullptr,   "S,V",        "FI,",    EShLangAll },
         { "mul",                              "M",     nullptr,   "S,M",        "FI,",    EShLangAll },
         { "mul",                              "V",     nullptr,   "V,S",        "FI,",    EShLangAll },
         { "mul",                              "S",     nullptr,   "V,V",        "FI,",    EShLangAll },
-        { "mul",                              "V",     nullptr,   "V,M",        "FI,",    EShLangAll },
+        { "mul",                              "#V",    nullptr,   "V,M",        "FI,",    EShLangAll },
         { "mul",                              "M",     nullptr,   "M,S",        "FI,",    EShLangAll },
-        { "mul",                              "V",     nullptr,   "M,V",        "FI,",    EShLangAll },
-        { "mul",                              "M",     nullptr,   "M,M",        "FI,",    EShLangAll },
+        { "mul",                              "V",     nullptr,   "M,#V",       "FI,",    EShLangAll },
+        // mat*mat form of mul is handled in createMatTimesMat()
         { "noise",                            "S",     "F",       "V",          "F",      EShLangFragmentMask },
         { "normalize",                        nullptr, nullptr,   "V",          "F",      EShLangAll },
         { "pow",                              nullptr, nullptr,   "SVM,",       "F,",     EShLangAll },
@@ -465,7 +523,7 @@ void TBuiltInParseablesHlsl::initialize(int version, EProfile profile, const Spv
                                 if (*nthArgOrder == ',' || *nthArgOrder == '\0') nthArgOrder = argOrder;
                                 if (*nthArgType == ',' || *nthArgType == '\0') nthArgType = argType;
 
-                                AppendTypeName(s, nthArgOrder, nthArgType, dim0, dim1); // Add first argument
+                                AppendTypeName(s, nthArgOrder, nthArgType, dim0, dim1); // Add arguments
                             }
                             
                             s.append(");\n");            // close paren and trailing semicolon
@@ -481,6 +539,8 @@ void TBuiltInParseablesHlsl::initialize(int version, EProfile profile, const Spv
                 break;
         }
     }
+
+    createMatTimesMat(); // handle this case separately, for convenience
 
     // printf("Common:\n%s\n",   getCommonString().c_str());
     // printf("Frag:\n%s\n",     getStageString(EShLangFragment).c_str());
@@ -586,6 +646,7 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, con
     symbolTable.relateToOperator("isnan",                       EOpIsNan);
     symbolTable.relateToOperator("ldexp",                       EOpLdexp);
     symbolTable.relateToOperator("length",                      EOpLength);
+    symbolTable.relateToOperator("lerp",                        EOpMix);
     symbolTable.relateToOperator("lit",                         EOpLit);
     symbolTable.relateToOperator("log",                         EOpLog);
     symbolTable.relateToOperator("log10",                       EOpLog10);
@@ -628,25 +689,25 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int version, EProfile profile, con
     symbolTable.relateToOperator("tan",                         EOpTan);
     symbolTable.relateToOperator("tanh",                        EOpTanh);
     symbolTable.relateToOperator("tex1D",                       EOpTexture);
-    // symbolTable.relateToOperator("tex1Dbias",                  // TODO:
+    symbolTable.relateToOperator("tex1Dbias",                   EOpTextureBias);
     symbolTable.relateToOperator("tex1Dgrad",                   EOpTextureGrad);
     symbolTable.relateToOperator("tex1Dlod",                    EOpTextureLod);
     symbolTable.relateToOperator("tex1Dproj",                   EOpTextureProj);
     symbolTable.relateToOperator("tex2D",                       EOpTexture);
-    // symbolTable.relateToOperator("tex2Dbias",                  // TODO:
+    symbolTable.relateToOperator("tex2Dbias",                   EOpTextureBias);
     symbolTable.relateToOperator("tex2Dgrad",                   EOpTextureGrad);
     symbolTable.relateToOperator("tex2Dlod",                    EOpTextureLod);
-    // symbolTable.relateToOperator("tex2Dproj",                   EOpTextureProj);
+    symbolTable.relateToOperator("tex2Dproj",                   EOpTextureProj);
     symbolTable.relateToOperator("tex3D",                       EOpTexture);
-    // symbolTable.relateToOperator("tex3Dbias");                // TODO
+    symbolTable.relateToOperator("tex3Dbias",                   EOpTextureBias);
     symbolTable.relateToOperator("tex3Dgrad",                   EOpTextureGrad);
     symbolTable.relateToOperator("tex3Dlod",                    EOpTextureLod);
-    // symbolTable.relateToOperator("tex3Dproj",                   EOpTextureProj);
+    symbolTable.relateToOperator("tex3Dproj",                   EOpTextureProj);
     symbolTable.relateToOperator("texCUBE",                     EOpTexture);
-    // symbolTable.relateToOperator("texCUBEbias",              // TODO
+    symbolTable.relateToOperator("texCUBEbias",                 EOpTextureBias);
     symbolTable.relateToOperator("texCUBEgrad",                 EOpTextureGrad);
     symbolTable.relateToOperator("texCUBElod",                  EOpTextureLod);
-    // symbolTable.relateToOperator("texCUBEproj",                 EOpTextureProj);
+    symbolTable.relateToOperator("texCUBEproj",                 EOpTextureProj);
     symbolTable.relateToOperator("transpose",                   EOpTranspose);
     symbolTable.relateToOperator("trunc",                       EOpTrunc);
 }

--- a/hlsl/hlslParseables.h
+++ b/hlsl/hlslParseables.h
@@ -54,6 +54,9 @@ public:
     void identifyBuiltIns(int version, EProfile profile, const SpvVersion& spvVersion, EShLanguage language, TSymbolTable& symbolTable);
     
     void identifyBuiltIns(int version, EProfile profile, const SpvVersion& spvVersion, EShLanguage language, TSymbolTable& symbolTable, const TBuiltInResource &resources);
+
+private:
+    void createMatTimesMat();
 };
 
 } // end namespace glslang


### PR DESCRIPTION
In this PR:

- Add lerp, which was missing due to an oversight.

- Adds non-square matricies to the HLSL proto generation, except for Nx1 flavors.

- Adds mul() support for VxM, MxV, MxM for non-square mat types.  Tests for these are also added.  Note that GLSL and HLSL have opposite row/col order on mat types.

- Adds return type tests (just for pixel shader fns), e.g to verify an intrinsic that should return a bool or a vec3 really does so.  This resulted in finding a bad return type, which this PR also fixes.

- Adds a translation from HLSL texture semantics to AST semantics.  This is currently untested pending the ability to declare samplers.  E.g: HLSL tx bias modes use the coordinate W as the bias, where it's a separate parameter in AST (& GLSL), and the standard tex1d intrinsics support optional parameters as gradients, which turns into EOpTextureGrad.

- The HLSL prototype generator has the ability to create the prototypes in either HLSL or GLSL syntax.  Only GLSL is currently used, pending other work.

*Editing for typo fix*