### PR TITLE
Build: C++ headers: Replace PR #366 with a more directed version.

### DIFF
--- a/OGLCompilersDLL/InitializeDll.cpp
+++ b/OGLCompilersDLL/InitializeDll.cpp
@@ -34,7 +34,7 @@
 
 #define SH_EXPORTING
 
-#include <assert.h>
+#include <cassert>
 
 #include "InitializeDll.h"
 #include "../glslang/Include/InitializeGlobals.h"

--- a/SPIRV/SPVRemapper.h
+++ b/SPIRV/SPVRemapper.h
@@ -38,7 +38,7 @@
 
 #include <string>
 #include <vector>
-#include <stdlib.h>
+#include <cstdlib>
 
 namespace spv {
 
@@ -74,7 +74,7 @@ public:
 } // namespace SPV
 
 #if !defined (use_cpp11)
-#include <stdio.h>
+#include <cstdio>
 
 namespace spv {
 class spirvbin_t : public spirvbin_base_t

--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -38,8 +38,8 @@
 // SpvBuilder.h.
 //
 
-#include <assert.h>
-#include <stdlib.h>
+#include <cassert>
+#include <cstdlib>
 
 #include <unordered_set>
 #include <algorithm>

--- a/SPIRV/disassemble.cpp
+++ b/SPIRV/disassemble.cpp
@@ -36,9 +36,9 @@
 // Disassembler for SPIR-V.
 //
 
-#include <stdlib.h>
-#include <string.h>
-#include <assert.h>
+#include <cstdlib>
+#include <cstring>
+#include <cassert>
 #include <iomanip>
 #include <stack>
 #include <sstream>

--- a/SPIRV/doc.cpp
+++ b/SPIRV/doc.cpp
@@ -33,7 +33,7 @@
 //POSSIBILITY OF SUCH DAMAGE.
 
 //
-// 1) Programatically fill in instruction/operand information.
+// 1) Programmatically fill in instruction/operand information.
 //    This can be used for disassembly, printing documentation, etc.
 //
 // 2) Print documentation from this parameterization.
@@ -41,8 +41,8 @@
 
 #include "doc.h"
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <algorithm>
 
 #ifdef AMD_EXTENSIONS

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -46,9 +46,9 @@
 #include "../SPIRV/GLSL.std.450.h"
 #include "../SPIRV/doc.h"
 #include "../SPIRV/disassemble.h"
-#include <string.h>
-#include <stdlib.h>
-#include <math.h>
+#include <cstring>
+#include <cstdlib>
+#include <cmath>
 
 #include "../glslang/OSDependent/osinclude.h"
 

--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -89,8 +89,8 @@ inline long long int atoll (const char* str)
 #include <list>
 #include <algorithm>
 #include <string>
-#include <stdio.h>
-#include <assert.h>
+#include <cstdio>
+#include <cassert>
 
 #include "PoolAlloc.h"
 

--- a/glslang/Include/InfoSink.h
+++ b/glslang/Include/InfoSink.h
@@ -36,7 +36,7 @@
 #define _INFOSINK_INCLUDED_
 
 #include "../Include/Common.h"
-#include <math.h>
+#include <cmath>
 
 namespace glslang {
 

--- a/glslang/Include/PoolAlloc.h
+++ b/glslang/Include/PoolAlloc.h
@@ -61,13 +61,13 @@
 // class as the allocator (second) template argument.
 //
 
-#include <stddef.h>
-#include <string.h>
+#include <cstddef>
+#include <cstring>
 #include <vector>
 
 namespace glslang {
 
-// If we are using guard blocks, we must track each indivual
+// If we are using guard blocks, we must track each individual
 // allocation.  If we aren't using guard blocks, these
 // never get instantiated, so won't have any impact.
 // 

--- a/glslang/Include/revision.h
+++ b/glslang/Include/revision.h
@@ -2,5 +2,5 @@
 // For the version, it uses the latest git tag followed by the number of commits.
 // For the date, it uses the current date (when then script is run).
 
-#define GLSLANG_REVISION "SPIRV99.1383"
-#define GLSLANG_DATE "04-Aug-2016"
+#define GLSLANG_REVISION "SPIRV99.1384"
+#define GLSLANG_DATE "05-Aug-2016"

--- a/glslang/MachineIndependent/InfoSink.cpp
+++ b/glslang/MachineIndependent/InfoSink.cpp
@@ -34,7 +34,7 @@
 
 #include "../Include/InfoSink.h"
 
-#include <string.h>
+#include <cstring>
 
 namespace glslang {
 

--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -44,7 +44,7 @@
 #include "SymbolTable.h"
 #include "propagateNoContraction.h"
 
-#include <float.h>
+#include <cfloat>
 
 namespace glslang {
 

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -39,7 +39,7 @@
 #include "Scan.h"
 
 #include "../OSDependent/osinclude.h"
-#include <stdarg.h>
+#include <cstdarg>
 #include <algorithm>
 
 #include "preprocessor/PpContext.h"

--- a/glslang/MachineIndependent/Scan.cpp
+++ b/glslang/MachineIndependent/Scan.cpp
@@ -38,7 +38,7 @@
 // GLSL scanning, leveraging the scanning done by the preprocessor.
 //
 
-#include <string.h>
+#include <cstring>
 #include <unordered_map>
 #include <unordered_set>
 

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -41,7 +41,7 @@
 // This is the platform independent interface between an OGL driver
 // and the shading language compiler/linker.
 //
-#include <string.h>
+#include <cstring>
 #include <iostream>
 #include <sstream>
 #include <memory>

--- a/glslang/MachineIndependent/intermOut.cpp
+++ b/glslang/MachineIndependent/intermOut.cpp
@@ -38,11 +38,9 @@
 #include "../Include/InfoSink.h"
 
 #ifdef _MSC_VER
-#include <float.h>
-#elif defined __ANDROID__ || defined __linux__ || __MINGW32__ || __MINGW64__
-#include <cmath>
+#include <cfloat>
 #else
-#include <math.h>
+#include <cmath>
 #endif
 
 namespace {
@@ -50,10 +48,8 @@ namespace {
 bool is_positive_infinity(double x) {
 #ifdef _MSC_VER
   return _fpclass(x) == _FPCLASS_PINF;
-#elif defined __ANDROID__ || defined __linux__ || __MINGW32__ || __MINGW64__
-  return std::isinf(x) && (x >= 0);
 #else
-  return isinf(x) && (x >= 0);
+  return std::isinf(x) && (x >= 0);
 #endif
 }
 

--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
+++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
@@ -81,12 +81,10 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define _CRT_SECURE_NO_WARNINGS
 
-#include <stdarg.h>
-#include <stdio.h>
 #include <sstream>
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
+#include <cstdlib>
+#include <cstring>
+#include <cctype>
 
 #include "PpContext.h"
 #include "PpTokens.h"

--- a/glslang/MachineIndependent/preprocessor/PpAtom.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpAtom.cpp
@@ -82,10 +82,9 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define _CRT_SECURE_NO_WARNINGS
 
-#include <assert.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
 
 #include "PpContext.h"
 #include "PpTokens.h"

--- a/glslang/MachineIndependent/preprocessor/PpContext.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpContext.cpp
@@ -76,8 +76,7 @@ TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY OR OTHERWISE, EVEN IF
 NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \****************************************************************************/
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdlib>
 
 #include "PpContext.h"
 

--- a/glslang/MachineIndependent/preprocessor/PpMemory.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpMemory.cpp
@@ -76,10 +76,9 @@ TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY OR OTHERWISE, EVEN IF
 NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \****************************************************************************/
 
-#include <stddef.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
 
 #include "PpContext.h"
 

--- a/glslang/MachineIndependent/preprocessor/PpScanner.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpScanner.cpp
@@ -81,10 +81,8 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define _CRT_SECURE_NO_WARNINGS
 
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 
 #include "PpContext.h"
 #include "PpTokens.h"

--- a/glslang/MachineIndependent/preprocessor/PpSymbols.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpSymbols.cpp
@@ -79,10 +79,9 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // symbols.c
 //
 
-#include <assert.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
 
 #include "PpContext.h"
 

--- a/glslang/MachineIndependent/preprocessor/PpTokens.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpTokens.cpp
@@ -85,11 +85,10 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define snprintf sprintf_s
 #endif
 
-#include <assert.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <cctype>
 
 #include "PpContext.h"
 #include "PpTokens.h"

--- a/glslang/OSDependent/Windows/ossource.cpp
+++ b/glslang/OSDependent/Windows/ossource.cpp
@@ -37,14 +37,14 @@
 #define STRICT
 #define VC_EXTRALEAN 1
 #include <windows.h>
-#include <assert.h>
+#include <cassert>
 #include <process.h>
 #include <psapi.h>
-#include <stdio.h>
-#include <stdint.h>
+#include <cstdio>
+#include <cstdint>
 
 //
-// This file contains contains the Window-OS-specific functions
+// This file contains the Window-OS-specific functions
 //
 
 #if !(defined(_WIN32) || defined(_WIN64))

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -37,7 +37,7 @@
 #include "../Include/ResourceLimits.h"
 #include "../MachineIndependent/Versions.h"
 
-#include <string.h>
+#include <cstring>
 
 #ifdef _WIN32
 #define C_DECL __cdecl

--- a/gtests/TestFixture.h
+++ b/gtests/TestFixture.h
@@ -35,7 +35,7 @@
 #ifndef GLSLANG_GTESTS_TEST_FIXTURE_H
 #define GLSLANG_GTESTS_TEST_FIXTURE_H
 
-#include <stdint.h>
+#include <cstdint>
 #include <fstream>
 #include <sstream>
 #include <streambuf>

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -43,7 +43,7 @@
 
 #include "../glslang/OSDependent/osinclude.h"
 
-#include <stdarg.h>
+#include <cstdarg>
 #include <algorithm>
 
 namespace glslang {

--- a/hlsl/hlslScanContext.cpp
+++ b/hlsl/hlslScanContext.cpp
@@ -38,7 +38,7 @@
 // HLSL scanning, leveraging the scanning done by the preprocessor.
 //
 
-#include <string.h>
+#include <cstring>
 #include <unordered_map>
 #include <unordered_set>
 


### PR DESCRIPTION
Replace PR #366 with a more directed version.

It's mostly a more conservative change, but does take a risk in reducing headers in a few places that don't seem to need them.  Will see how they build on different systems, then pull.
