### PR TITLE
HLSL: changing SPIRV defualt language for HLSL to unknown

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -212,7 +212,8 @@ spv::SourceLanguage TranslateSourceLanguage(glslang::EShSource source, EProfile 
             return spv::SourceLanguageUnknown;
         }
     case glslang::EShSourceHlsl:
-        return spv::SourceLanguageHLSL;
+        //Use SourceLanguageUnknown instead of SourceLanguageHLSL for now, until Vulkan knows what HLSL is
+        return spv::SourceLanguageUnknown;
     default:
         return spv::SourceLanguageUnknown;
     }

--- a/Test/baseResults/hlsl.array.frag.out
+++ b/Test/baseResults/hlsl.array.frag.out
@@ -108,7 +108,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 19 27
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 12  "a"
                               Name 19  "i"

--- a/Test/baseResults/hlsl.assoc.frag.out
+++ b/Test/baseResults/hlsl.assoc.frag.out
@@ -76,7 +76,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 9 10 11 12 13
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 9  "a1"
                               Name 10  "a2"

--- a/Test/baseResults/hlsl.attribute.frag.out
+++ b/Test/baseResults/hlsl.attribute.frag.out
@@ -40,7 +40,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                2:             TypeVoid
                3:             TypeFunction 2

--- a/Test/baseResults/hlsl.buffer.frag.out
+++ b/Test/baseResults/hlsl.buffer.frag.out
@@ -82,7 +82,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 9
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 9  "input"
                               Name 11  ""

--- a/Test/baseResults/hlsl.calculatelod.dx10.frag.out
+++ b/Test/baseResults/hlsl.calculatelod.dx10.frag.out
@@ -325,7 +325,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 8  "txval10"
                               Name 11  "g_tTex1df4a"

--- a/Test/baseResults/hlsl.cast.frag.out
+++ b/Test/baseResults/hlsl.cast.frag.out
@@ -56,7 +56,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 9
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 9  "input"
                2:             TypeVoid

--- a/Test/baseResults/hlsl.conditional.frag.out
+++ b/Test/baseResults/hlsl.conditional.frag.out
@@ -228,7 +228,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 22
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 8  "a"
                               Name 10  "b"

--- a/Test/baseResults/hlsl.constructexpr.frag.out
+++ b/Test/baseResults/hlsl.constructexpr.frag.out
@@ -90,7 +90,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 22  "PS_OUTPUT"
                               MemberName 22(PS_OUTPUT) 0  "color"

--- a/Test/baseResults/hlsl.discard.frag.out
+++ b/Test/baseResults/hlsl.discard.frag.out
@@ -96,7 +96,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 21
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 10  "foo(f1;"
                               Name 9  "f"

--- a/Test/baseResults/hlsl.doLoop.frag.out
+++ b/Test/baseResults/hlsl.doLoop.frag.out
@@ -66,7 +66,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 23
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 23  "input"
                2:             TypeVoid

--- a/Test/baseResults/hlsl.float1.frag.out
+++ b/Test/baseResults/hlsl.float1.frag.out
@@ -72,7 +72,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 11  "ShaderFunction(vf1;f1;"
                               Name 9  "inFloat1"

--- a/Test/baseResults/hlsl.float4.frag.out
+++ b/Test/baseResults/hlsl.float4.frag.out
@@ -67,7 +67,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 11  "ShaderFunction(vf4;"
                               Name 10  "input"

--- a/Test/baseResults/hlsl.forLoop.frag.out
+++ b/Test/baseResults/hlsl.forLoop.frag.out
@@ -232,7 +232,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 13
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 13  "input"
                               Name 89  "ii"

--- a/Test/baseResults/hlsl.gather.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.gather.array.dx10.frag.out
@@ -228,7 +228,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval20"
                               Name 12  "g_tTex2df4a"

--- a/Test/baseResults/hlsl.gather.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.gather.basic.dx10.frag.out
@@ -223,7 +223,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval20"
                               Name 12  "g_tTex2df4"

--- a/Test/baseResults/hlsl.gather.basic.dx10.vert.out
+++ b/Test/baseResults/hlsl.gather.basic.dx10.vert.out
@@ -206,7 +206,6 @@ Shader version: 450
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
                               EntryPoint Vertex 4  "main"
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval20"
                               Name 12  "g_tTex2df4"

--- a/Test/baseResults/hlsl.gather.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.gather.offset.dx10.frag.out
@@ -173,7 +173,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval20"
                               Name 12  "g_tTex2df4"

--- a/Test/baseResults/hlsl.gather.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.gather.offsetarray.dx10.frag.out
@@ -167,7 +167,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval20"
                               Name 12  "g_tTex2df4"

--- a/Test/baseResults/hlsl.gatherRGBA.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.gatherRGBA.array.dx10.frag.out
@@ -578,7 +578,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval00"
                               Name 12  "g_tTex2df4a"

--- a/Test/baseResults/hlsl.gatherRGBA.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.gatherRGBA.basic.dx10.frag.out
@@ -585,7 +585,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval00"
                               Name 12  "g_tTex2df4"

--- a/Test/baseResults/hlsl.gatherRGBA.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.gatherRGBA.offset.dx10.frag.out
@@ -738,7 +738,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval001"
                               Name 12  "g_tTex2df4"

--- a/Test/baseResults/hlsl.gatherRGBA.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.gatherRGBA.offsetarray.dx10.frag.out
@@ -731,7 +731,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval001"
                               Name 12  "g_tTex2df4a"

--- a/Test/baseResults/hlsl.getdimensions.dx10.frag.out
+++ b/Test/baseResults/hlsl.getdimensions.dx10.frag.out
@@ -2202,7 +2202,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 8  "sizeQueryTemp"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.getdimensions.dx10.vert.out
+++ b/Test/baseResults/hlsl.getdimensions.dx10.vert.out
@@ -99,7 +99,6 @@ Shader version: 450
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
                               EntryPoint Vertex 4  "main"
-                              Source HLSL 450
                               Name 4  "main"
                               Name 8  "sizeQueryTemp"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.if.frag.out
+++ b/Test/baseResults/hlsl.if.frag.out
@@ -166,7 +166,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 9
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 9  "input"
                               Name 65  "ii"

--- a/Test/baseResults/hlsl.init.frag.out
+++ b/Test/baseResults/hlsl.init.frag.out
@@ -310,7 +310,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "ShaderFunction" 88
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "ShaderFunction"
                               Name 9  "a1"
                               Name 14  "b1"

--- a/Test/baseResults/hlsl.init2.frag.out
+++ b/Test/baseResults/hlsl.init2.frag.out
@@ -108,7 +108,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 6  "Test1("
                               Name 10  "mystruct"

--- a/Test/baseResults/hlsl.inoutquals.frag.out
+++ b/Test/baseResults/hlsl.inoutquals.frag.out
@@ -132,7 +132,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main" 45
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 12  "MyFunc(f1;f1;f1;"
                               Name 9  "x"

--- a/Test/baseResults/hlsl.intrinsics.barriers.comp.out
+++ b/Test/baseResults/hlsl.intrinsics.barriers.comp.out
@@ -46,7 +46,6 @@ local_size = (1, 1, 1)
                               MemoryModel Logical GLSL450
                               EntryPoint GLCompute 4  "ComputeShaderFunction"
                               ExecutionMode 4 LocalSize 1 1 1
-                              Source HLSL 450
                               Name 4  "ComputeShaderFunction"
                2:             TypeVoid
                3:             TypeFunction 2

--- a/Test/baseResults/hlsl.intrinsics.comp.out
+++ b/Test/baseResults/hlsl.intrinsics.comp.out
@@ -652,7 +652,6 @@ local_size = (1, 1, 1)
                               MemoryModel Logical GLSL450
                               EntryPoint GLCompute 4  "ComputeShaderFunction" 175
                               ExecutionMode 4 LocalSize 1 1 1
-                              Source HLSL 450
                               Name 4  "ComputeShaderFunction"
                               Name 16  "ComputeShaderFunctionS(f1;f1;f1;u1;u1;"
                               Name 11  "inF0"

--- a/Test/baseResults/hlsl.intrinsics.double.frag.out
+++ b/Test/baseResults/hlsl.intrinsics.double.frag.out
@@ -79,7 +79,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 10 12 14 20 22
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 8  "r00"
                               Name 10  "inDV1a"

--- a/Test/baseResults/hlsl.intrinsics.evalfns.frag.out
+++ b/Test/baseResults/hlsl.intrinsics.evalfns.frag.out
@@ -105,7 +105,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main" 8 15 22 29 36
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 8  "inF1"
                               Name 15  "inF2"

--- a/Test/baseResults/hlsl.intrinsics.frag.out
+++ b/Test/baseResults/hlsl.intrinsics.frag.out
@@ -5561,7 +5561,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 810 837 845 854
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 16  "PixelShaderFunctionS(f1;f1;f1;u1;u1;"
                               Name 11  "inF0"

--- a/Test/baseResults/hlsl.intrinsics.lit.frag.out
+++ b/Test/baseResults/hlsl.intrinsics.lit.frag.out
@@ -88,7 +88,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 12 19 28
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 9  "r0"
                               Name 12  "n_dot_l"

--- a/Test/baseResults/hlsl.intrinsics.negative.comp.out
+++ b/Test/baseResults/hlsl.intrinsics.negative.comp.out
@@ -134,7 +134,6 @@ local_size = (1, 1, 1)
                               MemoryModel Logical GLSL450
                               EntryPoint GLCompute 4  "ComputeShaderFunction"
                               ExecutionMode 4 LocalSize 1 1 1
-                              Source HLSL 450
                               Name 4  "ComputeShaderFunction"
                               Name 15  "ComputeShaderFunctionS(f1;f1;f1;i1;"
                               Name 11  "inF0"

--- a/Test/baseResults/hlsl.intrinsics.negative.vert.out
+++ b/Test/baseResults/hlsl.intrinsics.negative.vert.out
@@ -261,7 +261,6 @@ Shader version: 450
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
                               EntryPoint Vertex 4  "VertexShaderFunction"
-                              Source HLSL 450
                               Name 4  "VertexShaderFunction"
                               Name 15  "VertexShaderFunctionS(f1;f1;f1;i1;"
                               Name 11  "inF0"

--- a/Test/baseResults/hlsl.intrinsics.vert.out
+++ b/Test/baseResults/hlsl.intrinsics.vert.out
@@ -2799,7 +2799,6 @@ Shader version: 450
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
                               EntryPoint Vertex 4  "VertexShaderFunction"
-                              Source HLSL 450
                               Name 4  "VertexShaderFunction"
                               Name 16  "VertexShaderFunctionS(f1;f1;f1;u1;u1;"
                               Name 11  "inF0"

--- a/Test/baseResults/hlsl.load.2dms.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.2dms.dx10.frag.out
@@ -230,7 +230,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "g_tTex2dmsf4"
                               Name 14  "c2"

--- a/Test/baseResults/hlsl.load.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.array.dx10.frag.out
@@ -296,7 +296,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "g_tTex1df4a"
                               Name 14  "c3"

--- a/Test/baseResults/hlsl.load.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.basic.dx10.frag.out
@@ -362,7 +362,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "g_tTex1df4"
                               Name 14  "c2"

--- a/Test/baseResults/hlsl.load.basic.dx10.vert.out
+++ b/Test/baseResults/hlsl.load.basic.dx10.vert.out
@@ -345,7 +345,6 @@ Shader version: 450
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
                               EntryPoint Vertex 4  "main"
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "g_tTex1df4"
                               Name 14  "c2"

--- a/Test/baseResults/hlsl.load.buffer.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.buffer.dx10.frag.out
@@ -127,7 +127,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "r00"
                               Name 13  "g_tTexbf4"

--- a/Test/baseResults/hlsl.load.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.offset.dx10.frag.out
@@ -381,7 +381,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "g_tTex1df4"
                               Name 14  "c2"

--- a/Test/baseResults/hlsl.load.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.offsetarray.dx10.frag.out
@@ -309,7 +309,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "g_tTex1df4a"
                               Name 14  "c3"

--- a/Test/baseResults/hlsl.matType.frag.out
+++ b/Test/baseResults/hlsl.matType.frag.out
@@ -53,7 +53,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 11  "ShaderFunction(vf1;f1;"
                               Name 9  "inFloat1"

--- a/Test/baseResults/hlsl.max.frag.out
+++ b/Test/baseResults/hlsl.max.frag.out
@@ -40,7 +40,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 9 11
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 9  "input1"
                               Name 11  "input2"

--- a/Test/baseResults/hlsl.numericsuffixes.frag.out
+++ b/Test/baseResults/hlsl.numericsuffixes.frag.out
@@ -138,7 +138,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 8  "r00"
                               Name 12  "r01"

--- a/Test/baseResults/hlsl.pp.line.frag.out
+++ b/Test/baseResults/hlsl.pp.line.frag.out
@@ -84,7 +84,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 8  "thisLineIs"
                               Name 12  "PS_OUTPUT"

--- a/Test/baseResults/hlsl.precedence.frag.out
+++ b/Test/baseResults/hlsl.precedence.frag.out
@@ -102,7 +102,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 9 11 13 17
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 9  "a1"
                               Name 11  "a2"

--- a/Test/baseResults/hlsl.precedence2.frag.out
+++ b/Test/baseResults/hlsl.precedence2.frag.out
@@ -68,7 +68,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 8 10 13 16
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 8  "a1"
                               Name 10  "a2"

--- a/Test/baseResults/hlsl.promotions.frag.out
+++ b/Test/baseResults/hlsl.promotions.frag.out
@@ -1035,7 +1035,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 11  "Fn_F3(vf3;"
                               Name 10  "x"

--- a/Test/baseResults/hlsl.sample.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.sample.array.dx10.frag.out
@@ -288,7 +288,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.sample.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.sample.basic.dx10.frag.out
@@ -515,7 +515,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 7  "MemberTest"
                               MemberName 7(MemberTest) 0  "Sample"

--- a/Test/baseResults/hlsl.sample.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.sample.offset.dx10.frag.out
@@ -329,7 +329,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.sample.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.sample.offsetarray.dx10.frag.out
@@ -239,7 +239,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplebias.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplebias.array.dx10.frag.out
@@ -324,7 +324,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplebias.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplebias.basic.dx10.frag.out
@@ -389,7 +389,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplebias.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplebias.offset.dx10.frag.out
@@ -365,7 +365,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplebias.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplebias.offsetarray.dx10.frag.out
@@ -263,7 +263,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplecmp.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmp.array.dx10.frag.out
@@ -364,7 +364,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 8  "r10"
                               Name 11  "g_tTex1df4a"

--- a/Test/baseResults/hlsl.samplecmp.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmp.basic.dx10.frag.out
@@ -346,7 +346,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 8  "r00"
                               Name 11  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplecmp.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmp.offset.dx10.frag.out
@@ -292,7 +292,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 8  "r01"
                               Name 11  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplecmp.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmp.offsetarray.dx10.frag.out
@@ -304,7 +304,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 8  "r11"
                               Name 11  "g_tTex1df4a"

--- a/Test/baseResults/hlsl.samplecmplevelzero.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmplevelzero.array.dx10.frag.out
@@ -400,7 +400,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 8  "r10"
                               Name 11  "g_tTex1df4a"

--- a/Test/baseResults/hlsl.samplecmplevelzero.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmplevelzero.basic.dx10.frag.out
@@ -382,7 +382,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 8  "r00"
                               Name 11  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplecmplevelzero.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmplevelzero.offset.dx10.frag.out
@@ -316,7 +316,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 8  "r01"
                               Name 11  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplecmplevelzero.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmplevelzero.offsetarray.dx10.frag.out
@@ -328,7 +328,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 8  "r11"
                               Name 11  "g_tTex1df4a"

--- a/Test/baseResults/hlsl.samplegrad.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplegrad.array.dx10.frag.out
@@ -396,7 +396,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplegrad.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplegrad.basic.dx10.frag.out
@@ -497,7 +497,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplegrad.basic.dx10.vert.out
+++ b/Test/baseResults/hlsl.samplegrad.basic.dx10.vert.out
@@ -480,7 +480,6 @@ Shader version: 450
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
                               EntryPoint Vertex 4  "main"
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplegrad.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplegrad.offset.dx10.frag.out
@@ -437,7 +437,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplegrad.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplegrad.offsetarray.dx10.frag.out
@@ -306,7 +306,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplelevel.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplelevel.array.dx10.frag.out
@@ -324,7 +324,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4a"

--- a/Test/baseResults/hlsl.samplelevel.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplelevel.basic.dx10.frag.out
@@ -391,7 +391,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplelevel.basic.dx10.vert.out
+++ b/Test/baseResults/hlsl.samplelevel.basic.dx10.vert.out
@@ -372,7 +372,6 @@ Shader version: 450
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
                               EntryPoint Vertex 4  "main"
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplelevel.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplelevel.offset.dx10.frag.out
@@ -365,7 +365,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.samplelevel.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplelevel.offsetarray.dx10.frag.out
@@ -263,7 +263,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 9  "txval10"
                               Name 12  "g_tTex1df4"

--- a/Test/baseResults/hlsl.scope.frag.out
+++ b/Test/baseResults/hlsl.scope.frag.out
@@ -92,7 +92,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 8  "x"
                               Name 11  "x"

--- a/Test/baseResults/hlsl.semicolons.frag.out
+++ b/Test/baseResults/hlsl.semicolons.frag.out
@@ -60,7 +60,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 6  "MyFunc("
                               Name 8  "MyFunc2("

--- a/Test/baseResults/hlsl.shapeConv.frag.out
+++ b/Test/baseResults/hlsl.shapeConv.frag.out
@@ -186,7 +186,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "main"
                               Name 13  "PixelShaderFunction(vf4;f1;"
                               Name 11  "input"

--- a/Test/baseResults/hlsl.sin.frag.out
+++ b/Test/baseResults/hlsl.sin.frag.out
@@ -36,7 +36,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 9
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 9  "input"
                2:             TypeVoid

--- a/Test/baseResults/hlsl.struct.frag.out
+++ b/Test/baseResults/hlsl.struct.frag.out
@@ -72,7 +72,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 34
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 8  "FS"
                               MemberName 8(FS) 0  "b3"

--- a/Test/baseResults/hlsl.switch.frag.out
+++ b/Test/baseResults/hlsl.switch.frag.out
@@ -260,7 +260,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 8 21 41
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 8  "c"
                               Name 21  "input"

--- a/Test/baseResults/hlsl.swizzle.frag.out
+++ b/Test/baseResults/hlsl.swizzle.frag.out
@@ -84,7 +84,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 11  "ShaderFunction(vf4;"
                               Name 10  "input"

--- a/Test/baseResults/hlsl.templatetypes.frag.out
+++ b/Test/baseResults/hlsl.templatetypes.frag.out
@@ -503,7 +503,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 9  "r00"
                               Name 15  "r01"

--- a/Test/baseResults/hlsl.typedef.frag.out
+++ b/Test/baseResults/hlsl.typedef.frag.out
@@ -86,7 +86,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 14  "ShaderFunction(vf4;i1;"
                               Name 12  "input"

--- a/Test/baseResults/hlsl.void.frag.out
+++ b/Test/baseResults/hlsl.void.frag.out
@@ -42,7 +42,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction"
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 6  "foo1("
                               Name 8  "foo2("

--- a/Test/baseResults/hlsl.whileLoop.frag.out
+++ b/Test/baseResults/hlsl.whileLoop.frag.out
@@ -78,7 +78,6 @@ gl_FragCoord origin is upper left
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "PixelShaderFunction" 14
                               ExecutionMode 4 OriginUpperLeft
-                              Source HLSL 450
                               Name 4  "PixelShaderFunction"
                               Name 14  "input"
                2:             TypeVoid


### PR DESCRIPTION
A very simple change, but of course all 88 tests needed to be updated. See bug #462