### PR TITLE
add reflection queries to return a TType.  Fix minor issue with inter…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ build/
 Test/localResults/
 Test/multiThread.out
 Test/singleThread.out
+Test/vert.spv
+Test/frag.spv
 External/googletest

--- a/Test/baseResults/hlsl.buffer.frag.out
+++ b/Test/baseResults/hlsl.buffer.frag.out
@@ -101,23 +101,23 @@ gl_FragCoord origin is upper left
                               Name 22  ""
                               MemberName 22 0  "v2"
                               Name 24  ""
-                              Name 28  ""
-                              MemberName 28 0  "v3"
-                              MemberName 28 1  "i3"
+                              Name 28  "cbufName"
+                              MemberName 28(cbufName) 0  "v3"
+                              MemberName 28(cbufName) 1  "i3"
                               Name 30  ""
-                              Name 35  ""
-                              MemberName 35 0  "v4"
-                              MemberName 35 1  "i4"
-                              MemberName 35 2  "f1"
-                              MemberName 35 3  "f3"
-                              MemberName 35 4  "f4"
-                              MemberName 35 5  "f5"
-                              MemberName 35 6  "f6"
-                              MemberName 35 7  "f7"
-                              MemberName 35 8  "m1"
-                              MemberName 35 9  "m2"
-                              MemberName 35 10  "m3"
-                              MemberName 35 11  "m4"
+                              Name 35  "tbufName"
+                              MemberName 35(tbufName) 0  "v4"
+                              MemberName 35(tbufName) 1  "i4"
+                              MemberName 35(tbufName) 2  "f1"
+                              MemberName 35(tbufName) 3  "f3"
+                              MemberName 35(tbufName) 4  "f4"
+                              MemberName 35(tbufName) 5  "f5"
+                              MemberName 35(tbufName) 6  "f6"
+                              MemberName 35(tbufName) 7  "f7"
+                              MemberName 35(tbufName) 8  "m1"
+                              MemberName 35(tbufName) 9  "m2"
+                              MemberName 35(tbufName) 10  "m3"
+                              MemberName 35(tbufName) 11  "m4"
                               Name 37  ""
                               Decorate 9(@entryPointOutput) Location 0
                               Decorate 11(input) Location 0
@@ -127,32 +127,32 @@ gl_FragCoord origin is upper left
                               MemberDecorate 22 0 Offset 0
                               Decorate 22 BufferBlock
                               Decorate 24 DescriptorSet 0
-                              MemberDecorate 28 0 Offset 0
-                              MemberDecorate 28 1 Offset 20
-                              Decorate 28 Block
+                              MemberDecorate 28(cbufName) 0 Offset 0
+                              MemberDecorate 28(cbufName) 1 Offset 20
+                              Decorate 28(cbufName) Block
                               Decorate 30 DescriptorSet 10
                               Decorate 30 Binding 2
-                              MemberDecorate 35 0 Offset 16
-                              MemberDecorate 35 1 Offset 48
-                              MemberDecorate 35 2 Offset 60
-                              MemberDecorate 35 3 Offset 64
-                              MemberDecorate 35 4 Offset 68
-                              MemberDecorate 35 5 Offset 72
-                              MemberDecorate 35 6 Offset 76
-                              MemberDecorate 35 7 Offset 80
-                              MemberDecorate 35 8 RowMajor
-                              MemberDecorate 35 8 Offset 96
-                              MemberDecorate 35 8 MatrixStride 16
-                              MemberDecorate 35 9 ColMajor
-                              MemberDecorate 35 9 Offset 160
-                              MemberDecorate 35 9 MatrixStride 16
-                              MemberDecorate 35 10 RowMajor
-                              MemberDecorate 35 10 Offset 208
-                              MemberDecorate 35 10 MatrixStride 16
-                              MemberDecorate 35 11 RowMajor
-                              MemberDecorate 35 11 Offset 272
-                              MemberDecorate 35 11 MatrixStride 16
-                              Decorate 35 BufferBlock
+                              MemberDecorate 35(tbufName) 0 Offset 16
+                              MemberDecorate 35(tbufName) 1 Offset 48
+                              MemberDecorate 35(tbufName) 2 Offset 60
+                              MemberDecorate 35(tbufName) 3 Offset 64
+                              MemberDecorate 35(tbufName) 4 Offset 68
+                              MemberDecorate 35(tbufName) 5 Offset 72
+                              MemberDecorate 35(tbufName) 6 Offset 76
+                              MemberDecorate 35(tbufName) 7 Offset 80
+                              MemberDecorate 35(tbufName) 8 RowMajor
+                              MemberDecorate 35(tbufName) 8 Offset 96
+                              MemberDecorate 35(tbufName) 8 MatrixStride 16
+                              MemberDecorate 35(tbufName) 9 ColMajor
+                              MemberDecorate 35(tbufName) 9 Offset 160
+                              MemberDecorate 35(tbufName) 9 MatrixStride 16
+                              MemberDecorate 35(tbufName) 10 RowMajor
+                              MemberDecorate 35(tbufName) 10 Offset 208
+                              MemberDecorate 35(tbufName) 10 MatrixStride 16
+                              MemberDecorate 35(tbufName) 11 RowMajor
+                              MemberDecorate 35(tbufName) 11 Offset 272
+                              MemberDecorate 35(tbufName) 11 MatrixStride 16
+                              Decorate 35(tbufName) BufferBlock
                               Decorate 37 DescriptorSet 0
                               Decorate 37 Binding 8
                2:             TypeVoid
@@ -172,12 +172,12 @@ gl_FragCoord origin is upper left
               22:             TypeStruct 7(fvec4)
               23:             TypePointer Uniform 22(struct)
               24:     23(ptr) Variable Uniform
-              28:             TypeStruct 7(fvec4) 16(int)
-              29:             TypePointer Uniform 28(struct)
+    28(cbufName):             TypeStruct 7(fvec4) 16(int)
+              29:             TypePointer Uniform 28(cbufName)
               30:     29(ptr) Variable Uniform
               34:             TypeMatrix 7(fvec4) 3
-              35:             TypeStruct 7(fvec4) 16(int) 6(float) 6(float) 6(float) 6(float) 6(float) 6(float) 34 34 34 34
-              36:             TypePointer Uniform 35(struct)
+    35(tbufName):             TypeStruct 7(fvec4) 16(int) 6(float) 6(float) 6(float) 6(float) 6(float) 6(float) 34 34 34 34
+              36:             TypePointer Uniform 35(tbufName)
               37:     36(ptr) Variable Uniform
 4(PixelShaderFunction):           2 Function None 3
                5:             Label

--- a/Test/baseResults/hlsl.layout.frag.out
+++ b/Test/baseResults/hlsl.layout.frag.out
@@ -77,23 +77,23 @@ gl_FragCoord origin is upper left
                               Name 4  "main"
                               Name 11  "PixelShaderFunction(vf4;"
                               Name 10  "input"
-                              Name 14  ""
-                              MemberName 14 0  "v1"
+                              Name 14  "tbufName"
+                              MemberName 14(tbufName) 0  "v1"
                               Name 16  ""
-                              Name 23  ""
-                              MemberName 23 0  "v5"
+                              Name 23  "tbufName2"
+                              MemberName 23(tbufName2) 0  "v5"
                               Name 25  ""
-                              Name 30  ""
-                              MemberName 30 0  "v1PostLayout"
+                              Name 30  "tbufName2"
+                              MemberName 30(tbufName2) 0  "v1PostLayout"
                               Name 32  ""
-                              MemberDecorate 14 0 Offset 16
-                              Decorate 14 BufferBlock
+                              MemberDecorate 14(tbufName) 0 Offset 16
+                              Decorate 14(tbufName) BufferBlock
                               Decorate 16 DescriptorSet 3
                               Decorate 16 Binding 5
-                              MemberDecorate 23 0 Offset 0
-                              Decorate 23 BufferBlock
-                              MemberDecorate 30 0 Offset 16
-                              Decorate 30 BufferBlock
+                              MemberDecorate 23(tbufName2) 0 Offset 0
+                              Decorate 23(tbufName2) BufferBlock
+                              MemberDecorate 30(tbufName2) 0 Offset 16
+                              Decorate 30(tbufName2) BufferBlock
                               Decorate 32 DescriptorSet 4
                               Decorate 32 Binding 7
                               Decorate 38 SpecId 17
@@ -103,18 +103,18 @@ gl_FragCoord origin is upper left
                7:             TypeVector 6(float) 4
                8:             TypePointer Function 7(fvec4)
                9:             TypeFunction 7(fvec4) 8(ptr)
-              14:             TypeStruct 7(fvec4)
-              15:             TypePointer Uniform 14(struct)
+    14(tbufName):             TypeStruct 7(fvec4)
+              15:             TypePointer Uniform 14(tbufName)
               16:     15(ptr) Variable Uniform
               17:             TypeInt 32 1
               18:     17(int) Constant 0
               19:             TypePointer Uniform 7(fvec4)
-              23:             TypeStruct 7(fvec4)
-              24:             TypePointer PushConstant 23(struct)
+   23(tbufName2):             TypeStruct 7(fvec4)
+              24:             TypePointer PushConstant 23(tbufName2)
               25:     24(ptr) Variable PushConstant
               26:             TypePointer PushConstant 7(fvec4)
-              30:             TypeStruct 7(fvec4)
-              31:             TypePointer Uniform 30(struct)
+   30(tbufName2):             TypeStruct 7(fvec4)
+              31:             TypePointer Uniform 30(tbufName2)
               32:     31(ptr) Variable Uniform
               38:     17(int) SpecConstant 10
          4(main):           2 Function None 3

--- a/Test/baseResults/hlsl.reflection.binding.frag.out
+++ b/Test/baseResults/hlsl.reflection.binding.frag.out
@@ -1,0 +1,23 @@
+hlsl.reflection.binding.frag
+
+Linked fragment stage:
+
+
+Uniform reflection:
+t1: offset -1, type 8b5d, size 1, index -1, binding 15
+s1: offset -1, type 0, size 1, index -1, binding 5
+t1a: offset -1, type 8b5d, size 1, index -1, binding 16
+s1a: offset -1, type 0, size 1, index -1, binding 6
+c1_a: offset 0, type 8b52, size 1, index 0, binding -1
+c1_b: offset 16, type 1404, size 1, index 0, binding -1
+c1_c: offset 20, type 1406, size 1, index 0, binding -1
+c2_a: offset 0, type 8b52, size 1, index 1, binding -1
+c2_b: offset 16, type 1404, size 1, index 1, binding -1
+c2_c: offset 20, type 1406, size 1, index 1, binding -1
+
+Uniform block reflection:
+cbuff1: offset -1, type ffffffff, size 24, index -1, binding 2
+cbuff2: offset -1, type ffffffff, size 24, index -1, binding 3
+
+Vertex attribute reflection:
+

--- a/Test/baseResults/hlsl.reflection.binding.vert.out
+++ b/Test/baseResults/hlsl.reflection.binding.vert.out
@@ -1,0 +1,15 @@
+hlsl.reflection.binding.vert
+
+Linked vertex stage:
+
+
+Uniform reflection:
+t1: offset -1, type 8b5d, size 1, index -1, binding 15
+s1: offset -1, type 0, size 1, index -1, binding 5
+t1a: offset -1, type 8b5d, size 1, index -1, binding 16
+s1a: offset -1, type 0, size 1, index -1, binding 6
+
+Uniform block reflection:
+
+Vertex attribute reflection:
+

--- a/Test/baseResults/hlsl.reflection.vert.out
+++ b/Test/baseResults/hlsl.reflection.vert.out
@@ -4,78 +4,85 @@ Linked vertex stage:
 
 
 Uniform reflection:
-anonMember3: offset 80, type 8b52, size 1, index 0
-s.a: offset 0, type 1404, size 1, index 1
-scalar: offset 12, type 1404, size 1, index 0
-m23: offset 16, type 8b67, size 1, index 0
-scalarAfterm23: offset 48, type 1404, size 1, index 0
-c_m23: offset 16, type 8b67, size 1, index 0
-c_scalarAfterm23: offset 48, type 1404, size 1, index 0
-scalarBeforeArray: offset 96, type 1404, size 1, index 0
-floatArray: offset 112, type 1406, size 5, index 0
-scalarAfterArray: offset 192, type 1404, size 1, index 0
-memfloat2: offset 48, type 8b50, size 1, index 0
-memf1: offset 56, type 1406, size 1, index 0
-memf2: offset 60, type 8b56, size 1, index 0
-memf3: offset 64, type 1404, size 1, index 0
-memfloat2a: offset 72, type 8b50, size 1, index 0
-m22: offset 80, type 8b5a, size 7, index 0
-dm22: offset 32, type 8b5a, size 4, index 1
-foo.n1.a: offset 0, type 1406, size 1, index 0
-foo.n2.b: offset 16, type 1406, size 1, index 0
-foo.n2.c: offset 20, type 1406, size 1, index 0
-foo.n2.d: offset 24, type 1406, size 1, index 0
-deepA.d2.d1[2].va: offset 376, type 8b50, size 2, index 1
-deepB.d2.d1.va: offset 984, type 8b50, size 2, index 1
-deepB.d2.d1[0].va: offset 984, type 8b50, size 2, index 1
-deepB.d2.d1[1].va: offset 984, type 8b50, size 2, index 1
-deepB.d2.d1[2].va: offset 984, type 8b50, size 2, index 1
-deepB.d2.d1[3].va: offset 984, type 8b50, size 2, index 1
-deepC.iv4: offset 1568, type 8b52, size 1, index 1
-deepC.d2.i: offset 1568, type 1404, size 1, index 1
-deepC.d2.d1[0].va: offset 1568, type 8b50, size 3, index 1
-deepC.d2.d1[0].b: offset 1568, type 8b56, size 1, index 1
-deepC.d2.d1[1].va: offset 1568, type 8b50, size 3, index 1
-deepC.d2.d1[1].b: offset 1568, type 8b56, size 1, index 1
-deepC.d2.d1[2].va: offset 1568, type 8b50, size 3, index 1
-deepC.d2.d1[2].b: offset 1568, type 8b56, size 1, index 1
-deepC.d2.d1[3].va: offset 1568, type 8b50, size 3, index 1
-deepC.d2.d1[3].b: offset 1568, type 8b56, size 1, index 1
-deepC.v3: offset 1568, type 8b54, size 1, index 1
-deepD[0].iv4: offset 2480, type 8b52, size 1, index 1
-deepD[0].d2.i: offset 2480, type 1404, size 1, index 1
-deepD[0].d2.d1[0].va: offset 2480, type 8b50, size 3, index 1
-deepD[0].d2.d1[0].b: offset 2480, type 8b56, size 1, index 1
-deepD[0].d2.d1[1].va: offset 2480, type 8b50, size 3, index 1
-deepD[0].d2.d1[1].b: offset 2480, type 8b56, size 1, index 1
-deepD[0].d2.d1[2].va: offset 2480, type 8b50, size 3, index 1
-deepD[0].d2.d1[2].b: offset 2480, type 8b56, size 1, index 1
-deepD[0].d2.d1[3].va: offset 2480, type 8b50, size 3, index 1
-deepD[0].d2.d1[3].b: offset 2480, type 8b56, size 1, index 1
-deepD[0].v3: offset 2480, type 8b54, size 1, index 1
-deepD[1].iv4: offset 2480, type 8b52, size 1, index 1
-deepD[1].d2.i: offset 2480, type 1404, size 1, index 1
-deepD[1].d2.d1[0].va: offset 2480, type 8b50, size 3, index 1
-deepD[1].d2.d1[0].b: offset 2480, type 8b56, size 1, index 1
-deepD[1].d2.d1[1].va: offset 2480, type 8b50, size 3, index 1
-deepD[1].d2.d1[1].b: offset 2480, type 8b56, size 1, index 1
-deepD[1].d2.d1[2].va: offset 2480, type 8b50, size 3, index 1
-deepD[1].d2.d1[2].b: offset 2480, type 8b56, size 1, index 1
-deepD[1].d2.d1[3].va: offset 2480, type 8b50, size 3, index 1
-deepD[1].d2.d1[3].b: offset 2480, type 8b56, size 1, index 1
-deepD[1].v3: offset 2480, type 8b54, size 1, index 1
-foo: offset 0, type 1406, size 1, index 0
-anonMember1: offset 0, type 8b51, size 1, index 0
-uf1: offset 16, type 1406, size 1, index 1
+anonMember3: offset 80, type 8b52, size 1, index 0, binding -1
+s.a: offset 0, type 1404, size 1, index 1, binding -1
+ablock.scalar: offset 12, type 1404, size 1, index 2, binding -1
+m23: offset 16, type 8b67, size 1, index 0, binding -1
+scalarAfterm23: offset 48, type 1404, size 1, index 0, binding -1
+c_m23: offset 16, type 8b67, size 1, index 3, binding -1
+c_scalarAfterm23: offset 48, type 1404, size 1, index 3, binding -1
+scalarBeforeArray: offset 96, type 1404, size 1, index 0, binding -1
+floatArray: offset 112, type 1406, size 5, index 0, binding -1
+scalarAfterArray: offset 192, type 1404, size 1, index 0, binding -1
+ablock.memfloat2: offset 48, type 8b50, size 1, index 2, binding -1
+ablock.memf1: offset 56, type 1406, size 1, index 2, binding -1
+ablock.memf2: offset 60, type 8b56, size 1, index 2, binding -1
+ablock.memf3: offset 64, type 1404, size 1, index 2, binding -1
+ablock.memfloat2a: offset 72, type 8b50, size 1, index 2, binding -1
+ablock.m22: offset 80, type 8b5a, size 7, index 2, binding -1
+dm22: offset 32, type 8b5a, size 4, index 1, binding -1
+m22: offset 208, type 8b5a, size 3, index 0, binding -1
+nest.foo.n1.a: offset 0, type 1406, size 1, index 4, binding -1
+nest.foo.n2.b: offset 16, type 1406, size 1, index 4, binding -1
+nest.foo.n2.c: offset 20, type 1406, size 1, index 4, binding -1
+nest.foo.n2.d: offset 24, type 1406, size 1, index 4, binding -1
+deepA.d2.d1[2].va: offset 376, type 8b50, size 2, index 1, binding -1
+deepB.d2.d1.va: offset 984, type 8b50, size 2, index 1, binding -1
+deepB.d2.d1[0].va: offset 984, type 8b50, size 2, index 1, binding -1
+deepB.d2.d1[1].va: offset 984, type 8b50, size 2, index 1, binding -1
+deepB.d2.d1[2].va: offset 984, type 8b50, size 2, index 1, binding -1
+deepB.d2.d1[3].va: offset 984, type 8b50, size 2, index 1, binding -1
+deepC.iv4: offset 1568, type 8b52, size 1, index 1, binding -1
+deepC.d2.i: offset 1568, type 1404, size 1, index 1, binding -1
+deepC.d2.d1[0].va: offset 1568, type 8b50, size 3, index 1, binding -1
+deepC.d2.d1[0].b: offset 1568, type 8b56, size 1, index 1, binding -1
+deepC.d2.d1[1].va: offset 1568, type 8b50, size 3, index 1, binding -1
+deepC.d2.d1[1].b: offset 1568, type 8b56, size 1, index 1, binding -1
+deepC.d2.d1[2].va: offset 1568, type 8b50, size 3, index 1, binding -1
+deepC.d2.d1[2].b: offset 1568, type 8b56, size 1, index 1, binding -1
+deepC.d2.d1[3].va: offset 1568, type 8b50, size 3, index 1, binding -1
+deepC.d2.d1[3].b: offset 1568, type 8b56, size 1, index 1, binding -1
+deepC.v3: offset 1568, type 8b54, size 1, index 1, binding -1
+deepD[0].iv4: offset 2480, type 8b52, size 1, index 1, binding -1
+deepD[0].d2.i: offset 2480, type 1404, size 1, index 1, binding -1
+deepD[0].d2.d1[0].va: offset 2480, type 8b50, size 3, index 1, binding -1
+deepD[0].d2.d1[0].b: offset 2480, type 8b56, size 1, index 1, binding -1
+deepD[0].d2.d1[1].va: offset 2480, type 8b50, size 3, index 1, binding -1
+deepD[0].d2.d1[1].b: offset 2480, type 8b56, size 1, index 1, binding -1
+deepD[0].d2.d1[2].va: offset 2480, type 8b50, size 3, index 1, binding -1
+deepD[0].d2.d1[2].b: offset 2480, type 8b56, size 1, index 1, binding -1
+deepD[0].d2.d1[3].va: offset 2480, type 8b50, size 3, index 1, binding -1
+deepD[0].d2.d1[3].b: offset 2480, type 8b56, size 1, index 1, binding -1
+deepD[0].v3: offset 2480, type 8b54, size 1, index 1, binding -1
+deepD[1].iv4: offset 2480, type 8b52, size 1, index 1, binding -1
+deepD[1].d2.i: offset 2480, type 1404, size 1, index 1, binding -1
+deepD[1].d2.d1[0].va: offset 2480, type 8b50, size 3, index 1, binding -1
+deepD[1].d2.d1[0].b: offset 2480, type 8b56, size 1, index 1, binding -1
+deepD[1].d2.d1[1].va: offset 2480, type 8b50, size 3, index 1, binding -1
+deepD[1].d2.d1[1].b: offset 2480, type 8b56, size 1, index 1, binding -1
+deepD[1].d2.d1[2].va: offset 2480, type 8b50, size 3, index 1, binding -1
+deepD[1].d2.d1[2].b: offset 2480, type 8b56, size 1, index 1, binding -1
+deepD[1].d2.d1[3].va: offset 2480, type 8b50, size 3, index 1, binding -1
+deepD[1].d2.d1[3].b: offset 2480, type 8b56, size 1, index 1, binding -1
+deepD[1].v3: offset 2480, type 8b54, size 1, index 1, binding -1
+arrBl.foo: offset 0, type 1406, size 1, index 5, binding -1
+arrBl2.foo: offset 0, type 1406, size 1, index 6, binding -1
+anonMember1: offset 0, type 8b51, size 1, index 0, binding -1
+uf1: offset 16, type 1406, size 1, index 1, binding -1
 
 Uniform block reflection:
-: offset -1, type ffffffff, size 496, index -1
-$Global: offset -1, type ffffffff, size 3088, index -1
+nameless: offset -1, type ffffffff, size 496, index -1, binding -1
+$Global: offset -1, type ffffffff, size 3088, index -1, binding -1
+ablock: offset -1, type ffffffff, size 304, index -1, binding -1
+c_nameless: offset -1, type ffffffff, size 96, index -1, binding -1
+nest: offset -1, type ffffffff, size 32, index -1, binding -1
+arrBl: offset -1, type ffffffff, size 4, index -1, binding -1
+arrBl2: offset -1, type ffffffff, size 4, index -1, binding -1
 
 Vertex attribute reflection:
-attributeFloat: offset 0, type 1406, size 0, index 0
-attributeFloat2: offset 0, type 8b50, size 0, index 0
-attributeFloat3: offset 0, type 8b51, size 0, index 0
-attributeFloat4: offset 0, type 8b52, size 0, index 0
-attributeMat4: offset 0, type 8b5c, size 0, index 0
+attributeFloat: offset 0, type 1406, size 0, index 0, binding -1
+attributeFloat2: offset 0, type 8b50, size 0, index 0, binding -1
+attributeFloat3: offset 0, type 8b51, size 0, index 0, binding -1
+attributeFloat4: offset 0, type 8b52, size 0, index 0, binding -1
+attributeMat4: offset 0, type 8b5c, size 0, index 0, binding -1
 

--- a/Test/baseResults/reflection.vert.out
+++ b/Test/baseResults/reflection.vert.out
@@ -6,99 +6,99 @@ Linked vertex stage:
 
 
 Uniform reflection:
-image_ui2D: offset -1, type 9063, size 1, index -1
-sampler_2D: offset -1, type 8b5e, size 1, index -1
-sampler_2DMSArray: offset -1, type 910b, size 1, index -1
-anonMember3: offset 80, type 8b52, size 1, index 0
-s.a: offset -1, type 1404, size 1, index -1
-named.scalar: offset 12, type 1404, size 1, index 1
-m23: offset 16, type 8b67, size 1, index 0
-scalarAfterm23: offset 48, type 1404, size 1, index 0
-c_m23: offset 16, type 8b67, size 1, index 2
-c_scalarAfterm23: offset 64, type 1404, size 1, index 2
-scalarBeforeArray: offset 96, type 1404, size 1, index 0
-floatArray: offset 112, type 1406, size 5, index 0
-scalarAfterArray: offset 192, type 1404, size 1, index 0
-named.memvec2: offset 48, type 8b50, size 1, index 1
-named.memf1: offset 56, type 1406, size 1, index 1
-named.memf2: offset 60, type 8b56, size 1, index 1
-named.memf3: offset 64, type 1404, size 1, index 1
-named.memvec2a: offset 72, type 8b50, size 1, index 1
-named.m22: offset 80, type 8b5a, size 7, index 1
-dm22: offset -1, type 8b5a, size 4, index -1
-m22: offset 208, type 8b5a, size 3, index 0
-nested.foo.n1.a: offset 0, type 1406, size 1, index 3
-nested.foo.n2.b: offset 16, type 1406, size 1, index 3
-nested.foo.n2.c: offset 20, type 1406, size 1, index 3
-nested.foo.n2.d: offset 24, type 1406, size 1, index 3
-deepA[0].d2.d1[2].va: offset -1, type 8b50, size 2, index -1
-deepA[1].d2.d1[2].va: offset -1, type 8b50, size 2, index -1
-deepB[1].d2.d1[0].va: offset -1, type 8b50, size 2, index -1
-deepB[1].d2.d1[1].va: offset -1, type 8b50, size 2, index -1
-deepB[1].d2.d1[2].va: offset -1, type 8b50, size 2, index -1
-deepB[1].d2.d1[3].va: offset -1, type 8b50, size 2, index -1
-deepB[0].d2.d1[0].va: offset -1, type 8b50, size 2, index -1
-deepB[0].d2.d1[1].va: offset -1, type 8b50, size 2, index -1
-deepB[0].d2.d1[2].va: offset -1, type 8b50, size 2, index -1
-deepB[0].d2.d1[3].va: offset -1, type 8b50, size 2, index -1
-deepC[1].iv4: offset -1, type 8b52, size 1, index -1
-deepC[1].d2.i: offset -1, type 1404, size 1, index -1
-deepC[1].d2.d1[0].va: offset -1, type 8b50, size 3, index -1
-deepC[1].d2.d1[0].b: offset -1, type 8b56, size 1, index -1
-deepC[1].d2.d1[1].va: offset -1, type 8b50, size 3, index -1
-deepC[1].d2.d1[1].b: offset -1, type 8b56, size 1, index -1
-deepC[1].d2.d1[2].va: offset -1, type 8b50, size 3, index -1
-deepC[1].d2.d1[2].b: offset -1, type 8b56, size 1, index -1
-deepC[1].d2.d1[3].va: offset -1, type 8b50, size 3, index -1
-deepC[1].d2.d1[3].b: offset -1, type 8b56, size 1, index -1
-deepC[1].v3: offset -1, type 8b54, size 1, index -1
-deepD[0].iv4: offset -1, type 8b52, size 1, index -1
-deepD[0].d2.i: offset -1, type 1404, size 1, index -1
-deepD[0].d2.d1[0].va: offset -1, type 8b50, size 3, index -1
-deepD[0].d2.d1[0].b: offset -1, type 8b56, size 1, index -1
-deepD[0].d2.d1[1].va: offset -1, type 8b50, size 3, index -1
-deepD[0].d2.d1[1].b: offset -1, type 8b56, size 1, index -1
-deepD[0].d2.d1[2].va: offset -1, type 8b50, size 3, index -1
-deepD[0].d2.d1[2].b: offset -1, type 8b56, size 1, index -1
-deepD[0].d2.d1[3].va: offset -1, type 8b50, size 3, index -1
-deepD[0].d2.d1[3].b: offset -1, type 8b56, size 1, index -1
-deepD[0].v3: offset -1, type 8b54, size 1, index -1
-deepD[1].iv4: offset -1, type 8b52, size 1, index -1
-deepD[1].d2.i: offset -1, type 1404, size 1, index -1
-deepD[1].d2.d1[0].va: offset -1, type 8b50, size 3, index -1
-deepD[1].d2.d1[0].b: offset -1, type 8b56, size 1, index -1
-deepD[1].d2.d1[1].va: offset -1, type 8b50, size 3, index -1
-deepD[1].d2.d1[1].b: offset -1, type 8b56, size 1, index -1
-deepD[1].d2.d1[2].va: offset -1, type 8b50, size 3, index -1
-deepD[1].d2.d1[2].b: offset -1, type 8b56, size 1, index -1
-deepD[1].d2.d1[3].va: offset -1, type 8b50, size 3, index -1
-deepD[1].d2.d1[3].b: offset -1, type 8b56, size 1, index -1
-deepD[1].v3: offset -1, type 8b54, size 1, index -1
-abl.foo: offset 0, type 1406, size 1, index 7
-abl2.foo: offset 0, type 1406, size 1, index 11
-anonMember1: offset 0, type 8b51, size 1, index 0
-uf1: offset -1, type 1406, size 1, index -1
-uf2: offset -1, type 1406, size 1, index -1
-named.member3: offset 32, type 8b52, size 1, index 1
+image_ui2D: offset -1, type 9063, size 1, index -1, binding -1
+sampler_2D: offset -1, type 8b5e, size 1, index -1, binding -1
+sampler_2DMSArray: offset -1, type 910b, size 1, index -1, binding -1
+anonMember3: offset 80, type 8b52, size 1, index 0, binding -1
+s.a: offset -1, type 1404, size 1, index -1, binding -1
+named.scalar: offset 12, type 1404, size 1, index 1, binding -1
+m23: offset 16, type 8b67, size 1, index 0, binding -1
+scalarAfterm23: offset 48, type 1404, size 1, index 0, binding -1
+c_m23: offset 16, type 8b67, size 1, index 2, binding -1
+c_scalarAfterm23: offset 64, type 1404, size 1, index 2, binding -1
+scalarBeforeArray: offset 96, type 1404, size 1, index 0, binding -1
+floatArray: offset 112, type 1406, size 5, index 0, binding -1
+scalarAfterArray: offset 192, type 1404, size 1, index 0, binding -1
+named.memvec2: offset 48, type 8b50, size 1, index 1, binding -1
+named.memf1: offset 56, type 1406, size 1, index 1, binding -1
+named.memf2: offset 60, type 8b56, size 1, index 1, binding -1
+named.memf3: offset 64, type 1404, size 1, index 1, binding -1
+named.memvec2a: offset 72, type 8b50, size 1, index 1, binding -1
+named.m22: offset 80, type 8b5a, size 7, index 1, binding -1
+dm22: offset -1, type 8b5a, size 4, index -1, binding -1
+m22: offset 208, type 8b5a, size 3, index 0, binding -1
+nested.foo.n1.a: offset 0, type 1406, size 1, index 3, binding -1
+nested.foo.n2.b: offset 16, type 1406, size 1, index 3, binding -1
+nested.foo.n2.c: offset 20, type 1406, size 1, index 3, binding -1
+nested.foo.n2.d: offset 24, type 1406, size 1, index 3, binding -1
+deepA[0].d2.d1[2].va: offset -1, type 8b50, size 2, index -1, binding -1
+deepA[1].d2.d1[2].va: offset -1, type 8b50, size 2, index -1, binding -1
+deepB[1].d2.d1[0].va: offset -1, type 8b50, size 2, index -1, binding -1
+deepB[1].d2.d1[1].va: offset -1, type 8b50, size 2, index -1, binding -1
+deepB[1].d2.d1[2].va: offset -1, type 8b50, size 2, index -1, binding -1
+deepB[1].d2.d1[3].va: offset -1, type 8b50, size 2, index -1, binding -1
+deepB[0].d2.d1[0].va: offset -1, type 8b50, size 2, index -1, binding -1
+deepB[0].d2.d1[1].va: offset -1, type 8b50, size 2, index -1, binding -1
+deepB[0].d2.d1[2].va: offset -1, type 8b50, size 2, index -1, binding -1
+deepB[0].d2.d1[3].va: offset -1, type 8b50, size 2, index -1, binding -1
+deepC[1].iv4: offset -1, type 8b52, size 1, index -1, binding -1
+deepC[1].d2.i: offset -1, type 1404, size 1, index -1, binding -1
+deepC[1].d2.d1[0].va: offset -1, type 8b50, size 3, index -1, binding -1
+deepC[1].d2.d1[0].b: offset -1, type 8b56, size 1, index -1, binding -1
+deepC[1].d2.d1[1].va: offset -1, type 8b50, size 3, index -1, binding -1
+deepC[1].d2.d1[1].b: offset -1, type 8b56, size 1, index -1, binding -1
+deepC[1].d2.d1[2].va: offset -1, type 8b50, size 3, index -1, binding -1
+deepC[1].d2.d1[2].b: offset -1, type 8b56, size 1, index -1, binding -1
+deepC[1].d2.d1[3].va: offset -1, type 8b50, size 3, index -1, binding -1
+deepC[1].d2.d1[3].b: offset -1, type 8b56, size 1, index -1, binding -1
+deepC[1].v3: offset -1, type 8b54, size 1, index -1, binding -1
+deepD[0].iv4: offset -1, type 8b52, size 1, index -1, binding -1
+deepD[0].d2.i: offset -1, type 1404, size 1, index -1, binding -1
+deepD[0].d2.d1[0].va: offset -1, type 8b50, size 3, index -1, binding -1
+deepD[0].d2.d1[0].b: offset -1, type 8b56, size 1, index -1, binding -1
+deepD[0].d2.d1[1].va: offset -1, type 8b50, size 3, index -1, binding -1
+deepD[0].d2.d1[1].b: offset -1, type 8b56, size 1, index -1, binding -1
+deepD[0].d2.d1[2].va: offset -1, type 8b50, size 3, index -1, binding -1
+deepD[0].d2.d1[2].b: offset -1, type 8b56, size 1, index -1, binding -1
+deepD[0].d2.d1[3].va: offset -1, type 8b50, size 3, index -1, binding -1
+deepD[0].d2.d1[3].b: offset -1, type 8b56, size 1, index -1, binding -1
+deepD[0].v3: offset -1, type 8b54, size 1, index -1, binding -1
+deepD[1].iv4: offset -1, type 8b52, size 1, index -1, binding -1
+deepD[1].d2.i: offset -1, type 1404, size 1, index -1, binding -1
+deepD[1].d2.d1[0].va: offset -1, type 8b50, size 3, index -1, binding -1
+deepD[1].d2.d1[0].b: offset -1, type 8b56, size 1, index -1, binding -1
+deepD[1].d2.d1[1].va: offset -1, type 8b50, size 3, index -1, binding -1
+deepD[1].d2.d1[1].b: offset -1, type 8b56, size 1, index -1, binding -1
+deepD[1].d2.d1[2].va: offset -1, type 8b50, size 3, index -1, binding -1
+deepD[1].d2.d1[2].b: offset -1, type 8b56, size 1, index -1, binding -1
+deepD[1].d2.d1[3].va: offset -1, type 8b50, size 3, index -1, binding -1
+deepD[1].d2.d1[3].b: offset -1, type 8b56, size 1, index -1, binding -1
+deepD[1].v3: offset -1, type 8b54, size 1, index -1, binding -1
+abl.foo: offset 0, type 1406, size 1, index 7, binding -1
+abl2.foo: offset 0, type 1406, size 1, index 11, binding -1
+anonMember1: offset 0, type 8b51, size 1, index 0, binding -1
+uf1: offset -1, type 1406, size 1, index -1, binding -1
+uf2: offset -1, type 1406, size 1, index -1, binding -1
+named.member3: offset 32, type 8b52, size 1, index 1, binding -1
 
 Uniform block reflection:
-nameless: offset -1, type ffffffff, size 496, index -1
-named: offset -1, type ffffffff, size 304, index -1
-c_nameless: offset -1, type ffffffff, size 112, index -1
-nested: offset -1, type ffffffff, size 32, index -1
-abl[0]: offset -1, type ffffffff, size 4, index -1
-abl[1]: offset -1, type ffffffff, size 4, index -1
-abl[2]: offset -1, type ffffffff, size 4, index -1
-abl[3]: offset -1, type ffffffff, size 4, index -1
-abl2[0]: offset -1, type ffffffff, size 4, index -1
-abl2[1]: offset -1, type ffffffff, size 4, index -1
-abl2[2]: offset -1, type ffffffff, size 4, index -1
-abl2[3]: offset -1, type ffffffff, size 4, index -1
+nameless: offset -1, type ffffffff, size 496, index -1, binding -1
+named: offset -1, type ffffffff, size 304, index -1, binding -1
+c_nameless: offset -1, type ffffffff, size 112, index -1, binding -1
+nested: offset -1, type ffffffff, size 32, index -1, binding -1
+abl[0]: offset -1, type ffffffff, size 4, index -1, binding -1
+abl[1]: offset -1, type ffffffff, size 4, index -1, binding -1
+abl[2]: offset -1, type ffffffff, size 4, index -1, binding -1
+abl[3]: offset -1, type ffffffff, size 4, index -1, binding -1
+abl2[0]: offset -1, type ffffffff, size 4, index -1, binding -1
+abl2[1]: offset -1, type ffffffff, size 4, index -1, binding -1
+abl2[2]: offset -1, type ffffffff, size 4, index -1, binding -1
+abl2[3]: offset -1, type ffffffff, size 4, index -1, binding -1
 
 Vertex attribute reflection:
-attributeFloat: offset 0, type 1406, size 0, index 0
-attributeFloat2: offset 0, type 8b50, size 0, index 0
-attributeFloat3: offset 0, type 8b51, size 0, index 0
-attributeFloat4: offset 0, type 8b52, size 0, index 0
-attributeMat4: offset 0, type 8b5c, size 0, index 0
+attributeFloat: offset 0, type 1406, size 0, index 0, binding -1
+attributeFloat2: offset 0, type 8b50, size 0, index 0, binding -1
+attributeFloat3: offset 0, type 8b51, size 0, index 0, binding -1
+attributeFloat4: offset 0, type 8b52, size 0, index 0, binding -1
+attributeMat4: offset 0, type 8b5c, size 0, index 0, binding -1
 

--- a/Test/baseResults/spv.buffer.autoassign.frag.out
+++ b/Test/baseResults/spv.buffer.autoassign.frag.out
@@ -16,28 +16,28 @@ Linked fragment stage:
                               Name 8  "PS_OUTPUT"
                               MemberName 8(PS_OUTPUT) 0  "Color"
                               Name 10  "psout"
-                              Name 13  ""
-                              MemberName 13 0  "g_a"
-                              MemberName 13 1  "g_b"
+                              Name 13  "MyUB1"
+                              MemberName 13(MyUB1) 0  "g_a"
+                              MemberName 13(MyUB1) 1  "g_b"
                               Name 15  ""
-                              Name 25  ""
-                              MemberName 25 0  "g_c"
+                              Name 25  "MyUB2"
+                              MemberName 25(MyUB2) 0  "g_c"
                               Name 27  ""
-                              Name 31  ""
-                              MemberName 31 0  "g_d"
+                              Name 31  "MyUB3"
+                              MemberName 31(MyUB3) 0  "g_d"
                               Name 33  ""
                               Name 41  "Color"
-                              MemberDecorate 13 0 Offset 0
-                              MemberDecorate 13 1 Offset 4
-                              Decorate 13 Block
+                              MemberDecorate 13(MyUB1) 0 Offset 0
+                              MemberDecorate 13(MyUB1) 1 Offset 4
+                              Decorate 13(MyUB1) Block
                               Decorate 15 DescriptorSet 0
                               Decorate 15 Binding 20
-                              MemberDecorate 25 0 Offset 0
-                              Decorate 25 Block
+                              MemberDecorate 25(MyUB2) 0 Offset 0
+                              Decorate 25(MyUB2) Block
                               Decorate 27 DescriptorSet 0
                               Decorate 27 Binding 15
-                              MemberDecorate 31 0 Offset 0
-                              Decorate 31 Block
+                              MemberDecorate 31(MyUB3) 0 Offset 0
+                              Decorate 31(MyUB3) Block
                               Decorate 33 DescriptorSet 0
                               Decorate 33 Binding 16
                               Decorate 41(Color) Location 0
@@ -49,17 +49,17 @@ Linked fragment stage:
                9:             TypePointer Function 8(PS_OUTPUT)
               11:             TypeInt 32 1
               12:     11(int) Constant 0
-              13:             TypeStruct 6(float) 11(int)
-              14:             TypePointer Uniform 13(struct)
+       13(MyUB1):             TypeStruct 6(float) 11(int)
+              14:             TypePointer Uniform 13(MyUB1)
               15:     14(ptr) Variable Uniform
               16:             TypePointer Uniform 6(float)
               19:     11(int) Constant 1
               20:             TypePointer Uniform 11(int)
-              25:             TypeStruct 6(float)
-              26:             TypePointer Uniform 25(struct)
+       25(MyUB2):             TypeStruct 6(float)
+              26:             TypePointer Uniform 25(MyUB2)
               27:     26(ptr) Variable Uniform
-              31:             TypeStruct 6(float)
-              32:             TypePointer Uniform 31(struct)
+       31(MyUB3):             TypeStruct 6(float)
+              32:             TypePointer Uniform 31(MyUB3)
               33:     32(ptr) Variable Uniform
               38:             TypePointer Function 7(fvec4)
               40:             TypePointer Output 7(fvec4)

--- a/Test/hlsl.reflection.binding.frag
+++ b/Test/hlsl.reflection.binding.frag
@@ -1,0 +1,34 @@
+
+uniform float u1 : register(b2);
+
+uniform SamplerState s1     : register(s5);
+uniform SamplerState s1a[3] : register(s6);
+
+uniform Texture1D t1     : register(t15);
+uniform Texture1D t1a[3] : register(t16);
+
+cbuffer cbuff1 : register(b2) {
+    float4 c1_a;
+    int c1_b;
+    float c1_c;
+};
+
+cbuffer cbuff2 : register(b3) {
+    float4 c2_a;
+    int c2_b;
+    float c2_c;
+};
+
+struct PS_OUTPUT
+{
+    float4 Color : Sv_Target0;
+};
+
+void main(out PS_OUTPUT psout)
+{
+    psout.Color = 
+        t1.Sample(s1, 0.3) +
+        t1a[0].Sample(s1a[0], 0.3) +
+        c1_a + c1_b + c1_c +
+        c2_a + c2_b + c2_c;
+}

--- a/Test/runtests
+++ b/Test/runtests
@@ -33,6 +33,9 @@ $EXE -l -q -C reflection.vert > $TARGETDIR/reflection.vert.out
 diff -b $BASEDIR/reflection.vert.out $TARGETDIR/reflection.vert.out || HASERROR=1
 $EXE -D -e flizv -l -q -C -V hlsl.reflection.vert > $TARGETDIR/hlsl.reflection.vert.out
 diff -b $BASEDIR/hlsl.reflection.vert.out $TARGETDIR/hlsl.reflection.vert.out || HASERROR=1
+$EXE -D -e main -l -q -C -V hlsl.reflection.binding.frag > $TARGETDIR/hlsl.reflection.binding.frag.out
+diff -b $BASEDIR/hlsl.reflection.binding.frag.out $TARGETDIR/hlsl.reflection.binding.frag.out || HASERROR=1
+
 
 #
 # multi-threaded test

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -1202,7 +1202,7 @@ public:
             typeName = NewPoolTString(copyOf.typeName->c_str());
     }
 
-    TType* clone()
+    TType* clone() const
     {
         TType *newType = new TType();
         newType->deepCopy(*this);

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1694,19 +1694,21 @@ bool TProgram::buildReflection()
     return true;
 }
 
-int TProgram::getNumLiveUniformVariables()           { return reflection->getNumUniforms(); }
-int TProgram::getNumLiveUniformBlocks()              { return reflection->getNumUniformBlocks(); }
-const char* TProgram::getUniformName(int index)      { return reflection->getUniform(index).name.c_str(); }
-const char* TProgram::getUniformBlockName(int index) { return reflection->getUniformBlock(index).name.c_str(); }
-int TProgram::getUniformBlockSize(int index)         { return reflection->getUniformBlock(index).size; }
-int TProgram::getUniformIndex(const char* name)      { return reflection->getIndex(name); }
-int TProgram::getUniformBlockIndex(int index)        { return reflection->getUniform(index).index; }
-int TProgram::getUniformType(int index)              { return reflection->getUniform(index).glDefineType; }
-int TProgram::getUniformBufferOffset(int index)      { return reflection->getUniform(index).offset; }
-int TProgram::getUniformArraySize(int index)         { return reflection->getUniform(index).size; }
-int TProgram::getNumLiveAttributes()                 { return reflection->getNumAttributes(); }
-const char* TProgram::getAttributeName(int index)    { return reflection->getAttribute(index).name.c_str(); }
-int TProgram::getAttributeType(int index)            { return reflection->getAttribute(index).glDefineType; }
+int TProgram::getNumLiveUniformVariables() const             { return reflection->getNumUniforms(); }
+int TProgram::getNumLiveUniformBlocks() const                { return reflection->getNumUniformBlocks(); }
+const char* TProgram::getUniformName(int index) const        { return reflection->getUniform(index).name.c_str(); }
+const char* TProgram::getUniformBlockName(int index) const   { return reflection->getUniformBlock(index).name.c_str(); }
+int TProgram::getUniformBlockSize(int index) const           { return reflection->getUniformBlock(index).size; }
+int TProgram::getUniformIndex(const char* name) const        { return reflection->getIndex(name); }
+int TProgram::getUniformBlockIndex(int index) const          { return reflection->getUniform(index).index; }
+int TProgram::getUniformType(int index) const                { return reflection->getUniform(index).glDefineType; }
+int TProgram::getUniformBufferOffset(int index) const        { return reflection->getUniform(index).offset; }
+int TProgram::getUniformArraySize(int index) const           { return reflection->getUniform(index).size; }
+int TProgram::getNumLiveAttributes() const                   { return reflection->getNumAttributes(); }
+const char* TProgram::getAttributeName(int index) const      { return reflection->getAttribute(index).name.c_str(); }
+int TProgram::getAttributeType(int index) const              { return reflection->getAttribute(index).glDefineType; }
+const TType* TProgram::getUniformTType(int index) const      { return reflection->getUniform(index).getType(); }
+const TType* TProgram::getUniformBlockTType(int index) const { return reflection->getUniformBlock(index).getType(); }
 
 void TProgram::dumpReflection()                      { reflection->dump(); }
 

--- a/glslang/MachineIndependent/reflection.h
+++ b/glslang/MachineIndependent/reflection.h
@@ -1,5 +1,5 @@
 //
-//Copyright (C) 2013 LunarG, Inc.
+//Copyright (C) 2013-2016 LunarG, Inc.
 //
 //All rights reserved.
 //
@@ -37,6 +37,7 @@
 #define _REFLECTION_INCLUDED
 
 #include "../Public/ShaderLang.h"
+#include "../Include/Types.h"
 
 #include <list>
 #include <set>
@@ -54,20 +55,41 @@ class TReflectionTraverser;
 // Data needed for just a single object at the granularity exchanged by the reflection API
 class TObjectReflection {
 public:
-    TObjectReflection(const TString& pName, int pOffset, int pGLDefineType, int pSize, int pIndex) : 
-        name(pName), offset(pOffset), glDefineType(pGLDefineType), size(pSize), index(pIndex) { }
-    void dump() const { printf("%s: offset %d, type %x, size %d, index %d\n", name.c_str(), offset, glDefineType, size, index); }
+    TObjectReflection(const TString& pName, const TType& pType, int pOffset, int pGLDefineType, int pSize, int pIndex) : 
+        name(pName), type(pType.clone()),
+        offset(pOffset), glDefineType(pGLDefineType), size(pSize), index(pIndex) { }
+
+    void dump() const {
+        printf("%s: offset %d, type %x, size %d, index %d, binding %d\n",
+               name.c_str(), offset, glDefineType, size, index, getBinding() );
+    }
+
+    const TType* const getType() const { return type; }
+
     TString name;
     int offset;
     int glDefineType;
     int size;         // data size in bytes for a block, array size for a (non-block) object that's an array
     int index;
+
+    static TObjectReflection badReflection() { return TObjectReflection(); }
+
+protected:
+    int getBinding() const {
+        if (type == nullptr || type->getQualifier().layoutBinding == TQualifier::layoutBindingEnd)
+            return -1;
+        return type->getQualifier().layoutBinding;
+    }
+
+    TObjectReflection() : type(nullptr), offset(-1), glDefineType(-1), size(-1), index(-1) { }
+
+    const TType* type;
 };
 
 // The full reflection database
 class TReflection {
 public:
-    TReflection() : badReflection("__bad__", -1, -1, -1, -1) {}
+    TReflection() : badReflection(TObjectReflection::badReflection()) { }
     virtual ~TReflection() {}
 
     // grow the reflection stage by stage

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -1,5 +1,7 @@
 //
 //Copyright (C) 2002-2005  3Dlabs Inc. Ltd.
+//Copyright (C) 2013-2016 LunarG, Inc.
+//
 //All rights reserved.
 //
 //Redistribution and use in source and binary forms, with or without
@@ -100,6 +102,8 @@ typedef enum {
 } EShLanguageMask;
 
 namespace glslang {
+
+class TType;
 
 typedef enum {
     EShSourceNone,
@@ -461,19 +465,22 @@ public:
 
     // Reflection Interface
     bool buildReflection();                          // call first, to do liveness analysis, index mapping, etc.; returns false on failure
-    int getNumLiveUniformVariables();                // can be used for glGetProgramiv(GL_ACTIVE_UNIFORMS)
-    int getNumLiveUniformBlocks();                   // can be used for glGetProgramiv(GL_ACTIVE_UNIFORM_BLOCKS)
-    const char* getUniformName(int index);           // can be used for "name" part of glGetActiveUniform()
-    const char* getUniformBlockName(int blockIndex); // can be used for glGetActiveUniformBlockName()
-    int getUniformBlockSize(int blockIndex);         // can be used for glGetActiveUniformBlockiv(UNIFORM_BLOCK_DATA_SIZE)
-    int getUniformIndex(const char* name);           // can be used for glGetUniformIndices()
-    int getUniformBlockIndex(int index);             // can be used for glGetActiveUniformsiv(GL_UNIFORM_BLOCK_INDEX)
-    int getUniformType(int index);                   // can be used for glGetActiveUniformsiv(GL_UNIFORM_TYPE)
-    int getUniformBufferOffset(int index);           // can be used for glGetActiveUniformsiv(GL_UNIFORM_OFFSET)
-    int getUniformArraySize(int index);              // can be used for glGetActiveUniformsiv(GL_UNIFORM_SIZE)
-    int getNumLiveAttributes();                      // can be used for glGetProgramiv(GL_ACTIVE_ATTRIBUTES)
-    const char *getAttributeName(int index);         // can be used for glGetActiveAttrib()
-    int getAttributeType(int index);                 // can be used for glGetActiveAttrib()
+    int getNumLiveUniformVariables() const;                // can be used for glGetProgramiv(GL_ACTIVE_UNIFORMS)
+    int getNumLiveUniformBlocks() const;                   // can be used for glGetProgramiv(GL_ACTIVE_UNIFORM_BLOCKS)
+    const char* getUniformName(int index) const;           // can be used for "name" part of glGetActiveUniform()
+    const char* getUniformBlockName(int blockIndex) const; // can be used for glGetActiveUniformBlockName()
+    int getUniformBlockSize(int blockIndex) const;         // can be used for glGetActiveUniformBlockiv(UNIFORM_BLOCK_DATA_SIZE)
+    int getUniformIndex(const char* name) const;           // can be used for glGetUniformIndices()
+    int getUniformBlockIndex(int index) const;             // can be used for glGetActiveUniformsiv(GL_UNIFORM_BLOCK_INDEX)
+    int getUniformType(int index) const;                   // can be used for glGetActiveUniformsiv(GL_UNIFORM_TYPE)
+    int getUniformBufferOffset(int index) const;           // can be used for glGetActiveUniformsiv(GL_UNIFORM_OFFSET)
+    int getUniformArraySize(int index) const;              // can be used for glGetActiveUniformsiv(GL_UNIFORM_SIZE)
+    int getNumLiveAttributes() const;                      // can be used for glGetProgramiv(GL_ACTIVE_ATTRIBUTES)
+    const char *getAttributeName(int index) const;         // can be used for glGetActiveAttrib()
+    int getAttributeType(int index) const;                 // can be used for glGetActiveAttrib()
+    const TType* getUniformTType(int index) const;         // returns a TType*
+    const TType* getUniformBlockTType(int index) const;    // returns a TType*    
+
     void dumpReflection();
 
     // I/O mapping: apply base offsets and map live unbound variables

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -4532,8 +4532,10 @@ void HlslParseContext::declareBlock(const TSourceLoc& loc, TType& type, const TS
     // Build and add the interface block as a new type named 'blockName'
     //
 
-    //?? need the block name to be a typename?
-    TType blockType(&typeList, "" /* *blockName */, type.getQualifier());
+    // Use the instance name as the interface name if one exists, else the block name.
+    const TString& interfaceName = (instanceName && !instanceName->empty()) ? *instanceName : type.getTypeName();
+
+    TType blockType(&typeList, interfaceName, type.getQualifier());
     if (arraySizes)
         blockType.newArraySizes(*arraySizes);
 


### PR DESCRIPTION
…face names.

- Add new queries: TProgram::getUniformTType and getUniformBlockTType, which return a const TType*, or nullptr on a bad index.  These are valid for any source language.

- Interface name for HLSL cbuffers is taken from the (only) available declaration name, whereas before it was always an empty string, which caused some troubles with reflection mapping them all to the same index slot.  This also makes it appear in the SPIR-V binary instead of an empty string.

- Print the binding as part of the reflection textual dump.

- Since it's invalid to have both an instance and a block name in HLSL (e.g, cbuffer A { ... } B), and some existing HLSL tests were doing that, I have changed a few of the tests so they don't. That in effect hoists the members to the global namespace, which caused a few collisions, so I renamed those.  E.g, in hlsl.reflection.vert.  This makes them valid code.

- TType::clone becomes const.  Needed to call it from a const method, and anyway it doesn't change the object it's called on.

- Because the TObjectReflection constructor is called with a TType *reference* (not pointer) so that it's guaranteed to pass in a type, and the "badReflection" value should use a nullptr there, that now has a dedicated static method to obtain the bad value.  It uses a private constructor, so external users can't create one with a nullptr type.