### PR TITLE
HLSL: Adding cast support for unsigned int (uint) for Load method, also upd…

### DIFF
--- a/Test/baseResults/hlsl.load.2dms.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.2dms.dx10.frag.out
@@ -2,94 +2,160 @@ hlsl.load.2dms.dx10.frag
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:57  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:28    Function Parameters: 
+0:76  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:34    Function Parameters: 
 0:?     Sequence
-0:32      textureFetch (global 4-component vector of float)
-0:32        'g_tTex2dmsf4' (uniform texture2DMS)
-0:32        'c2' (uniform 2-component vector of int)
-0:32        Constant:
-0:32          3 (const int)
-0:33      textureFetch (global 4-component vector of int)
-0:33        'g_tTex2dmsi4' (uniform itexture2DMS)
-0:33        'c2' (uniform 2-component vector of int)
-0:33        Constant:
-0:33          3 (const int)
-0:34      textureFetch (global 4-component vector of uint)
-0:34        'g_tTex2dmsu4' (uniform utexture2DMS)
-0:34        'c2' (uniform 2-component vector of int)
-0:34        Constant:
-0:34          3 (const int)
-0:37      textureFetchOffset (global 4-component vector of float)
-0:37        'g_tTex2dmsf4' (uniform texture2DMS)
-0:37        'c2' (uniform 2-component vector of int)
-0:37        Constant:
-0:37          3 (const int)
-0:37        'o2' (uniform 2-component vector of int)
-0:38      textureFetchOffset (global 4-component vector of int)
-0:38        'g_tTex2dmsi4' (uniform itexture2DMS)
+0:38      textureFetch (global 4-component vector of float)
+0:38        'g_tTex2dmsf4' (uniform texture2DMS)
 0:38        'c2' (uniform 2-component vector of int)
 0:38        Constant:
 0:38          3 (const int)
-0:38        'o2' (uniform 2-component vector of int)
-0:39      textureFetchOffset (global 4-component vector of uint)
-0:39        'g_tTex2dmsu4' (uniform utexture2DMS)
+0:39      textureFetch (global 4-component vector of int)
+0:39        'g_tTex2dmsi4' (uniform itexture2DMS)
 0:39        'c2' (uniform 2-component vector of int)
 0:39        Constant:
 0:39          3 (const int)
-0:39        'o2' (uniform 2-component vector of int)
-0:42      textureFetch (global 4-component vector of float)
-0:42        'g_tTex2dmsf4a' (uniform texture2DMSArray)
-0:42        'c3' (uniform 3-component vector of int)
+0:40      textureFetch (global 4-component vector of uint)
+0:40        'g_tTex2dmsu4' (uniform utexture2DMS)
+0:40        'c2' (uniform 2-component vector of int)
+0:40        Constant:
+0:40          3 (const int)
+0:41      textureFetch (global 4-component vector of float)
+0:41        'g_tTex2dmsf4' (uniform texture2DMS)
+0:41        'uc2' (uniform 2-component vector of uint)
+0:41        Constant:
+0:41          3 (const int)
+0:42      textureFetch (global 4-component vector of int)
+0:42        'g_tTex2dmsi4' (uniform itexture2DMS)
+0:42        'uc2' (uniform 2-component vector of uint)
 0:42        Constant:
 0:42          3 (const int)
-0:43      textureFetch (global 4-component vector of int)
-0:43        'g_tTex2dmsi4a' (uniform itexture2DMSArray)
-0:43        'c3' (uniform 3-component vector of int)
+0:43      textureFetch (global 4-component vector of uint)
+0:43        'g_tTex2dmsu4' (uniform utexture2DMS)
+0:43        'uc2' (uniform 2-component vector of uint)
 0:43        Constant:
 0:43          3 (const int)
-0:44      textureFetch (global 4-component vector of uint)
-0:44        'g_tTex2dmsu4a' (uniform utexture2DMSArray)
-0:44        'c3' (uniform 3-component vector of int)
-0:44        Constant:
-0:44          3 (const int)
-0:47      textureFetchOffset (global 4-component vector of float)
-0:47        'g_tTex2dmsf4a' (uniform texture2DMSArray)
-0:47        'c3' (uniform 3-component vector of int)
+0:46      textureFetchOffset (global 4-component vector of float)
+0:46        'g_tTex2dmsf4' (uniform texture2DMS)
+0:46        'c2' (uniform 2-component vector of int)
+0:46        Constant:
+0:46          3 (const int)
+0:46        'o2' (uniform 2-component vector of int)
+0:47      textureFetchOffset (global 4-component vector of int)
+0:47        'g_tTex2dmsi4' (uniform itexture2DMS)
+0:47        'c2' (uniform 2-component vector of int)
 0:47        Constant:
 0:47          3 (const int)
 0:47        'o2' (uniform 2-component vector of int)
-0:48      textureFetchOffset (global 4-component vector of int)
-0:48        'g_tTex2dmsi4a' (uniform itexture2DMSArray)
-0:48        'c3' (uniform 3-component vector of int)
+0:48      textureFetchOffset (global 4-component vector of uint)
+0:48        'g_tTex2dmsu4' (uniform utexture2DMS)
+0:48        'c2' (uniform 2-component vector of int)
 0:48        Constant:
 0:48          3 (const int)
 0:48        'o2' (uniform 2-component vector of int)
-0:49      textureFetchOffset (global 4-component vector of uint)
-0:49        'g_tTex2dmsu4a' (uniform utexture2DMSArray)
-0:49        'c3' (uniform 3-component vector of int)
+0:49      textureFetchOffset (global 4-component vector of float)
+0:49        'g_tTex2dmsf4' (uniform texture2DMS)
+0:49        'uc2' (uniform 2-component vector of uint)
 0:49        Constant:
 0:49          3 (const int)
 0:49        'o2' (uniform 2-component vector of int)
-0:51      move second child to first child (temp 4-component vector of float)
-0:51        Color: direct index for structure (temp 4-component vector of float)
-0:51          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:51          Constant:
-0:51            0 (const int)
+0:50      textureFetchOffset (global 4-component vector of int)
+0:50        'g_tTex2dmsi4' (uniform itexture2DMS)
+0:50        'uc2' (uniform 2-component vector of uint)
+0:50        Constant:
+0:50          3 (const int)
+0:50        'o2' (uniform 2-component vector of int)
+0:51      textureFetchOffset (global 4-component vector of uint)
+0:51        'g_tTex2dmsu4' (uniform utexture2DMS)
+0:51        'uc2' (uniform 2-component vector of uint)
 0:51        Constant:
-0:51          1.000000
-0:51          1.000000
-0:51          1.000000
-0:51          1.000000
-0:52      move second child to first child (temp float)
-0:52        Depth: direct index for structure (temp float FragDepth)
-0:52          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:52          Constant:
-0:52            1 (const int)
-0:52        Constant:
-0:52          1.000000
-0:54      Branch: Return with expression
-0:54        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:51          3 (const int)
+0:51        'o2' (uniform 2-component vector of int)
+0:54      textureFetch (global 4-component vector of float)
+0:54        'g_tTex2dmsf4a' (uniform texture2DMSArray)
+0:54        'c3' (uniform 3-component vector of int)
+0:54        Constant:
+0:54          3 (const int)
+0:55      textureFetch (global 4-component vector of int)
+0:55        'g_tTex2dmsi4a' (uniform itexture2DMSArray)
+0:55        'c3' (uniform 3-component vector of int)
+0:55        Constant:
+0:55          3 (const int)
+0:56      textureFetch (global 4-component vector of uint)
+0:56        'g_tTex2dmsu4a' (uniform utexture2DMSArray)
+0:56        'c3' (uniform 3-component vector of int)
+0:56        Constant:
+0:56          3 (const int)
+0:57      textureFetch (global 4-component vector of float)
+0:57        'g_tTex2dmsf4a' (uniform texture2DMSArray)
+0:57        'uc3' (uniform 3-component vector of uint)
+0:57        Constant:
+0:57          3 (const int)
+0:58      textureFetch (global 4-component vector of int)
+0:58        'g_tTex2dmsi4a' (uniform itexture2DMSArray)
+0:58        'uc3' (uniform 3-component vector of uint)
+0:58        Constant:
+0:58          3 (const int)
+0:59      textureFetch (global 4-component vector of uint)
+0:59        'g_tTex2dmsu4a' (uniform utexture2DMSArray)
+0:59        'uc3' (uniform 3-component vector of uint)
+0:59        Constant:
+0:59          3 (const int)
+0:63      textureFetchOffset (global 4-component vector of float)
+0:63        'g_tTex2dmsf4a' (uniform texture2DMSArray)
+0:63        'c3' (uniform 3-component vector of int)
+0:63        Constant:
+0:63          3 (const int)
+0:63        'o2' (uniform 2-component vector of int)
+0:64      textureFetchOffset (global 4-component vector of int)
+0:64        'g_tTex2dmsi4a' (uniform itexture2DMSArray)
+0:64        'c3' (uniform 3-component vector of int)
+0:64        Constant:
+0:64          3 (const int)
+0:64        'o2' (uniform 2-component vector of int)
+0:65      textureFetchOffset (global 4-component vector of uint)
+0:65        'g_tTex2dmsu4a' (uniform utexture2DMSArray)
+0:65        'c3' (uniform 3-component vector of int)
+0:65        Constant:
+0:65          3 (const int)
+0:65        'o2' (uniform 2-component vector of int)
+0:66      textureFetchOffset (global 4-component vector of float)
+0:66        'g_tTex2dmsf4a' (uniform texture2DMSArray)
+0:66        'uc3' (uniform 3-component vector of uint)
+0:66        Constant:
+0:66          3 (const int)
+0:66        'o2' (uniform 2-component vector of int)
+0:67      textureFetchOffset (global 4-component vector of int)
+0:67        'g_tTex2dmsi4a' (uniform itexture2DMSArray)
+0:67        'uc3' (uniform 3-component vector of uint)
+0:67        Constant:
+0:67          3 (const int)
+0:67        'o2' (uniform 2-component vector of int)
+0:68      textureFetchOffset (global 4-component vector of uint)
+0:68        'g_tTex2dmsu4a' (uniform utexture2DMSArray)
+0:68        'uc3' (uniform 3-component vector of uint)
+0:68        Constant:
+0:68          3 (const int)
+0:68        'o2' (uniform 2-component vector of int)
+0:70      move second child to first child (temp 4-component vector of float)
+0:70        Color: direct index for structure (temp 4-component vector of float)
+0:70          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:70          Constant:
+0:70            0 (const int)
+0:70        Constant:
+0:70          1.000000
+0:70          1.000000
+0:70          1.000000
+0:70          1.000000
+0:71      move second child to first child (temp float)
+0:71        Depth: direct index for structure (temp float FragDepth)
+0:71          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:71          Constant:
+0:71            1 (const int)
+0:71        Constant:
+0:71          1.000000
+0:73      Branch: Return with expression
+0:73        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
 0:?   Linker Objects
 0:?     'g_sSamp' (layout(binding=0 ) uniform sampler)
 0:?     'g_tTex2dmsf4' (uniform texture2DMS)
@@ -102,6 +168,10 @@ gl_FragCoord origin is upper left
 0:?     'c2' (uniform 2-component vector of int)
 0:?     'c3' (uniform 3-component vector of int)
 0:?     'c4' (uniform 4-component vector of int)
+0:?     'uc1' (uniform uint)
+0:?     'uc2' (uniform 2-component vector of uint)
+0:?     'uc3' (uniform 3-component vector of uint)
+0:?     'uc4' (uniform 4-component vector of uint)
 0:?     'o1' (uniform int)
 0:?     'o2' (uniform 2-component vector of int)
 0:?     'o3' (uniform 3-component vector of int)
@@ -114,94 +184,160 @@ Linked fragment stage:
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:57  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:28    Function Parameters: 
+0:76  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:34    Function Parameters: 
 0:?     Sequence
-0:32      textureFetch (global 4-component vector of float)
-0:32        'g_tTex2dmsf4' (uniform texture2DMS)
-0:32        'c2' (uniform 2-component vector of int)
-0:32        Constant:
-0:32          3 (const int)
-0:33      textureFetch (global 4-component vector of int)
-0:33        'g_tTex2dmsi4' (uniform itexture2DMS)
-0:33        'c2' (uniform 2-component vector of int)
-0:33        Constant:
-0:33          3 (const int)
-0:34      textureFetch (global 4-component vector of uint)
-0:34        'g_tTex2dmsu4' (uniform utexture2DMS)
-0:34        'c2' (uniform 2-component vector of int)
-0:34        Constant:
-0:34          3 (const int)
-0:37      textureFetchOffset (global 4-component vector of float)
-0:37        'g_tTex2dmsf4' (uniform texture2DMS)
-0:37        'c2' (uniform 2-component vector of int)
-0:37        Constant:
-0:37          3 (const int)
-0:37        'o2' (uniform 2-component vector of int)
-0:38      textureFetchOffset (global 4-component vector of int)
-0:38        'g_tTex2dmsi4' (uniform itexture2DMS)
+0:38      textureFetch (global 4-component vector of float)
+0:38        'g_tTex2dmsf4' (uniform texture2DMS)
 0:38        'c2' (uniform 2-component vector of int)
 0:38        Constant:
 0:38          3 (const int)
-0:38        'o2' (uniform 2-component vector of int)
-0:39      textureFetchOffset (global 4-component vector of uint)
-0:39        'g_tTex2dmsu4' (uniform utexture2DMS)
+0:39      textureFetch (global 4-component vector of int)
+0:39        'g_tTex2dmsi4' (uniform itexture2DMS)
 0:39        'c2' (uniform 2-component vector of int)
 0:39        Constant:
 0:39          3 (const int)
-0:39        'o2' (uniform 2-component vector of int)
-0:42      textureFetch (global 4-component vector of float)
-0:42        'g_tTex2dmsf4a' (uniform texture2DMSArray)
-0:42        'c3' (uniform 3-component vector of int)
+0:40      textureFetch (global 4-component vector of uint)
+0:40        'g_tTex2dmsu4' (uniform utexture2DMS)
+0:40        'c2' (uniform 2-component vector of int)
+0:40        Constant:
+0:40          3 (const int)
+0:41      textureFetch (global 4-component vector of float)
+0:41        'g_tTex2dmsf4' (uniform texture2DMS)
+0:41        'uc2' (uniform 2-component vector of uint)
+0:41        Constant:
+0:41          3 (const int)
+0:42      textureFetch (global 4-component vector of int)
+0:42        'g_tTex2dmsi4' (uniform itexture2DMS)
+0:42        'uc2' (uniform 2-component vector of uint)
 0:42        Constant:
 0:42          3 (const int)
-0:43      textureFetch (global 4-component vector of int)
-0:43        'g_tTex2dmsi4a' (uniform itexture2DMSArray)
-0:43        'c3' (uniform 3-component vector of int)
+0:43      textureFetch (global 4-component vector of uint)
+0:43        'g_tTex2dmsu4' (uniform utexture2DMS)
+0:43        'uc2' (uniform 2-component vector of uint)
 0:43        Constant:
 0:43          3 (const int)
-0:44      textureFetch (global 4-component vector of uint)
-0:44        'g_tTex2dmsu4a' (uniform utexture2DMSArray)
-0:44        'c3' (uniform 3-component vector of int)
-0:44        Constant:
-0:44          3 (const int)
-0:47      textureFetchOffset (global 4-component vector of float)
-0:47        'g_tTex2dmsf4a' (uniform texture2DMSArray)
-0:47        'c3' (uniform 3-component vector of int)
+0:46      textureFetchOffset (global 4-component vector of float)
+0:46        'g_tTex2dmsf4' (uniform texture2DMS)
+0:46        'c2' (uniform 2-component vector of int)
+0:46        Constant:
+0:46          3 (const int)
+0:46        'o2' (uniform 2-component vector of int)
+0:47      textureFetchOffset (global 4-component vector of int)
+0:47        'g_tTex2dmsi4' (uniform itexture2DMS)
+0:47        'c2' (uniform 2-component vector of int)
 0:47        Constant:
 0:47          3 (const int)
 0:47        'o2' (uniform 2-component vector of int)
-0:48      textureFetchOffset (global 4-component vector of int)
-0:48        'g_tTex2dmsi4a' (uniform itexture2DMSArray)
-0:48        'c3' (uniform 3-component vector of int)
+0:48      textureFetchOffset (global 4-component vector of uint)
+0:48        'g_tTex2dmsu4' (uniform utexture2DMS)
+0:48        'c2' (uniform 2-component vector of int)
 0:48        Constant:
 0:48          3 (const int)
 0:48        'o2' (uniform 2-component vector of int)
-0:49      textureFetchOffset (global 4-component vector of uint)
-0:49        'g_tTex2dmsu4a' (uniform utexture2DMSArray)
-0:49        'c3' (uniform 3-component vector of int)
+0:49      textureFetchOffset (global 4-component vector of float)
+0:49        'g_tTex2dmsf4' (uniform texture2DMS)
+0:49        'uc2' (uniform 2-component vector of uint)
 0:49        Constant:
 0:49          3 (const int)
 0:49        'o2' (uniform 2-component vector of int)
-0:51      move second child to first child (temp 4-component vector of float)
-0:51        Color: direct index for structure (temp 4-component vector of float)
-0:51          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:51          Constant:
-0:51            0 (const int)
+0:50      textureFetchOffset (global 4-component vector of int)
+0:50        'g_tTex2dmsi4' (uniform itexture2DMS)
+0:50        'uc2' (uniform 2-component vector of uint)
+0:50        Constant:
+0:50          3 (const int)
+0:50        'o2' (uniform 2-component vector of int)
+0:51      textureFetchOffset (global 4-component vector of uint)
+0:51        'g_tTex2dmsu4' (uniform utexture2DMS)
+0:51        'uc2' (uniform 2-component vector of uint)
 0:51        Constant:
-0:51          1.000000
-0:51          1.000000
-0:51          1.000000
-0:51          1.000000
-0:52      move second child to first child (temp float)
-0:52        Depth: direct index for structure (temp float FragDepth)
-0:52          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:52          Constant:
-0:52            1 (const int)
-0:52        Constant:
-0:52          1.000000
-0:54      Branch: Return with expression
-0:54        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:51          3 (const int)
+0:51        'o2' (uniform 2-component vector of int)
+0:54      textureFetch (global 4-component vector of float)
+0:54        'g_tTex2dmsf4a' (uniform texture2DMSArray)
+0:54        'c3' (uniform 3-component vector of int)
+0:54        Constant:
+0:54          3 (const int)
+0:55      textureFetch (global 4-component vector of int)
+0:55        'g_tTex2dmsi4a' (uniform itexture2DMSArray)
+0:55        'c3' (uniform 3-component vector of int)
+0:55        Constant:
+0:55          3 (const int)
+0:56      textureFetch (global 4-component vector of uint)
+0:56        'g_tTex2dmsu4a' (uniform utexture2DMSArray)
+0:56        'c3' (uniform 3-component vector of int)
+0:56        Constant:
+0:56          3 (const int)
+0:57      textureFetch (global 4-component vector of float)
+0:57        'g_tTex2dmsf4a' (uniform texture2DMSArray)
+0:57        'uc3' (uniform 3-component vector of uint)
+0:57        Constant:
+0:57          3 (const int)
+0:58      textureFetch (global 4-component vector of int)
+0:58        'g_tTex2dmsi4a' (uniform itexture2DMSArray)
+0:58        'uc3' (uniform 3-component vector of uint)
+0:58        Constant:
+0:58          3 (const int)
+0:59      textureFetch (global 4-component vector of uint)
+0:59        'g_tTex2dmsu4a' (uniform utexture2DMSArray)
+0:59        'uc3' (uniform 3-component vector of uint)
+0:59        Constant:
+0:59          3 (const int)
+0:63      textureFetchOffset (global 4-component vector of float)
+0:63        'g_tTex2dmsf4a' (uniform texture2DMSArray)
+0:63        'c3' (uniform 3-component vector of int)
+0:63        Constant:
+0:63          3 (const int)
+0:63        'o2' (uniform 2-component vector of int)
+0:64      textureFetchOffset (global 4-component vector of int)
+0:64        'g_tTex2dmsi4a' (uniform itexture2DMSArray)
+0:64        'c3' (uniform 3-component vector of int)
+0:64        Constant:
+0:64          3 (const int)
+0:64        'o2' (uniform 2-component vector of int)
+0:65      textureFetchOffset (global 4-component vector of uint)
+0:65        'g_tTex2dmsu4a' (uniform utexture2DMSArray)
+0:65        'c3' (uniform 3-component vector of int)
+0:65        Constant:
+0:65          3 (const int)
+0:65        'o2' (uniform 2-component vector of int)
+0:66      textureFetchOffset (global 4-component vector of float)
+0:66        'g_tTex2dmsf4a' (uniform texture2DMSArray)
+0:66        'uc3' (uniform 3-component vector of uint)
+0:66        Constant:
+0:66          3 (const int)
+0:66        'o2' (uniform 2-component vector of int)
+0:67      textureFetchOffset (global 4-component vector of int)
+0:67        'g_tTex2dmsi4a' (uniform itexture2DMSArray)
+0:67        'uc3' (uniform 3-component vector of uint)
+0:67        Constant:
+0:67          3 (const int)
+0:67        'o2' (uniform 2-component vector of int)
+0:68      textureFetchOffset (global 4-component vector of uint)
+0:68        'g_tTex2dmsu4a' (uniform utexture2DMSArray)
+0:68        'uc3' (uniform 3-component vector of uint)
+0:68        Constant:
+0:68          3 (const int)
+0:68        'o2' (uniform 2-component vector of int)
+0:70      move second child to first child (temp 4-component vector of float)
+0:70        Color: direct index for structure (temp 4-component vector of float)
+0:70          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:70          Constant:
+0:70            0 (const int)
+0:70        Constant:
+0:70          1.000000
+0:70          1.000000
+0:70          1.000000
+0:70          1.000000
+0:71      move second child to first child (temp float)
+0:71        Depth: direct index for structure (temp float FragDepth)
+0:71          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:71          Constant:
+0:71            1 (const int)
+0:71        Constant:
+0:71          1.000000
+0:73      Branch: Return with expression
+0:73        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
 0:?   Linker Objects
 0:?     'g_sSamp' (layout(binding=0 ) uniform sampler)
 0:?     'g_tTex2dmsf4' (uniform texture2DMS)
@@ -214,6 +350,10 @@ gl_FragCoord origin is upper left
 0:?     'c2' (uniform 2-component vector of int)
 0:?     'c3' (uniform 3-component vector of int)
 0:?     'c4' (uniform 4-component vector of int)
+0:?     'uc1' (uniform uint)
+0:?     'uc2' (uniform 2-component vector of uint)
+0:?     'uc3' (uniform 3-component vector of uint)
+0:?     'uc4' (uniform 4-component vector of uint)
 0:?     'o1' (uniform int)
 0:?     'o2' (uniform 2-component vector of int)
 0:?     'o3' (uniform 3-component vector of int)
@@ -221,7 +361,7 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 103
+// Id's are bound by 155
 
                               Capability Shader
                               Capability ImageGatherExtended
@@ -235,30 +375,34 @@ gl_FragCoord origin is upper left
                               Name 14  "c2"
                               Name 21  "g_tTex2dmsi4"
                               Name 29  "g_tTex2dmsu4"
-                              Name 36  "o2"
-                              Name 49  "g_tTex2dmsf4a"
-                              Name 53  "c3"
-                              Name 58  "g_tTex2dmsi4a"
-                              Name 64  "g_tTex2dmsu4a"
-                              Name 80  "PS_OUTPUT"
-                              MemberName 80(PS_OUTPUT) 0  "Color"
-                              MemberName 80(PS_OUTPUT) 1  "Depth"
-                              Name 82  "psout"
-                              Name 95  "g_sSamp"
-                              Name 97  "c1"
-                              Name 99  "c4"
-                              Name 100  "o1"
-                              Name 101  "o3"
-                              Name 102  "o4"
+                              Name 37  "uc2"
+                              Name 48  "o2"
+                              Name 73  "g_tTex2dmsf4a"
+                              Name 77  "c3"
+                              Name 82  "g_tTex2dmsi4a"
+                              Name 88  "g_tTex2dmsu4a"
+                              Name 95  "uc3"
+                              Name 128  "PS_OUTPUT"
+                              MemberName 128(PS_OUTPUT) 0  "Color"
+                              MemberName 128(PS_OUTPUT) 1  "Depth"
+                              Name 130  "psout"
+                              Name 143  "g_sSamp"
+                              Name 145  "c1"
+                              Name 147  "c4"
+                              Name 149  "uc1"
+                              Name 151  "uc4"
+                              Name 152  "o1"
+                              Name 153  "o3"
+                              Name 154  "o4"
                               Decorate 9(g_tTex2dmsf4) DescriptorSet 0
                               Decorate 21(g_tTex2dmsi4) DescriptorSet 0
                               Decorate 29(g_tTex2dmsu4) DescriptorSet 0
-                              Decorate 49(g_tTex2dmsf4a) DescriptorSet 0
-                              Decorate 58(g_tTex2dmsi4a) DescriptorSet 0
-                              Decorate 64(g_tTex2dmsu4a) DescriptorSet 0
-                              MemberDecorate 80(PS_OUTPUT) 1 BuiltIn FragDepth
-                              Decorate 95(g_sSamp) DescriptorSet 0
-                              Decorate 95(g_sSamp) Binding 0
+                              Decorate 73(g_tTex2dmsf4a) DescriptorSet 0
+                              Decorate 82(g_tTex2dmsi4a) DescriptorSet 0
+                              Decorate 88(g_tTex2dmsu4a) DescriptorSet 0
+                              MemberDecorate 128(PS_OUTPUT) 1 BuiltIn FragDepth
+                              Decorate 143(g_sSamp) DescriptorSet 0
+                              Decorate 143(g_sSamp) Binding 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -280,40 +424,50 @@ gl_FragCoord origin is upper left
               28:             TypePointer UniformConstant 27
 29(g_tTex2dmsu4):     28(ptr) Variable UniformConstant
               32:             TypeVector 26(int) 4
-          36(o2):     13(ptr) Variable UniformConstant
-              47:             TypeImage 6(float) 2D array multi-sampled sampled format:Unknown
-              48:             TypePointer UniformConstant 47
-49(g_tTex2dmsf4a):     48(ptr) Variable UniformConstant
-              51:             TypeVector 11(int) 3
-              52:             TypePointer UniformConstant 51(ivec3)
-          53(c3):     52(ptr) Variable UniformConstant
-              56:             TypeImage 11(int) 2D array multi-sampled sampled format:Unknown
-              57:             TypePointer UniformConstant 56
-58(g_tTex2dmsi4a):     57(ptr) Variable UniformConstant
-              62:             TypeImage 26(int) 2D array multi-sampled sampled format:Unknown
-              63:             TypePointer UniformConstant 62
-64(g_tTex2dmsu4a):     63(ptr) Variable UniformConstant
-   80(PS_OUTPUT):             TypeStruct 17(fvec4) 6(float)
-              81:             TypePointer Function 80(PS_OUTPUT)
-              83:     11(int) Constant 0
-              84:    6(float) Constant 1065353216
-              85:   17(fvec4) ConstantComposite 84 84 84 84
-              86:             TypePointer Function 17(fvec4)
-              88:     11(int) Constant 1
-              89:             TypePointer Function 6(float)
-              93:             TypeSampler
-              94:             TypePointer UniformConstant 93
-     95(g_sSamp):     94(ptr) Variable UniformConstant
-              96:             TypePointer UniformConstant 11(int)
-          97(c1):     96(ptr) Variable UniformConstant
-              98:             TypePointer UniformConstant 24(ivec4)
-          99(c4):     98(ptr) Variable UniformConstant
-         100(o1):     96(ptr) Variable UniformConstant
-         101(o3):     52(ptr) Variable UniformConstant
-         102(o4):     98(ptr) Variable UniformConstant
+              35:             TypeVector 26(int) 2
+              36:             TypePointer UniformConstant 35(ivec2)
+         37(uc2):     36(ptr) Variable UniformConstant
+          48(o2):     13(ptr) Variable UniformConstant
+              71:             TypeImage 6(float) 2D array multi-sampled sampled format:Unknown
+              72:             TypePointer UniformConstant 71
+73(g_tTex2dmsf4a):     72(ptr) Variable UniformConstant
+              75:             TypeVector 11(int) 3
+              76:             TypePointer UniformConstant 75(ivec3)
+          77(c3):     76(ptr) Variable UniformConstant
+              80:             TypeImage 11(int) 2D array multi-sampled sampled format:Unknown
+              81:             TypePointer UniformConstant 80
+82(g_tTex2dmsi4a):     81(ptr) Variable UniformConstant
+              86:             TypeImage 26(int) 2D array multi-sampled sampled format:Unknown
+              87:             TypePointer UniformConstant 86
+88(g_tTex2dmsu4a):     87(ptr) Variable UniformConstant
+              93:             TypeVector 26(int) 3
+              94:             TypePointer UniformConstant 93(ivec3)
+         95(uc3):     94(ptr) Variable UniformConstant
+  128(PS_OUTPUT):             TypeStruct 17(fvec4) 6(float)
+             129:             TypePointer Function 128(PS_OUTPUT)
+             131:     11(int) Constant 0
+             132:    6(float) Constant 1065353216
+             133:   17(fvec4) ConstantComposite 132 132 132 132
+             134:             TypePointer Function 17(fvec4)
+             136:     11(int) Constant 1
+             137:             TypePointer Function 6(float)
+             141:             TypeSampler
+             142:             TypePointer UniformConstant 141
+    143(g_sSamp):    142(ptr) Variable UniformConstant
+             144:             TypePointer UniformConstant 11(int)
+         145(c1):    144(ptr) Variable UniformConstant
+             146:             TypePointer UniformConstant 24(ivec4)
+         147(c4):    146(ptr) Variable UniformConstant
+             148:             TypePointer UniformConstant 26(int)
+        149(uc1):    148(ptr) Variable UniformConstant
+             150:             TypePointer UniformConstant 32(ivec4)
+        151(uc4):    150(ptr) Variable UniformConstant
+         152(o1):    144(ptr) Variable UniformConstant
+         153(o3):     76(ptr) Variable UniformConstant
+         154(o4):    146(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
-       82(psout):     81(ptr) Variable Function
+      130(psout):    129(ptr) Variable Function
               10:           7 Load 9(g_tTex2dmsf4)
               15:   12(ivec2) Load 14(c2)
               18:   17(fvec4) ImageFetch 10 15 Sample 16
@@ -324,42 +478,84 @@ gl_FragCoord origin is upper left
               31:   12(ivec2) Load 14(c2)
               33:   32(ivec4) ImageFetch 30 31 Sample 16
               34:           7 Load 9(g_tTex2dmsf4)
-              35:   12(ivec2) Load 14(c2)
-              37:   12(ivec2) Load 36(o2)
-              38:   17(fvec4) ImageFetch 34 35 Offset Sample 37 16
-              39:          19 Load 21(g_tTex2dmsi4)
-              40:   12(ivec2) Load 14(c2)
-              41:   12(ivec2) Load 36(o2)
-              42:   24(ivec4) ImageFetch 39 40 Offset Sample 41 16
+              38:   35(ivec2) Load 37(uc2)
+              39:   17(fvec4) ImageFetch 34 38 Sample 16
+              40:          19 Load 21(g_tTex2dmsi4)
+              41:   35(ivec2) Load 37(uc2)
+              42:   24(ivec4) ImageFetch 40 41 Sample 16
               43:          27 Load 29(g_tTex2dmsu4)
-              44:   12(ivec2) Load 14(c2)
-              45:   12(ivec2) Load 36(o2)
-              46:   32(ivec4) ImageFetch 43 44 Offset Sample 45 16
-              50:          47 Load 49(g_tTex2dmsf4a)
-              54:   51(ivec3) Load 53(c3)
-              55:   17(fvec4) ImageFetch 50 54 Sample 16
-              59:          56 Load 58(g_tTex2dmsi4a)
-              60:   51(ivec3) Load 53(c3)
-              61:   24(ivec4) ImageFetch 59 60 Sample 16
-              65:          62 Load 64(g_tTex2dmsu4a)
-              66:   51(ivec3) Load 53(c3)
-              67:   32(ivec4) ImageFetch 65 66 Sample 16
-              68:          47 Load 49(g_tTex2dmsf4a)
-              69:   51(ivec3) Load 53(c3)
-              70:   12(ivec2) Load 36(o2)
-              71:   17(fvec4) ImageFetch 68 69 Offset Sample 70 16
-              72:          56 Load 58(g_tTex2dmsi4a)
-              73:   51(ivec3) Load 53(c3)
-              74:   12(ivec2) Load 36(o2)
-              75:   24(ivec4) ImageFetch 72 73 Offset Sample 74 16
-              76:          62 Load 64(g_tTex2dmsu4a)
-              77:   51(ivec3) Load 53(c3)
-              78:   12(ivec2) Load 36(o2)
-              79:   32(ivec4) ImageFetch 76 77 Offset Sample 78 16
-              87:     86(ptr) AccessChain 82(psout) 83
-                              Store 87 85
-              90:     89(ptr) AccessChain 82(psout) 88
-                              Store 90 84
-              91:80(PS_OUTPUT) Load 82(psout)
-                              ReturnValue 91
+              44:   35(ivec2) Load 37(uc2)
+              45:   32(ivec4) ImageFetch 43 44 Sample 16
+              46:           7 Load 9(g_tTex2dmsf4)
+              47:   12(ivec2) Load 14(c2)
+              49:   12(ivec2) Load 48(o2)
+              50:   17(fvec4) ImageFetch 46 47 Offset Sample 49 16
+              51:          19 Load 21(g_tTex2dmsi4)
+              52:   12(ivec2) Load 14(c2)
+              53:   12(ivec2) Load 48(o2)
+              54:   24(ivec4) ImageFetch 51 52 Offset Sample 53 16
+              55:          27 Load 29(g_tTex2dmsu4)
+              56:   12(ivec2) Load 14(c2)
+              57:   12(ivec2) Load 48(o2)
+              58:   32(ivec4) ImageFetch 55 56 Offset Sample 57 16
+              59:           7 Load 9(g_tTex2dmsf4)
+              60:   35(ivec2) Load 37(uc2)
+              61:   12(ivec2) Load 48(o2)
+              62:   17(fvec4) ImageFetch 59 60 Offset Sample 61 16
+              63:          19 Load 21(g_tTex2dmsi4)
+              64:   35(ivec2) Load 37(uc2)
+              65:   12(ivec2) Load 48(o2)
+              66:   24(ivec4) ImageFetch 63 64 Offset Sample 65 16
+              67:          27 Load 29(g_tTex2dmsu4)
+              68:   35(ivec2) Load 37(uc2)
+              69:   12(ivec2) Load 48(o2)
+              70:   32(ivec4) ImageFetch 67 68 Offset Sample 69 16
+              74:          71 Load 73(g_tTex2dmsf4a)
+              78:   75(ivec3) Load 77(c3)
+              79:   17(fvec4) ImageFetch 74 78 Sample 16
+              83:          80 Load 82(g_tTex2dmsi4a)
+              84:   75(ivec3) Load 77(c3)
+              85:   24(ivec4) ImageFetch 83 84 Sample 16
+              89:          86 Load 88(g_tTex2dmsu4a)
+              90:   75(ivec3) Load 77(c3)
+              91:   32(ivec4) ImageFetch 89 90 Sample 16
+              92:          71 Load 73(g_tTex2dmsf4a)
+              96:   93(ivec3) Load 95(uc3)
+              97:   17(fvec4) ImageFetch 92 96 Sample 16
+              98:          80 Load 82(g_tTex2dmsi4a)
+              99:   93(ivec3) Load 95(uc3)
+             100:   24(ivec4) ImageFetch 98 99 Sample 16
+             101:          86 Load 88(g_tTex2dmsu4a)
+             102:   93(ivec3) Load 95(uc3)
+             103:   32(ivec4) ImageFetch 101 102 Sample 16
+             104:          71 Load 73(g_tTex2dmsf4a)
+             105:   75(ivec3) Load 77(c3)
+             106:   12(ivec2) Load 48(o2)
+             107:   17(fvec4) ImageFetch 104 105 Offset Sample 106 16
+             108:          80 Load 82(g_tTex2dmsi4a)
+             109:   75(ivec3) Load 77(c3)
+             110:   12(ivec2) Load 48(o2)
+             111:   24(ivec4) ImageFetch 108 109 Offset Sample 110 16
+             112:          86 Load 88(g_tTex2dmsu4a)
+             113:   75(ivec3) Load 77(c3)
+             114:   12(ivec2) Load 48(o2)
+             115:   32(ivec4) ImageFetch 112 113 Offset Sample 114 16
+             116:          71 Load 73(g_tTex2dmsf4a)
+             117:   93(ivec3) Load 95(uc3)
+             118:   12(ivec2) Load 48(o2)
+             119:   17(fvec4) ImageFetch 116 117 Offset Sample 118 16
+             120:          80 Load 82(g_tTex2dmsi4a)
+             121:   93(ivec3) Load 95(uc3)
+             122:   12(ivec2) Load 48(o2)
+             123:   24(ivec4) ImageFetch 120 121 Offset Sample 122 16
+             124:          86 Load 88(g_tTex2dmsu4a)
+             125:   93(ivec3) Load 95(uc3)
+             126:   12(ivec2) Load 48(o2)
+             127:   32(ivec4) ImageFetch 124 125 Offset Sample 126 16
+             135:    134(ptr) AccessChain 130(psout) 131
+                              Store 135 133
+             138:    137(ptr) AccessChain 130(psout) 136
+                              Store 138 132
+             139:128(PS_OUTPUT) Load 130(psout)
+                              ReturnValue 139
                               FunctionEnd

--- a/Test/baseResults/hlsl.load.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.array.dx10.frag.out
@@ -2,112 +2,196 @@ hlsl.load.array.dx10.frag
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:72  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:48    Function Parameters: 
+0:84  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:54    Function Parameters: 
 0:?     Sequence
-0:52      textureFetch (global 4-component vector of float)
-0:52        'g_tTex1df4a' (uniform texture1DArray)
-0:52        vector swizzle (temp 2-component vector of int)
-0:52          'c3' (uniform 3-component vector of int)
-0:52          Sequence
-0:52            Constant:
-0:52              0 (const int)
-0:52            Constant:
-0:52              1 (const int)
-0:52        direct index (temp int)
-0:52          'c3' (uniform 3-component vector of int)
-0:52          Constant:
-0:52            2 (const int)
-0:53      textureFetch (global 4-component vector of int)
-0:53        'g_tTex1di4a' (uniform itexture1DArray)
-0:53        vector swizzle (temp 2-component vector of int)
-0:53          'c3' (uniform 3-component vector of int)
-0:53          Sequence
-0:53            Constant:
-0:53              0 (const int)
-0:53            Constant:
-0:53              1 (const int)
-0:53        direct index (temp int)
-0:53          'c3' (uniform 3-component vector of int)
-0:53          Constant:
-0:53            2 (const int)
-0:54      textureFetch (global 4-component vector of uint)
-0:54        'g_tTex1du4a' (uniform utexture1DArray)
-0:54        vector swizzle (temp 2-component vector of int)
-0:54          'c3' (uniform 3-component vector of int)
-0:54          Sequence
-0:54            Constant:
-0:54              0 (const int)
-0:54            Constant:
-0:54              1 (const int)
-0:54        direct index (temp int)
-0:54          'c3' (uniform 3-component vector of int)
-0:54          Constant:
-0:54            2 (const int)
-0:57      textureFetch (global 4-component vector of float)
-0:57        'g_tTex2df4a' (uniform texture2DArray)
-0:57        vector swizzle (temp 3-component vector of int)
-0:57          'c4' (uniform 4-component vector of int)
-0:57          Sequence
-0:57            Constant:
-0:57              0 (const int)
-0:57            Constant:
-0:57              1 (const int)
-0:57            Constant:
-0:57              2 (const int)
-0:57        direct index (temp int)
-0:57          'c4' (uniform 4-component vector of int)
-0:57          Constant:
-0:57            3 (const int)
-0:58      textureFetch (global 4-component vector of int)
-0:58        'g_tTex2di4a' (uniform itexture2DArray)
-0:58        vector swizzle (temp 3-component vector of int)
-0:58          'c4' (uniform 4-component vector of int)
+0:58      textureFetch (global 4-component vector of float)
+0:58        'g_tTex1df4a' (uniform texture1DArray)
+0:58        vector swizzle (temp 2-component vector of int)
+0:58          'c3' (uniform 3-component vector of int)
 0:58          Sequence
 0:58            Constant:
 0:58              0 (const int)
 0:58            Constant:
 0:58              1 (const int)
-0:58            Constant:
-0:58              2 (const int)
 0:58        direct index (temp int)
-0:58          'c4' (uniform 4-component vector of int)
+0:58          'c3' (uniform 3-component vector of int)
 0:58          Constant:
-0:58            3 (const int)
-0:59      textureFetch (global 4-component vector of uint)
-0:59        'g_tTex2du4a' (uniform utexture2DArray)
-0:59        vector swizzle (temp 3-component vector of int)
-0:59          'c4' (uniform 4-component vector of int)
+0:58            2 (const int)
+0:59      textureFetch (global 4-component vector of int)
+0:59        'g_tTex1di4a' (uniform itexture1DArray)
+0:59        vector swizzle (temp 2-component vector of int)
+0:59          'c3' (uniform 3-component vector of int)
 0:59          Sequence
 0:59            Constant:
 0:59              0 (const int)
 0:59            Constant:
 0:59              1 (const int)
-0:59            Constant:
-0:59              2 (const int)
 0:59        direct index (temp int)
-0:59          'c4' (uniform 4-component vector of int)
+0:59          'c3' (uniform 3-component vector of int)
 0:59          Constant:
-0:59            3 (const int)
-0:67      move second child to first child (temp 4-component vector of float)
-0:67        Color: direct index for structure (temp 4-component vector of float)
-0:67          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:59            2 (const int)
+0:60      textureFetch (global 4-component vector of uint)
+0:60        'g_tTex1du4a' (uniform utexture1DArray)
+0:60        vector swizzle (temp 2-component vector of int)
+0:60          'c3' (uniform 3-component vector of int)
+0:60          Sequence
+0:60            Constant:
+0:60              0 (const int)
+0:60            Constant:
+0:60              1 (const int)
+0:60        direct index (temp int)
+0:60          'c3' (uniform 3-component vector of int)
+0:60          Constant:
+0:60            2 (const int)
+0:61      textureFetch (global 4-component vector of float)
+0:61        'g_tTex1df4a' (uniform texture1DArray)
+0:61        vector swizzle (temp 2-component vector of uint)
+0:61          'uc3' (uniform 3-component vector of uint)
+0:61          Sequence
+0:61            Constant:
+0:61              0 (const int)
+0:61            Constant:
+0:61              1 (const int)
+0:61        direct index (temp uint)
+0:61          'uc3' (uniform 3-component vector of uint)
+0:61          Constant:
+0:61            2 (const int)
+0:62      textureFetch (global 4-component vector of int)
+0:62        'g_tTex1di4a' (uniform itexture1DArray)
+0:62        vector swizzle (temp 2-component vector of uint)
+0:62          'uc3' (uniform 3-component vector of uint)
+0:62          Sequence
+0:62            Constant:
+0:62              0 (const int)
+0:62            Constant:
+0:62              1 (const int)
+0:62        direct index (temp uint)
+0:62          'uc3' (uniform 3-component vector of uint)
+0:62          Constant:
+0:62            2 (const int)
+0:63      textureFetch (global 4-component vector of uint)
+0:63        'g_tTex1du4a' (uniform utexture1DArray)
+0:63        vector swizzle (temp 2-component vector of uint)
+0:63          'uc3' (uniform 3-component vector of uint)
+0:63          Sequence
+0:63            Constant:
+0:63              0 (const int)
+0:63            Constant:
+0:63              1 (const int)
+0:63        direct index (temp uint)
+0:63          'uc3' (uniform 3-component vector of uint)
+0:63          Constant:
+0:63            2 (const int)
+0:66      textureFetch (global 4-component vector of float)
+0:66        'g_tTex2df4a' (uniform texture2DArray)
+0:66        vector swizzle (temp 3-component vector of int)
+0:66          'c4' (uniform 4-component vector of int)
+0:66          Sequence
+0:66            Constant:
+0:66              0 (const int)
+0:66            Constant:
+0:66              1 (const int)
+0:66            Constant:
+0:66              2 (const int)
+0:66        direct index (temp int)
+0:66          'c4' (uniform 4-component vector of int)
+0:66          Constant:
+0:66            3 (const int)
+0:67      textureFetch (global 4-component vector of int)
+0:67        'g_tTex2di4a' (uniform itexture2DArray)
+0:67        vector swizzle (temp 3-component vector of int)
+0:67          'c4' (uniform 4-component vector of int)
+0:67          Sequence
+0:67            Constant:
+0:67              0 (const int)
+0:67            Constant:
+0:67              1 (const int)
+0:67            Constant:
+0:67              2 (const int)
+0:67        direct index (temp int)
+0:67          'c4' (uniform 4-component vector of int)
 0:67          Constant:
-0:67            0 (const int)
-0:67        Constant:
-0:67          1.000000
-0:67          1.000000
-0:67          1.000000
-0:67          1.000000
-0:68      move second child to first child (temp float)
-0:68        Depth: direct index for structure (temp float FragDepth)
-0:68          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:67            3 (const int)
+0:68      textureFetch (global 4-component vector of uint)
+0:68        'g_tTex2du4a' (uniform utexture2DArray)
+0:68        vector swizzle (temp 3-component vector of int)
+0:68          'c4' (uniform 4-component vector of int)
+0:68          Sequence
+0:68            Constant:
+0:68              0 (const int)
+0:68            Constant:
+0:68              1 (const int)
+0:68            Constant:
+0:68              2 (const int)
+0:68        direct index (temp int)
+0:68          'c4' (uniform 4-component vector of int)
 0:68          Constant:
-0:68            1 (const int)
-0:68        Constant:
-0:68          1.000000
-0:70      Branch: Return with expression
-0:70        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:68            3 (const int)
+0:69      textureFetch (global 4-component vector of float)
+0:69        'g_tTex2df4a' (uniform texture2DArray)
+0:69        vector swizzle (temp 3-component vector of uint)
+0:69          'uc4' (uniform 4-component vector of uint)
+0:69          Sequence
+0:69            Constant:
+0:69              0 (const int)
+0:69            Constant:
+0:69              1 (const int)
+0:69            Constant:
+0:69              2 (const int)
+0:69        direct index (temp uint)
+0:69          'uc4' (uniform 4-component vector of uint)
+0:69          Constant:
+0:69            3 (const int)
+0:70      textureFetch (global 4-component vector of int)
+0:70        'g_tTex2di4a' (uniform itexture2DArray)
+0:70        vector swizzle (temp 3-component vector of uint)
+0:70          'uc4' (uniform 4-component vector of uint)
+0:70          Sequence
+0:70            Constant:
+0:70              0 (const int)
+0:70            Constant:
+0:70              1 (const int)
+0:70            Constant:
+0:70              2 (const int)
+0:70        direct index (temp uint)
+0:70          'uc4' (uniform 4-component vector of uint)
+0:70          Constant:
+0:70            3 (const int)
+0:71      textureFetch (global 4-component vector of uint)
+0:71        'g_tTex2du4a' (uniform utexture2DArray)
+0:71        vector swizzle (temp 3-component vector of uint)
+0:71          'uc4' (uniform 4-component vector of uint)
+0:71          Sequence
+0:71            Constant:
+0:71              0 (const int)
+0:71            Constant:
+0:71              1 (const int)
+0:71            Constant:
+0:71              2 (const int)
+0:71        direct index (temp uint)
+0:71          'uc4' (uniform 4-component vector of uint)
+0:71          Constant:
+0:71            3 (const int)
+0:79      move second child to first child (temp 4-component vector of float)
+0:79        Color: direct index for structure (temp 4-component vector of float)
+0:79          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:79          Constant:
+0:79            0 (const int)
+0:79        Constant:
+0:79          1.000000
+0:79          1.000000
+0:79          1.000000
+0:79          1.000000
+0:80      move second child to first child (temp float)
+0:80        Depth: direct index for structure (temp float FragDepth)
+0:80          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:80          Constant:
+0:80            1 (const int)
+0:80        Constant:
+0:80          1.000000
+0:82      Branch: Return with expression
+0:82        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
 0:?   Linker Objects
 0:?     'g_sSamp' (layout(binding=0 ) uniform sampler)
 0:?     'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
@@ -135,6 +219,10 @@ gl_FragCoord origin is upper left
 0:?     'c2' (uniform 2-component vector of int)
 0:?     'c3' (uniform 3-component vector of int)
 0:?     'c4' (uniform 4-component vector of int)
+0:?     'uc1' (uniform uint)
+0:?     'uc2' (uniform 2-component vector of uint)
+0:?     'uc3' (uniform 3-component vector of uint)
+0:?     'uc4' (uniform 4-component vector of uint)
 0:?     'o1' (uniform int)
 0:?     'o2' (uniform 2-component vector of int)
 0:?     'o3' (uniform 3-component vector of int)
@@ -147,112 +235,196 @@ Linked fragment stage:
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:72  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:48    Function Parameters: 
+0:84  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:54    Function Parameters: 
 0:?     Sequence
-0:52      textureFetch (global 4-component vector of float)
-0:52        'g_tTex1df4a' (uniform texture1DArray)
-0:52        vector swizzle (temp 2-component vector of int)
-0:52          'c3' (uniform 3-component vector of int)
-0:52          Sequence
-0:52            Constant:
-0:52              0 (const int)
-0:52            Constant:
-0:52              1 (const int)
-0:52        direct index (temp int)
-0:52          'c3' (uniform 3-component vector of int)
-0:52          Constant:
-0:52            2 (const int)
-0:53      textureFetch (global 4-component vector of int)
-0:53        'g_tTex1di4a' (uniform itexture1DArray)
-0:53        vector swizzle (temp 2-component vector of int)
-0:53          'c3' (uniform 3-component vector of int)
-0:53          Sequence
-0:53            Constant:
-0:53              0 (const int)
-0:53            Constant:
-0:53              1 (const int)
-0:53        direct index (temp int)
-0:53          'c3' (uniform 3-component vector of int)
-0:53          Constant:
-0:53            2 (const int)
-0:54      textureFetch (global 4-component vector of uint)
-0:54        'g_tTex1du4a' (uniform utexture1DArray)
-0:54        vector swizzle (temp 2-component vector of int)
-0:54          'c3' (uniform 3-component vector of int)
-0:54          Sequence
-0:54            Constant:
-0:54              0 (const int)
-0:54            Constant:
-0:54              1 (const int)
-0:54        direct index (temp int)
-0:54          'c3' (uniform 3-component vector of int)
-0:54          Constant:
-0:54            2 (const int)
-0:57      textureFetch (global 4-component vector of float)
-0:57        'g_tTex2df4a' (uniform texture2DArray)
-0:57        vector swizzle (temp 3-component vector of int)
-0:57          'c4' (uniform 4-component vector of int)
-0:57          Sequence
-0:57            Constant:
-0:57              0 (const int)
-0:57            Constant:
-0:57              1 (const int)
-0:57            Constant:
-0:57              2 (const int)
-0:57        direct index (temp int)
-0:57          'c4' (uniform 4-component vector of int)
-0:57          Constant:
-0:57            3 (const int)
-0:58      textureFetch (global 4-component vector of int)
-0:58        'g_tTex2di4a' (uniform itexture2DArray)
-0:58        vector swizzle (temp 3-component vector of int)
-0:58          'c4' (uniform 4-component vector of int)
+0:58      textureFetch (global 4-component vector of float)
+0:58        'g_tTex1df4a' (uniform texture1DArray)
+0:58        vector swizzle (temp 2-component vector of int)
+0:58          'c3' (uniform 3-component vector of int)
 0:58          Sequence
 0:58            Constant:
 0:58              0 (const int)
 0:58            Constant:
 0:58              1 (const int)
-0:58            Constant:
-0:58              2 (const int)
 0:58        direct index (temp int)
-0:58          'c4' (uniform 4-component vector of int)
+0:58          'c3' (uniform 3-component vector of int)
 0:58          Constant:
-0:58            3 (const int)
-0:59      textureFetch (global 4-component vector of uint)
-0:59        'g_tTex2du4a' (uniform utexture2DArray)
-0:59        vector swizzle (temp 3-component vector of int)
-0:59          'c4' (uniform 4-component vector of int)
+0:58            2 (const int)
+0:59      textureFetch (global 4-component vector of int)
+0:59        'g_tTex1di4a' (uniform itexture1DArray)
+0:59        vector swizzle (temp 2-component vector of int)
+0:59          'c3' (uniform 3-component vector of int)
 0:59          Sequence
 0:59            Constant:
 0:59              0 (const int)
 0:59            Constant:
 0:59              1 (const int)
-0:59            Constant:
-0:59              2 (const int)
 0:59        direct index (temp int)
-0:59          'c4' (uniform 4-component vector of int)
+0:59          'c3' (uniform 3-component vector of int)
 0:59          Constant:
-0:59            3 (const int)
-0:67      move second child to first child (temp 4-component vector of float)
-0:67        Color: direct index for structure (temp 4-component vector of float)
-0:67          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:59            2 (const int)
+0:60      textureFetch (global 4-component vector of uint)
+0:60        'g_tTex1du4a' (uniform utexture1DArray)
+0:60        vector swizzle (temp 2-component vector of int)
+0:60          'c3' (uniform 3-component vector of int)
+0:60          Sequence
+0:60            Constant:
+0:60              0 (const int)
+0:60            Constant:
+0:60              1 (const int)
+0:60        direct index (temp int)
+0:60          'c3' (uniform 3-component vector of int)
+0:60          Constant:
+0:60            2 (const int)
+0:61      textureFetch (global 4-component vector of float)
+0:61        'g_tTex1df4a' (uniform texture1DArray)
+0:61        vector swizzle (temp 2-component vector of uint)
+0:61          'uc3' (uniform 3-component vector of uint)
+0:61          Sequence
+0:61            Constant:
+0:61              0 (const int)
+0:61            Constant:
+0:61              1 (const int)
+0:61        direct index (temp uint)
+0:61          'uc3' (uniform 3-component vector of uint)
+0:61          Constant:
+0:61            2 (const int)
+0:62      textureFetch (global 4-component vector of int)
+0:62        'g_tTex1di4a' (uniform itexture1DArray)
+0:62        vector swizzle (temp 2-component vector of uint)
+0:62          'uc3' (uniform 3-component vector of uint)
+0:62          Sequence
+0:62            Constant:
+0:62              0 (const int)
+0:62            Constant:
+0:62              1 (const int)
+0:62        direct index (temp uint)
+0:62          'uc3' (uniform 3-component vector of uint)
+0:62          Constant:
+0:62            2 (const int)
+0:63      textureFetch (global 4-component vector of uint)
+0:63        'g_tTex1du4a' (uniform utexture1DArray)
+0:63        vector swizzle (temp 2-component vector of uint)
+0:63          'uc3' (uniform 3-component vector of uint)
+0:63          Sequence
+0:63            Constant:
+0:63              0 (const int)
+0:63            Constant:
+0:63              1 (const int)
+0:63        direct index (temp uint)
+0:63          'uc3' (uniform 3-component vector of uint)
+0:63          Constant:
+0:63            2 (const int)
+0:66      textureFetch (global 4-component vector of float)
+0:66        'g_tTex2df4a' (uniform texture2DArray)
+0:66        vector swizzle (temp 3-component vector of int)
+0:66          'c4' (uniform 4-component vector of int)
+0:66          Sequence
+0:66            Constant:
+0:66              0 (const int)
+0:66            Constant:
+0:66              1 (const int)
+0:66            Constant:
+0:66              2 (const int)
+0:66        direct index (temp int)
+0:66          'c4' (uniform 4-component vector of int)
+0:66          Constant:
+0:66            3 (const int)
+0:67      textureFetch (global 4-component vector of int)
+0:67        'g_tTex2di4a' (uniform itexture2DArray)
+0:67        vector swizzle (temp 3-component vector of int)
+0:67          'c4' (uniform 4-component vector of int)
+0:67          Sequence
+0:67            Constant:
+0:67              0 (const int)
+0:67            Constant:
+0:67              1 (const int)
+0:67            Constant:
+0:67              2 (const int)
+0:67        direct index (temp int)
+0:67          'c4' (uniform 4-component vector of int)
 0:67          Constant:
-0:67            0 (const int)
-0:67        Constant:
-0:67          1.000000
-0:67          1.000000
-0:67          1.000000
-0:67          1.000000
-0:68      move second child to first child (temp float)
-0:68        Depth: direct index for structure (temp float FragDepth)
-0:68          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:67            3 (const int)
+0:68      textureFetch (global 4-component vector of uint)
+0:68        'g_tTex2du4a' (uniform utexture2DArray)
+0:68        vector swizzle (temp 3-component vector of int)
+0:68          'c4' (uniform 4-component vector of int)
+0:68          Sequence
+0:68            Constant:
+0:68              0 (const int)
+0:68            Constant:
+0:68              1 (const int)
+0:68            Constant:
+0:68              2 (const int)
+0:68        direct index (temp int)
+0:68          'c4' (uniform 4-component vector of int)
 0:68          Constant:
-0:68            1 (const int)
-0:68        Constant:
-0:68          1.000000
-0:70      Branch: Return with expression
-0:70        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:68            3 (const int)
+0:69      textureFetch (global 4-component vector of float)
+0:69        'g_tTex2df4a' (uniform texture2DArray)
+0:69        vector swizzle (temp 3-component vector of uint)
+0:69          'uc4' (uniform 4-component vector of uint)
+0:69          Sequence
+0:69            Constant:
+0:69              0 (const int)
+0:69            Constant:
+0:69              1 (const int)
+0:69            Constant:
+0:69              2 (const int)
+0:69        direct index (temp uint)
+0:69          'uc4' (uniform 4-component vector of uint)
+0:69          Constant:
+0:69            3 (const int)
+0:70      textureFetch (global 4-component vector of int)
+0:70        'g_tTex2di4a' (uniform itexture2DArray)
+0:70        vector swizzle (temp 3-component vector of uint)
+0:70          'uc4' (uniform 4-component vector of uint)
+0:70          Sequence
+0:70            Constant:
+0:70              0 (const int)
+0:70            Constant:
+0:70              1 (const int)
+0:70            Constant:
+0:70              2 (const int)
+0:70        direct index (temp uint)
+0:70          'uc4' (uniform 4-component vector of uint)
+0:70          Constant:
+0:70            3 (const int)
+0:71      textureFetch (global 4-component vector of uint)
+0:71        'g_tTex2du4a' (uniform utexture2DArray)
+0:71        vector swizzle (temp 3-component vector of uint)
+0:71          'uc4' (uniform 4-component vector of uint)
+0:71          Sequence
+0:71            Constant:
+0:71              0 (const int)
+0:71            Constant:
+0:71              1 (const int)
+0:71            Constant:
+0:71              2 (const int)
+0:71        direct index (temp uint)
+0:71          'uc4' (uniform 4-component vector of uint)
+0:71          Constant:
+0:71            3 (const int)
+0:79      move second child to first child (temp 4-component vector of float)
+0:79        Color: direct index for structure (temp 4-component vector of float)
+0:79          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:79          Constant:
+0:79            0 (const int)
+0:79        Constant:
+0:79          1.000000
+0:79          1.000000
+0:79          1.000000
+0:79          1.000000
+0:80      move second child to first child (temp float)
+0:80        Depth: direct index for structure (temp float FragDepth)
+0:80          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:80          Constant:
+0:80            1 (const int)
+0:80        Constant:
+0:80          1.000000
+0:82      Branch: Return with expression
+0:82        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
 0:?   Linker Objects
 0:?     'g_sSamp' (layout(binding=0 ) uniform sampler)
 0:?     'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
@@ -280,6 +452,10 @@ gl_FragCoord origin is upper left
 0:?     'c2' (uniform 2-component vector of int)
 0:?     'c3' (uniform 3-component vector of int)
 0:?     'c4' (uniform 4-component vector of int)
+0:?     'uc1' (uniform uint)
+0:?     'uc2' (uniform 2-component vector of uint)
+0:?     'uc3' (uniform 3-component vector of uint)
+0:?     'uc4' (uniform 4-component vector of uint)
 0:?     'o1' (uniform int)
 0:?     'o2' (uniform 2-component vector of int)
 0:?     'o3' (uniform 3-component vector of int)
@@ -287,7 +463,7 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 143
+// Id's are bound by 189
 
                               Capability Shader
                               Capability Sampled1D
@@ -301,61 +477,65 @@ gl_FragCoord origin is upper left
                               Name 14  "c3"
                               Name 27  "g_tTex1di4a"
                               Name 37  "g_tTex1du4a"
-                              Name 47  "g_tTex2df4a"
-                              Name 50  "c4"
-                              Name 59  "g_tTex2di4a"
-                              Name 68  "g_tTex2du4a"
-                              Name 75  "PS_OUTPUT"
-                              MemberName 75(PS_OUTPUT) 0  "Color"
-                              MemberName 75(PS_OUTPUT) 1  "Depth"
-                              Name 77  "psout"
-                              Name 90  "g_sSamp"
-                              Name 93  "g_tTex1df4"
-                              Name 96  "g_tTex1di4"
-                              Name 99  "g_tTex1du4"
-                              Name 102  "g_tTex2df4"
-                              Name 105  "g_tTex2di4"
-                              Name 108  "g_tTex2du4"
-                              Name 111  "g_tTex3df4"
-                              Name 114  "g_tTex3di4"
-                              Name 117  "g_tTex3du4"
-                              Name 120  "g_tTexcdf4"
-                              Name 123  "g_tTexcdi4"
-                              Name 126  "g_tTexcdu4"
-                              Name 129  "g_tTexcdf4a"
-                              Name 132  "g_tTexcdi4a"
-                              Name 135  "g_tTexcdu4a"
-                              Name 136  "c1"
-                              Name 138  "c2"
-                              Name 139  "o1"
-                              Name 140  "o2"
-                              Name 141  "o3"
-                              Name 142  "o4"
+                              Name 48  "uc3"
+                              Name 70  "g_tTex2df4a"
+                              Name 73  "c4"
+                              Name 82  "g_tTex2di4a"
+                              Name 91  "g_tTex2du4a"
+                              Name 100  "uc4"
+                              Name 118  "PS_OUTPUT"
+                              MemberName 118(PS_OUTPUT) 0  "Color"
+                              MemberName 118(PS_OUTPUT) 1  "Depth"
+                              Name 120  "psout"
+                              Name 133  "g_sSamp"
+                              Name 136  "g_tTex1df4"
+                              Name 139  "g_tTex1di4"
+                              Name 142  "g_tTex1du4"
+                              Name 145  "g_tTex2df4"
+                              Name 148  "g_tTex2di4"
+                              Name 151  "g_tTex2du4"
+                              Name 154  "g_tTex3df4"
+                              Name 157  "g_tTex3di4"
+                              Name 160  "g_tTex3du4"
+                              Name 163  "g_tTexcdf4"
+                              Name 166  "g_tTexcdi4"
+                              Name 169  "g_tTexcdu4"
+                              Name 172  "g_tTexcdf4a"
+                              Name 175  "g_tTexcdi4a"
+                              Name 178  "g_tTexcdu4a"
+                              Name 179  "c1"
+                              Name 181  "c2"
+                              Name 182  "uc1"
+                              Name 184  "uc2"
+                              Name 185  "o1"
+                              Name 186  "o2"
+                              Name 187  "o3"
+                              Name 188  "o4"
                               Decorate 9(g_tTex1df4a) DescriptorSet 0
                               Decorate 27(g_tTex1di4a) DescriptorSet 0
                               Decorate 37(g_tTex1du4a) DescriptorSet 0
-                              Decorate 47(g_tTex2df4a) DescriptorSet 0
-                              Decorate 59(g_tTex2di4a) DescriptorSet 0
-                              Decorate 68(g_tTex2du4a) DescriptorSet 0
-                              MemberDecorate 75(PS_OUTPUT) 1 BuiltIn FragDepth
-                              Decorate 90(g_sSamp) DescriptorSet 0
-                              Decorate 90(g_sSamp) Binding 0
-                              Decorate 93(g_tTex1df4) DescriptorSet 0
-                              Decorate 93(g_tTex1df4) Binding 0
-                              Decorate 96(g_tTex1di4) DescriptorSet 0
-                              Decorate 99(g_tTex1du4) DescriptorSet 0
-                              Decorate 102(g_tTex2df4) DescriptorSet 0
-                              Decorate 105(g_tTex2di4) DescriptorSet 0
-                              Decorate 108(g_tTex2du4) DescriptorSet 0
-                              Decorate 111(g_tTex3df4) DescriptorSet 0
-                              Decorate 114(g_tTex3di4) DescriptorSet 0
-                              Decorate 117(g_tTex3du4) DescriptorSet 0
-                              Decorate 120(g_tTexcdf4) DescriptorSet 0
-                              Decorate 123(g_tTexcdi4) DescriptorSet 0
-                              Decorate 126(g_tTexcdu4) DescriptorSet 0
-                              Decorate 129(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 132(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 135(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 70(g_tTex2df4a) DescriptorSet 0
+                              Decorate 82(g_tTex2di4a) DescriptorSet 0
+                              Decorate 91(g_tTex2du4a) DescriptorSet 0
+                              MemberDecorate 118(PS_OUTPUT) 1 BuiltIn FragDepth
+                              Decorate 133(g_sSamp) DescriptorSet 0
+                              Decorate 133(g_sSamp) Binding 0
+                              Decorate 136(g_tTex1df4) DescriptorSet 0
+                              Decorate 136(g_tTex1df4) Binding 0
+                              Decorate 139(g_tTex1di4) DescriptorSet 0
+                              Decorate 142(g_tTex1du4) DescriptorSet 0
+                              Decorate 145(g_tTex2df4) DescriptorSet 0
+                              Decorate 148(g_tTex2di4) DescriptorSet 0
+                              Decorate 151(g_tTex2du4) DescriptorSet 0
+                              Decorate 154(g_tTex3df4) DescriptorSet 0
+                              Decorate 157(g_tTex3di4) DescriptorSet 0
+                              Decorate 160(g_tTex3du4) DescriptorSet 0
+                              Decorate 163(g_tTexcdf4) DescriptorSet 0
+                              Decorate 166(g_tTexcdi4) DescriptorSet 0
+                              Decorate 169(g_tTexcdu4) DescriptorSet 0
+                              Decorate 172(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 175(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 178(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -379,84 +559,94 @@ gl_FragCoord origin is upper left
               36:             TypePointer UniformConstant 35
  37(g_tTex1du4a):     36(ptr) Variable UniformConstant
               43:             TypeVector 18(int) 4
-              45:             TypeImage 6(float) 2D array sampled format:Unknown
-              46:             TypePointer UniformConstant 45
- 47(g_tTex2df4a):     46(ptr) Variable UniformConstant
-              49:             TypePointer UniformConstant 33(ivec4)
-          50(c4):     49(ptr) Variable UniformConstant
-              53:     18(int) Constant 3
-              57:             TypeImage 11(int) 2D array sampled format:Unknown
-              58:             TypePointer UniformConstant 57
- 59(g_tTex2di4a):     58(ptr) Variable UniformConstant
-              66:             TypeImage 18(int) 2D array sampled format:Unknown
-              67:             TypePointer UniformConstant 66
- 68(g_tTex2du4a):     67(ptr) Variable UniformConstant
-   75(PS_OUTPUT):             TypeStruct 23(fvec4) 6(float)
-              76:             TypePointer Function 75(PS_OUTPUT)
-              78:     11(int) Constant 0
-              79:    6(float) Constant 1065353216
-              80:   23(fvec4) ConstantComposite 79 79 79 79
-              81:             TypePointer Function 23(fvec4)
-              83:     11(int) Constant 1
-              84:             TypePointer Function 6(float)
-              88:             TypeSampler
-              89:             TypePointer UniformConstant 88
-     90(g_sSamp):     89(ptr) Variable UniformConstant
-              91:             TypeImage 6(float) 1D sampled format:Unknown
-              92:             TypePointer UniformConstant 91
-  93(g_tTex1df4):     92(ptr) Variable UniformConstant
-              94:             TypeImage 11(int) 1D sampled format:Unknown
-              95:             TypePointer UniformConstant 94
-  96(g_tTex1di4):     95(ptr) Variable UniformConstant
-              97:             TypeImage 18(int) 1D sampled format:Unknown
-              98:             TypePointer UniformConstant 97
-  99(g_tTex1du4):     98(ptr) Variable UniformConstant
-             100:             TypeImage 6(float) 2D sampled format:Unknown
-             101:             TypePointer UniformConstant 100
- 102(g_tTex2df4):    101(ptr) Variable UniformConstant
-             103:             TypeImage 11(int) 2D sampled format:Unknown
-             104:             TypePointer UniformConstant 103
- 105(g_tTex2di4):    104(ptr) Variable UniformConstant
-             106:             TypeImage 18(int) 2D sampled format:Unknown
-             107:             TypePointer UniformConstant 106
- 108(g_tTex2du4):    107(ptr) Variable UniformConstant
-             109:             TypeImage 6(float) 3D sampled format:Unknown
-             110:             TypePointer UniformConstant 109
- 111(g_tTex3df4):    110(ptr) Variable UniformConstant
-             112:             TypeImage 11(int) 3D sampled format:Unknown
-             113:             TypePointer UniformConstant 112
- 114(g_tTex3di4):    113(ptr) Variable UniformConstant
-             115:             TypeImage 18(int) 3D sampled format:Unknown
-             116:             TypePointer UniformConstant 115
- 117(g_tTex3du4):    116(ptr) Variable UniformConstant
-             118:             TypeImage 6(float) Cube sampled format:Unknown
-             119:             TypePointer UniformConstant 118
- 120(g_tTexcdf4):    119(ptr) Variable UniformConstant
-             121:             TypeImage 11(int) Cube sampled format:Unknown
-             122:             TypePointer UniformConstant 121
- 123(g_tTexcdi4):    122(ptr) Variable UniformConstant
-             124:             TypeImage 18(int) Cube sampled format:Unknown
-             125:             TypePointer UniformConstant 124
- 126(g_tTexcdu4):    125(ptr) Variable UniformConstant
-             127:             TypeImage 6(float) Cube array sampled format:Unknown
-             128:             TypePointer UniformConstant 127
-129(g_tTexcdf4a):    128(ptr) Variable UniformConstant
-             130:             TypeImage 11(int) Cube array sampled format:Unknown
-             131:             TypePointer UniformConstant 130
-132(g_tTexcdi4a):    131(ptr) Variable UniformConstant
-             133:             TypeImage 18(int) Cube array sampled format:Unknown
-             134:             TypePointer UniformConstant 133
-135(g_tTexcdu4a):    134(ptr) Variable UniformConstant
-         136(c1):     20(ptr) Variable UniformConstant
-             137:             TypePointer UniformConstant 15(ivec2)
-         138(c2):    137(ptr) Variable UniformConstant
-         139(o1):     20(ptr) Variable UniformConstant
-         140(o2):    137(ptr) Variable UniformConstant
-         141(o3):     13(ptr) Variable UniformConstant
-         142(o4):     49(ptr) Variable UniformConstant
+              46:             TypeVector 18(int) 3
+              47:             TypePointer UniformConstant 46(ivec3)
+         48(uc3):     47(ptr) Variable UniformConstant
+              49:             TypeVector 18(int) 2
+              52:             TypePointer UniformConstant 18(int)
+              68:             TypeImage 6(float) 2D array sampled format:Unknown
+              69:             TypePointer UniformConstant 68
+ 70(g_tTex2df4a):     69(ptr) Variable UniformConstant
+              72:             TypePointer UniformConstant 33(ivec4)
+          73(c4):     72(ptr) Variable UniformConstant
+              76:     18(int) Constant 3
+              80:             TypeImage 11(int) 2D array sampled format:Unknown
+              81:             TypePointer UniformConstant 80
+ 82(g_tTex2di4a):     81(ptr) Variable UniformConstant
+              89:             TypeImage 18(int) 2D array sampled format:Unknown
+              90:             TypePointer UniformConstant 89
+ 91(g_tTex2du4a):     90(ptr) Variable UniformConstant
+              99:             TypePointer UniformConstant 43(ivec4)
+        100(uc4):     99(ptr) Variable UniformConstant
+  118(PS_OUTPUT):             TypeStruct 23(fvec4) 6(float)
+             119:             TypePointer Function 118(PS_OUTPUT)
+             121:     11(int) Constant 0
+             122:    6(float) Constant 1065353216
+             123:   23(fvec4) ConstantComposite 122 122 122 122
+             124:             TypePointer Function 23(fvec4)
+             126:     11(int) Constant 1
+             127:             TypePointer Function 6(float)
+             131:             TypeSampler
+             132:             TypePointer UniformConstant 131
+    133(g_sSamp):    132(ptr) Variable UniformConstant
+             134:             TypeImage 6(float) 1D sampled format:Unknown
+             135:             TypePointer UniformConstant 134
+ 136(g_tTex1df4):    135(ptr) Variable UniformConstant
+             137:             TypeImage 11(int) 1D sampled format:Unknown
+             138:             TypePointer UniformConstant 137
+ 139(g_tTex1di4):    138(ptr) Variable UniformConstant
+             140:             TypeImage 18(int) 1D sampled format:Unknown
+             141:             TypePointer UniformConstant 140
+ 142(g_tTex1du4):    141(ptr) Variable UniformConstant
+             143:             TypeImage 6(float) 2D sampled format:Unknown
+             144:             TypePointer UniformConstant 143
+ 145(g_tTex2df4):    144(ptr) Variable UniformConstant
+             146:             TypeImage 11(int) 2D sampled format:Unknown
+             147:             TypePointer UniformConstant 146
+ 148(g_tTex2di4):    147(ptr) Variable UniformConstant
+             149:             TypeImage 18(int) 2D sampled format:Unknown
+             150:             TypePointer UniformConstant 149
+ 151(g_tTex2du4):    150(ptr) Variable UniformConstant
+             152:             TypeImage 6(float) 3D sampled format:Unknown
+             153:             TypePointer UniformConstant 152
+ 154(g_tTex3df4):    153(ptr) Variable UniformConstant
+             155:             TypeImage 11(int) 3D sampled format:Unknown
+             156:             TypePointer UniformConstant 155
+ 157(g_tTex3di4):    156(ptr) Variable UniformConstant
+             158:             TypeImage 18(int) 3D sampled format:Unknown
+             159:             TypePointer UniformConstant 158
+ 160(g_tTex3du4):    159(ptr) Variable UniformConstant
+             161:             TypeImage 6(float) Cube sampled format:Unknown
+             162:             TypePointer UniformConstant 161
+ 163(g_tTexcdf4):    162(ptr) Variable UniformConstant
+             164:             TypeImage 11(int) Cube sampled format:Unknown
+             165:             TypePointer UniformConstant 164
+ 166(g_tTexcdi4):    165(ptr) Variable UniformConstant
+             167:             TypeImage 18(int) Cube sampled format:Unknown
+             168:             TypePointer UniformConstant 167
+ 169(g_tTexcdu4):    168(ptr) Variable UniformConstant
+             170:             TypeImage 6(float) Cube array sampled format:Unknown
+             171:             TypePointer UniformConstant 170
+172(g_tTexcdf4a):    171(ptr) Variable UniformConstant
+             173:             TypeImage 11(int) Cube array sampled format:Unknown
+             174:             TypePointer UniformConstant 173
+175(g_tTexcdi4a):    174(ptr) Variable UniformConstant
+             176:             TypeImage 18(int) Cube array sampled format:Unknown
+             177:             TypePointer UniformConstant 176
+178(g_tTexcdu4a):    177(ptr) Variable UniformConstant
+         179(c1):     20(ptr) Variable UniformConstant
+             180:             TypePointer UniformConstant 15(ivec2)
+         181(c2):    180(ptr) Variable UniformConstant
+        182(uc1):     52(ptr) Variable UniformConstant
+             183:             TypePointer UniformConstant 49(ivec2)
+        184(uc2):    183(ptr) Variable UniformConstant
+         185(o1):     20(ptr) Variable UniformConstant
+         186(o2):    180(ptr) Variable UniformConstant
+         187(o3):     13(ptr) Variable UniformConstant
+         188(o4):     72(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
-       77(psout):     76(ptr) Variable Function
+      120(psout):    119(ptr) Variable Function
               10:           7 Load 9(g_tTex1df4a)
               16:   12(ivec3) Load 14(c3)
               17:   15(ivec2) VectorShuffle 16 16 0 1
@@ -475,28 +665,64 @@ gl_FragCoord origin is upper left
               41:     20(ptr) AccessChain 14(c3) 19
               42:     11(int) Load 41
               44:   43(ivec4) ImageFetch 38 40 Lod 42
-              48:          45 Load 47(g_tTex2df4a)
-              51:   33(ivec4) Load 50(c4)
-              52:   12(ivec3) VectorShuffle 51 51 0 1 2
-              54:     20(ptr) AccessChain 50(c4) 53
-              55:     11(int) Load 54
-              56:   23(fvec4) ImageFetch 48 52 Lod 55
-              60:          57 Load 59(g_tTex2di4a)
-              61:   33(ivec4) Load 50(c4)
-              62:   12(ivec3) VectorShuffle 61 61 0 1 2
-              63:     20(ptr) AccessChain 50(c4) 53
-              64:     11(int) Load 63
-              65:   33(ivec4) ImageFetch 60 62 Lod 64
-              69:          66 Load 68(g_tTex2du4a)
-              70:   33(ivec4) Load 50(c4)
-              71:   12(ivec3) VectorShuffle 70 70 0 1 2
-              72:     20(ptr) AccessChain 50(c4) 53
-              73:     11(int) Load 72
-              74:   43(ivec4) ImageFetch 69 71 Lod 73
-              82:     81(ptr) AccessChain 77(psout) 78
-                              Store 82 80
-              85:     84(ptr) AccessChain 77(psout) 83
-                              Store 85 79
-              86:75(PS_OUTPUT) Load 77(psout)
-                              ReturnValue 86
+              45:           7 Load 9(g_tTex1df4a)
+              50:   46(ivec3) Load 48(uc3)
+              51:   49(ivec2) VectorShuffle 50 50 0 1
+              53:     52(ptr) AccessChain 48(uc3) 19
+              54:     18(int) Load 53
+              55:   23(fvec4) ImageFetch 45 51 Lod 54
+              56:          25 Load 27(g_tTex1di4a)
+              57:   46(ivec3) Load 48(uc3)
+              58:   49(ivec2) VectorShuffle 57 57 0 1
+              59:     52(ptr) AccessChain 48(uc3) 19
+              60:     18(int) Load 59
+              61:   33(ivec4) ImageFetch 56 58 Lod 60
+              62:          35 Load 37(g_tTex1du4a)
+              63:   46(ivec3) Load 48(uc3)
+              64:   49(ivec2) VectorShuffle 63 63 0 1
+              65:     52(ptr) AccessChain 48(uc3) 19
+              66:     18(int) Load 65
+              67:   43(ivec4) ImageFetch 62 64 Lod 66
+              71:          68 Load 70(g_tTex2df4a)
+              74:   33(ivec4) Load 73(c4)
+              75:   12(ivec3) VectorShuffle 74 74 0 1 2
+              77:     20(ptr) AccessChain 73(c4) 76
+              78:     11(int) Load 77
+              79:   23(fvec4) ImageFetch 71 75 Lod 78
+              83:          80 Load 82(g_tTex2di4a)
+              84:   33(ivec4) Load 73(c4)
+              85:   12(ivec3) VectorShuffle 84 84 0 1 2
+              86:     20(ptr) AccessChain 73(c4) 76
+              87:     11(int) Load 86
+              88:   33(ivec4) ImageFetch 83 85 Lod 87
+              92:          89 Load 91(g_tTex2du4a)
+              93:   33(ivec4) Load 73(c4)
+              94:   12(ivec3) VectorShuffle 93 93 0 1 2
+              95:     20(ptr) AccessChain 73(c4) 76
+              96:     11(int) Load 95
+              97:   43(ivec4) ImageFetch 92 94 Lod 96
+              98:          68 Load 70(g_tTex2df4a)
+             101:   43(ivec4) Load 100(uc4)
+             102:   46(ivec3) VectorShuffle 101 101 0 1 2
+             103:     52(ptr) AccessChain 100(uc4) 76
+             104:     18(int) Load 103
+             105:   23(fvec4) ImageFetch 98 102 Lod 104
+             106:          80 Load 82(g_tTex2di4a)
+             107:   43(ivec4) Load 100(uc4)
+             108:   46(ivec3) VectorShuffle 107 107 0 1 2
+             109:     52(ptr) AccessChain 100(uc4) 76
+             110:     18(int) Load 109
+             111:   33(ivec4) ImageFetch 106 108 Lod 110
+             112:          89 Load 91(g_tTex2du4a)
+             113:   43(ivec4) Load 100(uc4)
+             114:   46(ivec3) VectorShuffle 113 113 0 1 2
+             115:     52(ptr) AccessChain 100(uc4) 76
+             116:     18(int) Load 115
+             117:   43(ivec4) ImageFetch 112 114 Lod 116
+             125:    124(ptr) AccessChain 120(psout) 121
+                              Store 125 123
+             128:    127(ptr) AccessChain 120(psout) 126
+                              Store 128 122
+             129:118(PS_OUTPUT) Load 120(psout)
+                              ReturnValue 129
                               FunctionEnd

--- a/Test/baseResults/hlsl.load.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.basic.dx10.frag.out
@@ -2,145 +2,262 @@ hlsl.load.basic.dx10.frag
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:77  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:48    Function Parameters: 
+0:93  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:54    Function Parameters: 
 0:?     Sequence
-0:52      textureFetch (global 4-component vector of float)
-0:52        'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
-0:52        vector swizzle (temp int)
-0:52          'c2' (uniform 2-component vector of int)
-0:52          Sequence
-0:52            Constant:
-0:52              0 (const int)
-0:52        direct index (temp int)
-0:52          'c2' (uniform 2-component vector of int)
-0:52          Constant:
-0:52            1 (const int)
-0:53      textureFetch (global 4-component vector of int)
-0:53        'g_tTex1di4' (uniform itexture1D)
-0:53        vector swizzle (temp int)
-0:53          'c2' (uniform 2-component vector of int)
-0:53          Sequence
-0:53            Constant:
-0:53              0 (const int)
-0:53        direct index (temp int)
-0:53          'c2' (uniform 2-component vector of int)
-0:53          Constant:
-0:53            1 (const int)
-0:54      textureFetch (global 4-component vector of uint)
-0:54        'g_tTex1du4' (uniform utexture1D)
-0:54        vector swizzle (temp int)
-0:54          'c2' (uniform 2-component vector of int)
-0:54          Sequence
-0:54            Constant:
-0:54              0 (const int)
-0:54        direct index (temp int)
-0:54          'c2' (uniform 2-component vector of int)
-0:54          Constant:
-0:54            1 (const int)
-0:57      textureFetch (global 4-component vector of float)
-0:57        'g_tTex2df4' (uniform texture2D)
-0:57        vector swizzle (temp 2-component vector of int)
-0:57          'c3' (uniform 3-component vector of int)
-0:57          Sequence
-0:57            Constant:
-0:57              0 (const int)
-0:57            Constant:
-0:57              1 (const int)
-0:57        direct index (temp int)
-0:57          'c3' (uniform 3-component vector of int)
-0:57          Constant:
-0:57            2 (const int)
-0:58      textureFetch (global 4-component vector of int)
-0:58        'g_tTex2di4' (uniform itexture2D)
-0:58        vector swizzle (temp 2-component vector of int)
-0:58          'c3' (uniform 3-component vector of int)
+0:58      textureFetch (global 4-component vector of float)
+0:58        'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
+0:58        vector swizzle (temp int)
+0:58          'c2' (uniform 2-component vector of int)
 0:58          Sequence
 0:58            Constant:
 0:58              0 (const int)
-0:58            Constant:
-0:58              1 (const int)
 0:58        direct index (temp int)
-0:58          'c3' (uniform 3-component vector of int)
+0:58          'c2' (uniform 2-component vector of int)
 0:58          Constant:
-0:58            2 (const int)
-0:59      textureFetch (global 4-component vector of uint)
-0:59        'g_tTex2du4' (uniform utexture2D)
-0:59        vector swizzle (temp 2-component vector of int)
-0:59          'c3' (uniform 3-component vector of int)
+0:58            1 (const int)
+0:59      textureFetch (global 4-component vector of int)
+0:59        'g_tTex1di4' (uniform itexture1D)
+0:59        vector swizzle (temp int)
+0:59          'c2' (uniform 2-component vector of int)
 0:59          Sequence
 0:59            Constant:
 0:59              0 (const int)
-0:59            Constant:
-0:59              1 (const int)
 0:59        direct index (temp int)
-0:59          'c3' (uniform 3-component vector of int)
+0:59          'c2' (uniform 2-component vector of int)
 0:59          Constant:
-0:59            2 (const int)
-0:62      textureFetch (global 4-component vector of float)
-0:62        'g_tTex3df4' (uniform texture3D)
-0:62        vector swizzle (temp 3-component vector of int)
-0:62          'c4' (uniform 4-component vector of int)
+0:59            1 (const int)
+0:60      textureFetch (global 4-component vector of uint)
+0:60        'g_tTex1du4' (uniform utexture1D)
+0:60        vector swizzle (temp int)
+0:60          'c2' (uniform 2-component vector of int)
+0:60          Sequence
+0:60            Constant:
+0:60              0 (const int)
+0:60        direct index (temp int)
+0:60          'c2' (uniform 2-component vector of int)
+0:60          Constant:
+0:60            1 (const int)
+0:61      textureFetch (global 4-component vector of float)
+0:61        'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
+0:61        vector swizzle (temp uint)
+0:61          'uc2' (uniform 2-component vector of uint)
+0:61          Sequence
+0:61            Constant:
+0:61              0 (const int)
+0:61        direct index (temp uint)
+0:61          'uc2' (uniform 2-component vector of uint)
+0:61          Constant:
+0:61            1 (const int)
+0:62      textureFetch (global 4-component vector of int)
+0:62        'g_tTex1di4' (uniform itexture1D)
+0:62        vector swizzle (temp uint)
+0:62          'uc2' (uniform 2-component vector of uint)
 0:62          Sequence
 0:62            Constant:
 0:62              0 (const int)
-0:62            Constant:
-0:62              1 (const int)
-0:62            Constant:
-0:62              2 (const int)
-0:62        direct index (temp int)
-0:62          'c4' (uniform 4-component vector of int)
+0:62        direct index (temp uint)
+0:62          'uc2' (uniform 2-component vector of uint)
 0:62          Constant:
-0:62            3 (const int)
-0:63      textureFetch (global 4-component vector of int)
-0:63        'g_tTex3di4' (uniform itexture3D)
-0:63        vector swizzle (temp 3-component vector of int)
-0:63          'c4' (uniform 4-component vector of int)
+0:62            1 (const int)
+0:63      textureFetch (global 4-component vector of uint)
+0:63        'g_tTex1du4' (uniform utexture1D)
+0:63        vector swizzle (temp uint)
+0:63          'uc2' (uniform 2-component vector of uint)
 0:63          Sequence
 0:63            Constant:
 0:63              0 (const int)
-0:63            Constant:
-0:63              1 (const int)
-0:63            Constant:
-0:63              2 (const int)
-0:63        direct index (temp int)
-0:63          'c4' (uniform 4-component vector of int)
+0:63        direct index (temp uint)
+0:63          'uc2' (uniform 2-component vector of uint)
 0:63          Constant:
-0:63            3 (const int)
-0:64      textureFetch (global 4-component vector of uint)
-0:64        'g_tTex3du4' (uniform utexture3D)
-0:64        vector swizzle (temp 3-component vector of int)
-0:64          'c4' (uniform 4-component vector of int)
-0:64          Sequence
-0:64            Constant:
-0:64              0 (const int)
-0:64            Constant:
-0:64              1 (const int)
-0:64            Constant:
-0:64              2 (const int)
-0:64        direct index (temp int)
-0:64          'c4' (uniform 4-component vector of int)
-0:64          Constant:
-0:64            3 (const int)
-0:72      move second child to first child (temp 4-component vector of float)
-0:72        Color: direct index for structure (temp 4-component vector of float)
-0:72          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:72          Constant:
-0:72            0 (const int)
-0:72        Constant:
-0:72          1.000000
-0:72          1.000000
-0:72          1.000000
-0:72          1.000000
-0:73      move second child to first child (temp float)
-0:73        Depth: direct index for structure (temp float FragDepth)
-0:73          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:73          Constant:
-0:73            1 (const int)
-0:73        Constant:
-0:73          1.000000
-0:75      Branch: Return with expression
-0:75        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:63            1 (const int)
+0:66      textureFetch (global 4-component vector of float)
+0:66        'g_tTex2df4' (uniform texture2D)
+0:66        vector swizzle (temp 2-component vector of int)
+0:66          'c3' (uniform 3-component vector of int)
+0:66          Sequence
+0:66            Constant:
+0:66              0 (const int)
+0:66            Constant:
+0:66              1 (const int)
+0:66        direct index (temp int)
+0:66          'c3' (uniform 3-component vector of int)
+0:66          Constant:
+0:66            2 (const int)
+0:67      textureFetch (global 4-component vector of int)
+0:67        'g_tTex2di4' (uniform itexture2D)
+0:67        vector swizzle (temp 2-component vector of int)
+0:67          'c3' (uniform 3-component vector of int)
+0:67          Sequence
+0:67            Constant:
+0:67              0 (const int)
+0:67            Constant:
+0:67              1 (const int)
+0:67        direct index (temp int)
+0:67          'c3' (uniform 3-component vector of int)
+0:67          Constant:
+0:67            2 (const int)
+0:68      textureFetch (global 4-component vector of uint)
+0:68        'g_tTex2du4' (uniform utexture2D)
+0:68        vector swizzle (temp 2-component vector of int)
+0:68          'c3' (uniform 3-component vector of int)
+0:68          Sequence
+0:68            Constant:
+0:68              0 (const int)
+0:68            Constant:
+0:68              1 (const int)
+0:68        direct index (temp int)
+0:68          'c3' (uniform 3-component vector of int)
+0:68          Constant:
+0:68            2 (const int)
+0:69      textureFetch (global 4-component vector of float)
+0:69        'g_tTex2df4' (uniform texture2D)
+0:69        vector swizzle (temp 2-component vector of uint)
+0:69          'uc3' (uniform 3-component vector of uint)
+0:69          Sequence
+0:69            Constant:
+0:69              0 (const int)
+0:69            Constant:
+0:69              1 (const int)
+0:69        direct index (temp uint)
+0:69          'uc3' (uniform 3-component vector of uint)
+0:69          Constant:
+0:69            2 (const int)
+0:70      textureFetch (global 4-component vector of int)
+0:70        'g_tTex2di4' (uniform itexture2D)
+0:70        vector swizzle (temp 2-component vector of uint)
+0:70          'uc3' (uniform 3-component vector of uint)
+0:70          Sequence
+0:70            Constant:
+0:70              0 (const int)
+0:70            Constant:
+0:70              1 (const int)
+0:70        direct index (temp uint)
+0:70          'uc3' (uniform 3-component vector of uint)
+0:70          Constant:
+0:70            2 (const int)
+0:71      textureFetch (global 4-component vector of uint)
+0:71        'g_tTex2du4' (uniform utexture2D)
+0:71        vector swizzle (temp 2-component vector of uint)
+0:71          'uc3' (uniform 3-component vector of uint)
+0:71          Sequence
+0:71            Constant:
+0:71              0 (const int)
+0:71            Constant:
+0:71              1 (const int)
+0:71        direct index (temp uint)
+0:71          'uc3' (uniform 3-component vector of uint)
+0:71          Constant:
+0:71            2 (const int)
+0:75      textureFetch (global 4-component vector of float)
+0:75        'g_tTex3df4' (uniform texture3D)
+0:75        vector swizzle (temp 3-component vector of int)
+0:75          'c4' (uniform 4-component vector of int)
+0:75          Sequence
+0:75            Constant:
+0:75              0 (const int)
+0:75            Constant:
+0:75              1 (const int)
+0:75            Constant:
+0:75              2 (const int)
+0:75        direct index (temp int)
+0:75          'c4' (uniform 4-component vector of int)
+0:75          Constant:
+0:75            3 (const int)
+0:76      textureFetch (global 4-component vector of int)
+0:76        'g_tTex3di4' (uniform itexture3D)
+0:76        vector swizzle (temp 3-component vector of int)
+0:76          'c4' (uniform 4-component vector of int)
+0:76          Sequence
+0:76            Constant:
+0:76              0 (const int)
+0:76            Constant:
+0:76              1 (const int)
+0:76            Constant:
+0:76              2 (const int)
+0:76        direct index (temp int)
+0:76          'c4' (uniform 4-component vector of int)
+0:76          Constant:
+0:76            3 (const int)
+0:77      textureFetch (global 4-component vector of uint)
+0:77        'g_tTex3du4' (uniform utexture3D)
+0:77        vector swizzle (temp 3-component vector of int)
+0:77          'c4' (uniform 4-component vector of int)
+0:77          Sequence
+0:77            Constant:
+0:77              0 (const int)
+0:77            Constant:
+0:77              1 (const int)
+0:77            Constant:
+0:77              2 (const int)
+0:77        direct index (temp int)
+0:77          'c4' (uniform 4-component vector of int)
+0:77          Constant:
+0:77            3 (const int)
+0:78      textureFetch (global 4-component vector of float)
+0:78        'g_tTex3df4' (uniform texture3D)
+0:78        vector swizzle (temp 3-component vector of uint)
+0:78          'uc4' (uniform 4-component vector of uint)
+0:78          Sequence
+0:78            Constant:
+0:78              0 (const int)
+0:78            Constant:
+0:78              1 (const int)
+0:78            Constant:
+0:78              2 (const int)
+0:78        direct index (temp uint)
+0:78          'uc4' (uniform 4-component vector of uint)
+0:78          Constant:
+0:78            3 (const int)
+0:79      textureFetch (global 4-component vector of int)
+0:79        'g_tTex3di4' (uniform itexture3D)
+0:79        vector swizzle (temp 3-component vector of uint)
+0:79          'uc4' (uniform 4-component vector of uint)
+0:79          Sequence
+0:79            Constant:
+0:79              0 (const int)
+0:79            Constant:
+0:79              1 (const int)
+0:79            Constant:
+0:79              2 (const int)
+0:79        direct index (temp uint)
+0:79          'uc4' (uniform 4-component vector of uint)
+0:79          Constant:
+0:79            3 (const int)
+0:80      textureFetch (global 4-component vector of uint)
+0:80        'g_tTex3du4' (uniform utexture3D)
+0:80        vector swizzle (temp 3-component vector of uint)
+0:80          'uc4' (uniform 4-component vector of uint)
+0:80          Sequence
+0:80            Constant:
+0:80              0 (const int)
+0:80            Constant:
+0:80              1 (const int)
+0:80            Constant:
+0:80              2 (const int)
+0:80        direct index (temp uint)
+0:80          'uc4' (uniform 4-component vector of uint)
+0:80          Constant:
+0:80            3 (const int)
+0:88      move second child to first child (temp 4-component vector of float)
+0:88        Color: direct index for structure (temp 4-component vector of float)
+0:88          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:88          Constant:
+0:88            0 (const int)
+0:88        Constant:
+0:88          1.000000
+0:88          1.000000
+0:88          1.000000
+0:88          1.000000
+0:89      move second child to first child (temp float)
+0:89        Depth: direct index for structure (temp float FragDepth)
+0:89          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:89          Constant:
+0:89            1 (const int)
+0:89        Constant:
+0:89          1.000000
+0:91      Branch: Return with expression
+0:91        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
 0:?   Linker Objects
 0:?     'g_sSamp' (layout(binding=0 ) uniform sampler)
 0:?     'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
@@ -168,6 +285,10 @@ gl_FragCoord origin is upper left
 0:?     'c2' (uniform 2-component vector of int)
 0:?     'c3' (uniform 3-component vector of int)
 0:?     'c4' (uniform 4-component vector of int)
+0:?     'uc1' (uniform uint)
+0:?     'uc2' (uniform 2-component vector of uint)
+0:?     'uc3' (uniform 3-component vector of uint)
+0:?     'uc4' (uniform 4-component vector of uint)
 0:?     'o1' (uniform int)
 0:?     'o2' (uniform 2-component vector of int)
 0:?     'o3' (uniform 3-component vector of int)
@@ -180,145 +301,262 @@ Linked fragment stage:
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:77  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:48    Function Parameters: 
+0:93  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:54    Function Parameters: 
 0:?     Sequence
-0:52      textureFetch (global 4-component vector of float)
-0:52        'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
-0:52        vector swizzle (temp int)
-0:52          'c2' (uniform 2-component vector of int)
-0:52          Sequence
-0:52            Constant:
-0:52              0 (const int)
-0:52        direct index (temp int)
-0:52          'c2' (uniform 2-component vector of int)
-0:52          Constant:
-0:52            1 (const int)
-0:53      textureFetch (global 4-component vector of int)
-0:53        'g_tTex1di4' (uniform itexture1D)
-0:53        vector swizzle (temp int)
-0:53          'c2' (uniform 2-component vector of int)
-0:53          Sequence
-0:53            Constant:
-0:53              0 (const int)
-0:53        direct index (temp int)
-0:53          'c2' (uniform 2-component vector of int)
-0:53          Constant:
-0:53            1 (const int)
-0:54      textureFetch (global 4-component vector of uint)
-0:54        'g_tTex1du4' (uniform utexture1D)
-0:54        vector swizzle (temp int)
-0:54          'c2' (uniform 2-component vector of int)
-0:54          Sequence
-0:54            Constant:
-0:54              0 (const int)
-0:54        direct index (temp int)
-0:54          'c2' (uniform 2-component vector of int)
-0:54          Constant:
-0:54            1 (const int)
-0:57      textureFetch (global 4-component vector of float)
-0:57        'g_tTex2df4' (uniform texture2D)
-0:57        vector swizzle (temp 2-component vector of int)
-0:57          'c3' (uniform 3-component vector of int)
-0:57          Sequence
-0:57            Constant:
-0:57              0 (const int)
-0:57            Constant:
-0:57              1 (const int)
-0:57        direct index (temp int)
-0:57          'c3' (uniform 3-component vector of int)
-0:57          Constant:
-0:57            2 (const int)
-0:58      textureFetch (global 4-component vector of int)
-0:58        'g_tTex2di4' (uniform itexture2D)
-0:58        vector swizzle (temp 2-component vector of int)
-0:58          'c3' (uniform 3-component vector of int)
+0:58      textureFetch (global 4-component vector of float)
+0:58        'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
+0:58        vector swizzle (temp int)
+0:58          'c2' (uniform 2-component vector of int)
 0:58          Sequence
 0:58            Constant:
 0:58              0 (const int)
-0:58            Constant:
-0:58              1 (const int)
 0:58        direct index (temp int)
-0:58          'c3' (uniform 3-component vector of int)
+0:58          'c2' (uniform 2-component vector of int)
 0:58          Constant:
-0:58            2 (const int)
-0:59      textureFetch (global 4-component vector of uint)
-0:59        'g_tTex2du4' (uniform utexture2D)
-0:59        vector swizzle (temp 2-component vector of int)
-0:59          'c3' (uniform 3-component vector of int)
+0:58            1 (const int)
+0:59      textureFetch (global 4-component vector of int)
+0:59        'g_tTex1di4' (uniform itexture1D)
+0:59        vector swizzle (temp int)
+0:59          'c2' (uniform 2-component vector of int)
 0:59          Sequence
 0:59            Constant:
 0:59              0 (const int)
-0:59            Constant:
-0:59              1 (const int)
 0:59        direct index (temp int)
-0:59          'c3' (uniform 3-component vector of int)
+0:59          'c2' (uniform 2-component vector of int)
 0:59          Constant:
-0:59            2 (const int)
-0:62      textureFetch (global 4-component vector of float)
-0:62        'g_tTex3df4' (uniform texture3D)
-0:62        vector swizzle (temp 3-component vector of int)
-0:62          'c4' (uniform 4-component vector of int)
+0:59            1 (const int)
+0:60      textureFetch (global 4-component vector of uint)
+0:60        'g_tTex1du4' (uniform utexture1D)
+0:60        vector swizzle (temp int)
+0:60          'c2' (uniform 2-component vector of int)
+0:60          Sequence
+0:60            Constant:
+0:60              0 (const int)
+0:60        direct index (temp int)
+0:60          'c2' (uniform 2-component vector of int)
+0:60          Constant:
+0:60            1 (const int)
+0:61      textureFetch (global 4-component vector of float)
+0:61        'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
+0:61        vector swizzle (temp uint)
+0:61          'uc2' (uniform 2-component vector of uint)
+0:61          Sequence
+0:61            Constant:
+0:61              0 (const int)
+0:61        direct index (temp uint)
+0:61          'uc2' (uniform 2-component vector of uint)
+0:61          Constant:
+0:61            1 (const int)
+0:62      textureFetch (global 4-component vector of int)
+0:62        'g_tTex1di4' (uniform itexture1D)
+0:62        vector swizzle (temp uint)
+0:62          'uc2' (uniform 2-component vector of uint)
 0:62          Sequence
 0:62            Constant:
 0:62              0 (const int)
-0:62            Constant:
-0:62              1 (const int)
-0:62            Constant:
-0:62              2 (const int)
-0:62        direct index (temp int)
-0:62          'c4' (uniform 4-component vector of int)
+0:62        direct index (temp uint)
+0:62          'uc2' (uniform 2-component vector of uint)
 0:62          Constant:
-0:62            3 (const int)
-0:63      textureFetch (global 4-component vector of int)
-0:63        'g_tTex3di4' (uniform itexture3D)
-0:63        vector swizzle (temp 3-component vector of int)
-0:63          'c4' (uniform 4-component vector of int)
+0:62            1 (const int)
+0:63      textureFetch (global 4-component vector of uint)
+0:63        'g_tTex1du4' (uniform utexture1D)
+0:63        vector swizzle (temp uint)
+0:63          'uc2' (uniform 2-component vector of uint)
 0:63          Sequence
 0:63            Constant:
 0:63              0 (const int)
-0:63            Constant:
-0:63              1 (const int)
-0:63            Constant:
-0:63              2 (const int)
-0:63        direct index (temp int)
-0:63          'c4' (uniform 4-component vector of int)
+0:63        direct index (temp uint)
+0:63          'uc2' (uniform 2-component vector of uint)
 0:63          Constant:
-0:63            3 (const int)
-0:64      textureFetch (global 4-component vector of uint)
-0:64        'g_tTex3du4' (uniform utexture3D)
-0:64        vector swizzle (temp 3-component vector of int)
-0:64          'c4' (uniform 4-component vector of int)
-0:64          Sequence
-0:64            Constant:
-0:64              0 (const int)
-0:64            Constant:
-0:64              1 (const int)
-0:64            Constant:
-0:64              2 (const int)
-0:64        direct index (temp int)
-0:64          'c4' (uniform 4-component vector of int)
-0:64          Constant:
-0:64            3 (const int)
-0:72      move second child to first child (temp 4-component vector of float)
-0:72        Color: direct index for structure (temp 4-component vector of float)
-0:72          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:72          Constant:
-0:72            0 (const int)
-0:72        Constant:
-0:72          1.000000
-0:72          1.000000
-0:72          1.000000
-0:72          1.000000
-0:73      move second child to first child (temp float)
-0:73        Depth: direct index for structure (temp float FragDepth)
-0:73          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:73          Constant:
-0:73            1 (const int)
-0:73        Constant:
-0:73          1.000000
-0:75      Branch: Return with expression
-0:75        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:63            1 (const int)
+0:66      textureFetch (global 4-component vector of float)
+0:66        'g_tTex2df4' (uniform texture2D)
+0:66        vector swizzle (temp 2-component vector of int)
+0:66          'c3' (uniform 3-component vector of int)
+0:66          Sequence
+0:66            Constant:
+0:66              0 (const int)
+0:66            Constant:
+0:66              1 (const int)
+0:66        direct index (temp int)
+0:66          'c3' (uniform 3-component vector of int)
+0:66          Constant:
+0:66            2 (const int)
+0:67      textureFetch (global 4-component vector of int)
+0:67        'g_tTex2di4' (uniform itexture2D)
+0:67        vector swizzle (temp 2-component vector of int)
+0:67          'c3' (uniform 3-component vector of int)
+0:67          Sequence
+0:67            Constant:
+0:67              0 (const int)
+0:67            Constant:
+0:67              1 (const int)
+0:67        direct index (temp int)
+0:67          'c3' (uniform 3-component vector of int)
+0:67          Constant:
+0:67            2 (const int)
+0:68      textureFetch (global 4-component vector of uint)
+0:68        'g_tTex2du4' (uniform utexture2D)
+0:68        vector swizzle (temp 2-component vector of int)
+0:68          'c3' (uniform 3-component vector of int)
+0:68          Sequence
+0:68            Constant:
+0:68              0 (const int)
+0:68            Constant:
+0:68              1 (const int)
+0:68        direct index (temp int)
+0:68          'c3' (uniform 3-component vector of int)
+0:68          Constant:
+0:68            2 (const int)
+0:69      textureFetch (global 4-component vector of float)
+0:69        'g_tTex2df4' (uniform texture2D)
+0:69        vector swizzle (temp 2-component vector of uint)
+0:69          'uc3' (uniform 3-component vector of uint)
+0:69          Sequence
+0:69            Constant:
+0:69              0 (const int)
+0:69            Constant:
+0:69              1 (const int)
+0:69        direct index (temp uint)
+0:69          'uc3' (uniform 3-component vector of uint)
+0:69          Constant:
+0:69            2 (const int)
+0:70      textureFetch (global 4-component vector of int)
+0:70        'g_tTex2di4' (uniform itexture2D)
+0:70        vector swizzle (temp 2-component vector of uint)
+0:70          'uc3' (uniform 3-component vector of uint)
+0:70          Sequence
+0:70            Constant:
+0:70              0 (const int)
+0:70            Constant:
+0:70              1 (const int)
+0:70        direct index (temp uint)
+0:70          'uc3' (uniform 3-component vector of uint)
+0:70          Constant:
+0:70            2 (const int)
+0:71      textureFetch (global 4-component vector of uint)
+0:71        'g_tTex2du4' (uniform utexture2D)
+0:71        vector swizzle (temp 2-component vector of uint)
+0:71          'uc3' (uniform 3-component vector of uint)
+0:71          Sequence
+0:71            Constant:
+0:71              0 (const int)
+0:71            Constant:
+0:71              1 (const int)
+0:71        direct index (temp uint)
+0:71          'uc3' (uniform 3-component vector of uint)
+0:71          Constant:
+0:71            2 (const int)
+0:75      textureFetch (global 4-component vector of float)
+0:75        'g_tTex3df4' (uniform texture3D)
+0:75        vector swizzle (temp 3-component vector of int)
+0:75          'c4' (uniform 4-component vector of int)
+0:75          Sequence
+0:75            Constant:
+0:75              0 (const int)
+0:75            Constant:
+0:75              1 (const int)
+0:75            Constant:
+0:75              2 (const int)
+0:75        direct index (temp int)
+0:75          'c4' (uniform 4-component vector of int)
+0:75          Constant:
+0:75            3 (const int)
+0:76      textureFetch (global 4-component vector of int)
+0:76        'g_tTex3di4' (uniform itexture3D)
+0:76        vector swizzle (temp 3-component vector of int)
+0:76          'c4' (uniform 4-component vector of int)
+0:76          Sequence
+0:76            Constant:
+0:76              0 (const int)
+0:76            Constant:
+0:76              1 (const int)
+0:76            Constant:
+0:76              2 (const int)
+0:76        direct index (temp int)
+0:76          'c4' (uniform 4-component vector of int)
+0:76          Constant:
+0:76            3 (const int)
+0:77      textureFetch (global 4-component vector of uint)
+0:77        'g_tTex3du4' (uniform utexture3D)
+0:77        vector swizzle (temp 3-component vector of int)
+0:77          'c4' (uniform 4-component vector of int)
+0:77          Sequence
+0:77            Constant:
+0:77              0 (const int)
+0:77            Constant:
+0:77              1 (const int)
+0:77            Constant:
+0:77              2 (const int)
+0:77        direct index (temp int)
+0:77          'c4' (uniform 4-component vector of int)
+0:77          Constant:
+0:77            3 (const int)
+0:78      textureFetch (global 4-component vector of float)
+0:78        'g_tTex3df4' (uniform texture3D)
+0:78        vector swizzle (temp 3-component vector of uint)
+0:78          'uc4' (uniform 4-component vector of uint)
+0:78          Sequence
+0:78            Constant:
+0:78              0 (const int)
+0:78            Constant:
+0:78              1 (const int)
+0:78            Constant:
+0:78              2 (const int)
+0:78        direct index (temp uint)
+0:78          'uc4' (uniform 4-component vector of uint)
+0:78          Constant:
+0:78            3 (const int)
+0:79      textureFetch (global 4-component vector of int)
+0:79        'g_tTex3di4' (uniform itexture3D)
+0:79        vector swizzle (temp 3-component vector of uint)
+0:79          'uc4' (uniform 4-component vector of uint)
+0:79          Sequence
+0:79            Constant:
+0:79              0 (const int)
+0:79            Constant:
+0:79              1 (const int)
+0:79            Constant:
+0:79              2 (const int)
+0:79        direct index (temp uint)
+0:79          'uc4' (uniform 4-component vector of uint)
+0:79          Constant:
+0:79            3 (const int)
+0:80      textureFetch (global 4-component vector of uint)
+0:80        'g_tTex3du4' (uniform utexture3D)
+0:80        vector swizzle (temp 3-component vector of uint)
+0:80          'uc4' (uniform 4-component vector of uint)
+0:80          Sequence
+0:80            Constant:
+0:80              0 (const int)
+0:80            Constant:
+0:80              1 (const int)
+0:80            Constant:
+0:80              2 (const int)
+0:80        direct index (temp uint)
+0:80          'uc4' (uniform 4-component vector of uint)
+0:80          Constant:
+0:80            3 (const int)
+0:88      move second child to first child (temp 4-component vector of float)
+0:88        Color: direct index for structure (temp 4-component vector of float)
+0:88          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:88          Constant:
+0:88            0 (const int)
+0:88        Constant:
+0:88          1.000000
+0:88          1.000000
+0:88          1.000000
+0:88          1.000000
+0:89      move second child to first child (temp float)
+0:89        Depth: direct index for structure (temp float FragDepth)
+0:89          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:89          Constant:
+0:89            1 (const int)
+0:89        Constant:
+0:89          1.000000
+0:91      Branch: Return with expression
+0:91        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
 0:?   Linker Objects
 0:?     'g_sSamp' (layout(binding=0 ) uniform sampler)
 0:?     'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
@@ -346,6 +584,10 @@ gl_FragCoord origin is upper left
 0:?     'c2' (uniform 2-component vector of int)
 0:?     'c3' (uniform 3-component vector of int)
 0:?     'c4' (uniform 4-component vector of int)
+0:?     'uc1' (uniform uint)
+0:?     'uc2' (uniform 2-component vector of uint)
+0:?     'uc3' (uniform 3-component vector of uint)
+0:?     'uc4' (uniform 4-component vector of uint)
 0:?     'o1' (uniform int)
 0:?     'o2' (uniform 2-component vector of int)
 0:?     'o3' (uniform 3-component vector of int)
@@ -353,7 +595,7 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 163
+// Id's are bound by 227
 
                               Capability Shader
                               Capability Sampled1D
@@ -367,61 +609,65 @@ gl_FragCoord origin is upper left
                               Name 14  "c2"
                               Name 27  "g_tTex1di4"
                               Name 37  "g_tTex1du4"
-                              Name 47  "g_tTex2df4"
-                              Name 51  "c3"
-                              Name 60  "g_tTex2di4"
-                              Name 69  "g_tTex2du4"
-                              Name 78  "g_tTex3df4"
-                              Name 81  "c4"
-                              Name 90  "g_tTex3di4"
-                              Name 99  "g_tTex3du4"
-                              Name 106  "PS_OUTPUT"
-                              MemberName 106(PS_OUTPUT) 0  "Color"
-                              MemberName 106(PS_OUTPUT) 1  "Depth"
-                              Name 108  "psout"
-                              Name 121  "g_sSamp"
-                              Name 124  "g_tTexcdf4"
-                              Name 127  "g_tTexcdi4"
-                              Name 130  "g_tTexcdu4"
-                              Name 133  "g_tTex1df4a"
-                              Name 136  "g_tTex1di4a"
-                              Name 139  "g_tTex1du4a"
-                              Name 142  "g_tTex2df4a"
-                              Name 145  "g_tTex2di4a"
-                              Name 148  "g_tTex2du4a"
-                              Name 151  "g_tTexcdf4a"
-                              Name 154  "g_tTexcdi4a"
-                              Name 157  "g_tTexcdu4a"
-                              Name 158  "c1"
-                              Name 159  "o1"
-                              Name 160  "o2"
-                              Name 161  "o3"
-                              Name 162  "o4"
+                              Name 48  "uc2"
+                              Name 69  "g_tTex2df4"
+                              Name 73  "c3"
+                              Name 82  "g_tTex2di4"
+                              Name 91  "g_tTex2du4"
+                              Name 101  "uc3"
+                              Name 121  "g_tTex3df4"
+                              Name 124  "c4"
+                              Name 133  "g_tTex3di4"
+                              Name 142  "g_tTex3du4"
+                              Name 151  "uc4"
+                              Name 169  "PS_OUTPUT"
+                              MemberName 169(PS_OUTPUT) 0  "Color"
+                              MemberName 169(PS_OUTPUT) 1  "Depth"
+                              Name 171  "psout"
+                              Name 184  "g_sSamp"
+                              Name 187  "g_tTexcdf4"
+                              Name 190  "g_tTexcdi4"
+                              Name 193  "g_tTexcdu4"
+                              Name 196  "g_tTex1df4a"
+                              Name 199  "g_tTex1di4a"
+                              Name 202  "g_tTex1du4a"
+                              Name 205  "g_tTex2df4a"
+                              Name 208  "g_tTex2di4a"
+                              Name 211  "g_tTex2du4a"
+                              Name 214  "g_tTexcdf4a"
+                              Name 217  "g_tTexcdi4a"
+                              Name 220  "g_tTexcdu4a"
+                              Name 221  "c1"
+                              Name 222  "uc1"
+                              Name 223  "o1"
+                              Name 224  "o2"
+                              Name 225  "o3"
+                              Name 226  "o4"
                               Decorate 9(g_tTex1df4) DescriptorSet 0
                               Decorate 9(g_tTex1df4) Binding 0
                               Decorate 27(g_tTex1di4) DescriptorSet 0
                               Decorate 37(g_tTex1du4) DescriptorSet 0
-                              Decorate 47(g_tTex2df4) DescriptorSet 0
-                              Decorate 60(g_tTex2di4) DescriptorSet 0
-                              Decorate 69(g_tTex2du4) DescriptorSet 0
-                              Decorate 78(g_tTex3df4) DescriptorSet 0
-                              Decorate 90(g_tTex3di4) DescriptorSet 0
-                              Decorate 99(g_tTex3du4) DescriptorSet 0
-                              MemberDecorate 106(PS_OUTPUT) 1 BuiltIn FragDepth
-                              Decorate 121(g_sSamp) DescriptorSet 0
-                              Decorate 121(g_sSamp) Binding 0
-                              Decorate 124(g_tTexcdf4) DescriptorSet 0
-                              Decorate 127(g_tTexcdi4) DescriptorSet 0
-                              Decorate 130(g_tTexcdu4) DescriptorSet 0
-                              Decorate 133(g_tTex1df4a) DescriptorSet 0
-                              Decorate 136(g_tTex1di4a) DescriptorSet 0
-                              Decorate 139(g_tTex1du4a) DescriptorSet 0
-                              Decorate 142(g_tTex2df4a) DescriptorSet 0
-                              Decorate 145(g_tTex2di4a) DescriptorSet 0
-                              Decorate 148(g_tTex2du4a) DescriptorSet 0
-                              Decorate 151(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 154(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 157(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 69(g_tTex2df4) DescriptorSet 0
+                              Decorate 82(g_tTex2di4) DescriptorSet 0
+                              Decorate 91(g_tTex2du4) DescriptorSet 0
+                              Decorate 121(g_tTex3df4) DescriptorSet 0
+                              Decorate 133(g_tTex3di4) DescriptorSet 0
+                              Decorate 142(g_tTex3du4) DescriptorSet 0
+                              MemberDecorate 169(PS_OUTPUT) 1 BuiltIn FragDepth
+                              Decorate 184(g_sSamp) DescriptorSet 0
+                              Decorate 184(g_sSamp) Binding 0
+                              Decorate 187(g_tTexcdf4) DescriptorSet 0
+                              Decorate 190(g_tTexcdi4) DescriptorSet 0
+                              Decorate 193(g_tTexcdu4) DescriptorSet 0
+                              Decorate 196(g_tTex1df4a) DescriptorSet 0
+                              Decorate 199(g_tTex1di4a) DescriptorSet 0
+                              Decorate 202(g_tTex1du4a) DescriptorSet 0
+                              Decorate 205(g_tTex2df4a) DescriptorSet 0
+                              Decorate 208(g_tTex2di4a) DescriptorSet 0
+                              Decorate 211(g_tTex2du4a) DescriptorSet 0
+                              Decorate 214(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 217(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 220(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -445,86 +691,96 @@ gl_FragCoord origin is upper left
               36:             TypePointer UniformConstant 35
   37(g_tTex1du4):     36(ptr) Variable UniformConstant
               43:             TypeVector 15(int) 4
-              45:             TypeImage 6(float) 2D sampled format:Unknown
-              46:             TypePointer UniformConstant 45
-  47(g_tTex2df4):     46(ptr) Variable UniformConstant
-              49:             TypeVector 11(int) 3
-              50:             TypePointer UniformConstant 49(ivec3)
-          51(c3):     50(ptr) Variable UniformConstant
-              54:     15(int) Constant 2
-              58:             TypeImage 11(int) 2D sampled format:Unknown
-              59:             TypePointer UniformConstant 58
-  60(g_tTex2di4):     59(ptr) Variable UniformConstant
-              67:             TypeImage 15(int) 2D sampled format:Unknown
+              46:             TypeVector 15(int) 2
+              47:             TypePointer UniformConstant 46(ivec2)
+         48(uc2):     47(ptr) Variable UniformConstant
+              49:             TypePointer UniformConstant 15(int)
+              67:             TypeImage 6(float) 2D sampled format:Unknown
               68:             TypePointer UniformConstant 67
-  69(g_tTex2du4):     68(ptr) Variable UniformConstant
-              76:             TypeImage 6(float) 3D sampled format:Unknown
-              77:             TypePointer UniformConstant 76
-  78(g_tTex3df4):     77(ptr) Variable UniformConstant
-              80:             TypePointer UniformConstant 33(ivec4)
-          81(c4):     80(ptr) Variable UniformConstant
-              84:     15(int) Constant 3
-              88:             TypeImage 11(int) 3D sampled format:Unknown
-              89:             TypePointer UniformConstant 88
-  90(g_tTex3di4):     89(ptr) Variable UniformConstant
-              97:             TypeImage 15(int) 3D sampled format:Unknown
-              98:             TypePointer UniformConstant 97
-  99(g_tTex3du4):     98(ptr) Variable UniformConstant
-  106(PS_OUTPUT):             TypeStruct 23(fvec4) 6(float)
-             107:             TypePointer Function 106(PS_OUTPUT)
-             109:     11(int) Constant 0
-             110:    6(float) Constant 1065353216
-             111:   23(fvec4) ConstantComposite 110 110 110 110
-             112:             TypePointer Function 23(fvec4)
-             114:     11(int) Constant 1
-             115:             TypePointer Function 6(float)
-             119:             TypeSampler
+  69(g_tTex2df4):     68(ptr) Variable UniformConstant
+              71:             TypeVector 11(int) 3
+              72:             TypePointer UniformConstant 71(ivec3)
+          73(c3):     72(ptr) Variable UniformConstant
+              76:     15(int) Constant 2
+              80:             TypeImage 11(int) 2D sampled format:Unknown
+              81:             TypePointer UniformConstant 80
+  82(g_tTex2di4):     81(ptr) Variable UniformConstant
+              89:             TypeImage 15(int) 2D sampled format:Unknown
+              90:             TypePointer UniformConstant 89
+  91(g_tTex2du4):     90(ptr) Variable UniformConstant
+              99:             TypeVector 15(int) 3
+             100:             TypePointer UniformConstant 99(ivec3)
+        101(uc3):    100(ptr) Variable UniformConstant
+             119:             TypeImage 6(float) 3D sampled format:Unknown
              120:             TypePointer UniformConstant 119
-    121(g_sSamp):    120(ptr) Variable UniformConstant
-             122:             TypeImage 6(float) Cube sampled format:Unknown
-             123:             TypePointer UniformConstant 122
- 124(g_tTexcdf4):    123(ptr) Variable UniformConstant
-             125:             TypeImage 11(int) Cube sampled format:Unknown
-             126:             TypePointer UniformConstant 125
- 127(g_tTexcdi4):    126(ptr) Variable UniformConstant
-             128:             TypeImage 15(int) Cube sampled format:Unknown
-             129:             TypePointer UniformConstant 128
- 130(g_tTexcdu4):    129(ptr) Variable UniformConstant
-             131:             TypeImage 6(float) 1D array sampled format:Unknown
+ 121(g_tTex3df4):    120(ptr) Variable UniformConstant
+             123:             TypePointer UniformConstant 33(ivec4)
+         124(c4):    123(ptr) Variable UniformConstant
+             127:     15(int) Constant 3
+             131:             TypeImage 11(int) 3D sampled format:Unknown
              132:             TypePointer UniformConstant 131
-133(g_tTex1df4a):    132(ptr) Variable UniformConstant
-             134:             TypeImage 11(int) 1D array sampled format:Unknown
-             135:             TypePointer UniformConstant 134
-136(g_tTex1di4a):    135(ptr) Variable UniformConstant
-             137:             TypeImage 15(int) 1D array sampled format:Unknown
-             138:             TypePointer UniformConstant 137
-139(g_tTex1du4a):    138(ptr) Variable UniformConstant
-             140:             TypeImage 6(float) 2D array sampled format:Unknown
+ 133(g_tTex3di4):    132(ptr) Variable UniformConstant
+             140:             TypeImage 15(int) 3D sampled format:Unknown
              141:             TypePointer UniformConstant 140
-142(g_tTex2df4a):    141(ptr) Variable UniformConstant
-             143:             TypeImage 11(int) 2D array sampled format:Unknown
-             144:             TypePointer UniformConstant 143
-145(g_tTex2di4a):    144(ptr) Variable UniformConstant
-             146:             TypeImage 15(int) 2D array sampled format:Unknown
-             147:             TypePointer UniformConstant 146
-148(g_tTex2du4a):    147(ptr) Variable UniformConstant
-             149:             TypeImage 6(float) Cube array sampled format:Unknown
-             150:             TypePointer UniformConstant 149
-151(g_tTexcdf4a):    150(ptr) Variable UniformConstant
-             152:             TypeImage 11(int) Cube array sampled format:Unknown
-             153:             TypePointer UniformConstant 152
-154(g_tTexcdi4a):    153(ptr) Variable UniformConstant
-             155:             TypeImage 15(int) Cube array sampled format:Unknown
-             156:             TypePointer UniformConstant 155
-157(g_tTexcdu4a):    156(ptr) Variable UniformConstant
-         158(c1):     17(ptr) Variable UniformConstant
-         159(o1):     17(ptr) Variable UniformConstant
-         160(o2):     13(ptr) Variable UniformConstant
-         161(o3):     50(ptr) Variable UniformConstant
-         162(o4):     80(ptr) Variable UniformConstant
+ 142(g_tTex3du4):    141(ptr) Variable UniformConstant
+             150:             TypePointer UniformConstant 43(ivec4)
+        151(uc4):    150(ptr) Variable UniformConstant
+  169(PS_OUTPUT):             TypeStruct 23(fvec4) 6(float)
+             170:             TypePointer Function 169(PS_OUTPUT)
+             172:     11(int) Constant 0
+             173:    6(float) Constant 1065353216
+             174:   23(fvec4) ConstantComposite 173 173 173 173
+             175:             TypePointer Function 23(fvec4)
+             177:     11(int) Constant 1
+             178:             TypePointer Function 6(float)
+             182:             TypeSampler
+             183:             TypePointer UniformConstant 182
+    184(g_sSamp):    183(ptr) Variable UniformConstant
+             185:             TypeImage 6(float) Cube sampled format:Unknown
+             186:             TypePointer UniformConstant 185
+ 187(g_tTexcdf4):    186(ptr) Variable UniformConstant
+             188:             TypeImage 11(int) Cube sampled format:Unknown
+             189:             TypePointer UniformConstant 188
+ 190(g_tTexcdi4):    189(ptr) Variable UniformConstant
+             191:             TypeImage 15(int) Cube sampled format:Unknown
+             192:             TypePointer UniformConstant 191
+ 193(g_tTexcdu4):    192(ptr) Variable UniformConstant
+             194:             TypeImage 6(float) 1D array sampled format:Unknown
+             195:             TypePointer UniformConstant 194
+196(g_tTex1df4a):    195(ptr) Variable UniformConstant
+             197:             TypeImage 11(int) 1D array sampled format:Unknown
+             198:             TypePointer UniformConstant 197
+199(g_tTex1di4a):    198(ptr) Variable UniformConstant
+             200:             TypeImage 15(int) 1D array sampled format:Unknown
+             201:             TypePointer UniformConstant 200
+202(g_tTex1du4a):    201(ptr) Variable UniformConstant
+             203:             TypeImage 6(float) 2D array sampled format:Unknown
+             204:             TypePointer UniformConstant 203
+205(g_tTex2df4a):    204(ptr) Variable UniformConstant
+             206:             TypeImage 11(int) 2D array sampled format:Unknown
+             207:             TypePointer UniformConstant 206
+208(g_tTex2di4a):    207(ptr) Variable UniformConstant
+             209:             TypeImage 15(int) 2D array sampled format:Unknown
+             210:             TypePointer UniformConstant 209
+211(g_tTex2du4a):    210(ptr) Variable UniformConstant
+             212:             TypeImage 6(float) Cube array sampled format:Unknown
+             213:             TypePointer UniformConstant 212
+214(g_tTexcdf4a):    213(ptr) Variable UniformConstant
+             215:             TypeImage 11(int) Cube array sampled format:Unknown
+             216:             TypePointer UniformConstant 215
+217(g_tTexcdi4a):    216(ptr) Variable UniformConstant
+             218:             TypeImage 15(int) Cube array sampled format:Unknown
+             219:             TypePointer UniformConstant 218
+220(g_tTexcdu4a):    219(ptr) Variable UniformConstant
+         221(c1):     17(ptr) Variable UniformConstant
+        222(uc1):     49(ptr) Variable UniformConstant
+         223(o1):     17(ptr) Variable UniformConstant
+         224(o2):     13(ptr) Variable UniformConstant
+         225(o3):     72(ptr) Variable UniformConstant
+         226(o4):    123(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
-      108(psout):    107(ptr) Variable Function
+      171(psout):    170(ptr) Variable Function
               10:           7 Load 9(g_tTex1df4)
               18:     17(ptr) AccessChain 14(c2) 16
               19:     11(int) Load 18
@@ -543,46 +799,100 @@ gl_FragCoord origin is upper left
               41:     17(ptr) AccessChain 14(c2) 20
               42:     11(int) Load 41
               44:   43(ivec4) ImageFetch 38 40 Lod 42
-              48:          45 Load 47(g_tTex2df4)
-              52:   49(ivec3) Load 51(c3)
-              53:   12(ivec2) VectorShuffle 52 52 0 1
-              55:     17(ptr) AccessChain 51(c3) 54
-              56:     11(int) Load 55
-              57:   23(fvec4) ImageFetch 48 53 Lod 56
-              61:          58 Load 60(g_tTex2di4)
-              62:   49(ivec3) Load 51(c3)
-              63:   12(ivec2) VectorShuffle 62 62 0 1
-              64:     17(ptr) AccessChain 51(c3) 54
-              65:     11(int) Load 64
-              66:   33(ivec4) ImageFetch 61 63 Lod 65
-              70:          67 Load 69(g_tTex2du4)
-              71:   49(ivec3) Load 51(c3)
-              72:   12(ivec2) VectorShuffle 71 71 0 1
-              73:     17(ptr) AccessChain 51(c3) 54
-              74:     11(int) Load 73
-              75:   43(ivec4) ImageFetch 70 72 Lod 74
-              79:          76 Load 78(g_tTex3df4)
-              82:   33(ivec4) Load 81(c4)
-              83:   49(ivec3) VectorShuffle 82 82 0 1 2
-              85:     17(ptr) AccessChain 81(c4) 84
-              86:     11(int) Load 85
-              87:   23(fvec4) ImageFetch 79 83 Lod 86
-              91:          88 Load 90(g_tTex3di4)
-              92:   33(ivec4) Load 81(c4)
-              93:   49(ivec3) VectorShuffle 92 92 0 1 2
-              94:     17(ptr) AccessChain 81(c4) 84
-              95:     11(int) Load 94
-              96:   33(ivec4) ImageFetch 91 93 Lod 95
-             100:          97 Load 99(g_tTex3du4)
-             101:   33(ivec4) Load 81(c4)
-             102:   49(ivec3) VectorShuffle 101 101 0 1 2
-             103:     17(ptr) AccessChain 81(c4) 84
-             104:     11(int) Load 103
-             105:   43(ivec4) ImageFetch 100 102 Lod 104
-             113:    112(ptr) AccessChain 108(psout) 109
-                              Store 113 111
-             116:    115(ptr) AccessChain 108(psout) 114
-                              Store 116 110
-             117:106(PS_OUTPUT) Load 108(psout)
-                              ReturnValue 117
+              45:           7 Load 9(g_tTex1df4)
+              50:     49(ptr) AccessChain 48(uc2) 16
+              51:     15(int) Load 50
+              52:     49(ptr) AccessChain 48(uc2) 20
+              53:     15(int) Load 52
+              54:   23(fvec4) ImageFetch 45 51 Lod 53
+              55:          25 Load 27(g_tTex1di4)
+              56:     49(ptr) AccessChain 48(uc2) 16
+              57:     15(int) Load 56
+              58:     49(ptr) AccessChain 48(uc2) 20
+              59:     15(int) Load 58
+              60:   33(ivec4) ImageFetch 55 57 Lod 59
+              61:          35 Load 37(g_tTex1du4)
+              62:     49(ptr) AccessChain 48(uc2) 16
+              63:     15(int) Load 62
+              64:     49(ptr) AccessChain 48(uc2) 20
+              65:     15(int) Load 64
+              66:   43(ivec4) ImageFetch 61 63 Lod 65
+              70:          67 Load 69(g_tTex2df4)
+              74:   71(ivec3) Load 73(c3)
+              75:   12(ivec2) VectorShuffle 74 74 0 1
+              77:     17(ptr) AccessChain 73(c3) 76
+              78:     11(int) Load 77
+              79:   23(fvec4) ImageFetch 70 75 Lod 78
+              83:          80 Load 82(g_tTex2di4)
+              84:   71(ivec3) Load 73(c3)
+              85:   12(ivec2) VectorShuffle 84 84 0 1
+              86:     17(ptr) AccessChain 73(c3) 76
+              87:     11(int) Load 86
+              88:   33(ivec4) ImageFetch 83 85 Lod 87
+              92:          89 Load 91(g_tTex2du4)
+              93:   71(ivec3) Load 73(c3)
+              94:   12(ivec2) VectorShuffle 93 93 0 1
+              95:     17(ptr) AccessChain 73(c3) 76
+              96:     11(int) Load 95
+              97:   43(ivec4) ImageFetch 92 94 Lod 96
+              98:          67 Load 69(g_tTex2df4)
+             102:   99(ivec3) Load 101(uc3)
+             103:   46(ivec2) VectorShuffle 102 102 0 1
+             104:     49(ptr) AccessChain 101(uc3) 76
+             105:     15(int) Load 104
+             106:   23(fvec4) ImageFetch 98 103 Lod 105
+             107:          80 Load 82(g_tTex2di4)
+             108:   99(ivec3) Load 101(uc3)
+             109:   46(ivec2) VectorShuffle 108 108 0 1
+             110:     49(ptr) AccessChain 101(uc3) 76
+             111:     15(int) Load 110
+             112:   33(ivec4) ImageFetch 107 109 Lod 111
+             113:          89 Load 91(g_tTex2du4)
+             114:   99(ivec3) Load 101(uc3)
+             115:   46(ivec2) VectorShuffle 114 114 0 1
+             116:     49(ptr) AccessChain 101(uc3) 76
+             117:     15(int) Load 116
+             118:   43(ivec4) ImageFetch 113 115 Lod 117
+             122:         119 Load 121(g_tTex3df4)
+             125:   33(ivec4) Load 124(c4)
+             126:   71(ivec3) VectorShuffle 125 125 0 1 2
+             128:     17(ptr) AccessChain 124(c4) 127
+             129:     11(int) Load 128
+             130:   23(fvec4) ImageFetch 122 126 Lod 129
+             134:         131 Load 133(g_tTex3di4)
+             135:   33(ivec4) Load 124(c4)
+             136:   71(ivec3) VectorShuffle 135 135 0 1 2
+             137:     17(ptr) AccessChain 124(c4) 127
+             138:     11(int) Load 137
+             139:   33(ivec4) ImageFetch 134 136 Lod 138
+             143:         140 Load 142(g_tTex3du4)
+             144:   33(ivec4) Load 124(c4)
+             145:   71(ivec3) VectorShuffle 144 144 0 1 2
+             146:     17(ptr) AccessChain 124(c4) 127
+             147:     11(int) Load 146
+             148:   43(ivec4) ImageFetch 143 145 Lod 147
+             149:         119 Load 121(g_tTex3df4)
+             152:   43(ivec4) Load 151(uc4)
+             153:   99(ivec3) VectorShuffle 152 152 0 1 2
+             154:     49(ptr) AccessChain 151(uc4) 127
+             155:     15(int) Load 154
+             156:   23(fvec4) ImageFetch 149 153 Lod 155
+             157:         131 Load 133(g_tTex3di4)
+             158:   43(ivec4) Load 151(uc4)
+             159:   99(ivec3) VectorShuffle 158 158 0 1 2
+             160:     49(ptr) AccessChain 151(uc4) 127
+             161:     15(int) Load 160
+             162:   33(ivec4) ImageFetch 157 159 Lod 161
+             163:         140 Load 142(g_tTex3du4)
+             164:   43(ivec4) Load 151(uc4)
+             165:   99(ivec3) VectorShuffle 164 164 0 1 2
+             166:     49(ptr) AccessChain 151(uc4) 127
+             167:     15(int) Load 166
+             168:   43(ivec4) ImageFetch 163 165 Lod 167
+             176:    175(ptr) AccessChain 171(psout) 172
+                              Store 176 174
+             179:    178(ptr) AccessChain 171(psout) 177
+                              Store 179 173
+             180:169(PS_OUTPUT) Load 171(psout)
+                              ReturnValue 180
                               FunctionEnd

--- a/Test/baseResults/hlsl.load.buffer.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.buffer.dx10.frag.out
@@ -2,46 +2,61 @@ hlsl.load.buffer.dx10.frag
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:39  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:24    Function Parameters: 
+0:49  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:29    Function Parameters: 
 0:?     Sequence
-0:28      Sequence
-0:28        move second child to first child (temp 4-component vector of float)
-0:28          'r00' (temp 4-component vector of float)
-0:28          textureFetch (global 4-component vector of float)
-0:28            'g_tTexbf4' (uniform samplerBuffer)
-0:28            'c1' (uniform int)
-0:29      Sequence
-0:29        move second child to first child (temp 4-component vector of int)
-0:29          'r01' (temp 4-component vector of int)
-0:29          textureFetch (global 4-component vector of int)
-0:29            'g_tTexbi4' (uniform isamplerBuffer)
-0:29            'c1' (uniform int)
-0:30      Sequence
-0:30        move second child to first child (temp 4-component vector of uint)
-0:30          'r02' (temp 4-component vector of uint)
-0:30          textureFetch (global 4-component vector of uint)
-0:30            'g_tTexbu4' (uniform usamplerBuffer)
-0:30            'c1' (uniform int)
-0:34      move second child to first child (temp 4-component vector of float)
-0:34        Color: direct index for structure (temp 4-component vector of float)
-0:34          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:34          Constant:
-0:34            0 (const int)
-0:34        Constant:
-0:34          1.000000
-0:34          1.000000
-0:34          1.000000
-0:34          1.000000
-0:35      move second child to first child (temp float)
-0:35        Depth: direct index for structure (temp float FragDepth)
-0:35          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:35          Constant:
-0:35            1 (const int)
-0:35        Constant:
-0:35          1.000000
-0:37      Branch: Return with expression
-0:37        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:33      Sequence
+0:33        move second child to first child (temp 4-component vector of float)
+0:33          'r00' (temp 4-component vector of float)
+0:33          textureFetch (global 4-component vector of float)
+0:33            'g_tTexbf4' (uniform samplerBuffer)
+0:33            'c1' (uniform int)
+0:34      Sequence
+0:34        move second child to first child (temp 4-component vector of int)
+0:34          'r01' (temp 4-component vector of int)
+0:34          textureFetch (global 4-component vector of int)
+0:34            'g_tTexbi4' (uniform isamplerBuffer)
+0:34            'c1' (uniform int)
+0:35      Sequence
+0:35        move second child to first child (temp 4-component vector of uint)
+0:35          'r02' (temp 4-component vector of uint)
+0:35          textureFetch (global 4-component vector of uint)
+0:35            'g_tTexbu4' (uniform usamplerBuffer)
+0:35            'c1' (uniform int)
+0:38      move second child to first child (temp 4-component vector of float)
+0:38        'r00' (temp 4-component vector of float)
+0:38        textureFetch (global 4-component vector of float)
+0:38          'g_tTexbf4' (uniform samplerBuffer)
+0:38          'uc1' (uniform int)
+0:39      move second child to first child (temp 4-component vector of int)
+0:39        'r01' (temp 4-component vector of int)
+0:39        textureFetch (global 4-component vector of int)
+0:39          'g_tTexbi4' (uniform isamplerBuffer)
+0:39          'uc1' (uniform int)
+0:40      move second child to first child (temp 4-component vector of uint)
+0:40        'r02' (temp 4-component vector of uint)
+0:40        textureFetch (global 4-component vector of uint)
+0:40          'g_tTexbu4' (uniform usamplerBuffer)
+0:40          'uc1' (uniform int)
+0:44      move second child to first child (temp 4-component vector of float)
+0:44        Color: direct index for structure (temp 4-component vector of float)
+0:44          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:44          Constant:
+0:44            0 (const int)
+0:44        Constant:
+0:44          1.000000
+0:44          1.000000
+0:44          1.000000
+0:44          1.000000
+0:45      move second child to first child (temp float)
+0:45        Depth: direct index for structure (temp float FragDepth)
+0:45          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:45          Constant:
+0:45            1 (const int)
+0:45        Constant:
+0:45          1.000000
+0:47      Branch: Return with expression
+0:47        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
 0:?   Linker Objects
 0:?     'g_tTexbf4_test' (layout(binding=0 ) uniform samplerBuffer)
 0:?     'g_tTexbf4' (uniform samplerBuffer)
@@ -51,6 +66,10 @@ gl_FragCoord origin is upper left
 0:?     'c2' (uniform 2-component vector of int)
 0:?     'c3' (uniform 3-component vector of int)
 0:?     'c4' (uniform 4-component vector of int)
+0:?     'uc1' (uniform int)
+0:?     'uc2' (uniform 2-component vector of int)
+0:?     'uc3' (uniform 3-component vector of int)
+0:?     'uc4' (uniform 4-component vector of int)
 0:?     'o1' (uniform int)
 0:?     'o2' (uniform 2-component vector of int)
 0:?     'o3' (uniform 3-component vector of int)
@@ -63,46 +82,61 @@ Linked fragment stage:
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:39  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:24    Function Parameters: 
+0:49  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:29    Function Parameters: 
 0:?     Sequence
-0:28      Sequence
-0:28        move second child to first child (temp 4-component vector of float)
-0:28          'r00' (temp 4-component vector of float)
-0:28          textureFetch (global 4-component vector of float)
-0:28            'g_tTexbf4' (uniform samplerBuffer)
-0:28            'c1' (uniform int)
-0:29      Sequence
-0:29        move second child to first child (temp 4-component vector of int)
-0:29          'r01' (temp 4-component vector of int)
-0:29          textureFetch (global 4-component vector of int)
-0:29            'g_tTexbi4' (uniform isamplerBuffer)
-0:29            'c1' (uniform int)
-0:30      Sequence
-0:30        move second child to first child (temp 4-component vector of uint)
-0:30          'r02' (temp 4-component vector of uint)
-0:30          textureFetch (global 4-component vector of uint)
-0:30            'g_tTexbu4' (uniform usamplerBuffer)
-0:30            'c1' (uniform int)
-0:34      move second child to first child (temp 4-component vector of float)
-0:34        Color: direct index for structure (temp 4-component vector of float)
-0:34          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:34          Constant:
-0:34            0 (const int)
-0:34        Constant:
-0:34          1.000000
-0:34          1.000000
-0:34          1.000000
-0:34          1.000000
-0:35      move second child to first child (temp float)
-0:35        Depth: direct index for structure (temp float FragDepth)
-0:35          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:35          Constant:
-0:35            1 (const int)
-0:35        Constant:
-0:35          1.000000
-0:37      Branch: Return with expression
-0:37        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:33      Sequence
+0:33        move second child to first child (temp 4-component vector of float)
+0:33          'r00' (temp 4-component vector of float)
+0:33          textureFetch (global 4-component vector of float)
+0:33            'g_tTexbf4' (uniform samplerBuffer)
+0:33            'c1' (uniform int)
+0:34      Sequence
+0:34        move second child to first child (temp 4-component vector of int)
+0:34          'r01' (temp 4-component vector of int)
+0:34          textureFetch (global 4-component vector of int)
+0:34            'g_tTexbi4' (uniform isamplerBuffer)
+0:34            'c1' (uniform int)
+0:35      Sequence
+0:35        move second child to first child (temp 4-component vector of uint)
+0:35          'r02' (temp 4-component vector of uint)
+0:35          textureFetch (global 4-component vector of uint)
+0:35            'g_tTexbu4' (uniform usamplerBuffer)
+0:35            'c1' (uniform int)
+0:38      move second child to first child (temp 4-component vector of float)
+0:38        'r00' (temp 4-component vector of float)
+0:38        textureFetch (global 4-component vector of float)
+0:38          'g_tTexbf4' (uniform samplerBuffer)
+0:38          'uc1' (uniform int)
+0:39      move second child to first child (temp 4-component vector of int)
+0:39        'r01' (temp 4-component vector of int)
+0:39        textureFetch (global 4-component vector of int)
+0:39          'g_tTexbi4' (uniform isamplerBuffer)
+0:39          'uc1' (uniform int)
+0:40      move second child to first child (temp 4-component vector of uint)
+0:40        'r02' (temp 4-component vector of uint)
+0:40        textureFetch (global 4-component vector of uint)
+0:40          'g_tTexbu4' (uniform usamplerBuffer)
+0:40          'uc1' (uniform int)
+0:44      move second child to first child (temp 4-component vector of float)
+0:44        Color: direct index for structure (temp 4-component vector of float)
+0:44          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:44          Constant:
+0:44            0 (const int)
+0:44        Constant:
+0:44          1.000000
+0:44          1.000000
+0:44          1.000000
+0:44          1.000000
+0:45      move second child to first child (temp float)
+0:45        Depth: direct index for structure (temp float FragDepth)
+0:45          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:45          Constant:
+0:45            1 (const int)
+0:45        Constant:
+0:45          1.000000
+0:47      Branch: Return with expression
+0:47        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
 0:?   Linker Objects
 0:?     'g_tTexbf4_test' (layout(binding=0 ) uniform samplerBuffer)
 0:?     'g_tTexbf4' (uniform samplerBuffer)
@@ -112,6 +146,10 @@ gl_FragCoord origin is upper left
 0:?     'c2' (uniform 2-component vector of int)
 0:?     'c3' (uniform 3-component vector of int)
 0:?     'c4' (uniform 4-component vector of int)
+0:?     'uc1' (uniform int)
+0:?     'uc2' (uniform 2-component vector of int)
+0:?     'uc3' (uniform 3-component vector of int)
+0:?     'uc4' (uniform 4-component vector of int)
 0:?     'o1' (uniform int)
 0:?     'o2' (uniform 2-component vector of int)
 0:?     'o3' (uniform 3-component vector of int)
@@ -119,7 +157,7 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 69
+// Id's are bound by 85
 
                               Capability Shader
                               Capability SampledBuffer
@@ -135,24 +173,28 @@ gl_FragCoord origin is upper left
                               Name 27  "g_tTexbi4"
                               Name 35  "r02"
                               Name 39  "g_tTexbu4"
-                              Name 44  "PS_OUTPUT"
-                              MemberName 44(PS_OUTPUT) 0  "Color"
-                              MemberName 44(PS_OUTPUT) 1  "Depth"
-                              Name 46  "psout"
-                              Name 56  "g_tTexbf4_test"
-                              Name 59  "c2"
-                              Name 62  "c3"
-                              Name 64  "c4"
-                              Name 65  "o1"
-                              Name 66  "o2"
-                              Name 67  "o3"
-                              Name 68  "o4"
+                              Name 45  "uc1"
+                              Name 57  "PS_OUTPUT"
+                              MemberName 57(PS_OUTPUT) 0  "Color"
+                              MemberName 57(PS_OUTPUT) 1  "Depth"
+                              Name 59  "psout"
+                              Name 69  "g_tTexbf4_test"
+                              Name 72  "c2"
+                              Name 75  "c3"
+                              Name 77  "c4"
+                              Name 78  "uc2"
+                              Name 79  "uc3"
+                              Name 80  "uc4"
+                              Name 81  "o1"
+                              Name 82  "o2"
+                              Name 83  "o3"
+                              Name 84  "o4"
                               Decorate 13(g_tTexbf4) DescriptorSet 0
                               Decorate 27(g_tTexbi4) DescriptorSet 0
                               Decorate 39(g_tTexbu4) DescriptorSet 0
-                              MemberDecorate 44(PS_OUTPUT) 1 BuiltIn FragDepth
-                              Decorate 56(g_tTexbf4_test) DescriptorSet 0
-                              Decorate 56(g_tTexbf4_test) Binding 0
+                              MemberDecorate 57(PS_OUTPUT) 1 BuiltIn FragDepth
+                              Decorate 69(g_tTexbf4_test) DescriptorSet 0
+                              Decorate 69(g_tTexbf4_test) Binding 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -178,32 +220,36 @@ gl_FragCoord origin is upper left
               37:             TypeSampledImage 36
               38:             TypePointer UniformConstant 37
    39(g_tTexbu4):     38(ptr) Variable UniformConstant
-   44(PS_OUTPUT):             TypeStruct 7(fvec4) 6(float)
-              45:             TypePointer Function 44(PS_OUTPUT)
-              47:     15(int) Constant 0
-              48:    6(float) Constant 1065353216
-              49:    7(fvec4) ConstantComposite 48 48 48 48
-              51:     15(int) Constant 1
-              52:             TypePointer Function 6(float)
-56(g_tTexbf4_test):     12(ptr) Variable UniformConstant
-              57:             TypeVector 15(int) 2
-              58:             TypePointer UniformConstant 57(ivec2)
-          59(c2):     58(ptr) Variable UniformConstant
-              60:             TypeVector 15(int) 3
-              61:             TypePointer UniformConstant 60(ivec3)
-          62(c3):     61(ptr) Variable UniformConstant
-              63:             TypePointer UniformConstant 21(ivec4)
-          64(c4):     63(ptr) Variable UniformConstant
-          65(o1):     16(ptr) Variable UniformConstant
-          66(o2):     58(ptr) Variable UniformConstant
-          67(o3):     61(ptr) Variable UniformConstant
-          68(o4):     63(ptr) Variable UniformConstant
+         45(uc1):     16(ptr) Variable UniformConstant
+   57(PS_OUTPUT):             TypeStruct 7(fvec4) 6(float)
+              58:             TypePointer Function 57(PS_OUTPUT)
+              60:     15(int) Constant 0
+              61:    6(float) Constant 1065353216
+              62:    7(fvec4) ConstantComposite 61 61 61 61
+              64:     15(int) Constant 1
+              65:             TypePointer Function 6(float)
+69(g_tTexbf4_test):     12(ptr) Variable UniformConstant
+              70:             TypeVector 15(int) 2
+              71:             TypePointer UniformConstant 70(ivec2)
+          72(c2):     71(ptr) Variable UniformConstant
+              73:             TypeVector 15(int) 3
+              74:             TypePointer UniformConstant 73(ivec3)
+          75(c3):     74(ptr) Variable UniformConstant
+              76:             TypePointer UniformConstant 21(ivec4)
+          77(c4):     76(ptr) Variable UniformConstant
+         78(uc2):     71(ptr) Variable UniformConstant
+         79(uc3):     74(ptr) Variable UniformConstant
+         80(uc4):     76(ptr) Variable UniformConstant
+          81(o1):     16(ptr) Variable UniformConstant
+          82(o2):     71(ptr) Variable UniformConstant
+          83(o3):     74(ptr) Variable UniformConstant
+          84(o4):     76(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
           9(r00):      8(ptr) Variable Function
          23(r01):     22(ptr) Variable Function
          35(r02):     34(ptr) Variable Function
-       46(psout):     45(ptr) Variable Function
+       59(psout):     58(ptr) Variable Function
               14:          11 Load 13(g_tTexbf4)
               18:     15(int) Load 17(c1)
               19:          10 Image 14
@@ -219,10 +265,25 @@ gl_FragCoord origin is upper left
               42:          36 Image 40
               43:   33(ivec4) ImageFetch 42 41
                               Store 35(r02) 43
-              50:      8(ptr) AccessChain 46(psout) 47
-                              Store 50 49
-              53:     52(ptr) AccessChain 46(psout) 51
-                              Store 53 48
-              54:44(PS_OUTPUT) Load 46(psout)
-                              ReturnValue 54
+              44:          11 Load 13(g_tTexbf4)
+              46:     15(int) Load 45(uc1)
+              47:          10 Image 44
+              48:    7(fvec4) ImageFetch 47 46
+                              Store 9(r00) 48
+              49:          25 Load 27(g_tTexbi4)
+              50:     15(int) Load 45(uc1)
+              51:          24 Image 49
+              52:   21(ivec4) ImageFetch 51 50
+                              Store 23(r01) 52
+              53:          37 Load 39(g_tTexbu4)
+              54:     15(int) Load 45(uc1)
+              55:          36 Image 53
+              56:   33(ivec4) ImageFetch 55 54
+                              Store 35(r02) 56
+              63:      8(ptr) AccessChain 59(psout) 60
+                              Store 63 62
+              66:     65(ptr) AccessChain 59(psout) 64
+                              Store 66 61
+              67:57(PS_OUTPUT) Load 59(psout)
+                              ReturnValue 67
                               FunctionEnd

--- a/Test/baseResults/hlsl.load.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.offset.dx10.frag.out
@@ -2,154 +2,280 @@ hlsl.load.offset.dx10.frag
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:77  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:48    Function Parameters: 
+0:92  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:53    Function Parameters: 
 0:?     Sequence
-0:52      textureFetchOffset (global 4-component vector of float)
-0:52        'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
-0:52        vector swizzle (temp int)
-0:52          'c2' (uniform 2-component vector of int)
-0:52          Sequence
-0:52            Constant:
-0:52              0 (const int)
-0:52        direct index (temp int)
-0:52          'c2' (uniform 2-component vector of int)
-0:52          Constant:
-0:52            1 (const int)
-0:52        'o1' (uniform int)
-0:53      textureFetchOffset (global 4-component vector of int)
-0:53        'g_tTex1di4' (uniform itexture1D)
-0:53        vector swizzle (temp int)
-0:53          'c2' (uniform 2-component vector of int)
-0:53          Sequence
-0:53            Constant:
-0:53              0 (const int)
-0:53        direct index (temp int)
-0:53          'c2' (uniform 2-component vector of int)
-0:53          Constant:
-0:53            1 (const int)
-0:53        'o1' (uniform int)
-0:54      textureFetchOffset (global 4-component vector of uint)
-0:54        'g_tTex1du4' (uniform utexture1D)
-0:54        vector swizzle (temp int)
-0:54          'c2' (uniform 2-component vector of int)
-0:54          Sequence
-0:54            Constant:
-0:54              0 (const int)
-0:54        direct index (temp int)
-0:54          'c2' (uniform 2-component vector of int)
-0:54          Constant:
-0:54            1 (const int)
-0:54        'o1' (uniform int)
 0:57      textureFetchOffset (global 4-component vector of float)
-0:57        'g_tTex2df4' (uniform texture2D)
-0:57        vector swizzle (temp 2-component vector of int)
-0:57          'c3' (uniform 3-component vector of int)
+0:57        'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
+0:57        vector swizzle (temp int)
+0:57          'c2' (uniform 2-component vector of int)
 0:57          Sequence
 0:57            Constant:
 0:57              0 (const int)
-0:57            Constant:
-0:57              1 (const int)
 0:57        direct index (temp int)
-0:57          'c3' (uniform 3-component vector of int)
+0:57          'c2' (uniform 2-component vector of int)
 0:57          Constant:
-0:57            2 (const int)
-0:57        'o2' (uniform 2-component vector of int)
+0:57            1 (const int)
+0:57        'o1' (uniform int)
 0:58      textureFetchOffset (global 4-component vector of int)
-0:58        'g_tTex2di4' (uniform itexture2D)
-0:58        vector swizzle (temp 2-component vector of int)
-0:58          'c3' (uniform 3-component vector of int)
+0:58        'g_tTex1di4' (uniform itexture1D)
+0:58        vector swizzle (temp int)
+0:58          'c2' (uniform 2-component vector of int)
 0:58          Sequence
 0:58            Constant:
 0:58              0 (const int)
-0:58            Constant:
-0:58              1 (const int)
 0:58        direct index (temp int)
-0:58          'c3' (uniform 3-component vector of int)
+0:58          'c2' (uniform 2-component vector of int)
 0:58          Constant:
-0:58            2 (const int)
-0:58        'o2' (uniform 2-component vector of int)
+0:58            1 (const int)
+0:58        'o1' (uniform int)
 0:59      textureFetchOffset (global 4-component vector of uint)
-0:59        'g_tTex2du4' (uniform utexture2D)
-0:59        vector swizzle (temp 2-component vector of int)
-0:59          'c3' (uniform 3-component vector of int)
+0:59        'g_tTex1du4' (uniform utexture1D)
+0:59        vector swizzle (temp int)
+0:59          'c2' (uniform 2-component vector of int)
 0:59          Sequence
 0:59            Constant:
 0:59              0 (const int)
-0:59            Constant:
-0:59              1 (const int)
 0:59        direct index (temp int)
-0:59          'c3' (uniform 3-component vector of int)
+0:59          'c2' (uniform 2-component vector of int)
 0:59          Constant:
-0:59            2 (const int)
-0:59        'o2' (uniform 2-component vector of int)
-0:62      textureFetchOffset (global 4-component vector of float)
-0:62        'g_tTex3df4' (uniform texture3D)
-0:62        vector swizzle (temp 3-component vector of int)
-0:62          'c4' (uniform 4-component vector of int)
+0:59            1 (const int)
+0:59        'o1' (uniform int)
+0:60      textureFetchOffset (global 4-component vector of float)
+0:60        'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
+0:60        vector swizzle (temp uint)
+0:60          'uc2' (uniform 2-component vector of uint)
+0:60          Sequence
+0:60            Constant:
+0:60              0 (const int)
+0:60        direct index (temp uint)
+0:60          'uc2' (uniform 2-component vector of uint)
+0:60          Constant:
+0:60            1 (const int)
+0:60        'o1' (uniform int)
+0:61      textureFetchOffset (global 4-component vector of int)
+0:61        'g_tTex1di4' (uniform itexture1D)
+0:61        vector swizzle (temp uint)
+0:61          'uc2' (uniform 2-component vector of uint)
+0:61          Sequence
+0:61            Constant:
+0:61              0 (const int)
+0:61        direct index (temp uint)
+0:61          'uc2' (uniform 2-component vector of uint)
+0:61          Constant:
+0:61            1 (const int)
+0:61        'o1' (uniform int)
+0:62      textureFetchOffset (global 4-component vector of uint)
+0:62        'g_tTex1du4' (uniform utexture1D)
+0:62        vector swizzle (temp uint)
+0:62          'uc2' (uniform 2-component vector of uint)
 0:62          Sequence
 0:62            Constant:
 0:62              0 (const int)
-0:62            Constant:
-0:62              1 (const int)
-0:62            Constant:
-0:62              2 (const int)
-0:62        direct index (temp int)
-0:62          'c4' (uniform 4-component vector of int)
+0:62        direct index (temp uint)
+0:62          'uc2' (uniform 2-component vector of uint)
 0:62          Constant:
-0:62            3 (const int)
-0:62        'o3' (uniform 3-component vector of int)
-0:63      textureFetchOffset (global 4-component vector of int)
-0:63        'g_tTex3di4' (uniform itexture3D)
-0:63        vector swizzle (temp 3-component vector of int)
-0:63          'c4' (uniform 4-component vector of int)
-0:63          Sequence
-0:63            Constant:
-0:63              0 (const int)
-0:63            Constant:
-0:63              1 (const int)
-0:63            Constant:
-0:63              2 (const int)
-0:63        direct index (temp int)
-0:63          'c4' (uniform 4-component vector of int)
-0:63          Constant:
-0:63            3 (const int)
-0:63        'o3' (uniform 3-component vector of int)
-0:64      textureFetchOffset (global 4-component vector of uint)
-0:64        'g_tTex3du4' (uniform utexture3D)
-0:64        vector swizzle (temp 3-component vector of int)
-0:64          'c4' (uniform 4-component vector of int)
-0:64          Sequence
-0:64            Constant:
-0:64              0 (const int)
-0:64            Constant:
-0:64              1 (const int)
-0:64            Constant:
-0:64              2 (const int)
-0:64        direct index (temp int)
-0:64          'c4' (uniform 4-component vector of int)
-0:64          Constant:
-0:64            3 (const int)
-0:64        'o3' (uniform 3-component vector of int)
-0:72      move second child to first child (temp 4-component vector of float)
-0:72        Color: direct index for structure (temp 4-component vector of float)
-0:72          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:72          Constant:
-0:72            0 (const int)
-0:72        Constant:
-0:72          1.000000
-0:72          1.000000
-0:72          1.000000
-0:72          1.000000
-0:73      move second child to first child (temp float)
-0:73        Depth: direct index for structure (temp float FragDepth)
-0:73          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:73          Constant:
-0:73            1 (const int)
-0:73        Constant:
-0:73          1.000000
-0:75      Branch: Return with expression
-0:75        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:62            1 (const int)
+0:62        'o1' (uniform int)
+0:66      textureFetchOffset (global 4-component vector of float)
+0:66        'g_tTex2df4' (uniform texture2D)
+0:66        vector swizzle (temp 2-component vector of int)
+0:66          'c3' (uniform 3-component vector of int)
+0:66          Sequence
+0:66            Constant:
+0:66              0 (const int)
+0:66            Constant:
+0:66              1 (const int)
+0:66        direct index (temp int)
+0:66          'c3' (uniform 3-component vector of int)
+0:66          Constant:
+0:66            2 (const int)
+0:66        'o2' (uniform 2-component vector of int)
+0:67      textureFetchOffset (global 4-component vector of int)
+0:67        'g_tTex2di4' (uniform itexture2D)
+0:67        vector swizzle (temp 2-component vector of int)
+0:67          'c3' (uniform 3-component vector of int)
+0:67          Sequence
+0:67            Constant:
+0:67              0 (const int)
+0:67            Constant:
+0:67              1 (const int)
+0:67        direct index (temp int)
+0:67          'c3' (uniform 3-component vector of int)
+0:67          Constant:
+0:67            2 (const int)
+0:67        'o2' (uniform 2-component vector of int)
+0:68      textureFetchOffset (global 4-component vector of uint)
+0:68        'g_tTex2du4' (uniform utexture2D)
+0:68        vector swizzle (temp 2-component vector of int)
+0:68          'c3' (uniform 3-component vector of int)
+0:68          Sequence
+0:68            Constant:
+0:68              0 (const int)
+0:68            Constant:
+0:68              1 (const int)
+0:68        direct index (temp int)
+0:68          'c3' (uniform 3-component vector of int)
+0:68          Constant:
+0:68            2 (const int)
+0:68        'o2' (uniform 2-component vector of int)
+0:69      textureFetchOffset (global 4-component vector of float)
+0:69        'g_tTex2df4' (uniform texture2D)
+0:69        vector swizzle (temp 2-component vector of uint)
+0:69          'uc3' (uniform 3-component vector of uint)
+0:69          Sequence
+0:69            Constant:
+0:69              0 (const int)
+0:69            Constant:
+0:69              1 (const int)
+0:69        direct index (temp uint)
+0:69          'uc3' (uniform 3-component vector of uint)
+0:69          Constant:
+0:69            2 (const int)
+0:69        'o2' (uniform 2-component vector of int)
+0:70      textureFetchOffset (global 4-component vector of int)
+0:70        'g_tTex2di4' (uniform itexture2D)
+0:70        vector swizzle (temp 2-component vector of uint)
+0:70          'uc3' (uniform 3-component vector of uint)
+0:70          Sequence
+0:70            Constant:
+0:70              0 (const int)
+0:70            Constant:
+0:70              1 (const int)
+0:70        direct index (temp uint)
+0:70          'uc3' (uniform 3-component vector of uint)
+0:70          Constant:
+0:70            2 (const int)
+0:70        'o2' (uniform 2-component vector of int)
+0:71      textureFetchOffset (global 4-component vector of uint)
+0:71        'g_tTex2du4' (uniform utexture2D)
+0:71        vector swizzle (temp 2-component vector of uint)
+0:71          'uc3' (uniform 3-component vector of uint)
+0:71          Sequence
+0:71            Constant:
+0:71              0 (const int)
+0:71            Constant:
+0:71              1 (const int)
+0:71        direct index (temp uint)
+0:71          'uc3' (uniform 3-component vector of uint)
+0:71          Constant:
+0:71            2 (const int)
+0:71        'o2' (uniform 2-component vector of int)
+0:74      textureFetchOffset (global 4-component vector of float)
+0:74        'g_tTex3df4' (uniform texture3D)
+0:74        vector swizzle (temp 3-component vector of int)
+0:74          'c4' (uniform 4-component vector of int)
+0:74          Sequence
+0:74            Constant:
+0:74              0 (const int)
+0:74            Constant:
+0:74              1 (const int)
+0:74            Constant:
+0:74              2 (const int)
+0:74        direct index (temp int)
+0:74          'c4' (uniform 4-component vector of int)
+0:74          Constant:
+0:74            3 (const int)
+0:74        'o3' (uniform 3-component vector of int)
+0:75      textureFetchOffset (global 4-component vector of int)
+0:75        'g_tTex3di4' (uniform itexture3D)
+0:75        vector swizzle (temp 3-component vector of int)
+0:75          'c4' (uniform 4-component vector of int)
+0:75          Sequence
+0:75            Constant:
+0:75              0 (const int)
+0:75            Constant:
+0:75              1 (const int)
+0:75            Constant:
+0:75              2 (const int)
+0:75        direct index (temp int)
+0:75          'c4' (uniform 4-component vector of int)
+0:75          Constant:
+0:75            3 (const int)
+0:75        'o3' (uniform 3-component vector of int)
+0:76      textureFetchOffset (global 4-component vector of uint)
+0:76        'g_tTex3du4' (uniform utexture3D)
+0:76        vector swizzle (temp 3-component vector of int)
+0:76          'c4' (uniform 4-component vector of int)
+0:76          Sequence
+0:76            Constant:
+0:76              0 (const int)
+0:76            Constant:
+0:76              1 (const int)
+0:76            Constant:
+0:76              2 (const int)
+0:76        direct index (temp int)
+0:76          'c4' (uniform 4-component vector of int)
+0:76          Constant:
+0:76            3 (const int)
+0:76        'o3' (uniform 3-component vector of int)
+0:77      textureFetchOffset (global 4-component vector of float)
+0:77        'g_tTex3df4' (uniform texture3D)
+0:77        vector swizzle (temp 3-component vector of uint)
+0:77          'uc4' (uniform 4-component vector of uint)
+0:77          Sequence
+0:77            Constant:
+0:77              0 (const int)
+0:77            Constant:
+0:77              1 (const int)
+0:77            Constant:
+0:77              2 (const int)
+0:77        direct index (temp uint)
+0:77          'uc4' (uniform 4-component vector of uint)
+0:77          Constant:
+0:77            3 (const int)
+0:77        'o3' (uniform 3-component vector of int)
+0:78      textureFetchOffset (global 4-component vector of int)
+0:78        'g_tTex3di4' (uniform itexture3D)
+0:78        vector swizzle (temp 3-component vector of uint)
+0:78          'uc4' (uniform 4-component vector of uint)
+0:78          Sequence
+0:78            Constant:
+0:78              0 (const int)
+0:78            Constant:
+0:78              1 (const int)
+0:78            Constant:
+0:78              2 (const int)
+0:78        direct index (temp uint)
+0:78          'uc4' (uniform 4-component vector of uint)
+0:78          Constant:
+0:78            3 (const int)
+0:78        'o3' (uniform 3-component vector of int)
+0:79      textureFetchOffset (global 4-component vector of uint)
+0:79        'g_tTex3du4' (uniform utexture3D)
+0:79        vector swizzle (temp 3-component vector of uint)
+0:79          'uc4' (uniform 4-component vector of uint)
+0:79          Sequence
+0:79            Constant:
+0:79              0 (const int)
+0:79            Constant:
+0:79              1 (const int)
+0:79            Constant:
+0:79              2 (const int)
+0:79        direct index (temp uint)
+0:79          'uc4' (uniform 4-component vector of uint)
+0:79          Constant:
+0:79            3 (const int)
+0:79        'o3' (uniform 3-component vector of int)
+0:87      move second child to first child (temp 4-component vector of float)
+0:87        Color: direct index for structure (temp 4-component vector of float)
+0:87          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:87          Constant:
+0:87            0 (const int)
+0:87        Constant:
+0:87          1.000000
+0:87          1.000000
+0:87          1.000000
+0:87          1.000000
+0:88      move second child to first child (temp float)
+0:88        Depth: direct index for structure (temp float FragDepth)
+0:88          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:88          Constant:
+0:88            1 (const int)
+0:88        Constant:
+0:88          1.000000
+0:90      Branch: Return with expression
+0:90        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
 0:?   Linker Objects
 0:?     'g_sSamp' (layout(binding=0 ) uniform sampler)
 0:?     'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
@@ -177,6 +303,10 @@ gl_FragCoord origin is upper left
 0:?     'c2' (uniform 2-component vector of int)
 0:?     'c3' (uniform 3-component vector of int)
 0:?     'c4' (uniform 4-component vector of int)
+0:?     'uc1' (uniform uint)
+0:?     'uc2' (uniform 2-component vector of uint)
+0:?     'uc3' (uniform 3-component vector of uint)
+0:?     'uc4' (uniform 4-component vector of uint)
 0:?     'o1' (uniform int)
 0:?     'o2' (uniform 2-component vector of int)
 0:?     'o3' (uniform 3-component vector of int)
@@ -189,154 +319,280 @@ Linked fragment stage:
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:77  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:48    Function Parameters: 
+0:92  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:53    Function Parameters: 
 0:?     Sequence
-0:52      textureFetchOffset (global 4-component vector of float)
-0:52        'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
-0:52        vector swizzle (temp int)
-0:52          'c2' (uniform 2-component vector of int)
-0:52          Sequence
-0:52            Constant:
-0:52              0 (const int)
-0:52        direct index (temp int)
-0:52          'c2' (uniform 2-component vector of int)
-0:52          Constant:
-0:52            1 (const int)
-0:52        'o1' (uniform int)
-0:53      textureFetchOffset (global 4-component vector of int)
-0:53        'g_tTex1di4' (uniform itexture1D)
-0:53        vector swizzle (temp int)
-0:53          'c2' (uniform 2-component vector of int)
-0:53          Sequence
-0:53            Constant:
-0:53              0 (const int)
-0:53        direct index (temp int)
-0:53          'c2' (uniform 2-component vector of int)
-0:53          Constant:
-0:53            1 (const int)
-0:53        'o1' (uniform int)
-0:54      textureFetchOffset (global 4-component vector of uint)
-0:54        'g_tTex1du4' (uniform utexture1D)
-0:54        vector swizzle (temp int)
-0:54          'c2' (uniform 2-component vector of int)
-0:54          Sequence
-0:54            Constant:
-0:54              0 (const int)
-0:54        direct index (temp int)
-0:54          'c2' (uniform 2-component vector of int)
-0:54          Constant:
-0:54            1 (const int)
-0:54        'o1' (uniform int)
 0:57      textureFetchOffset (global 4-component vector of float)
-0:57        'g_tTex2df4' (uniform texture2D)
-0:57        vector swizzle (temp 2-component vector of int)
-0:57          'c3' (uniform 3-component vector of int)
+0:57        'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
+0:57        vector swizzle (temp int)
+0:57          'c2' (uniform 2-component vector of int)
 0:57          Sequence
 0:57            Constant:
 0:57              0 (const int)
-0:57            Constant:
-0:57              1 (const int)
 0:57        direct index (temp int)
-0:57          'c3' (uniform 3-component vector of int)
+0:57          'c2' (uniform 2-component vector of int)
 0:57          Constant:
-0:57            2 (const int)
-0:57        'o2' (uniform 2-component vector of int)
+0:57            1 (const int)
+0:57        'o1' (uniform int)
 0:58      textureFetchOffset (global 4-component vector of int)
-0:58        'g_tTex2di4' (uniform itexture2D)
-0:58        vector swizzle (temp 2-component vector of int)
-0:58          'c3' (uniform 3-component vector of int)
+0:58        'g_tTex1di4' (uniform itexture1D)
+0:58        vector swizzle (temp int)
+0:58          'c2' (uniform 2-component vector of int)
 0:58          Sequence
 0:58            Constant:
 0:58              0 (const int)
-0:58            Constant:
-0:58              1 (const int)
 0:58        direct index (temp int)
-0:58          'c3' (uniform 3-component vector of int)
+0:58          'c2' (uniform 2-component vector of int)
 0:58          Constant:
-0:58            2 (const int)
-0:58        'o2' (uniform 2-component vector of int)
+0:58            1 (const int)
+0:58        'o1' (uniform int)
 0:59      textureFetchOffset (global 4-component vector of uint)
-0:59        'g_tTex2du4' (uniform utexture2D)
-0:59        vector swizzle (temp 2-component vector of int)
-0:59          'c3' (uniform 3-component vector of int)
+0:59        'g_tTex1du4' (uniform utexture1D)
+0:59        vector swizzle (temp int)
+0:59          'c2' (uniform 2-component vector of int)
 0:59          Sequence
 0:59            Constant:
 0:59              0 (const int)
-0:59            Constant:
-0:59              1 (const int)
 0:59        direct index (temp int)
-0:59          'c3' (uniform 3-component vector of int)
+0:59          'c2' (uniform 2-component vector of int)
 0:59          Constant:
-0:59            2 (const int)
-0:59        'o2' (uniform 2-component vector of int)
-0:62      textureFetchOffset (global 4-component vector of float)
-0:62        'g_tTex3df4' (uniform texture3D)
-0:62        vector swizzle (temp 3-component vector of int)
-0:62          'c4' (uniform 4-component vector of int)
+0:59            1 (const int)
+0:59        'o1' (uniform int)
+0:60      textureFetchOffset (global 4-component vector of float)
+0:60        'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
+0:60        vector swizzle (temp uint)
+0:60          'uc2' (uniform 2-component vector of uint)
+0:60          Sequence
+0:60            Constant:
+0:60              0 (const int)
+0:60        direct index (temp uint)
+0:60          'uc2' (uniform 2-component vector of uint)
+0:60          Constant:
+0:60            1 (const int)
+0:60        'o1' (uniform int)
+0:61      textureFetchOffset (global 4-component vector of int)
+0:61        'g_tTex1di4' (uniform itexture1D)
+0:61        vector swizzle (temp uint)
+0:61          'uc2' (uniform 2-component vector of uint)
+0:61          Sequence
+0:61            Constant:
+0:61              0 (const int)
+0:61        direct index (temp uint)
+0:61          'uc2' (uniform 2-component vector of uint)
+0:61          Constant:
+0:61            1 (const int)
+0:61        'o1' (uniform int)
+0:62      textureFetchOffset (global 4-component vector of uint)
+0:62        'g_tTex1du4' (uniform utexture1D)
+0:62        vector swizzle (temp uint)
+0:62          'uc2' (uniform 2-component vector of uint)
 0:62          Sequence
 0:62            Constant:
 0:62              0 (const int)
-0:62            Constant:
-0:62              1 (const int)
-0:62            Constant:
-0:62              2 (const int)
-0:62        direct index (temp int)
-0:62          'c4' (uniform 4-component vector of int)
+0:62        direct index (temp uint)
+0:62          'uc2' (uniform 2-component vector of uint)
 0:62          Constant:
-0:62            3 (const int)
-0:62        'o3' (uniform 3-component vector of int)
-0:63      textureFetchOffset (global 4-component vector of int)
-0:63        'g_tTex3di4' (uniform itexture3D)
-0:63        vector swizzle (temp 3-component vector of int)
-0:63          'c4' (uniform 4-component vector of int)
-0:63          Sequence
-0:63            Constant:
-0:63              0 (const int)
-0:63            Constant:
-0:63              1 (const int)
-0:63            Constant:
-0:63              2 (const int)
-0:63        direct index (temp int)
-0:63          'c4' (uniform 4-component vector of int)
-0:63          Constant:
-0:63            3 (const int)
-0:63        'o3' (uniform 3-component vector of int)
-0:64      textureFetchOffset (global 4-component vector of uint)
-0:64        'g_tTex3du4' (uniform utexture3D)
-0:64        vector swizzle (temp 3-component vector of int)
-0:64          'c4' (uniform 4-component vector of int)
-0:64          Sequence
-0:64            Constant:
-0:64              0 (const int)
-0:64            Constant:
-0:64              1 (const int)
-0:64            Constant:
-0:64              2 (const int)
-0:64        direct index (temp int)
-0:64          'c4' (uniform 4-component vector of int)
-0:64          Constant:
-0:64            3 (const int)
-0:64        'o3' (uniform 3-component vector of int)
-0:72      move second child to first child (temp 4-component vector of float)
-0:72        Color: direct index for structure (temp 4-component vector of float)
-0:72          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:72          Constant:
-0:72            0 (const int)
-0:72        Constant:
-0:72          1.000000
-0:72          1.000000
-0:72          1.000000
-0:72          1.000000
-0:73      move second child to first child (temp float)
-0:73        Depth: direct index for structure (temp float FragDepth)
-0:73          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:73          Constant:
-0:73            1 (const int)
-0:73        Constant:
-0:73          1.000000
-0:75      Branch: Return with expression
-0:75        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:62            1 (const int)
+0:62        'o1' (uniform int)
+0:66      textureFetchOffset (global 4-component vector of float)
+0:66        'g_tTex2df4' (uniform texture2D)
+0:66        vector swizzle (temp 2-component vector of int)
+0:66          'c3' (uniform 3-component vector of int)
+0:66          Sequence
+0:66            Constant:
+0:66              0 (const int)
+0:66            Constant:
+0:66              1 (const int)
+0:66        direct index (temp int)
+0:66          'c3' (uniform 3-component vector of int)
+0:66          Constant:
+0:66            2 (const int)
+0:66        'o2' (uniform 2-component vector of int)
+0:67      textureFetchOffset (global 4-component vector of int)
+0:67        'g_tTex2di4' (uniform itexture2D)
+0:67        vector swizzle (temp 2-component vector of int)
+0:67          'c3' (uniform 3-component vector of int)
+0:67          Sequence
+0:67            Constant:
+0:67              0 (const int)
+0:67            Constant:
+0:67              1 (const int)
+0:67        direct index (temp int)
+0:67          'c3' (uniform 3-component vector of int)
+0:67          Constant:
+0:67            2 (const int)
+0:67        'o2' (uniform 2-component vector of int)
+0:68      textureFetchOffset (global 4-component vector of uint)
+0:68        'g_tTex2du4' (uniform utexture2D)
+0:68        vector swizzle (temp 2-component vector of int)
+0:68          'c3' (uniform 3-component vector of int)
+0:68          Sequence
+0:68            Constant:
+0:68              0 (const int)
+0:68            Constant:
+0:68              1 (const int)
+0:68        direct index (temp int)
+0:68          'c3' (uniform 3-component vector of int)
+0:68          Constant:
+0:68            2 (const int)
+0:68        'o2' (uniform 2-component vector of int)
+0:69      textureFetchOffset (global 4-component vector of float)
+0:69        'g_tTex2df4' (uniform texture2D)
+0:69        vector swizzle (temp 2-component vector of uint)
+0:69          'uc3' (uniform 3-component vector of uint)
+0:69          Sequence
+0:69            Constant:
+0:69              0 (const int)
+0:69            Constant:
+0:69              1 (const int)
+0:69        direct index (temp uint)
+0:69          'uc3' (uniform 3-component vector of uint)
+0:69          Constant:
+0:69            2 (const int)
+0:69        'o2' (uniform 2-component vector of int)
+0:70      textureFetchOffset (global 4-component vector of int)
+0:70        'g_tTex2di4' (uniform itexture2D)
+0:70        vector swizzle (temp 2-component vector of uint)
+0:70          'uc3' (uniform 3-component vector of uint)
+0:70          Sequence
+0:70            Constant:
+0:70              0 (const int)
+0:70            Constant:
+0:70              1 (const int)
+0:70        direct index (temp uint)
+0:70          'uc3' (uniform 3-component vector of uint)
+0:70          Constant:
+0:70            2 (const int)
+0:70        'o2' (uniform 2-component vector of int)
+0:71      textureFetchOffset (global 4-component vector of uint)
+0:71        'g_tTex2du4' (uniform utexture2D)
+0:71        vector swizzle (temp 2-component vector of uint)
+0:71          'uc3' (uniform 3-component vector of uint)
+0:71          Sequence
+0:71            Constant:
+0:71              0 (const int)
+0:71            Constant:
+0:71              1 (const int)
+0:71        direct index (temp uint)
+0:71          'uc3' (uniform 3-component vector of uint)
+0:71          Constant:
+0:71            2 (const int)
+0:71        'o2' (uniform 2-component vector of int)
+0:74      textureFetchOffset (global 4-component vector of float)
+0:74        'g_tTex3df4' (uniform texture3D)
+0:74        vector swizzle (temp 3-component vector of int)
+0:74          'c4' (uniform 4-component vector of int)
+0:74          Sequence
+0:74            Constant:
+0:74              0 (const int)
+0:74            Constant:
+0:74              1 (const int)
+0:74            Constant:
+0:74              2 (const int)
+0:74        direct index (temp int)
+0:74          'c4' (uniform 4-component vector of int)
+0:74          Constant:
+0:74            3 (const int)
+0:74        'o3' (uniform 3-component vector of int)
+0:75      textureFetchOffset (global 4-component vector of int)
+0:75        'g_tTex3di4' (uniform itexture3D)
+0:75        vector swizzle (temp 3-component vector of int)
+0:75          'c4' (uniform 4-component vector of int)
+0:75          Sequence
+0:75            Constant:
+0:75              0 (const int)
+0:75            Constant:
+0:75              1 (const int)
+0:75            Constant:
+0:75              2 (const int)
+0:75        direct index (temp int)
+0:75          'c4' (uniform 4-component vector of int)
+0:75          Constant:
+0:75            3 (const int)
+0:75        'o3' (uniform 3-component vector of int)
+0:76      textureFetchOffset (global 4-component vector of uint)
+0:76        'g_tTex3du4' (uniform utexture3D)
+0:76        vector swizzle (temp 3-component vector of int)
+0:76          'c4' (uniform 4-component vector of int)
+0:76          Sequence
+0:76            Constant:
+0:76              0 (const int)
+0:76            Constant:
+0:76              1 (const int)
+0:76            Constant:
+0:76              2 (const int)
+0:76        direct index (temp int)
+0:76          'c4' (uniform 4-component vector of int)
+0:76          Constant:
+0:76            3 (const int)
+0:76        'o3' (uniform 3-component vector of int)
+0:77      textureFetchOffset (global 4-component vector of float)
+0:77        'g_tTex3df4' (uniform texture3D)
+0:77        vector swizzle (temp 3-component vector of uint)
+0:77          'uc4' (uniform 4-component vector of uint)
+0:77          Sequence
+0:77            Constant:
+0:77              0 (const int)
+0:77            Constant:
+0:77              1 (const int)
+0:77            Constant:
+0:77              2 (const int)
+0:77        direct index (temp uint)
+0:77          'uc4' (uniform 4-component vector of uint)
+0:77          Constant:
+0:77            3 (const int)
+0:77        'o3' (uniform 3-component vector of int)
+0:78      textureFetchOffset (global 4-component vector of int)
+0:78        'g_tTex3di4' (uniform itexture3D)
+0:78        vector swizzle (temp 3-component vector of uint)
+0:78          'uc4' (uniform 4-component vector of uint)
+0:78          Sequence
+0:78            Constant:
+0:78              0 (const int)
+0:78            Constant:
+0:78              1 (const int)
+0:78            Constant:
+0:78              2 (const int)
+0:78        direct index (temp uint)
+0:78          'uc4' (uniform 4-component vector of uint)
+0:78          Constant:
+0:78            3 (const int)
+0:78        'o3' (uniform 3-component vector of int)
+0:79      textureFetchOffset (global 4-component vector of uint)
+0:79        'g_tTex3du4' (uniform utexture3D)
+0:79        vector swizzle (temp 3-component vector of uint)
+0:79          'uc4' (uniform 4-component vector of uint)
+0:79          Sequence
+0:79            Constant:
+0:79              0 (const int)
+0:79            Constant:
+0:79              1 (const int)
+0:79            Constant:
+0:79              2 (const int)
+0:79        direct index (temp uint)
+0:79          'uc4' (uniform 4-component vector of uint)
+0:79          Constant:
+0:79            3 (const int)
+0:79        'o3' (uniform 3-component vector of int)
+0:87      move second child to first child (temp 4-component vector of float)
+0:87        Color: direct index for structure (temp 4-component vector of float)
+0:87          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:87          Constant:
+0:87            0 (const int)
+0:87        Constant:
+0:87          1.000000
+0:87          1.000000
+0:87          1.000000
+0:87          1.000000
+0:88      move second child to first child (temp float)
+0:88        Depth: direct index for structure (temp float FragDepth)
+0:88          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:88          Constant:
+0:88            1 (const int)
+0:88        Constant:
+0:88          1.000000
+0:90      Branch: Return with expression
+0:90        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
 0:?   Linker Objects
 0:?     'g_sSamp' (layout(binding=0 ) uniform sampler)
 0:?     'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
@@ -364,6 +620,10 @@ gl_FragCoord origin is upper left
 0:?     'c2' (uniform 2-component vector of int)
 0:?     'c3' (uniform 3-component vector of int)
 0:?     'c4' (uniform 4-component vector of int)
+0:?     'uc1' (uniform uint)
+0:?     'uc2' (uniform 2-component vector of uint)
+0:?     'uc3' (uniform 3-component vector of uint)
+0:?     'uc4' (uniform 4-component vector of uint)
 0:?     'o1' (uniform int)
 0:?     'o2' (uniform 2-component vector of int)
 0:?     'o3' (uniform 3-component vector of int)
@@ -371,7 +631,7 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 172
+// Id's are bound by 245
 
                               Capability Shader
                               Capability ImageGatherExtended
@@ -387,60 +647,64 @@ gl_FragCoord origin is upper left
                               Name 23  "o1"
                               Name 29  "g_tTex1di4"
                               Name 40  "g_tTex1du4"
-                              Name 51  "g_tTex2df4"
-                              Name 55  "c3"
-                              Name 61  "o2"
-                              Name 66  "g_tTex2di4"
-                              Name 76  "g_tTex2du4"
-                              Name 86  "g_tTex3df4"
-                              Name 89  "c4"
-                              Name 95  "o3"
-                              Name 100  "g_tTex3di4"
-                              Name 110  "g_tTex3du4"
-                              Name 118  "PS_OUTPUT"
-                              MemberName 118(PS_OUTPUT) 0  "Color"
-                              MemberName 118(PS_OUTPUT) 1  "Depth"
-                              Name 120  "psout"
-                              Name 133  "g_sSamp"
-                              Name 136  "g_tTexcdf4"
-                              Name 139  "g_tTexcdi4"
-                              Name 142  "g_tTexcdu4"
-                              Name 145  "g_tTex1df4a"
-                              Name 148  "g_tTex1di4a"
-                              Name 151  "g_tTex1du4a"
-                              Name 154  "g_tTex2df4a"
-                              Name 157  "g_tTex2di4a"
-                              Name 160  "g_tTex2du4a"
-                              Name 163  "g_tTexcdf4a"
-                              Name 166  "g_tTexcdi4a"
-                              Name 169  "g_tTexcdu4a"
-                              Name 170  "c1"
-                              Name 171  "o4"
+                              Name 52  "uc2"
+                              Name 76  "g_tTex2df4"
+                              Name 80  "c3"
+                              Name 86  "o2"
+                              Name 91  "g_tTex2di4"
+                              Name 101  "g_tTex2du4"
+                              Name 112  "uc3"
+                              Name 135  "g_tTex3df4"
+                              Name 138  "c4"
+                              Name 144  "o3"
+                              Name 149  "g_tTex3di4"
+                              Name 159  "g_tTex3du4"
+                              Name 169  "uc4"
+                              Name 190  "PS_OUTPUT"
+                              MemberName 190(PS_OUTPUT) 0  "Color"
+                              MemberName 190(PS_OUTPUT) 1  "Depth"
+                              Name 192  "psout"
+                              Name 205  "g_sSamp"
+                              Name 208  "g_tTexcdf4"
+                              Name 211  "g_tTexcdi4"
+                              Name 214  "g_tTexcdu4"
+                              Name 217  "g_tTex1df4a"
+                              Name 220  "g_tTex1di4a"
+                              Name 223  "g_tTex1du4a"
+                              Name 226  "g_tTex2df4a"
+                              Name 229  "g_tTex2di4a"
+                              Name 232  "g_tTex2du4a"
+                              Name 235  "g_tTexcdf4a"
+                              Name 238  "g_tTexcdi4a"
+                              Name 241  "g_tTexcdu4a"
+                              Name 242  "c1"
+                              Name 243  "uc1"
+                              Name 244  "o4"
                               Decorate 9(g_tTex1df4) DescriptorSet 0
                               Decorate 9(g_tTex1df4) Binding 0
                               Decorate 29(g_tTex1di4) DescriptorSet 0
                               Decorate 40(g_tTex1du4) DescriptorSet 0
-                              Decorate 51(g_tTex2df4) DescriptorSet 0
-                              Decorate 66(g_tTex2di4) DescriptorSet 0
-                              Decorate 76(g_tTex2du4) DescriptorSet 0
-                              Decorate 86(g_tTex3df4) DescriptorSet 0
-                              Decorate 100(g_tTex3di4) DescriptorSet 0
-                              Decorate 110(g_tTex3du4) DescriptorSet 0
-                              MemberDecorate 118(PS_OUTPUT) 1 BuiltIn FragDepth
-                              Decorate 133(g_sSamp) DescriptorSet 0
-                              Decorate 133(g_sSamp) Binding 0
-                              Decorate 136(g_tTexcdf4) DescriptorSet 0
-                              Decorate 139(g_tTexcdi4) DescriptorSet 0
-                              Decorate 142(g_tTexcdu4) DescriptorSet 0
-                              Decorate 145(g_tTex1df4a) DescriptorSet 0
-                              Decorate 148(g_tTex1di4a) DescriptorSet 0
-                              Decorate 151(g_tTex1du4a) DescriptorSet 0
-                              Decorate 154(g_tTex2df4a) DescriptorSet 0
-                              Decorate 157(g_tTex2di4a) DescriptorSet 0
-                              Decorate 160(g_tTex2du4a) DescriptorSet 0
-                              Decorate 163(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 166(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 169(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 76(g_tTex2df4) DescriptorSet 0
+                              Decorate 91(g_tTex2di4) DescriptorSet 0
+                              Decorate 101(g_tTex2du4) DescriptorSet 0
+                              Decorate 135(g_tTex3df4) DescriptorSet 0
+                              Decorate 149(g_tTex3di4) DescriptorSet 0
+                              Decorate 159(g_tTex3du4) DescriptorSet 0
+                              MemberDecorate 190(PS_OUTPUT) 1 BuiltIn FragDepth
+                              Decorate 205(g_sSamp) DescriptorSet 0
+                              Decorate 205(g_sSamp) Binding 0
+                              Decorate 208(g_tTexcdf4) DescriptorSet 0
+                              Decorate 211(g_tTexcdi4) DescriptorSet 0
+                              Decorate 214(g_tTexcdu4) DescriptorSet 0
+                              Decorate 217(g_tTex1df4a) DescriptorSet 0
+                              Decorate 220(g_tTex1di4a) DescriptorSet 0
+                              Decorate 223(g_tTex1du4a) DescriptorSet 0
+                              Decorate 226(g_tTex2df4a) DescriptorSet 0
+                              Decorate 229(g_tTex2di4a) DescriptorSet 0
+                              Decorate 232(g_tTex2du4a) DescriptorSet 0
+                              Decorate 235(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 238(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 241(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -465,85 +729,95 @@ gl_FragCoord origin is upper left
               39:             TypePointer UniformConstant 38
   40(g_tTex1du4):     39(ptr) Variable UniformConstant
               47:             TypeVector 15(int) 4
-              49:             TypeImage 6(float) 2D sampled format:Unknown
-              50:             TypePointer UniformConstant 49
-  51(g_tTex2df4):     50(ptr) Variable UniformConstant
-              53:             TypeVector 11(int) 3
-              54:             TypePointer UniformConstant 53(ivec3)
-          55(c3):     54(ptr) Variable UniformConstant
-              58:     15(int) Constant 2
-          61(o2):     13(ptr) Variable UniformConstant
-              64:             TypeImage 11(int) 2D sampled format:Unknown
-              65:             TypePointer UniformConstant 64
-  66(g_tTex2di4):     65(ptr) Variable UniformConstant
-              74:             TypeImage 15(int) 2D sampled format:Unknown
+              50:             TypeVector 15(int) 2
+              51:             TypePointer UniformConstant 50(ivec2)
+         52(uc2):     51(ptr) Variable UniformConstant
+              53:             TypePointer UniformConstant 15(int)
+              74:             TypeImage 6(float) 2D sampled format:Unknown
               75:             TypePointer UniformConstant 74
-  76(g_tTex2du4):     75(ptr) Variable UniformConstant
-              84:             TypeImage 6(float) 3D sampled format:Unknown
-              85:             TypePointer UniformConstant 84
-  86(g_tTex3df4):     85(ptr) Variable UniformConstant
-              88:             TypePointer UniformConstant 36(ivec4)
-          89(c4):     88(ptr) Variable UniformConstant
-              92:     15(int) Constant 3
-          95(o3):     54(ptr) Variable UniformConstant
-              98:             TypeImage 11(int) 3D sampled format:Unknown
-              99:             TypePointer UniformConstant 98
- 100(g_tTex3di4):     99(ptr) Variable UniformConstant
-             108:             TypeImage 15(int) 3D sampled format:Unknown
-             109:             TypePointer UniformConstant 108
- 110(g_tTex3du4):    109(ptr) Variable UniformConstant
-  118(PS_OUTPUT):             TypeStruct 25(fvec4) 6(float)
-             119:             TypePointer Function 118(PS_OUTPUT)
-             121:     11(int) Constant 0
-             122:    6(float) Constant 1065353216
-             123:   25(fvec4) ConstantComposite 122 122 122 122
-             124:             TypePointer Function 25(fvec4)
-             126:     11(int) Constant 1
-             127:             TypePointer Function 6(float)
-             131:             TypeSampler
-             132:             TypePointer UniformConstant 131
-    133(g_sSamp):    132(ptr) Variable UniformConstant
-             134:             TypeImage 6(float) Cube sampled format:Unknown
-             135:             TypePointer UniformConstant 134
- 136(g_tTexcdf4):    135(ptr) Variable UniformConstant
-             137:             TypeImage 11(int) Cube sampled format:Unknown
-             138:             TypePointer UniformConstant 137
- 139(g_tTexcdi4):    138(ptr) Variable UniformConstant
-             140:             TypeImage 15(int) Cube sampled format:Unknown
-             141:             TypePointer UniformConstant 140
- 142(g_tTexcdu4):    141(ptr) Variable UniformConstant
-             143:             TypeImage 6(float) 1D array sampled format:Unknown
-             144:             TypePointer UniformConstant 143
-145(g_tTex1df4a):    144(ptr) Variable UniformConstant
-             146:             TypeImage 11(int) 1D array sampled format:Unknown
-             147:             TypePointer UniformConstant 146
-148(g_tTex1di4a):    147(ptr) Variable UniformConstant
-             149:             TypeImage 15(int) 1D array sampled format:Unknown
-             150:             TypePointer UniformConstant 149
-151(g_tTex1du4a):    150(ptr) Variable UniformConstant
-             152:             TypeImage 6(float) 2D array sampled format:Unknown
-             153:             TypePointer UniformConstant 152
-154(g_tTex2df4a):    153(ptr) Variable UniformConstant
-             155:             TypeImage 11(int) 2D array sampled format:Unknown
-             156:             TypePointer UniformConstant 155
-157(g_tTex2di4a):    156(ptr) Variable UniformConstant
-             158:             TypeImage 15(int) 2D array sampled format:Unknown
-             159:             TypePointer UniformConstant 158
-160(g_tTex2du4a):    159(ptr) Variable UniformConstant
-             161:             TypeImage 6(float) Cube array sampled format:Unknown
-             162:             TypePointer UniformConstant 161
-163(g_tTexcdf4a):    162(ptr) Variable UniformConstant
-             164:             TypeImage 11(int) Cube array sampled format:Unknown
-             165:             TypePointer UniformConstant 164
-166(g_tTexcdi4a):    165(ptr) Variable UniformConstant
-             167:             TypeImage 15(int) Cube array sampled format:Unknown
-             168:             TypePointer UniformConstant 167
-169(g_tTexcdu4a):    168(ptr) Variable UniformConstant
-         170(c1):     17(ptr) Variable UniformConstant
-         171(o4):     88(ptr) Variable UniformConstant
+  76(g_tTex2df4):     75(ptr) Variable UniformConstant
+              78:             TypeVector 11(int) 3
+              79:             TypePointer UniformConstant 78(ivec3)
+          80(c3):     79(ptr) Variable UniformConstant
+              83:     15(int) Constant 2
+          86(o2):     13(ptr) Variable UniformConstant
+              89:             TypeImage 11(int) 2D sampled format:Unknown
+              90:             TypePointer UniformConstant 89
+  91(g_tTex2di4):     90(ptr) Variable UniformConstant
+              99:             TypeImage 15(int) 2D sampled format:Unknown
+             100:             TypePointer UniformConstant 99
+ 101(g_tTex2du4):    100(ptr) Variable UniformConstant
+             110:             TypeVector 15(int) 3
+             111:             TypePointer UniformConstant 110(ivec3)
+        112(uc3):    111(ptr) Variable UniformConstant
+             133:             TypeImage 6(float) 3D sampled format:Unknown
+             134:             TypePointer UniformConstant 133
+ 135(g_tTex3df4):    134(ptr) Variable UniformConstant
+             137:             TypePointer UniformConstant 36(ivec4)
+         138(c4):    137(ptr) Variable UniformConstant
+             141:     15(int) Constant 3
+         144(o3):     79(ptr) Variable UniformConstant
+             147:             TypeImage 11(int) 3D sampled format:Unknown
+             148:             TypePointer UniformConstant 147
+ 149(g_tTex3di4):    148(ptr) Variable UniformConstant
+             157:             TypeImage 15(int) 3D sampled format:Unknown
+             158:             TypePointer UniformConstant 157
+ 159(g_tTex3du4):    158(ptr) Variable UniformConstant
+             168:             TypePointer UniformConstant 47(ivec4)
+        169(uc4):    168(ptr) Variable UniformConstant
+  190(PS_OUTPUT):             TypeStruct 25(fvec4) 6(float)
+             191:             TypePointer Function 190(PS_OUTPUT)
+             193:     11(int) Constant 0
+             194:    6(float) Constant 1065353216
+             195:   25(fvec4) ConstantComposite 194 194 194 194
+             196:             TypePointer Function 25(fvec4)
+             198:     11(int) Constant 1
+             199:             TypePointer Function 6(float)
+             203:             TypeSampler
+             204:             TypePointer UniformConstant 203
+    205(g_sSamp):    204(ptr) Variable UniformConstant
+             206:             TypeImage 6(float) Cube sampled format:Unknown
+             207:             TypePointer UniformConstant 206
+ 208(g_tTexcdf4):    207(ptr) Variable UniformConstant
+             209:             TypeImage 11(int) Cube sampled format:Unknown
+             210:             TypePointer UniformConstant 209
+ 211(g_tTexcdi4):    210(ptr) Variable UniformConstant
+             212:             TypeImage 15(int) Cube sampled format:Unknown
+             213:             TypePointer UniformConstant 212
+ 214(g_tTexcdu4):    213(ptr) Variable UniformConstant
+             215:             TypeImage 6(float) 1D array sampled format:Unknown
+             216:             TypePointer UniformConstant 215
+217(g_tTex1df4a):    216(ptr) Variable UniformConstant
+             218:             TypeImage 11(int) 1D array sampled format:Unknown
+             219:             TypePointer UniformConstant 218
+220(g_tTex1di4a):    219(ptr) Variable UniformConstant
+             221:             TypeImage 15(int) 1D array sampled format:Unknown
+             222:             TypePointer UniformConstant 221
+223(g_tTex1du4a):    222(ptr) Variable UniformConstant
+             224:             TypeImage 6(float) 2D array sampled format:Unknown
+             225:             TypePointer UniformConstant 224
+226(g_tTex2df4a):    225(ptr) Variable UniformConstant
+             227:             TypeImage 11(int) 2D array sampled format:Unknown
+             228:             TypePointer UniformConstant 227
+229(g_tTex2di4a):    228(ptr) Variable UniformConstant
+             230:             TypeImage 15(int) 2D array sampled format:Unknown
+             231:             TypePointer UniformConstant 230
+232(g_tTex2du4a):    231(ptr) Variable UniformConstant
+             233:             TypeImage 6(float) Cube array sampled format:Unknown
+             234:             TypePointer UniformConstant 233
+235(g_tTexcdf4a):    234(ptr) Variable UniformConstant
+             236:             TypeImage 11(int) Cube array sampled format:Unknown
+             237:             TypePointer UniformConstant 236
+238(g_tTexcdi4a):    237(ptr) Variable UniformConstant
+             239:             TypeImage 15(int) Cube array sampled format:Unknown
+             240:             TypePointer UniformConstant 239
+241(g_tTexcdu4a):    240(ptr) Variable UniformConstant
+         242(c1):     17(ptr) Variable UniformConstant
+        243(uc1):     53(ptr) Variable UniformConstant
+         244(o4):    137(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
-      120(psout):    119(ptr) Variable Function
+      192(psout):    191(ptr) Variable Function
               10:           7 Load 9(g_tTex1df4)
               18:     17(ptr) AccessChain 14(c2) 16
               19:     11(int) Load 18
@@ -565,52 +839,115 @@ gl_FragCoord origin is upper left
               45:     11(int) Load 44
               46:     11(int) Load 23(o1)
               48:   47(ivec4) ImageFetch 41 43 Lod Offset 45 46
-              52:          49 Load 51(g_tTex2df4)
-              56:   53(ivec3) Load 55(c3)
-              57:   12(ivec2) VectorShuffle 56 56 0 1
-              59:     17(ptr) AccessChain 55(c3) 58
-              60:     11(int) Load 59
-              62:   12(ivec2) Load 61(o2)
-              63:   25(fvec4) ImageFetch 52 57 Lod Offset 60 62
-              67:          64 Load 66(g_tTex2di4)
-              68:   53(ivec3) Load 55(c3)
-              69:   12(ivec2) VectorShuffle 68 68 0 1
-              70:     17(ptr) AccessChain 55(c3) 58
-              71:     11(int) Load 70
-              72:   12(ivec2) Load 61(o2)
-              73:   36(ivec4) ImageFetch 67 69 Lod Offset 71 72
-              77:          74 Load 76(g_tTex2du4)
-              78:   53(ivec3) Load 55(c3)
-              79:   12(ivec2) VectorShuffle 78 78 0 1
-              80:     17(ptr) AccessChain 55(c3) 58
-              81:     11(int) Load 80
-              82:   12(ivec2) Load 61(o2)
-              83:   47(ivec4) ImageFetch 77 79 Lod Offset 81 82
-              87:          84 Load 86(g_tTex3df4)
-              90:   36(ivec4) Load 89(c4)
-              91:   53(ivec3) VectorShuffle 90 90 0 1 2
-              93:     17(ptr) AccessChain 89(c4) 92
-              94:     11(int) Load 93
-              96:   53(ivec3) Load 95(o3)
-              97:   25(fvec4) ImageFetch 87 91 Lod Offset 94 96
-             101:          98 Load 100(g_tTex3di4)
-             102:   36(ivec4) Load 89(c4)
-             103:   53(ivec3) VectorShuffle 102 102 0 1 2
-             104:     17(ptr) AccessChain 89(c4) 92
-             105:     11(int) Load 104
-             106:   53(ivec3) Load 95(o3)
-             107:   36(ivec4) ImageFetch 101 103 Lod Offset 105 106
-             111:         108 Load 110(g_tTex3du4)
-             112:   36(ivec4) Load 89(c4)
-             113:   53(ivec3) VectorShuffle 112 112 0 1 2
-             114:     17(ptr) AccessChain 89(c4) 92
-             115:     11(int) Load 114
-             116:   53(ivec3) Load 95(o3)
-             117:   47(ivec4) ImageFetch 111 113 Lod Offset 115 116
-             125:    124(ptr) AccessChain 120(psout) 121
-                              Store 125 123
-             128:    127(ptr) AccessChain 120(psout) 126
-                              Store 128 122
-             129:118(PS_OUTPUT) Load 120(psout)
-                              ReturnValue 129
+              49:           7 Load 9(g_tTex1df4)
+              54:     53(ptr) AccessChain 52(uc2) 16
+              55:     15(int) Load 54
+              56:     53(ptr) AccessChain 52(uc2) 20
+              57:     15(int) Load 56
+              58:     11(int) Load 23(o1)
+              59:   25(fvec4) ImageFetch 49 55 Lod Offset 57 58
+              60:          27 Load 29(g_tTex1di4)
+              61:     53(ptr) AccessChain 52(uc2) 16
+              62:     15(int) Load 61
+              63:     53(ptr) AccessChain 52(uc2) 20
+              64:     15(int) Load 63
+              65:     11(int) Load 23(o1)
+              66:   36(ivec4) ImageFetch 60 62 Lod Offset 64 65
+              67:          38 Load 40(g_tTex1du4)
+              68:     53(ptr) AccessChain 52(uc2) 16
+              69:     15(int) Load 68
+              70:     53(ptr) AccessChain 52(uc2) 20
+              71:     15(int) Load 70
+              72:     11(int) Load 23(o1)
+              73:   47(ivec4) ImageFetch 67 69 Lod Offset 71 72
+              77:          74 Load 76(g_tTex2df4)
+              81:   78(ivec3) Load 80(c3)
+              82:   12(ivec2) VectorShuffle 81 81 0 1
+              84:     17(ptr) AccessChain 80(c3) 83
+              85:     11(int) Load 84
+              87:   12(ivec2) Load 86(o2)
+              88:   25(fvec4) ImageFetch 77 82 Lod Offset 85 87
+              92:          89 Load 91(g_tTex2di4)
+              93:   78(ivec3) Load 80(c3)
+              94:   12(ivec2) VectorShuffle 93 93 0 1
+              95:     17(ptr) AccessChain 80(c3) 83
+              96:     11(int) Load 95
+              97:   12(ivec2) Load 86(o2)
+              98:   36(ivec4) ImageFetch 92 94 Lod Offset 96 97
+             102:          99 Load 101(g_tTex2du4)
+             103:   78(ivec3) Load 80(c3)
+             104:   12(ivec2) VectorShuffle 103 103 0 1
+             105:     17(ptr) AccessChain 80(c3) 83
+             106:     11(int) Load 105
+             107:   12(ivec2) Load 86(o2)
+             108:   47(ivec4) ImageFetch 102 104 Lod Offset 106 107
+             109:          74 Load 76(g_tTex2df4)
+             113:  110(ivec3) Load 112(uc3)
+             114:   50(ivec2) VectorShuffle 113 113 0 1
+             115:     53(ptr) AccessChain 112(uc3) 83
+             116:     15(int) Load 115
+             117:   12(ivec2) Load 86(o2)
+             118:   25(fvec4) ImageFetch 109 114 Lod Offset 116 117
+             119:          89 Load 91(g_tTex2di4)
+             120:  110(ivec3) Load 112(uc3)
+             121:   50(ivec2) VectorShuffle 120 120 0 1
+             122:     53(ptr) AccessChain 112(uc3) 83
+             123:     15(int) Load 122
+             124:   12(ivec2) Load 86(o2)
+             125:   36(ivec4) ImageFetch 119 121 Lod Offset 123 124
+             126:          99 Load 101(g_tTex2du4)
+             127:  110(ivec3) Load 112(uc3)
+             128:   50(ivec2) VectorShuffle 127 127 0 1
+             129:     53(ptr) AccessChain 112(uc3) 83
+             130:     15(int) Load 129
+             131:   12(ivec2) Load 86(o2)
+             132:   47(ivec4) ImageFetch 126 128 Lod Offset 130 131
+             136:         133 Load 135(g_tTex3df4)
+             139:   36(ivec4) Load 138(c4)
+             140:   78(ivec3) VectorShuffle 139 139 0 1 2
+             142:     17(ptr) AccessChain 138(c4) 141
+             143:     11(int) Load 142
+             145:   78(ivec3) Load 144(o3)
+             146:   25(fvec4) ImageFetch 136 140 Lod Offset 143 145
+             150:         147 Load 149(g_tTex3di4)
+             151:   36(ivec4) Load 138(c4)
+             152:   78(ivec3) VectorShuffle 151 151 0 1 2
+             153:     17(ptr) AccessChain 138(c4) 141
+             154:     11(int) Load 153
+             155:   78(ivec3) Load 144(o3)
+             156:   36(ivec4) ImageFetch 150 152 Lod Offset 154 155
+             160:         157 Load 159(g_tTex3du4)
+             161:   36(ivec4) Load 138(c4)
+             162:   78(ivec3) VectorShuffle 161 161 0 1 2
+             163:     17(ptr) AccessChain 138(c4) 141
+             164:     11(int) Load 163
+             165:   78(ivec3) Load 144(o3)
+             166:   47(ivec4) ImageFetch 160 162 Lod Offset 164 165
+             167:         133 Load 135(g_tTex3df4)
+             170:   47(ivec4) Load 169(uc4)
+             171:  110(ivec3) VectorShuffle 170 170 0 1 2
+             172:     53(ptr) AccessChain 169(uc4) 141
+             173:     15(int) Load 172
+             174:   78(ivec3) Load 144(o3)
+             175:   25(fvec4) ImageFetch 167 171 Lod Offset 173 174
+             176:         147 Load 149(g_tTex3di4)
+             177:   47(ivec4) Load 169(uc4)
+             178:  110(ivec3) VectorShuffle 177 177 0 1 2
+             179:     53(ptr) AccessChain 169(uc4) 141
+             180:     15(int) Load 179
+             181:   78(ivec3) Load 144(o3)
+             182:   36(ivec4) ImageFetch 176 178 Lod Offset 180 181
+             183:         157 Load 159(g_tTex3du4)
+             184:   47(ivec4) Load 169(uc4)
+             185:  110(ivec3) VectorShuffle 184 184 0 1 2
+             186:     53(ptr) AccessChain 169(uc4) 141
+             187:     15(int) Load 186
+             188:   78(ivec3) Load 144(o3)
+             189:   47(ivec4) ImageFetch 183 185 Lod Offset 187 188
+             197:    196(ptr) AccessChain 192(psout) 193
+                              Store 197 195
+             200:    199(ptr) AccessChain 192(psout) 198
+                              Store 200 194
+             201:190(PS_OUTPUT) Load 192(psout)
+                              ReturnValue 201
                               FunctionEnd

--- a/Test/baseResults/hlsl.load.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.offsetarray.dx10.frag.out
@@ -2,118 +2,208 @@ hlsl.load.offsetarray.dx10.frag
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:70  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:48    Function Parameters: 
+0:81  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:53    Function Parameters: 
 0:?     Sequence
-0:52      textureFetchOffset (global 4-component vector of float)
-0:52        'g_tTex1df4a' (uniform texture1DArray)
-0:52        vector swizzle (temp 2-component vector of int)
-0:52          'c3' (uniform 3-component vector of int)
-0:52          Sequence
-0:52            Constant:
-0:52              0 (const int)
-0:52            Constant:
-0:52              1 (const int)
-0:52        direct index (temp int)
-0:52          'c3' (uniform 3-component vector of int)
-0:52          Constant:
-0:52            2 (const int)
-0:52        'o1' (uniform int)
-0:53      textureFetchOffset (global 4-component vector of int)
-0:53        'g_tTex1di4a' (uniform itexture1DArray)
-0:53        vector swizzle (temp 2-component vector of int)
-0:53          'c3' (uniform 3-component vector of int)
-0:53          Sequence
-0:53            Constant:
-0:53              0 (const int)
-0:53            Constant:
-0:53              1 (const int)
-0:53        direct index (temp int)
-0:53          'c3' (uniform 3-component vector of int)
-0:53          Constant:
-0:53            2 (const int)
-0:53        'o1' (uniform int)
-0:54      textureFetchOffset (global 4-component vector of uint)
-0:54        'g_tTex1du4a' (uniform utexture1DArray)
-0:54        vector swizzle (temp 2-component vector of int)
-0:54          'c3' (uniform 3-component vector of int)
-0:54          Sequence
-0:54            Constant:
-0:54              0 (const int)
-0:54            Constant:
-0:54              1 (const int)
-0:54        direct index (temp int)
-0:54          'c3' (uniform 3-component vector of int)
-0:54          Constant:
-0:54            2 (const int)
-0:54        'o1' (uniform int)
 0:57      textureFetchOffset (global 4-component vector of float)
-0:57        'g_tTex2df4a' (uniform texture2DArray)
-0:57        vector swizzle (temp 3-component vector of int)
-0:57          'c4' (uniform 4-component vector of int)
+0:57        'g_tTex1df4a' (uniform texture1DArray)
+0:57        vector swizzle (temp 2-component vector of int)
+0:57          'c3' (uniform 3-component vector of int)
 0:57          Sequence
 0:57            Constant:
 0:57              0 (const int)
 0:57            Constant:
 0:57              1 (const int)
-0:57            Constant:
-0:57              2 (const int)
 0:57        direct index (temp int)
-0:57          'c4' (uniform 4-component vector of int)
+0:57          'c3' (uniform 3-component vector of int)
 0:57          Constant:
-0:57            3 (const int)
-0:57        'o2' (uniform 2-component vector of int)
+0:57            2 (const int)
+0:57        'o1' (uniform int)
 0:58      textureFetchOffset (global 4-component vector of int)
-0:58        'g_tTex2di4a' (uniform itexture2DArray)
-0:58        vector swizzle (temp 3-component vector of int)
-0:58          'c4' (uniform 4-component vector of int)
+0:58        'g_tTex1di4a' (uniform itexture1DArray)
+0:58        vector swizzle (temp 2-component vector of int)
+0:58          'c3' (uniform 3-component vector of int)
 0:58          Sequence
 0:58            Constant:
 0:58              0 (const int)
 0:58            Constant:
 0:58              1 (const int)
-0:58            Constant:
-0:58              2 (const int)
 0:58        direct index (temp int)
-0:58          'c4' (uniform 4-component vector of int)
+0:58          'c3' (uniform 3-component vector of int)
 0:58          Constant:
-0:58            3 (const int)
-0:58        'o2' (uniform 2-component vector of int)
+0:58            2 (const int)
+0:58        'o1' (uniform int)
 0:59      textureFetchOffset (global 4-component vector of uint)
-0:59        'g_tTex2du4a' (uniform utexture2DArray)
-0:59        vector swizzle (temp 3-component vector of int)
-0:59          'c4' (uniform 4-component vector of int)
+0:59        'g_tTex1du4a' (uniform utexture1DArray)
+0:59        vector swizzle (temp 2-component vector of int)
+0:59          'c3' (uniform 3-component vector of int)
 0:59          Sequence
 0:59            Constant:
 0:59              0 (const int)
 0:59            Constant:
 0:59              1 (const int)
-0:59            Constant:
-0:59              2 (const int)
 0:59        direct index (temp int)
-0:59          'c4' (uniform 4-component vector of int)
+0:59          'c3' (uniform 3-component vector of int)
 0:59          Constant:
-0:59            3 (const int)
-0:59        'o2' (uniform 2-component vector of int)
-0:65      move second child to first child (temp 4-component vector of float)
-0:65        Color: direct index for structure (temp 4-component vector of float)
-0:65          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:59            2 (const int)
+0:59        'o1' (uniform int)
+0:60      textureFetchOffset (global 4-component vector of float)
+0:60        'g_tTex1df4a' (uniform texture1DArray)
+0:60        vector swizzle (temp 2-component vector of uint)
+0:60          'uc3' (uniform 3-component vector of uint)
+0:60          Sequence
+0:60            Constant:
+0:60              0 (const int)
+0:60            Constant:
+0:60              1 (const int)
+0:60        direct index (temp uint)
+0:60          'uc3' (uniform 3-component vector of uint)
+0:60          Constant:
+0:60            2 (const int)
+0:60        'o1' (uniform int)
+0:61      textureFetchOffset (global 4-component vector of int)
+0:61        'g_tTex1di4a' (uniform itexture1DArray)
+0:61        vector swizzle (temp 2-component vector of uint)
+0:61          'uc3' (uniform 3-component vector of uint)
+0:61          Sequence
+0:61            Constant:
+0:61              0 (const int)
+0:61            Constant:
+0:61              1 (const int)
+0:61        direct index (temp uint)
+0:61          'uc3' (uniform 3-component vector of uint)
+0:61          Constant:
+0:61            2 (const int)
+0:61        'o1' (uniform int)
+0:62      textureFetchOffset (global 4-component vector of uint)
+0:62        'g_tTex1du4a' (uniform utexture1DArray)
+0:62        vector swizzle (temp 2-component vector of uint)
+0:62          'uc3' (uniform 3-component vector of uint)
+0:62          Sequence
+0:62            Constant:
+0:62              0 (const int)
+0:62            Constant:
+0:62              1 (const int)
+0:62        direct index (temp uint)
+0:62          'uc3' (uniform 3-component vector of uint)
+0:62          Constant:
+0:62            2 (const int)
+0:62        'o1' (uniform int)
+0:65      textureFetchOffset (global 4-component vector of float)
+0:65        'g_tTex2df4a' (uniform texture2DArray)
+0:65        vector swizzle (temp 3-component vector of int)
+0:65          'c4' (uniform 4-component vector of int)
+0:65          Sequence
+0:65            Constant:
+0:65              0 (const int)
+0:65            Constant:
+0:65              1 (const int)
+0:65            Constant:
+0:65              2 (const int)
+0:65        direct index (temp int)
+0:65          'c4' (uniform 4-component vector of int)
 0:65          Constant:
-0:65            0 (const int)
-0:65        Constant:
-0:65          1.000000
-0:65          1.000000
-0:65          1.000000
-0:65          1.000000
-0:66      move second child to first child (temp float)
-0:66        Depth: direct index for structure (temp float FragDepth)
-0:66          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:65            3 (const int)
+0:65        'o2' (uniform 2-component vector of int)
+0:66      textureFetchOffset (global 4-component vector of int)
+0:66        'g_tTex2di4a' (uniform itexture2DArray)
+0:66        vector swizzle (temp 3-component vector of int)
+0:66          'c4' (uniform 4-component vector of int)
+0:66          Sequence
+0:66            Constant:
+0:66              0 (const int)
+0:66            Constant:
+0:66              1 (const int)
+0:66            Constant:
+0:66              2 (const int)
+0:66        direct index (temp int)
+0:66          'c4' (uniform 4-component vector of int)
 0:66          Constant:
-0:66            1 (const int)
-0:66        Constant:
-0:66          1.000000
-0:68      Branch: Return with expression
-0:68        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:66            3 (const int)
+0:66        'o2' (uniform 2-component vector of int)
+0:67      textureFetchOffset (global 4-component vector of uint)
+0:67        'g_tTex2du4a' (uniform utexture2DArray)
+0:67        vector swizzle (temp 3-component vector of int)
+0:67          'c4' (uniform 4-component vector of int)
+0:67          Sequence
+0:67            Constant:
+0:67              0 (const int)
+0:67            Constant:
+0:67              1 (const int)
+0:67            Constant:
+0:67              2 (const int)
+0:67        direct index (temp int)
+0:67          'c4' (uniform 4-component vector of int)
+0:67          Constant:
+0:67            3 (const int)
+0:67        'o2' (uniform 2-component vector of int)
+0:68      textureFetchOffset (global 4-component vector of float)
+0:68        'g_tTex2df4a' (uniform texture2DArray)
+0:68        vector swizzle (temp 3-component vector of uint)
+0:68          'uc4' (uniform 4-component vector of uint)
+0:68          Sequence
+0:68            Constant:
+0:68              0 (const int)
+0:68            Constant:
+0:68              1 (const int)
+0:68            Constant:
+0:68              2 (const int)
+0:68        direct index (temp uint)
+0:68          'uc4' (uniform 4-component vector of uint)
+0:68          Constant:
+0:68            3 (const int)
+0:68        'o2' (uniform 2-component vector of int)
+0:69      textureFetchOffset (global 4-component vector of int)
+0:69        'g_tTex2di4a' (uniform itexture2DArray)
+0:69        vector swizzle (temp 3-component vector of uint)
+0:69          'uc4' (uniform 4-component vector of uint)
+0:69          Sequence
+0:69            Constant:
+0:69              0 (const int)
+0:69            Constant:
+0:69              1 (const int)
+0:69            Constant:
+0:69              2 (const int)
+0:69        direct index (temp uint)
+0:69          'uc4' (uniform 4-component vector of uint)
+0:69          Constant:
+0:69            3 (const int)
+0:69        'o2' (uniform 2-component vector of int)
+0:70      textureFetchOffset (global 4-component vector of uint)
+0:70        'g_tTex2du4a' (uniform utexture2DArray)
+0:70        vector swizzle (temp 3-component vector of uint)
+0:70          'uc4' (uniform 4-component vector of uint)
+0:70          Sequence
+0:70            Constant:
+0:70              0 (const int)
+0:70            Constant:
+0:70              1 (const int)
+0:70            Constant:
+0:70              2 (const int)
+0:70        direct index (temp uint)
+0:70          'uc4' (uniform 4-component vector of uint)
+0:70          Constant:
+0:70            3 (const int)
+0:70        'o2' (uniform 2-component vector of int)
+0:76      move second child to first child (temp 4-component vector of float)
+0:76        Color: direct index for structure (temp 4-component vector of float)
+0:76          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:76          Constant:
+0:76            0 (const int)
+0:76        Constant:
+0:76          1.000000
+0:76          1.000000
+0:76          1.000000
+0:76          1.000000
+0:77      move second child to first child (temp float)
+0:77        Depth: direct index for structure (temp float FragDepth)
+0:77          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:77          Constant:
+0:77            1 (const int)
+0:77        Constant:
+0:77          1.000000
+0:79      Branch: Return with expression
+0:79        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
 0:?   Linker Objects
 0:?     'g_sSamp' (layout(binding=0 ) uniform sampler)
 0:?     'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
@@ -141,6 +231,10 @@ gl_FragCoord origin is upper left
 0:?     'c2' (uniform 2-component vector of int)
 0:?     'c3' (uniform 3-component vector of int)
 0:?     'c4' (uniform 4-component vector of int)
+0:?     'uc1' (uniform uint)
+0:?     'uc2' (uniform 2-component vector of uint)
+0:?     'uc3' (uniform 3-component vector of uint)
+0:?     'uc4' (uniform 4-component vector of uint)
 0:?     'o1' (uniform int)
 0:?     'o2' (uniform 2-component vector of int)
 0:?     'o3' (uniform 3-component vector of int)
@@ -153,118 +247,208 @@ Linked fragment stage:
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:70  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
-0:48    Function Parameters: 
+0:81  Function Definition: main( (global structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:53    Function Parameters: 
 0:?     Sequence
-0:52      textureFetchOffset (global 4-component vector of float)
-0:52        'g_tTex1df4a' (uniform texture1DArray)
-0:52        vector swizzle (temp 2-component vector of int)
-0:52          'c3' (uniform 3-component vector of int)
-0:52          Sequence
-0:52            Constant:
-0:52              0 (const int)
-0:52            Constant:
-0:52              1 (const int)
-0:52        direct index (temp int)
-0:52          'c3' (uniform 3-component vector of int)
-0:52          Constant:
-0:52            2 (const int)
-0:52        'o1' (uniform int)
-0:53      textureFetchOffset (global 4-component vector of int)
-0:53        'g_tTex1di4a' (uniform itexture1DArray)
-0:53        vector swizzle (temp 2-component vector of int)
-0:53          'c3' (uniform 3-component vector of int)
-0:53          Sequence
-0:53            Constant:
-0:53              0 (const int)
-0:53            Constant:
-0:53              1 (const int)
-0:53        direct index (temp int)
-0:53          'c3' (uniform 3-component vector of int)
-0:53          Constant:
-0:53            2 (const int)
-0:53        'o1' (uniform int)
-0:54      textureFetchOffset (global 4-component vector of uint)
-0:54        'g_tTex1du4a' (uniform utexture1DArray)
-0:54        vector swizzle (temp 2-component vector of int)
-0:54          'c3' (uniform 3-component vector of int)
-0:54          Sequence
-0:54            Constant:
-0:54              0 (const int)
-0:54            Constant:
-0:54              1 (const int)
-0:54        direct index (temp int)
-0:54          'c3' (uniform 3-component vector of int)
-0:54          Constant:
-0:54            2 (const int)
-0:54        'o1' (uniform int)
 0:57      textureFetchOffset (global 4-component vector of float)
-0:57        'g_tTex2df4a' (uniform texture2DArray)
-0:57        vector swizzle (temp 3-component vector of int)
-0:57          'c4' (uniform 4-component vector of int)
+0:57        'g_tTex1df4a' (uniform texture1DArray)
+0:57        vector swizzle (temp 2-component vector of int)
+0:57          'c3' (uniform 3-component vector of int)
 0:57          Sequence
 0:57            Constant:
 0:57              0 (const int)
 0:57            Constant:
 0:57              1 (const int)
-0:57            Constant:
-0:57              2 (const int)
 0:57        direct index (temp int)
-0:57          'c4' (uniform 4-component vector of int)
+0:57          'c3' (uniform 3-component vector of int)
 0:57          Constant:
-0:57            3 (const int)
-0:57        'o2' (uniform 2-component vector of int)
+0:57            2 (const int)
+0:57        'o1' (uniform int)
 0:58      textureFetchOffset (global 4-component vector of int)
-0:58        'g_tTex2di4a' (uniform itexture2DArray)
-0:58        vector swizzle (temp 3-component vector of int)
-0:58          'c4' (uniform 4-component vector of int)
+0:58        'g_tTex1di4a' (uniform itexture1DArray)
+0:58        vector swizzle (temp 2-component vector of int)
+0:58          'c3' (uniform 3-component vector of int)
 0:58          Sequence
 0:58            Constant:
 0:58              0 (const int)
 0:58            Constant:
 0:58              1 (const int)
-0:58            Constant:
-0:58              2 (const int)
 0:58        direct index (temp int)
-0:58          'c4' (uniform 4-component vector of int)
+0:58          'c3' (uniform 3-component vector of int)
 0:58          Constant:
-0:58            3 (const int)
-0:58        'o2' (uniform 2-component vector of int)
+0:58            2 (const int)
+0:58        'o1' (uniform int)
 0:59      textureFetchOffset (global 4-component vector of uint)
-0:59        'g_tTex2du4a' (uniform utexture2DArray)
-0:59        vector swizzle (temp 3-component vector of int)
-0:59          'c4' (uniform 4-component vector of int)
+0:59        'g_tTex1du4a' (uniform utexture1DArray)
+0:59        vector swizzle (temp 2-component vector of int)
+0:59          'c3' (uniform 3-component vector of int)
 0:59          Sequence
 0:59            Constant:
 0:59              0 (const int)
 0:59            Constant:
 0:59              1 (const int)
-0:59            Constant:
-0:59              2 (const int)
 0:59        direct index (temp int)
-0:59          'c4' (uniform 4-component vector of int)
+0:59          'c3' (uniform 3-component vector of int)
 0:59          Constant:
-0:59            3 (const int)
-0:59        'o2' (uniform 2-component vector of int)
-0:65      move second child to first child (temp 4-component vector of float)
-0:65        Color: direct index for structure (temp 4-component vector of float)
-0:65          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:59            2 (const int)
+0:59        'o1' (uniform int)
+0:60      textureFetchOffset (global 4-component vector of float)
+0:60        'g_tTex1df4a' (uniform texture1DArray)
+0:60        vector swizzle (temp 2-component vector of uint)
+0:60          'uc3' (uniform 3-component vector of uint)
+0:60          Sequence
+0:60            Constant:
+0:60              0 (const int)
+0:60            Constant:
+0:60              1 (const int)
+0:60        direct index (temp uint)
+0:60          'uc3' (uniform 3-component vector of uint)
+0:60          Constant:
+0:60            2 (const int)
+0:60        'o1' (uniform int)
+0:61      textureFetchOffset (global 4-component vector of int)
+0:61        'g_tTex1di4a' (uniform itexture1DArray)
+0:61        vector swizzle (temp 2-component vector of uint)
+0:61          'uc3' (uniform 3-component vector of uint)
+0:61          Sequence
+0:61            Constant:
+0:61              0 (const int)
+0:61            Constant:
+0:61              1 (const int)
+0:61        direct index (temp uint)
+0:61          'uc3' (uniform 3-component vector of uint)
+0:61          Constant:
+0:61            2 (const int)
+0:61        'o1' (uniform int)
+0:62      textureFetchOffset (global 4-component vector of uint)
+0:62        'g_tTex1du4a' (uniform utexture1DArray)
+0:62        vector swizzle (temp 2-component vector of uint)
+0:62          'uc3' (uniform 3-component vector of uint)
+0:62          Sequence
+0:62            Constant:
+0:62              0 (const int)
+0:62            Constant:
+0:62              1 (const int)
+0:62        direct index (temp uint)
+0:62          'uc3' (uniform 3-component vector of uint)
+0:62          Constant:
+0:62            2 (const int)
+0:62        'o1' (uniform int)
+0:65      textureFetchOffset (global 4-component vector of float)
+0:65        'g_tTex2df4a' (uniform texture2DArray)
+0:65        vector swizzle (temp 3-component vector of int)
+0:65          'c4' (uniform 4-component vector of int)
+0:65          Sequence
+0:65            Constant:
+0:65              0 (const int)
+0:65            Constant:
+0:65              1 (const int)
+0:65            Constant:
+0:65              2 (const int)
+0:65        direct index (temp int)
+0:65          'c4' (uniform 4-component vector of int)
 0:65          Constant:
-0:65            0 (const int)
-0:65        Constant:
-0:65          1.000000
-0:65          1.000000
-0:65          1.000000
-0:65          1.000000
-0:66      move second child to first child (temp float)
-0:66        Depth: direct index for structure (temp float FragDepth)
-0:66          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:65            3 (const int)
+0:65        'o2' (uniform 2-component vector of int)
+0:66      textureFetchOffset (global 4-component vector of int)
+0:66        'g_tTex2di4a' (uniform itexture2DArray)
+0:66        vector swizzle (temp 3-component vector of int)
+0:66          'c4' (uniform 4-component vector of int)
+0:66          Sequence
+0:66            Constant:
+0:66              0 (const int)
+0:66            Constant:
+0:66              1 (const int)
+0:66            Constant:
+0:66              2 (const int)
+0:66        direct index (temp int)
+0:66          'c4' (uniform 4-component vector of int)
 0:66          Constant:
-0:66            1 (const int)
-0:66        Constant:
-0:66          1.000000
-0:68      Branch: Return with expression
-0:68        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:66            3 (const int)
+0:66        'o2' (uniform 2-component vector of int)
+0:67      textureFetchOffset (global 4-component vector of uint)
+0:67        'g_tTex2du4a' (uniform utexture2DArray)
+0:67        vector swizzle (temp 3-component vector of int)
+0:67          'c4' (uniform 4-component vector of int)
+0:67          Sequence
+0:67            Constant:
+0:67              0 (const int)
+0:67            Constant:
+0:67              1 (const int)
+0:67            Constant:
+0:67              2 (const int)
+0:67        direct index (temp int)
+0:67          'c4' (uniform 4-component vector of int)
+0:67          Constant:
+0:67            3 (const int)
+0:67        'o2' (uniform 2-component vector of int)
+0:68      textureFetchOffset (global 4-component vector of float)
+0:68        'g_tTex2df4a' (uniform texture2DArray)
+0:68        vector swizzle (temp 3-component vector of uint)
+0:68          'uc4' (uniform 4-component vector of uint)
+0:68          Sequence
+0:68            Constant:
+0:68              0 (const int)
+0:68            Constant:
+0:68              1 (const int)
+0:68            Constant:
+0:68              2 (const int)
+0:68        direct index (temp uint)
+0:68          'uc4' (uniform 4-component vector of uint)
+0:68          Constant:
+0:68            3 (const int)
+0:68        'o2' (uniform 2-component vector of int)
+0:69      textureFetchOffset (global 4-component vector of int)
+0:69        'g_tTex2di4a' (uniform itexture2DArray)
+0:69        vector swizzle (temp 3-component vector of uint)
+0:69          'uc4' (uniform 4-component vector of uint)
+0:69          Sequence
+0:69            Constant:
+0:69              0 (const int)
+0:69            Constant:
+0:69              1 (const int)
+0:69            Constant:
+0:69              2 (const int)
+0:69        direct index (temp uint)
+0:69          'uc4' (uniform 4-component vector of uint)
+0:69          Constant:
+0:69            3 (const int)
+0:69        'o2' (uniform 2-component vector of int)
+0:70      textureFetchOffset (global 4-component vector of uint)
+0:70        'g_tTex2du4a' (uniform utexture2DArray)
+0:70        vector swizzle (temp 3-component vector of uint)
+0:70          'uc4' (uniform 4-component vector of uint)
+0:70          Sequence
+0:70            Constant:
+0:70              0 (const int)
+0:70            Constant:
+0:70              1 (const int)
+0:70            Constant:
+0:70              2 (const int)
+0:70        direct index (temp uint)
+0:70          'uc4' (uniform 4-component vector of uint)
+0:70          Constant:
+0:70            3 (const int)
+0:70        'o2' (uniform 2-component vector of int)
+0:76      move second child to first child (temp 4-component vector of float)
+0:76        Color: direct index for structure (temp 4-component vector of float)
+0:76          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:76          Constant:
+0:76            0 (const int)
+0:76        Constant:
+0:76          1.000000
+0:76          1.000000
+0:76          1.000000
+0:76          1.000000
+0:77      move second child to first child (temp float)
+0:77        Depth: direct index for structure (temp float FragDepth)
+0:77          'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
+0:77          Constant:
+0:77            1 (const int)
+0:77        Constant:
+0:77          1.000000
+0:79      Branch: Return with expression
+0:79        'psout' (temp structure{temp 4-component vector of float Color, temp float FragDepth Depth})
 0:?   Linker Objects
 0:?     'g_sSamp' (layout(binding=0 ) uniform sampler)
 0:?     'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
@@ -292,6 +476,10 @@ gl_FragCoord origin is upper left
 0:?     'c2' (uniform 2-component vector of int)
 0:?     'c3' (uniform 3-component vector of int)
 0:?     'c4' (uniform 4-component vector of int)
+0:?     'uc1' (uniform uint)
+0:?     'uc2' (uniform 2-component vector of uint)
+0:?     'uc3' (uniform 3-component vector of uint)
+0:?     'uc4' (uniform 4-component vector of uint)
 0:?     'o1' (uniform int)
 0:?     'o2' (uniform 2-component vector of int)
 0:?     'o3' (uniform 3-component vector of int)
@@ -299,7 +487,7 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 149
+// Id's are bound by 201
 
                               Capability Shader
                               Capability ImageGatherExtended
@@ -315,60 +503,64 @@ gl_FragCoord origin is upper left
                               Name 23  "o1"
                               Name 29  "g_tTex1di4a"
                               Name 40  "g_tTex1du4a"
-                              Name 51  "g_tTex2df4a"
-                              Name 54  "c4"
-                              Name 61  "o2"
-                              Name 66  "g_tTex2di4a"
-                              Name 76  "g_tTex2du4a"
-                              Name 84  "PS_OUTPUT"
-                              MemberName 84(PS_OUTPUT) 0  "Color"
-                              MemberName 84(PS_OUTPUT) 1  "Depth"
-                              Name 86  "psout"
-                              Name 99  "g_sSamp"
-                              Name 102  "g_tTex1df4"
-                              Name 105  "g_tTex1di4"
-                              Name 108  "g_tTex1du4"
-                              Name 111  "g_tTex2df4"
-                              Name 114  "g_tTex2di4"
-                              Name 117  "g_tTex2du4"
-                              Name 120  "g_tTex3df4"
-                              Name 123  "g_tTex3di4"
-                              Name 126  "g_tTex3du4"
-                              Name 129  "g_tTexcdf4"
-                              Name 132  "g_tTexcdi4"
-                              Name 135  "g_tTexcdu4"
-                              Name 138  "g_tTexcdf4a"
-                              Name 141  "g_tTexcdi4a"
-                              Name 144  "g_tTexcdu4a"
-                              Name 145  "c1"
-                              Name 146  "c2"
-                              Name 147  "o3"
-                              Name 148  "o4"
+                              Name 52  "uc3"
+                              Name 77  "g_tTex2df4a"
+                              Name 80  "c4"
+                              Name 87  "o2"
+                              Name 92  "g_tTex2di4a"
+                              Name 102  "g_tTex2du4a"
+                              Name 112  "uc4"
+                              Name 133  "PS_OUTPUT"
+                              MemberName 133(PS_OUTPUT) 0  "Color"
+                              MemberName 133(PS_OUTPUT) 1  "Depth"
+                              Name 135  "psout"
+                              Name 148  "g_sSamp"
+                              Name 151  "g_tTex1df4"
+                              Name 154  "g_tTex1di4"
+                              Name 157  "g_tTex1du4"
+                              Name 160  "g_tTex2df4"
+                              Name 163  "g_tTex2di4"
+                              Name 166  "g_tTex2du4"
+                              Name 169  "g_tTex3df4"
+                              Name 172  "g_tTex3di4"
+                              Name 175  "g_tTex3du4"
+                              Name 178  "g_tTexcdf4"
+                              Name 181  "g_tTexcdi4"
+                              Name 184  "g_tTexcdu4"
+                              Name 187  "g_tTexcdf4a"
+                              Name 190  "g_tTexcdi4a"
+                              Name 193  "g_tTexcdu4a"
+                              Name 194  "c1"
+                              Name 195  "c2"
+                              Name 196  "uc1"
+                              Name 198  "uc2"
+                              Name 199  "o3"
+                              Name 200  "o4"
                               Decorate 9(g_tTex1df4a) DescriptorSet 0
                               Decorate 29(g_tTex1di4a) DescriptorSet 0
                               Decorate 40(g_tTex1du4a) DescriptorSet 0
-                              Decorate 51(g_tTex2df4a) DescriptorSet 0
-                              Decorate 66(g_tTex2di4a) DescriptorSet 0
-                              Decorate 76(g_tTex2du4a) DescriptorSet 0
-                              MemberDecorate 84(PS_OUTPUT) 1 BuiltIn FragDepth
-                              Decorate 99(g_sSamp) DescriptorSet 0
-                              Decorate 99(g_sSamp) Binding 0
-                              Decorate 102(g_tTex1df4) DescriptorSet 0
-                              Decorate 102(g_tTex1df4) Binding 0
-                              Decorate 105(g_tTex1di4) DescriptorSet 0
-                              Decorate 108(g_tTex1du4) DescriptorSet 0
-                              Decorate 111(g_tTex2df4) DescriptorSet 0
-                              Decorate 114(g_tTex2di4) DescriptorSet 0
-                              Decorate 117(g_tTex2du4) DescriptorSet 0
-                              Decorate 120(g_tTex3df4) DescriptorSet 0
-                              Decorate 123(g_tTex3di4) DescriptorSet 0
-                              Decorate 126(g_tTex3du4) DescriptorSet 0
-                              Decorate 129(g_tTexcdf4) DescriptorSet 0
-                              Decorate 132(g_tTexcdi4) DescriptorSet 0
-                              Decorate 135(g_tTexcdu4) DescriptorSet 0
-                              Decorate 138(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 141(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 144(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 77(g_tTex2df4a) DescriptorSet 0
+                              Decorate 92(g_tTex2di4a) DescriptorSet 0
+                              Decorate 102(g_tTex2du4a) DescriptorSet 0
+                              MemberDecorate 133(PS_OUTPUT) 1 BuiltIn FragDepth
+                              Decorate 148(g_sSamp) DescriptorSet 0
+                              Decorate 148(g_sSamp) Binding 0
+                              Decorate 151(g_tTex1df4) DescriptorSet 0
+                              Decorate 151(g_tTex1df4) Binding 0
+                              Decorate 154(g_tTex1di4) DescriptorSet 0
+                              Decorate 157(g_tTex1du4) DescriptorSet 0
+                              Decorate 160(g_tTex2df4) DescriptorSet 0
+                              Decorate 163(g_tTex2di4) DescriptorSet 0
+                              Decorate 166(g_tTex2du4) DescriptorSet 0
+                              Decorate 169(g_tTex3df4) DescriptorSet 0
+                              Decorate 172(g_tTex3di4) DescriptorSet 0
+                              Decorate 175(g_tTex3du4) DescriptorSet 0
+                              Decorate 178(g_tTexcdf4) DescriptorSet 0
+                              Decorate 181(g_tTexcdi4) DescriptorSet 0
+                              Decorate 184(g_tTexcdu4) DescriptorSet 0
+                              Decorate 187(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 190(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 193(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -393,83 +585,93 @@ gl_FragCoord origin is upper left
               39:             TypePointer UniformConstant 38
  40(g_tTex1du4a):     39(ptr) Variable UniformConstant
               47:             TypeVector 18(int) 4
-              49:             TypeImage 6(float) 2D array sampled format:Unknown
-              50:             TypePointer UniformConstant 49
- 51(g_tTex2df4a):     50(ptr) Variable UniformConstant
-              53:             TypePointer UniformConstant 36(ivec4)
-          54(c4):     53(ptr) Variable UniformConstant
-              57:     18(int) Constant 3
-              60:             TypePointer UniformConstant 15(ivec2)
-          61(o2):     60(ptr) Variable UniformConstant
-              64:             TypeImage 11(int) 2D array sampled format:Unknown
-              65:             TypePointer UniformConstant 64
- 66(g_tTex2di4a):     65(ptr) Variable UniformConstant
-              74:             TypeImage 18(int) 2D array sampled format:Unknown
-              75:             TypePointer UniformConstant 74
- 76(g_tTex2du4a):     75(ptr) Variable UniformConstant
-   84(PS_OUTPUT):             TypeStruct 25(fvec4) 6(float)
-              85:             TypePointer Function 84(PS_OUTPUT)
-              87:     11(int) Constant 0
-              88:    6(float) Constant 1065353216
-              89:   25(fvec4) ConstantComposite 88 88 88 88
-              90:             TypePointer Function 25(fvec4)
-              92:     11(int) Constant 1
-              93:             TypePointer Function 6(float)
-              97:             TypeSampler
-              98:             TypePointer UniformConstant 97
-     99(g_sSamp):     98(ptr) Variable UniformConstant
-             100:             TypeImage 6(float) 1D sampled format:Unknown
+              50:             TypeVector 18(int) 3
+              51:             TypePointer UniformConstant 50(ivec3)
+         52(uc3):     51(ptr) Variable UniformConstant
+              53:             TypeVector 18(int) 2
+              56:             TypePointer UniformConstant 18(int)
+              75:             TypeImage 6(float) 2D array sampled format:Unknown
+              76:             TypePointer UniformConstant 75
+ 77(g_tTex2df4a):     76(ptr) Variable UniformConstant
+              79:             TypePointer UniformConstant 36(ivec4)
+          80(c4):     79(ptr) Variable UniformConstant
+              83:     18(int) Constant 3
+              86:             TypePointer UniformConstant 15(ivec2)
+          87(o2):     86(ptr) Variable UniformConstant
+              90:             TypeImage 11(int) 2D array sampled format:Unknown
+              91:             TypePointer UniformConstant 90
+ 92(g_tTex2di4a):     91(ptr) Variable UniformConstant
+             100:             TypeImage 18(int) 2D array sampled format:Unknown
              101:             TypePointer UniformConstant 100
- 102(g_tTex1df4):    101(ptr) Variable UniformConstant
-             103:             TypeImage 11(int) 1D sampled format:Unknown
-             104:             TypePointer UniformConstant 103
- 105(g_tTex1di4):    104(ptr) Variable UniformConstant
-             106:             TypeImage 18(int) 1D sampled format:Unknown
-             107:             TypePointer UniformConstant 106
- 108(g_tTex1du4):    107(ptr) Variable UniformConstant
-             109:             TypeImage 6(float) 2D sampled format:Unknown
-             110:             TypePointer UniformConstant 109
- 111(g_tTex2df4):    110(ptr) Variable UniformConstant
-             112:             TypeImage 11(int) 2D sampled format:Unknown
-             113:             TypePointer UniformConstant 112
- 114(g_tTex2di4):    113(ptr) Variable UniformConstant
-             115:             TypeImage 18(int) 2D sampled format:Unknown
-             116:             TypePointer UniformConstant 115
- 117(g_tTex2du4):    116(ptr) Variable UniformConstant
-             118:             TypeImage 6(float) 3D sampled format:Unknown
-             119:             TypePointer UniformConstant 118
- 120(g_tTex3df4):    119(ptr) Variable UniformConstant
-             121:             TypeImage 11(int) 3D sampled format:Unknown
-             122:             TypePointer UniformConstant 121
- 123(g_tTex3di4):    122(ptr) Variable UniformConstant
-             124:             TypeImage 18(int) 3D sampled format:Unknown
-             125:             TypePointer UniformConstant 124
- 126(g_tTex3du4):    125(ptr) Variable UniformConstant
-             127:             TypeImage 6(float) Cube sampled format:Unknown
-             128:             TypePointer UniformConstant 127
- 129(g_tTexcdf4):    128(ptr) Variable UniformConstant
-             130:             TypeImage 11(int) Cube sampled format:Unknown
-             131:             TypePointer UniformConstant 130
- 132(g_tTexcdi4):    131(ptr) Variable UniformConstant
-             133:             TypeImage 18(int) Cube sampled format:Unknown
-             134:             TypePointer UniformConstant 133
- 135(g_tTexcdu4):    134(ptr) Variable UniformConstant
-             136:             TypeImage 6(float) Cube array sampled format:Unknown
-             137:             TypePointer UniformConstant 136
-138(g_tTexcdf4a):    137(ptr) Variable UniformConstant
-             139:             TypeImage 11(int) Cube array sampled format:Unknown
-             140:             TypePointer UniformConstant 139
-141(g_tTexcdi4a):    140(ptr) Variable UniformConstant
-             142:             TypeImage 18(int) Cube array sampled format:Unknown
-             143:             TypePointer UniformConstant 142
-144(g_tTexcdu4a):    143(ptr) Variable UniformConstant
-         145(c1):     20(ptr) Variable UniformConstant
-         146(c2):     60(ptr) Variable UniformConstant
-         147(o3):     13(ptr) Variable UniformConstant
-         148(o4):     53(ptr) Variable UniformConstant
+102(g_tTex2du4a):    101(ptr) Variable UniformConstant
+             111:             TypePointer UniformConstant 47(ivec4)
+        112(uc4):    111(ptr) Variable UniformConstant
+  133(PS_OUTPUT):             TypeStruct 25(fvec4) 6(float)
+             134:             TypePointer Function 133(PS_OUTPUT)
+             136:     11(int) Constant 0
+             137:    6(float) Constant 1065353216
+             138:   25(fvec4) ConstantComposite 137 137 137 137
+             139:             TypePointer Function 25(fvec4)
+             141:     11(int) Constant 1
+             142:             TypePointer Function 6(float)
+             146:             TypeSampler
+             147:             TypePointer UniformConstant 146
+    148(g_sSamp):    147(ptr) Variable UniformConstant
+             149:             TypeImage 6(float) 1D sampled format:Unknown
+             150:             TypePointer UniformConstant 149
+ 151(g_tTex1df4):    150(ptr) Variable UniformConstant
+             152:             TypeImage 11(int) 1D sampled format:Unknown
+             153:             TypePointer UniformConstant 152
+ 154(g_tTex1di4):    153(ptr) Variable UniformConstant
+             155:             TypeImage 18(int) 1D sampled format:Unknown
+             156:             TypePointer UniformConstant 155
+ 157(g_tTex1du4):    156(ptr) Variable UniformConstant
+             158:             TypeImage 6(float) 2D sampled format:Unknown
+             159:             TypePointer UniformConstant 158
+ 160(g_tTex2df4):    159(ptr) Variable UniformConstant
+             161:             TypeImage 11(int) 2D sampled format:Unknown
+             162:             TypePointer UniformConstant 161
+ 163(g_tTex2di4):    162(ptr) Variable UniformConstant
+             164:             TypeImage 18(int) 2D sampled format:Unknown
+             165:             TypePointer UniformConstant 164
+ 166(g_tTex2du4):    165(ptr) Variable UniformConstant
+             167:             TypeImage 6(float) 3D sampled format:Unknown
+             168:             TypePointer UniformConstant 167
+ 169(g_tTex3df4):    168(ptr) Variable UniformConstant
+             170:             TypeImage 11(int) 3D sampled format:Unknown
+             171:             TypePointer UniformConstant 170
+ 172(g_tTex3di4):    171(ptr) Variable UniformConstant
+             173:             TypeImage 18(int) 3D sampled format:Unknown
+             174:             TypePointer UniformConstant 173
+ 175(g_tTex3du4):    174(ptr) Variable UniformConstant
+             176:             TypeImage 6(float) Cube sampled format:Unknown
+             177:             TypePointer UniformConstant 176
+ 178(g_tTexcdf4):    177(ptr) Variable UniformConstant
+             179:             TypeImage 11(int) Cube sampled format:Unknown
+             180:             TypePointer UniformConstant 179
+ 181(g_tTexcdi4):    180(ptr) Variable UniformConstant
+             182:             TypeImage 18(int) Cube sampled format:Unknown
+             183:             TypePointer UniformConstant 182
+ 184(g_tTexcdu4):    183(ptr) Variable UniformConstant
+             185:             TypeImage 6(float) Cube array sampled format:Unknown
+             186:             TypePointer UniformConstant 185
+187(g_tTexcdf4a):    186(ptr) Variable UniformConstant
+             188:             TypeImage 11(int) Cube array sampled format:Unknown
+             189:             TypePointer UniformConstant 188
+190(g_tTexcdi4a):    189(ptr) Variable UniformConstant
+             191:             TypeImage 18(int) Cube array sampled format:Unknown
+             192:             TypePointer UniformConstant 191
+193(g_tTexcdu4a):    192(ptr) Variable UniformConstant
+         194(c1):     20(ptr) Variable UniformConstant
+         195(c2):     86(ptr) Variable UniformConstant
+        196(uc1):     56(ptr) Variable UniformConstant
+             197:             TypePointer UniformConstant 53(ivec2)
+        198(uc2):    197(ptr) Variable UniformConstant
+         199(o3):     13(ptr) Variable UniformConstant
+         200(o4):     79(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
-       86(psout):     85(ptr) Variable Function
+      135(psout):    134(ptr) Variable Function
               10:           7 Load 9(g_tTex1df4a)
               16:   12(ivec3) Load 14(c3)
               17:   15(ivec2) VectorShuffle 16 16 0 1
@@ -491,31 +693,73 @@ gl_FragCoord origin is upper left
               45:     11(int) Load 44
               46:     11(int) Load 23(o1)
               48:   47(ivec4) ImageFetch 41 43 Lod Offset 45 46
-              52:          49 Load 51(g_tTex2df4a)
-              55:   36(ivec4) Load 54(c4)
-              56:   12(ivec3) VectorShuffle 55 55 0 1 2
-              58:     20(ptr) AccessChain 54(c4) 57
-              59:     11(int) Load 58
-              62:   15(ivec2) Load 61(o2)
-              63:   25(fvec4) ImageFetch 52 56 Lod Offset 59 62
-              67:          64 Load 66(g_tTex2di4a)
-              68:   36(ivec4) Load 54(c4)
-              69:   12(ivec3) VectorShuffle 68 68 0 1 2
-              70:     20(ptr) AccessChain 54(c4) 57
-              71:     11(int) Load 70
-              72:   15(ivec2) Load 61(o2)
-              73:   36(ivec4) ImageFetch 67 69 Lod Offset 71 72
-              77:          74 Load 76(g_tTex2du4a)
-              78:   36(ivec4) Load 54(c4)
-              79:   12(ivec3) VectorShuffle 78 78 0 1 2
-              80:     20(ptr) AccessChain 54(c4) 57
-              81:     11(int) Load 80
-              82:   15(ivec2) Load 61(o2)
-              83:   47(ivec4) ImageFetch 77 79 Lod Offset 81 82
-              91:     90(ptr) AccessChain 86(psout) 87
-                              Store 91 89
-              94:     93(ptr) AccessChain 86(psout) 92
-                              Store 94 88
-              95:84(PS_OUTPUT) Load 86(psout)
-                              ReturnValue 95
+              49:           7 Load 9(g_tTex1df4a)
+              54:   50(ivec3) Load 52(uc3)
+              55:   53(ivec2) VectorShuffle 54 54 0 1
+              57:     56(ptr) AccessChain 52(uc3) 19
+              58:     18(int) Load 57
+              59:     11(int) Load 23(o1)
+              60:   25(fvec4) ImageFetch 49 55 Lod Offset 58 59
+              61:          27 Load 29(g_tTex1di4a)
+              62:   50(ivec3) Load 52(uc3)
+              63:   53(ivec2) VectorShuffle 62 62 0 1
+              64:     56(ptr) AccessChain 52(uc3) 19
+              65:     18(int) Load 64
+              66:     11(int) Load 23(o1)
+              67:   36(ivec4) ImageFetch 61 63 Lod Offset 65 66
+              68:          38 Load 40(g_tTex1du4a)
+              69:   50(ivec3) Load 52(uc3)
+              70:   53(ivec2) VectorShuffle 69 69 0 1
+              71:     56(ptr) AccessChain 52(uc3) 19
+              72:     18(int) Load 71
+              73:     11(int) Load 23(o1)
+              74:   47(ivec4) ImageFetch 68 70 Lod Offset 72 73
+              78:          75 Load 77(g_tTex2df4a)
+              81:   36(ivec4) Load 80(c4)
+              82:   12(ivec3) VectorShuffle 81 81 0 1 2
+              84:     20(ptr) AccessChain 80(c4) 83
+              85:     11(int) Load 84
+              88:   15(ivec2) Load 87(o2)
+              89:   25(fvec4) ImageFetch 78 82 Lod Offset 85 88
+              93:          90 Load 92(g_tTex2di4a)
+              94:   36(ivec4) Load 80(c4)
+              95:   12(ivec3) VectorShuffle 94 94 0 1 2
+              96:     20(ptr) AccessChain 80(c4) 83
+              97:     11(int) Load 96
+              98:   15(ivec2) Load 87(o2)
+              99:   36(ivec4) ImageFetch 93 95 Lod Offset 97 98
+             103:         100 Load 102(g_tTex2du4a)
+             104:   36(ivec4) Load 80(c4)
+             105:   12(ivec3) VectorShuffle 104 104 0 1 2
+             106:     20(ptr) AccessChain 80(c4) 83
+             107:     11(int) Load 106
+             108:   15(ivec2) Load 87(o2)
+             109:   47(ivec4) ImageFetch 103 105 Lod Offset 107 108
+             110:          75 Load 77(g_tTex2df4a)
+             113:   47(ivec4) Load 112(uc4)
+             114:   50(ivec3) VectorShuffle 113 113 0 1 2
+             115:     56(ptr) AccessChain 112(uc4) 83
+             116:     18(int) Load 115
+             117:   15(ivec2) Load 87(o2)
+             118:   25(fvec4) ImageFetch 110 114 Lod Offset 116 117
+             119:          90 Load 92(g_tTex2di4a)
+             120:   47(ivec4) Load 112(uc4)
+             121:   50(ivec3) VectorShuffle 120 120 0 1 2
+             122:     56(ptr) AccessChain 112(uc4) 83
+             123:     18(int) Load 122
+             124:   15(ivec2) Load 87(o2)
+             125:   36(ivec4) ImageFetch 119 121 Lod Offset 123 124
+             126:         100 Load 102(g_tTex2du4a)
+             127:   47(ivec4) Load 112(uc4)
+             128:   50(ivec3) VectorShuffle 127 127 0 1 2
+             129:     56(ptr) AccessChain 112(uc4) 83
+             130:     18(int) Load 129
+             131:   15(ivec2) Load 87(o2)
+             132:   47(ivec4) ImageFetch 126 128 Lod Offset 130 131
+             140:    139(ptr) AccessChain 135(psout) 136
+                              Store 140 138
+             143:    142(ptr) AccessChain 135(psout) 141
+                              Store 143 137
+             144:133(PS_OUTPUT) Load 135(psout)
+                              ReturnValue 144
                               FunctionEnd

--- a/Test/hlsl.load.2dms.dx10.frag
+++ b/Test/hlsl.load.2dms.dx10.frag
@@ -19,6 +19,12 @@ uniform int2  c2;
 uniform int3  c3;
 uniform int4  c4;
 
+uniform uint   uc1;
+uniform uint2  uc2;
+uniform uint3  uc3;
+uniform uint4  uc4;
+
+
 uniform int   o1;
 uniform int2  o2;
 uniform int3  o3;
@@ -32,21 +38,34 @@ PS_OUTPUT main()
    g_tTex2dmsf4.Load(c2, 3);
    g_tTex2dmsi4.Load(c2, 3);
    g_tTex2dmsu4.Load(c2, 3);
+   g_tTex2dmsf4.Load(uc2, 3);
+   g_tTex2dmsi4.Load(uc2, 3);
+   g_tTex2dmsu4.Load(uc2, 3);
 
    // 2DMS, offset
    g_tTex2dmsf4.Load(c2, 3, o2);
    g_tTex2dmsi4.Load(c2, 3, o2);
    g_tTex2dmsu4.Load(c2, 3, o2);
+   g_tTex2dmsf4.Load(uc2, 3, o2);
+   g_tTex2dmsi4.Load(uc2, 3, o2);
+   g_tTex2dmsu4.Load(uc2, 3, o2);
 
    // 2DMSArray, no offset
    g_tTex2dmsf4a.Load(c3, 3);
    g_tTex2dmsi4a.Load(c3, 3);
    g_tTex2dmsu4a.Load(c3, 3);
+   g_tTex2dmsf4a.Load(uc3, 3);
+   g_tTex2dmsi4a.Load(uc3, 3);
+   g_tTex2dmsu4a.Load(uc3, 3);
+
 
    // 2DMSArray, offset
    g_tTex2dmsf4a.Load(c3, 3, o2);
    g_tTex2dmsi4a.Load(c3, 3, o2);
    g_tTex2dmsu4a.Load(c3, 3, o2);
+   g_tTex2dmsf4a.Load(uc3, 3, o2);
+   g_tTex2dmsi4a.Load(uc3, 3, o2);
+   g_tTex2dmsu4a.Load(uc3, 3, o2);
 
    psout.Color = 1.0;
    psout.Depth = 1.0;

--- a/Test/hlsl.load.array.dx10.frag
+++ b/Test/hlsl.load.array.dx10.frag
@@ -39,6 +39,12 @@ uniform int2  c2;
 uniform int3  c3;
 uniform int4  c4;
 
+uniform uint   uc1;
+uniform uint2  uc2;
+uniform uint3  uc3;
+uniform uint4  uc4;
+
+
 uniform int   o1;
 uniform int2  o2;
 uniform int3  o3;
@@ -52,11 +58,17 @@ PS_OUTPUT main()
    g_tTex1df4a.Load(c3);
    g_tTex1di4a.Load(c3);
    g_tTex1du4a.Load(c3);
+   g_tTex1df4a.Load(uc3);
+   g_tTex1di4a.Load(uc3);
+   g_tTex1du4a.Load(uc3);
 
    // 2DArray
    g_tTex2df4a.Load(c4);
    g_tTex2di4a.Load(c4);
    g_tTex2du4a.Load(c4);
+   g_tTex2df4a.Load(uc4);
+   g_tTex2di4a.Load(uc4);
+   g_tTex2du4a.Load(uc4);
 
    // Offset has no Cube or CubeArray forms
 

--- a/Test/hlsl.load.basic.dx10.frag
+++ b/Test/hlsl.load.basic.dx10.frag
@@ -39,6 +39,12 @@ uniform int2  c2;
 uniform int3  c3;
 uniform int4  c4;
 
+uniform uint   uc1;
+uniform uint2  uc2;
+uniform uint3  uc3;
+uniform uint4  uc4;
+
+
 uniform int   o1;
 uniform int2  o2;
 uniform int3  o3;
@@ -52,16 +58,26 @@ PS_OUTPUT main()
    g_tTex1df4.Load(c2);
    g_tTex1di4.Load(c2);
    g_tTex1du4.Load(c2);
+   g_tTex1df4.Load(uc2);
+   g_tTex1di4.Load(uc2);
+   g_tTex1du4.Load(uc2);
 
    // 2D
    g_tTex2df4.Load(c3);
    g_tTex2di4.Load(c3);
    g_tTex2du4.Load(c3);
+   g_tTex2df4.Load(uc3);
+   g_tTex2di4.Load(uc3);
+   g_tTex2du4.Load(uc3);
+
 
    // 3D
    g_tTex3df4.Load(c4);
    g_tTex3di4.Load(c4);
    g_tTex3du4.Load(c4);
+   g_tTex3df4.Load(uc4);
+   g_tTex3di4.Load(uc4);
+   g_tTex3du4.Load(uc4);
 
    // Offset has no Cube or CubeArray forms
 

--- a/Test/hlsl.load.buffer.dx10.frag
+++ b/Test/hlsl.load.buffer.dx10.frag
@@ -15,6 +15,11 @@ uniform int2  c2;
 uniform int3  c3;
 uniform int4  c4;
 
+uniform int   uc1;
+uniform int2  uc2;
+uniform int3  uc3;
+uniform int4  uc4;
+
 uniform int   o1;
 uniform int2  o2;
 uniform int3  o3;
@@ -28,6 +33,11 @@ PS_OUTPUT main()
    float4 r00 = g_tTexbf4.Load(c1);
    int4   r01 = g_tTexbi4.Load(c1);
    uint4  r02 = g_tTexbu4.Load(c1);
+
+   //uint cast
+   r00 = g_tTexbf4.Load(uc1);
+   r01 = g_tTexbi4.Load(uc1);
+   r02 = g_tTexbu4.Load(uc1);
 
    // TODO: other types that can be put in sampler buffers, like float2x2, and float3.
 

--- a/Test/hlsl.load.offset.dx10.frag
+++ b/Test/hlsl.load.offset.dx10.frag
@@ -39,6 +39,11 @@ uniform int2  c2;
 uniform int3  c3;
 uniform int4  c4;
 
+uniform uint   uc1;
+uniform uint2  uc2;
+uniform uint3  uc3;
+uniform uint4  uc4;
+
 uniform int   o1;
 uniform int2  o2;
 uniform int3  o3;
@@ -52,16 +57,26 @@ PS_OUTPUT main()
    g_tTex1df4.Load(c2, o1);
    g_tTex1di4.Load(c2, o1);
    g_tTex1du4.Load(c2, o1);
+   g_tTex1df4.Load(uc2, o1);
+   g_tTex1di4.Load(uc2, o1);
+   g_tTex1du4.Load(uc2, o1);
+
 
    // 2D
    g_tTex2df4.Load(c3, o2);
    g_tTex2di4.Load(c3, o2);
    g_tTex2du4.Load(c3, o2);
+   g_tTex2df4.Load(uc3, o2);
+   g_tTex2di4.Load(uc3, o2);
+   g_tTex2du4.Load(uc3, o2);
 
    // 3D
    g_tTex3df4.Load(c4, o3);
    g_tTex3di4.Load(c4, o3);
    g_tTex3du4.Load(c4, o3);
+   g_tTex3df4.Load(uc4, o3);
+   g_tTex3di4.Load(uc4, o3);
+   g_tTex3du4.Load(uc4, o3);
 
    // Offset has no Cube or CubeArray forms
 

--- a/Test/hlsl.load.offsetarray.dx10.frag
+++ b/Test/hlsl.load.offsetarray.dx10.frag
@@ -39,6 +39,11 @@ uniform int2  c2;
 uniform int3  c3;
 uniform int4  c4;
 
+uniform uint   uc1;
+uniform uint2  uc2;
+uniform uint3  uc3;
+uniform uint4  uc4;
+
 uniform int   o1;
 uniform int2  o2;
 uniform int3  o3;
@@ -52,11 +57,17 @@ PS_OUTPUT main()
    g_tTex1df4a.Load(c3, o1);
    g_tTex1di4a.Load(c3, o1);
    g_tTex1du4a.Load(c3, o1);
+   g_tTex1df4a.Load(uc3, o1);
+   g_tTex1di4a.Load(uc3, o1);
+   g_tTex1du4a.Load(uc3, o1);
 
    // 2DArray
    g_tTex2df4a.Load(c4, o2);
    g_tTex2di4a.Load(c4, o2);
    g_tTex2du4a.Load(c4, o2);
+   g_tTex2df4a.Load(uc4, o2);
+   g_tTex2di4a.Load(uc4, o2);
+   g_tTex2du4a.Load(uc4, o2);
 
    // TODO:
    // Load, SampleIndex

--- a/hlsl/hlslParseables.cpp
+++ b/hlsl/hlslParseables.cpp
@@ -676,6 +676,12 @@ void TBuiltInParseablesHlsl::initialize(int /*version*/, EProfile /*profile*/, c
         { "SampleLevel",        /*!O*/        "V4",    nullptr,   "%@,S,V,S",       "FIU,S,F,",      EShLangAll },
         { "SampleLevel",        /* O*/        "V4",    nullptr,   "%@,S,V,S,V",     "FIU,S,F,,I",    EShLangAll },
 
+        //Multiple fields in non first field are ignored, so need seperate entries for unsigned int version of Load
+        { "Load",               /*!O*/        "V4",    nullptr,   "%@*,V",          "FIU,U",         EShLangAll },
+        { "Load",               /* O*/        "V4",    nullptr,   "%@,V,V",         "FIU,U,I",       EShLangAll },
+        { "Load", /* +sampleidex*/            "V4",    nullptr,   "$&,V,S",         "FIU,U,I",       EShLangAll },
+        { "Load", /* +samplindex, offset*/    "V4",    nullptr,   "$&,V,S,V",       "FIU,U,I,I",     EShLangAll },
+
         { "Load",               /*!O*/        "V4",    nullptr,   "%@*,V",          "FIU,I",         EShLangAll },
         { "Load",               /* O*/        "V4",    nullptr,   "%@,V,V",         "FIU,I,I",       EShLangAll },
         { "Load", /* +sampleidex*/            "V4",    nullptr,   "$&,V,S",         "FIU,I,I",       EShLangAll },


### PR DESCRIPTION
…ating tests to test for it.

Problem: Load method wasn't accepting uint inputs, because no entry in the symbol tables.

Added entries in symbol tables and also updated tests to check that loads from UINT are supported.