### PR TITLE
Change binding auto-map to use provided offsets.

### DIFF
--- a/Test/baseResults/spv.buffer.autoassign.frag.out
+++ b/Test/baseResults/spv.buffer.autoassign.frag.out
@@ -35,11 +35,11 @@ Linked fragment stage:
                               MemberDecorate 25 0 Offset 0
                               Decorate 25 Block
                               Decorate 27 DescriptorSet 0
-                              Decorate 27 Binding 1
+                              Decorate 27 Binding 15
                               MemberDecorate 31 0 Offset 0
                               Decorate 31 Block
                               Decorate 33 DescriptorSet 0
-                              Decorate 33 Binding 2
+                              Decorate 33 Binding 16
                               Decorate 41(Color) Location 0
                2:             TypeVoid
                3:             TypeFunction 2

--- a/Test/baseResults/spv.glsl.register.autoassign.frag.out
+++ b/Test/baseResults/spv.glsl.register.autoassign.frag.out
@@ -51,21 +51,21 @@ Linked fragment stage:
                               Decorate 21(g_sSamp1) DescriptorSet 0
                               Decorate 21(g_sSamp1) Binding 5
                               Decorate 27(g_tTex2) DescriptorSet 0
-                              Decorate 27(g_tTex2) Binding 1
+                              Decorate 27(g_tTex2) Binding 14
                               Decorate 29(g_sSamp2) DescriptorSet 0
-                              Decorate 29(g_sSamp2) Binding 2
+                              Decorate 29(g_sSamp2) Binding 6
                               Decorate 39(g_tTex3) DescriptorSet 0
                               Decorate 39(g_tTex3) Binding 13
                               Decorate 46(g_sSamp3) DescriptorSet 0
                               Decorate 46(g_sSamp3) Binding 7
                               Decorate 64(g_tTex4) DescriptorSet 0
-                              Decorate 64(g_tTex4) Binding 3
+                              Decorate 64(g_tTex4) Binding 15
                               Decorate 69(g_sSamp4) DescriptorSet 0
-                              Decorate 69(g_sSamp4) Binding 4
+                              Decorate 69(g_sSamp4) Binding 8
                               Decorate 84(g_tTex5) DescriptorSet 0
-                              Decorate 84(g_tTex5) Binding 6
+                              Decorate 84(g_tTex5) Binding 16
                               Decorate 86(g_sSamp5) DescriptorSet 0
-                              Decorate 86(g_sSamp5) Binding 8
+                              Decorate 86(g_sSamp5) Binding 9
                               MemberDecorate 93(MyStruct_t) 0 Offset 0
                               MemberDecorate 93(MyStruct_t) 1 Offset 4
                               MemberDecorate 93(MyStruct_t) 2 Offset 16
@@ -75,7 +75,7 @@ Linked fragment stage:
                               MemberDecorate 95(myblock) 3 Offset 64
                               Decorate 95(myblock) Block
                               Decorate 97 DescriptorSet 0
-                              Decorate 97 Binding 19
+                              Decorate 97 Binding 24
                               Decorate 119(g_tTex_unused1) DescriptorSet 0
                               Decorate 119(g_tTex_unused1) Binding 10
                               Decorate 121(g_sSamp_unused1) DescriptorSet 0

--- a/Test/baseResults/spv.register.autoassign.frag.out
+++ b/Test/baseResults/spv.register.autoassign.frag.out
@@ -51,21 +51,21 @@ Linked fragment stage:
                               Decorate 21(g_sSamp1) DescriptorSet 0
                               Decorate 21(g_sSamp1) Binding 5
                               Decorate 27(g_tTex2) DescriptorSet 0
-                              Decorate 27(g_tTex2) Binding 1
+                              Decorate 27(g_tTex2) Binding 14
                               Decorate 29(g_sSamp2) DescriptorSet 0
-                              Decorate 29(g_sSamp2) Binding 2
+                              Decorate 29(g_sSamp2) Binding 6
                               Decorate 39(g_tTex3) DescriptorSet 0
                               Decorate 39(g_tTex3) Binding 13
                               Decorate 46(g_sSamp3) DescriptorSet 0
                               Decorate 46(g_sSamp3) Binding 7
                               Decorate 64(g_tTex4) DescriptorSet 0
-                              Decorate 64(g_tTex4) Binding 3
+                              Decorate 64(g_tTex4) Binding 15
                               Decorate 69(g_sSamp4) DescriptorSet 0
-                              Decorate 69(g_sSamp4) Binding 4
+                              Decorate 69(g_sSamp4) Binding 8
                               Decorate 84(g_tTex5) DescriptorSet 0
-                              Decorate 84(g_tTex5) Binding 6
+                              Decorate 84(g_tTex5) Binding 16
                               Decorate 86(g_sSamp5) DescriptorSet 0
-                              Decorate 86(g_sSamp5) Binding 8
+                              Decorate 86(g_sSamp5) Binding 9
                               MemberDecorate 93(MyStruct_t) 0 Offset 0
                               MemberDecorate 93(MyStruct_t) 1 Offset 4
                               MemberDecorate 93(MyStruct_t) 2 Offset 16
@@ -75,7 +75,7 @@ Linked fragment stage:
                               MemberDecorate 95($Global) 3 Offset 64
                               Decorate 95($Global) Block
                               Decorate 97 DescriptorSet 0
-                              Decorate 97 Binding 9
+                              Decorate 97 Binding 20
                               Decorate 119(g_tTex_unused1) DescriptorSet 0
                               Decorate 119(g_tTex_unused1) Binding 10
                               Decorate 121(g_sSamp_unused1) DescriptorSet 0

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -151,8 +151,7 @@ class TIoMappingTraverser : public TBindingTraverser {
 public:
     TIoMappingTraverser(TIntermediate& i, TBindingMap& bindingMap, TUsedBindings& usedBindings,
                         bool traverseDeadCode) :
-        TBindingTraverser(i, bindingMap, usedBindings, traverseDeadCode),
-        nextBinding(1)
+        TBindingTraverser(i, bindingMap, usedBindings, traverseDeadCode)
     { }
 
 protected:
@@ -172,7 +171,7 @@ protected:
 
         if (intermediate.getAutoMapBindings()) {
             // Otherwise, find a free spot for it.
-            const int freeBinding = getFreeBinding(base.getType());
+            const int freeBinding = getFreeBinding(base.getType(), getBindingBase(base.getType()));
 
             markBinding(base, freeBinding);
             base.getWritableType().getQualifier().layoutBinding = freeBinding;
@@ -190,14 +189,12 @@ protected:
     }
 
     // Find a free binding spot 
-    int getFreeBinding(const TType&) {
+    int getFreeBinding(const TType&, int nextBinding) {
         while (!hasNFreeSlots(nextBinding, 1))
             ++nextBinding;
 
         return nextBinding;
     }
-
-    int nextBinding;
 };
 
 // Map I/O variables to provided offsets, and make bindings for

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -281,7 +281,7 @@ INSTANTIATE_TEST_CASE_P(
 INSTANTIATE_TEST_CASE_P(
     Hlsl, HlslIoMap,
     ::testing::ValuesIn(std::vector<IoMapData>{
-        { "spv.register.autoassign.frag", "main_ep", 5, 10, 15, true, false },
+        { "spv.register.autoassign.frag", "main_ep", 5, 10, 20, true, false },
         { "spv.register.noautoassign.frag", "main_ep", 5, 10, 15, false, false },
         { "spv.register.autoassign-2.frag", "main", 5, 10, 15, true, true },
         { "spv.buffer.autoassign.frag", "main", 5, 10, 15, true, true },
@@ -293,7 +293,7 @@ INSTANTIATE_TEST_CASE_P(
 INSTANTIATE_TEST_CASE_P(
     Hlsl, GlslIoMap,
     ::testing::ValuesIn(std::vector<IoMapData>{
-        { "spv.glsl.register.autoassign.frag", "main", 5, 10, 15, true, false },
+        { "spv.glsl.register.autoassign.frag", "main", 5, 10, 20, true, false },
         { "spv.glsl.register.noautoassign.frag", "main", 5, 10, 15, false, false },
     }),
     FileNameAsCustomTestSuffixIoMap


### PR DESCRIPTION
Previously, the binding auto-mapping facility was free to use any unused binding.  This change makes auto-bindings use the same offset value as explicit bindings.
