### PR TITLE
Revert "Merge pull request #456 from steve-lunarg/remapper-literal64"

### DIFF
--- a/SPIRV/SPVRemapper.h
+++ b/SPIRV/SPVRemapper.h
@@ -162,15 +162,13 @@ private:
    // handle error
    void error(const std::string& txt) const { errorHandler(txt); }
 
-   bool     isConstOp(spv::Op opCode)      const;
-   bool     isTypeOp(spv::Op opCode)       const;
-   bool     isStripOp(spv::Op opCode)      const;
-   bool     isFlowCtrl(spv::Op opCode)     const;
-   range_t  literalRange(spv::Op opCode)   const;
-   range_t  typeRange(spv::Op opCode)      const;
-   range_t  constRange(spv::Op opCode)     const;
-   unsigned typeSizeInWords(spv::Id id)    const;
-   unsigned idTypeSizeInWords(spv::Id id)  const;
+   bool    isConstOp(spv::Op opCode)       const;
+   bool    isTypeOp(spv::Op opCode)        const;
+   bool    isStripOp(spv::Op opCode)       const;
+   bool    isFlowCtrl(spv::Op opCode)      const;
+   range_t literalRange(spv::Op opCode)    const;
+   range_t typeRange(spv::Op opCode)       const;
+   range_t constRange(spv::Op opCode)      const;
    
    spv::Id&        asId(unsigned word)                { return spv[word]; }
    const spv::Id&  asId(unsigned word)          const { return spv[word]; }
@@ -179,10 +177,10 @@ private:
    spv::Decoration asDecoration(unsigned word)  const { return spv::Decoration(spv[word]); }
    unsigned        asWordCount(unsigned word)   const { return opWordCount(spv[word]); }
    spv::Id         asTypeConstId(unsigned word) const { return asId(word + (isTypeOp(asOpCode(word)) ? 1 : 2)); }
-   unsigned        idPos(spv::Id id)            const;
+   unsigned        typePos(spv::Id id)          const;
 
-   static unsigned opWordCount(spirword_t data) { return data >> spv::WordCountShift; }
-   static spv::Op  opOpCode(spirword_t data)    { return spv::Op(data & spv::OpCodeMask); }
+   static unsigned    opWordCount(spirword_t data) { return data >> spv::WordCountShift; }
+   static spv::Op     opOpCode(spirword_t data)    { return spv::Op(data & spv::OpCodeMask); }
 
    // Header access & set methods
    spirword_t  magic()    const       { return spv[0]; } // return magic number
@@ -265,8 +263,8 @@ private:
    // Which functions are called, anywhere in the module, with a call count
    std::unordered_map<spv::Id, int> fnCalls;
    
-   posmap_t     typeConstPos;  // word positions that define types & consts (ordered)
-   posmap_rev_t idPosR;        // reverse map from IDs to positions
+   posmap_t     typeConstPos;   // word positions that define types & consts (ordered)
+   posmap_rev_t typeConstPosR;  // reverse map from IDs to positions
    
    std::vector<spv::Id>  idMapL;   // ID {M}ap from {L}ocal to {G}lobal IDs
 


### PR DESCRIPTION
This reverts commit ad08b30f696267ec6243dd0ad68a3db889cd2d21, reversing
changes made to 28660bb580d4c61e16ef75008550a87b3be90b91.

This backs out the pull request
https://github.com/KhronosGroup/glslang/pull/456 because it introduced
several internal errors even on code that only uses 32-bit numeric
types.