### PR TITLE
Allowing explicit specification of shader compiltion type via -T opti…

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -155,6 +155,7 @@ int Options = 0;
 const char* ExecutableName = nullptr;
 const char* binaryFileName = nullptr;
 const char* entryPointName = nullptr;
+const char* shaderTargetName = nullptr;
 
 //
 // Create the default name for saving a binary if -o is not provided.
@@ -236,6 +237,15 @@ void ProcessArguments(int argc, char* argv[])
                 Options |= EOptionVulkanRules;
                 Options |= EOptionLinkProgram;
                 break;
+            case 'T':
+                shaderTargetName = argv[1];
+                if (argc > 0) {
+                    argc--;
+                    argv++;
+                }
+                else
+                    Error("no <target> specified for -T");
+                break;
             case 'G':
                 Options |= EOptionSpv;
                 Options |= EOptionLinkProgram;
@@ -260,6 +270,7 @@ void ProcessArguments(int argc, char* argv[])
             case 'e':
                 // HLSL todo: entry point handle needs much more sophistication.
                 // This is okay for one compilation unit with one entry point.
+                // dankbaker - not sure it needs to be, fxc has no more sophistication then this
                 entryPointName = argv[1];
                 if (argc > 0) {
                     argc--;
@@ -685,6 +696,9 @@ EShLanguage FindLanguage(const std::string& name)
     }
 
     std::string suffix = name.substr(ext + 1, std::string::npos);
+    if (shaderTargetName)
+        suffix = shaderTargetName;
+
     if (suffix == "vert")
         return EShLangVertex;
     else if (suffix == "tesc")
@@ -778,6 +792,8 @@ void usage()
            "  -H          print human readable form of SPIR-V; turns on -V\n"
            "  -E          print pre-processed GLSL; cannot be used with -l;\n"
            "              errors will appear on stderr.\n"
+           "  -T <target> uses explicit target specified, rather then the file extension.\n"
+           "              valid choices are vert,tesc, tese,geom, rag,comp\n"
            "  -c          configuration dump;\n"
            "              creates the default configuration file (redirect to a .conf file)\n"
            "  -C          cascading errors; risks crashes from accumulation of error recoveries\n"

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -155,7 +155,7 @@ int Options = 0;
 const char* ExecutableName = nullptr;
 const char* binaryFileName = nullptr;
 const char* entryPointName = nullptr;
-const char* shaderTargetName = nullptr;
+const char* shaderStageName = nullptr;
 
 //
 // Create the default name for saving a binary if -o is not provided.
@@ -238,7 +238,7 @@ void ProcessArguments(int argc, char* argv[])
                 Options |= EOptionLinkProgram;
                 break;
             case 'T':
-                shaderTargetName = argv[1];
+                shaderStageName = argv[1];
                 if (argc > 0) {
                     argc--;
                     argv++;
@@ -696,8 +696,8 @@ EShLanguage FindLanguage(const std::string& name)
     }
 
     std::string suffix = name.substr(ext + 1, std::string::npos);
-    if (shaderTargetName)
-        suffix = shaderTargetName;
+    if (shaderStageName)
+        suffix = shaderStageName;
 
     if (suffix == "vert")
         return EShLangVertex;
@@ -792,7 +792,7 @@ void usage()
            "  -H          print human readable form of SPIR-V; turns on -V\n"
            "  -E          print pre-processed GLSL; cannot be used with -l;\n"
            "              errors will appear on stderr.\n"
-           "  -T <target> uses explicit target specified, rather then the file extension.\n"
+           "  -S <stage>  uses explicit stage specified, rather then the file extension.\n"
            "              valid choices are vert,tesc, tese,geom, rag,comp\n"
            "  -c          configuration dump;\n"
            "              creates the default configuration file (redirect to a .conf file)\n"

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -237,14 +237,14 @@ void ProcessArguments(int argc, char* argv[])
                 Options |= EOptionVulkanRules;
                 Options |= EOptionLinkProgram;
                 break;
-            case 'T':
+            case 'S':
                 shaderStageName = argv[1];
                 if (argc > 0) {
                     argc--;
                     argv++;
                 }
                 else
-                    Error("no <stage> specified for -T");
+                    Error("no <stage> specified for -S");
                 break;
             case 'G':
                 Options |= EOptionSpv;

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -244,7 +244,7 @@ void ProcessArguments(int argc, char* argv[])
                     argv++;
                 }
                 else
-                    Error("no <target> specified for -T");
+                    Error("no <stage> specified for -T");
                 break;
             case 'G':
                 Options |= EOptionSpv;
@@ -270,7 +270,6 @@ void ProcessArguments(int argc, char* argv[])
             case 'e':
                 // HLSL todo: entry point handle needs much more sophistication.
                 // This is okay for one compilation unit with one entry point.
-                // dankbaker - not sure it needs to be, fxc has no more sophistication then this
                 entryPointName = argv[1];
                 if (argc > 0) {
                     argc--;
@@ -793,7 +792,7 @@ void usage()
            "  -E          print pre-processed GLSL; cannot be used with -l;\n"
            "              errors will appear on stderr.\n"
            "  -S <stage>  uses explicit stage specified, rather then the file extension.\n"
-           "              valid choices are vert,tesc, tese,geom, rag,comp\n"
+           "              valid choices are vert, tesc, tese, geom, frag, or comp\n"
            "  -c          configuration dump;\n"
            "              creates the default configuration file (redirect to a .conf file)\n"
            "  -C          cascading errors; risks crashes from accumulation of error recoveries\n"


### PR DESCRIPTION
…on, rather then looking at file extension. For HLSL files, this is nice because .hlsl extension is natively udnerstood by visual studio, likely to be used with the -e option.