### PR TITLE
fix x64 warning about conversion size_t -> int

### DIFF
--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -1346,7 +1346,7 @@ void HlslParseContext::decomposeSampleMethods(const TSourceLoc& loc, TIntermType
 
             const TSamplerDim dim = argTex->getType().getSampler().dim;
 
-            const int  argSize = argAggregate->getSequence().size();
+            const int  argSize = (int)argAggregate->getSequence().size();
             bool hasStatus     = (argSize == (5+cmpValues) || argSize == (8+cmpValues));
             bool hasOffset1    = false;
             bool hasOffset4    = false;


### PR DESCRIPTION
As it says, just a warning fix that shows up on MSVC (useful to silence so you can build with warnings-as-errors).