### PR TITLE
Front-end: allow max size built-in arrays like gl_ClipDistance

### DIFF
--- a/Test/baseResults/120.vert.out
+++ b/Test/baseResults/120.vert.out
@@ -44,7 +44,7 @@ ERROR: 0:107: 'overloadE' : no matching overloaded function found
 ERROR: 0:108: 'overloadE' : no matching overloaded function found 
 ERROR: 0:111: 'overloadE' : no matching overloaded function found 
 ERROR: 0:117: 'overloadF' : no matching overloaded function found 
-ERROR: 0:121: 'gl_TexCoord array size' : must be less than gl_MaxTextureCoords (32)
+ERROR: 0:121: 'gl_TexCoord array size' : must be less than or equal to gl_MaxTextureCoords (32)
 ERROR: 0:165: 'switch' : Reserved word. 
 ERROR: 0:171: 'default' : Reserved word. 
 ERROR: 0:165: 'switch statements' : not supported for this version or the enabled extensions 

--- a/Test/baseResults/430.vert.out
+++ b/Test/baseResults/430.vert.out
@@ -14,7 +14,7 @@ ERROR: 0:28: '' : cannot use invariant qualifier on a function parameter
 ERROR: 0:30: '' : cannot use layout qualifiers on a function parameter 
 ERROR: 0:31: '' : cannot use auxiliary or interpolation qualifiers on a function parameter 
 ERROR: 0:42: 'location' : overlapping use of location 53
-ERROR: 0:47: 'gl_ClipDistance array size' : must be less than gl_MaxClipDistances (8)
+ERROR: 0:47: 'gl_ClipDistance array size' : must be less than or equal to gl_MaxClipDistances (8)
 ERROR: 0:51: 'start' : undeclared identifier 
 ERROR: 0:51: '' : constant expression required 
 ERROR: 0:51: 'layout-id value' : scalar integer expression required 

--- a/Test/baseResults/maxClipDistances.vert.out
+++ b/Test/baseResults/maxClipDistances.vert.out
@@ -1,0 +1,23 @@
+maxClipDistances.vert
+Shader version: 130
+0:? Sequence
+0:5  Function Definition: main( (global void)
+0:5    Function Parameters: 
+0:?   Linker Objects
+0:?     'gl_ClipDistance' (smooth out 8-element array of float ClipDistance)
+0:?     'gl_ClipDistance' (smooth out 8-element array of float ClipDistance)
+0:?     'gl_VertexID' (gl_VertexId int VertexId)
+
+
+Linked vertex stage:
+
+
+Shader version: 130
+0:? Sequence
+0:5  Function Definition: main( (global void)
+0:5    Function Parameters: 
+0:?   Linker Objects
+0:?     'gl_ClipDistance' (smooth out 8-element array of float ClipDistance)
+0:?     'gl_ClipDistance' (smooth out 8-element array of float ClipDistance)
+0:?     'gl_VertexID' (gl_VertexId int VertexId)
+

--- a/Test/maxClipDistances.vert
+++ b/Test/maxClipDistances.vert
@@ -1,0 +1,7 @@
+#version 130
+
+out float gl_ClipDistance[8];	// OK, 8 is gl_MaxClipDistances
+
+void main()
+{
+}

--- a/Test/testlist
+++ b/Test/testlist
@@ -132,3 +132,4 @@ negativeArraySize.comp
 spv.atomic.comp
 precise.tesc
 precise_struct_block.vert
+maxClipDistances.vert

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -3824,7 +3824,7 @@ void TParseContext::arrayLimitCheck(const TSourceLoc& loc, const TString& identi
         limitCheck(loc, size, "gl_MaxCullDistances", "gl_CullDistance array size");
 }
 
-// See if the provided value is less than the symbol indicated by limit,
+// See if the provided value is less than or equal to the symbol indicated by limit,
 // which should be a constant in the symbol table.
 void TParseContext::limitCheck(const TSourceLoc& loc, int value, const char* limit, const char* feature)
 {
@@ -3832,8 +3832,8 @@ void TParseContext::limitCheck(const TSourceLoc& loc, int value, const char* lim
     assert(symbol->getAsVariable());
     const TConstUnionArray& constArray = symbol->getAsVariable()->getConstArray();
     assert(! constArray.empty());
-    if (value >= constArray[0].getIConst())
-        error(loc, "must be less than", feature, "%s (%d)", limit, constArray[0].getIConst());
+    if (value > constArray[0].getIConst())
+        error(loc, "must be less than or equal to", feature, "%s (%d)", limit, constArray[0].getIConst());
 }
 
 //


### PR DESCRIPTION
Fixed off-by-one error with gl_MaxClipDistances and similar limits.

I tried to compile the following shader and it failed:

```
#version 450

layout(constant_id = 1) const int numClipDistances = 8;

out gl_PerVertex {
    vec4  gl_Position;
    float gl_ClipDistance[numClipDistances];
};
```

Based on Vulkan and OpenGL specs array of up to ```maxClipDistances``` should be allowed.