### PR TITLE
WIP: replacing C style includes with their correct C++ equivalents

### DIFF
--- a/glslang/Include/InfoSink.h
+++ b/glslang/Include/InfoSink.h
@@ -36,7 +36,7 @@
 #define _INFOSINK_INCLUDED_
 
 #include "../Include/Common.h"
-#include <math.h>
+#include <cmath>
 
 namespace glslang {
 

--- a/glslang/MachineIndependent/InfoSink.cpp
+++ b/glslang/MachineIndependent/InfoSink.cpp
@@ -34,7 +34,7 @@
 
 #include "../Include/InfoSink.h"
 
-#include <string.h>
+#include <cstring>
 
 namespace glslang {
 

--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -44,7 +44,7 @@
 #include "SymbolTable.h"
 #include "propagateNoContraction.h"
 
-#include <float.h>
+#include <cfloat>
 
 namespace glslang {
 

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -39,7 +39,7 @@
 #include "Scan.h"
 
 #include "../OSDependent/osinclude.h"
-#include <stdarg.h>
+#include <cstdarg>
 #include <algorithm>
 
 #include "preprocessor/PpContext.h"

--- a/glslang/MachineIndependent/Scan.cpp
+++ b/glslang/MachineIndependent/Scan.cpp
@@ -38,7 +38,7 @@
 // GLSL scanning, leveraging the scanning done by the preprocessor.
 //
 
-#include <string.h>
+#include <cstring>
 #include <unordered_map>
 #include <unordered_set>
 

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -41,7 +41,7 @@
 // This is the platform independent interface between an OGL driver
 // and the shading language compiler/linker.
 //
-#include <string.h>
+#include <cstring>
 #include <iostream>
 #include <sstream>
 #include <memory>

--- a/glslang/MachineIndependent/glslang_tab.cpp
+++ b/glslang/MachineIndependent/glslang_tab.cpp
@@ -2526,7 +2526,7 @@ while (0)
 #if YYDEBUG
 
 # ifndef YYFPRINTF
-#  include <stdio.h> /* INFRINGES ON USER NAME SPACE */
+#  include <cstdio> /* INFRINGES ON USER NAME SPACE */
 #  define YYFPRINTF fprintf
 # endif
 

--- a/glslang/MachineIndependent/intermOut.cpp
+++ b/glslang/MachineIndependent/intermOut.cpp
@@ -38,11 +38,11 @@
 #include "../Include/InfoSink.h"
 
 #ifdef _MSC_VER
-#include <float.h>
+#include <cfloat>
 #elif defined __ANDROID__ || defined __linux__ || __MINGW32__ || __MINGW64__
 #include <cmath>
 #else
-#include <math.h>
+#include <cmath>
 #endif
 
 namespace {

--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
+++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
@@ -81,12 +81,12 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define _CRT_SECURE_NO_WARNINGS
 
-#include <stdarg.h>
-#include <stdio.h>
+#include <cstdarg>
+#include <cstdio>
 #include <sstream>
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
+#include <cstdlib>
+#include <cstring>
+#include <cctype>
 
 #include "PpContext.h"
 #include "PpTokens.h"

--- a/glslang/MachineIndependent/preprocessor/PpAtom.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpAtom.cpp
@@ -82,10 +82,10 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define _CRT_SECURE_NO_WARNINGS
 
-#include <assert.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <cassert>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
 
 #include "PpContext.h"
 #include "PpTokens.h"

--- a/glslang/MachineIndependent/preprocessor/PpContext.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpContext.cpp
@@ -76,8 +76,8 @@ TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY OR OTHERWISE, EVEN IF
 NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \****************************************************************************/
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include "PpContext.h"
 

--- a/glslang/MachineIndependent/preprocessor/PpMemory.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpMemory.cpp
@@ -76,10 +76,10 @@ TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY OR OTHERWISE, EVEN IF
 NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \****************************************************************************/
 
-#include <stddef.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <cstdint>
 
 #include "PpContext.h"
 

--- a/glslang/MachineIndependent/preprocessor/PpScanner.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpScanner.cpp
@@ -81,10 +81,10 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define _CRT_SECURE_NO_WARNINGS
 
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include "PpContext.h"
 #include "PpTokens.h"

--- a/glslang/MachineIndependent/preprocessor/PpSymbols.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpSymbols.cpp
@@ -79,10 +79,10 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // symbols.c
 //
 
-#include <assert.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <cassert>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
 
 #include "PpContext.h"
 

--- a/glslang/MachineIndependent/preprocessor/PpTokens.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpTokens.cpp
@@ -85,11 +85,11 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define snprintf sprintf_s
 #endif
 
-#include <assert.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
+#include <cassert>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <cctype>
 
 #include "PpContext.h"
 #include "PpTokens.h"

--- a/glslang/OSDependent/Unix/ossource.cpp
+++ b/glslang/OSDependent/Unix/ossource.cpp
@@ -40,9 +40,9 @@
 
 #include <pthread.h>
 #include <semaphore.h>
-#include <assert.h>
-#include <errno.h>
-#include <stdint.h>
+#include <cassert>
+#include <cerrno>
+#include <cstdint>
 
 namespace glslang {
 
@@ -69,7 +69,7 @@ static void DetachThreadLinux(void *)
 void OS_CleanupThreadData(void)
 {
 #ifdef __ANDROID__
-	DetachThreadLinux(NULL);
+  DetachThread();
 #else
 	int old_cancel_state, old_cancel_type;
 	void *cleanupArg = NULL;

--- a/glslang/OSDependent/Windows/main.cpp
+++ b/glslang/OSDependent/Windows/main.cpp
@@ -37,7 +37,7 @@
 #define STRICT
 #define VC_EXTRALEAN 1
 #include <windows.h>
-#include <assert.h>
+#include <cassert>
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {

--- a/glslang/OSDependent/Windows/ossource.cpp
+++ b/glslang/OSDependent/Windows/ossource.cpp
@@ -37,11 +37,11 @@
 #define STRICT
 #define VC_EXTRALEAN 1
 #include <windows.h>
-#include <assert.h>
+#include <cassert>
 #include <process.h>
 #include <psapi.h>
-#include <stdio.h>
-#include <stdint.h>
+#include <cstdio>
+#include <cstdint>
 
 //
 // This file contains contains the Window-OS-specific functions
@@ -134,7 +134,7 @@ unsigned int __stdcall EnterGenericThread (void* entry)
 
 void* OS_CreateThread(TThreadEntrypoint entry)
 {
-    return (void*)_beginthreadex(0, 0, EnterGenericThread, (void*)entry, 0, 0);
+    return (void*)_beginthreadex(0, 0, EnterGenericThread, entry, 0, 0);
 }
 
 void OS_WaitForAllThreads(void* threads, int numThreads)


### PR DESCRIPTION
...resolves some issues building the Vulkan samples under g++ 5.4.

Fixes the following error:
```
[ 26%] Building CXX object glslang/CMakeFiles/glslang.dir/MachineIndependent/intermOut.cpp.o
In file included from /home/slowriot/code/libraries/VulkanSDK/VulkanSamples/external/glslang/glslang/MachineIndependent/../Include/InfoSink.h:39:0,
                 from /home/slowriot/code/libraries/VulkanSDK/VulkanSamples/external/glslang/glslang/MachineIndependent/intermOut.cpp:38:
/home/slowriot/code/libraries/VulkanSDK/VulkanSamples/external/glslang/glslang/MachineIndependent/intermOut.cpp: In function ‘bool {anonymous}::is_positive_infinity(double)’:
/home/slowriot/code/libraries/VulkanSDK/VulkanSamples/external/glslang/glslang/MachineIndependent/intermOut.cpp:52:15: error: expected unqualified-id before ‘(’ token
   return std::isinf(x) && (x >= 0);
               ^
glslang/CMakeFiles/glslang.dir/build.make:374: recipe for target 'glslang/CMakeFiles/glslang.dir/MachineIndependent/intermOut.cpp.o' failed
```