### PR TITLE
WIP: HLSL Buffer intrinsic fixes take 2, replaces #459

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -1837,7 +1837,7 @@ spv::Id TGlslangToSpvTraverser::createSpvVariable(const glslang::TIntermSymbol* 
 // Return type Id of the sampled type.
 spv::Id TGlslangToSpvTraverser::getSampledType(const glslang::TSampler& sampler)
 {
-    switch (sampler.type) {
+    switch (sampler.getBasicType()) {
         case glslang::EbtFloat:    return builder.makeFloatType(32);
         case glslang::EbtInt:      return builder.makeIntType(32);
         case glslang::EbtUint:     return builder.makeUintType(32);

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SOURCES
     MachineIndependent/preprocessor/PpTokens.cpp
     MachineIndependent/propagateNoContraction.cpp
     GenericCodeGen/CodeGen.cpp
+    GenericCodeGen/Types.cpp
     GenericCodeGen/Link.cpp)
 
 set(HEADERS

--- a/glslang/GenericCodeGen/Types.cpp
+++ b/glslang/GenericCodeGen/Types.cpp
@@ -1,0 +1,266 @@
+
+//
+//Copyright (C) 2002-2005  3Dlabs Inc. Ltd.
+//Copyright (C) 2012-2016 LunarG, Inc.
+//Copyright (C) 2015-2016 Google, Inc.
+//Copyright (C) 2016 Oxide Games
+//
+//All rights reserved.
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions
+//are met:
+//
+//    Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//    Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//    Neither the name of 3Dlabs Inc. Ltd. nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+//"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+//LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+//FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+//COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+//CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+//LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+//ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "../Include/Types.h"
+
+namespace glslang {
+
+void TSampler::deepCopy(const TSampler& copyOf)
+{
+    if (copyOf.samplerType != nullptr)
+    {
+        samplerType = new TType;
+        samplerType->deepCopy(*copyOf.samplerType);
+    }
+    else
+        samplerType = nullptr;
+
+    dim = copyOf.dim;;
+    arrayed = copyOf.arrayed;
+    shadow = copyOf.shadow;
+    ms = copyOf.ms;
+    image = copyOf.image;
+    combined = copyOf.combined;
+    sampler = copyOf.sampler;
+    external = copyOf.external;
+}
+
+TBasicType TSampler::getBasicType() const
+{
+    if (samplerType == nullptr)
+        return EbtVoid;
+    else
+        return samplerType->getBasicType();
+
+}
+
+void TSampler::clear()
+{
+    samplerType = nullptr;
+    dim = EsdNone;
+    arrayed = false;
+    shadow = false;
+    ms = false;
+    image = false;
+    combined = false;
+    sampler = false;
+    external = false;
+}
+
+// make a combined sampler and texture, basic type
+void TSampler::set(TBasicType t, TSamplerDim d, bool a , bool s , bool m )
+{
+    clear();
+    samplerType = new TType(t);
+    dim = d;
+    arrayed = a;
+    shadow = s;
+    ms = m;
+    combined = true;
+}
+
+// make a combined sampler and texture
+void  TSampler::set(TType *t, TSamplerDim d, bool a, bool s, bool m)
+{
+    clear();
+    samplerType = t;
+    dim = d;
+    arrayed = a;
+    shadow = s;
+    ms = m;
+    combined = true;
+}
+
+// make an image
+void  TSampler::setImage(TType *t, TSamplerDim d, bool a , bool s, bool m)
+{
+    clear();
+    samplerType = t;
+    dim = d;
+    arrayed = a;
+    shadow = s;
+    ms = m;
+    image = true;
+}
+
+
+// make an image, basic type
+void  TSampler::setImage(TBasicType t, TSamplerDim d, bool a, bool s, bool m)
+{
+    clear();
+    samplerType = new TType(t);
+    dim = d;
+    arrayed = a;
+    shadow = s;
+    ms = m;
+    image = true;
+}
+
+// make a texture with no sampler
+void  TSampler::setTexture(TType *t, TSamplerDim d, bool a, bool s , bool m )
+{
+    clear();
+    samplerType = t;
+    dim = d;
+    arrayed = a;
+    shadow = s;
+    ms = m;
+}
+
+// make a texture with no sampler, basic type
+void  TSampler::setTexture(TBasicType t, TSamplerDim d, bool a, bool s, bool m)
+{
+    clear();
+    samplerType = new TType(t);
+    dim = d;
+    arrayed = a;
+    shadow = s;
+    ms = m;
+}
+
+
+// make a subpass input attachment
+void  TSampler::setSubpass(TType *t, bool m)
+{
+    clear();
+    samplerType = t;
+    image = true;
+    dim = EsdSubpass;
+    ms = m;
+}
+
+// make a subpass input attachment, basic type
+void  TSampler::setSubpass(TBasicType t, bool m)
+{
+    clear();
+    samplerType = new TType(t);
+    image = true;
+    dim = EsdSubpass;
+    ms = m;
+}
+
+// make a pure sampler, no texture, no image, nothing combined, the 'sampler' keyword
+void  TSampler::setPureSampler(bool s)
+{
+    clear();
+    sampler = true;
+    shadow = s;
+}
+
+bool  TSampler::operator==(const TSampler& right) const
+{
+    bool bTypesEqual = true;
+    if (samplerType == nullptr && right.samplerType != nullptr)
+        bTypesEqual = false;
+    else if (samplerType != nullptr && right.samplerType == nullptr )
+        bTypesEqual = false;
+    //For now, just check if there base types match, there appear to be cases where the some of the intrinsic functions have type info
+    //in them that don't need to, like GetDimensions. Perhaps a baseless type is needed.
+    else if(samplerType != nullptr && right.samplerType != nullptr )
+        bTypesEqual = (samplerType->getBasicType() == right.samplerType->getBasicType());
+
+    return bTypesEqual &&
+        dim == right.dim &&
+        arrayed == right.arrayed &&
+        shadow == right.shadow &&
+        ms == right.ms &&
+        image == right.image &&
+        combined == right.combined &&
+        sampler == right.sampler &&
+        external == right.external;
+}
+
+bool  TSampler::operator!=(const TSampler& right) const
+{
+    return !operator==(right);
+}
+
+TString  TSampler::getString() const
+{
+    TString s;
+
+    if (sampler) {
+        s.append("sampler");
+        return s;
+    }
+
+    switch (samplerType->getBasicType()) {
+    case EbtFloat:               break;
+    case EbtInt:  s.append("i"); break;
+    case EbtUint: s.append("u"); break;
+    case EbtInt64:  s.append("i64"); break;
+    case EbtUint64: s.append("u64"); break;
+    default:  break;  // some compilers want this
+    }
+    if (image) {
+        if (dim == EsdSubpass)
+            s.append("subpass");
+        else
+            s.append("image");
+    }
+    else if (combined) {
+        s.append("sampler");
+    }
+    else {
+        s.append("texture");
+    }
+    if (external) {
+        s.append("ExternalOES");
+        return s;
+    }
+    switch (dim) {
+    case Esd1D:      s.append("1D");      break;
+    case Esd2D:      s.append("2D");      break;
+    case Esd3D:      s.append("3D");      break;
+    case EsdCube:    s.append("Cube");    break;
+    case EsdRect:    s.append("2DRect");  break;
+    case EsdBuffer:  s.append("Buffer");  break;
+    case EsdSubpass: s.append("Input"); break;
+    default:  break;  // some compilers want this
+    }
+    if (ms)
+        s.append("MS");
+    if (arrayed)
+        s.append("Array");
+    if (shadow)
+        s.append("Shadow");
+
+    return s;
+}
+}

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -2684,7 +2684,11 @@ void TBuiltIns::add2ndGenerationSamplingImaging(int version, EProfile profile, c
     // to enumerate all the uses for that type.
     //
 
-    TBasicType bTypes[3] = { EbtFloat, EbtInt, EbtUint };
+	TType *bTypes[3];
+	bTypes[0] = new TType(EbtFloat);
+	bTypes[1] = new TType(EbtInt);
+	bTypes[2] = new TType(EbtUint);
+
     bool skipBuffer = (profile == EEsProfile && version < 310) || (profile != EEsProfile && version < 140);
     bool skipCubeArrayed = (profile == EEsProfile && version < 310) || (profile != EEsProfile && version < 130);
 
@@ -2883,7 +2887,7 @@ void TBuiltIns::addImageFunctions(TSampler sampler, TString& typeName, int versi
 
     if (profile == EEsProfile)
         commonBuiltins.append("highp ");
-    commonBuiltins.append(prefixes[sampler.type]);
+    commonBuiltins.append(prefixes[sampler.getBasicType()]);
     commonBuiltins.append("vec4 imageLoad(readonly volatile coherent ");
     commonBuiltins.append(imageParams);
     commonBuiltins.append(");\n");
@@ -2891,22 +2895,22 @@ void TBuiltIns::addImageFunctions(TSampler sampler, TString& typeName, int versi
     commonBuiltins.append("void imageStore(writeonly volatile coherent ");
     commonBuiltins.append(imageParams);
     commonBuiltins.append(", ");
-    commonBuiltins.append(prefixes[sampler.type]);
+    commonBuiltins.append(prefixes[sampler.getBasicType()]);
     commonBuiltins.append("vec4);\n");
 
     if (sampler.dim != Esd1D && sampler.dim != EsdBuffer && profile != EEsProfile && version >= 450) {
         commonBuiltins.append("int sparseImageLoadARB(readonly volatile coherent ");
         commonBuiltins.append(imageParams);
         commonBuiltins.append(", out ");
-        commonBuiltins.append(prefixes[sampler.type]);
+        commonBuiltins.append(prefixes[sampler.getBasicType()]);
         commonBuiltins.append("vec4");
         commonBuiltins.append(");\n");
     }
 
     if ( profile != EEsProfile ||
         (profile == EEsProfile && version >= 310)) {
-        if (sampler.type == EbtInt || sampler.type == EbtUint) {
-            const char* dataType = sampler.type == EbtInt ? "highp int" : "highp uint";
+        if (sampler.getBasicType() == EbtInt || sampler.getBasicType() == EbtUint) {
+            const char* dataType = sampler.getBasicType() == EbtInt ? "highp int" : "highp uint";
 
             const int numBuiltins = 7;
 
@@ -2959,7 +2963,7 @@ void TBuiltIns::addImageFunctions(TSampler sampler, TString& typeName, int versi
 //
 void TBuiltIns::addSubpassSampling(TSampler sampler, TString& typeName, int /*version*/, EProfile /*profile*/)
 {
-    stageBuiltins[EShLangFragment].append(prefixes[sampler.type]);
+    stageBuiltins[EShLangFragment].append(prefixes[sampler.getBasicType()]);
     stageBuiltins[EShLangFragment].append("vec4 subpassLoad");
     stageBuiltins[EShLangFragment].append("(");
     stageBuiltins[EShLangFragment].append(typeName.c_str());
@@ -3071,7 +3075,7 @@ void TBuiltIns::addSamplingFunctions(TSampler sampler, TString& typeName, int ve
                                             if (sampler.shadow)
                                                 s.append("float ");
                                             else {
-                                                s.append(prefixes[sampler.type]);
+                                                s.append(prefixes[sampler.getBasicType()]);
                                                 s.append("vec4 ");
                                             }
                                         }
@@ -3170,7 +3174,7 @@ void TBuiltIns::addSamplingFunctions(TSampler sampler, TString& typeName, int ve
                                             if (sampler.shadow)
                                                 s.append("float ");
                                             else {
-                                                s.append(prefixes[sampler.type]);
+                                                s.append(prefixes[sampler.getBasicType()]);
                                                 s.append("vec4 ");
                                             }
                                         }
@@ -3219,7 +3223,7 @@ void TBuiltIns::addGatherFunctions(TSampler sampler, TString& typeName, int vers
     if (sampler.ms)
         return;
 
-    if (version < 140 && sampler.dim == EsdRect && sampler.type != EbtFloat)
+    if (version < 140 && sampler.dim == EsdRect && sampler.getBasicType() != EbtFloat)
         return;
 
     for (int offset = 0; offset < 3; ++offset) { // loop over three forms of offset in the call name:  none, Offset, and Offsets
@@ -3242,7 +3246,7 @@ void TBuiltIns::addGatherFunctions(TSampler sampler, TString& typeName, int vers
                 if (sparse)
                     s.append("int ");
                 else {
-                    s.append(prefixes[sampler.type]);
+                    s.append(prefixes[sampler.getBasicType()]);
                     s.append("vec4 ");
                 }
 
@@ -3286,7 +3290,7 @@ void TBuiltIns::addGatherFunctions(TSampler sampler, TString& typeName, int vers
                 // texel out (for sparse texture)
                 if (sparse) {
                     s.append(",out ");
-                    s.append(prefixes[sampler.type]);
+                    s.append(prefixes[sampler.getBasicType()]);
                     s.append("vec4 ");
                 }
 

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -1669,7 +1669,7 @@ void TParseContext::builtInOpCheck(const TSourceLoc& loc, const TFunction& fnCan
     {
         // Make sure the image types have the correct layout() format and correct argument types
         const TType& imageType = arg0->getType();
-        if (imageType.getSampler().type == EbtInt || imageType.getSampler().type == EbtUint) {
+        if (imageType.getSampler().getBasicType() == EbtInt || imageType.getSampler().getBasicType() == EbtUint) {
             if (imageType.getQualifier().layoutFormat != ElfR32i && imageType.getQualifier().layoutFormat != ElfR32ui)
                 error(loc, "only supported on image with format r32i or r32ui", fnCandidate.getName().c_str(), "");
         } else {
@@ -1824,7 +1824,7 @@ void TParseContext::nonOpBuiltInCheck(const TSourceLoc& loc, const TFunction& fn
 
     if (fnCandidate.getName().compare(0, 11, "imageAtomic") == 0) {
         const TType& imageType = callNode.getSequence()[0]->getAsTyped()->getType();
-        if (imageType.getSampler().type == EbtInt || imageType.getSampler().type == EbtUint) {
+        if (imageType.getSampler().getBasicType() == EbtInt || imageType.getSampler().getBasicType() == EbtUint) {
             if (imageType.getQualifier().layoutFormat != ElfR32i && imageType.getQualifier().layoutFormat != ElfR32ui)
                 error(loc, "only supported on image with format r32i or r32ui", fnCandidate.getName().c_str(), "");
         } else {
@@ -2916,7 +2916,7 @@ int TParseContext::computeSamplerTypeIndex(TSampler& sampler)
     int msIndex       = sampler.ms      ? 1 : 0;
 
     int flattened = EsdNumDims * (EbtNumTypes * (2 * (2 * (2 * (2 * arrayIndex + msIndex) + imageIndex) + shadowIndex) +
-                                                 externalIndex) + sampler.type) + sampler.dim;
+                                                 externalIndex) + sampler.getBasicType()) + sampler.dim;
     assert(flattened < maxSamplerIndex);
 
     return flattened;
@@ -4568,11 +4568,11 @@ void TParseContext::layoutTypeCheck(const TSourceLoc& loc, const TType& type)
         if (! type.isImage())
             error(loc, "only apply to images", TQualifier::getLayoutFormatString(qualifier.layoutFormat), "");
         else {
-            if (type.getSampler().type == EbtFloat && qualifier.layoutFormat > ElfFloatGuard)
+            if (type.getSampler().getBasicType() == EbtFloat && qualifier.layoutFormat > ElfFloatGuard)
                 error(loc, "does not apply to floating point images", TQualifier::getLayoutFormatString(qualifier.layoutFormat), "");
-            if (type.getSampler().type == EbtInt && (qualifier.layoutFormat < ElfFloatGuard || qualifier.layoutFormat > ElfIntGuard))
+            if (type.getSampler().getBasicType() == EbtInt && (qualifier.layoutFormat < ElfFloatGuard || qualifier.layoutFormat > ElfIntGuard))
                 error(loc, "does not apply to signed integer images", TQualifier::getLayoutFormatString(qualifier.layoutFormat), "");
-            if (type.getSampler().type == EbtUint && qualifier.layoutFormat < ElfIntGuard)
+            if (type.getSampler().getBasicType() == EbtUint && qualifier.layoutFormat < ElfIntGuard)
                 error(loc, "does not apply to unsigned integer images", TQualifier::getLayoutFormatString(qualifier.layoutFormat), "");
 
             if (profile == EEsProfile) {

--- a/glslang/MachineIndependent/SymbolTable.cpp
+++ b/glslang/MachineIndependent/SymbolTable.cpp
@@ -67,7 +67,7 @@ void TType::buildMangledName(TString& mangledName)
     case EbtBool:               mangledName += 'b';      break;
     case EbtAtomicUint:         mangledName += "au";     break;
     case EbtSampler:
-        switch (sampler.type) {
+        switch (sampler.getBasicType()) {
         case EbtInt:   mangledName += "i"; break;
         case EbtUint:  mangledName += "u"; break;
         default: break; // some compilers want this

--- a/glslang/MachineIndependent/reflection.cpp
+++ b/glslang/MachineIndependent/reflection.cpp
@@ -401,7 +401,7 @@ public:
     {
         if (! sampler.image) {
             // a sampler...
-            switch (sampler.type) {
+            switch (sampler.getBasicType()) {
             case EbtFloat:
                 switch ((int)sampler.dim) {
                 case Esd1D:
@@ -471,7 +471,7 @@ public:
             }
         } else {
             // an image...
-            switch (sampler.type) {
+            switch (sampler.getBasicType()) {
             case EbtFloat:
                 switch ((int)sampler.dim) {
                 case Esd1D:

--- a/hlsl/hlslGrammar.cpp
+++ b/hlsl/hlslGrammar.cpp
@@ -747,18 +747,18 @@ bool HlslGrammar::acceptTextureType(TType& type)
 
     advanceToken();  // consume the texture object keyword
 
-    TType txType(EbtFloat, EvqUniform, 4); // default type is float4
-    
+	TType* txType = new TType(EbtFloat, EvqUniform, 4);
+
     TIntermTyped* msCount = nullptr;
 
     // texture type: required for multisample types!
     if (acceptTokenClass(EHTokLeftAngle)) {
-        if (! acceptType(txType)) {
+        if (! acceptType(*txType)) {
             expected("scalar or vector type");
             return false;
         }
 
-        const TBasicType basicRetType = txType.getBasicType() ;
+        const TBasicType basicRetType = txType->getBasicType() ;
 
         if (basicRetType != EbtFloat && basicRetType != EbtUint && basicRetType != EbtInt) {
             unimplemented("basic type in texture");
@@ -766,8 +766,8 @@ bool HlslGrammar::acceptTextureType(TType& type)
         }
 
         // Buffers can handle small mats if they fit in 4 components
-        if (dim == EsdBuffer && txType.isMatrix()) {
-            if ((txType.getMatrixCols() * txType.getMatrixRows()) > 4) {
+        if (dim == EsdBuffer && txType->isMatrix()) {
+            if ((txType->getMatrixCols() * txType->getMatrixRows()) > 4) {
                 expected("components < 4 in matrix buffer type");
                 return false;
             }
@@ -777,14 +777,14 @@ bool HlslGrammar::acceptTextureType(TType& type)
             return false;
         }
 
-        if (!txType.isScalar() && !txType.isVector()) {
+        if (!txType->isScalar() && !txType->isVector()) {
             expected("scalar or vector type");
             return false;
         }
 
-        if (txType.getVectorSize() != 1 && txType.getVectorSize() != 4) {
+        if (txType->getVectorSize() < 1 || txType->getVectorSize() > 4) {
             // TODO: handle vec2/3 types
-            expected("vector size not yet supported in texture type");
+            expected("vector size must between 1 and 4");
             return false;
         }
 
@@ -809,16 +809,16 @@ bool HlslGrammar::acceptTextureType(TType& type)
     }
 
     TArraySizes* arraySizes = nullptr;
-    const bool shadow = txType.isScalar() || (txType.isVector() && txType.getVectorSize() == 1);
+    const bool shadow = txType->isScalar() || (txType->isVector() && txType->getVectorSize() == 1);
 
     TSampler sampler;
 
     // Buffers are combined.
     if (dim == EsdBuffer) {
-        sampler.set(txType.getBasicType(), dim, array);
+        sampler.set(txType, dim, array, false, false);
     } else {
         // DX10 textures are separated.  TODO: DX9.
-        sampler.setTexture(txType.getBasicType(), dim, array, shadow, ms);
+        sampler.setTexture(txType, dim, array, shadow, ms);
     }
     
     type.shallowCopy(TType(sampler, EvqUniform, arraySizes));

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -604,7 +604,7 @@ TIntermTyped* HlslParseContext::handleDotDereference(const TSourceLoc& loc, TInt
             const TSampler& texType = base->getType().getSampler();
             if (! texType.isPureSampler()) {
                 const int vecSize = texType.isShadow() ? 1 : 4;
-                return intermediate.addMethod(base, TType(texType.type, EvqTemporary, vecSize), &field, loc);
+                return intermediate.addMethod(base, TType(texType.getBasicType(), EvqTemporary, vecSize), &field, loc);
             }
         }
     }
@@ -2754,7 +2754,7 @@ int HlslParseContext::computeSamplerTypeIndex(TSampler& sampler)
     int shadowIndex = sampler.shadow ? 1 : 0;
     int externalIndex = sampler.external ? 1 : 0;
 
-    return EsdNumDims * (EbtNumTypes * (2 * (2 * arrayIndex + shadowIndex) + externalIndex) + sampler.type) + sampler.dim;
+    return EsdNumDims * (EbtNumTypes * (2 * (2 * arrayIndex + shadowIndex) + externalIndex) + sampler.getBasicType()) + sampler.dim;
 }
 
 //

--- a/hlsl/hlslParseables.cpp
+++ b/hlsl/hlslParseables.cpp
@@ -676,10 +676,21 @@ void TBuiltInParseablesHlsl::initialize(int /*version*/, EProfile /*profile*/, c
         { "SampleLevel",        /*!O*/        "V4",    nullptr,   "%@,S,V,S",       "FIU,S,F,",      EShLangAll },
         { "SampleLevel",        /* O*/        "V4",    nullptr,   "%@,S,V,S,V",     "FIU,S,F,,I",    EShLangAll },
 
-        { "Load",               /*!O*/        "V4",    nullptr,   "%@*,V",          "FIU,I",         EShLangAll },
-        { "Load",               /* O*/        "V4",    nullptr,   "%@,V,V",         "FIU,I,I",       EShLangAll },
-        { "Load", /* +sampleidex*/            "V4",    nullptr,   "$&,V,S",         "FIU,I,I",       EShLangAll },
-        { "Load", /* +samplindex, offset*/    "V4",    nullptr,   "$&,V,S,V",       "FIU,I,I,I",     EShLangAll },
+
+        //It appears that if you have multiple types that not in the second column, that these are not iterated over,
+        // that is    { "Load",               /*!O*/        "V4",    nullptr,   "%@*,V",          "FIU,UI",        EShLangAll },
+        // ends up being { "Load",               /*!O*/        "V4",    nullptr,   "%@*,V",          "FIU,U",        EShLangAll },
+        // Since that is the case, these functions need to be repeated to get both the uint and int versions of them
+
+        { "Load",               /*!O*/        "V4",    nullptr,   "%@*,V",          "FIU,U",        EShLangAll },
+        { "Load",               /* O*/        "V4",    nullptr,   "%@,V,V",         "FIU,U,I",      EShLangAll },
+        { "Load", /* +sampleidex*/            "V4",    nullptr,   "$&,V,S",         "FIU,U,I",      EShLangAll },
+        { "Load", /* +samplindex, offset*/    "V4",    nullptr,   "$&,V,S,V",       "FIU,U,I,I",    EShLangAll },
+
+        { "Load",               /*!O*/        "V4",    nullptr,   "%@*,V",          "FIU,I",        EShLangAll },
+        { "Load",               /* O*/        "V4",    nullptr,   "%@,V,V",         "FIU,I,I",      EShLangAll },
+        { "Load", /* +sampleidex*/            "V4",    nullptr,   "$&,V,S",         "FIU,I,I",      EShLangAll },
+        { "Load", /* +samplindex, offset*/    "V4",    nullptr,   "$&,V,S,V",       "FIU,I,I,I",    EShLangAll },
 
         { "Gather",             /*!O*/        "V4",    nullptr,   "%@,S,V",         "FIU,S,F",       EShLangAll },
         { "Gather",             /* O*/        "V4",    nullptr,   "%@,S,V,V",       "FIU,S,F,I",     EShLangAll },
@@ -810,6 +821,7 @@ void TBuiltInParseablesHlsl::initialize(int /*version*/, EProfile /*profile*/, c
         const auto& intrinsic = hlslIntrinsics[icount];
 
         for (int stage = 0; stage < EShLangCount; ++stage) {                                // for each stage...
+         
             if ((intrinsic.stage & (1<<stage)) == 0) // skip inapplicable stages
                 continue;
 


### PR DESCRIPTION
Here, I've rearranged the sampler object to take a full type object. this allows generalization for the return type.  This is meant to replace PR #459 

It passed all the tests and seems to work well. The 2 open questions:

1) If the dimensionality of the sampler type is actually checked to be equal, then some of the intrinsic matches fail, specifically GetDimension (which doesn't care at all about the return type of the texture object)

2) I'm not 100% sure about the news are getting cleaned up. It looked to me like there was a special allocator for news that was context specific and got garbage collected - as I did not see deletes in the destructor for the type object
 