### PR TITLE
Generate an error for unsized atomic counter array uniforms.

### DIFF
--- a/Test/baseResults/unsizedAtomicCounterArrayUniform.frag.out
+++ b/Test/baseResults/unsizedAtomicCounterArrayUniform.frag.out
@@ -1,0 +1,6 @@
+unsizedAtomicCounterArrayUniform.frag
+Warning, version 420 is not yet complete; most version-specific features are present, but some are missing.
+ERROR: 0:2: '' : atomic counter arrays can not be unsized or implicitly sized. 
+ERROR: 1 compilation errors.  No code generated.
+
+

--- a/Test/unsizedAtomicCounterArrayUniform.frag
+++ b/Test/unsizedAtomicCounterArrayUniform.frag
@@ -1,0 +1,2 @@
+#version 420
+layout(binding=0) uniform atomic_uint a[];

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -4753,7 +4753,10 @@ void TParseContext::fixOffset(const TSourceLoc& loc, TSymbol& symbol)
             // Check for overlap
             int numOffsets = 4;
             if (symbol.getType().isArray())
-                numOffsets *= symbol.getType().getCumulativeArraySize();
+                if(symbol.getType().isImplicitlySizedArray())
+                    error(loc, "atomic counter arrays can not be unsized or implicitly sized.", "", "");
+                else
+                    numOffsets *= symbol.getType().getCumulativeArraySize();
             int repeated = intermediate.addUsedOffsets(qualifier.layoutBinding, offset, numOffsets);
             if (repeated >= 0)
                 error(loc, "atomic counters sharing the same offset:", "offset", "%d", repeated);


### PR DESCRIPTION
This should resolve #382.

I'm not certain, but it seems that with this accounted for, the `ARB_shader_atomic_counters` layout offset rules should be working. It occurred to me while reading the spec, it would be interesting/nice to warn for exceeding minimums for `GL_MAX_ATOMIC_COUNTER_BUFFER_SIZE` and friends.

If this looks good enough, I will add a test.