### PR TITLE
Use pthread_mutex for global lock on Linux.

### DIFF
--- a/glslang/OSDependent/Unix/ossource.cpp
+++ b/glslang/OSDependent/Unix/ossource.cpp
@@ -165,11 +165,12 @@ bool OS_FreeTLSIndex(OS_TLSIndex nIndex)
 		return false;
 }
 
-// TODO: non-windows: if we need these on linux, flesh them out
-void InitGlobalLock() { }
-void GetGlobalLock() { }
-void ReleaseGlobalLock() { }
+static pthread_mutex_t gMutex;
+void InitGlobalLock() { pthread_mutex_init(&gMutex, NULL); }
+void GetGlobalLock() { pthread_mutex_lock(&gMutex); }
+void ReleaseGlobalLock() { pthread_mutex_unlock(&gMutex); }
 
+// TODO: non-windows: if we need these on linux, flesh them out
 void* OS_CreateThread(TThreadEntrypoint /*entry*/)
 {
     return 0;

--- a/glslang/OSDependent/Unix/ossource.cpp
+++ b/glslang/OSDependent/Unix/ossource.cpp
@@ -165,10 +165,27 @@ bool OS_FreeTLSIndex(OS_TLSIndex nIndex)
 		return false;
 }
 
-static pthread_mutex_t gMutex;
-void InitGlobalLock() { pthread_mutex_init(&gMutex, NULL); }
-void GetGlobalLock() { pthread_mutex_lock(&gMutex); }
-void ReleaseGlobalLock() { pthread_mutex_unlock(&gMutex); }
+namespace {
+pthread_mutex_t gMutex;
+}
+
+void InitGlobalLock()
+{
+  pthread_mutexattr_t mutexattr;
+  pthread_mutexattr_init(&mutexattr);
+  pthread_mutexattr_settype(&mutexattr, PTHREAD_MUTEX_RECURSIVE);
+  pthread_mutex_init(&gMutex, &mutexattr);
+}
+
+void GetGlobalLock()
+{
+  pthread_mutex_lock(&gMutex);
+}
+
+void ReleaseGlobalLock()
+{
+  pthread_mutex_unlock(&gMutex);
+}
 
 // TODO: non-windows: if we need these on linux, flesh them out
 void* OS_CreateThread(TThreadEntrypoint /*entry*/)


### PR DESCRIPTION
This allows multithreaded use of multiple TShader instances on Linux.  If I wasn't lazy, I'd also implement OS_CreateThread() and friends, but I don't need them and I already spent hours tracing my crash to the silent lack of a global lock.