### PR TITLE
HLSL: Sampler/texture declarations, method syntax, partial Sample method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.so
 *.exe
 tags
+TAGS
 build/
 Test/localResults/
 Test/multiThread.out

--- a/Test/baseResults/hlsl.sample.basicdx10.frag.out
+++ b/Test/baseResults/hlsl.sample.basicdx10.frag.out
@@ -1,0 +1,768 @@
+hlsl.sample.basicdx10.frag
+WARNING: 0:4: 'immediate sampler state' : unimplemented 
+
+Shader version: 450
+gl_FragCoord origin is upper left
+0:? Sequence
+0:91  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:53    Function Parameters: 
+0:?     Sequence
+0:57      move second child to first child (temp int)
+0:57        CalculateLevelOfDetail: direct index for structure (temp int)
+0:57          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:57          Constant:
+0:57            1 (const int)
+0:57        Constant:
+0:57          1 (const int)
+0:58      move second child to first child (temp int)
+0:58        CalculateLevelOfDetailUnclamped: direct index for structure (temp int)
+0:58          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:58          Constant:
+0:58            2 (const int)
+0:58        Constant:
+0:58          1 (const int)
+0:59      move second child to first child (temp int)
+0:59        Gather: direct index for structure (temp int)
+0:59          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:59          Constant:
+0:59            3 (const int)
+0:59        Constant:
+0:59          1 (const int)
+0:60      move second child to first child (temp int)
+0:60        GetDimensions: direct index for structure (temp int)
+0:60          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:60          Constant:
+0:60            4 (const int)
+0:60        Constant:
+0:60          1 (const int)
+0:61      move second child to first child (temp int)
+0:61        GetSamplePosition: direct index for structure (temp int)
+0:61          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:61          Constant:
+0:61            5 (const int)
+0:61        Constant:
+0:61          1 (const int)
+0:62      move second child to first child (temp int)
+0:62        Load: direct index for structure (temp int)
+0:62          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:62          Constant:
+0:62            6 (const int)
+0:62        Constant:
+0:62          1 (const int)
+0:63      move second child to first child (temp int)
+0:63        Sample: direct index for structure (temp int)
+0:63          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:63          Constant:
+0:63            0 (const int)
+0:63        Constant:
+0:63          1 (const int)
+0:64      move second child to first child (temp int)
+0:64        SampleBias: direct index for structure (temp int)
+0:64          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:64          Constant:
+0:64            7 (const int)
+0:64        Constant:
+0:64          1 (const int)
+0:65      move second child to first child (temp int)
+0:65        SampleCmp: direct index for structure (temp int)
+0:65          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:65          Constant:
+0:65            8 (const int)
+0:65        Constant:
+0:65          1 (const int)
+0:66      move second child to first child (temp int)
+0:66        SampleCmpLevelZero: direct index for structure (temp int)
+0:66          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:66          Constant:
+0:66            9 (const int)
+0:66        Constant:
+0:66          1 (const int)
+0:67      move second child to first child (temp int)
+0:67        SampleGrad: direct index for structure (temp int)
+0:67          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:67          Constant:
+0:67            10 (const int)
+0:67        Constant:
+0:67          1 (const int)
+0:68      move second child to first child (temp int)
+0:68        SampleLevel: direct index for structure (temp int)
+0:68          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:68          Constant:
+0:68            11 (const int)
+0:68        Constant:
+0:68          1 (const int)
+0:70      Sequence
+0:70        move second child to first child (temp 4-component vector of float)
+0:70          'txval10' (temp 4-component vector of float)
+0:70          texture (global 4-component vector of float)
+0:70            Construct combined texture-sampler (temp sampler1D)
+0:70              'g_tTex1df4' (uniform texture1D)
+0:70              'g_sSamp' (uniform sampler)
+0:70            Constant:
+0:70              0.100000
+0:71      Sequence
+0:71        move second child to first child (temp 4-component vector of int)
+0:71          'txval11' (temp 4-component vector of int)
+0:71          texture (global 4-component vector of int)
+0:71            Construct combined texture-sampler (temp isampler1D)
+0:71              'g_tTex1di4' (uniform itexture1D)
+0:71              'g_sSamp' (uniform sampler)
+0:71            Constant:
+0:71              0.200000
+0:72      Sequence
+0:72        move second child to first child (temp 4-component vector of uint)
+0:72          'txval12' (temp 4-component vector of uint)
+0:72          texture (global 4-component vector of uint)
+0:72            Construct combined texture-sampler (temp usampler1D)
+0:72              'g_tTex1du4' (uniform utexture1D)
+0:72              'g_sSamp' (uniform sampler)
+0:72            Constant:
+0:72              0.300000
+0:74      Sequence
+0:74        move second child to first child (temp 4-component vector of float)
+0:74          'txval20' (temp 4-component vector of float)
+0:74          texture (global 4-component vector of float)
+0:74            Construct combined texture-sampler (temp sampler2D)
+0:74              'g_tTex2df4' (uniform texture2D)
+0:74              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.100000
+0:?               0.200000
+0:75      Sequence
+0:75        move second child to first child (temp 4-component vector of int)
+0:75          'txval21' (temp 4-component vector of int)
+0:75          texture (global 4-component vector of int)
+0:75            Construct combined texture-sampler (temp isampler2D)
+0:75              'g_tTex2di4' (uniform itexture2D)
+0:75              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.300000
+0:?               0.400000
+0:76      Sequence
+0:76        move second child to first child (temp 4-component vector of uint)
+0:76          'txval22' (temp 4-component vector of uint)
+0:76          texture (global 4-component vector of uint)
+0:76            Construct combined texture-sampler (temp usampler2D)
+0:76              'g_tTex2du4' (uniform utexture2D)
+0:76              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.500000
+0:?               0.600000
+0:78      Sequence
+0:78        move second child to first child (temp 4-component vector of float)
+0:78          'txval30' (temp 4-component vector of float)
+0:78          texture (global 4-component vector of float)
+0:78            Construct combined texture-sampler (temp sampler3D)
+0:78              'g_tTex3df4' (uniform texture3D)
+0:78              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.100000
+0:?               0.200000
+0:?               0.300000
+0:79      Sequence
+0:79        move second child to first child (temp 4-component vector of int)
+0:79          'txval31' (temp 4-component vector of int)
+0:79          texture (global 4-component vector of int)
+0:79            Construct combined texture-sampler (temp isampler3D)
+0:79              'g_tTex3di4' (uniform itexture3D)
+0:79              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.400000
+0:?               0.500000
+0:?               0.600000
+0:80      Sequence
+0:80        move second child to first child (temp 4-component vector of uint)
+0:80          'txval32' (temp 4-component vector of uint)
+0:80          texture (global 4-component vector of uint)
+0:80            Construct combined texture-sampler (temp usampler3D)
+0:80              'g_tTex3du4' (uniform utexture3D)
+0:80              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.700000
+0:?               0.800000
+0:?               0.900000
+0:82      Sequence
+0:82        move second child to first child (temp 4-component vector of float)
+0:82          'txval40' (temp 4-component vector of float)
+0:82          texture (global 4-component vector of float)
+0:82            Construct combined texture-sampler (temp samplerCube)
+0:82              'g_tTexcdf4' (uniform textureCube)
+0:82              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.100000
+0:?               0.200000
+0:?               0.300000
+0:83      Sequence
+0:83        move second child to first child (temp 4-component vector of int)
+0:83          'txval41' (temp 4-component vector of int)
+0:83          texture (global 4-component vector of int)
+0:83            Construct combined texture-sampler (temp isamplerCube)
+0:83              'g_tTexcdi4' (uniform itextureCube)
+0:83              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.400000
+0:?               0.500000
+0:?               0.600000
+0:84      Sequence
+0:84        move second child to first child (temp 4-component vector of uint)
+0:84          'txval42' (temp 4-component vector of uint)
+0:84          texture (global 4-component vector of uint)
+0:84            Construct combined texture-sampler (temp usamplerCube)
+0:84              'g_tTexcdu4' (uniform utextureCube)
+0:84              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.700000
+0:?               0.800000
+0:?               0.900000
+0:87      move second child to first child (temp float)
+0:87        Depth: direct index for structure (temp float FragDepth)
+0:87          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:87          Constant:
+0:87            1 (const int)
+0:87        Constant:
+0:87          1.000000
+0:89      Branch: Return with expression
+0:89        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:?   Linker Objects
+0:?     'g_sSamp' (uniform sampler)
+0:?     'g_sSamp2d' (uniform sampler)
+0:?     'g_sSamp2D_b' (uniform sampler)
+0:?     'g_tTex1df4a' (uniform texture1D)
+0:?     'g_tTex1df4' (uniform texture1D)
+0:?     'g_tTex1di4' (uniform itexture1D)
+0:?     'g_tTex1du4' (uniform utexture1D)
+0:?     'g_tTex2df4' (uniform texture2D)
+0:?     'g_tTex2di4' (uniform itexture2D)
+0:?     'g_tTex2du4' (uniform utexture2D)
+0:?     'g_tTex3df4' (uniform texture3D)
+0:?     'g_tTex3di4' (uniform itexture3D)
+0:?     'g_tTex3du4' (uniform utexture3D)
+0:?     'g_tTexcdf4' (uniform textureCube)
+0:?     'g_tTexcdi4' (uniform itextureCube)
+0:?     'g_tTexcdu4' (uniform utextureCube)
+
+
+Linked fragment stage:
+
+
+Shader version: 450
+gl_FragCoord origin is upper left
+0:? Sequence
+0:91  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:53    Function Parameters: 
+0:?     Sequence
+0:57      move second child to first child (temp int)
+0:57        CalculateLevelOfDetail: direct index for structure (temp int)
+0:57          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:57          Constant:
+0:57            1 (const int)
+0:57        Constant:
+0:57          1 (const int)
+0:58      move second child to first child (temp int)
+0:58        CalculateLevelOfDetailUnclamped: direct index for structure (temp int)
+0:58          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:58          Constant:
+0:58            2 (const int)
+0:58        Constant:
+0:58          1 (const int)
+0:59      move second child to first child (temp int)
+0:59        Gather: direct index for structure (temp int)
+0:59          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:59          Constant:
+0:59            3 (const int)
+0:59        Constant:
+0:59          1 (const int)
+0:60      move second child to first child (temp int)
+0:60        GetDimensions: direct index for structure (temp int)
+0:60          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:60          Constant:
+0:60            4 (const int)
+0:60        Constant:
+0:60          1 (const int)
+0:61      move second child to first child (temp int)
+0:61        GetSamplePosition: direct index for structure (temp int)
+0:61          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:61          Constant:
+0:61            5 (const int)
+0:61        Constant:
+0:61          1 (const int)
+0:62      move second child to first child (temp int)
+0:62        Load: direct index for structure (temp int)
+0:62          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:62          Constant:
+0:62            6 (const int)
+0:62        Constant:
+0:62          1 (const int)
+0:63      move second child to first child (temp int)
+0:63        Sample: direct index for structure (temp int)
+0:63          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:63          Constant:
+0:63            0 (const int)
+0:63        Constant:
+0:63          1 (const int)
+0:64      move second child to first child (temp int)
+0:64        SampleBias: direct index for structure (temp int)
+0:64          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:64          Constant:
+0:64            7 (const int)
+0:64        Constant:
+0:64          1 (const int)
+0:65      move second child to first child (temp int)
+0:65        SampleCmp: direct index for structure (temp int)
+0:65          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:65          Constant:
+0:65            8 (const int)
+0:65        Constant:
+0:65          1 (const int)
+0:66      move second child to first child (temp int)
+0:66        SampleCmpLevelZero: direct index for structure (temp int)
+0:66          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:66          Constant:
+0:66            9 (const int)
+0:66        Constant:
+0:66          1 (const int)
+0:67      move second child to first child (temp int)
+0:67        SampleGrad: direct index for structure (temp int)
+0:67          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:67          Constant:
+0:67            10 (const int)
+0:67        Constant:
+0:67          1 (const int)
+0:68      move second child to first child (temp int)
+0:68        SampleLevel: direct index for structure (temp int)
+0:68          'mtest' (temp structure{temp int Sample, temp int CalculateLevelOfDetail, temp int CalculateLevelOfDetailUnclamped, temp int Gather, temp int GetDimensions, temp int GetSamplePosition, temp int Load, temp int SampleBias, temp int SampleCmp, temp int SampleCmpLevelZero, temp int SampleGrad, temp int SampleLevel})
+0:68          Constant:
+0:68            11 (const int)
+0:68        Constant:
+0:68          1 (const int)
+0:70      Sequence
+0:70        move second child to first child (temp 4-component vector of float)
+0:70          'txval10' (temp 4-component vector of float)
+0:70          texture (global 4-component vector of float)
+0:70            Construct combined texture-sampler (temp sampler1D)
+0:70              'g_tTex1df4' (uniform texture1D)
+0:70              'g_sSamp' (uniform sampler)
+0:70            Constant:
+0:70              0.100000
+0:71      Sequence
+0:71        move second child to first child (temp 4-component vector of int)
+0:71          'txval11' (temp 4-component vector of int)
+0:71          texture (global 4-component vector of int)
+0:71            Construct combined texture-sampler (temp isampler1D)
+0:71              'g_tTex1di4' (uniform itexture1D)
+0:71              'g_sSamp' (uniform sampler)
+0:71            Constant:
+0:71              0.200000
+0:72      Sequence
+0:72        move second child to first child (temp 4-component vector of uint)
+0:72          'txval12' (temp 4-component vector of uint)
+0:72          texture (global 4-component vector of uint)
+0:72            Construct combined texture-sampler (temp usampler1D)
+0:72              'g_tTex1du4' (uniform utexture1D)
+0:72              'g_sSamp' (uniform sampler)
+0:72            Constant:
+0:72              0.300000
+0:74      Sequence
+0:74        move second child to first child (temp 4-component vector of float)
+0:74          'txval20' (temp 4-component vector of float)
+0:74          texture (global 4-component vector of float)
+0:74            Construct combined texture-sampler (temp sampler2D)
+0:74              'g_tTex2df4' (uniform texture2D)
+0:74              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.100000
+0:?               0.200000
+0:75      Sequence
+0:75        move second child to first child (temp 4-component vector of int)
+0:75          'txval21' (temp 4-component vector of int)
+0:75          texture (global 4-component vector of int)
+0:75            Construct combined texture-sampler (temp isampler2D)
+0:75              'g_tTex2di4' (uniform itexture2D)
+0:75              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.300000
+0:?               0.400000
+0:76      Sequence
+0:76        move second child to first child (temp 4-component vector of uint)
+0:76          'txval22' (temp 4-component vector of uint)
+0:76          texture (global 4-component vector of uint)
+0:76            Construct combined texture-sampler (temp usampler2D)
+0:76              'g_tTex2du4' (uniform utexture2D)
+0:76              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.500000
+0:?               0.600000
+0:78      Sequence
+0:78        move second child to first child (temp 4-component vector of float)
+0:78          'txval30' (temp 4-component vector of float)
+0:78          texture (global 4-component vector of float)
+0:78            Construct combined texture-sampler (temp sampler3D)
+0:78              'g_tTex3df4' (uniform texture3D)
+0:78              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.100000
+0:?               0.200000
+0:?               0.300000
+0:79      Sequence
+0:79        move second child to first child (temp 4-component vector of int)
+0:79          'txval31' (temp 4-component vector of int)
+0:79          texture (global 4-component vector of int)
+0:79            Construct combined texture-sampler (temp isampler3D)
+0:79              'g_tTex3di4' (uniform itexture3D)
+0:79              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.400000
+0:?               0.500000
+0:?               0.600000
+0:80      Sequence
+0:80        move second child to first child (temp 4-component vector of uint)
+0:80          'txval32' (temp 4-component vector of uint)
+0:80          texture (global 4-component vector of uint)
+0:80            Construct combined texture-sampler (temp usampler3D)
+0:80              'g_tTex3du4' (uniform utexture3D)
+0:80              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.700000
+0:?               0.800000
+0:?               0.900000
+0:82      Sequence
+0:82        move second child to first child (temp 4-component vector of float)
+0:82          'txval40' (temp 4-component vector of float)
+0:82          texture (global 4-component vector of float)
+0:82            Construct combined texture-sampler (temp samplerCube)
+0:82              'g_tTexcdf4' (uniform textureCube)
+0:82              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.100000
+0:?               0.200000
+0:?               0.300000
+0:83      Sequence
+0:83        move second child to first child (temp 4-component vector of int)
+0:83          'txval41' (temp 4-component vector of int)
+0:83          texture (global 4-component vector of int)
+0:83            Construct combined texture-sampler (temp isamplerCube)
+0:83              'g_tTexcdi4' (uniform itextureCube)
+0:83              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.400000
+0:?               0.500000
+0:?               0.600000
+0:84      Sequence
+0:84        move second child to first child (temp 4-component vector of uint)
+0:84          'txval42' (temp 4-component vector of uint)
+0:84          texture (global 4-component vector of uint)
+0:84            Construct combined texture-sampler (temp usamplerCube)
+0:84              'g_tTexcdu4' (uniform utextureCube)
+0:84              'g_sSamp' (uniform sampler)
+0:?             Constant:
+0:?               0.700000
+0:?               0.800000
+0:?               0.900000
+0:87      move second child to first child (temp float)
+0:87        Depth: direct index for structure (temp float FragDepth)
+0:87          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:87          Constant:
+0:87            1 (const int)
+0:87        Constant:
+0:87          1.000000
+0:89      Branch: Return with expression
+0:89        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:?   Linker Objects
+0:?     'g_sSamp' (uniform sampler)
+0:?     'g_sSamp2d' (uniform sampler)
+0:?     'g_sSamp2D_b' (uniform sampler)
+0:?     'g_tTex1df4a' (uniform texture1D)
+0:?     'g_tTex1df4' (uniform texture1D)
+0:?     'g_tTex1di4' (uniform itexture1D)
+0:?     'g_tTex1du4' (uniform utexture1D)
+0:?     'g_tTex2df4' (uniform texture2D)
+0:?     'g_tTex2di4' (uniform itexture2D)
+0:?     'g_tTex2du4' (uniform utexture2D)
+0:?     'g_tTex3df4' (uniform texture3D)
+0:?     'g_tTex3di4' (uniform itexture3D)
+0:?     'g_tTex3du4' (uniform utexture3D)
+0:?     'g_tTexcdf4' (uniform textureCube)
+0:?     'g_tTexcdi4' (uniform itextureCube)
+0:?     'g_tTexcdu4' (uniform utextureCube)
+
+// Module Version 10000
+// Generated by (magic number): 80001
+// Id's are bound by 182
+
+                              Capability Shader
+                              Capability Sampled1D
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Fragment 4  "main"
+                              ExecutionMode 4 OriginUpperLeft
+                              Source HLSL 450
+                              Name 4  "main"
+                              Name 7  "MemberTest"
+                              MemberName 7(MemberTest) 0  "Sample"
+                              MemberName 7(MemberTest) 1  "CalculateLevelOfDetail"
+                              MemberName 7(MemberTest) 2  "CalculateLevelOfDetailUnclamped"
+                              MemberName 7(MemberTest) 3  "Gather"
+                              MemberName 7(MemberTest) 4  "GetDimensions"
+                              MemberName 7(MemberTest) 5  "GetSamplePosition"
+                              MemberName 7(MemberTest) 6  "Load"
+                              MemberName 7(MemberTest) 7  "SampleBias"
+                              MemberName 7(MemberTest) 8  "SampleCmp"
+                              MemberName 7(MemberTest) 9  "SampleCmpLevelZero"
+                              MemberName 7(MemberTest) 10  "SampleGrad"
+                              MemberName 7(MemberTest) 11  "SampleLevel"
+                              Name 9  "mtest"
+                              Name 38  "txval10"
+                              Name 41  "g_tTex1df4"
+                              Name 45  "g_sSamp"
+                              Name 53  "txval11"
+                              Name 56  "g_tTex1di4"
+                              Name 66  "txval12"
+                              Name 69  "g_tTex1du4"
+                              Name 76  "txval20"
+                              Name 79  "g_tTex2df4"
+                              Name 87  "txval21"
+                              Name 90  "g_tTex2di4"
+                              Name 98  "txval22"
+                              Name 101  "g_tTex2du4"
+                              Name 110  "txval30"
+                              Name 113  "g_tTex3df4"
+                              Name 121  "txval31"
+                              Name 124  "g_tTex3di4"
+                              Name 131  "txval32"
+                              Name 134  "g_tTex3du4"
+                              Name 144  "txval40"
+                              Name 147  "g_tTexcdf4"
+                              Name 153  "txval41"
+                              Name 156  "g_tTexcdi4"
+                              Name 162  "txval42"
+                              Name 165  "g_tTexcdu4"
+                              Name 171  "PS_OUTPUT"
+                              MemberName 171(PS_OUTPUT) 0  "Color"
+                              MemberName 171(PS_OUTPUT) 1  "Depth"
+                              Name 173  "psout"
+                              Name 179  "g_sSamp2d"
+                              Name 180  "g_sSamp2D_b"
+                              Name 181  "g_tTex1df4a"
+                              Decorate 41(g_tTex1df4) DescriptorSet 0
+                              Decorate 45(g_sSamp) DescriptorSet 0
+                              Decorate 56(g_tTex1di4) DescriptorSet 0
+                              Decorate 69(g_tTex1du4) DescriptorSet 0
+                              Decorate 79(g_tTex2df4) DescriptorSet 0
+                              Decorate 90(g_tTex2di4) DescriptorSet 0
+                              Decorate 101(g_tTex2du4) DescriptorSet 0
+                              Decorate 113(g_tTex3df4) DescriptorSet 0
+                              Decorate 124(g_tTex3di4) DescriptorSet 0
+                              Decorate 134(g_tTex3du4) DescriptorSet 0
+                              Decorate 147(g_tTexcdf4) DescriptorSet 0
+                              Decorate 156(g_tTexcdi4) DescriptorSet 0
+                              Decorate 165(g_tTexcdu4) DescriptorSet 0
+                              MemberDecorate 171(PS_OUTPUT) 1 BuiltIn FragDepth
+                              Decorate 179(g_sSamp2d) DescriptorSet 0
+                              Decorate 180(g_sSamp2D_b) DescriptorSet 0
+                              Decorate 181(g_tTex1df4a) DescriptorSet 0
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeInt 32 1
+   7(MemberTest):             TypeStruct 6(int) 6(int) 6(int) 6(int) 6(int) 6(int) 6(int) 6(int) 6(int) 6(int) 6(int) 6(int)
+               8:             TypePointer Function 7(MemberTest)
+              10:      6(int) Constant 1
+              11:             TypePointer Function 6(int)
+              13:      6(int) Constant 2
+              15:      6(int) Constant 3
+              17:      6(int) Constant 4
+              19:      6(int) Constant 5
+              21:      6(int) Constant 6
+              23:      6(int) Constant 0
+              25:      6(int) Constant 7
+              27:      6(int) Constant 8
+              29:      6(int) Constant 9
+              31:      6(int) Constant 10
+              33:      6(int) Constant 11
+              35:             TypeFloat 32
+              36:             TypeVector 35(float) 4
+              37:             TypePointer Function 36(fvec4)
+              39:             TypeImage 35(float) 1D sampled format:Unknown
+              40:             TypePointer UniformConstant 39
+  41(g_tTex1df4):     40(ptr) Variable UniformConstant
+              43:             TypeSampler
+              44:             TypePointer UniformConstant 43
+     45(g_sSamp):     44(ptr) Variable UniformConstant
+              47:             TypeSampledImage 39
+              49:   35(float) Constant 1036831949
+              51:             TypeVector 6(int) 4
+              52:             TypePointer Function 51(ivec4)
+              54:             TypeImage 6(int) 1D sampled format:Unknown
+              55:             TypePointer UniformConstant 54
+  56(g_tTex1di4):     55(ptr) Variable UniformConstant
+              59:             TypeSampledImage 54
+              61:   35(float) Constant 1045220557
+              63:             TypeInt 32 0
+              64:             TypeVector 63(int) 4
+              65:             TypePointer Function 64(ivec4)
+              67:             TypeImage 63(int) 1D sampled format:Unknown
+              68:             TypePointer UniformConstant 67
+  69(g_tTex1du4):     68(ptr) Variable UniformConstant
+              72:             TypeSampledImage 67
+              74:   35(float) Constant 1050253722
+              77:             TypeImage 35(float) 2D sampled format:Unknown
+              78:             TypePointer UniformConstant 77
+  79(g_tTex2df4):     78(ptr) Variable UniformConstant
+              82:             TypeSampledImage 77
+              84:             TypeVector 35(float) 2
+              85:   84(fvec2) ConstantComposite 49 61
+              88:             TypeImage 6(int) 2D sampled format:Unknown
+              89:             TypePointer UniformConstant 88
+  90(g_tTex2di4):     89(ptr) Variable UniformConstant
+              93:             TypeSampledImage 88
+              95:   35(float) Constant 1053609165
+              96:   84(fvec2) ConstantComposite 74 95
+              99:             TypeImage 63(int) 2D sampled format:Unknown
+             100:             TypePointer UniformConstant 99
+ 101(g_tTex2du4):    100(ptr) Variable UniformConstant
+             104:             TypeSampledImage 99
+             106:   35(float) Constant 1056964608
+             107:   35(float) Constant 1058642330
+             108:   84(fvec2) ConstantComposite 106 107
+             111:             TypeImage 35(float) 3D sampled format:Unknown
+             112:             TypePointer UniformConstant 111
+ 113(g_tTex3df4):    112(ptr) Variable UniformConstant
+             116:             TypeSampledImage 111
+             118:             TypeVector 35(float) 3
+             119:  118(fvec3) ConstantComposite 49 61 74
+             122:             TypeImage 6(int) 3D sampled format:Unknown
+             123:             TypePointer UniformConstant 122
+ 124(g_tTex3di4):    123(ptr) Variable UniformConstant
+             127:             TypeSampledImage 122
+             129:  118(fvec3) ConstantComposite 95 106 107
+             132:             TypeImage 63(int) 3D sampled format:Unknown
+             133:             TypePointer UniformConstant 132
+ 134(g_tTex3du4):    133(ptr) Variable UniformConstant
+             137:             TypeSampledImage 132
+             139:   35(float) Constant 1060320051
+             140:   35(float) Constant 1061997773
+             141:   35(float) Constant 1063675494
+             142:  118(fvec3) ConstantComposite 139 140 141
+             145:             TypeImage 35(float) Cube sampled format:Unknown
+             146:             TypePointer UniformConstant 145
+ 147(g_tTexcdf4):    146(ptr) Variable UniformConstant
+             150:             TypeSampledImage 145
+             154:             TypeImage 6(int) Cube sampled format:Unknown
+             155:             TypePointer UniformConstant 154
+ 156(g_tTexcdi4):    155(ptr) Variable UniformConstant
+             159:             TypeSampledImage 154
+             163:             TypeImage 63(int) Cube sampled format:Unknown
+             164:             TypePointer UniformConstant 163
+ 165(g_tTexcdu4):    164(ptr) Variable UniformConstant
+             168:             TypeSampledImage 163
+  171(PS_OUTPUT):             TypeStruct 36(fvec4) 35(float)
+             172:             TypePointer Function 171(PS_OUTPUT)
+             174:   35(float) Constant 1065353216
+             175:             TypePointer Function 35(float)
+  179(g_sSamp2d):     44(ptr) Variable UniformConstant
+180(g_sSamp2D_b):     44(ptr) Variable UniformConstant
+181(g_tTex1df4a):     40(ptr) Variable UniformConstant
+         4(main):           2 Function None 3
+               5:             Label
+        9(mtest):      8(ptr) Variable Function
+     38(txval10):     37(ptr) Variable Function
+     53(txval11):     52(ptr) Variable Function
+     66(txval12):     65(ptr) Variable Function
+     76(txval20):     37(ptr) Variable Function
+     87(txval21):     52(ptr) Variable Function
+     98(txval22):     65(ptr) Variable Function
+    110(txval30):     37(ptr) Variable Function
+    121(txval31):     52(ptr) Variable Function
+    131(txval32):     65(ptr) Variable Function
+    144(txval40):     37(ptr) Variable Function
+    153(txval41):     52(ptr) Variable Function
+    162(txval42):     65(ptr) Variable Function
+      173(psout):    172(ptr) Variable Function
+              12:     11(ptr) AccessChain 9(mtest) 10
+                              Store 12 10
+              14:     11(ptr) AccessChain 9(mtest) 13
+                              Store 14 10
+              16:     11(ptr) AccessChain 9(mtest) 15
+                              Store 16 10
+              18:     11(ptr) AccessChain 9(mtest) 17
+                              Store 18 10
+              20:     11(ptr) AccessChain 9(mtest) 19
+                              Store 20 10
+              22:     11(ptr) AccessChain 9(mtest) 21
+                              Store 22 10
+              24:     11(ptr) AccessChain 9(mtest) 23
+                              Store 24 10
+              26:     11(ptr) AccessChain 9(mtest) 25
+                              Store 26 10
+              28:     11(ptr) AccessChain 9(mtest) 27
+                              Store 28 10
+              30:     11(ptr) AccessChain 9(mtest) 29
+                              Store 30 10
+              32:     11(ptr) AccessChain 9(mtest) 31
+                              Store 32 10
+              34:     11(ptr) AccessChain 9(mtest) 33
+                              Store 34 10
+              42:          39 Load 41(g_tTex1df4)
+              46:          43 Load 45(g_sSamp)
+              48:          47 SampledImage 42 46
+              50:   36(fvec4) ImageSampleImplicitLod 48 49
+                              Store 38(txval10) 50
+              57:          54 Load 56(g_tTex1di4)
+              58:          43 Load 45(g_sSamp)
+              60:          59 SampledImage 57 58
+              62:   51(ivec4) ImageSampleImplicitLod 60 61
+                              Store 53(txval11) 62
+              70:          67 Load 69(g_tTex1du4)
+              71:          43 Load 45(g_sSamp)
+              73:          72 SampledImage 70 71
+              75:   64(ivec4) ImageSampleImplicitLod 73 74
+                              Store 66(txval12) 75
+              80:          77 Load 79(g_tTex2df4)
+              81:          43 Load 45(g_sSamp)
+              83:          82 SampledImage 80 81
+              86:   36(fvec4) ImageSampleImplicitLod 83 85
+                              Store 76(txval20) 86
+              91:          88 Load 90(g_tTex2di4)
+              92:          43 Load 45(g_sSamp)
+              94:          93 SampledImage 91 92
+              97:   51(ivec4) ImageSampleImplicitLod 94 96
+                              Store 87(txval21) 97
+             102:          99 Load 101(g_tTex2du4)
+             103:          43 Load 45(g_sSamp)
+             105:         104 SampledImage 102 103
+             109:   64(ivec4) ImageSampleImplicitLod 105 108
+                              Store 98(txval22) 109
+             114:         111 Load 113(g_tTex3df4)
+             115:          43 Load 45(g_sSamp)
+             117:         116 SampledImage 114 115
+             120:   36(fvec4) ImageSampleImplicitLod 117 119
+                              Store 110(txval30) 120
+             125:         122 Load 124(g_tTex3di4)
+             126:          43 Load 45(g_sSamp)
+             128:         127 SampledImage 125 126
+             130:   51(ivec4) ImageSampleImplicitLod 128 129
+                              Store 121(txval31) 130
+             135:         132 Load 134(g_tTex3du4)
+             136:          43 Load 45(g_sSamp)
+             138:         137 SampledImage 135 136
+             143:   64(ivec4) ImageSampleImplicitLod 138 142
+                              Store 131(txval32) 143
+             148:         145 Load 147(g_tTexcdf4)
+             149:          43 Load 45(g_sSamp)
+             151:         150 SampledImage 148 149
+             152:   36(fvec4) ImageSampleImplicitLod 151 119
+                              Store 144(txval40) 152
+             157:         154 Load 156(g_tTexcdi4)
+             158:          43 Load 45(g_sSamp)
+             160:         159 SampledImage 157 158
+             161:   51(ivec4) ImageSampleImplicitLod 160 129
+                              Store 153(txval41) 161
+             166:         163 Load 165(g_tTexcdu4)
+             167:          43 Load 45(g_sSamp)
+             169:         168 SampledImage 166 167
+             170:   64(ivec4) ImageSampleImplicitLod 169 142
+                              Store 162(txval42) 170
+             176:    175(ptr) AccessChain 173(psout) 10
+                              Store 176 174
+             177:171(PS_OUTPUT) Load 173(psout)
+                              ReturnValue 177
+                              FunctionEnd

--- a/Test/hlsl.sample.basicdx10.frag
+++ b/Test/hlsl.sample.basicdx10.frag
@@ -1,0 +1,90 @@
+SamplerState       g_sSamp : register(s0);
+uniform sampler2D          g_sSamp2d
+{
+    AddressU = MIRROR;
+    AddressV = WRAP;
+    MinLOD = 0;
+    MaxLOD = 10;
+    MaxAnisotropy = 2;
+    MipLodBias = 0.2;
+}, g_sSamp2D_b;
+
+Texture1D          g_tTex1df4a : register(t1);
+
+uniform Texture1D <float4> g_tTex1df4 : register(t0);
+Texture1D <int4>   g_tTex1di4;
+Texture1D <uint4>  g_tTex1du4;
+
+Texture2D <float4> g_tTex2df4;
+Texture2D <int4>   g_tTex2di4;
+Texture2D <uint4>  g_tTex2du4;
+
+Texture3D <float4> g_tTex3df4;
+Texture3D <int4>   g_tTex3di4;
+Texture3D <uint4>  g_tTex3du4;
+
+TextureCube <float4> g_tTexcdf4;
+TextureCube <int4>   g_tTexcdi4;
+TextureCube <uint4>  g_tTexcdu4;
+
+struct MemberTest
+{
+    int Sample;                          // in HLSL, method names are valid struct members.
+    int CalculateLevelOfDetail;          // ...
+    int CalculateLevelOfDetailUnclamped; // ...
+    int Gather;                          // ...
+    int GetDimensions;                   // ...
+    int GetSamplePosition;               // ...
+    int Load;                            // ...
+    int SampleBias;                      // ...
+    int SampleCmp;                       // ...
+    int SampleCmpLevelZero;              // ...
+    int SampleGrad;                      // ...
+    int SampleLevel;                     // ...
+};
+
+struct PS_OUTPUT
+{
+    float4 Color : SV_Target0;
+    float  Depth : SV_Depth;
+};
+
+PS_OUTPUT main()
+{
+   PS_OUTPUT psout;
+
+   MemberTest mtest;
+   mtest.CalculateLevelOfDetail = 1;          // in HLSL, method names are valid struct members.
+   mtest.CalculateLevelOfDetailUnclamped = 1; // ...
+   mtest.Gather = 1;                          // ...
+   mtest.GetDimensions = 1;                   // ...
+   mtest.GetSamplePosition = 1;               // ...
+   mtest.Load = 1;                            // ...
+   mtest.Sample = 1;                          // ...
+   mtest.SampleBias = 1;                      // ...
+   mtest.SampleCmp = 1;                       // ...
+   mtest.SampleCmpLevelZero = 1;              // ...
+   mtest.SampleGrad = 1;                      // ...
+   mtest.SampleLevel = 1;                     // ...
+
+   float4 txval10 = g_tTex1df4 . Sample(g_sSamp, 0.1);
+   int4   txval11 = g_tTex1di4 . Sample(g_sSamp, 0.2);
+   uint4  txval12 = g_tTex1du4 . Sample(g_sSamp, 0.3);
+
+   float4 txval20 = g_tTex2df4 . Sample(g_sSamp, float2(0.1, 0.2));
+   int4   txval21 = g_tTex2di4 . Sample(g_sSamp, float2(0.3, 0.4));
+   uint4  txval22 = g_tTex2du4 . Sample(g_sSamp, float2(0.5, 0.6));
+
+   float4 txval30 = g_tTex3df4 . Sample(g_sSamp, float3(0.1, 0.2, 0.3));
+   int4   txval31 = g_tTex3di4 . Sample(g_sSamp, float3(0.4, 0.5, 0.6));
+   uint4  txval32 = g_tTex3du4 . Sample(g_sSamp, float3(0.7, 0.8, 0.9));
+
+   float4 txval40 = g_tTexcdf4 . Sample(g_sSamp, float3(0.1, 0.2, 0.3));
+   int4   txval41 = g_tTexcdi4 . Sample(g_sSamp, float3(0.4, 0.5, 0.6));
+   uint4  txval42 = g_tTexcdu4 . Sample(g_sSamp, float3(0.7, 0.8, 0.9));
+
+   psout.Color = 1.0;
+   psout.Depth = 1.0;
+
+   return psout;
+}

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -84,6 +84,7 @@ struct TSampler {   // misnomer now; includes images, textures without sampler, 
     bool isCombined()    const { return combined; }
     bool isPureSampler() const { return sampler; }
     bool isTexture()     const { return !sampler && !image; }
+    bool isShadow()      const { return shadow; }
 
     void clear()
     {
@@ -1080,6 +1081,15 @@ public:
                                     typeName = NewPoolTString(p.userDef->getTypeName().c_str());
                                 }
                             }
+    // for construction of sampler types
+    TType(const TSampler& sampler, TStorageQualifier q = EvqUniform, TArraySizes* as = nullptr) :
+        basicType(EbtSampler), vectorSize(1), matrixCols(0), matrixRows(0), vector1(false),
+        arraySizes(as), structure(nullptr), fieldName(nullptr), typeName(nullptr),
+        sampler(sampler)
+    {
+        qualifier.clear();
+        qualifier.storage = q;
+    }
     // to efficiently make a dereferenced type
     // without ever duplicating the outer structure that will be thrown away
     // and using only shallow copy

--- a/glslang/Include/intermediate.h
+++ b/glslang/Include/intermediate.h
@@ -525,6 +525,8 @@ enum TOperator {
     EOpLit,                              // HLSL lighting coefficient vector
     EOpTextureBias,                      // HLSL texture bias: will be lowered to EOpTexture
     EOpAsDouble,                         // slightly different from EOpUint64BitsToDouble
+
+    EOpMethodSample,
 };
 
 class TIntermTraverser;

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -93,6 +93,7 @@ INSTANTIATE_TEST_CASE_P(
         {"hlsl.intrinsics.negative.comp", "ComputeShaderFunction"},
         {"hlsl.intrinsics.negative.frag", "PixelShaderFunction"},
         {"hlsl.intrinsics.negative.vert", "VertexShaderFunction"},
+        {"hlsl.sample.basicdx10.frag", "main"},
         {"hlsl.intrinsics.vert", "VertexShaderFunction"},
         {"hlsl.matType.frag", "PixelShaderFunction"},
         {"hlsl.max.frag", "PixelShaderFunction"},

--- a/hlsl/hlslGrammar.h
+++ b/hlsl/hlslGrammar.h
@@ -59,16 +59,21 @@ namespace glslang {
         HlslGrammar& operator=(const HlslGrammar&);
 
         void expected(const char*);
+        void unimplemented(const char*);
         bool acceptIdentifier(HlslToken&);
         bool acceptCompilationUnit();
         bool acceptDeclaration(TIntermNode*& node);
         bool acceptControlDeclaration(TIntermNode*& node);
+        bool acceptSamplerDeclarationDX9(TType&);
+        bool acceptSamplerState();
         bool acceptFullySpecifiedType(TType&);
         void acceptQualifier(TQualifier&);
         bool acceptType(TType&);
         bool acceptTemplateType(TBasicType&);
         bool acceptVectorTemplateType(TType&);
         bool acceptMatrixTemplateType(TType&);
+        bool acceptSamplerType(TType&);
+        bool acceptTextureType(TType&);
         bool acceptStruct(TType&);
         bool acceptStructDeclarationList(TTypeList*&);
         bool acceptFunctionParameters(TFunction&);
@@ -82,7 +87,7 @@ namespace glslang {
         bool acceptUnaryExpression(TIntermTyped*&);
         bool acceptPostfixExpression(TIntermTyped*&);
         bool acceptConstructor(TIntermTyped*&);
-        bool acceptFunctionCall(HlslToken, TIntermTyped*&);
+        bool acceptFunctionCall(HlslToken, TIntermTyped*&, TIntermTyped* base = nullptr);
         bool acceptArguments(TFunction*, TIntermTyped*&);
         bool acceptLiteral(TIntermTyped*&);
         bool acceptCompoundStatement(TIntermNode*&);

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -564,12 +564,32 @@ TIntermTyped* HlslParseContext::handleDotDereference(const TSourceLoc& loc, TInt
     variableCheck(base);
 
     //
-    // .length() can't be resolved until we later see the function-calling syntax.
+    // methods can't be resolved until we later see the function-calling syntax.
     // Save away the name in the AST for now.  Processing is completed in 
-    // handleLengthMethod().
+    // handleLengthMethod(), etc.
     //
     if (field == "length") {
         return intermediate.addMethod(base, TType(EbtInt), &field, loc);
+    } else if (field == "CalculateLevelOfDetail"          ||
+               field == "CalculateLevelOfDetailUnclamped" ||
+               field == "Gather"                          ||
+               field == "GetDimensions"                   ||
+               field == "GetSamplePosition"               ||
+               field == "Load"                            ||
+               field == "Sample"                          ||
+               field == "SampleBias"                      ||
+               field == "SampleCmp"                       ||
+               field == "SampleCmpLevelZero"              ||
+               field == "SampleGrad"                      ||
+               field == "SampleLevel") {
+        // If it's not a method on a sampler object, we fall through in case it is a struct member.
+        if (base->getType().getBasicType() == EbtSampler) {
+            const TSampler& texType = base->getType().getSampler();
+            if (! texType.isPureSampler()) {
+                const int vecSize = texType.isShadow() ? 1 : 4;
+                return intermediate.addMethod(base, TType(texType.type, EvqTemporary, vecSize), &field, loc);
+            }
+        }
     }
 
     // It's not .length() if we get to here.
@@ -1006,9 +1026,7 @@ void HlslParseContext::decomposeIntrinsic(const TSourceLoc& loc, TIntermTyped*& 
 
             TIntermTyped* arg0 = argAggregate->getSequence()[0]->getAsTyped();
             TIntermTyped* arg1 = argAggregate->getSequence()[1]->getAsTyped();
-            TBasicType    type0 = arg0->getBasicType();
 
-            TIntermTyped* x = intermediate.addConstantUnion(0, loc, true);
             TIntermTyped* y = intermediate.addConstantUnion(1, loc, true);
             TIntermTyped* z = intermediate.addConstantUnion(2, loc, true);
             TIntermTyped* w = intermediate.addConstantUnion(3, loc, true);
@@ -1205,6 +1223,49 @@ void HlslParseContext::decomposeIntrinsic(const TSourceLoc& loc, TIntermTyped*& 
 }
 
 //
+// Decompose sample methods into AST
+//
+void HlslParseContext::decomposeSampleMethods(const TSourceLoc& loc, TIntermTyped*& node, TIntermNode* arguments)
+{
+    if (!node || !node->getAsOperator())
+        return;
+
+    const TIntermAggregate* argAggregate = arguments ? arguments->getAsAggregate() : nullptr;
+    const TOperator op  = node->getAsOperator()->getOp();
+
+    switch (op) {
+    case EOpMethodSample:
+        {
+            TIntermTyped* argTex   = argAggregate->getSequence()[0]->getAsTyped();
+            TIntermTyped* argSamp  = argAggregate->getSequence()[1]->getAsTyped();
+            TIntermTyped* argCoord = argAggregate->getSequence()[2]->getAsTyped();
+
+            TIntermAggregate* txcombine = new TIntermAggregate(EOpConstructTextureSampler);
+
+            txcombine->getSequence().push_back(argTex);
+            txcombine->getSequence().push_back(argSamp);
+            TSampler samplerType = argTex->getType().getSampler();
+            samplerType.combined = true;
+            txcombine->setType(TType(samplerType, EvqTemporary));
+            txcombine->setLoc(loc);
+
+            TIntermAggregate* txsample = new TIntermAggregate(EOpTexture);
+            txsample->getSequence().push_back(txcombine);
+            txsample->getSequence().push_back(argCoord);
+            txsample->setType(node->getType());
+            txsample->setLoc(loc);
+            node = txsample;
+
+            break;
+        }
+        
+    default:
+        break; // most pass through unchanged
+    }
+}
+
+
+//
 // Handle seeing function call syntax in the grammar, which could be any of
 //  - .length() method
 //  - constructor
@@ -1307,8 +1368,9 @@ TIntermTyped* HlslParseContext::handleFunctionCall(const TSourceLoc& loc, TFunct
                 result = addOutputArgumentConversions(*fnCandidate, *result->getAsAggregate());
             }
 
-            decomposeIntrinsic(loc, result, arguments);
-            textureParameters(loc, result, arguments);
+            decomposeIntrinsic(loc, result, arguments);      // HLSL->AST intrinsic decompositions
+            decomposeSampleMethods(loc, result, arguments);  // HLSL->AST sample method decompositions
+            textureParameters(loc, result, arguments);       // HLSL->AST texture intrinsics
         }
     }
 

--- a/hlsl/hlslParseHelper.h
+++ b/hlsl/hlslParseHelper.h
@@ -87,6 +87,7 @@ public:
     void handleFunctionArgument(TFunction*, TIntermTyped*& arguments, TIntermTyped* newArg);
     TIntermTyped* handleFunctionCall(const TSourceLoc&, TFunction*, TIntermNode*);
     void decomposeIntrinsic(const TSourceLoc&, TIntermTyped*& node, TIntermNode* arguments);
+    void decomposeSampleMethods(const TSourceLoc&, TIntermTyped*& node, TIntermNode* arguments);
     void textureParameters(const TSourceLoc&, TIntermTyped*& node, TIntermNode* arguments);
     TIntermTyped* handleLengthMethod(const TSourceLoc&, TFunction*, TIntermNode*);
     void addInputArgumentConversions(const TFunction&, TIntermNode*&) const;

--- a/hlsl/hlslParseables.cpp
+++ b/hlsl/hlslParseables.cpp
@@ -65,6 +65,12 @@ const char* BaseTypeName(const char* argOrder, const char* scalarName, const cha
     default:  return "UNKNOWN_TYPE";
     }
 }
+
+bool IsTextureType(const char argType)
+{
+    return argType == 'T' || argType == 'i' || argType == 'u';
+}
+
     
 // Create and return a type name.  This is done in GLSL, not HLSL conventions, until such
 // time as builtins are parsed using the HLSL parser.
@@ -95,6 +101,9 @@ glslang::TString& AppendTypeName(glslang::TString& s, const char* argOrder, cons
         case 'U': s += "uint";    break;
         case 'B': s += "bool";    break;
         case 'S': s += "sampler"; break;
+        case 'T': s += "Texture"; break;
+        case 'i': assert(0); // TODO: ...
+        case 'u': assert(0); // TODO: ...
         default:  s += "UNKNOWN_TYPE"; break;
         }
     } else {
@@ -105,7 +114,10 @@ glslang::TString& AppendTypeName(glslang::TString& s, const char* argOrder, cons
         case 'I': s += BaseTypeName(argOrder, "int",     "ivec",    "imat"); break;
         case 'U': s += BaseTypeName(argOrder, "uint",    "uvec",    "umat"); break;
         case 'B': s += BaseTypeName(argOrder, "bool",    "bvec",    "bmat"); break;
-        case 'S': s += BaseTypeName(argOrder, "sampler", "sampler", "sampler"); break; // TODO: 
+        case 'S': s += BaseTypeName(argOrder, "sampler", "sampler", "sampler"); break;
+        case 'T': s += BaseTypeName(argOrder, "texture", "texture", "texture"); break;
+        case 'i': s += BaseTypeName(argOrder, "itexture", "itexture", "itexture"); break;
+        case 'u': s += BaseTypeName(argOrder, "utexture", "utexture", "utexture"); break;
         default:  s += "UNKNOWN_TYPE"; break;
         }
     }
@@ -116,35 +128,38 @@ glslang::TString& AppendTypeName(glslang::TString& s, const char* argOrder, cons
         dim0 = dim1 = fixedVecSize;
 
     // Add sampler dimensions
-    if (*argType == 'S') {
-        switch (dim0) {
-        case 1: s += "1D";   break;
-        case 2: s += "2D";   break;
-        case 3: s += "3D";   break;
-        case 4: s += "Cube"; break;
-        default: s += "UNKNOWN_SAMPLER"; break;
+    if (*argType == 'S' || IsTextureType(*argType)) {
+        if (*argOrder == 'V') {
+            switch (dim0) {
+            case 1: s += "1D";   break;
+            case 2: s += "2D";   break;
+            case 3: s += "3D";   break;
+            case 4: s += "Cube"; break;
+            default: s += "UNKNOWN_SAMPLER"; break;
+            }
         }
-    }
+    } else {
+        // Non-sampler type:
+        // verify dimensions
+        if (((*argOrder == 'V' || *argOrder == 'M') && (dim0 < 1 || dim0 > 4)) ||
+            (*argOrder == 'M' && (dim1 < 1 || dim1 > 4))) {
+            s += "UNKNOWN_DIMENSION";
+            return s;
+        }
 
-    // verify dimensions
-    if ((*argOrder == 'V' || *argOrder == 'M') && (dim0 < 1 || dim0 > 4) ||
-        (*argOrder == 'M' && (dim1 < 1 || dim1 > 4))) {
-        s += "UNKNOWN_DIMENSION";
-        return s;
-    }
-
-    switch (*argOrder) {
-    case '-': break;  // no dimensions for voids
-    case 'S': break;  // no dimensions on scalars
-    case 'V': s += ('0' + (char)dim0); break;
-    case 'M': 
-        {
-            if (!UseHlslTypes)  // GLSL has column first for mat types
-                std::swap(dim0, dim1);
-            s += ('0' + (char)dim0);
-            s += 'x';
-            s += ('0' + (char)dim1);
-            break;
+        switch (*argOrder) {
+        case '-': break;  // no dimensions for voids
+        case 'S': break;  // no dimensions on scalars
+        case 'V': s += ('0' + (char)dim0); break;
+        case 'M': 
+            {
+                if (!UseHlslTypes)  // GLSL has column first for mat types
+                    std::swap(dim0, dim1);
+                s += ('0' + (char)dim0);
+                s += 'x';
+                s += ('0' + (char)dim1);
+                break;
+            }
         }
     }
 
@@ -160,17 +175,18 @@ inline bool IsValidGlsl(const char* cname, char retOrder, char retType, char /*a
     const bool isVec = dim0Max > 1 || argType == 'V';
     const bool isMat = dim1Max > 1 || argType == 'M';
 
-    if ((isVec && dim0 == 1)            ||  // avoid vec1
-        (isMat && dim0 == 1 && dim1 == 1))  // avoid mat1x1
+    if (!IsTextureType(argType) &&
+        ((isVec && dim0 == 1)            ||  // avoid vec1
+         (isMat && dim0 == 1 && dim1 == 1)))  // avoid mat1x1
         return false;
 
     const std::string name(cname);  // for ease of comparison. slow, but temporary, until HLSL parser is online.
-                                
+
     if (isMat && dim1 == 1)  // TODO: avoid mat Nx1 until we find the right GLSL profile
         return false;
 
-    if (isMat && (argType == 'I' || argType == 'U' || argType == 'B') ||
-        retOrder == 'M' && (retType == 'I' || retType == 'U' || retType == 'B'))
+    if ((isMat && (argType == 'I' || argType == 'U' || argType == 'B')) ||
+        (retOrder == 'M' && (retType == 'I' || retType == 'U' || retType == 'B')))
         return false;
 
     if (name == "GetRenderTargetSamplePosition" ||
@@ -284,7 +300,8 @@ void TBuiltInParseablesHlsl::initialize(int /*version*/, EProfile /*profile*/, c
     // orderKey can be:
     //   S = scalar, V = vector, M = matrix, - = void
     // typekey can be:
-    //   D = double, F = float, U = uint, I = int, B = bool, S = sampler, - = void
+    //   D = double, F = float, U = uint, I = int, B = bool,
+    //   S = sampler, T = texture, i = itexture, u = utexture, - = void
     // An empty order or type key repeats the first one.  E.g: SVM,, means 3 args each of SVM.
     // '>' as first letter of order creates an output parameter
     // '<' as first letter of order creates an input parameter
@@ -429,32 +446,38 @@ void TBuiltInParseablesHlsl::initialize(int /*version*/, EProfile /*profile*/, c
         { "step",                             nullptr, nullptr,   "SVM,",       "F,",     EShLangAll },
         { "tan",                              nullptr, nullptr,   "SVM",        "F",      EShLangAll },
         { "tanh",                             nullptr, nullptr,   "SVM",        "F",      EShLangAll },
-        { "tex1D",                            "V4",    "F",       "S1,S",       "S,F",    EShLangFragmentMask },
-        { "tex1D",                            "V4",    "F",       "S1,S,V1,V1", "S,F,F,F",EShLangFragmentMask },
-        { "tex1Dbias",                        "V4",    "F",       "S1,V4",      "S,F",    EShLangFragmentMask },
-        { "tex1Dgrad",                        "V4",    "F",       "S1,V1,V1,V1","S,F,F,F",EShLangFragmentMask },
-        { "tex1Dlod",                         "V4",    "F",       "S1,V4",      "S,F",    EShLangFragmentMask },
-        { "tex1Dproj",                        "V4",    "F",       "S1,V4",      "S,F",    EShLangFragmentMask },
-        { "tex2D",                            "V4",    "F",       "S2,V2",      "S,F",    EShLangFragmentMask },
-        { "tex2D",                            "V4",    "F",       "S2,V2,V2,V2","S,F,F,F",EShLangFragmentMask },
-        { "tex2Dbias",                        "V4",    "F",       "S2,V4",      "S,F",    EShLangFragmentMask },
-        { "tex2Dgrad",                        "V4",    "F",       "S2,V2,V2,V2","S,F,F,F",EShLangFragmentMask },
-        { "tex2Dlod",                         "V4",    "F",       "S2,V4",      "S,F",    EShLangFragmentMask },
-        { "tex2Dproj",                        "V4",    "F",       "S2,V4",      "S,F",    EShLangFragmentMask },
-        { "tex3D",                            "V4",    "F",       "S3,V3",      "S,F",    EShLangFragmentMask },
-        { "tex3D",                            "V4",    "F",       "S3,V3,V3,V3","S,F,F,F",EShLangFragmentMask },
-        { "tex3Dbias",                        "V4",    "F",       "S3,V4",      "S,F",    EShLangFragmentMask },
-        { "tex3Dgrad",                        "V4",    "F",       "S3,V3,V3,V3","S,F,F,F",EShLangFragmentMask },
-        { "tex3Dlod",                         "V4",    "F",       "S3,V4",      "S,F",    EShLangFragmentMask },
-        { "tex3Dproj",                        "V4",    "F",       "S3,V4",      "S,F",    EShLangFragmentMask },
-        { "texCUBE",                          "V4",    "F",       "S4,V3",      "S,F",    EShLangFragmentMask },
-        { "texCUBE",                          "V4",    "F",       "S4,V3,V3,V3","S,F,F,F",EShLangFragmentMask },
-        { "texCUBEbias",                      "V4",    "F",       "S4,V4",      "S,F",    EShLangFragmentMask },
-        { "texCUBEgrad",                      "V4",    "F",       "S4,V3,V3,V3","S,F,F,F",EShLangFragmentMask },
-        { "texCUBElod",                       "V4",    "F",       "S4,V4",      "S,F",    EShLangFragmentMask },
-        { "texCUBEproj",                      "V4",    "F",       "S4,V4",      "S,F",    EShLangFragmentMask },
+        { "tex1D",                            "V4",    "F",       "V1,S",       "S,F",    EShLangFragmentMask },
+        { "tex1D",                            "V4",    "F",       "V1,S,V1,V1", "S,F,F,F",EShLangFragmentMask },
+        { "tex1Dbias",                        "V4",    "F",       "V1,V4",      "S,F",    EShLangFragmentMask },
+        { "tex1Dgrad",                        "V4",    "F",       "V1,V1,V1,V1","S,F,F,F",EShLangFragmentMask },
+        { "tex1Dlod",                         "V4",    "F",       "V1,V4",      "S,F",    EShLangFragmentMask },
+        { "tex1Dproj",                        "V4",    "F",       "V1,V4",      "S,F",    EShLangFragmentMask },
+        { "tex2D",                            "V4",    "F",       "V2,V2",      "S,F",    EShLangFragmentMask },
+        { "tex2D",                            "V4",    "F",       "V2,V2,V2,V2","S,F,F,F",EShLangFragmentMask },
+        { "tex2Dbias",                        "V4",    "F",       "V2,V4",      "S,F",    EShLangFragmentMask },
+        { "tex2Dgrad",                        "V4",    "F",       "V2,V2,V2,V2","S,F,F,F",EShLangFragmentMask },
+        { "tex2Dlod",                         "V4",    "F",       "V2,V4",      "S,F",    EShLangFragmentMask },
+        { "tex2Dproj",                        "V4",    "F",       "V2,V4",      "S,F",    EShLangFragmentMask },
+        { "tex3D",                            "V4",    "F",       "V3,V3",      "S,F",    EShLangFragmentMask },
+        { "tex3D",                            "V4",    "F",       "V3,V3,V3,V3","S,F,F,F",EShLangFragmentMask },
+        { "tex3Dbias",                        "V4",    "F",       "V3,V4",      "S,F",    EShLangFragmentMask },
+        { "tex3Dgrad",                        "V4",    "F",       "V3,V3,V3,V3","S,F,F,F",EShLangFragmentMask },
+        { "tex3Dlod",                         "V4",    "F",       "V3,V4",      "S,F",    EShLangFragmentMask },
+        { "tex3Dproj",                        "V4",    "F",       "V3,V4",      "S,F",    EShLangFragmentMask },
+        { "texCUBE",                          "V4",    "F",       "V4,V3",      "S,F",    EShLangFragmentMask },
+        { "texCUBE",                          "V4",    "F",       "V4,V3,V3,V3","S,F,F,F",EShLangFragmentMask },
+        { "texCUBEbias",                      "V4",    "F",       "V4,V4",      "S,F",    EShLangFragmentMask },
+        { "texCUBEgrad",                      "V4",    "F",       "V4,V3,V3,V3","S,F,F,F",EShLangFragmentMask },
+        { "texCUBElod",                       "V4",    "F",       "V4,V4",      "S,F",    EShLangFragmentMask },
+        { "texCUBEproj",                      "V4",    "F",       "V4,V4",      "S,F",    EShLangFragmentMask },
         { "transpose",                        "^M",    nullptr,   "M",          "F",      EShLangAll },
         { "trunc",                            nullptr, nullptr,   "SVM",        "F",      EShLangAll },
+
+        // Texture object methods.  Return type can be overridden by shader declaration.
+        { "Sample",                           "V4",    "F",       "V,S,V",      "T,S,F",  EShLangFragmentMask },
+        { "Sample",                           "V4",    "I",       "V,S,V",      "i,S,F",  EShLangFragmentMask },
+        { "Sample",                           "V4",    "U",       "V,S,V",      "u,S,F",  EShLangFragmentMask },
+        // TODO: forms with texel-space offset parameter
 
         // Mark end of list, since we want to avoid a range-based for, as some compilers don't handle it yet.
         { nullptr,                            nullptr, nullptr,   nullptr,      nullptr,  0 },
@@ -501,6 +524,8 @@ void TBuiltInParseablesHlsl::initialize(int /*version*/, EProfile /*profile*/, c
                             s.append(intrinsic.name);                          // intrinsic name
                             s.append("(");                                     // open paren
 
+                            const bool isTexture = IsTextureType(*argType);
+
                             // Append argument types, if any.
                             for (int arg = 0; ; ++arg) {
                                 const char* nthArgOrder(NthArg(argOrder, arg));
@@ -508,6 +533,13 @@ void TBuiltInParseablesHlsl::initialize(int /*version*/, EProfile /*profile*/, c
 
                                 if (nthArgOrder == nullptr || nthArgType == nullptr)
                                     break;
+
+                                // For textures, the 1D case isn't a 1-vector, but a scalar.
+                                if (isTexture && dim0 == 1 && arg > 0 && *nthArgOrder == 'V')
+                                    nthArgOrder = "S";
+
+                                // cube textures use vec3 coordinates
+                                const int argDim0 = isTexture && arg > 0 ? std::min(dim0, 3) : dim0;
 
                                 s.append(arg > 0 ? ", ": "");  // comma separator if needed
                                 
@@ -523,7 +555,7 @@ void TBuiltInParseablesHlsl::initialize(int /*version*/, EProfile /*profile*/, c
                                 if (*nthArgOrder == ',' || *nthArgOrder == '\0') nthArgOrder = argOrder;
                                 if (*nthArgType == ',' || *nthArgType == '\0') nthArgType = argType;
 
-                                AppendTypeName(s, nthArgOrder, nthArgType, dim0, dim1); // Add arguments
+                                AppendTypeName(s, nthArgOrder, nthArgType, argDim0, dim1); // Add arguments
                             }
                             
                             s.append(");\n");            // close paren and trailing semicolon
@@ -606,7 +638,7 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int /*version*/, EProfile /*profil
     symbolTable.relateToOperator("ddy_fine",                    EOpDPdyFine);
     symbolTable.relateToOperator("degrees",                     EOpDegrees);
     symbolTable.relateToOperator("determinant",                 EOpDeterminant);
-    symbolTable.relateToOperator("DeviceMemoryBarrier",         EOpGroupMemoryBarrier); // == ScopeDevice+CrossWorkGroup
+    symbolTable.relateToOperator("DeviceMemoryBarrier",         EOpGroupMemoryBarrier);
     symbolTable.relateToOperator("DeviceMemoryBarrierWithGroupSync", EOpGroupMemoryBarrierWithGroupSync); // ...
     symbolTable.relateToOperator("distance",                    EOpDistance);
     symbolTable.relateToOperator("dot",                         EOpDot);
@@ -710,6 +742,9 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int /*version*/, EProfile /*profil
     symbolTable.relateToOperator("texCUBEproj",                 EOpTextureProj);
     symbolTable.relateToOperator("transpose",                   EOpTranspose);
     symbolTable.relateToOperator("trunc",                       EOpTrunc);
+
+    // Texture methods
+    symbolTable.relateToOperator("Sample",                      EOpMethodSample);
 }
 
 //

--- a/hlsl/hlslScanContext.cpp
+++ b/hlsl/hlslScanContext.cpp
@@ -1,5 +1,6 @@
 //
 //Copyright (C) 2016 Google, Inc.
+//Copyright (C) 2016 LunarG, Inc.
 //
 //All rights reserved.
 //
@@ -249,6 +250,9 @@ void HlslScanContext::fillInKeywordMap()
     (*KeywordMap)["Texture2DArray"] =          EHTokTexture2darray;
     (*KeywordMap)["Texture3D"] =               EHTokTexture3d;
     (*KeywordMap)["TextureCube"] =             EHTokTextureCube;
+    (*KeywordMap)["TextureCubeArray"] =        EHTokTextureCubearray;
+    (*KeywordMap)["Texture2DMS"] =             EHTokTexture2DMS;
+    (*KeywordMap)["Texture2DMSArray"] =        EHTokTexture2DMSarray;
 
     (*KeywordMap)["struct"] =                  EHTokStruct;
     (*KeywordMap)["typedef"] =                 EHTokTypedef;
@@ -556,6 +560,9 @@ EHlslTokenClass HlslScanContext::tokenizeIdentifier()
     case EHTokTexture2darray:
     case EHTokTexture3d:
     case EHTokTextureCube:
+    case EHTokTextureCubearray:
+    case EHTokTexture2DMS:
+    case EHTokTexture2DMSarray:
         return keyword;
 
     // variable, user type, ...

--- a/hlsl/hlslTokens.h
+++ b/hlsl/hlslTokens.h
@@ -1,5 +1,6 @@
 //
 //Copyright (C) 2016 Google, Inc.
+//Copyright (C) 2016 LunarG, Inc.
 //
 //All rights reserved.
 //
@@ -200,6 +201,9 @@ enum EHlslTokenClass {
     EHTokTexture2darray,
     EHTokTexture3d,
     EHTokTextureCube,
+    EHTokTextureCubearray,
+    EHTokTexture2DMS,
+    EHTokTexture2DMSarray,
 
     // variable, user type, ...
     EHTokIdentifier,


### PR DESCRIPTION
This PR adds:

- Declarations for HLSL sampler and texture types.  Some features such as immediate sampler state declarations are parsed but dropped with a warning.  Only separate declarations are currently allowed, so no DX9 style.

- Method syntax.  The calling object becomes the hidden first parameter.

- A partial implementation of the texture object Sample() method.

- Compiler warning fix from fbarchard

This PR is aimed at a narrow vertical path, which will be broadened in future PRs.  Limitations include:

- Only DX10 style syntax is in place (though DX9 will be added later).

- Only the features seen in Test/hlsl.sample.basicdx10.frag are connected.  Stray outside that, and it won't work.  For example, no arrays, no multisample, no texel offset, no other methods, etc.
