### PR TITLE
Check for out-of-range bindings during IO mapping.

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -584,6 +584,12 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
     if (! (Options & EOptionOutputPreprocessed) && ! program.link(messages))
         LinkFailed = true;
 
+    // Map IO
+    if (Options & EOptionSpv) {
+        if (!program.mapIO())
+            LinkFailed = true;
+    }
+    
     // Report
     if (! (Options & EOptionSuppressInfolog) &&
         ! (Options & EOptionMemoryLeakMode)) {
@@ -591,10 +597,6 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
         PutsIfNonEmpty(program.getInfoDebugLog());
     }
 
-    // Map IO
-    if (Options & EOptionSpv)
-        program.mapIO();
-    
     // Reflect
     if (Options & EOptionDumpReflection) {
         program.buildReflection();

--- a/Test/baseResults/spv.register.autoassign.rangetest.frag.out
+++ b/Test/baseResults/spv.register.autoassign.rangetest.frag.out
@@ -1,0 +1,12 @@
+spv.register.autoassign.rangetest.frag
+
+Linked fragment stage:
+
+INTERNAL ERROR: mapped binding out of range: g_tScene
+INTERNAL ERROR: mapped binding out of range: g_tSamp
+INTERNAL ERROR: mapped binding out of range: g_tScene
+INTERNAL ERROR: mapped binding out of range: g_tSamp
+INTERNAL ERROR: mapped binding out of range: g_tSamp
+INTERNAL ERROR: mapped binding out of range: g_tScene
+
+SPIR-V is not generated for failed compile or link

--- a/Test/spv.register.autoassign.rangetest.frag
+++ b/Test/spv.register.autoassign.rangetest.frag
@@ -1,0 +1,15 @@
+
+SamplerState g_tSamp : register(s5);
+
+Texture2D g_tScene[2] : register(t5);
+
+struct PS_OUTPUT
+{
+    float4 Color : SV_Target0;
+};
+
+void main(out PS_OUTPUT psout)
+{
+    psout.Color = g_tScene[0].Sample(g_tSamp, 0.3) +
+                  g_tScene[1].Sample(g_tSamp, 0.3);
+}

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1724,7 +1724,7 @@ bool TProgram::mapIO()
 
     for (int s = 0; s < EShLangCount; ++s) {
         if (intermediate[s]) {
-            if (! ioMapper->addStage((EShLanguage)s, *intermediate[s]))
+            if (! ioMapper->addStage((EShLanguage)s, *intermediate[s], *infoSink))
                 return false;
         }
     }

--- a/glslang/MachineIndependent/iomapper.h
+++ b/glslang/MachineIndependent/iomapper.h
@@ -42,6 +42,8 @@
 // A reflection database and its interface, consistent with the OpenGL API reflection queries.
 //
 
+class TInfoSink;
+
 namespace glslang {
 
 class TIntermediate;
@@ -53,7 +55,7 @@ public:
     virtual ~TIoMapper() {}
 
     // grow the reflection stage by stage
-    bool addStage(EShLanguage, TIntermediate&);
+    bool addStage(EShLanguage, TIntermediate&, TInfoSink&);
 };
 
 } // end namespace glslang

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -285,6 +285,10 @@ INSTANTIATE_TEST_CASE_P(
         { "spv.register.noautoassign.frag", "main_ep", 5, 10, 15, false, false },
         { "spv.register.autoassign-2.frag", "main", 5, 10, 15, true, true },
         { "spv.buffer.autoassign.frag", "main", 5, 10, 15, true, true },
+        { "spv.register.autoassign.rangetest.frag", "main", 
+                glslang::TQualifier::layoutBindingEnd-2,
+                glslang::TQualifier::layoutBindingEnd+5,
+                20, true, false },
     }),
     FileNameAsCustomTestSuffixIoMap
 );


### PR DESCRIPTION
Produces an error if IO mapping attempts to apply a binding out of the valid range.

