### PR TITLE
Address some compiler warnings.

### DIFF
--- a/glslang/Include/InfoSink.h
+++ b/glslang/Include/InfoSink.h
@@ -74,7 +74,6 @@ public:
     TInfoSinkBase& operator<<(const char* s)           { append(s); return *this; }
     TInfoSinkBase& operator<<(int n)                   { append(String(n)); return *this; }
     TInfoSinkBase& operator<<(unsigned int n)          { append(String(n)); return *this; }
-    TInfoSinkBase& operator<<(long unsigned int n)     { append(String((int)n)); return *this; }
     TInfoSinkBase& operator<<(float n)                 { const int size = 40; char buf[size]; 
                                                          snprintf(buf, size, (fabs(n) > 1e-8 && fabs(n) < 1e8) || n == 0.0f ? "%f" : "%g", n);
                                                          append(buf); 

--- a/glslang/Include/InfoSink.h
+++ b/glslang/Include/InfoSink.h
@@ -74,7 +74,7 @@ public:
     TInfoSinkBase& operator<<(const char* s)           { append(s); return *this; }
     TInfoSinkBase& operator<<(int n)                   { append(String(n)); return *this; }
     TInfoSinkBase& operator<<(unsigned int n)          { append(String(n)); return *this; }
-    TInfoSinkBase& operator<<(long unsigned int n)     { append(String(n)); return *this; }
+    TInfoSinkBase& operator<<(long unsigned int n)     { append(String((int)n)); return *this; }
     TInfoSinkBase& operator<<(float n)                 { const int size = 40; char buf[size]; 
                                                          snprintf(buf, size, (fabs(n) > 1e-8 && fabs(n) < 1e8) || n == 0.0f ? "%f" : "%g", n);
                                                          append(buf); 

--- a/glslang/MachineIndependent/ParseContextBase.cpp
+++ b/glslang/MachineIndependent/ParseContextBase.cpp
@@ -320,8 +320,8 @@ bool TParseContextBase::insertGlobalUniformBlock()
     if (globalUniformBlock == nullptr)
         return true;
 
-    int numMembers = globalUniformBlock->getType().getStruct()->size();
-    bool inserted;
+    int numMembers = (int)globalUniformBlock->getType().getStruct()->size();
+    bool inserted = false;
     if (firstNewMember == 0) {
         // This is the first request; we need a normal symbol table insert
         inserted = symbolTable.insert(*globalUniformBlock);

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -1813,7 +1813,7 @@ TFunction* TParseContext::handleConstructorCall(const TSourceLoc& loc, const TPu
 }
 
 // Handle seeing a precision qualifier in the grammar.
-void TParseContext::handlePrecisionQualifier(const TSourceLoc& loc, TQualifier& qualifier, TPrecisionQualifier precision)
+void TParseContext::handlePrecisionQualifier(const TSourceLoc& /*loc*/, TQualifier& qualifier, TPrecisionQualifier precision)
 {
     if (obeyPrecisionQualifiers())
         qualifier.precision = precision;

--- a/glslang/MachineIndependent/preprocessor/PpTokens.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpTokens.cpp
@@ -235,9 +235,9 @@ int TPpContext::ReadToken(TokenStream *pTok, TPpToken *ppToken)
         case PpAtomConstInt:
             if (len > 0 && tokenText[0] == '0') {
                 if (len > 1 && (tokenText[1] == 'x' || tokenText[1] == 'X'))
-                    ppToken->ival = strtol(ppToken->name, 0, 16);
+                    ppToken->ival = (int)strtol(ppToken->name, 0, 16);
                 else
-                    ppToken->ival = strtol(ppToken->name, 0, 8);
+                    ppToken->ival = (int)strtol(ppToken->name, 0, 8);
             } else
                 ppToken->ival = atoi(ppToken->name);
             break;

--- a/glslang/MachineIndependent/propagateNoContraction.cpp
+++ b/glslang/MachineIndependent/propagateNoContraction.cpp
@@ -670,7 +670,7 @@ protected:
             // Gets the struct dereference index that leads to 'precise' object.
             ObjectAccessChain precise_accesschain_index_str =
                 getFrontElement(remained_accesschain_);
-            unsigned precise_accesschain_index = strtoul(precise_accesschain_index_str.c_str(), nullptr, 10);
+            unsigned precise_accesschain_index = (unsigned)strtoul(precise_accesschain_index_str.c_str(), nullptr, 10);
             // Gets the node pointed by the access chain index extracted before.
             glslang::TIntermTyped* potential_precise_node =
                 node->getSequence()[precise_accesschain_index]->getAsTyped();

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -966,7 +966,7 @@ TIntermTyped* HlslParseContext::handleAssign(const TSourceLoc& loc, TOperator op
 
     // Track how many items there are to copy.
     if (left->getType().isStruct())
-        memberCount = left->getType().getStruct()->size();
+        memberCount = (int)left->getType().getStruct()->size();
     if (left->getType().isArray())
         memberCount = left->getType().getCumulativeArraySize();
 
@@ -3980,7 +3980,7 @@ const TFunction* HlslParseContext::findFunction(const TSourceLoc& loc, const TFu
 // 'parseType' is the type part of the declaration (to the left)
 // 'arraySizes' is the arrayness tagged on the identifier (to the right)
 //
-void HlslParseContext::declareTypedef(const TSourceLoc& loc, TString& identifier, const TType& parseType, TArraySizes* arraySizes)
+void HlslParseContext::declareTypedef(const TSourceLoc& loc, TString& identifier, const TType& parseType, TArraySizes* /*arraySizes*/)
 {
     TType type;
     type.deepCopy(parseType);


### PR DESCRIPTION
- Add explicit casts from long to int.
- Comment out method argument names that are unused.
- Always initialize a boolean variable before it's read.