### PR TITLE
Add g++/clang warnings to match some enabled by /W4 in MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,14 @@ else(WIN32)
 endif(WIN32)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
+    add_definitions(-Wall -Wmaybe-uninitialized -Wuninitialized -Wunused -Wunused-local-typedefs
+      -Wunused-parameter -Wunused-value  -Wunused-variable -Wunused-but-set-parameter -Wunused-but-set-variable)
+    add_definitions(-Wno-reorder)  # disable this from -Wall, since it happens all over.
     add_definitions(-std=c++11)
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    add_definitions(-Wall -Wuninitialized -Wunused -Wunused-local-typedefs
+      -Wunused-parameter -Wunused-value  -Wunused-variable)
+    add_definitions(-Wno-reorder)  # disable this from -Wall, since it happens all over.
     add_definitions(-std=c++11)
 endif()
 

--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -197,20 +197,25 @@ template <class T> T Max(const T a, const T b) { return a > b ? a : b; }
 //
 // Create a TString object from an integer.
 //
+#if defined _MSC_VER || defined MINGW_HAS_SECURE_API
 inline const TString String(const int i, const int base = 10)
 {
     char text[16];     // 32 bit ints are at most 10 digits in base 10
+    _itoa_s(i, text, sizeof(text), base);
+    return text;
+}
+#else
+inline const TString String(const int i, const int /*base*/ = 10)
+{
+    char text[16];     // 32 bit ints are at most 10 digits in base 10
     
-    #if defined _MSC_VER || defined MINGW_HAS_SECURE_API
-        _itoa_s(i, text, sizeof(text), base);
-    #else
-        // we assume base 10 for all cases
-        snprintf(text, sizeof(text), "%d", i);
-    #endif
+    // we assume base 10 for all cases
+    snprintf(text, sizeof(text), "%d", i);
 
     return text;
 }
-
+#endif
+    
 struct TSourceLoc {
     void init() { name = nullptr; string = 0; line = 0; column = 0; }
     // Returns the name if it exists. Otherwise, returns the string number.

--- a/glslang/OSDependent/Unix/ossource.cpp
+++ b/glslang/OSDependent/Unix/ossource.cpp
@@ -170,16 +170,16 @@ void InitGlobalLock() { }
 void GetGlobalLock() { }
 void ReleaseGlobalLock() { }
 
-void* OS_CreateThread(TThreadEntrypoint entry)
+void* OS_CreateThread(TThreadEntrypoint /*entry*/)
 {
     return 0;
 }
 
-void OS_WaitForAllThreads(void* threads, int numThreads)
+void OS_WaitForAllThreads(void* /*threads*/, int /*numThreads*/)
 {
 }
 
-void OS_Sleep(int milliseconds)
+void OS_Sleep(int /*milliseconds*/)
 {
 }
 

--- a/hlsl/hlslParseables.cpp
+++ b/hlsl/hlslParseables.cpp
@@ -69,14 +69,14 @@ const char* BaseTypeName(const char argOrder, const char* scalarName, const char
 
 bool IsTextureType(const char argOrder)    { return argOrder == '%' || argOrder == '@'; }
 bool IsTextureArrayed(const char argOrder) { return argOrder == '@'; }
-bool IsTextureMS(const char /*argOrder*/)  { return false; } // TODO: ...
+// bool IsTextureMS(const char /*argOrder*/)  { return false; } // TODO: ...
 
 // Reject certain combinations that are illegal sample methods.  For example,
 // 3D arrays.
 bool IsIllegalSample(const glslang::TString& name, const char* argOrder, int dim0)
 {
     const bool isArrayed = IsTextureArrayed(*argOrder);
-    const bool isMS      = IsTextureMS(*argOrder);
+    // const bool isMS      = IsTextureMS(*argOrder);
 
     // there are no 3D arrayed textures, or 3D SampleCmp(LevelZero)
     if (dim0 == 3 && (isArrayed || name == "SampleCmp" || name == "SampleCmpLevelZero"))


### PR DESCRIPTION
This PR adds some warnings to the g++ build which are already enabled in the MSVC build, to prevent code triggering them from escaping notice.
