### PR TITLE
HLSL: Restrict uniform array flattening to sampler and texture arrays

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -941,7 +941,7 @@ void usage()
            "                                          explicit bindings.\n"
            "  --amb                                   synonym for --auto-map-bindings\n"
            "\n"
-           "  --flatten-uniform-arrays                flatten uniform array references to scalars\n"
+           "  --flatten-uniform-arrays                flatten uniform texture & sampler arrays to scalars\n"
            "  --fua                                   synonym for --flatten-uniform-arrays\n"
            );
 

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -736,7 +736,9 @@ bool HlslParseContext::shouldFlattenUniform(const TType& type) const
 
     return type.isArray() &&
         intermediate.getFlattenUniformArrays() &&
-        qualifier == EvqUniform;
+        qualifier == EvqUniform &&
+        // Testing the EbtSampler basic type covers samplers and textures
+        type.getBasicType() == EbtSampler;
 }
 
 void HlslParseContext::flatten(const TSourceLoc& loc, const TVariable& variable)


### PR DESCRIPTION
Previously the uniform array flattening feature would trigger on loose uniform arrays of any basic type (e.g, floats).  This PR restricts it to sampler and texture arrays.  Other arrays would end up in their own uniform block (anonymous or otherwise).  (Atomic counter arrays might be an exception, but those are not currently flattened).
