### PR TITLE
HLSL: Add template style constructors for vector & matrix types

### DIFF
--- a/Test/baseResults/hlsl.templatetypes.frag.out
+++ b/Test/baseResults/hlsl.templatetypes.frag.out
@@ -1,0 +1,651 @@
+hlsl.templatetypes.frag
+Shader version: 450
+gl_FragCoord origin is upper left
+0:? Sequence
+0:48  Function Definition: PixelShaderFunction( (temp float)
+0:3    Function Parameters: 
+0:?     Sequence
+0:4      move second child to first child (temp 4-component vector of float)
+0:4        'r00' (temp 4-component vector of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:5      move second child to first child (temp 4-component vector of float)
+0:5        'r01' (temp 4-component vector of float)
+0:?         Constant:
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:?           5.000000
+0:7      move second child to first child (temp 1-component vector of bool)
+0:7        'r12' (temp 1-component vector of bool)
+0:7        Constant:
+0:7          false (const bool)
+0:8      move second child to first child (temp 1-component vector of int)
+0:8        'r13' (temp 1-component vector of int)
+0:8        Constant:
+0:8          1 (const int)
+0:9      move second child to first child (temp 1-component vector of float)
+0:9        'r14' (temp 1-component vector of float)
+0:9        Constant:
+0:9          1.000000
+0:10      move second child to first child (temp 1-component vector of double)
+0:10        'r15' (temp 1-component vector of double)
+0:10        Constant:
+0:10          1.000000
+0:11      move second child to first child (temp 1-component vector of uint)
+0:11        'r16' (temp 1-component vector of uint)
+0:11        Constant:
+0:11          1 (const uint)
+0:13      move second child to first child (temp 2-component vector of bool)
+0:13        'r20' (temp 2-component vector of bool)
+0:?         Constant:
+0:?           false (const bool)
+0:?           true (const bool)
+0:14      move second child to first child (temp 2-component vector of int)
+0:14        'r21' (temp 2-component vector of int)
+0:?         Constant:
+0:?           1 (const int)
+0:?           2 (const int)
+0:15      move second child to first child (temp 2-component vector of float)
+0:15        'r22' (temp 2-component vector of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:16      move second child to first child (temp 2-component vector of double)
+0:16        'r23' (temp 2-component vector of double)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:17      move second child to first child (temp 2-component vector of uint)
+0:17        'r24' (temp 2-component vector of uint)
+0:?         Constant:
+0:?           1 (const uint)
+0:?           2 (const uint)
+0:19      move second child to first child (temp 3-component vector of bool)
+0:19        'r30' (temp 3-component vector of bool)
+0:?         Constant:
+0:?           false (const bool)
+0:?           true (const bool)
+0:?           true (const bool)
+0:20      move second child to first child (temp 3-component vector of int)
+0:20        'r31' (temp 3-component vector of int)
+0:?         Constant:
+0:?           1 (const int)
+0:?           2 (const int)
+0:?           3 (const int)
+0:21      move second child to first child (temp 3-component vector of float)
+0:21        'r32' (temp 3-component vector of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:22      move second child to first child (temp 3-component vector of double)
+0:22        'r33' (temp 3-component vector of double)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:23      move second child to first child (temp 3-component vector of uint)
+0:23        'r34' (temp 3-component vector of uint)
+0:?         Constant:
+0:?           1 (const uint)
+0:?           2 (const uint)
+0:?           3 (const uint)
+0:25      move second child to first child (temp 4-component vector of bool)
+0:25        'r40' (temp 4-component vector of bool)
+0:?         Constant:
+0:?           false (const bool)
+0:?           true (const bool)
+0:?           true (const bool)
+0:?           false (const bool)
+0:26      move second child to first child (temp 4-component vector of int)
+0:26        'r41' (temp 4-component vector of int)
+0:?         Constant:
+0:?           1 (const int)
+0:?           2 (const int)
+0:?           3 (const int)
+0:?           4 (const int)
+0:27      move second child to first child (temp 4-component vector of float)
+0:27        'r42' (temp 4-component vector of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:28      move second child to first child (temp 4-component vector of double)
+0:28        'r43' (temp 4-component vector of double)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:29      move second child to first child (temp 4-component vector of uint)
+0:29        'r44' (temp 4-component vector of uint)
+0:?         Constant:
+0:?           1 (const uint)
+0:?           2 (const uint)
+0:?           3 (const uint)
+0:?           4 (const uint)
+0:31      move second child to first child (temp 4X4 matrix of float)
+0:31        'r50' (temp 4X4 matrix of float)
+0:?         Constant:
+0:?           0.000000
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:?           5.000000
+0:?           6.000000
+0:?           7.000000
+0:?           8.000000
+0:?           9.000000
+0:?           10.000000
+0:?           11.000000
+0:?           12.000000
+0:?           13.000000
+0:?           14.000000
+0:?           15.000000
+0:32      move second child to first child (temp 4X4 matrix of float)
+0:32        'r51' (temp 4X4 matrix of float)
+0:?         Constant:
+0:?           0.000000
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:?           5.000000
+0:?           6.000000
+0:?           7.000000
+0:?           8.000000
+0:?           9.000000
+0:?           10.000000
+0:?           11.000000
+0:?           12.000000
+0:?           13.000000
+0:?           14.000000
+0:?           15.000000
+0:35      move second child to first child (temp 3X2 matrix of float)
+0:35        'r61' (temp 3X2 matrix of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:?           5.000000
+0:?           6.000000
+0:36      move second child to first child (temp 2X3 matrix of float)
+0:36        'r62' (temp 2X3 matrix of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:?           5.000000
+0:?           6.000000
+0:39      move second child to first child (temp 2X4 matrix of float)
+0:39        'r65' (temp 2X4 matrix of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:?           5.000000
+0:?           6.000000
+0:?           7.000000
+0:?           8.000000
+0:40      move second child to first child (temp 3X4 matrix of float)
+0:40        'r66' (temp 3X4 matrix of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:?           5.000000
+0:?           6.000000
+0:?           7.000000
+0:?           8.000000
+0:?           9.000000
+0:?           10.000000
+0:?           11.000000
+0:?           12.000000
+0:45      Branch: Return with expression
+0:45        Constant:
+0:45          0.000000
+0:?   Linker Objects
+
+
+Linked fragment stage:
+
+
+Shader version: 450
+gl_FragCoord origin is upper left
+0:? Sequence
+0:48  Function Definition: PixelShaderFunction( (temp float)
+0:3    Function Parameters: 
+0:?     Sequence
+0:4      move second child to first child (temp 4-component vector of float)
+0:4        'r00' (temp 4-component vector of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:5      move second child to first child (temp 4-component vector of float)
+0:5        'r01' (temp 4-component vector of float)
+0:?         Constant:
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:?           5.000000
+0:7      move second child to first child (temp 1-component vector of bool)
+0:7        'r12' (temp 1-component vector of bool)
+0:7        Constant:
+0:7          false (const bool)
+0:8      move second child to first child (temp 1-component vector of int)
+0:8        'r13' (temp 1-component vector of int)
+0:8        Constant:
+0:8          1 (const int)
+0:9      move second child to first child (temp 1-component vector of float)
+0:9        'r14' (temp 1-component vector of float)
+0:9        Constant:
+0:9          1.000000
+0:10      move second child to first child (temp 1-component vector of double)
+0:10        'r15' (temp 1-component vector of double)
+0:10        Constant:
+0:10          1.000000
+0:11      move second child to first child (temp 1-component vector of uint)
+0:11        'r16' (temp 1-component vector of uint)
+0:11        Constant:
+0:11          1 (const uint)
+0:13      move second child to first child (temp 2-component vector of bool)
+0:13        'r20' (temp 2-component vector of bool)
+0:?         Constant:
+0:?           false (const bool)
+0:?           true (const bool)
+0:14      move second child to first child (temp 2-component vector of int)
+0:14        'r21' (temp 2-component vector of int)
+0:?         Constant:
+0:?           1 (const int)
+0:?           2 (const int)
+0:15      move second child to first child (temp 2-component vector of float)
+0:15        'r22' (temp 2-component vector of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:16      move second child to first child (temp 2-component vector of double)
+0:16        'r23' (temp 2-component vector of double)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:17      move second child to first child (temp 2-component vector of uint)
+0:17        'r24' (temp 2-component vector of uint)
+0:?         Constant:
+0:?           1 (const uint)
+0:?           2 (const uint)
+0:19      move second child to first child (temp 3-component vector of bool)
+0:19        'r30' (temp 3-component vector of bool)
+0:?         Constant:
+0:?           false (const bool)
+0:?           true (const bool)
+0:?           true (const bool)
+0:20      move second child to first child (temp 3-component vector of int)
+0:20        'r31' (temp 3-component vector of int)
+0:?         Constant:
+0:?           1 (const int)
+0:?           2 (const int)
+0:?           3 (const int)
+0:21      move second child to first child (temp 3-component vector of float)
+0:21        'r32' (temp 3-component vector of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:22      move second child to first child (temp 3-component vector of double)
+0:22        'r33' (temp 3-component vector of double)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:23      move second child to first child (temp 3-component vector of uint)
+0:23        'r34' (temp 3-component vector of uint)
+0:?         Constant:
+0:?           1 (const uint)
+0:?           2 (const uint)
+0:?           3 (const uint)
+0:25      move second child to first child (temp 4-component vector of bool)
+0:25        'r40' (temp 4-component vector of bool)
+0:?         Constant:
+0:?           false (const bool)
+0:?           true (const bool)
+0:?           true (const bool)
+0:?           false (const bool)
+0:26      move second child to first child (temp 4-component vector of int)
+0:26        'r41' (temp 4-component vector of int)
+0:?         Constant:
+0:?           1 (const int)
+0:?           2 (const int)
+0:?           3 (const int)
+0:?           4 (const int)
+0:27      move second child to first child (temp 4-component vector of float)
+0:27        'r42' (temp 4-component vector of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:28      move second child to first child (temp 4-component vector of double)
+0:28        'r43' (temp 4-component vector of double)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:29      move second child to first child (temp 4-component vector of uint)
+0:29        'r44' (temp 4-component vector of uint)
+0:?         Constant:
+0:?           1 (const uint)
+0:?           2 (const uint)
+0:?           3 (const uint)
+0:?           4 (const uint)
+0:31      move second child to first child (temp 4X4 matrix of float)
+0:31        'r50' (temp 4X4 matrix of float)
+0:?         Constant:
+0:?           0.000000
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:?           5.000000
+0:?           6.000000
+0:?           7.000000
+0:?           8.000000
+0:?           9.000000
+0:?           10.000000
+0:?           11.000000
+0:?           12.000000
+0:?           13.000000
+0:?           14.000000
+0:?           15.000000
+0:32      move second child to first child (temp 4X4 matrix of float)
+0:32        'r51' (temp 4X4 matrix of float)
+0:?         Constant:
+0:?           0.000000
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:?           5.000000
+0:?           6.000000
+0:?           7.000000
+0:?           8.000000
+0:?           9.000000
+0:?           10.000000
+0:?           11.000000
+0:?           12.000000
+0:?           13.000000
+0:?           14.000000
+0:?           15.000000
+0:35      move second child to first child (temp 3X2 matrix of float)
+0:35        'r61' (temp 3X2 matrix of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:?           5.000000
+0:?           6.000000
+0:36      move second child to first child (temp 2X3 matrix of float)
+0:36        'r62' (temp 2X3 matrix of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:?           5.000000
+0:?           6.000000
+0:39      move second child to first child (temp 2X4 matrix of float)
+0:39        'r65' (temp 2X4 matrix of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:?           5.000000
+0:?           6.000000
+0:?           7.000000
+0:?           8.000000
+0:40      move second child to first child (temp 3X4 matrix of float)
+0:40        'r66' (temp 3X4 matrix of float)
+0:?         Constant:
+0:?           1.000000
+0:?           2.000000
+0:?           3.000000
+0:?           4.000000
+0:?           5.000000
+0:?           6.000000
+0:?           7.000000
+0:?           8.000000
+0:?           9.000000
+0:?           10.000000
+0:?           11.000000
+0:?           12.000000
+0:45      Branch: Return with expression
+0:45        Constant:
+0:45          0.000000
+0:?   Linker Objects
+
+// Module Version 10000
+// Generated by (magic number): 80001
+// Id's are bound by 145
+
+                              Capability Shader
+                              Capability Float64
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Fragment 4  "PixelShaderFunction"
+                              ExecutionMode 4 OriginUpperLeft
+                              Source HLSL 450
+                              Name 4  "PixelShaderFunction"
+                              Name 9  "r00"
+                              Name 15  "r01"
+                              Name 20  "r12"
+                              Name 24  "r13"
+                              Name 27  "r14"
+                              Name 30  "r15"
+                              Name 34  "r16"
+                              Name 38  "r20"
+                              Name 43  "r21"
+                              Name 48  "r22"
+                              Name 52  "r23"
+                              Name 57  "r24"
+                              Name 62  "r30"
+                              Name 66  "r31"
+                              Name 71  "r32"
+                              Name 75  "r33"
+                              Name 80  "r34"
+                              Name 85  "r40"
+                              Name 89  "r41"
+                              Name 92  "r42"
+                              Name 95  "r43"
+                              Name 100  "r44"
+                              Name 105  "r50"
+                              Name 122  "r51"
+                              Name 125  "r61"
+                              Name 131  "r62"
+                              Name 136  "r65"
+                              Name 141  "r66"
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeFloat 32
+               7:             TypeVector 6(float) 4
+               8:             TypePointer Function 7(fvec4)
+              10:    6(float) Constant 1065353216
+              11:    6(float) Constant 1073741824
+              12:    6(float) Constant 1077936128
+              13:    6(float) Constant 1082130432
+              14:    7(fvec4) ConstantComposite 10 11 12 13
+              16:    6(float) Constant 1084227584
+              17:    7(fvec4) ConstantComposite 11 12 13 16
+              18:             TypeBool
+              19:             TypePointer Function 18(bool)
+              21:    18(bool) ConstantFalse
+              22:             TypeInt 32 1
+              23:             TypePointer Function 22(int)
+              25:     22(int) Constant 1
+              26:             TypePointer Function 6(float)
+              28:             TypeFloat 64
+              29:             TypePointer Function 28(float)
+              31:   28(float) Constant 0 1072693248
+              32:             TypeInt 32 0
+              33:             TypePointer Function 32(int)
+              35:     32(int) Constant 1
+              36:             TypeVector 18(bool) 2
+              37:             TypePointer Function 36(bvec2)
+              39:    18(bool) ConstantTrue
+              40:   36(bvec2) ConstantComposite 21 39
+              41:             TypeVector 22(int) 2
+              42:             TypePointer Function 41(ivec2)
+              44:     22(int) Constant 2
+              45:   41(ivec2) ConstantComposite 25 44
+              46:             TypeVector 6(float) 2
+              47:             TypePointer Function 46(fvec2)
+              49:   46(fvec2) ConstantComposite 10 11
+              50:             TypeVector 28(float) 2
+              51:             TypePointer Function 50(fvec2)
+              53:   28(float) Constant 0 1073741824
+              54:   50(fvec2) ConstantComposite 31 53
+              55:             TypeVector 32(int) 2
+              56:             TypePointer Function 55(ivec2)
+              58:     32(int) Constant 2
+              59:   55(ivec2) ConstantComposite 35 58
+              60:             TypeVector 18(bool) 3
+              61:             TypePointer Function 60(bvec3)
+              63:   60(bvec3) ConstantComposite 21 39 39
+              64:             TypeVector 22(int) 3
+              65:             TypePointer Function 64(ivec3)
+              67:     22(int) Constant 3
+              68:   64(ivec3) ConstantComposite 25 44 67
+              69:             TypeVector 6(float) 3
+              70:             TypePointer Function 69(fvec3)
+              72:   69(fvec3) ConstantComposite 10 11 12
+              73:             TypeVector 28(float) 3
+              74:             TypePointer Function 73(fvec3)
+              76:   28(float) Constant 0 1074266112
+              77:   73(fvec3) ConstantComposite 31 53 76
+              78:             TypeVector 32(int) 3
+              79:             TypePointer Function 78(ivec3)
+              81:     32(int) Constant 3
+              82:   78(ivec3) ConstantComposite 35 58 81
+              83:             TypeVector 18(bool) 4
+              84:             TypePointer Function 83(bvec4)
+              86:   83(bvec4) ConstantComposite 21 39 39 21
+              87:             TypeVector 22(int) 4
+              88:             TypePointer Function 87(ivec4)
+              90:     22(int) Constant 4
+              91:   87(ivec4) ConstantComposite 25 44 67 90
+              93:             TypeVector 28(float) 4
+              94:             TypePointer Function 93(fvec4)
+              96:   28(float) Constant 0 1074790400
+              97:   93(fvec4) ConstantComposite 31 53 76 96
+              98:             TypeVector 32(int) 4
+              99:             TypePointer Function 98(ivec4)
+             101:     32(int) Constant 4
+             102:   98(ivec4) ConstantComposite 35 58 81 101
+             103:             TypeMatrix 7(fvec4) 4
+             104:             TypePointer Function 103
+             106:    6(float) Constant 0
+             107:    7(fvec4) ConstantComposite 106 10 11 12
+             108:    6(float) Constant 1086324736
+             109:    6(float) Constant 1088421888
+             110:    7(fvec4) ConstantComposite 13 16 108 109
+             111:    6(float) Constant 1090519040
+             112:    6(float) Constant 1091567616
+             113:    6(float) Constant 1092616192
+             114:    6(float) Constant 1093664768
+             115:    7(fvec4) ConstantComposite 111 112 113 114
+             116:    6(float) Constant 1094713344
+             117:    6(float) Constant 1095761920
+             118:    6(float) Constant 1096810496
+             119:    6(float) Constant 1097859072
+             120:    7(fvec4) ConstantComposite 116 117 118 119
+             121:         103 ConstantComposite 107 110 115 120
+             123:             TypeMatrix 46(fvec2) 3
+             124:             TypePointer Function 123
+             126:   46(fvec2) ConstantComposite 12 13
+             127:   46(fvec2) ConstantComposite 16 108
+             128:         123 ConstantComposite 49 126 127
+             129:             TypeMatrix 69(fvec3) 2
+             130:             TypePointer Function 129
+             132:   69(fvec3) ConstantComposite 13 16 108
+             133:         129 ConstantComposite 72 132
+             134:             TypeMatrix 7(fvec4) 2
+             135:             TypePointer Function 134
+             137:    7(fvec4) ConstantComposite 16 108 109 111
+             138:         134 ConstantComposite 14 137
+             139:             TypeMatrix 7(fvec4) 3
+             140:             TypePointer Function 139
+             142:    7(fvec4) ConstantComposite 112 113 114 116
+             143:         139 ConstantComposite 14 137 142
+4(PixelShaderFunction):           2 Function None 3
+               5:             Label
+          9(r00):      8(ptr) Variable Function
+         15(r01):      8(ptr) Variable Function
+         20(r12):     19(ptr) Variable Function
+         24(r13):     23(ptr) Variable Function
+         27(r14):     26(ptr) Variable Function
+         30(r15):     29(ptr) Variable Function
+         34(r16):     33(ptr) Variable Function
+         38(r20):     37(ptr) Variable Function
+         43(r21):     42(ptr) Variable Function
+         48(r22):     47(ptr) Variable Function
+         52(r23):     51(ptr) Variable Function
+         57(r24):     56(ptr) Variable Function
+         62(r30):     61(ptr) Variable Function
+         66(r31):     65(ptr) Variable Function
+         71(r32):     70(ptr) Variable Function
+         75(r33):     74(ptr) Variable Function
+         80(r34):     79(ptr) Variable Function
+         85(r40):     84(ptr) Variable Function
+         89(r41):     88(ptr) Variable Function
+         92(r42):      8(ptr) Variable Function
+         95(r43):     94(ptr) Variable Function
+        100(r44):     99(ptr) Variable Function
+        105(r50):    104(ptr) Variable Function
+        122(r51):    104(ptr) Variable Function
+        125(r61):    124(ptr) Variable Function
+        131(r62):    130(ptr) Variable Function
+        136(r65):    135(ptr) Variable Function
+        141(r66):    140(ptr) Variable Function
+                              Store 9(r00) 14
+                              Store 15(r01) 17
+                              Store 20(r12) 21
+                              Store 24(r13) 25
+                              Store 27(r14) 10
+                              Store 30(r15) 31
+                              Store 34(r16) 35
+                              Store 38(r20) 40
+                              Store 43(r21) 45
+                              Store 48(r22) 49
+                              Store 52(r23) 54
+                              Store 57(r24) 59
+                              Store 62(r30) 63
+                              Store 66(r31) 68
+                              Store 71(r32) 72
+                              Store 75(r33) 77
+                              Store 80(r34) 82
+                              Store 85(r40) 86
+                              Store 89(r41) 91
+                              Store 92(r42) 14
+                              Store 95(r43) 97
+                              Store 100(r44) 102
+                              Store 105(r50) 121
+                              Store 122(r51) 121
+                              Store 125(r61) 128
+                              Store 131(r62) 133
+                              Store 136(r65) 138
+                              Store 141(r66) 143
+                              ReturnValue 106
+                              FunctionEnd

--- a/Test/hlsl.templatetypes.frag
+++ b/Test/hlsl.templatetypes.frag
@@ -1,0 +1,47 @@
+
+float PixelShaderFunction()
+{
+    vector r00 = float4(1,2,3,4);  // vector means float4
+    float4 r01 = vector(2,3,4,5);  // vector means float4
+
+    vector<bool, 1>   r12 = bool1(false);
+    vector<int, 1>    r13 = int1(1);
+    vector<float, 1>  r14 = float1(1);
+    vector<double, 1> r15 = double1(1);
+    vector<uint, 1>   r16 = uint1(1);
+
+    vector<bool, 2>   r20 = bool2(false, true);
+    vector<int, 2>    r21 = int2(1,2);
+    vector<float, 2>  r22 = float2(1,2);
+    vector<double, 2> r23 = double2(1,2);
+    vector<uint, 2>   r24 = uint2(1,2);
+    
+    vector<bool, 3>   r30 = bool3(false, true, true);
+    vector<int, 3>    r31 = int3(1,2,3);
+    vector<float, 3>  r32 = float3(1,2,3);
+    vector<double, 3> r33 = double3(1,2,3);
+    vector<uint, 3>   r34 = uint3(1,2,3);
+
+    vector<bool, 4>   r40 = bool4(false, true, true, false);
+    vector<int, 4>    r41 = int4(1,2,3,4);
+    vector<float, 4>  r42 = float4(1,2,3,4);
+    vector<double, 4> r43 = double4(1,2,3,4);
+    vector<uint, 4>   r44 = uint4(1,2,3,4);
+
+    matrix   r50 = float4x4(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15); // matrix means float4x4
+    float4x4 r51 = matrix(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15);   // matrix means float4x4
+
+    // matrix<bool, 2, 3>  r60 = bool2x3(false, true, false, true, false, true);   // TODO: 
+    matrix<float, 2, 3> r61 = float2x3(1,2,3,4,5,6);
+    matrix<float, 3, 2> r62 = float3x2(1,2,3,4,5,6);
+    // matrix<float, 4, 1> r63 = float4x1(1,2,3,4);  // TODO: 
+    // matrix<float, 1, 4> r64 = float1x4(1,2,3,4);  // TODO: 
+    matrix<float, 4, 2> r65 = float4x2(1,2,3,4,5,6,7,8);
+    matrix<float, 4, 3> r66 = float4x3(1,2,3,4,5,6,7,8,9,10,11,12);
+
+    // TODO: bool mats
+    // TODO: int mats
+    
+    return 0.0;
+}
+

--- a/Test/hlsl.templatetypes.negative.frag
+++ b/Test/hlsl.templatetypes.negative.frag
@@ -1,0 +1,23 @@
+
+float PixelShaderFunction()
+{
+    // TODO: All of the below should fail, although presently the first failure
+    // aborts compilation and the rest are skipped.  Having a separate test for
+    // each would be cumbersome.
+
+    vector<void, 2>    r00;  // cannot declare vectors of voids
+    matrix<void, 2, 3> r01;  // cannot declare matrices of voids
+
+    vector<float, 2, 3> r02;  // too many parameters to vector
+    matrix<float, 2>    r03;  // not enough parameters to matrix
+
+    int three = 3;
+    vector<void, three> r04; // size must be a literal constant integer
+    matrix<void, three, three> r05; // size must be a literal constant integer
+
+    vector<vector<int, 3>, 3> r06;  // type must be a simple scalar
+    vector<float3, 3> r07;          // type must be a simple scalar
+
+    return 0.0;
+}
+

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -102,6 +102,7 @@ INSTANTIATE_TEST_CASE_P(
         {"hlsl.struct.frag", "PixelShaderFunction"},
         {"hlsl.switch.frag", "PixelShaderFunction"},
         {"hlsl.swizzle.frag", "PixelShaderFunction"},
+        {"hlsl.templatetypes.frag", "PixelShaderFunction"},
         {"hlsl.whileLoop.frag", "PixelShaderFunction"},
         {"hlsl.void.frag", "PixelShaderFunction"},
     }),

--- a/hlsl/hlslGrammar.h
+++ b/hlsl/hlslGrammar.h
@@ -1,5 +1,6 @@
 //
 //Copyright (C) 2016 Google, Inc.
+//Copyright (C) 2016 LunarG, Inc.
 //
 //All rights reserved.
 //
@@ -62,6 +63,9 @@ namespace glslang {
         bool acceptFullySpecifiedType(TType&);
         void acceptQualifier(TQualifier&);
         bool acceptType(TType&);
+        bool acceptTemplateType(TBasicType&);
+        bool acceptVectorTemplateType(TType&);
+        bool acceptMatrixTemplateType(TType&);
         bool acceptStruct(TType&);
         bool acceptStructDeclarationList(TTypeList*&);
         bool acceptFunctionParameters(TFunction&);


### PR DESCRIPTION
This PR adds vector&lt;float, 3&gt; and similar matrix style type parsing.

The simple scalar types are accepted in HlslGrammar::acceptBasicType(), which is used by both of those forms as well as acceptType(). This is because only basic types may appear, and constructs such as vector&lt;vector&lt;float, 2&gt;, 2&gt; are illegal.

A new test for these type declarations is also added.

This is another try for this PR: previously there was a git error during one of the auto-build processes: "fatal: index-pack failed", which happened when the "travis CI" build attempted to check out the branch.
