### PR TITLE
Gtests can be run on another source tree

### DIFF
--- a/gtests/AST.FromFile.cpp
+++ b/gtests/AST.FromFile.cpp
@@ -43,7 +43,7 @@ using CompileToAstTest = GlslangTest<::testing::TestWithParam<std::string>>;
 
 TEST_P(CompileToAstTest, FromFile)
 {
-    loadFileCompileAndCheck(GLSLANG_TEST_DIRECTORY, GetParam(),
+    loadFileCompileAndCheck(GlobalTestSettings.testRoot, GetParam(),
                             Source::GLSL, Semantics::OpenGL,
                             Target::AST);
 }

--- a/gtests/BuiltInResource.FromFile.cpp
+++ b/gtests/BuiltInResource.FromFile.cpp
@@ -46,7 +46,7 @@ using DefaultResourceTest = GlslangTest<::testing::Test>;
 
 TEST_F(DefaultResourceTest, FromFile)
 {
-    const std::string path = GLSLANG_TEST_DIRECTORY "/baseResults/test.conf";
+    const std::string path = GlobalTestSettings.testRoot + "/baseResults/test.conf";
     std::string expectedConfig;
     tryLoadFile(path, "expected resource limit", &expectedConfig);
     const std::string realConfig = glslang::GetDefaultTBuiltInResourceString();

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -29,8 +29,12 @@ if (TARGET gmock)
   install(TARGETS glslangtests
         RUNTIME DESTINATION bin)
 
+  set(GLSLANG_TEST_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../Test")
+  # Supply a default test root directory, so that manual testing
+  # doesn't have to specify the --test-root option in the normal
+  # case that you want to use the tests from the same source tree.
   target_compile_definitions(glslangtests
-    PRIVATE GLSLANG_TEST_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}/../Test")
+    PRIVATE GLSLANG_TEST_DIRECTORY="${GLSLANG_TEST_DIRECTORY}")
   target_include_directories(glslangtests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${PROJECT_SOURCE_DIR}
@@ -39,5 +43,6 @@ if (TARGET gmock)
   target_link_libraries(glslangtests PRIVATE
     SPVRemapper glslang OSDependent OGLCompiler HLSL glslang
     SPIRV glslang-default-resource-limits gmock)
-  add_test(NAME glslang-gtests COMMAND glslangtests)
+  add_test(NAME glslang-gtests
+	   COMMAND glslangtests --test-root "${GLSLANG_TEST_DIRECTORY}")
 endif()

--- a/gtests/Config.FromFile.cpp
+++ b/gtests/Config.FromFile.cpp
@@ -54,8 +54,8 @@ TEST_P(ConfigTest, FromFile)
 
     // Get the contents for input shader and limit configurations.
     std::string shaderContents, configContents;
-    tryLoadFile(GLSLANG_TEST_DIRECTORY "/" + testCase.input, "input", &shaderContents);
-    tryLoadFile(GLSLANG_TEST_DIRECTORY "/" + testCase.config, "limits config", &configContents);
+    tryLoadFile(GlobalTestSettings.testRoot + "/" + testCase.input, "input", &shaderContents);
+    tryLoadFile(GlobalTestSettings.testRoot + "/" + testCase.config, "limits config", &configContents);
 
     // Decode limit configurations.
     TBuiltInResource resources = {};
@@ -86,7 +86,7 @@ TEST_P(ConfigTest, FromFile)
 
     // Check with expected results.
     const std::string expectedOutputFname =
-        GLSLANG_TEST_DIRECTORY "/baseResults/" + testCase.output;
+        GlobalTestSettings.testRoot + "/baseResults/" + testCase.output;
     std::string expectedOutput;
     tryLoadFile(expectedOutputFname, "expected output", &expectedOutput);
 

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -64,14 +64,14 @@ using HlslCompileAndFlattenTest = GlslangTest<::testing::TestWithParam<FileNameE
 // generate both AST and SPIR-V.
 TEST_P(HlslCompileTest, FromFile)
 {
-    loadFileCompileAndCheck(GLSLANG_TEST_DIRECTORY, GetParam().fileName,
+    loadFileCompileAndCheck(GlobalTestSettings.testRoot, GetParam().fileName,
                             Source::HLSL, Semantics::Vulkan,
                             Target::BothASTAndSpv, GetParam().entryPoint);
 }
 
 TEST_P(HlslCompileAndFlattenTest, FromFile)
 {
-    loadFileCompileFlattenUniformsAndCheck(GLSLANG_TEST_DIRECTORY, GetParam().fileName,
+    loadFileCompileFlattenUniformsAndCheck(GlobalTestSettings.testRoot, GetParam().fileName,
                                            Source::HLSL, Semantics::Vulkan,
                                            Target::BothASTAndSpv, GetParam().entryPoint);
 }

--- a/gtests/Link.FromFile.cpp
+++ b/gtests/Link.FromFile.cpp
@@ -55,7 +55,7 @@ TEST_P(LinkTest, FromFile)
     std::vector<std::unique_ptr<glslang::TShader>> shaders;
     for (size_t i = 0; i < fileCount; ++i) {
         std::string contents;
-        tryLoadFile(GLSLANG_TEST_DIRECTORY "/" + fileNames[i],
+        tryLoadFile(GlobalTestSettings.testRoot + "/" + fileNames[i],
                     "input", &contents);
         shaders.emplace_back(
                 new glslang::TShader(GetShaderStage(GetSuffix(fileNames[i]))));
@@ -77,7 +77,7 @@ TEST_P(LinkTest, FromFile)
 
     // Check with expected results.
     const std::string expectedOutputFname =
-        GLSLANG_TEST_DIRECTORY "/baseResults/" + fileNames.front() + ".out";
+        GlobalTestSettings.testRoot + "/baseResults/" + fileNames.front() + ".out";
     std::string expectedOutput;
     tryLoadFile(expectedOutputFname, "expected output", &expectedOutput);
 

--- a/gtests/Pp.FromFile.cpp
+++ b/gtests/Pp.FromFile.cpp
@@ -43,7 +43,7 @@ using PreprocessingTest = GlslangTest<::testing::TestWithParam<std::string>>;
 
 TEST_P(PreprocessingTest, FromFile)
 {
-    loadFilePreprocessAndCheck(GLSLANG_TEST_DIRECTORY, GetParam());
+    loadFilePreprocessAndCheck(GlobalTestSettings.testRoot, GetParam());
 }
 
 // clang-format off

--- a/gtests/Remap.FromFile.cpp
+++ b/gtests/Remap.FromFile.cpp
@@ -60,17 +60,17 @@ std::string FileNameAsCustomTestSuffix(
 
 using RemapTest = GlslangTest<::testing::TestWithParam<RemapTestArgs>>;
 
-// Remapping SPIR-V modules. 
+// Remapping SPIR-V modules.
 TEST_P(RemapTest, FromFile)
 {
     if (GetSuffix(GetParam().fileName) == "spv") {
-        loadFileRemapAndCheck(GLSLANG_TEST_DIRECTORY, GetParam().fileName,
+        loadFileRemapAndCheck(GlobalTestSettings.testRoot, GetParam().fileName,
                               GetParam().sourceLanguage,
                               Semantics::Vulkan,
                               Target::Spv,
                               GetParam().remapOpts);
     } else {
-        loadFileCompileRemapAndCheck(GLSLANG_TEST_DIRECTORY, GetParam().fileName,
+        loadFileCompileRemapAndCheck(GlobalTestSettings.testRoot, GetParam().fileName,
                                      GetParam().sourceLanguage,
                                      Semantics::Vulkan,
                                      Target::Spv,

--- a/gtests/Settings.cpp
+++ b/gtests/Settings.cpp
@@ -36,6 +36,16 @@
 
 namespace glslangtest {
 
-GTestSettings GlobalTestSettings = {nullptr, false};
+// We need CMake to provide us the absolute path to the directory containing
+// test files, so we are certain to find those files no matter where the test
+// harness binary is generated. This provides out-of-source build capability.
+// This will be used as the default test root, but can be overridden with
+// the --test-root argument.
+#ifndef GLSLANG_TEST_DIRECTORY
+#error \
+    "GLSLANG_TEST_DIRECTORY needs to be defined for gtest to locate test files."
+#endif
+
+GTestSettings GlobalTestSettings = {nullptr, false, GLSLANG_TEST_DIRECTORY};
 
 }  // namespace glslangtest

--- a/gtests/Settings.h
+++ b/gtests/Settings.h
@@ -35,6 +35,8 @@
 #ifndef GLSLANG_GTESTS_SETTINGS_H
 #define GLSLANG_GTESTS_SETTINGS_H
 
+#include <string>
+
 namespace glslangtest {
 
 class GlslangInitializer;
@@ -45,6 +47,8 @@ struct GTestSettings {
     // An indicator of whether GTest should write real output to the file for
     // the expected output.
     bool updateMode;
+    // The root directory for test files.
+    std::string testRoot;
 };
 
 extern GTestSettings GlobalTestSettings;

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -75,7 +75,7 @@ using CompileVulkanToSpirvTestAMD = GlslangTest<::testing::TestWithParam<std::st
 // generate SPIR-V.
 TEST_P(CompileVulkanToSpirvTest, FromFile)
 {
-    loadFileCompileAndCheck(GLSLANG_TEST_DIRECTORY, GetParam(),
+    loadFileCompileAndCheck(GlobalTestSettings.testRoot, GetParam(),
                             Source::GLSL, Semantics::Vulkan,
                             Target::Spv);
 }
@@ -84,7 +84,7 @@ TEST_P(CompileVulkanToSpirvTest, FromFile)
 // generate SPIR-V.
 TEST_P(CompileOpenGLToSpirvTest, FromFile)
 {
-    loadFileCompileAndCheck(GLSLANG_TEST_DIRECTORY, GetParam(),
+    loadFileCompileAndCheck(GlobalTestSettings.testRoot, GetParam(),
                             Source::GLSL, Semantics::OpenGL,
                             Target::Spv);
 }
@@ -93,7 +93,7 @@ TEST_P(CompileOpenGLToSpirvTest, FromFile)
 // SPIR-V.
 TEST_P(VulkanSemantics, FromFile)
 {
-    loadFileCompileAndCheck(GLSLANG_TEST_DIRECTORY, GetParam(),
+    loadFileCompileAndCheck(GlobalTestSettings.testRoot, GetParam(),
                             Source::GLSL, Semantics::Vulkan,
                             Target::Spv);
 }
@@ -102,7 +102,7 @@ TEST_P(VulkanSemantics, FromFile)
 // SPIR-V.
 TEST_P(OpenGLSemantics, FromFile)
 {
-    loadFileCompileAndCheck(GLSLANG_TEST_DIRECTORY, GetParam(),
+    loadFileCompileAndCheck(GlobalTestSettings.testRoot, GetParam(),
                             Source::GLSL, Semantics::OpenGL,
                             Target::Spv);
 }
@@ -110,7 +110,7 @@ TEST_P(OpenGLSemantics, FromFile)
 // GLSL-level Vulkan semantics test that need to see the AST for validation.
 TEST_P(VulkanAstSemantics, FromFile)
 {
-    loadFileCompileAndCheck(GLSLANG_TEST_DIRECTORY, GetParam(),
+    loadFileCompileAndCheck(GlobalTestSettings.testRoot, GetParam(),
                             Source::GLSL, Semantics::Vulkan,
                             Target::AST);
 }
@@ -118,7 +118,7 @@ TEST_P(VulkanAstSemantics, FromFile)
 // HLSL-level Vulkan semantics tests.
 TEST_P(HlslIoMap, FromFile)
 {
-    loadFileCompileIoMapAndCheck(GLSLANG_TEST_DIRECTORY, GetParam().fileName,
+    loadFileCompileIoMapAndCheck(GlobalTestSettings.testRoot, GetParam().fileName,
                                  Source::HLSL, Semantics::Vulkan,
                                  Target::Spv, GetParam().entryPoint,
                                  GetParam().baseSamplerBinding,
@@ -131,7 +131,7 @@ TEST_P(HlslIoMap, FromFile)
 // GLSL-level Vulkan semantics tests.
 TEST_P(GlslIoMap, FromFile)
 {
-    loadFileCompileIoMapAndCheck(GLSLANG_TEST_DIRECTORY, GetParam().fileName,
+    loadFileCompileIoMapAndCheck(GlobalTestSettings.testRoot, GetParam().fileName,
                                  Source::GLSL, Semantics::Vulkan,
                                  Target::Spv, GetParam().entryPoint,
                                  GetParam().baseSamplerBinding,
@@ -146,7 +146,7 @@ TEST_P(GlslIoMap, FromFile)
 // Expected to successfully generate SPIR-V.
 TEST_P(CompileVulkanToSpirvTestAMD, FromFile)
 {
-    loadFileCompileAndCheck(GLSLANG_TEST_DIRECTORY, GetParam(),
+    loadFileCompileAndCheck(GlobalTestSettings.testRoot, GetParam(),
                             Source::GLSL, Semantics::Vulkan,
                             Target::Spv);
 }

--- a/gtests/TestFixture.h
+++ b/gtests/TestFixture.h
@@ -54,14 +54,6 @@
 #include "Initializer.h"
 #include "Settings.h"
 
-// We need CMake to provide us the absolute path to the directory containing
-// test files, so we are certain to find those files no matter where the test
-// harness binary is generated. This provides out-of-source build capability.
-#ifndef GLSLANG_TEST_DIRECTORY
-#error \
-    "GLSLANG_TEST_DIRECTORY needs to be defined for gtest to locate test files."
-#endif
-
 namespace glslangtest {
 
 // This function is used to provide custom test name suffixes based on the

--- a/gtests/main.cpp
+++ b/gtests/main.cpp
@@ -33,6 +33,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include <memory>
+#include <string>
 
 #include <gtest/gtest.h>
 
@@ -49,9 +50,19 @@ int main(int argc, char** argv)
     glslangtest::GlobalTestSettings.initializer = initializer.get();
 
     for (int i = 1; i < argc; ++i) {
-        if (!strncmp("--update-mode", argv[i], 13)) {
+        if (std::string("--update-mode") == argv[i]) {
             glslangtest::GlobalTestSettings.updateMode = true;
-            break;
+        }
+        if (std::string("--test-root") == argv[i]) {
+            // Allow the user set the tets root directory.  This is useful
+            // for testing with files from another source tree.
+            if (i + 1 < argc) {
+                glslangtest::GlobalTestSettings.testRoot = argv[i + 1];
+                i++;
+            } else {
+                printf("error: --test-root requires an argument\n");
+                return 1;
+            }
         }
     }
 


### PR DESCRIPTION
The gtest executable accepts a --test-root option to specify
a root directory for test files.  It defaults to the Test directory
in the source tree from which the executable is built.

For example, this lets us run test exectuables built with MinGW on Linux
on a Windows machine with its own copy of the source tree.