### PR TITLE
SPV: Certain decorations are missing for structure-typed in/out variables

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -4024,7 +4024,7 @@ spv::Id TGlslangToSpvTraverser::getSymbolId(const glslang::TIntermSymbol* symbol
     id = createSpvVariable(symbol);
     symbolValues[symbol->getId()] = id;
 
-    if (! symbol->getType().isStruct()) {
+    if (symbol->getBasicType() != glslang::EbtBlock) {
         addDecoration(id, TranslatePrecisionDecoration(symbol->getType()));
         addDecoration(id, TranslateInterpolationDecoration(symbol->getType().getQualifier()));
         addDecoration(id, TranslateAuxiliaryStorageDecoration(symbol->getType().getQualifier()));

--- a/Test/baseResults/spv.430.vert.out
+++ b/Test/baseResults/spv.430.vert.out
@@ -63,6 +63,7 @@ Linked vertex stage:
                               Decorate 55(sampb2) Binding 5
                               Decorate 56(sampb4) DescriptorSet 0
                               Decorate 56(sampb4) Binding 31
+                              Decorate 62(var) Flat
                               Decorate 62(var) Location 0
                               MemberDecorate 63(MS) 0 Location 17
                               Decorate 63(MS) Block

--- a/Test/baseResults/spv.layoutNested.vert.out
+++ b/Test/baseResults/spv.layoutNested.vert.out
@@ -162,6 +162,7 @@ Linked vertex stage:
                               Decorate 58(bBt3) BufferBlock
                               Decorate 60(bBtn3) DescriptorSet 1
                               Decorate 60(bBtn3) Binding 0
+                              Decorate 62(sout) Flat
                               MemberDecorate 63(S) 0 Invariant
                               MemberDecorate 63(S) 1 Invariant
                               MemberDecorate 63(S) 2 Invariant

--- a/Test/baseResults/spv.localAggregates.frag.out
+++ b/Test/baseResults/spv.localAggregates.frag.out
@@ -44,8 +44,11 @@ Linked fragment stage:
                               Name 128  "samp2D"
                               Name 134  "foo"
                               Name 135  "foo2"
+                              Decorate 15(foo3) Flat
                               Decorate 90(condition) Flat
                               Decorate 128(samp2D) DescriptorSet 0
+                              Decorate 134(foo) Flat
+                              Decorate 135(foo2) Flat
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeInt 32 1

--- a/Test/baseResults/spv.variableArrayIndex.frag.out
+++ b/Test/baseResults/spv.variableArrayIndex.frag.out
@@ -39,6 +39,9 @@ Linked fragment stage:
                               Name 63  "coord"
                               Name 69  "constructed"
                               Decorate 10(Count) Flat
+                              Decorate 20(foo3) Flat
+                              Decorate 34(foo2) Flat
+                              Decorate 36(foo) Flat
                               Decorate 59(samp2D) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2


### PR DESCRIPTION
We encounter a problem from Vulkan conformance tests. This is a tessellation evaluation shader. The "patch" decoration is missing for "block[4]". After investigation, this problem seems much more generic. For instance, you could define a structure and define an input variable with that structure as fragment shader input. When you decorate the input with "flat". The qualifier is not converted to "flat" decoration in SPIR-V tokens.

```
#version 450

layout(quads, equal_spacing, ccw) in;

struct S
{
    int   i1;
    vec4  f4;
    float f1[2];
};

struct TheBlock
{
    float f1[3];
    S     s[3];
    float f1_0;
};

out float f1;

layout(location = 2) in patch TheBlock block[4];

void main()
{
    f1 = block[3].s[2].f4.x;
}
```