### PR TITLE
bump required CMake version down to 2.8.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.11)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 option(ENABLE_AMD_EXTENSIONS "Enables support of AMD-specific extensions" OFF)


### PR DESCRIPTION
There are no CMake features that require CMake > 2.8.11 and that is the version that ships on stock CentOS 7. By dropping the CMake version down to 2.8.11 we can build glslang out of the box on stock CentOS 7.