### PR TITLE
HLSL: Put all intrinsics in common stage symbol table

### DIFF
--- a/Test/baseResults/hlsl.intrinsics.negative.comp.out
+++ b/Test/baseResults/hlsl.intrinsics.negative.comp.out
@@ -1,157 +1,7 @@
 hlsl.intrinsics.negative.comp
-ERROR: 0:7: 'asdouble' : no matching overloaded function found 
-ERROR: 0:8: 'CheckAccessFullyMapped' : no matching overloaded function found 
-ERROR: 0:9: 'clip' : no matching overloaded function found 
-ERROR: 0:10: 'countbits' : no matching overloaded function found 
-ERROR: 0:11: 'cross' : no matching overloaded function found 
-ERROR: 0:12: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
-ERROR: 0:13: 'ddx' : no matching overloaded function found 
-ERROR: 0:14: 'ddx_coarse' : no matching overloaded function found 
-ERROR: 0:15: 'ddx_fine' : no matching overloaded function found 
-ERROR: 0:16: 'ddy' : no matching overloaded function found 
-ERROR: 0:17: 'ddy_coarse' : no matching overloaded function found 
-ERROR: 0:18: 'ddy_fine' : no matching overloaded function found 
-ERROR: 0:19: 'determinant' : no matching overloaded function found 
-ERROR: 0:20: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
-ERROR: 0:21: 'EvaluateAttributeAtSample' : no matching overloaded function found 
-ERROR: 0:22: 'EvaluateAttributeSnapped' : no matching overloaded function found 
-ERROR: 0:23: 'f16tof32' : no matching overloaded function found 
-ERROR: 0:24: 'firstbithigh' : no matching overloaded function found 
-ERROR: 0:25: 'firstbitlow' : no matching overloaded function found 
-ERROR: 0:27: 'fwidth' : no matching overloaded function found 
-ERROR: 0:28: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:29: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:30: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:31: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:32: 'InterlockedCompareExchange' : no matching overloaded function found 
-ERROR: 0:33: 'InterlockedExchange' : no matching overloaded function found 
-ERROR: 0:34: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:35: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:36: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:37: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:38: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:39: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:40: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:41: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:42: 'length' : no matching overloaded function found 
-ERROR: 0:43: 'msad4' : no matching overloaded function found 
-ERROR: 0:44: 'normalize' : no matching overloaded function found 
-ERROR: 0:45: 'reflect' : no matching overloaded function found 
-ERROR: 0:46: 'refract' : no matching overloaded function found 
-ERROR: 0:47: 'refract' : no matching overloaded function found 
-ERROR: 0:48: 'reversebits' : no matching overloaded function found 
-ERROR: 0:49: 'transpose' : no matching overloaded function found 
-ERROR: 0:60: 'GetRenderTargetSamplePosition' : no matching overloaded function found 
-ERROR: 0:69: 'asdouble' : no matching overloaded function found 
-ERROR: 0:70: 'CheckAccessFullyMapped' : no matching overloaded function found 
-ERROR: 0:71: 'countbits' : no matching overloaded function found 
-ERROR: 0:72: 'cross' : no matching overloaded function found 
-ERROR: 0:73: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
-ERROR: 0:74: 'ddx' : no matching overloaded function found 
-ERROR: 0:75: 'ddx_coarse' : no matching overloaded function found 
-ERROR: 0:76: 'ddx_fine' : no matching overloaded function found 
-ERROR: 0:77: 'ddy' : no matching overloaded function found 
-ERROR: 0:78: 'ddy_coarse' : no matching overloaded function found 
-ERROR: 0:79: 'ddy_fine' : no matching overloaded function found 
-ERROR: 0:80: 'determinant' : no matching overloaded function found 
-ERROR: 0:81: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
-ERROR: 0:82: 'EvaluateAttributeAtSample' : no matching overloaded function found 
-ERROR: 0:83: 'EvaluateAttributeSnapped' : no matching overloaded function found 
-ERROR: 0:84: 'f16tof32' : no matching overloaded function found 
-ERROR: 0:85: 'firstbithigh' : no matching overloaded function found 
-ERROR: 0:86: 'firstbitlow' : no matching overloaded function found 
-ERROR: 0:88: 'fwidth' : no matching overloaded function found 
-ERROR: 0:89: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:90: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:91: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:92: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:93: 'InterlockedCompareExchange' : no matching overloaded function found 
-ERROR: 0:94: 'InterlockedExchange' : no matching overloaded function found 
-ERROR: 0:95: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:96: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:97: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:98: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:99: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:100: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:101: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:102: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:103: 'noise' : no matching overloaded function found 
-ERROR: 0:104: 'reversebits' : no matching overloaded function found 
-ERROR: 0:105: 'transpose' : no matching overloaded function found 
-ERROR: 0:116: 'CheckAccessFullyMapped' : no matching overloaded function found 
-ERROR: 0:117: 'countbits' : no matching overloaded function found 
-ERROR: 0:118: 'ddx' : no matching overloaded function found 
-ERROR: 0:119: 'ddx_coarse' : no matching overloaded function found 
-ERROR: 0:120: 'ddx_fine' : no matching overloaded function found 
-ERROR: 0:121: 'ddy' : no matching overloaded function found 
-ERROR: 0:122: 'ddy_coarse' : no matching overloaded function found 
-ERROR: 0:123: 'ddy_fine' : no matching overloaded function found 
-ERROR: 0:124: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
-ERROR: 0:125: 'determinant' : no matching overloaded function found 
-ERROR: 0:126: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
-ERROR: 0:127: 'EvaluateAttributeAtSample' : no matching overloaded function found 
-ERROR: 0:128: 'EvaluateAttributeSnapped' : no matching overloaded function found 
-ERROR: 0:129: 'f16tof32' : no matching overloaded function found 
-ERROR: 0:130: 'firstbithigh' : no matching overloaded function found 
-ERROR: 0:131: 'firstbitlow' : no matching overloaded function found 
-ERROR: 0:133: 'fwidth' : no matching overloaded function found 
-ERROR: 0:134: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:135: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:136: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:137: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:138: 'InterlockedCompareExchange' : no matching overloaded function found 
-ERROR: 0:139: 'InterlockedExchange' : no matching overloaded function found 
-ERROR: 0:140: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:141: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:142: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:143: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:144: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:145: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:146: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:147: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:148: 'noise' : no matching overloaded function found 
-ERROR: 0:149: 'reversebits' : no matching overloaded function found 
-ERROR: 0:150: 'transpose' : no matching overloaded function found 
-ERROR: 0:161: 'CheckAccessFullyMapped' : no matching overloaded function found 
-ERROR: 0:162: 'countbits' : no matching overloaded function found 
-ERROR: 0:163: 'cross' : no matching overloaded function found 
-ERROR: 0:164: 'determinant' : no matching overloaded function found 
-ERROR: 0:165: 'ddx' : no matching overloaded function found 
-ERROR: 0:166: 'ddx_coarse' : no matching overloaded function found 
-ERROR: 0:167: 'ddx_fine' : no matching overloaded function found 
-ERROR: 0:168: 'ddy' : no matching overloaded function found 
-ERROR: 0:169: 'ddy_coarse' : no matching overloaded function found 
-ERROR: 0:170: 'ddy_fine' : no matching overloaded function found 
-ERROR: 0:171: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
-ERROR: 0:172: 'EvaluateAttributeAtSample' : no matching overloaded function found 
-ERROR: 0:173: 'EvaluateAttributeSnapped' : no matching overloaded function found 
-ERROR: 0:174: 'f16tof32' : no matching overloaded function found 
-ERROR: 0:175: 'firstbithigh' : no matching overloaded function found 
-ERROR: 0:176: 'firstbitlow' : no matching overloaded function found 
-ERROR: 0:178: 'fwidth' : no matching overloaded function found 
-ERROR: 0:179: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:180: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:181: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:182: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:183: 'InterlockedCompareExchange' : no matching overloaded function found 
-ERROR: 0:184: 'InterlockedExchange' : no matching overloaded function found 
-ERROR: 0:185: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:186: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:187: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:188: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:189: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:190: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:191: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:192: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:193: 'noise' : no matching overloaded function found 
-ERROR: 0:194: 'reversebits' : no matching overloaded function found 
-ERROR: 0:195: 'transpose' : no matching overloaded function found 
-ERROR: 147 compilation errors.  No code generated.
-
-
 Shader version: 450
 local_size = (1, 1, 1)
-ERROR: node is still EOpNull!
+0:? Sequence
 0:56  Function Definition: ComputeShaderFunctionS(f1;f1;f1;i1; (global float)
 0:2    Function Parameters: 
 0:2      'inF0' (in float)
@@ -159,90 +9,6 @@ ERROR: node is still EOpNull!
 0:2      'inF2' (in float)
 0:2      'inI0' (in int)
 0:?     Sequence
-0:7      Constant:
-0:7        0.000000
-0:8      Constant:
-0:8        0.000000
-0:9      Constant:
-0:9        0.000000
-0:10      Constant:
-0:10        0.000000
-0:11      Constant:
-0:11        0.000000
-0:12      Constant:
-0:12        0.000000
-0:13      Constant:
-0:13        0.000000
-0:14      Constant:
-0:14        0.000000
-0:15      Constant:
-0:15        0.000000
-0:16      Constant:
-0:16        0.000000
-0:17      Constant:
-0:17        0.000000
-0:18      Constant:
-0:18        0.000000
-0:19      Constant:
-0:19        0.000000
-0:20      Constant:
-0:20        0.000000
-0:21      Constant:
-0:21        0.000000
-0:22      Constant:
-0:22        0.000000
-0:23      Constant:
-0:23        0.000000
-0:24      Constant:
-0:24        0.000000
-0:25      Constant:
-0:25        0.000000
-0:27      Constant:
-0:27        0.000000
-0:28      Constant:
-0:28        0.000000
-0:29      Constant:
-0:29        0.000000
-0:30      Constant:
-0:30        0.000000
-0:31      Constant:
-0:31        0.000000
-0:32      Constant:
-0:32        0.000000
-0:33      Constant:
-0:33        0.000000
-0:34      Constant:
-0:34        0.000000
-0:35      Constant:
-0:35        0.000000
-0:36      Constant:
-0:36        0.000000
-0:37      Constant:
-0:37        0.000000
-0:38      Constant:
-0:38        0.000000
-0:39      Constant:
-0:39        0.000000
-0:40      Constant:
-0:40        0.000000
-0:41      Constant:
-0:41        0.000000
-0:42      Constant:
-0:42        0.000000
-0:43      Constant:
-0:43        0.000000
-0:44      Constant:
-0:44        0.000000
-0:45      Constant:
-0:45        0.000000
-0:46      Constant:
-0:46        0.000000
-0:47      Constant:
-0:47        0.000000
-0:48      Constant:
-0:48        0.000000
-0:49      Constant:
-0:49        0.000000
 0:53      Branch: Return with expression
 0:53        Constant:
 0:53          0.000000
@@ -253,8 +19,6 @@ ERROR: node is still EOpNull!
 0:57      'inF2' (in 1-component vector of float)
 0:57      'inI0' (in 1-component vector of int)
 0:?     Sequence
-0:60      Constant:
-0:60        0.000000
 0:62      Branch: Return with expression
 0:62        Constant:
 0:62          0.000000
@@ -265,78 +29,6 @@ ERROR: node is still EOpNull!
 0:66      'inF2' (in 2-component vector of float)
 0:66      'inI0' (in 2-component vector of int)
 0:?     Sequence
-0:69      Constant:
-0:69        0.000000
-0:70      Constant:
-0:70        0.000000
-0:71      Constant:
-0:71        0.000000
-0:72      Constant:
-0:72        0.000000
-0:73      Constant:
-0:73        0.000000
-0:74      Constant:
-0:74        0.000000
-0:75      Constant:
-0:75        0.000000
-0:76      Constant:
-0:76        0.000000
-0:77      Constant:
-0:77        0.000000
-0:78      Constant:
-0:78        0.000000
-0:79      Constant:
-0:79        0.000000
-0:80      Constant:
-0:80        0.000000
-0:81      Constant:
-0:81        0.000000
-0:82      Constant:
-0:82        0.000000
-0:83      Constant:
-0:83        0.000000
-0:84      Constant:
-0:84        0.000000
-0:85      Constant:
-0:85        0.000000
-0:86      Constant:
-0:86        0.000000
-0:88      Constant:
-0:88        0.000000
-0:89      Constant:
-0:89        0.000000
-0:90      Constant:
-0:90        0.000000
-0:91      Constant:
-0:91        0.000000
-0:92      Constant:
-0:92        0.000000
-0:93      Constant:
-0:93        0.000000
-0:94      Constant:
-0:94        0.000000
-0:95      Constant:
-0:95        0.000000
-0:96      Constant:
-0:96        0.000000
-0:97      Constant:
-0:97        0.000000
-0:98      Constant:
-0:98        0.000000
-0:99      Constant:
-0:99        0.000000
-0:100      Constant:
-0:100        0.000000
-0:101      Constant:
-0:101        0.000000
-0:102      Constant:
-0:102        0.000000
-0:103      Constant:
-0:103        0.000000
-0:104      Constant:
-0:104        0.000000
-0:105      Constant:
-0:105        0.000000
 0:109      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
@@ -348,74 +40,6 @@ ERROR: node is still EOpNull!
 0:113      'inF2' (in 3-component vector of float)
 0:113      'inI0' (in 3-component vector of int)
 0:?     Sequence
-0:116      Constant:
-0:116        0.000000
-0:117      Constant:
-0:117        0.000000
-0:118      Constant:
-0:118        0.000000
-0:119      Constant:
-0:119        0.000000
-0:120      Constant:
-0:120        0.000000
-0:121      Constant:
-0:121        0.000000
-0:122      Constant:
-0:122        0.000000
-0:123      Constant:
-0:123        0.000000
-0:124      Constant:
-0:124        0.000000
-0:125      Constant:
-0:125        0.000000
-0:126      Constant:
-0:126        0.000000
-0:127      Constant:
-0:127        0.000000
-0:128      Constant:
-0:128        0.000000
-0:129      Constant:
-0:129        0.000000
-0:130      Constant:
-0:130        0.000000
-0:131      Constant:
-0:131        0.000000
-0:133      Constant:
-0:133        0.000000
-0:134      Constant:
-0:134        0.000000
-0:135      Constant:
-0:135        0.000000
-0:136      Constant:
-0:136        0.000000
-0:137      Constant:
-0:137        0.000000
-0:138      Constant:
-0:138        0.000000
-0:139      Constant:
-0:139        0.000000
-0:140      Constant:
-0:140        0.000000
-0:141      Constant:
-0:141        0.000000
-0:142      Constant:
-0:142        0.000000
-0:143      Constant:
-0:143        0.000000
-0:144      Constant:
-0:144        0.000000
-0:145      Constant:
-0:145        0.000000
-0:146      Constant:
-0:146        0.000000
-0:147      Constant:
-0:147        0.000000
-0:148      Constant:
-0:148        0.000000
-0:149      Constant:
-0:149        0.000000
-0:150      Constant:
-0:150        0.000000
 0:154      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
@@ -428,74 +52,6 @@ ERROR: node is still EOpNull!
 0:158      'inF2' (in 4-component vector of float)
 0:158      'inI0' (in 4-component vector of int)
 0:?     Sequence
-0:161      Constant:
-0:161        0.000000
-0:162      Constant:
-0:162        0.000000
-0:163      Constant:
-0:163        0.000000
-0:164      Constant:
-0:164        0.000000
-0:165      Constant:
-0:165        0.000000
-0:166      Constant:
-0:166        0.000000
-0:167      Constant:
-0:167        0.000000
-0:168      Constant:
-0:168        0.000000
-0:169      Constant:
-0:169        0.000000
-0:170      Constant:
-0:170        0.000000
-0:171      Constant:
-0:171        0.000000
-0:172      Constant:
-0:172        0.000000
-0:173      Constant:
-0:173        0.000000
-0:174      Constant:
-0:174        0.000000
-0:175      Constant:
-0:175        0.000000
-0:176      Constant:
-0:176        0.000000
-0:178      Constant:
-0:178        0.000000
-0:179      Constant:
-0:179        0.000000
-0:180      Constant:
-0:180        0.000000
-0:181      Constant:
-0:181        0.000000
-0:182      Constant:
-0:182        0.000000
-0:183      Constant:
-0:183        0.000000
-0:184      Constant:
-0:184        0.000000
-0:185      Constant:
-0:185        0.000000
-0:186      Constant:
-0:186        0.000000
-0:187      Constant:
-0:187        0.000000
-0:188      Constant:
-0:188        0.000000
-0:189      Constant:
-0:189        0.000000
-0:190      Constant:
-0:190        0.000000
-0:191      Constant:
-0:191        0.000000
-0:192      Constant:
-0:192        0.000000
-0:193      Constant:
-0:193        0.000000
-0:194      Constant:
-0:194        0.000000
-0:195      Constant:
-0:195        0.000000
 0:199      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
@@ -510,7 +66,7 @@ Linked compute stage:
 
 Shader version: 450
 local_size = (1, 1, 1)
-ERROR: node is still EOpNull!
+0:? Sequence
 0:56  Function Definition: ComputeShaderFunctionS(f1;f1;f1;i1; (global float)
 0:2    Function Parameters: 
 0:2      'inF0' (in float)
@@ -518,90 +74,6 @@ ERROR: node is still EOpNull!
 0:2      'inF2' (in float)
 0:2      'inI0' (in int)
 0:?     Sequence
-0:7      Constant:
-0:7        0.000000
-0:8      Constant:
-0:8        0.000000
-0:9      Constant:
-0:9        0.000000
-0:10      Constant:
-0:10        0.000000
-0:11      Constant:
-0:11        0.000000
-0:12      Constant:
-0:12        0.000000
-0:13      Constant:
-0:13        0.000000
-0:14      Constant:
-0:14        0.000000
-0:15      Constant:
-0:15        0.000000
-0:16      Constant:
-0:16        0.000000
-0:17      Constant:
-0:17        0.000000
-0:18      Constant:
-0:18        0.000000
-0:19      Constant:
-0:19        0.000000
-0:20      Constant:
-0:20        0.000000
-0:21      Constant:
-0:21        0.000000
-0:22      Constant:
-0:22        0.000000
-0:23      Constant:
-0:23        0.000000
-0:24      Constant:
-0:24        0.000000
-0:25      Constant:
-0:25        0.000000
-0:27      Constant:
-0:27        0.000000
-0:28      Constant:
-0:28        0.000000
-0:29      Constant:
-0:29        0.000000
-0:30      Constant:
-0:30        0.000000
-0:31      Constant:
-0:31        0.000000
-0:32      Constant:
-0:32        0.000000
-0:33      Constant:
-0:33        0.000000
-0:34      Constant:
-0:34        0.000000
-0:35      Constant:
-0:35        0.000000
-0:36      Constant:
-0:36        0.000000
-0:37      Constant:
-0:37        0.000000
-0:38      Constant:
-0:38        0.000000
-0:39      Constant:
-0:39        0.000000
-0:40      Constant:
-0:40        0.000000
-0:41      Constant:
-0:41        0.000000
-0:42      Constant:
-0:42        0.000000
-0:43      Constant:
-0:43        0.000000
-0:44      Constant:
-0:44        0.000000
-0:45      Constant:
-0:45        0.000000
-0:46      Constant:
-0:46        0.000000
-0:47      Constant:
-0:47        0.000000
-0:48      Constant:
-0:48        0.000000
-0:49      Constant:
-0:49        0.000000
 0:53      Branch: Return with expression
 0:53        Constant:
 0:53          0.000000
@@ -612,8 +84,6 @@ ERROR: node is still EOpNull!
 0:57      'inF2' (in 1-component vector of float)
 0:57      'inI0' (in 1-component vector of int)
 0:?     Sequence
-0:60      Constant:
-0:60        0.000000
 0:62      Branch: Return with expression
 0:62        Constant:
 0:62          0.000000
@@ -624,78 +94,6 @@ ERROR: node is still EOpNull!
 0:66      'inF2' (in 2-component vector of float)
 0:66      'inI0' (in 2-component vector of int)
 0:?     Sequence
-0:69      Constant:
-0:69        0.000000
-0:70      Constant:
-0:70        0.000000
-0:71      Constant:
-0:71        0.000000
-0:72      Constant:
-0:72        0.000000
-0:73      Constant:
-0:73        0.000000
-0:74      Constant:
-0:74        0.000000
-0:75      Constant:
-0:75        0.000000
-0:76      Constant:
-0:76        0.000000
-0:77      Constant:
-0:77        0.000000
-0:78      Constant:
-0:78        0.000000
-0:79      Constant:
-0:79        0.000000
-0:80      Constant:
-0:80        0.000000
-0:81      Constant:
-0:81        0.000000
-0:82      Constant:
-0:82        0.000000
-0:83      Constant:
-0:83        0.000000
-0:84      Constant:
-0:84        0.000000
-0:85      Constant:
-0:85        0.000000
-0:86      Constant:
-0:86        0.000000
-0:88      Constant:
-0:88        0.000000
-0:89      Constant:
-0:89        0.000000
-0:90      Constant:
-0:90        0.000000
-0:91      Constant:
-0:91        0.000000
-0:92      Constant:
-0:92        0.000000
-0:93      Constant:
-0:93        0.000000
-0:94      Constant:
-0:94        0.000000
-0:95      Constant:
-0:95        0.000000
-0:96      Constant:
-0:96        0.000000
-0:97      Constant:
-0:97        0.000000
-0:98      Constant:
-0:98        0.000000
-0:99      Constant:
-0:99        0.000000
-0:100      Constant:
-0:100        0.000000
-0:101      Constant:
-0:101        0.000000
-0:102      Constant:
-0:102        0.000000
-0:103      Constant:
-0:103        0.000000
-0:104      Constant:
-0:104        0.000000
-0:105      Constant:
-0:105        0.000000
 0:109      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
@@ -707,74 +105,6 @@ ERROR: node is still EOpNull!
 0:113      'inF2' (in 3-component vector of float)
 0:113      'inI0' (in 3-component vector of int)
 0:?     Sequence
-0:116      Constant:
-0:116        0.000000
-0:117      Constant:
-0:117        0.000000
-0:118      Constant:
-0:118        0.000000
-0:119      Constant:
-0:119        0.000000
-0:120      Constant:
-0:120        0.000000
-0:121      Constant:
-0:121        0.000000
-0:122      Constant:
-0:122        0.000000
-0:123      Constant:
-0:123        0.000000
-0:124      Constant:
-0:124        0.000000
-0:125      Constant:
-0:125        0.000000
-0:126      Constant:
-0:126        0.000000
-0:127      Constant:
-0:127        0.000000
-0:128      Constant:
-0:128        0.000000
-0:129      Constant:
-0:129        0.000000
-0:130      Constant:
-0:130        0.000000
-0:131      Constant:
-0:131        0.000000
-0:133      Constant:
-0:133        0.000000
-0:134      Constant:
-0:134        0.000000
-0:135      Constant:
-0:135        0.000000
-0:136      Constant:
-0:136        0.000000
-0:137      Constant:
-0:137        0.000000
-0:138      Constant:
-0:138        0.000000
-0:139      Constant:
-0:139        0.000000
-0:140      Constant:
-0:140        0.000000
-0:141      Constant:
-0:141        0.000000
-0:142      Constant:
-0:142        0.000000
-0:143      Constant:
-0:143        0.000000
-0:144      Constant:
-0:144        0.000000
-0:145      Constant:
-0:145        0.000000
-0:146      Constant:
-0:146        0.000000
-0:147      Constant:
-0:147        0.000000
-0:148      Constant:
-0:148        0.000000
-0:149      Constant:
-0:149        0.000000
-0:150      Constant:
-0:150        0.000000
 0:154      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
@@ -787,74 +117,6 @@ ERROR: node is still EOpNull!
 0:158      'inF2' (in 4-component vector of float)
 0:158      'inI0' (in 4-component vector of int)
 0:?     Sequence
-0:161      Constant:
-0:161        0.000000
-0:162      Constant:
-0:162        0.000000
-0:163      Constant:
-0:163        0.000000
-0:164      Constant:
-0:164        0.000000
-0:165      Constant:
-0:165        0.000000
-0:166      Constant:
-0:166        0.000000
-0:167      Constant:
-0:167        0.000000
-0:168      Constant:
-0:168        0.000000
-0:169      Constant:
-0:169        0.000000
-0:170      Constant:
-0:170        0.000000
-0:171      Constant:
-0:171        0.000000
-0:172      Constant:
-0:172        0.000000
-0:173      Constant:
-0:173        0.000000
-0:174      Constant:
-0:174        0.000000
-0:175      Constant:
-0:175        0.000000
-0:176      Constant:
-0:176        0.000000
-0:178      Constant:
-0:178        0.000000
-0:179      Constant:
-0:179        0.000000
-0:180      Constant:
-0:180        0.000000
-0:181      Constant:
-0:181        0.000000
-0:182      Constant:
-0:182        0.000000
-0:183      Constant:
-0:183        0.000000
-0:184      Constant:
-0:184        0.000000
-0:185      Constant:
-0:185        0.000000
-0:186      Constant:
-0:186        0.000000
-0:187      Constant:
-0:187        0.000000
-0:188      Constant:
-0:188        0.000000
-0:189      Constant:
-0:189        0.000000
-0:190      Constant:
-0:190        0.000000
-0:191      Constant:
-0:191        0.000000
-0:192      Constant:
-0:192        0.000000
-0:193      Constant:
-0:193        0.000000
-0:194      Constant:
-0:194        0.000000
-0:195      Constant:
-0:195        0.000000
 0:199      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
@@ -863,4 +125,96 @@ ERROR: node is still EOpNull!
 0:?           4.000000
 0:?   Linker Objects
 
-SPIR-V is not generated for failed compile or link
+// Module Version 10000
+// Generated by (magic number): 80001
+// Id's are bound by 63
+
+                              Capability Shader
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint GLCompute 4  "ComputeShaderFunction"
+                              ExecutionMode 4 LocalSize 1 1 1
+                              Source HLSL 450
+                              Name 4  "ComputeShaderFunction"
+                              Name 15  "ComputeShaderFunctionS(f1;f1;f1;i1;"
+                              Name 11  "inF0"
+                              Name 12  "inF1"
+                              Name 13  "inF2"
+                              Name 14  "inI0"
+                              Name 21  "ComputeShaderFunction1(vf1;vf1;vf1;vi1;"
+                              Name 17  "inF0"
+                              Name 18  "inF1"
+                              Name 19  "inF2"
+                              Name 20  "inI0"
+                              Name 32  "ComputeShaderFunction2(vf2;vf2;vf2;vi2;"
+                              Name 28  "inF0"
+                              Name 29  "inF1"
+                              Name 30  "inF2"
+                              Name 31  "inI0"
+                              Name 43  "ComputeShaderFunction3(vf3;vf3;vf3;vi3;"
+                              Name 39  "inF0"
+                              Name 40  "inF1"
+                              Name 41  "inF2"
+                              Name 42  "inI0"
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeFloat 32
+               7:             TypePointer Function 6(float)
+               8:             TypeInt 32 1
+               9:             TypePointer Function 8(int)
+              10:             TypeFunction 6(float) 7(ptr) 7(ptr) 7(ptr) 9(ptr)
+              23:             TypeVector 6(float) 2
+              24:             TypePointer Function 23(fvec2)
+              25:             TypeVector 8(int) 2
+              26:             TypePointer Function 25(ivec2)
+              27:             TypeFunction 23(fvec2) 24(ptr) 24(ptr) 24(ptr) 26(ptr)
+              34:             TypeVector 6(float) 3
+              35:             TypePointer Function 34(fvec3)
+              36:             TypeVector 8(int) 3
+              37:             TypePointer Function 36(ivec3)
+              38:             TypeFunction 34(fvec3) 35(ptr) 35(ptr) 35(ptr) 37(ptr)
+              45:    6(float) Constant 0
+              50:    6(float) Constant 1065353216
+              51:    6(float) Constant 1073741824
+              52:   23(fvec2) ConstantComposite 50 51
+              55:    6(float) Constant 1077936128
+              56:   34(fvec3) ConstantComposite 50 51 55
+              59:             TypeVector 6(float) 4
+              60:    6(float) Constant 1082130432
+              61:   59(fvec4) ConstantComposite 50 51 55 60
+4(ComputeShaderFunction):           2 Function None 3
+               5:             Label
+                              ReturnValue 61
+                              FunctionEnd
+15(ComputeShaderFunctionS(f1;f1;f1;i1;):    6(float) Function None 10
+        11(inF0):      7(ptr) FunctionParameter
+        12(inF1):      7(ptr) FunctionParameter
+        13(inF2):      7(ptr) FunctionParameter
+        14(inI0):      9(ptr) FunctionParameter
+              16:             Label
+                              ReturnValue 45
+                              FunctionEnd
+21(ComputeShaderFunction1(vf1;vf1;vf1;vi1;):    6(float) Function None 10
+        17(inF0):      7(ptr) FunctionParameter
+        18(inF1):      7(ptr) FunctionParameter
+        19(inF2):      7(ptr) FunctionParameter
+        20(inI0):      9(ptr) FunctionParameter
+              22:             Label
+                              ReturnValue 45
+                              FunctionEnd
+32(ComputeShaderFunction2(vf2;vf2;vf2;vi2;):   23(fvec2) Function None 27
+        28(inF0):     24(ptr) FunctionParameter
+        29(inF1):     24(ptr) FunctionParameter
+        30(inF2):     24(ptr) FunctionParameter
+        31(inI0):     26(ptr) FunctionParameter
+              33:             Label
+                              ReturnValue 52
+                              FunctionEnd
+43(ComputeShaderFunction3(vf3;vf3;vf3;vi3;):   34(fvec3) Function None 38
+        39(inF0):     35(ptr) FunctionParameter
+        40(inF1):     35(ptr) FunctionParameter
+        41(inF2):     35(ptr) FunctionParameter
+        42(inI0):     37(ptr) FunctionParameter
+              44:             Label
+                              ReturnValue 56
+                              FunctionEnd

--- a/Test/baseResults/hlsl.intrinsics.negative.vert.out
+++ b/Test/baseResults/hlsl.intrinsics.negative.vert.out
@@ -1,235 +1,6 @@
 hlsl.intrinsics.negative.vert
-ERROR: 0:18: 'AllMemoryBarrier' : no matching overloaded function found 
-ERROR: 0:19: 'AllMemoryBarrierWithGroupSync' : no matching overloaded function found 
-ERROR: 0:20: 'asdouble' : no matching overloaded function found 
-ERROR: 0:21: 'CheckAccessFullyMapped' : no matching overloaded function found 
-ERROR: 0:22: 'CheckAccessFullyMapped' : no matching overloaded function found 
-ERROR: 0:23: 'clip' : no matching overloaded function found 
-ERROR: 0:24: 'countbits' : no matching overloaded function found 
-ERROR: 0:25: 'cross' : no matching overloaded function found 
-ERROR: 0:26: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
-ERROR: 0:27: 'DeviceMemoryBarrier' : no matching overloaded function found 
-ERROR: 0:28: 'DeviceMemoryBarrierWithGroupSync' : no matching overloaded function found 
-ERROR: 0:29: 'ddx' : no matching overloaded function found 
-ERROR: 0:30: 'ddx_coarse' : no matching overloaded function found 
-ERROR: 0:31: 'ddx_fine' : no matching overloaded function found 
-ERROR: 0:32: 'ddy' : no matching overloaded function found 
-ERROR: 0:33: 'ddy_coarse' : no matching overloaded function found 
-ERROR: 0:34: 'ddy_fine' : no matching overloaded function found 
-ERROR: 0:35: 'determinant' : no matching overloaded function found 
-ERROR: 0:36: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
-ERROR: 0:37: 'EvaluateAttributeAtSample' : no matching overloaded function found 
-ERROR: 0:38: 'EvaluateAttributeSnapped' : no matching overloaded function found 
-ERROR: 0:39: 'f16tof32' : no matching overloaded function found 
-ERROR: 0:40: 'firstbithigh' : no matching overloaded function found 
-ERROR: 0:41: 'firstbitlow' : no matching overloaded function found 
-ERROR: 0:43: 'fwidth' : no matching overloaded function found 
-ERROR: 0:44: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:45: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:46: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:47: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:48: 'InterlockedCompareExchange' : no matching overloaded function found 
-ERROR: 0:49: 'InterlockedExchange' : no matching overloaded function found 
-ERROR: 0:50: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:51: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:52: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:53: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:54: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:55: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:56: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:57: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:58: 'GroupMemoryBarrier' : no matching overloaded function found 
-ERROR: 0:59: 'GroupMemoryBarrierWithGroupSync' : no matching overloaded function found 
-ERROR: 0:60: 'length' : no matching overloaded function found 
-ERROR: 0:61: 'msad4' : no matching overloaded function found 
-ERROR: 0:62: 'normalize' : no matching overloaded function found 
-ERROR: 0:63: 'reflect' : no matching overloaded function found 
-ERROR: 0:64: 'refract' : no matching overloaded function found 
-ERROR: 0:65: 'refract' : no matching overloaded function found 
-ERROR: 0:66: 'reversebits' : no matching overloaded function found 
-ERROR: 0:67: 'transpose' : no matching overloaded function found 
-ERROR: 0:78: 'GetRenderTargetSamplePosition' : no matching overloaded function found 
-ERROR: 0:87: 'asdouble' : no matching overloaded function found 
-ERROR: 0:88: 'CheckAccessFullyMapped' : no matching overloaded function found 
-ERROR: 0:89: 'countbits' : no matching overloaded function found 
-ERROR: 0:90: 'cross' : no matching overloaded function found 
-ERROR: 0:91: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
-ERROR: 0:92: 'ddx' : no matching overloaded function found 
-ERROR: 0:93: 'ddx_coarse' : no matching overloaded function found 
-ERROR: 0:94: 'ddx_fine' : no matching overloaded function found 
-ERROR: 0:95: 'ddy' : no matching overloaded function found 
-ERROR: 0:96: 'ddy_coarse' : no matching overloaded function found 
-ERROR: 0:97: 'ddy_fine' : no matching overloaded function found 
-ERROR: 0:98: 'determinant' : no matching overloaded function found 
-ERROR: 0:99: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
-ERROR: 0:100: 'EvaluateAttributeAtSample' : no matching overloaded function found 
-ERROR: 0:101: 'EvaluateAttributeSnapped' : no matching overloaded function found 
-ERROR: 0:102: 'f16tof32' : no matching overloaded function found 
-ERROR: 0:103: 'firstbithigh' : no matching overloaded function found 
-ERROR: 0:104: 'firstbitlow' : no matching overloaded function found 
-ERROR: 0:106: 'fwidth' : no matching overloaded function found 
-ERROR: 0:107: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:108: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:109: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:110: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:111: 'InterlockedCompareExchange' : no matching overloaded function found 
-ERROR: 0:112: 'InterlockedExchange' : no matching overloaded function found 
-ERROR: 0:113: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:114: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:115: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:116: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:117: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:118: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:119: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:120: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:121: 'noise' : no matching overloaded function found 
-ERROR: 0:122: 'reversebits' : no matching overloaded function found 
-ERROR: 0:123: 'transpose' : no matching overloaded function found 
-ERROR: 0:134: 'CheckAccessFullyMapped' : no matching overloaded function found 
-ERROR: 0:135: 'countbits' : no matching overloaded function found 
-ERROR: 0:136: 'ddx' : no matching overloaded function found 
-ERROR: 0:137: 'ddx_coarse' : no matching overloaded function found 
-ERROR: 0:138: 'ddx_fine' : no matching overloaded function found 
-ERROR: 0:139: 'ddy' : no matching overloaded function found 
-ERROR: 0:140: 'ddy_coarse' : no matching overloaded function found 
-ERROR: 0:141: 'ddy_fine' : no matching overloaded function found 
-ERROR: 0:142: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
-ERROR: 0:143: 'determinant' : no matching overloaded function found 
-ERROR: 0:144: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
-ERROR: 0:145: 'EvaluateAttributeAtSample' : no matching overloaded function found 
-ERROR: 0:146: 'EvaluateAttributeSnapped' : no matching overloaded function found 
-ERROR: 0:147: 'f16tof32' : no matching overloaded function found 
-ERROR: 0:148: 'firstbithigh' : no matching overloaded function found 
-ERROR: 0:149: 'firstbitlow' : no matching overloaded function found 
-ERROR: 0:151: 'fwidth' : no matching overloaded function found 
-ERROR: 0:152: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:153: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:154: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:155: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:156: 'InterlockedCompareExchange' : no matching overloaded function found 
-ERROR: 0:157: 'InterlockedExchange' : no matching overloaded function found 
-ERROR: 0:158: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:159: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:160: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:161: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:162: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:163: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:164: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:165: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:166: 'noise' : no matching overloaded function found 
-ERROR: 0:167: 'reversebits' : no matching overloaded function found 
-ERROR: 0:168: 'transpose' : no matching overloaded function found 
-ERROR: 0:179: 'CheckAccessFullyMapped' : no matching overloaded function found 
-ERROR: 0:180: 'countbits' : no matching overloaded function found 
-ERROR: 0:181: 'cross' : no matching overloaded function found 
-ERROR: 0:182: 'determinant' : no matching overloaded function found 
-ERROR: 0:183: 'ddx' : no matching overloaded function found 
-ERROR: 0:184: 'ddx_coarse' : no matching overloaded function found 
-ERROR: 0:185: 'ddx_fine' : no matching overloaded function found 
-ERROR: 0:186: 'ddy' : no matching overloaded function found 
-ERROR: 0:187: 'ddy_coarse' : no matching overloaded function found 
-ERROR: 0:188: 'ddy_fine' : no matching overloaded function found 
-ERROR: 0:189: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
-ERROR: 0:190: 'EvaluateAttributeAtSample' : no matching overloaded function found 
-ERROR: 0:191: 'EvaluateAttributeSnapped' : no matching overloaded function found 
-ERROR: 0:192: 'f16tof32' : no matching overloaded function found 
-ERROR: 0:193: 'firstbithigh' : no matching overloaded function found 
-ERROR: 0:194: 'firstbitlow' : no matching overloaded function found 
-ERROR: 0:196: 'fwidth' : no matching overloaded function found 
-ERROR: 0:197: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:198: 'InterlockedAdd' : no matching overloaded function found 
-ERROR: 0:199: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:200: 'InterlockedAnd' : no matching overloaded function found 
-ERROR: 0:201: 'InterlockedCompareExchange' : no matching overloaded function found 
-ERROR: 0:202: 'InterlockedExchange' : no matching overloaded function found 
-ERROR: 0:203: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:204: 'InterlockedMax' : no matching overloaded function found 
-ERROR: 0:205: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:206: 'InterlockedMin' : no matching overloaded function found 
-ERROR: 0:207: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:208: 'InterlockedOr' : no matching overloaded function found 
-ERROR: 0:209: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:210: 'InterlockedXor' : no matching overloaded function found 
-ERROR: 0:211: 'noise' : no matching overloaded function found 
-ERROR: 0:212: 'reversebits' : no matching overloaded function found 
-ERROR: 0:213: 'transpose' : no matching overloaded function found 
-ERROR: 0:253: 'countbits' : no matching overloaded function found 
-ERROR: 0:253: 'cross' : no matching overloaded function found 
-ERROR: 0:253: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
-ERROR: 0:253: 'ddx' : no matching overloaded function found 
-ERROR: 0:253: 'ddx_coarse' : no matching overloaded function found 
-ERROR: 0:253: 'ddx_fine' : no matching overloaded function found 
-ERROR: 0:253: 'ddy' : no matching overloaded function found 
-ERROR: 0:253: 'ddy_coarse' : no matching overloaded function found 
-ERROR: 0:253: 'ddy_fine' : no matching overloaded function found 
-ERROR: 0:253: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
-ERROR: 0:253: 'EvaluateAttributeAtSample' : no matching overloaded function found 
-ERROR: 0:253: 'EvaluateAttributeSnapped' : no matching overloaded function found 
-ERROR: 0:253: 'f16tof32' : no matching overloaded function found 
-ERROR: 0:253: 'firstbithigh' : no matching overloaded function found 
-ERROR: 0:253: 'firstbitlow' : no matching overloaded function found 
-ERROR: 0:253: 'fwidth' : no matching overloaded function found 
-ERROR: 0:253: 'noise' : no matching overloaded function found 
-ERROR: 0:253: 'reversebits' : no matching overloaded function found 
-ERROR: 0:253: 'length' : no matching overloaded function found 
-ERROR: 0:253: 'noise' : no matching overloaded function found 
-ERROR: 0:253: 'normalize' : no matching overloaded function found 
-ERROR: 0:253: 'reflect' : no matching overloaded function found 
-ERROR: 0:253: 'refract' : no matching overloaded function found 
-ERROR: 0:253: 'reversebits' : no matching overloaded function found 
-ERROR: 0:261: 'countbits' : no matching overloaded function found 
-ERROR: 0:261: 'cross' : no matching overloaded function found 
-ERROR: 0:261: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
-ERROR: 0:261: 'ddx' : no matching overloaded function found 
-ERROR: 0:261: 'ddx_coarse' : no matching overloaded function found 
-ERROR: 0:261: 'ddx_fine' : no matching overloaded function found 
-ERROR: 0:261: 'ddy' : no matching overloaded function found 
-ERROR: 0:261: 'ddy_coarse' : no matching overloaded function found 
-ERROR: 0:261: 'ddy_fine' : no matching overloaded function found 
-ERROR: 0:261: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
-ERROR: 0:261: 'EvaluateAttributeAtSample' : no matching overloaded function found 
-ERROR: 0:261: 'EvaluateAttributeSnapped' : no matching overloaded function found 
-ERROR: 0:261: 'f16tof32' : no matching overloaded function found 
-ERROR: 0:261: 'firstbithigh' : no matching overloaded function found 
-ERROR: 0:261: 'firstbitlow' : no matching overloaded function found 
-ERROR: 0:261: 'fwidth' : no matching overloaded function found 
-ERROR: 0:261: 'noise' : no matching overloaded function found 
-ERROR: 0:261: 'reversebits' : no matching overloaded function found 
-ERROR: 0:261: 'length' : no matching overloaded function found 
-ERROR: 0:261: 'noise' : no matching overloaded function found 
-ERROR: 0:261: 'normalize' : no matching overloaded function found 
-ERROR: 0:261: 'reflect' : no matching overloaded function found 
-ERROR: 0:261: 'refract' : no matching overloaded function found 
-ERROR: 0:261: 'reversebits' : no matching overloaded function found 
-ERROR: 0:269: 'countbits' : no matching overloaded function found 
-ERROR: 0:269: 'cross' : no matching overloaded function found 
-ERROR: 0:269: 'D3DCOLORtoUBYTE4' : no matching overloaded function found 
-ERROR: 0:269: 'ddx' : no matching overloaded function found 
-ERROR: 0:269: 'ddx_coarse' : no matching overloaded function found 
-ERROR: 0:269: 'ddx_fine' : no matching overloaded function found 
-ERROR: 0:269: 'ddy' : no matching overloaded function found 
-ERROR: 0:269: 'ddy_coarse' : no matching overloaded function found 
-ERROR: 0:269: 'ddy_fine' : no matching overloaded function found 
-ERROR: 0:269: 'EvaluateAttributeAtCentroid' : no matching overloaded function found 
-ERROR: 0:269: 'EvaluateAttributeAtSample' : no matching overloaded function found 
-ERROR: 0:269: 'EvaluateAttributeSnapped' : no matching overloaded function found 
-ERROR: 0:269: 'f16tof32' : no matching overloaded function found 
-ERROR: 0:269: 'firstbithigh' : no matching overloaded function found 
-ERROR: 0:269: 'firstbitlow' : no matching overloaded function found 
-ERROR: 0:269: 'fwidth' : no matching overloaded function found 
-ERROR: 0:269: 'noise' : no matching overloaded function found 
-ERROR: 0:269: 'reversebits' : no matching overloaded function found 
-ERROR: 0:269: 'length' : no matching overloaded function found 
-ERROR: 0:269: 'noise' : no matching overloaded function found 
-ERROR: 0:269: 'normalize' : no matching overloaded function found 
-ERROR: 0:269: 'reflect' : no matching overloaded function found 
-ERROR: 0:269: 'refract' : no matching overloaded function found 
-ERROR: 0:269: 'reversebits' : no matching overloaded function found 
-ERROR: 226 compilation errors.  No code generated.
-
-
 Shader version: 450
-ERROR: node is still EOpNull!
+0:? Sequence
 0:74  Function Definition: VertexShaderFunctionS(f1;f1;f1;i1; (global float)
 0:15    Function Parameters: 
 0:15      'inF0' (in float)
@@ -237,104 +8,6 @@ ERROR: node is still EOpNull!
 0:15      'inF2' (in float)
 0:15      'inI0' (in int)
 0:?     Sequence
-0:18      Constant:
-0:18        0.000000
-0:19      Constant:
-0:19        0.000000
-0:20      Constant:
-0:20        0.000000
-0:21      Constant:
-0:21        0.000000
-0:22      Constant:
-0:22        0.000000
-0:23      Constant:
-0:23        0.000000
-0:24      Constant:
-0:24        0.000000
-0:25      Constant:
-0:25        0.000000
-0:26      Constant:
-0:26        0.000000
-0:27      Constant:
-0:27        0.000000
-0:28      Constant:
-0:28        0.000000
-0:29      Constant:
-0:29        0.000000
-0:30      Constant:
-0:30        0.000000
-0:31      Constant:
-0:31        0.000000
-0:32      Constant:
-0:32        0.000000
-0:33      Constant:
-0:33        0.000000
-0:34      Constant:
-0:34        0.000000
-0:35      Constant:
-0:35        0.000000
-0:36      Constant:
-0:36        0.000000
-0:37      Constant:
-0:37        0.000000
-0:38      Constant:
-0:38        0.000000
-0:39      Constant:
-0:39        0.000000
-0:40      Constant:
-0:40        0.000000
-0:41      Constant:
-0:41        0.000000
-0:43      Constant:
-0:43        0.000000
-0:44      Constant:
-0:44        0.000000
-0:45      Constant:
-0:45        0.000000
-0:46      Constant:
-0:46        0.000000
-0:47      Constant:
-0:47        0.000000
-0:48      Constant:
-0:48        0.000000
-0:49      Constant:
-0:49        0.000000
-0:50      Constant:
-0:50        0.000000
-0:51      Constant:
-0:51        0.000000
-0:52      Constant:
-0:52        0.000000
-0:53      Constant:
-0:53        0.000000
-0:54      Constant:
-0:54        0.000000
-0:55      Constant:
-0:55        0.000000
-0:56      Constant:
-0:56        0.000000
-0:57      Constant:
-0:57        0.000000
-0:58      Constant:
-0:58        0.000000
-0:59      Constant:
-0:59        0.000000
-0:60      Constant:
-0:60        0.000000
-0:61      Constant:
-0:61        0.000000
-0:62      Constant:
-0:62        0.000000
-0:63      Constant:
-0:63        0.000000
-0:64      Constant:
-0:64        0.000000
-0:65      Constant:
-0:65        0.000000
-0:66      Constant:
-0:66        0.000000
-0:67      Constant:
-0:67        0.000000
 0:71      Branch: Return with expression
 0:71        Constant:
 0:71          0.000000
@@ -345,8 +18,6 @@ ERROR: node is still EOpNull!
 0:75      'inF2' (in 1-component vector of float)
 0:75      'inI0' (in 1-component vector of int)
 0:?     Sequence
-0:78      Constant:
-0:78        0.000000
 0:80      Branch: Return with expression
 0:80        Constant:
 0:80          0.000000
@@ -357,78 +28,6 @@ ERROR: node is still EOpNull!
 0:84      'inF2' (in 2-component vector of float)
 0:84      'inI0' (in 2-component vector of int)
 0:?     Sequence
-0:87      Constant:
-0:87        0.000000
-0:88      Constant:
-0:88        0.000000
-0:89      Constant:
-0:89        0.000000
-0:90      Constant:
-0:90        0.000000
-0:91      Constant:
-0:91        0.000000
-0:92      Constant:
-0:92        0.000000
-0:93      Constant:
-0:93        0.000000
-0:94      Constant:
-0:94        0.000000
-0:95      Constant:
-0:95        0.000000
-0:96      Constant:
-0:96        0.000000
-0:97      Constant:
-0:97        0.000000
-0:98      Constant:
-0:98        0.000000
-0:99      Constant:
-0:99        0.000000
-0:100      Constant:
-0:100        0.000000
-0:101      Constant:
-0:101        0.000000
-0:102      Constant:
-0:102        0.000000
-0:103      Constant:
-0:103        0.000000
-0:104      Constant:
-0:104        0.000000
-0:106      Constant:
-0:106        0.000000
-0:107      Constant:
-0:107        0.000000
-0:108      Constant:
-0:108        0.000000
-0:109      Constant:
-0:109        0.000000
-0:110      Constant:
-0:110        0.000000
-0:111      Constant:
-0:111        0.000000
-0:112      Constant:
-0:112        0.000000
-0:113      Constant:
-0:113        0.000000
-0:114      Constant:
-0:114        0.000000
-0:115      Constant:
-0:115        0.000000
-0:116      Constant:
-0:116        0.000000
-0:117      Constant:
-0:117        0.000000
-0:118      Constant:
-0:118        0.000000
-0:119      Constant:
-0:119        0.000000
-0:120      Constant:
-0:120        0.000000
-0:121      Constant:
-0:121        0.000000
-0:122      Constant:
-0:122        0.000000
-0:123      Constant:
-0:123        0.000000
 0:127      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
@@ -440,275 +39,43 @@ ERROR: node is still EOpNull!
 0:131      'inF2' (in 3-component vector of float)
 0:131      'inI0' (in 3-component vector of int)
 0:?     Sequence
-0:134      Constant:
-0:134        0.000000
-0:135      Constant:
-0:135        0.000000
-0:136      Constant:
-0:136        0.000000
-0:137      Constant:
-0:137        0.000000
-0:138      Constant:
-0:138        0.000000
-0:139      Constant:
-0:139        0.000000
-0:140      Constant:
-0:140        0.000000
-0:141      Constant:
-0:141        0.000000
-0:142      Constant:
-0:142        0.000000
-0:143      Constant:
-0:143        0.000000
-0:144      Constant:
-0:144        0.000000
-0:145      Constant:
-0:145        0.000000
-0:146      Constant:
-0:146        0.000000
-0:147      Constant:
-0:147        0.000000
-0:148      Constant:
-0:148        0.000000
-0:149      Constant:
-0:149        0.000000
-0:151      Constant:
-0:151        0.000000
-0:152      Constant:
-0:152        0.000000
-0:153      Constant:
-0:153        0.000000
-0:154      Constant:
-0:154        0.000000
-0:155      Constant:
-0:155        0.000000
-0:156      Constant:
-0:156        0.000000
-0:157      Constant:
-0:157        0.000000
-0:158      Constant:
-0:158        0.000000
-0:159      Constant:
-0:159        0.000000
-0:160      Constant:
-0:160        0.000000
-0:161      Constant:
-0:161        0.000000
-0:162      Constant:
-0:162        0.000000
-0:163      Constant:
-0:163        0.000000
-0:164      Constant:
-0:164        0.000000
-0:165      Constant:
-0:165        0.000000
-0:166      Constant:
-0:166        0.000000
-0:167      Constant:
-0:167        0.000000
-0:168      Constant:
-0:168        0.000000
 0:172      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
-0:250  Function Definition: VertexShaderFunction(vf4;vf4;vf4;vi4; (global 4-component vector of float)
+0:225  Function Definition: VertexShaderFunction(vf4;vf4;vf4;vi4; (global 4-component vector of float)
 0:176    Function Parameters: 
 0:176      'inF0' (in 4-component vector of float)
 0:176      'inF1' (in 4-component vector of float)
 0:176      'inF2' (in 4-component vector of float)
 0:176      'inI0' (in 4-component vector of int)
 0:?     Sequence
-0:179      Constant:
-0:179        0.000000
-0:180      Constant:
-0:180        0.000000
-0:181      Constant:
-0:181        0.000000
-0:182      Constant:
-0:182        0.000000
-0:183      Constant:
-0:183        0.000000
-0:184      Constant:
-0:184        0.000000
-0:185      Constant:
-0:185        0.000000
-0:186      Constant:
-0:186        0.000000
-0:187      Constant:
-0:187        0.000000
-0:188      Constant:
-0:188        0.000000
-0:189      Constant:
-0:189        0.000000
-0:190      Constant:
-0:190        0.000000
-0:191      Constant:
-0:191        0.000000
-0:192      Constant:
-0:192        0.000000
-0:193      Constant:
-0:193        0.000000
-0:194      Constant:
-0:194        0.000000
-0:196      Constant:
-0:196        0.000000
-0:197      Constant:
-0:197        0.000000
-0:198      Constant:
-0:198        0.000000
-0:199      Constant:
-0:199        0.000000
-0:200      Constant:
-0:200        0.000000
-0:201      Constant:
-0:201        0.000000
-0:202      Constant:
-0:202        0.000000
-0:203      Constant:
-0:203        0.000000
-0:204      Constant:
-0:204        0.000000
-0:205      Constant:
-0:205        0.000000
-0:206      Constant:
-0:206        0.000000
-0:207      Constant:
-0:207        0.000000
-0:208      Constant:
-0:208        0.000000
-0:209      Constant:
-0:209        0.000000
-0:210      Constant:
-0:210        0.000000
-0:211      Constant:
-0:211        0.000000
-0:212      Constant:
-0:212        0.000000
-0:213      Constant:
-0:213        0.000000
 0:217      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
 0:?           4.000000
-0:258  Function Definition: VertexShaderFunction2x2(mf22;mf22;mf22; (global 2X2 matrix of float)
-0:251    Function Parameters: 
-0:251      'inF0' (in 2X2 matrix of float)
-0:251      'inF1' (in 2X2 matrix of float)
-0:251      'inF2' (in 2X2 matrix of float)
+0:233  Function Definition: VertexShaderFunction2x2(mf22;mf22;mf22; (global 2X2 matrix of float)
+0:226    Function Parameters: 
+0:226      'inF0' (in 2X2 matrix of float)
+0:226      'inF1' (in 2X2 matrix of float)
+0:226      'inF2' (in 2X2 matrix of float)
 0:?     Sequence
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:255      Branch: Return with expression
+0:230      Branch: Return with expression
 0:?         Constant:
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
-0:266  Function Definition: VertexShaderFunction3x3(mf33;mf33;mf33; (global 3X3 matrix of float)
-0:259    Function Parameters: 
-0:259      'inF0' (in 3X3 matrix of float)
-0:259      'inF1' (in 3X3 matrix of float)
-0:259      'inF2' (in 3X3 matrix of float)
+0:241  Function Definition: VertexShaderFunction3x3(mf33;mf33;mf33; (global 3X3 matrix of float)
+0:234    Function Parameters: 
+0:234      'inF0' (in 3X3 matrix of float)
+0:234      'inF1' (in 3X3 matrix of float)
+0:234      'inF2' (in 3X3 matrix of float)
 0:?     Sequence
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:263      Branch: Return with expression
+0:238      Branch: Return with expression
 0:?         Constant:
 0:?           3.000000
 0:?           3.000000
@@ -719,61 +86,13 @@ ERROR: node is still EOpNull!
 0:?           3.000000
 0:?           3.000000
 0:?           3.000000
-0:273  Function Definition: VertexShaderFunction4x4(mf44;mf44;mf44; (global 4X4 matrix of float)
-0:267    Function Parameters: 
-0:267      'inF0' (in 4X4 matrix of float)
-0:267      'inF1' (in 4X4 matrix of float)
-0:267      'inF2' (in 4X4 matrix of float)
+0:248  Function Definition: VertexShaderFunction4x4(mf44;mf44;mf44; (global 4X4 matrix of float)
+0:242    Function Parameters: 
+0:242      'inF0' (in 4X4 matrix of float)
+0:242      'inF1' (in 4X4 matrix of float)
+0:242      'inF2' (in 4X4 matrix of float)
 0:?     Sequence
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:271      Branch: Return with expression
+0:246      Branch: Return with expression
 0:?         Constant:
 0:?           4.000000
 0:?           4.000000
@@ -810,7 +129,7 @@ Linked vertex stage:
 
 
 Shader version: 450
-ERROR: node is still EOpNull!
+0:? Sequence
 0:74  Function Definition: VertexShaderFunctionS(f1;f1;f1;i1; (global float)
 0:15    Function Parameters: 
 0:15      'inF0' (in float)
@@ -818,104 +137,6 @@ ERROR: node is still EOpNull!
 0:15      'inF2' (in float)
 0:15      'inI0' (in int)
 0:?     Sequence
-0:18      Constant:
-0:18        0.000000
-0:19      Constant:
-0:19        0.000000
-0:20      Constant:
-0:20        0.000000
-0:21      Constant:
-0:21        0.000000
-0:22      Constant:
-0:22        0.000000
-0:23      Constant:
-0:23        0.000000
-0:24      Constant:
-0:24        0.000000
-0:25      Constant:
-0:25        0.000000
-0:26      Constant:
-0:26        0.000000
-0:27      Constant:
-0:27        0.000000
-0:28      Constant:
-0:28        0.000000
-0:29      Constant:
-0:29        0.000000
-0:30      Constant:
-0:30        0.000000
-0:31      Constant:
-0:31        0.000000
-0:32      Constant:
-0:32        0.000000
-0:33      Constant:
-0:33        0.000000
-0:34      Constant:
-0:34        0.000000
-0:35      Constant:
-0:35        0.000000
-0:36      Constant:
-0:36        0.000000
-0:37      Constant:
-0:37        0.000000
-0:38      Constant:
-0:38        0.000000
-0:39      Constant:
-0:39        0.000000
-0:40      Constant:
-0:40        0.000000
-0:41      Constant:
-0:41        0.000000
-0:43      Constant:
-0:43        0.000000
-0:44      Constant:
-0:44        0.000000
-0:45      Constant:
-0:45        0.000000
-0:46      Constant:
-0:46        0.000000
-0:47      Constant:
-0:47        0.000000
-0:48      Constant:
-0:48        0.000000
-0:49      Constant:
-0:49        0.000000
-0:50      Constant:
-0:50        0.000000
-0:51      Constant:
-0:51        0.000000
-0:52      Constant:
-0:52        0.000000
-0:53      Constant:
-0:53        0.000000
-0:54      Constant:
-0:54        0.000000
-0:55      Constant:
-0:55        0.000000
-0:56      Constant:
-0:56        0.000000
-0:57      Constant:
-0:57        0.000000
-0:58      Constant:
-0:58        0.000000
-0:59      Constant:
-0:59        0.000000
-0:60      Constant:
-0:60        0.000000
-0:61      Constant:
-0:61        0.000000
-0:62      Constant:
-0:62        0.000000
-0:63      Constant:
-0:63        0.000000
-0:64      Constant:
-0:64        0.000000
-0:65      Constant:
-0:65        0.000000
-0:66      Constant:
-0:66        0.000000
-0:67      Constant:
-0:67        0.000000
 0:71      Branch: Return with expression
 0:71        Constant:
 0:71          0.000000
@@ -926,8 +147,6 @@ ERROR: node is still EOpNull!
 0:75      'inF2' (in 1-component vector of float)
 0:75      'inI0' (in 1-component vector of int)
 0:?     Sequence
-0:78      Constant:
-0:78        0.000000
 0:80      Branch: Return with expression
 0:80        Constant:
 0:80          0.000000
@@ -938,78 +157,6 @@ ERROR: node is still EOpNull!
 0:84      'inF2' (in 2-component vector of float)
 0:84      'inI0' (in 2-component vector of int)
 0:?     Sequence
-0:87      Constant:
-0:87        0.000000
-0:88      Constant:
-0:88        0.000000
-0:89      Constant:
-0:89        0.000000
-0:90      Constant:
-0:90        0.000000
-0:91      Constant:
-0:91        0.000000
-0:92      Constant:
-0:92        0.000000
-0:93      Constant:
-0:93        0.000000
-0:94      Constant:
-0:94        0.000000
-0:95      Constant:
-0:95        0.000000
-0:96      Constant:
-0:96        0.000000
-0:97      Constant:
-0:97        0.000000
-0:98      Constant:
-0:98        0.000000
-0:99      Constant:
-0:99        0.000000
-0:100      Constant:
-0:100        0.000000
-0:101      Constant:
-0:101        0.000000
-0:102      Constant:
-0:102        0.000000
-0:103      Constant:
-0:103        0.000000
-0:104      Constant:
-0:104        0.000000
-0:106      Constant:
-0:106        0.000000
-0:107      Constant:
-0:107        0.000000
-0:108      Constant:
-0:108        0.000000
-0:109      Constant:
-0:109        0.000000
-0:110      Constant:
-0:110        0.000000
-0:111      Constant:
-0:111        0.000000
-0:112      Constant:
-0:112        0.000000
-0:113      Constant:
-0:113        0.000000
-0:114      Constant:
-0:114        0.000000
-0:115      Constant:
-0:115        0.000000
-0:116      Constant:
-0:116        0.000000
-0:117      Constant:
-0:117        0.000000
-0:118      Constant:
-0:118        0.000000
-0:119      Constant:
-0:119        0.000000
-0:120      Constant:
-0:120        0.000000
-0:121      Constant:
-0:121        0.000000
-0:122      Constant:
-0:122        0.000000
-0:123      Constant:
-0:123        0.000000
 0:127      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
@@ -1021,275 +168,43 @@ ERROR: node is still EOpNull!
 0:131      'inF2' (in 3-component vector of float)
 0:131      'inI0' (in 3-component vector of int)
 0:?     Sequence
-0:134      Constant:
-0:134        0.000000
-0:135      Constant:
-0:135        0.000000
-0:136      Constant:
-0:136        0.000000
-0:137      Constant:
-0:137        0.000000
-0:138      Constant:
-0:138        0.000000
-0:139      Constant:
-0:139        0.000000
-0:140      Constant:
-0:140        0.000000
-0:141      Constant:
-0:141        0.000000
-0:142      Constant:
-0:142        0.000000
-0:143      Constant:
-0:143        0.000000
-0:144      Constant:
-0:144        0.000000
-0:145      Constant:
-0:145        0.000000
-0:146      Constant:
-0:146        0.000000
-0:147      Constant:
-0:147        0.000000
-0:148      Constant:
-0:148        0.000000
-0:149      Constant:
-0:149        0.000000
-0:151      Constant:
-0:151        0.000000
-0:152      Constant:
-0:152        0.000000
-0:153      Constant:
-0:153        0.000000
-0:154      Constant:
-0:154        0.000000
-0:155      Constant:
-0:155        0.000000
-0:156      Constant:
-0:156        0.000000
-0:157      Constant:
-0:157        0.000000
-0:158      Constant:
-0:158        0.000000
-0:159      Constant:
-0:159        0.000000
-0:160      Constant:
-0:160        0.000000
-0:161      Constant:
-0:161        0.000000
-0:162      Constant:
-0:162        0.000000
-0:163      Constant:
-0:163        0.000000
-0:164      Constant:
-0:164        0.000000
-0:165      Constant:
-0:165        0.000000
-0:166      Constant:
-0:166        0.000000
-0:167      Constant:
-0:167        0.000000
-0:168      Constant:
-0:168        0.000000
 0:172      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
-0:250  Function Definition: VertexShaderFunction(vf4;vf4;vf4;vi4; (global 4-component vector of float)
+0:225  Function Definition: VertexShaderFunction(vf4;vf4;vf4;vi4; (global 4-component vector of float)
 0:176    Function Parameters: 
 0:176      'inF0' (in 4-component vector of float)
 0:176      'inF1' (in 4-component vector of float)
 0:176      'inF2' (in 4-component vector of float)
 0:176      'inI0' (in 4-component vector of int)
 0:?     Sequence
-0:179      Constant:
-0:179        0.000000
-0:180      Constant:
-0:180        0.000000
-0:181      Constant:
-0:181        0.000000
-0:182      Constant:
-0:182        0.000000
-0:183      Constant:
-0:183        0.000000
-0:184      Constant:
-0:184        0.000000
-0:185      Constant:
-0:185        0.000000
-0:186      Constant:
-0:186        0.000000
-0:187      Constant:
-0:187        0.000000
-0:188      Constant:
-0:188        0.000000
-0:189      Constant:
-0:189        0.000000
-0:190      Constant:
-0:190        0.000000
-0:191      Constant:
-0:191        0.000000
-0:192      Constant:
-0:192        0.000000
-0:193      Constant:
-0:193        0.000000
-0:194      Constant:
-0:194        0.000000
-0:196      Constant:
-0:196        0.000000
-0:197      Constant:
-0:197        0.000000
-0:198      Constant:
-0:198        0.000000
-0:199      Constant:
-0:199        0.000000
-0:200      Constant:
-0:200        0.000000
-0:201      Constant:
-0:201        0.000000
-0:202      Constant:
-0:202        0.000000
-0:203      Constant:
-0:203        0.000000
-0:204      Constant:
-0:204        0.000000
-0:205      Constant:
-0:205        0.000000
-0:206      Constant:
-0:206        0.000000
-0:207      Constant:
-0:207        0.000000
-0:208      Constant:
-0:208        0.000000
-0:209      Constant:
-0:209        0.000000
-0:210      Constant:
-0:210        0.000000
-0:211      Constant:
-0:211        0.000000
-0:212      Constant:
-0:212        0.000000
-0:213      Constant:
-0:213        0.000000
 0:217      Branch: Return with expression
 0:?         Constant:
 0:?           1.000000
 0:?           2.000000
 0:?           3.000000
 0:?           4.000000
-0:258  Function Definition: VertexShaderFunction2x2(mf22;mf22;mf22; (global 2X2 matrix of float)
-0:251    Function Parameters: 
-0:251      'inF0' (in 2X2 matrix of float)
-0:251      'inF1' (in 2X2 matrix of float)
-0:251      'inF2' (in 2X2 matrix of float)
+0:233  Function Definition: VertexShaderFunction2x2(mf22;mf22;mf22; (global 2X2 matrix of float)
+0:226    Function Parameters: 
+0:226      'inF0' (in 2X2 matrix of float)
+0:226      'inF1' (in 2X2 matrix of float)
+0:226      'inF2' (in 2X2 matrix of float)
 0:?     Sequence
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:253      Constant:
-0:253        0.000000
-0:255      Branch: Return with expression
+0:230      Branch: Return with expression
 0:?         Constant:
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
 0:?           2.000000
-0:266  Function Definition: VertexShaderFunction3x3(mf33;mf33;mf33; (global 3X3 matrix of float)
-0:259    Function Parameters: 
-0:259      'inF0' (in 3X3 matrix of float)
-0:259      'inF1' (in 3X3 matrix of float)
-0:259      'inF2' (in 3X3 matrix of float)
+0:241  Function Definition: VertexShaderFunction3x3(mf33;mf33;mf33; (global 3X3 matrix of float)
+0:234    Function Parameters: 
+0:234      'inF0' (in 3X3 matrix of float)
+0:234      'inF1' (in 3X3 matrix of float)
+0:234      'inF2' (in 3X3 matrix of float)
 0:?     Sequence
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:261      Constant:
-0:261        0.000000
-0:263      Branch: Return with expression
+0:238      Branch: Return with expression
 0:?         Constant:
 0:?           3.000000
 0:?           3.000000
@@ -1300,61 +215,13 @@ ERROR: node is still EOpNull!
 0:?           3.000000
 0:?           3.000000
 0:?           3.000000
-0:273  Function Definition: VertexShaderFunction4x4(mf44;mf44;mf44; (global 4X4 matrix of float)
-0:267    Function Parameters: 
-0:267      'inF0' (in 4X4 matrix of float)
-0:267      'inF1' (in 4X4 matrix of float)
-0:267      'inF2' (in 4X4 matrix of float)
+0:248  Function Definition: VertexShaderFunction4x4(mf44;mf44;mf44; (global 4X4 matrix of float)
+0:242    Function Parameters: 
+0:242      'inF0' (in 4X4 matrix of float)
+0:242      'inF1' (in 4X4 matrix of float)
+0:242      'inF2' (in 4X4 matrix of float)
 0:?     Sequence
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:269      Constant:
-0:269        0.000000
-0:271      Branch: Return with expression
+0:246      Branch: Return with expression
 0:?         Constant:
 0:?           4.000000
 0:?           4.000000
@@ -1386,4 +253,175 @@ ERROR: node is still EOpNull!
 0:?     'gs_ub4' (global 4-component vector of uint)
 0:?     'gs_uc4' (global 4-component vector of uint)
 
-SPIR-V is not generated for failed compile or link
+// Module Version 10000
+// Generated by (magic number): 80001
+// Id's are bound by 119
+
+                              Capability Shader
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Vertex 4  "VertexShaderFunction"
+                              Source HLSL 450
+                              Name 4  "VertexShaderFunction"
+                              Name 15  "VertexShaderFunctionS(f1;f1;f1;i1;"
+                              Name 11  "inF0"
+                              Name 12  "inF1"
+                              Name 13  "inF2"
+                              Name 14  "inI0"
+                              Name 21  "VertexShaderFunction1(vf1;vf1;vf1;vi1;"
+                              Name 17  "inF0"
+                              Name 18  "inF1"
+                              Name 19  "inF2"
+                              Name 20  "inI0"
+                              Name 32  "VertexShaderFunction2(vf2;vf2;vf2;vi2;"
+                              Name 28  "inF0"
+                              Name 29  "inF1"
+                              Name 30  "inF2"
+                              Name 31  "inI0"
+                              Name 43  "VertexShaderFunction3(vf3;vf3;vf3;vi3;"
+                              Name 39  "inF0"
+                              Name 40  "inF1"
+                              Name 41  "inF2"
+                              Name 42  "inI0"
+                              Name 51  "VertexShaderFunction2x2(mf22;mf22;mf22;"
+                              Name 48  "inF0"
+                              Name 49  "inF1"
+                              Name 50  "inF2"
+                              Name 59  "VertexShaderFunction3x3(mf33;mf33;mf33;"
+                              Name 56  "inF0"
+                              Name 57  "inF1"
+                              Name 58  "inF2"
+                              Name 68  "VertexShaderFunction4x4(mf44;mf44;mf44;"
+                              Name 65  "inF0"
+                              Name 66  "inF1"
+                              Name 67  "inF2"
+                              Name 101  "gs_ua"
+                              Name 102  "gs_ub"
+                              Name 103  "gs_uc"
+                              Name 106  "gs_ua2"
+                              Name 107  "gs_ub2"
+                              Name 108  "gs_uc2"
+                              Name 111  "gs_ua3"
+                              Name 112  "gs_ub3"
+                              Name 113  "gs_uc3"
+                              Name 116  "gs_ua4"
+                              Name 117  "gs_ub4"
+                              Name 118  "gs_uc4"
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeFloat 32
+               7:             TypePointer Function 6(float)
+               8:             TypeInt 32 1
+               9:             TypePointer Function 8(int)
+              10:             TypeFunction 6(float) 7(ptr) 7(ptr) 7(ptr) 9(ptr)
+              23:             TypeVector 6(float) 2
+              24:             TypePointer Function 23(fvec2)
+              25:             TypeVector 8(int) 2
+              26:             TypePointer Function 25(ivec2)
+              27:             TypeFunction 23(fvec2) 24(ptr) 24(ptr) 24(ptr) 26(ptr)
+              34:             TypeVector 6(float) 3
+              35:             TypePointer Function 34(fvec3)
+              36:             TypeVector 8(int) 3
+              37:             TypePointer Function 36(ivec3)
+              38:             TypeFunction 34(fvec3) 35(ptr) 35(ptr) 35(ptr) 37(ptr)
+              45:             TypeMatrix 23(fvec2) 2
+              46:             TypePointer Function 45
+              47:             TypeFunction 45 46(ptr) 46(ptr) 46(ptr)
+              53:             TypeMatrix 34(fvec3) 3
+              54:             TypePointer Function 53
+              55:             TypeFunction 53 54(ptr) 54(ptr) 54(ptr)
+              61:             TypeVector 6(float) 4
+              62:             TypeMatrix 61(fvec4) 4
+              63:             TypePointer Function 62
+              64:             TypeFunction 62 63(ptr) 63(ptr) 63(ptr)
+              70:    6(float) Constant 0
+              75:    6(float) Constant 1065353216
+              76:    6(float) Constant 1073741824
+              77:   23(fvec2) ConstantComposite 75 76
+              80:    6(float) Constant 1077936128
+              81:   34(fvec3) ConstantComposite 75 76 80
+              84:    6(float) Constant 1082130432
+              85:   61(fvec4) ConstantComposite 75 76 80 84
+              87:   23(fvec2) ConstantComposite 76 76
+              88:          45 ConstantComposite 87 87
+              91:   34(fvec3) ConstantComposite 80 80 80
+              92:          53 ConstantComposite 91 91 91
+              95:   61(fvec4) ConstantComposite 84 84 84 84
+              96:          62 ConstantComposite 95 95 95 95
+              99:             TypeInt 32 0
+             100:             TypePointer Private 99(int)
+      101(gs_ua):    100(ptr) Variable Private
+      102(gs_ub):    100(ptr) Variable Private
+      103(gs_uc):    100(ptr) Variable Private
+             104:             TypeVector 99(int) 2
+             105:             TypePointer Private 104(ivec2)
+     106(gs_ua2):    105(ptr) Variable Private
+     107(gs_ub2):    105(ptr) Variable Private
+     108(gs_uc2):    105(ptr) Variable Private
+             109:             TypeVector 99(int) 3
+             110:             TypePointer Private 109(ivec3)
+     111(gs_ua3):    110(ptr) Variable Private
+     112(gs_ub3):    110(ptr) Variable Private
+     113(gs_uc3):    110(ptr) Variable Private
+             114:             TypeVector 99(int) 4
+             115:             TypePointer Private 114(ivec4)
+     116(gs_ua4):    115(ptr) Variable Private
+     117(gs_ub4):    115(ptr) Variable Private
+     118(gs_uc4):    115(ptr) Variable Private
+4(VertexShaderFunction):           2 Function None 3
+               5:             Label
+                              ReturnValue 85
+                              FunctionEnd
+15(VertexShaderFunctionS(f1;f1;f1;i1;):    6(float) Function None 10
+        11(inF0):      7(ptr) FunctionParameter
+        12(inF1):      7(ptr) FunctionParameter
+        13(inF2):      7(ptr) FunctionParameter
+        14(inI0):      9(ptr) FunctionParameter
+              16:             Label
+                              ReturnValue 70
+                              FunctionEnd
+21(VertexShaderFunction1(vf1;vf1;vf1;vi1;):    6(float) Function None 10
+        17(inF0):      7(ptr) FunctionParameter
+        18(inF1):      7(ptr) FunctionParameter
+        19(inF2):      7(ptr) FunctionParameter
+        20(inI0):      9(ptr) FunctionParameter
+              22:             Label
+                              ReturnValue 70
+                              FunctionEnd
+32(VertexShaderFunction2(vf2;vf2;vf2;vi2;):   23(fvec2) Function None 27
+        28(inF0):     24(ptr) FunctionParameter
+        29(inF1):     24(ptr) FunctionParameter
+        30(inF2):     24(ptr) FunctionParameter
+        31(inI0):     26(ptr) FunctionParameter
+              33:             Label
+                              ReturnValue 77
+                              FunctionEnd
+43(VertexShaderFunction3(vf3;vf3;vf3;vi3;):   34(fvec3) Function None 38
+        39(inF0):     35(ptr) FunctionParameter
+        40(inF1):     35(ptr) FunctionParameter
+        41(inF2):     35(ptr) FunctionParameter
+        42(inI0):     37(ptr) FunctionParameter
+              44:             Label
+                              ReturnValue 81
+                              FunctionEnd
+51(VertexShaderFunction2x2(mf22;mf22;mf22;):          45 Function None 47
+        48(inF0):     46(ptr) FunctionParameter
+        49(inF1):     46(ptr) FunctionParameter
+        50(inF2):     46(ptr) FunctionParameter
+              52:             Label
+                              ReturnValue 88
+                              FunctionEnd
+59(VertexShaderFunction3x3(mf33;mf33;mf33;):          53 Function None 55
+        56(inF0):     54(ptr) FunctionParameter
+        57(inF1):     54(ptr) FunctionParameter
+        58(inF2):     54(ptr) FunctionParameter
+              60:             Label
+                              ReturnValue 92
+                              FunctionEnd
+68(VertexShaderFunction4x4(mf44;mf44;mf44;):          62 Function None 64
+        65(inF0):     63(ptr) FunctionParameter
+        66(inF1):     63(ptr) FunctionParameter
+        67(inF2):     63(ptr) FunctionParameter
+              69:             Label
+                              ReturnValue 96
+                              FunctionEnd

--- a/Test/hlsl.intrinsics.negative.comp
+++ b/Test/hlsl.intrinsics.negative.comp
@@ -4,49 +4,49 @@ float ComputeShaderFunctionS(float inF0, float inF1, float inF2, int inI0)
 
     // AllMemoryBarrier();              // invalid in fragment stage  TODO: parser currently crashes on empty arg list
     // AllMemoryBarrierWithGroupSync(); // invalid in fragment stage  TODO: parser currently crashes on empty arg list
-    asdouble(inF0, inF1);                     // expected error: only integer inputs
-    CheckAccessFullyMapped(3.0);              // expected error: only valid on integers
-    clip(inF0);                               // expected error: only valid in pixel stage
-    countbits(inF0);                          // expected error: only integer inputs
-    cross(inF0, inF1);                        // expected error: only on float3 inputs
-    D3DCOLORtoUBYTE4(inF0);                   // expected error: only on float4 inputs
-    ddx(inF0);                                // expected error: only valid in pixel stage
-    ddx_coarse(inF0);                         // expected error: only valid in pixel stage
-    ddx_fine(inF0);                           // expected error: only valid in pixel stage
-    ddy(inF0);                                // expected error: only valid in pixel stage
-    ddy_coarse(inF0);                         // expected error: only valid in pixel stage
-    ddy_fine(inF0);                           // expected error: only valid in pixel stage
-    determinant(inF0);                        // expected error: only valid on mats
-    EvaluateAttributeAtCentroid(inF0);        // expected error: only valid in pixel stage
-    EvaluateAttributeAtSample(inF0, 2);       // expected error: only valid in pixel stage
-    EvaluateAttributeSnapped(inF0, int2(2));  // expected error: only valid in pixel stage
-    f16tof32(inF0);                           // expected error: only integer inputs
-    firstbithigh(inF0);                       // expected error: only integer inputs
-    firstbitlow(inF0);                        // expected error: only integer inputs
+    // asdouble(inF0, inF1);                     // expected error: only integer inputs
+    // CheckAccessFullyMapped(3.0);              // expected error: only valid on integers
+    // clip(inF0);                               // expected error: only valid in pixel stage
+    // countbits(inF0);                          // expected error: only integer inputs
+    // cross(inF0, inF1);                        // expected error: only on float3 inputs
+    // D3DCOLORtoUBYTE4(inF0);                   // expected error: only on float4 inputs
+    // ddx(inF0);                                // expected error: only valid in pixel stage
+    // ddx_coarse(inF0);                         // expected error: only valid in pixel stage
+    // ddx_fine(inF0);                           // expected error: only valid in pixel stage
+    // ddy(inF0);                                // expected error: only valid in pixel stage
+    // ddy_coarse(inF0);                         // expected error: only valid in pixel stage
+    // ddy_fine(inF0);                           // expected error: only valid in pixel stage
+    // determinant(inF0);                        // expected error: only valid on mats
+    // EvaluateAttributeAtCentroid(inF0);        // expected error: only interpolant
+    // EvaluateAttributeAtSample(inF0, 2);       // expected error: only interpolant
+    // EvaluateAttributeSnapped(inF0, int2(2));  // expected error: only interpolant
+    // f16tof32(inF0);                           // expected error: only integer inputs
+    // firstbithigh(inF0);                       // expected error: only integer inputs
+    // firstbitlow(inF0);                        // expected error: only integer inputs
     // fma(inF0, inF1, inF2); // TODO: this might auto-promote: need to check against FXC
-    fwidth(inF0);                             // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua, gs_ub);             // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua, gs_ub);             // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
-    InterlockedCompareExchange(gs_ua, gs_ub, gs_uc, out_u1); // expected error: only valid in pixel stage
-    InterlockedExchange(gs_ua, gs_ub, out_u1);// expected error: only valid in pixel stage
-    InterlockedMax(gs_ua, gs_ub);             // expected error: only valid in pixel stage
-    InterlockedMax(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua, gs_ub);             // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua, gs_ub);              // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua, gs_ub, out_u1);      // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua, gs_ub);             // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
-    length(inF0);                             // expect error: invalid on scalars
-    msad4(inF0, float2(0), float4(0));        // expected error: only integer inputs
-    normalize(inF0);                          // expect error: invalid on scalars
-    reflect(inF0, inF1);                      // expect error: invalid on scalars
-    refract(inF0, inF1, inF2);                // expect error: invalid on scalars
-    refract(float2(0), float2(0), float2(0)); // expected error: last parameter only scalar
-    reversebits(inF0);                        // expected error: only integer inputs
-    transpose(inF0);                          // expect error: only valid on mats
+    // fwidth(inF0);                             // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua, gs_ub);             // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua, gs_ub);             // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
+    // InterlockedCompareExchange(gs_ua, gs_ub, gs_uc, out_u1); // expected error: only valid in pixel stage
+    // InterlockedExchange(gs_ua, gs_ub, out_u1);// expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua, gs_ub);             // expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua, gs_ub);             // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua, gs_ub);              // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua, gs_ub, out_u1);      // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua, gs_ub);             // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
+    // length(inF0);                             // expect error: invalid on scalars
+    // msad4(inF0, float2(0), float4(0));        // expected error: only integer inputs
+    // normalize(inF0);                          // expect error: invalid on scalars
+    // reflect(inF0, inF1);                      // expect error: invalid on scalars
+    // refract(inF0, inF1, inF2);                // expect error: invalid on scalars
+    // refract(float2(0), float2(0), float2(0)); // expected error: last parameter only scalar
+    // reversebits(inF0);                        // expected error: only integer inputs
+    // transpose(inF0);                          // expect error: only valid on mats
 
     // TODO: texture intrinsics, when we can declare samplers.
 
@@ -57,7 +57,7 @@ float1 ComputeShaderFunction1(float1 inF0, float1 inF1, float1 inF2, int1 inI0)
 {
     // TODO: ... add when float1 prototypes are generated
 
-    GetRenderTargetSamplePosition(inF0); // expected error: only integer inputs
+    // GetRenderTargetSamplePosition(inF0); // expected error: only integer inputs
 
     return 0.0;
 }
@@ -66,43 +66,43 @@ float2 ComputeShaderFunction2(float2 inF0, float2 inF1, float2 inF2, int2 inI0)
 {
     uint2 out_u2;
 
-    asdouble(inF0, inF1);         // expected error: only integer inputs
-    CheckAccessFullyMapped(inF0); // expect error: only valid on scalars
-    countbits(inF0);              // expected error: only integer inputs
-    cross(inF0, inF1);            // expected error: only on float3 inputs
-    D3DCOLORtoUBYTE4(inF0);       // expected error: only on float4 inputs
-    ddx(inF0);                                // only valid in pixel stage
-    ddx_coarse(inF0);                         // only valid in pixel stage
-    ddx_fine(inF0);                           // only valid in pixel stage
-    ddy(inF0);                                // only valid in pixel stage
-    ddy_coarse(inF0);                         // only valid in pixel stage
-    ddy_fine(inF0);                           // only valid in pixel stage
-    determinant(inF0);            // expect error: only valid on mats
-    EvaluateAttributeAtCentroid(inF0);        // expected error: only valid in pixel stage
-    EvaluateAttributeAtSample(inF0, 2);       // expected error: only valid in pixel stage
-    EvaluateAttributeSnapped(inF0, int2(2));  // expected error: only valid in pixel stage
-    f16tof32(inF0);               // expected error: only integer inputs
-    firstbithigh(inF0);           // expected error: only integer inputs
-    firstbitlow(inF0);            // expected error: only integer inputs
+    // asdouble(inF0, inF1);         // expected error: only integer inputs
+    // CheckAccessFullyMapped(inF0); // expect error: only valid on scalars
+    // countbits(inF0);              // expected error: only integer inputs
+    // cross(inF0, inF1);            // expected error: only on float3 inputs
+    // D3DCOLORtoUBYTE4(inF0);       // expected error: only on float4 inputs
+    // ddx(inF0);                                // only valid in pixel stage
+    // ddx_coarse(inF0);                         // only valid in pixel stage
+    // ddx_fine(inF0);                           // only valid in pixel stage
+    // ddy(inF0);                                // only valid in pixel stage
+    // ddy_coarse(inF0);                         // only valid in pixel stage
+    // ddy_fine(inF0);                           // only valid in pixel stage
+    // determinant(inF0);            // expect error: only valid on mats
+    // EvaluateAttributeAtCentroid(inF0);        // expected error: only interpolant
+    // EvaluateAttributeAtSample(inF0, 2);       // expected error: only interpolant
+    // EvaluateAttributeSnapped(inF0, int2(2));  // expected error: only interpolant
+    // f16tof32(inF0);               // expected error: only integer inputs
+    // firstbithigh(inF0);           // expected error: only integer inputs
+    // firstbitlow(inF0);            // expected error: only integer inputs
     // fma(inF0, inF1, inF2); // TODO: this might auto-promote: need to check against FXC
-    fwidth(inF0);                 // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua2, gs_ub2);         // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua2, gs_ub2, out_u2); // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua2, gs_ub2);         // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua2, gs_ub2, out_u2); // expected error: only valid in pixel stage
-    InterlockedCompareExchange(gs_ua2, gs_ub2, gs_uc2, out_u2); // expected error: only valid in pixel stage
-    InterlockedExchange(gs_ua2, gs_ub2, out_u2);// expected error: only valid in pixel stage
-    InterlockedMax(gs_ua2, gs_ub2);         // expected error: only valid in pixel stage
-    InterlockedMax(gs_ua2, gs_ub2, out_u2); // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua2, gs_ub2);         // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua2, gs_ub2, out_u2); // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua2, gs_ub2);          // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua2, gs_ub2, out_u2);  // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua2, gs_ub2);         // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua2, gs_ub2, out_u2); // expected error: only valid in pixel stage
-    noise(inF0);                  // expected error: only valid in pixel stage
-    reversebits(inF0);            // expected error: only integer inputs
-    transpose(inF0);              // expect error: only valid on mats
+    // fwidth(inF0);                 // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua2, gs_ub2);         // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua2, gs_ub2, out_u2); // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua2, gs_ub2);         // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua2, gs_ub2, out_u2); // expected error: only valid in pixel stage
+    // InterlockedCompareExchange(gs_ua2, gs_ub2, gs_uc2, out_u2); // expected error: only valid in pixel stage
+    // InterlockedExchange(gs_ua2, gs_ub2, out_u2);// expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua2, gs_ub2);         // expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua2, gs_ub2, out_u2); // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua2, gs_ub2);         // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua2, gs_ub2, out_u2); // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua2, gs_ub2);          // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua2, gs_ub2, out_u2);  // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua2, gs_ub2);         // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua2, gs_ub2, out_u2); // expected error: only valid in pixel stage
+    // noise(inF0);                  // expected error: only valid in pixel stage
+    // reversebits(inF0);            // expected error: only integer inputs
+    // transpose(inF0);              // expect error: only valid on mats
 
     // TODO: texture intrinsics, when we can declare samplers.
 
@@ -113,41 +113,41 @@ float3 ComputeShaderFunction3(float3 inF0, float3 inF1, float3 inF2, int3 inI0)
 {
     uint3 out_u3;
 
-    CheckAccessFullyMapped(inF0);                               // expect error: only valid on scalars
-    countbits(inF0);                                            // expected error: only integer inputs
-    ddx(inF0);                                                  // only valid in pixel stage
-    ddx_coarse(inF0);                                           // only valid in pixel stage
-    ddx_fine(inF0);                                             // only valid in pixel stage
-    ddy(inF0);                                                  // only valid in pixel stage
-    ddy_coarse(inF0);                                           // only valid in pixel stage
-    ddy_fine(inF0);                                             // only valid in pixel stage
-    D3DCOLORtoUBYTE4(inF0);                                     // expected error: only on float4 inputs
-    determinant(inF0);                                          // expect error: only valid on mats
-    EvaluateAttributeAtCentroid(inF0);                          // expected error: only valid in pixel stage
-    EvaluateAttributeAtSample(inF0, 2);                         // expected error: only valid in pixel stage
-    EvaluateAttributeSnapped(inF0, int2(2));                    // expected error: only valid in pixel stage
-    f16tof32(inF0);                                             // expected error: only integer inputs
-    firstbithigh(inF0);                                         // expected error: only integer inputs
-    firstbitlow(inF0);                                          // expected error: only integer inputs
+    // CheckAccessFullyMapped(inF0);                               // expect error: only valid on scalars
+    // countbits(inF0);                                            // expected error: only integer inputs
+    // ddx(inF0);                                                  // only valid in pixel stage
+    // ddx_coarse(inF0);                                           // only valid in pixel stage
+    // ddx_fine(inF0);                                             // only valid in pixel stage
+    // ddy(inF0);                                                  // only valid in pixel stage
+    // ddy_coarse(inF0);                                           // only valid in pixel stage
+    // ddy_fine(inF0);                                             // only valid in pixel stage
+    // D3DCOLORtoUBYTE4(inF0);                                     // expected error: only on float4 inputs
+    // determinant(inF0);                                          // expect error: only valid on mats
+    // EvaluateAttributeAtCentroid(inF0);                          // expected error: only interpolant
+    // EvaluateAttributeAtSample(inF0, 2);                         // expected error: only interpolant
+    // EvaluateAttributeSnapped(inF0, int2(2));                    // expected error: only interpolant
+    // f16tof32(inF0);                                             // expected error: only integer inputs
+    // firstbithigh(inF0);                                         // expected error: only integer inputs
+    // firstbitlow(inF0);                                          // expected error: only integer inputs
     // fma(inF0, inF1, inF2); // TODO: this might auto-promote: need to check against FXC
-    fwidth(inF0);                                               // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
-    InterlockedCompareExchange(gs_ua3, gs_ub3, gs_uc3, out_u3); // expected error: only valid in pixel stage
-    InterlockedExchange(gs_ua3, gs_ub3, out_u3);                // expected error: only valid in pixel stage
-    InterlockedMax(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
-    InterlockedMax(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua3, gs_ub3);                              // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua3, gs_ub3, out_u3);                      // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
-    noise(inF0);                                                // expected error: only valid in pixel stage
-    reversebits(inF0);                                          // expected error: only integer inputs
-    transpose(inF0);                                            // expect error: only valid on mats
+    // fwidth(inF0);                                               // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
+    // InterlockedCompareExchange(gs_ua3, gs_ub3, gs_uc3, out_u3); // expected error: only valid in pixel stage
+    // InterlockedExchange(gs_ua3, gs_ub3, out_u3);                // expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua3, gs_ub3);                              // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua3, gs_ub3, out_u3);                      // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
+    // noise(inF0);                                                // expected error: only valid in pixel stage
+    // reversebits(inF0);                                          // expected error: only integer inputs
+    // transpose(inF0);                                            // expect error: only valid on mats
 
     // TODO: texture intrinsics, when we can declare samplers.
 
@@ -158,41 +158,41 @@ float4 ComputeShaderFunction(float4 inF0, float4 inF1, float4 inF2, int4 inI0)
 {
     uint4 out_u4;
 
-    CheckAccessFullyMapped(inF0);                               // expect error: only valid on scalars
-    countbits(inF0);                                            // expected error: only integer inputs
-    cross(inF0, inF1);                                          // expected error: only on float3 inputs
-    determinant(inF0);                                          // expect error: only valid on mats
-    ddx(inF0);                                                  // only valid in pixel stage
-    ddx_coarse(inF0);                                           // only valid in pixel stage
-    ddx_fine(inF0);                                             // only valid in pixel stage
-    ddy(inF0);                                                  // only valid in pixel stage
-    ddy_coarse(inF0);                                           // only valid in pixel stage
-    ddy_fine(inF0);                                             // only valid in pixel stage
-    EvaluateAttributeAtCentroid(inF0);                          // expected error: only valid in pixel stage
-    EvaluateAttributeAtSample(inF0, 2);                         // expected error: only valid in pixel stage
-    EvaluateAttributeSnapped(inF0, int2(2));                    // expected error: only valid in pixel stage
-    f16tof32(inF0);                                             // expected error: only integer inputs
-    firstbithigh(inF0);                                         // expected error: only integer inputs
-    firstbitlow(inF0);                                          // expected error: only integer inputs
+    // CheckAccessFullyMapped(inF0);                               // expect error: only valid on scalars
+    // countbits(inF0);                                            // expected error: only integer inputs
+    // cross(inF0, inF1);                                          // expected error: only on float3 inputs
+    // determinant(inF0);                                          // expect error: only valid on mats
+    // ddx(inF0);                                                  // only valid in pixel stage
+    // ddx_coarse(inF0);                                           // only valid in pixel stage
+    // ddx_fine(inF0);                                             // only valid in pixel stage
+    // ddy(inF0);                                                  // only valid in pixel stage
+    // ddy_coarse(inF0);                                           // only valid in pixel stage
+    // ddy_fine(inF0);                                             // only valid in pixel stage
+    // EvaluateAttributeAtCentroid(inF0);                          // expected error: only valid in pixel stage
+    // EvaluateAttributeAtSample(inF0, 2);                         // expected error: only valid in pixel stage
+    // EvaluateAttributeSnapped(inF0, int2(2));                    // expected error: only valid in pixel stage
+    // f16tof32(inF0);                                             // expected error: only integer inputs
+    // firstbithigh(inF0);                                         // expected error: only integer inputs
+    // firstbitlow(inF0);                                          // expected error: only integer inputs
     // fma(inF0, inF1, inF2); // TODO: this might auto-promote: need to check against FXC
-    fwidth(inF0);                                               // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
-    InterlockedCompareExchange(gs_ua4, gs_ub4, gs_uc4, out_u4); // expected error: only valid in pixel stage
-    InterlockedExchange(gs_ua4, gs_ub4, out_u4);                // expected error: only valid in pixel stage
-    InterlockedMax(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
-    InterlockedMax(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua4, gs_ub4);                              // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua4, gs_ub4, out_u4);                      // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
-    noise(inF0);                                                // expected error: only valid in pixel stage
-    reversebits(inF0);                                          // expected error: only integer inputs
-    transpose(inF0);                                            // expect error: only valid on mats
+    // fwidth(inF0);                                               // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
+    // InterlockedCompareExchange(gs_ua4, gs_ub4, gs_uc4, out_u4); // expected error: only valid in pixel stage
+    // InterlockedExchange(gs_ua4, gs_ub4, out_u4);                // expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua4, gs_ub4);                              // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua4, gs_ub4, out_u4);                      // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
+    // noise(inF0);                                                // expected error: only valid in pixel stage
+    // reversebits(inF0);                                          // expected error: only integer inputs
+    // transpose(inF0);                                            // expect error: only valid on mats
 
     // TODO: texture intrinsics, when we can declare samplers.
 

--- a/Test/hlsl.intrinsics.negative.vert
+++ b/Test/hlsl.intrinsics.negative.vert
@@ -15,56 +15,56 @@ float VertexShaderFunctionS(float inF0, float inF1, float inF2, int inI0)
 {
     uint out_u1;
 
-    AllMemoryBarrier();                       // expected error: only valid in compute stage
-    AllMemoryBarrierWithGroupSync();          // expected error: only valid in compute stage
-    asdouble(inF0, inF1);                     // expected error: only integer inputs
-    CheckAccessFullyMapped(3.0);              // expected error: only valid on integers
-    CheckAccessFullyMapped(3);                // expected error: only valid in pixel & compute stages
-    clip(inF0);                               // expected error: only valid in pixel stage
-    countbits(inF0);                          // expected error: only integer inputs
-    cross(inF0, inF1);                        // expected error: only on float3 inputs
-    D3DCOLORtoUBYTE4(inF0);                   // expected error: only on float4 inputs
-    DeviceMemoryBarrier();                    // expected error: only valid in pixel & compute stages
-    DeviceMemoryBarrierWithGroupSync();       // expected error: only valid in compute stage
-    ddx(inF0);                                // expected error: only valid in pixel stage
-    ddx_coarse(inF0);                         // expected error: only valid in pixel stage
-    ddx_fine(inF0);                           // expected error: only valid in pixel stage
-    ddy(inF0);                                // expected error: only valid in pixel stage
-    ddy_coarse(inF0);                         // expected error: only valid in pixel stage
-    ddy_fine(inF0);                           // expected error: only valid in pixel stage
-    determinant(inF0);                        // expected error: only valid on mats
-    EvaluateAttributeAtCentroid(inF0);        // expected error: only valid in pixel stage
-    EvaluateAttributeAtSample(inF0, 2);       // expected error: only valid in pixel stage
-    EvaluateAttributeSnapped(inF0, int2(2));  // expected error: only valid in pixel stage
-    f16tof32(inF0);                           // expected error: only integer inputs
-    firstbithigh(inF0);                       // expected error: only integer inputs
-    firstbitlow(inF0);                        // expected error: only integer inputs
+    // AllMemoryBarrier();                       // expected error: only valid in compute stage
+    // AllMemoryBarrierWithGroupSync();          // expected error: only valid in compute stage
+    // asdouble(inF0, inF1);                     // expected error: only integer inputs
+    // CheckAccessFullyMapped(3.0);              // expected error: only valid on integers
+    // CheckAccessFullyMapped(3);                // expected error: only valid in pixel & compute stages
+    // clip(inF0);                               // expected error: only valid in pixel stage
+    // countbits(inF0);                          // expected error: only integer inputs
+    // cross(inF0, inF1);                        // expected error: only on float3 inputs
+    // D3DCOLORtoUBYTE4(inF0);                   // expected error: only on float4 inputs
+    // DeviceMemoryBarrier();                    // expected error: only valid in pixel & compute stages
+    // DeviceMemoryBarrierWithGroupSync();       // expected error: only valid in compute stage
+    // ddx(inF0);                                // expected error: only valid in pixel stage
+    // ddx_coarse(inF0);                         // expected error: only valid in pixel stage
+    // ddx_fine(inF0);                           // expected error: only valid in pixel stage
+    // ddy(inF0);                                // expected error: only valid in pixel stage
+    // ddy_coarse(inF0);                         // expected error: only valid in pixel stage
+    // ddy_fine(inF0);                           // expected error: only valid in pixel stage
+    // determinant(inF0);                        // expected error: only valid on mats
+    // EvaluateAttributeAtCentroid(inF0);        // expected error: only interpolant
+    // EvaluateAttributeAtSample(inF0, 2);       // expected error: only interpolant
+    // EvaluateAttributeSnapped(inF0, int2(2));  // expected error: only interpolant
+    // f16tof32(inF0);                           // expected error: only integer inputs
+    // firstbithigh(inF0);                       // expected error: only integer inputs
+    // firstbitlow(inF0);                        // expected error: only integer inputs
     // fma(inF0, inF1, inF2); // TODO: this might auto-promote: need to check against FXC
-    fwidth(inF0);                             // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua, gs_ub);             // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua, gs_ub);             // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
-    InterlockedCompareExchange(gs_ua, gs_ub, gs_uc, out_u1); // expected error: only valid in pixel stage
-    InterlockedExchange(gs_ua, gs_ub, out_u1);// expected error: only valid in pixel stage
-    InterlockedMax(gs_ua, gs_ub);             // expected error: only valid in pixel stage
-    InterlockedMax(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua, gs_ub);             // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua, gs_ub);              // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua, gs_ub, out_u1);      // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua, gs_ub);             // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
-    GroupMemoryBarrier();                     // expected error: only valid in compute stage
-    GroupMemoryBarrierWithGroupSync();        // expected error: only valid in compute stage
-    length(inF0);                             // expect error: invalid on scalars
-    msad4(inF0, float2(0), float4(0));        // expected error: only integer inputs
-    normalize(inF0);                          // expect error: invalid on scalars
-    reflect(inF0, inF1);                      // expect error: invalid on scalars
-    refract(inF0, inF1, inF2);                // expect error: invalid on scalars
-    refract(float2(0), float2(0), float2(0)); // expected error: last parameter only scalar
-    reversebits(inF0);                        // expected error: only integer inputs
-    transpose(inF0);                          // expect error: only valid on mats
+    // fwidth(inF0);                             // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua, gs_ub);             // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua, gs_ub);             // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
+    // InterlockedCompareExchange(gs_ua, gs_ub, gs_uc, out_u1); // expected error: only valid in pixel stage
+    // InterlockedExchange(gs_ua, gs_ub, out_u1);// expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua, gs_ub);             // expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua, gs_ub);             // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua, gs_ub);              // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua, gs_ub, out_u1);      // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua, gs_ub);             // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua, gs_ub, out_u1);     // expected error: only valid in pixel stage
+    // GroupMemoryBarrier();                     // expected error: only valid in compute stage
+    // GroupMemoryBarrierWithGroupSync();        // expected error: only valid in compute stage
+    // length(inF0);                             // expect error: invalid on scalars
+    // msad4(inF0, float2(0), float4(0));        // expected error: only integer inputs
+    // normalize(inF0);                          // expect error: invalid on scalars
+    // reflect(inF0, inF1);                      // expect error: invalid on scalars
+    // refract(inF0, inF1, inF2);                // expect error: invalid on scalars
+    // refract(float2(0), float2(0), float2(0)); // expected error: last parameter only scalar
+    // reversebits(inF0);                        // expected error: only integer inputs
+    // transpose(inF0);                          // expect error: only valid on mats
 
     // TODO: texture intrinsics, when we can declare samplers.
 
@@ -75,7 +75,7 @@ float1 VertexShaderFunction1(float1 inF0, float1 inF1, float1 inF2, int1 inI0)
 {
     // TODO: ... add when float1 prototypes are generated
 
-    GetRenderTargetSamplePosition(inF0); // expected error: only integer inputs
+    // GetRenderTargetSamplePosition(inF0); // expected error: only integer inputs
 
     return 0.0;
 }
@@ -84,43 +84,43 @@ float2 VertexShaderFunction2(float2 inF0, float2 inF1, float2 inF2, int2 inI0)
 {
     uint2 out_u2;
 
-    asdouble(inF0, inF1);                                       // expected error: only integer inputs
-    CheckAccessFullyMapped(inF0);                               // expect error: only valid on scalars
-    countbits(inF0);                                            // expected error: only integer inputs
-    cross(inF0, inF1);                                          // expected error: only on float3 inputs
-    D3DCOLORtoUBYTE4(inF0);                                     // expected error: only on float4 inputs
-    ddx(inF0);                                                  // only valid in pixel stage
-    ddx_coarse(inF0);                                           // only valid in pixel stage
-    ddx_fine(inF0);                                             // only valid in pixel stage
-    ddy(inF0);                                                  // only valid in pixel stage
-    ddy_coarse(inF0);                                           // only valid in pixel stage
-    ddy_fine(inF0);                                             // only valid in pixel stage
-    determinant(inF0);                                          // expect error: only valid on mats
-    EvaluateAttributeAtCentroid(inF0);                          // expected error: only valid in pixel stage
-    EvaluateAttributeAtSample(inF0, 2);                         // expected error: only valid in pixel stage
-    EvaluateAttributeSnapped(inF0, int2(2));                    // expected error: only valid in pixel stage
-    f16tof32(inF0);                                             // expected error: only integer inputs
-    firstbithigh(inF0);                                         // expected error: only integer inputs
-    firstbitlow(inF0);                                          // expected error: only integer inputs
+    // asdouble(inF0, inF1);                                       // expected error: only integer inputs
+    // CheckAccessFullyMapped(inF0);                               // expect error: only valid on scalars
+    // countbits(inF0);                                            // expected error: only integer inputs
+    // cross(inF0, inF1);                                          // expected error: only on float3 inputs
+    // D3DCOLORtoUBYTE4(inF0);                                     // expected error: only on float4 inputs
+    // ddx(inF0);                                                  // only valid in pixel stage
+    // ddx_coarse(inF0);                                           // only valid in pixel stage
+    // ddx_fine(inF0);                                             // only valid in pixel stage
+    // ddy(inF0);                                                  // only valid in pixel stage
+    // ddy_coarse(inF0);                                           // only valid in pixel stage
+    // ddy_fine(inF0);                                             // only valid in pixel stage
+    // determinant(inF0);                                          // expect error: only valid on mats
+    // EvaluateAttributeAtCentroid(inF0);                          // expected error: only interpolant
+    // EvaluateAttributeAtSample(inF0, 2);                         // expected error: only interpolant
+    // EvaluateAttributeSnapped(inF0, int2(2));                    // expected error: only interpolant
+    // f16tof32(inF0);                                             // expected error: only integer inputs
+    // firstbithigh(inF0);                                         // expected error: only integer inputs
+    // firstbitlow(inF0);                                          // expected error: only integer inputs
     // fma(inF0, inF1, inF2); // TODO: this might auto-promote: need to check against FXC
-    fwidth(inF0);                                               // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua2, gs_ub2);                             // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua2, gs_ub2, out_u2);                     // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua2, gs_ub2);                             // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua2, gs_ub2, out_u2);                     // expected error: only valid in pixel stage
-    InterlockedCompareExchange(gs_ua2, gs_ub2, gs_uc2, out_u2); // expected error: only valid in pixel stage
-    InterlockedExchange(gs_ua2, gs_ub2, out_u2);                // expected error: only valid in pixel stage
-    InterlockedMax(gs_ua2, gs_ub2);                             // expected error: only valid in pixel stage
-    InterlockedMax(gs_ua2, gs_ub2, out_u2);                     // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua2, gs_ub2);                             // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua2, gs_ub2, out_u2);                     // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua2, gs_ub2);                              // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua2, gs_ub2, out_u2);                      // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua2, gs_ub2);                             // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua2, gs_ub2, out_u2);                     // expected error: only valid in pixel stage
-    noise(inF0);                                                // expected error: only valid in pixel stage
-    reversebits(inF0);                                          // expected error: only integer inputs
-    transpose(inF0);                                            // expect error: only valid on mats
+    // fwidth(inF0);                                               // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua2, gs_ub2);                             // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua2, gs_ub2, out_u2);                     // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua2, gs_ub2);                             // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua2, gs_ub2, out_u2);                     // expected error: only valid in pixel stage
+    // InterlockedCompareExchange(gs_ua2, gs_ub2, gs_uc2, out_u2); // expected error: only valid in pixel stage
+    // InterlockedExchange(gs_ua2, gs_ub2, out_u2);                // expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua2, gs_ub2);                             // expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua2, gs_ub2, out_u2);                     // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua2, gs_ub2);                             // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua2, gs_ub2, out_u2);                     // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua2, gs_ub2);                              // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua2, gs_ub2, out_u2);                      // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua2, gs_ub2);                             // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua2, gs_ub2, out_u2);                     // expected error: only valid in pixel stage
+    // noise(inF0);                                                // expected error: only valid in pixel stage
+    // reversebits(inF0);                                          // expected error: only integer inputs
+    // transpose(inF0);                                            // expect error: only valid on mats
 
     // TODO: texture intrinsics, when we can declare samplers.
 
@@ -131,41 +131,41 @@ float3 VertexShaderFunction3(float3 inF0, float3 inF1, float3 inF2, int3 inI0)
 {
     uint3 out_u3;
 
-    CheckAccessFullyMapped(inF0);                               // expect error: only valid on scalars
-    countbits(inF0);                                            // expected error: only integer inputs
-    ddx(inF0);                                                  // only valid in pixel stage
-    ddx_coarse(inF0);                                           // only valid in pixel stage
-    ddx_fine(inF0);                                             // only valid in pixel stage
-    ddy(inF0);                                                  // only valid in pixel stage
-    ddy_coarse(inF0);                                           // only valid in pixel stage
-    ddy_fine(inF0);                                             // only valid in pixel stage
-    D3DCOLORtoUBYTE4(inF0);                                     // expected error: only on float4 inputs
-    determinant(inF0);                                          // expect error: only valid on mats
-    EvaluateAttributeAtCentroid(inF0);                          // expected error: only valid in pixel stage
-    EvaluateAttributeAtSample(inF0, 2);                         // expected error: only valid in pixel stage
-    EvaluateAttributeSnapped(inF0, int2(2));                    // expected error: only valid in pixel stage
-    f16tof32(inF0);                                             // expected error: only integer inputs
-    firstbithigh(inF0);                                         // expected error: only integer inputs
-    firstbitlow(inF0);                                          // expected error: only integer inputs
+    // CheckAccessFullyMapped(inF0);                               // expect error: only valid on scalars
+    // countbits(inF0);                                            // expected error: only integer inputs
+    // ddx(inF0);                                                  // only valid in pixel stage
+    // ddx_coarse(inF0);                                           // only valid in pixel stage
+    // ddx_fine(inF0);                                             // only valid in pixel stage
+    // ddy(inF0);                                                  // only valid in pixel stage
+    // ddy_coarse(inF0);                                           // only valid in pixel stage
+    // ddy_fine(inF0);                                             // only valid in pixel stage
+    // D3DCOLORtoUBYTE4(inF0);                                     // expected error: only on float4 inputs
+    // determinant(inF0);                                          // expect error: only valid on mats
+    // EvaluateAttributeAtCentroid(inF0);                          // expected error: only interpolant
+    // EvaluateAttributeAtSample(inF0, 2);                         // expected error: only interpolant
+    // EvaluateAttributeSnapped(inF0, int2(2));                    // expected error: only interpolant
+    // f16tof32(inF0);                                             // expected error: only integer inputs
+    // firstbithigh(inF0);                                         // expected error: only integer inputs
+    // firstbitlow(inF0);                                          // expected error: only integer inputs
     // fma(inF0, inF1, inF2); // TODO: this might auto-promote: need to check against FXC
-    fwidth(inF0);                                               // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
-    InterlockedCompareExchange(gs_ua3, gs_ub3, gs_uc3, out_u3); // expected error: only valid in pixel stage
-    InterlockedExchange(gs_ua3, gs_ub3, out_u3);                // expected error: only valid in pixel stage
-    InterlockedMax(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
-    InterlockedMax(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua3, gs_ub3);                              // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua3, gs_ub3, out_u3);                      // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
-    noise(inF0);                                                // expected error: only valid in pixel stage
-    reversebits(inF0);                                          // expected error: only integer inputs
-    transpose(inF0);                                            // expect error: only valid on mats
+    // fwidth(inF0);                                               // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
+    // InterlockedCompareExchange(gs_ua3, gs_ub3, gs_uc3, out_u3); // expected error: only valid in pixel stage
+    // InterlockedExchange(gs_ua3, gs_ub3, out_u3);                // expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua3, gs_ub3);                              // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua3, gs_ub3, out_u3);                      // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua3, gs_ub3);                             // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua3, gs_ub3, out_u3);                     // expected error: only valid in pixel stage
+    // noise(inF0);                                                // expected error: only valid in pixel stage
+    // reversebits(inF0);                                          // expected error: only integer inputs
+    // transpose(inF0);                                            // expect error: only valid on mats
 
     // TODO: texture intrinsics, when we can declare samplers.
 
@@ -176,41 +176,41 @@ float4 VertexShaderFunction(float4 inF0, float4 inF1, float4 inF2, int4 inI0)
 {
     uint4 out_u4;
 
-    CheckAccessFullyMapped(inF0);                               // expect error: only valid on scalars
-    countbits(inF0);                                            // expected error: only integer inputs
-    cross(inF0, inF1);                                          // expected error: only on float3 inputs
-    determinant(inF0);                                          // expect error: only valid on mats
-    ddx(inF0);                                                  // only valid in pixel stage
-    ddx_coarse(inF0);                                           // only valid in pixel stage
-    ddx_fine(inF0);                                             // only valid in pixel stage
-    ddy(inF0);                                                  // only valid in pixel stage
-    ddy_coarse(inF0);                                           // only valid in pixel stage
-    ddy_fine(inF0);                                             // only valid in pixel stage
-    EvaluateAttributeAtCentroid(inF0);                          // expected error: only valid in pixel stage
-    EvaluateAttributeAtSample(inF0, 2);                         // expected error: only valid in pixel stage
-    EvaluateAttributeSnapped(inF0, int2(2));                    // expected error: only valid in pixel stage
-    f16tof32(inF0);                                             // expected error: only integer inputs
-    firstbithigh(inF0);                                         // expected error: only integer inputs
-    firstbitlow(inF0);                                          // expected error: only integer inputs
+    // CheckAccessFullyMapped(inF0);                               // expect error: only valid on scalars
+    // countbits(inF0);                                            // expected error: only integer inputs
+    // cross(inF0, inF1);                                          // expected error: only on float3 inputs
+    // determinant(inF0);                                          // expect error: only valid on mats
+    // ddx(inF0);                                                  // only valid in pixel stage
+    // ddx_coarse(inF0);                                           // only valid in pixel stage
+    // ddx_fine(inF0);                                             // only valid in pixel stage
+    // ddy(inF0);                                                  // only valid in pixel stage
+    // ddy_coarse(inF0);                                           // only valid in pixel stage
+    // ddy_fine(inF0);                                             // only valid in pixel stage
+    // EvaluateAttributeAtCentroid(inF0);                          // expected error: only interpolant
+    // EvaluateAttributeAtSample(inF0, 2);                         // expected error: only interpolant
+    // EvaluateAttributeSnapped(inF0, int2(2));                    // expected error: only interpolant
+    // f16tof32(inF0);                                             // expected error: only integer inputs
+    // firstbithigh(inF0);                                         // expected error: only integer inputs
+    // firstbitlow(inF0);                                          // expected error: only integer inputs
     // fma(inF0, inF1, inF2); // TODO: this might auto-promote: need to check against FXC
-    fwidth(inF0);                                               // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
-    InterlockedAdd(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
-    InterlockedAnd(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
-    InterlockedCompareExchange(gs_ua4, gs_ub4, gs_uc4, out_u4); // expected error: only valid in pixel stage
-    InterlockedExchange(gs_ua4, gs_ub4, out_u4);                // expected error: only valid in pixel stage
-    InterlockedMax(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
-    InterlockedMax(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
-    InterlockedMin(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua4, gs_ub4);                              // expected error: only valid in pixel stage
-    InterlockedOr(gs_ua4, gs_ub4, out_u4);                      // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
-    InterlockedXor(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
-    noise(inF0);                                                // expected error: only valid in pixel stage
-    reversebits(inF0);                                          // expected error: only integer inputs
-    transpose(inF0);                                            // expect error: only valid on mats
+    // fwidth(inF0);                                               // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
+    // InterlockedAdd(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
+    // InterlockedAnd(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
+    // InterlockedCompareExchange(gs_ua4, gs_ub4, gs_uc4, out_u4); // expected error: only valid in pixel stage
+    // InterlockedExchange(gs_ua4, gs_ub4, out_u4);                // expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
+    // InterlockedMax(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
+    // InterlockedMin(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua4, gs_ub4);                              // expected error: only valid in pixel stage
+    // InterlockedOr(gs_ua4, gs_ub4, out_u4);                      // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua4, gs_ub4);                             // expected error: only valid in pixel stage
+    // InterlockedXor(gs_ua4, gs_ub4, out_u4);                     // expected error: only valid in pixel stage
+    // noise(inF0);                                                // expected error: only valid in pixel stage
+    // reversebits(inF0);                                          // expected error: only integer inputs
+    // transpose(inF0);                                            // expect error: only valid on mats
 
     // TODO: texture intrinsics, when we can declare samplers.
 
@@ -218,32 +218,7 @@ float4 VertexShaderFunction(float4 inF0, float4 inF1, float4 inF2, int4 inI0)
 }
 
 // TODO: FXC doesn't accept this with (), but glslang doesn't accept it without.
-#define MATFNS() \
-    countbits(inF0);                         \
-    cross(inF0, inF1);                       \
-    D3DCOLORtoUBYTE4(inF0);                  \
-    ddx(inF0);                               \
-    ddx_coarse(inF0);                        \
-    ddx_fine(inF0);                          \
-    ddy(inF0);                               \
-    ddy_coarse(inF0);                        \
-    ddy_fine(inF0);                          \
-    EvaluateAttributeAtCentroid(inF0);       \
-    EvaluateAttributeAtSample(inF0, 2);      \
-    EvaluateAttributeSnapped(inF0, int2(2)); \
-    f16tof32(inF0);                          \
-    firstbithigh(inF0);                      \
-    firstbitlow(inF0);                       \
-    fwidth(inF0);                            \
-    noise(inF0);                             \
-    reversebits(inF0);                       \
-    length(inF0);                            \
-    noise(inF0);                             \
-    normalize(inF0);                         \
-    reflect(inF0, inF1);                     \
-    refract(inF0, inF1, 1.0);                \
-    reversebits(inF0);                       \
-    
+#define MATFNS()
 
 // TODO: turn on non-square matrix tests when protos are available.
 

--- a/hlsl/hlslParseables.cpp
+++ b/hlsl/hlslParseables.cpp
@@ -453,8 +453,24 @@ void TBuiltInParseablesHlsl::createMatTimesMat()
 void TBuiltInParseablesHlsl::initialize(int /*version*/, EProfile /*profile*/, const SpvVersion& /*spvVersion*/)
 {
     static const EShLanguageMask EShLangAll    = EShLanguageMask(EShLangCount - 1);
-    static const EShLanguageMask EShLangPSCS   = EShLanguageMask(EShLangFragmentMask | EShLangComputeMask);
-    static const EShLanguageMask EShLangVSPSGS = EShLanguageMask(EShLangVertexMask | EShLangFragmentMask | EShLangGeometryMask);
+
+    // These are the actual stage masks defined in the documentation, in case they are
+    // needed for furture validation.  For now, they are commented out, and set below
+    // to EShLangAll, to allow any intrinsic to be used in any shader, which is legal
+    // if it is not called.
+    // 
+    // static const EShLanguageMask EShLangPSCS   = EShLanguageMask(EShLangFragmentMask | EShLangComputeMask);
+    // static const EShLanguageMask EShLangVSPSGS = EShLanguageMask(EShLangVertexMask | EShLangFragmentMask | EShLangGeometryMask);
+    // static const EShLanguageMask EShLangCS     = EShLangComputeMask;
+    // static const EShLanguageMask EShLangPS     = EShLangFragmentMask;
+    // static const EShLanguageMask EShLangHS     = EShLangTessControlMask;
+
+    // This set uses EShLangAll for everything.
+    static const EShLanguageMask EShLangPSCS   = EShLangAll;
+    static const EShLanguageMask EShLangVSPSGS = EShLangAll;
+    static const EShLanguageMask EShLangCS     = EShLangAll;
+    static const EShLanguageMask EShLangPS     = EShLangAll;
+    static const EShLanguageMask EShLangHS     = EShLangAll;
 
     // This structure encodes the prototype information for each HLSL intrinsic.
     // Because explicit enumeration would be cumbersome, it's procedurally generated.
@@ -486,8 +502,8 @@ void TBuiltInParseablesHlsl::initialize(int /*version*/, EProfile /*profile*/, c
         { "abs",                              nullptr, nullptr,   "SVM",            "DFUI",          EShLangAll },
         { "acos",                             nullptr, nullptr,   "SVM",            "F",             EShLangAll },
         { "all",                              "S",    "B",        "SVM",            "BFI",           EShLangAll },
-        { "AllMemoryBarrier",                 nullptr, nullptr,   "-",              "-",             EShLangComputeMask },
-        { "AllMemoryBarrierWithGroupSync",    nullptr, nullptr,   "-",              "-",             EShLangComputeMask },
+        { "AllMemoryBarrier",                 nullptr, nullptr,   "-",              "-",             EShLangCS },
+        { "AllMemoryBarrierWithGroupSync",    nullptr, nullptr,   "-",              "-",             EShLangCS },
         { "any",                              "S",     "B",       "SVM",            "BFI",           EShLangAll },
         { "asdouble",                         "S",     "D",       "S,",             "U,",            EShLangAll },
         { "asdouble",                         "V2",    "D",       "V2,",            "U,",            EShLangAll },
@@ -500,29 +516,29 @@ void TBuiltInParseablesHlsl::initialize(int /*version*/, EProfile /*profile*/, c
         { "ceil",                             nullptr, nullptr,   "SVM",            "F",             EShLangAll },
         { "CheckAccessFullyMapped",           "S",     "B" ,      "S",              "U",             EShLangPSCS },
         { "clamp",                            nullptr, nullptr,   "SVM,,",          "FUI,,",         EShLangAll },
-        { "clip",                             "-",     "-",       "SVM",            "F",             EShLangFragmentMask },
+        { "clip",                             "-",     "-",       "SVM",            "F",             EShLangPS },
         { "cos",                              nullptr, nullptr,   "SVM",            "F",             EShLangAll },
         { "cosh",                             nullptr, nullptr,   "SVM",            "F",             EShLangAll },
         { "countbits",                        nullptr, nullptr,   "SV",             "U",             EShLangAll },
         { "cross",                            nullptr, nullptr,   "V3,",            "F,",            EShLangAll },
         { "D3DCOLORtoUBYTE4",                 "V4",    "I",       "V4",             "F",             EShLangAll },
-        { "ddx",                              nullptr, nullptr,   "SVM",            "F",             EShLangFragmentMask },
-        { "ddx_coarse",                       nullptr, nullptr,   "SVM",            "F",             EShLangFragmentMask },
-        { "ddx_fine",                         nullptr, nullptr,   "SVM",            "F",             EShLangFragmentMask },
-        { "ddy",                              nullptr, nullptr,   "SVM",            "F",             EShLangFragmentMask },
-        { "ddy_coarse",                       nullptr, nullptr,   "SVM",            "F",             EShLangFragmentMask },
-        { "ddy_fine",                         nullptr, nullptr,   "SVM",            "F",             EShLangFragmentMask },
+        { "ddx",                              nullptr, nullptr,   "SVM",            "F",             EShLangPS },
+        { "ddx_coarse",                       nullptr, nullptr,   "SVM",            "F",             EShLangPS },
+        { "ddx_fine",                         nullptr, nullptr,   "SVM",            "F",             EShLangPS },
+        { "ddy",                              nullptr, nullptr,   "SVM",            "F",             EShLangPS },
+        { "ddy_coarse",                       nullptr, nullptr,   "SVM",            "F",             EShLangPS },
+        { "ddy_fine",                         nullptr, nullptr,   "SVM",            "F",             EShLangPS },
         { "degrees",                          nullptr, nullptr,   "SVM",            "F",             EShLangAll },
         { "determinant",                      "S",     "F",       "M",              "F",             EShLangAll },
         { "DeviceMemoryBarrier",              nullptr, nullptr,   "-",              "-",             EShLangPSCS },
-        { "DeviceMemoryBarrierWithGroupSync", nullptr, nullptr,   "-",              "-",             EShLangComputeMask },
+        { "DeviceMemoryBarrierWithGroupSync", nullptr, nullptr,   "-",              "-",             EShLangCS },
         { "distance",                         "S",     "F",       "V,",             "F,",            EShLangAll },
         { "dot",                              "S",     nullptr,   "V,",             "FI,",           EShLangAll },
         { "dst",                              nullptr, nullptr,   "V4,",            "F,",            EShLangAll },
         // { "errorf",                           "-",     "-",       "",             "",             EShLangAll }, TODO: varargs
-        { "EvaluateAttributeAtCentroid",      nullptr, nullptr,   "SVM",            "F",             EShLangFragmentMask },
-        { "EvaluateAttributeAtSample",        nullptr, nullptr,   "SVM,S",          "F,U",           EShLangFragmentMask },
-        { "EvaluateAttributeSnapped",         nullptr, nullptr,   "SVM,V2",         "F,I",           EShLangFragmentMask },
+        { "EvaluateAttributeAtCentroid",      nullptr, nullptr,   "SVM",            "F",             EShLangPS },
+        { "EvaluateAttributeAtSample",        nullptr, nullptr,   "SVM,S",          "F,U",           EShLangPS },
+        { "EvaluateAttributeSnapped",         nullptr, nullptr,   "SVM,V2",         "F,I",           EShLangPS },
         { "exp",                              nullptr, nullptr,   "SVM",            "F",             EShLangAll },
         { "exp2",                             nullptr, nullptr,   "SVM",            "F",             EShLangAll },
         { "f16tof32",                         nullptr, "F",       "SV",             "U",             EShLangAll },
@@ -535,11 +551,11 @@ void TBuiltInParseablesHlsl::initialize(int /*version*/, EProfile /*profile*/, c
         { "fmod",                             nullptr, nullptr,   "SVM,",           "F,",            EShLangAll },
         { "frac",                             nullptr, nullptr,   "SVM",            "F",             EShLangAll },
         { "frexp",                            nullptr, nullptr,   "SVM,",           "F,",            EShLangAll },
-        { "fwidth",                           nullptr, nullptr,   "SVM",            "F",             EShLangFragmentMask },
+        { "fwidth",                           nullptr, nullptr,   "SVM",            "F",             EShLangPS },
         { "GetRenderTargetSampleCount",       "S",     "U",       "-",              "-",             EShLangAll },
         { "GetRenderTargetSamplePosition",    "V2",    "F",       "V1",             "I",             EShLangAll },
-        { "GroupMemoryBarrier",               nullptr, nullptr,   "-",              "-",             EShLangComputeMask },
-        { "GroupMemoryBarrierWithGroupSync",  nullptr, nullptr,   "-",              "-",             EShLangComputeMask },
+        { "GroupMemoryBarrier",               nullptr, nullptr,   "-",              "-",             EShLangCS },
+        { "GroupMemoryBarrierWithGroupSync",  nullptr, nullptr,   "-",              "-",             EShLangCS },
         { "InterlockedAdd",                   "-",     "-",       "SVM,,>",         "UI,,",          EShLangPSCS },
         { "InterlockedAdd",                   "-",     "-",       "SVM,",           "UI,",           EShLangPSCS },
         { "InterlockedAnd",                   "-",     "-",       "SVM,,>",         "UI,,",          EShLangPSCS },
@@ -580,20 +596,20 @@ void TBuiltInParseablesHlsl::initialize(int /*version*/, EProfile /*profile*/, c
         { "mul",                              "M",     nullptr,   "M,S",            "FI,",           EShLangAll },
         { "mul",                              "V",     nullptr,   "M,#V",           "FI,",           EShLangAll },
         // mat*mat form of mul is handled in createMatTimesMat()
-        { "noise",                            "S",     "F",       "V",              "F",             EShLangFragmentMask },
+        { "noise",                            "S",     "F",       "V",              "F",             EShLangPS },
         { "normalize",                        nullptr, nullptr,   "V",              "F",             EShLangAll },
         { "pow",                              nullptr, nullptr,   "SVM,",           "F,",            EShLangAll },
         // { "printf",                           "-",     "-",       "",            "",              EShLangAll }, TODO: varargs
-        { "Process2DQuadTessFactorsAvg",      "-",     "-",       "V4,V2,>V4,>V2,", "F,,,,",         EShLangTessControlMask },
-        { "Process2DQuadTessFactorsMax",      "-",     "-",       "V4,V2,>V4,>V2,", "F,,,,",         EShLangTessControlMask },
-        { "Process2DQuadTessFactorsMin",      "-",     "-",       "V4,V2,>V4,>V2,", "F,,,,",         EShLangTessControlMask },
-        { "ProcessIsolineTessFactors",        "-",     "-",       "S,,>,>",         "F,,,",          EShLangTessControlMask },
-        { "ProcessQuadTessFactorsAvg",        "-",     "-",       "V4,S,>V4,>V2,",  "F,,,,",         EShLangTessControlMask },
-        { "ProcessQuadTessFactorsMax",        "-",     "-",       "V4,S,>V4,>V2,",  "F,,,,",         EShLangTessControlMask },
-        { "ProcessQuadTessFactorsMin",        "-",     "-",       "V4,S,>V4,>V2,",  "F,,,,",         EShLangTessControlMask },
-        { "ProcessTriTessFactorsAvg",         "-",     "-",       "V3,S,>V3,>S,",   "F,,,,",         EShLangTessControlMask },
-        { "ProcessTriTessFactorsMax",         "-",     "-",       "V3,S,>V3,>S,",   "F,,,,",         EShLangTessControlMask },
-        { "ProcessTriTessFactorsMin",         "-",     "-",       "V3,S,>V3,>S,",   "F,,,,",         EShLangTessControlMask },
+        { "Process2DQuadTessFactorsAvg",      "-",     "-",       "V4,V2,>V4,>V2,", "F,,,,",         EShLangHS },
+        { "Process2DQuadTessFactorsMax",      "-",     "-",       "V4,V2,>V4,>V2,", "F,,,,",         EShLangHS },
+        { "Process2DQuadTessFactorsMin",      "-",     "-",       "V4,V2,>V4,>V2,", "F,,,,",         EShLangHS },
+        { "ProcessIsolineTessFactors",        "-",     "-",       "S,,>,>",         "F,,,",          EShLangHS },
+        { "ProcessQuadTessFactorsAvg",        "-",     "-",       "V4,S,>V4,>V2,",  "F,,,,",         EShLangHS },
+        { "ProcessQuadTessFactorsMax",        "-",     "-",       "V4,S,>V4,>V2,",  "F,,,,",         EShLangHS },
+        { "ProcessQuadTessFactorsMin",        "-",     "-",       "V4,S,>V4,>V2,",  "F,,,,",         EShLangHS },
+        { "ProcessTriTessFactorsAvg",         "-",     "-",       "V3,S,>V3,>S,",   "F,,,,",         EShLangHS },
+        { "ProcessTriTessFactorsMax",         "-",     "-",       "V3,S,>V3,>S,",   "F,,,,",         EShLangHS },
+        { "ProcessTriTessFactorsMin",         "-",     "-",       "V3,S,>V3,>S,",   "F,,,,",         EShLangHS },
         { "radians",                          nullptr, nullptr,   "SVM",            "F",             EShLangAll },
         { "rcp",                              nullptr, nullptr,   "SVM",            "FD",            EShLangAll },
         { "reflect",                          nullptr, nullptr,   "V,",             "F,",            EShLangAll },
@@ -611,48 +627,48 @@ void TBuiltInParseablesHlsl::initialize(int /*version*/, EProfile /*profile*/, c
         { "step",                             nullptr, nullptr,   "SVM,",           "F,",            EShLangAll },
         { "tan",                              nullptr, nullptr,   "SVM",            "F",             EShLangAll },
         { "tanh",                             nullptr, nullptr,   "SVM",            "F",             EShLangAll },
-        { "tex1D",                            "V4",    "F",       "V1,S",           "S,F",           EShLangFragmentMask },
-        { "tex1D",                            "V4",    "F",       "V1,S,V1,",       "S,F,,",         EShLangFragmentMask },
-        { "tex1Dbias",                        "V4",    "F",       "V1,V4",          "S,F",           EShLangFragmentMask },
-        { "tex1Dgrad",                        "V4",    "F",       "V1,,,",          "S,F,,",         EShLangFragmentMask },
-        { "tex1Dlod",                         "V4",    "F",       "V1,V4",          "S,F",           EShLangFragmentMask },
-        { "tex1Dproj",                        "V4",    "F",       "V1,V4",          "S,F",           EShLangFragmentMask },
-        { "tex2D",                            "V4",    "F",       "V2,",            "S,F",           EShLangFragmentMask },
-        { "tex2D",                            "V4",    "F",       "V2,,,",          "S,F,,",         EShLangFragmentMask },
-        { "tex2Dbias",                        "V4",    "F",       "V2,V4",          "S,F",           EShLangFragmentMask },
-        { "tex2Dgrad",                        "V4",    "F",       "V2,,,",          "S,F,,",         EShLangFragmentMask },
-        { "tex2Dlod",                         "V4",    "F",       "V2,V4",          "S,F",           EShLangFragmentMask },
-        { "tex2Dproj",                        "V4",    "F",       "V2,V4",          "S,F",           EShLangFragmentMask },
-        { "tex3D",                            "V4",    "F",       "V3,",            "S,F",           EShLangFragmentMask },
-        { "tex3D",                            "V4",    "F",       "V3,,,",          "S,F,,",         EShLangFragmentMask },
-        { "tex3Dbias",                        "V4",    "F",       "V3,V4",          "S,F",           EShLangFragmentMask },
-        { "tex3Dgrad",                        "V4",    "F",       "V3,,,",          "S,F,,",         EShLangFragmentMask },
-        { "tex3Dlod",                         "V4",    "F",       "V3,V4",          "S,F",           EShLangFragmentMask },
-        { "tex3Dproj",                        "V4",    "F",       "V3,V4",          "S,F",           EShLangFragmentMask },
-        { "texCUBE",                          "V4",    "F",       "V4,V3",          "S,F",           EShLangFragmentMask },
-        { "texCUBE",                          "V4",    "F",       "V4,V3,,",        "S,F,,",         EShLangFragmentMask },
-        { "texCUBEbias",                      "V4",    "F",       "V4,",            "S,F",           EShLangFragmentMask },
-        { "texCUBEgrad",                      "V4",    "F",       "V4,V3,,",        "S,F,,",         EShLangFragmentMask },
-        { "texCUBElod",                       "V4",    "F",       "V4,",            "S,F",           EShLangFragmentMask },
-        { "texCUBEproj",                      "V4",    "F",       "V4,",            "S,F",           EShLangFragmentMask },
+        { "tex1D",                            "V4",    "F",       "V1,S",           "S,F",           EShLangPS },
+        { "tex1D",                            "V4",    "F",       "V1,S,V1,",       "S,F,,",         EShLangPS },
+        { "tex1Dbias",                        "V4",    "F",       "V1,V4",          "S,F",           EShLangPS },
+        { "tex1Dgrad",                        "V4",    "F",       "V1,,,",          "S,F,,",         EShLangPS },
+        { "tex1Dlod",                         "V4",    "F",       "V1,V4",          "S,F",           EShLangPS },
+        { "tex1Dproj",                        "V4",    "F",       "V1,V4",          "S,F",           EShLangPS },
+        { "tex2D",                            "V4",    "F",       "V2,",            "S,F",           EShLangPS },
+        { "tex2D",                            "V4",    "F",       "V2,,,",          "S,F,,",         EShLangPS },
+        { "tex2Dbias",                        "V4",    "F",       "V2,V4",          "S,F",           EShLangPS },
+        { "tex2Dgrad",                        "V4",    "F",       "V2,,,",          "S,F,,",         EShLangPS },
+        { "tex2Dlod",                         "V4",    "F",       "V2,V4",          "S,F",           EShLangPS },
+        { "tex2Dproj",                        "V4",    "F",       "V2,V4",          "S,F",           EShLangPS },
+        { "tex3D",                            "V4",    "F",       "V3,",            "S,F",           EShLangPS },
+        { "tex3D",                            "V4",    "F",       "V3,,,",          "S,F,,",         EShLangPS },
+        { "tex3Dbias",                        "V4",    "F",       "V3,V4",          "S,F",           EShLangPS },
+        { "tex3Dgrad",                        "V4",    "F",       "V3,,,",          "S,F,,",         EShLangPS },
+        { "tex3Dlod",                         "V4",    "F",       "V3,V4",          "S,F",           EShLangPS },
+        { "tex3Dproj",                        "V4",    "F",       "V3,V4",          "S,F",           EShLangPS },
+        { "texCUBE",                          "V4",    "F",       "V4,V3",          "S,F",           EShLangPS },
+        { "texCUBE",                          "V4",    "F",       "V4,V3,,",        "S,F,,",         EShLangPS },
+        { "texCUBEbias",                      "V4",    "F",       "V4,",            "S,F",           EShLangPS },
+        { "texCUBEgrad",                      "V4",    "F",       "V4,V3,,",        "S,F,,",         EShLangPS },
+        { "texCUBElod",                       "V4",    "F",       "V4,",            "S,F",           EShLangPS },
+        { "texCUBEproj",                      "V4",    "F",       "V4,",            "S,F",           EShLangPS },
         { "transpose",                        "^M",    nullptr,   "M",              "F",             EShLangAll },
         { "trunc",                            nullptr, nullptr,   "SVM",            "F",             EShLangAll },
 
         // Texture object methods.  Return type can be overridden by shader declaration.
         // !O = no offset, O = offset
-        { "Sample",             /*!O*/        "V4",    nullptr,   "%@,S,V",         "FIU,S,F",       EShLangFragmentMask },
-        { "Sample",             /* O*/        "V4",    nullptr,   "%@,S,V,",        "FIU,S,F,I",     EShLangFragmentMask },
+        { "Sample",             /*!O*/        "V4",    nullptr,   "%@,S,V",         "FIU,S,F",       EShLangPS },
+        { "Sample",             /* O*/        "V4",    nullptr,   "%@,S,V,",        "FIU,S,F,I",     EShLangPS },
 
-        { "SampleBias",         /*!O*/        "V4",    nullptr,   "%@,S,V,S",       "FIU,S,F,",      EShLangFragmentMask },
-        { "SampleBias",         /* O*/        "V4",    nullptr,   "%@,S,V,S,V",     "FIU,S,F,,I",    EShLangFragmentMask },
-
-        // TODO: FXC accepts int/uint samplers here.  unclear what that means.
-        { "SampleCmp",          /*!O*/        "S",     "F",       "%@,S,V,S",       "FIU,s,F,",      EShLangFragmentMask },
-        { "SampleCmp",          /* O*/        "S",     "F",       "%@,S,V,S,V",     "FIU,s,F,,I",    EShLangFragmentMask },
+        { "SampleBias",         /*!O*/        "V4",    nullptr,   "%@,S,V,S",       "FIU,S,F,",      EShLangPS },
+        { "SampleBias",         /* O*/        "V4",    nullptr,   "%@,S,V,S,V",     "FIU,S,F,,I",    EShLangPS },
 
         // TODO: FXC accepts int/uint samplers here.  unclear what that means.
-        { "SampleCmpLevelZero", /*!O*/        "S",     "F",       "%@,S,V,S",       "FIU,s,F,F",     EShLangFragmentMask },
-        { "SampleCmpLevelZero", /* O*/        "S",     "F",       "%@,S,V,S,V",     "FIU,s,F,F,I",   EShLangFragmentMask },
+        { "SampleCmp",          /*!O*/        "S",     "F",       "%@,S,V,S",       "FIU,s,F,",      EShLangPS },
+        { "SampleCmp",          /* O*/        "S",     "F",       "%@,S,V,S,V",     "FIU,s,F,,I",    EShLangPS },
+
+        // TODO: FXC accepts int/uint samplers here.  unclear what that means.
+        { "SampleCmpLevelZero", /*!O*/        "S",     "F",       "%@,S,V,S",       "FIU,s,F,F",     EShLangPS },
+        { "SampleCmpLevelZero", /* O*/        "S",     "F",       "%@,S,V,S,V",     "FIU,s,F,F,I",   EShLangPS },
 
         { "SampleGrad",         /*!O*/        "V4",    nullptr,   "%@,S,V,,",       "FIU,S,F,,",     EShLangAll },
         { "SampleGrad",         /* O*/        "V4",    nullptr,   "%@,S,V,,,",      "FIU,S,F,,,I",   EShLangAll },
@@ -668,8 +684,8 @@ void TBuiltInParseablesHlsl::initialize(int /*version*/, EProfile /*profile*/, c
         { "Gather",             /*!O*/        "V4",    nullptr,   "%@,S,V",         "FIU,S,F",       EShLangAll },
         { "Gather",             /* O*/        "V4",    nullptr,   "%@,S,V,V",       "FIU,S,F,I",     EShLangAll },
 
-        { "CalculateLevelOfDetail",           "S",     "F",       "%@,S,V",         "FUI,S,F",       EShLangFragmentMask },
-        { "CalculateLevelOfDetailUnclamped",  "S",     "F",       "%@,S,V",         "FUI,S,F",       EShLangFragmentMask },
+        { "CalculateLevelOfDetail",           "S",     "F",       "%@,S,V",         "FUI,S,F",       EShLangPS },
+        { "CalculateLevelOfDetailUnclamped",  "S",     "F",       "%@,S,V",         "FUI,S,F",       EShLangPS },
 
         { "GetSamplePosition",                "V2",    "F",       "$&2,S",          "FUI,I",         EShLangVSPSGS },
 


### PR DESCRIPTION
It is legal to call e.g, a PS only intrinsic from a VS, as long as it is not called.  Previously, the intrinsics were only in the symbol table for the stages in which they belonged.

This information is still lexically preserved in case of a future validation use, but the mask variables are all set to EShLangAll, which puts them in the common symbol table.

Negative tests for their absence are disabled.
