### PR TITLE
HLSL: phase 4 of RWTexture support: add image atomics

### DIFF
--- a/Test/baseResults/hlsl.rw.atomics.frag.out
+++ b/Test/baseResults/hlsl.rw.atomics.frag.out
@@ -1,0 +1,5261 @@
+hlsl.rw.atomics.frag
+Shader version: 450
+gl_FragCoord origin is upper left
+0:? Sequence
+0:45  Function Definition: main( (temp structure{temp 4-component vector of float Color})
+0:45    Function Parameters: 
+0:?     Sequence
+0:50      imageAtomicAdd (temp int)
+0:50        'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:50        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:50          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:50          Constant:
+0:50            5 (const uint)
+0:50        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:50          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:50          Constant:
+0:50            8 (const uint)
+0:51      move second child to first child (temp int)
+0:51        'out_i1' (temp int)
+0:51        imageAtomicAdd (temp int)
+0:51          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:51          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:51            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:51            Constant:
+0:51              5 (const uint)
+0:51          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:51            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:51            Constant:
+0:51              5 (const uint)
+0:52      imageAtomicAnd (temp int)
+0:52        'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:52        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:52          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:52          Constant:
+0:52            5 (const uint)
+0:52        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:52          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:52          Constant:
+0:52            8 (const uint)
+0:53      move second child to first child (temp int)
+0:53        'out_i1' (temp int)
+0:53        imageAtomicAnd (temp int)
+0:53          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:53          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:53            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:53            Constant:
+0:53              5 (const uint)
+0:53          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:53            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:53            Constant:
+0:53              5 (const uint)
+0:54      move second child to first child (temp int)
+0:54        'out_i1' (temp int)
+0:54        imageAtomicCompSwap (temp int)
+0:54          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:54          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:54            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:54            Constant:
+0:54              5 (const uint)
+0:54          i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:54            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:54            Constant:
+0:54              8 (const uint)
+0:54          i1c: direct index for structure (layout(offset=64 ) uniform int)
+0:54            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:54            Constant:
+0:54              9 (const uint)
+0:55      move second child to first child (temp int)
+0:55        'out_i1' (temp int)
+0:55        imageAtomicExchange (temp int)
+0:55          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:55          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:55            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:55            Constant:
+0:55              5 (const uint)
+0:55          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:55            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:55            Constant:
+0:55              5 (const uint)
+0:56      imageAtomicMax (temp int)
+0:56        'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:56        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:56          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:56          Constant:
+0:56            5 (const uint)
+0:56        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:56          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:56          Constant:
+0:56            8 (const uint)
+0:57      move second child to first child (temp int)
+0:57        'out_i1' (temp int)
+0:57        imageAtomicMax (temp int)
+0:57          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:57          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:57            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:57            Constant:
+0:57              5 (const uint)
+0:57          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:57            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:57            Constant:
+0:57              5 (const uint)
+0:58      imageAtomicMin (temp int)
+0:58        'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:58        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:58          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:58          Constant:
+0:58            5 (const uint)
+0:58        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:58          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:58          Constant:
+0:58            8 (const uint)
+0:59      move second child to first child (temp int)
+0:59        'out_i1' (temp int)
+0:59        imageAtomicMin (temp int)
+0:59          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:59          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:59            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:59            Constant:
+0:59              5 (const uint)
+0:59          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:59            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:59            Constant:
+0:59              5 (const uint)
+0:60      imageAtomicOr (temp int)
+0:60        'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:60        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:60          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:60          Constant:
+0:60            5 (const uint)
+0:60        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:60          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:60          Constant:
+0:60            8 (const uint)
+0:61      move second child to first child (temp int)
+0:61        'out_i1' (temp int)
+0:61        imageAtomicOr (temp int)
+0:61          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:61          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:61            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:61            Constant:
+0:61              5 (const uint)
+0:61          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:61            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:61            Constant:
+0:61              5 (const uint)
+0:62      imageAtomicXor (temp int)
+0:62        'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:62        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:62          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:62          Constant:
+0:62            5 (const uint)
+0:62        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:62          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:62          Constant:
+0:62            8 (const uint)
+0:63      move second child to first child (temp int)
+0:63        'out_i1' (temp int)
+0:63        imageAtomicXor (temp int)
+0:63          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:63          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:63            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:63            Constant:
+0:63              5 (const uint)
+0:63          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:63            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:63            Constant:
+0:63              5 (const uint)
+0:66      imageAtomicAdd (temp uint)
+0:66        'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:66        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:66          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:66          Constant:
+0:66            0 (const uint)
+0:66        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:66          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:66          Constant:
+0:66            0 (const uint)
+0:67      move second child to first child (temp uint)
+0:67        'out_u1' (temp uint)
+0:67        imageAtomicAdd (temp uint)
+0:67          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:67          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:67            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:67            Constant:
+0:67              0 (const uint)
+0:67          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:67            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:67            Constant:
+0:67              0 (const uint)
+0:68      imageAtomicAnd (temp uint)
+0:68        'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:68        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:68          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:68          Constant:
+0:68            0 (const uint)
+0:68        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:68          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:68          Constant:
+0:68            0 (const uint)
+0:69      move second child to first child (temp uint)
+0:69        'out_u1' (temp uint)
+0:69        imageAtomicAnd (temp uint)
+0:69          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:69          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:69            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:69            Constant:
+0:69              0 (const uint)
+0:69          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:69            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:69            Constant:
+0:69              0 (const uint)
+0:70      move second child to first child (temp uint)
+0:70        'out_u1' (temp uint)
+0:70        imageAtomicCompSwap (temp uint)
+0:70          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:70          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:70            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:70            Constant:
+0:70              0 (const uint)
+0:70          u1b: direct index for structure (layout(offset=28 ) uniform uint)
+0:70            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:70            Constant:
+0:70              3 (const uint)
+0:70          u1c: direct index for structure (layout(offset=32 ) uniform uint)
+0:70            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:70            Constant:
+0:70              4 (const uint)
+0:71      move second child to first child (temp uint)
+0:71        'out_u1' (temp uint)
+0:71        imageAtomicExchange (temp uint)
+0:71          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:71          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:71            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:71            Constant:
+0:71              0 (const uint)
+0:71          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:71            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:71            Constant:
+0:71              0 (const uint)
+0:72      imageAtomicMax (temp uint)
+0:72        'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:72        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:72          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:72          Constant:
+0:72            0 (const uint)
+0:72        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:72          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:72          Constant:
+0:72            0 (const uint)
+0:73      move second child to first child (temp uint)
+0:73        'out_u1' (temp uint)
+0:73        imageAtomicMax (temp uint)
+0:73          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:73          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:73            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:73            Constant:
+0:73              0 (const uint)
+0:73          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:73            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:73            Constant:
+0:73              0 (const uint)
+0:74      imageAtomicMin (temp uint)
+0:74        'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:74        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:74          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:74          Constant:
+0:74            0 (const uint)
+0:74        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:74          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:74          Constant:
+0:74            0 (const uint)
+0:75      move second child to first child (temp uint)
+0:75        'out_u1' (temp uint)
+0:75        imageAtomicMin (temp uint)
+0:75          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:75          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:75            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:75            Constant:
+0:75              0 (const uint)
+0:75          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:75            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:75            Constant:
+0:75              0 (const uint)
+0:76      imageAtomicOr (temp uint)
+0:76        'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:76        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:76          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:76          Constant:
+0:76            0 (const uint)
+0:76        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:76          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:76          Constant:
+0:76            0 (const uint)
+0:77      move second child to first child (temp uint)
+0:77        'out_u1' (temp uint)
+0:77        imageAtomicOr (temp uint)
+0:77          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:77          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:77            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:77            Constant:
+0:77              0 (const uint)
+0:77          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:77            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:77            Constant:
+0:77              0 (const uint)
+0:78      imageAtomicXor (temp uint)
+0:78        'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:78        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:78          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:78          Constant:
+0:78            0 (const uint)
+0:78        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:78          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:78          Constant:
+0:78            0 (const uint)
+0:79      move second child to first child (temp uint)
+0:79        'out_u1' (temp uint)
+0:79        imageAtomicXor (temp uint)
+0:79          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:79          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:79            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:79            Constant:
+0:79              0 (const uint)
+0:79          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:79            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:79            Constant:
+0:79              0 (const uint)
+0:82      imageAtomicAdd (temp int)
+0:82        'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:82        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:82          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:82          Constant:
+0:82            6 (const uint)
+0:82        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:82          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:82          Constant:
+0:82            8 (const uint)
+0:83      move second child to first child (temp int)
+0:83        'out_i1' (temp int)
+0:83        imageAtomicAdd (temp int)
+0:83          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:83          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:83            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:83            Constant:
+0:83              6 (const uint)
+0:83          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:83            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:83            Constant:
+0:83              5 (const uint)
+0:84      imageAtomicAnd (temp int)
+0:84        'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:84        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:84          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:84          Constant:
+0:84            6 (const uint)
+0:84        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:84          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:84          Constant:
+0:84            8 (const uint)
+0:85      move second child to first child (temp int)
+0:85        'out_i1' (temp int)
+0:85        imageAtomicAnd (temp int)
+0:85          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:85          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:85            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:85            Constant:
+0:85              6 (const uint)
+0:85          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:85            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:85            Constant:
+0:85              5 (const uint)
+0:86      move second child to first child (temp int)
+0:86        'out_i1' (temp int)
+0:86        imageAtomicCompSwap (temp int)
+0:86          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:86          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:86            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:86            Constant:
+0:86              6 (const uint)
+0:86          i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:86            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:86            Constant:
+0:86              8 (const uint)
+0:86          i1c: direct index for structure (layout(offset=64 ) uniform int)
+0:86            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:86            Constant:
+0:86              9 (const uint)
+0:87      move second child to first child (temp int)
+0:87        'out_i1' (temp int)
+0:87        imageAtomicExchange (temp int)
+0:87          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:87          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:87            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:87            Constant:
+0:87              6 (const uint)
+0:87          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:87            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:87            Constant:
+0:87              5 (const uint)
+0:88      imageAtomicMax (temp int)
+0:88        'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:88        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:88          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:88          Constant:
+0:88            6 (const uint)
+0:88        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:88          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:88          Constant:
+0:88            8 (const uint)
+0:89      move second child to first child (temp int)
+0:89        'out_i1' (temp int)
+0:89        imageAtomicMax (temp int)
+0:89          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:89          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:89            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:89            Constant:
+0:89              6 (const uint)
+0:89          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:89            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:89            Constant:
+0:89              5 (const uint)
+0:90      imageAtomicMin (temp int)
+0:90        'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:90        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:90          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:90          Constant:
+0:90            6 (const uint)
+0:90        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:90          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:90          Constant:
+0:90            8 (const uint)
+0:91      move second child to first child (temp int)
+0:91        'out_i1' (temp int)
+0:91        imageAtomicMin (temp int)
+0:91          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:91          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:91            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:91            Constant:
+0:91              6 (const uint)
+0:91          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:91            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:91            Constant:
+0:91              5 (const uint)
+0:92      imageAtomicOr (temp int)
+0:92        'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:92        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:92          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:92          Constant:
+0:92            6 (const uint)
+0:92        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:92          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:92          Constant:
+0:92            8 (const uint)
+0:93      move second child to first child (temp int)
+0:93        'out_i1' (temp int)
+0:93        imageAtomicOr (temp int)
+0:93          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:93          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:93            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:93            Constant:
+0:93              6 (const uint)
+0:93          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:93            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:93            Constant:
+0:93              5 (const uint)
+0:94      imageAtomicXor (temp int)
+0:94        'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:94        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:94          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:94          Constant:
+0:94            6 (const uint)
+0:94        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:94          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:94          Constant:
+0:94            8 (const uint)
+0:95      move second child to first child (temp int)
+0:95        'out_i1' (temp int)
+0:95        imageAtomicXor (temp int)
+0:95          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:95          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:95            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:95            Constant:
+0:95              6 (const uint)
+0:95          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:95            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:95            Constant:
+0:95              5 (const uint)
+0:98      imageAtomicAdd (temp uint)
+0:98        'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:98        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:98          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:98          Constant:
+0:98            1 (const uint)
+0:98        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:98          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:98          Constant:
+0:98            0 (const uint)
+0:99      move second child to first child (temp uint)
+0:99        'out_u1' (temp uint)
+0:99        imageAtomicAdd (temp uint)
+0:99          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:99          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:99            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:99            Constant:
+0:99              1 (const uint)
+0:99          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:99            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:99            Constant:
+0:99              0 (const uint)
+0:100      imageAtomicAnd (temp uint)
+0:100        'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:100        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:100          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:100          Constant:
+0:100            1 (const uint)
+0:100        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:100          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:100          Constant:
+0:100            0 (const uint)
+0:101      move second child to first child (temp uint)
+0:101        'out_u1' (temp uint)
+0:101        imageAtomicAnd (temp uint)
+0:101          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:101          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:101            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:101            Constant:
+0:101              1 (const uint)
+0:101          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:101            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:101            Constant:
+0:101              0 (const uint)
+0:102      move second child to first child (temp uint)
+0:102        'out_u1' (temp uint)
+0:102        imageAtomicCompSwap (temp uint)
+0:102          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:102          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:102            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:102            Constant:
+0:102              1 (const uint)
+0:102          u1b: direct index for structure (layout(offset=28 ) uniform uint)
+0:102            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:102            Constant:
+0:102              3 (const uint)
+0:102          u1c: direct index for structure (layout(offset=32 ) uniform uint)
+0:102            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:102            Constant:
+0:102              4 (const uint)
+0:103      move second child to first child (temp uint)
+0:103        'out_u1' (temp uint)
+0:103        imageAtomicExchange (temp uint)
+0:103          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:103          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:103            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:103            Constant:
+0:103              1 (const uint)
+0:103          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:103            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:103            Constant:
+0:103              0 (const uint)
+0:104      imageAtomicMax (temp uint)
+0:104        'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:104        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:104          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:104          Constant:
+0:104            1 (const uint)
+0:104        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:104          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:104          Constant:
+0:104            0 (const uint)
+0:105      move second child to first child (temp uint)
+0:105        'out_u1' (temp uint)
+0:105        imageAtomicMax (temp uint)
+0:105          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:105          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:105            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:105            Constant:
+0:105              1 (const uint)
+0:105          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:105            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:105            Constant:
+0:105              0 (const uint)
+0:106      imageAtomicMin (temp uint)
+0:106        'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:106        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:106          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:106          Constant:
+0:106            1 (const uint)
+0:106        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:106          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:106          Constant:
+0:106            0 (const uint)
+0:107      move second child to first child (temp uint)
+0:107        'out_u1' (temp uint)
+0:107        imageAtomicMin (temp uint)
+0:107          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:107          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:107            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:107            Constant:
+0:107              1 (const uint)
+0:107          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:107            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:107            Constant:
+0:107              0 (const uint)
+0:108      imageAtomicOr (temp uint)
+0:108        'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:108        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:108          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:108          Constant:
+0:108            1 (const uint)
+0:108        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:108          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:108          Constant:
+0:108            0 (const uint)
+0:109      move second child to first child (temp uint)
+0:109        'out_u1' (temp uint)
+0:109        imageAtomicOr (temp uint)
+0:109          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:109          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:109            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:109            Constant:
+0:109              1 (const uint)
+0:109          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:109            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:109            Constant:
+0:109              0 (const uint)
+0:110      imageAtomicXor (temp uint)
+0:110        'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:110        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:110          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:110          Constant:
+0:110            1 (const uint)
+0:110        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:110          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:110          Constant:
+0:110            0 (const uint)
+0:111      move second child to first child (temp uint)
+0:111        'out_u1' (temp uint)
+0:111        imageAtomicXor (temp uint)
+0:111          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:111          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:111            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:111            Constant:
+0:111              1 (const uint)
+0:111          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:111            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:111            Constant:
+0:111              0 (const uint)
+0:114      imageAtomicAdd (temp int)
+0:114        'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:114        i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:114          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:114          Constant:
+0:114            7 (const uint)
+0:114        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:114          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:114          Constant:
+0:114            8 (const uint)
+0:115      move second child to first child (temp int)
+0:115        'out_i1' (temp int)
+0:115        imageAtomicAdd (temp int)
+0:115          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:115          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:115            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:115            Constant:
+0:115              7 (const uint)
+0:115          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:115            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:115            Constant:
+0:115              5 (const uint)
+0:116      imageAtomicAnd (temp int)
+0:116        'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:116        i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:116          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:116          Constant:
+0:116            7 (const uint)
+0:116        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:116          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:116          Constant:
+0:116            8 (const uint)
+0:117      move second child to first child (temp int)
+0:117        'out_i1' (temp int)
+0:117        imageAtomicAnd (temp int)
+0:117          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:117          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:117            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:117            Constant:
+0:117              7 (const uint)
+0:117          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:117            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:117            Constant:
+0:117              5 (const uint)
+0:118      move second child to first child (temp int)
+0:118        'out_i1' (temp int)
+0:118        imageAtomicCompSwap (temp int)
+0:118          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:118          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:118            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:118            Constant:
+0:118              7 (const uint)
+0:118          i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:118            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:118            Constant:
+0:118              8 (const uint)
+0:118          i1c: direct index for structure (layout(offset=64 ) uniform int)
+0:118            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:118            Constant:
+0:118              9 (const uint)
+0:119      move second child to first child (temp int)
+0:119        'out_i1' (temp int)
+0:119        imageAtomicExchange (temp int)
+0:119          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:119          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:119            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:119            Constant:
+0:119              7 (const uint)
+0:119          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:119            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:119            Constant:
+0:119              5 (const uint)
+0:120      imageAtomicMax (temp int)
+0:120        'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:120        i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:120          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:120          Constant:
+0:120            7 (const uint)
+0:120        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:120          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:120          Constant:
+0:120            8 (const uint)
+0:121      move second child to first child (temp int)
+0:121        'out_i1' (temp int)
+0:121        imageAtomicMax (temp int)
+0:121          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:121          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:121            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:121            Constant:
+0:121              7 (const uint)
+0:121          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:121            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:121            Constant:
+0:121              5 (const uint)
+0:122      imageAtomicMin (temp int)
+0:122        'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:122        i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:122          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:122          Constant:
+0:122            7 (const uint)
+0:122        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:122          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:122          Constant:
+0:122            8 (const uint)
+0:123      move second child to first child (temp int)
+0:123        'out_i1' (temp int)
+0:123        imageAtomicMin (temp int)
+0:123          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:123          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:123            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:123            Constant:
+0:123              7 (const uint)
+0:123          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:123            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:123            Constant:
+0:123              5 (const uint)
+0:124      imageAtomicOr (temp int)
+0:124        'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:124        i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:124          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:124          Constant:
+0:124            7 (const uint)
+0:124        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:124          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:124          Constant:
+0:124            8 (const uint)
+0:125      move second child to first child (temp int)
+0:125        'out_i1' (temp int)
+0:125        imageAtomicOr (temp int)
+0:125          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:125          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:125            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:125            Constant:
+0:125              7 (const uint)
+0:125          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:125            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:125            Constant:
+0:125              5 (const uint)
+0:126      imageAtomicXor (temp int)
+0:126        'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:126        i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:126          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:126          Constant:
+0:126            7 (const uint)
+0:126        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:126          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:126          Constant:
+0:126            8 (const uint)
+0:127      move second child to first child (temp int)
+0:127        'out_i1' (temp int)
+0:127        imageAtomicXor (temp int)
+0:127          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:127          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:127            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:127            Constant:
+0:127              7 (const uint)
+0:127          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:127            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:127            Constant:
+0:127              5 (const uint)
+0:130      imageAtomicAdd (temp uint)
+0:130        'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:130        u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:130          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:130          Constant:
+0:130            2 (const uint)
+0:130        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:130          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:130          Constant:
+0:130            0 (const uint)
+0:131      move second child to first child (temp uint)
+0:131        'out_u1' (temp uint)
+0:131        imageAtomicAdd (temp uint)
+0:131          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:131          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:131            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:131            Constant:
+0:131              2 (const uint)
+0:131          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:131            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:131            Constant:
+0:131              0 (const uint)
+0:132      imageAtomicAnd (temp uint)
+0:132        'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:132        u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:132          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:132          Constant:
+0:132            2 (const uint)
+0:132        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:132          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:132          Constant:
+0:132            0 (const uint)
+0:133      move second child to first child (temp uint)
+0:133        'out_u1' (temp uint)
+0:133        imageAtomicAnd (temp uint)
+0:133          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:133          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:133            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:133            Constant:
+0:133              2 (const uint)
+0:133          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:133            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:133            Constant:
+0:133              0 (const uint)
+0:134      move second child to first child (temp uint)
+0:134        'out_u1' (temp uint)
+0:134        imageAtomicCompSwap (temp uint)
+0:134          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:134          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:134            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:134            Constant:
+0:134              2 (const uint)
+0:134          u1b: direct index for structure (layout(offset=28 ) uniform uint)
+0:134            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:134            Constant:
+0:134              3 (const uint)
+0:134          u1c: direct index for structure (layout(offset=32 ) uniform uint)
+0:134            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:134            Constant:
+0:134              4 (const uint)
+0:135      move second child to first child (temp uint)
+0:135        'out_u1' (temp uint)
+0:135        imageAtomicExchange (temp uint)
+0:135          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:135          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:135            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:135            Constant:
+0:135              2 (const uint)
+0:135          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:135            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:135            Constant:
+0:135              0 (const uint)
+0:136      imageAtomicMax (temp uint)
+0:136        'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:136        u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:136          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:136          Constant:
+0:136            2 (const uint)
+0:136        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:136          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:136          Constant:
+0:136            0 (const uint)
+0:137      move second child to first child (temp uint)
+0:137        'out_u1' (temp uint)
+0:137        imageAtomicMax (temp uint)
+0:137          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:137          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:137            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:137            Constant:
+0:137              2 (const uint)
+0:137          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:137            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:137            Constant:
+0:137              0 (const uint)
+0:138      imageAtomicMin (temp uint)
+0:138        'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:138        u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:138          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:138          Constant:
+0:138            2 (const uint)
+0:138        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:138          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:138          Constant:
+0:138            0 (const uint)
+0:139      move second child to first child (temp uint)
+0:139        'out_u1' (temp uint)
+0:139        imageAtomicMin (temp uint)
+0:139          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:139          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:139            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:139            Constant:
+0:139              2 (const uint)
+0:139          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:139            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:139            Constant:
+0:139              0 (const uint)
+0:140      imageAtomicOr (temp uint)
+0:140        'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:140        u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:140          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:140          Constant:
+0:140            2 (const uint)
+0:140        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:140          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:140          Constant:
+0:140            0 (const uint)
+0:141      move second child to first child (temp uint)
+0:141        'out_u1' (temp uint)
+0:141        imageAtomicOr (temp uint)
+0:141          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:141          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:141            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:141            Constant:
+0:141              2 (const uint)
+0:141          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:141            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:141            Constant:
+0:141              0 (const uint)
+0:142      imageAtomicXor (temp uint)
+0:142        'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:142        u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:142          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:142          Constant:
+0:142            2 (const uint)
+0:142        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:142          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:142          Constant:
+0:142            0 (const uint)
+0:143      move second child to first child (temp uint)
+0:143        'out_u1' (temp uint)
+0:143        imageAtomicXor (temp uint)
+0:143          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:143          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:143            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:143            Constant:
+0:143              2 (const uint)
+0:143          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:143            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:143            Constant:
+0:143              0 (const uint)
+0:146      imageAtomicAdd (temp int)
+0:146        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:146        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:146          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:146          Constant:
+0:146            6 (const uint)
+0:146        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:146          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:146          Constant:
+0:146            8 (const uint)
+0:147      move second child to first child (temp int)
+0:147        'out_i1' (temp int)
+0:147        imageAtomicAdd (temp int)
+0:147          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:147          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:147            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:147            Constant:
+0:147              6 (const uint)
+0:147          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:147            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:147            Constant:
+0:147              5 (const uint)
+0:148      imageAtomicAnd (temp int)
+0:148        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:148        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:148          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:148          Constant:
+0:148            6 (const uint)
+0:148        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:148          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:148          Constant:
+0:148            8 (const uint)
+0:149      move second child to first child (temp int)
+0:149        'out_i1' (temp int)
+0:149        imageAtomicAnd (temp int)
+0:149          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:149          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:149            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:149            Constant:
+0:149              6 (const uint)
+0:149          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:149            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:149            Constant:
+0:149              5 (const uint)
+0:150      move second child to first child (temp int)
+0:150        'out_i1' (temp int)
+0:150        imageAtomicCompSwap (temp int)
+0:150          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:150          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:150            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:150            Constant:
+0:150              6 (const uint)
+0:150          i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:150            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:150            Constant:
+0:150              8 (const uint)
+0:150          i1c: direct index for structure (layout(offset=64 ) uniform int)
+0:150            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:150            Constant:
+0:150              9 (const uint)
+0:151      move second child to first child (temp int)
+0:151        'out_i1' (temp int)
+0:151        imageAtomicExchange (temp int)
+0:151          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:151          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:151            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:151            Constant:
+0:151              6 (const uint)
+0:151          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:151            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:151            Constant:
+0:151              5 (const uint)
+0:152      imageAtomicMax (temp int)
+0:152        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:152        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:152          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:152          Constant:
+0:152            6 (const uint)
+0:152        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:152          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:152          Constant:
+0:152            8 (const uint)
+0:153      move second child to first child (temp int)
+0:153        'out_i1' (temp int)
+0:153        imageAtomicMax (temp int)
+0:153          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:153          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:153            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:153            Constant:
+0:153              6 (const uint)
+0:153          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:153            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:153            Constant:
+0:153              5 (const uint)
+0:154      imageAtomicMin (temp int)
+0:154        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:154        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:154          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:154          Constant:
+0:154            6 (const uint)
+0:154        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:154          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:154          Constant:
+0:154            8 (const uint)
+0:155      move second child to first child (temp int)
+0:155        'out_i1' (temp int)
+0:155        imageAtomicMin (temp int)
+0:155          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:155          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:155            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:155            Constant:
+0:155              6 (const uint)
+0:155          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:155            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:155            Constant:
+0:155              5 (const uint)
+0:156      imageAtomicOr (temp int)
+0:156        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:156        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:156          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:156          Constant:
+0:156            6 (const uint)
+0:156        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:156          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:156          Constant:
+0:156            8 (const uint)
+0:157      move second child to first child (temp int)
+0:157        'out_i1' (temp int)
+0:157        imageAtomicOr (temp int)
+0:157          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:157          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:157            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:157            Constant:
+0:157              6 (const uint)
+0:157          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:157            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:157            Constant:
+0:157              5 (const uint)
+0:158      imageAtomicXor (temp int)
+0:158        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:158        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:158          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:158          Constant:
+0:158            6 (const uint)
+0:158        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:158          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:158          Constant:
+0:158            8 (const uint)
+0:159      move second child to first child (temp int)
+0:159        'out_i1' (temp int)
+0:159        imageAtomicXor (temp int)
+0:159          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:159          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:159            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:159            Constant:
+0:159              6 (const uint)
+0:159          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:159            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:159            Constant:
+0:159              5 (const uint)
+0:162      imageAtomicAdd (temp uint)
+0:162        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:162        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:162          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:162          Constant:
+0:162            1 (const uint)
+0:162        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:162          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:162          Constant:
+0:162            0 (const uint)
+0:163      move second child to first child (temp uint)
+0:163        'out_u1' (temp uint)
+0:163        imageAtomicAdd (temp uint)
+0:163          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:163          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:163            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:163            Constant:
+0:163              1 (const uint)
+0:163          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:163            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:163            Constant:
+0:163              0 (const uint)
+0:164      imageAtomicAnd (temp uint)
+0:164        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:164        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:164          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:164          Constant:
+0:164            1 (const uint)
+0:164        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:164          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:164          Constant:
+0:164            0 (const uint)
+0:165      move second child to first child (temp uint)
+0:165        'out_u1' (temp uint)
+0:165        imageAtomicAnd (temp uint)
+0:165          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:165          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:165            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:165            Constant:
+0:165              1 (const uint)
+0:165          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:165            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:165            Constant:
+0:165              0 (const uint)
+0:166      move second child to first child (temp uint)
+0:166        'out_u1' (temp uint)
+0:166        imageAtomicCompSwap (temp uint)
+0:166          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:166          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:166            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:166            Constant:
+0:166              1 (const uint)
+0:166          u1b: direct index for structure (layout(offset=28 ) uniform uint)
+0:166            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:166            Constant:
+0:166              3 (const uint)
+0:166          u1c: direct index for structure (layout(offset=32 ) uniform uint)
+0:166            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:166            Constant:
+0:166              4 (const uint)
+0:167      move second child to first child (temp uint)
+0:167        'out_u1' (temp uint)
+0:167        imageAtomicExchange (temp uint)
+0:167          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:167          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:167            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:167            Constant:
+0:167              1 (const uint)
+0:167          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:167            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:167            Constant:
+0:167              0 (const uint)
+0:168      imageAtomicMax (temp uint)
+0:168        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:168        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:168          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:168          Constant:
+0:168            1 (const uint)
+0:168        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:168          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:168          Constant:
+0:168            0 (const uint)
+0:169      move second child to first child (temp uint)
+0:169        'out_u1' (temp uint)
+0:169        imageAtomicMax (temp uint)
+0:169          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:169          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:169            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:169            Constant:
+0:169              1 (const uint)
+0:169          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:169            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:169            Constant:
+0:169              0 (const uint)
+0:170      imageAtomicMin (temp uint)
+0:170        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:170        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:170          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:170          Constant:
+0:170            1 (const uint)
+0:170        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:170          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:170          Constant:
+0:170            0 (const uint)
+0:171      move second child to first child (temp uint)
+0:171        'out_u1' (temp uint)
+0:171        imageAtomicMin (temp uint)
+0:171          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:171          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:171            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:171            Constant:
+0:171              1 (const uint)
+0:171          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:171            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:171            Constant:
+0:171              0 (const uint)
+0:172      imageAtomicOr (temp uint)
+0:172        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:172        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:172          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:172          Constant:
+0:172            1 (const uint)
+0:172        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:172          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:172          Constant:
+0:172            0 (const uint)
+0:173      move second child to first child (temp uint)
+0:173        'out_u1' (temp uint)
+0:173        imageAtomicOr (temp uint)
+0:173          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:173          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:173            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:173            Constant:
+0:173              1 (const uint)
+0:173          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:173            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:173            Constant:
+0:173              0 (const uint)
+0:174      imageAtomicXor (temp uint)
+0:174        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:174        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:174          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:174          Constant:
+0:174            1 (const uint)
+0:174        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:174          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:174          Constant:
+0:174            0 (const uint)
+0:175      move second child to first child (temp uint)
+0:175        'out_u1' (temp uint)
+0:175        imageAtomicXor (temp uint)
+0:175          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:175          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:175            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:175            Constant:
+0:175              1 (const uint)
+0:175          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:175            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:175            Constant:
+0:175              0 (const uint)
+0:178      imageAtomicAdd (temp int)
+0:178        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:178        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:178          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:178          Constant:
+0:178            6 (const uint)
+0:178        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:178          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:178          Constant:
+0:178            8 (const uint)
+0:179      move second child to first child (temp int)
+0:179        'out_i1' (temp int)
+0:179        imageAtomicAdd (temp int)
+0:179          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:179          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:179            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:179            Constant:
+0:179              6 (const uint)
+0:179          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:179            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:179            Constant:
+0:179              5 (const uint)
+0:180      imageAtomicAnd (temp int)
+0:180        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:180        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:180          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:180          Constant:
+0:180            6 (const uint)
+0:180        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:180          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:180          Constant:
+0:180            8 (const uint)
+0:181      move second child to first child (temp int)
+0:181        'out_i1' (temp int)
+0:181        imageAtomicAnd (temp int)
+0:181          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:181          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:181            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:181            Constant:
+0:181              6 (const uint)
+0:181          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:181            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:181            Constant:
+0:181              5 (const uint)
+0:182      move second child to first child (temp int)
+0:182        'out_i1' (temp int)
+0:182        imageAtomicCompSwap (temp int)
+0:182          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:182          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:182            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:182            Constant:
+0:182              6 (const uint)
+0:182          i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:182            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:182            Constant:
+0:182              8 (const uint)
+0:182          i1c: direct index for structure (layout(offset=64 ) uniform int)
+0:182            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:182            Constant:
+0:182              9 (const uint)
+0:183      move second child to first child (temp int)
+0:183        'out_i1' (temp int)
+0:183        imageAtomicExchange (temp int)
+0:183          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:183          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:183            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:183            Constant:
+0:183              6 (const uint)
+0:183          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:183            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:183            Constant:
+0:183              5 (const uint)
+0:184      imageAtomicMax (temp int)
+0:184        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:184        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:184          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:184          Constant:
+0:184            6 (const uint)
+0:184        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:184          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:184          Constant:
+0:184            8 (const uint)
+0:185      move second child to first child (temp int)
+0:185        'out_i1' (temp int)
+0:185        imageAtomicMax (temp int)
+0:185          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:185          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:185            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:185            Constant:
+0:185              6 (const uint)
+0:185          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:185            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:185            Constant:
+0:185              5 (const uint)
+0:186      imageAtomicMin (temp int)
+0:186        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:186        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:186          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:186          Constant:
+0:186            6 (const uint)
+0:186        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:186          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:186          Constant:
+0:186            8 (const uint)
+0:187      move second child to first child (temp int)
+0:187        'out_i1' (temp int)
+0:187        imageAtomicMin (temp int)
+0:187          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:187          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:187            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:187            Constant:
+0:187              6 (const uint)
+0:187          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:187            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:187            Constant:
+0:187              5 (const uint)
+0:188      imageAtomicOr (temp int)
+0:188        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:188        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:188          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:188          Constant:
+0:188            6 (const uint)
+0:188        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:188          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:188          Constant:
+0:188            8 (const uint)
+0:189      move second child to first child (temp int)
+0:189        'out_i1' (temp int)
+0:189        imageAtomicOr (temp int)
+0:189          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:189          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:189            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:189            Constant:
+0:189              6 (const uint)
+0:189          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:189            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:189            Constant:
+0:189              5 (const uint)
+0:190      imageAtomicXor (temp int)
+0:190        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:190        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:190          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:190          Constant:
+0:190            6 (const uint)
+0:190        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:190          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:190          Constant:
+0:190            8 (const uint)
+0:191      move second child to first child (temp int)
+0:191        'out_i1' (temp int)
+0:191        imageAtomicXor (temp int)
+0:191          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:191          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:191            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:191            Constant:
+0:191              6 (const uint)
+0:191          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:191            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:191            Constant:
+0:191              5 (const uint)
+0:194      imageAtomicAdd (temp uint)
+0:194        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:194        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:194          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:194          Constant:
+0:194            1 (const uint)
+0:194        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:194          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:194          Constant:
+0:194            0 (const uint)
+0:195      move second child to first child (temp uint)
+0:195        'out_u1' (temp uint)
+0:195        imageAtomicAdd (temp uint)
+0:195          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:195          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:195            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:195            Constant:
+0:195              1 (const uint)
+0:195          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:195            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:195            Constant:
+0:195              0 (const uint)
+0:196      imageAtomicAnd (temp uint)
+0:196        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:196        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:196          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:196          Constant:
+0:196            1 (const uint)
+0:196        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:196          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:196          Constant:
+0:196            0 (const uint)
+0:197      move second child to first child (temp uint)
+0:197        'out_u1' (temp uint)
+0:197        imageAtomicAnd (temp uint)
+0:197          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:197          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:197            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:197            Constant:
+0:197              1 (const uint)
+0:197          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:197            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:197            Constant:
+0:197              0 (const uint)
+0:198      move second child to first child (temp uint)
+0:198        'out_u1' (temp uint)
+0:198        imageAtomicCompSwap (temp uint)
+0:198          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:198          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:198            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:198            Constant:
+0:198              1 (const uint)
+0:198          u1b: direct index for structure (layout(offset=28 ) uniform uint)
+0:198            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:198            Constant:
+0:198              3 (const uint)
+0:198          u1c: direct index for structure (layout(offset=32 ) uniform uint)
+0:198            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:198            Constant:
+0:198              4 (const uint)
+0:199      move second child to first child (temp uint)
+0:199        'out_u1' (temp uint)
+0:199        imageAtomicExchange (temp uint)
+0:199          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:199          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:199            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:199            Constant:
+0:199              1 (const uint)
+0:199          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:199            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:199            Constant:
+0:199              0 (const uint)
+0:200      imageAtomicMax (temp uint)
+0:200        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:200        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:200          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:200          Constant:
+0:200            1 (const uint)
+0:200        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:200          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:200          Constant:
+0:200            0 (const uint)
+0:201      move second child to first child (temp uint)
+0:201        'out_u1' (temp uint)
+0:201        imageAtomicMax (temp uint)
+0:201          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:201          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:201            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:201            Constant:
+0:201              1 (const uint)
+0:201          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:201            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:201            Constant:
+0:201              0 (const uint)
+0:202      imageAtomicMin (temp uint)
+0:202        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:202        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:202          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:202          Constant:
+0:202            1 (const uint)
+0:202        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:202          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:202          Constant:
+0:202            0 (const uint)
+0:203      move second child to first child (temp uint)
+0:203        'out_u1' (temp uint)
+0:203        imageAtomicMin (temp uint)
+0:203          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:203          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:203            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:203            Constant:
+0:203              1 (const uint)
+0:203          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:203            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:203            Constant:
+0:203              0 (const uint)
+0:204      imageAtomicOr (temp uint)
+0:204        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:204        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:204          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:204          Constant:
+0:204            1 (const uint)
+0:204        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:204          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:204          Constant:
+0:204            0 (const uint)
+0:205      move second child to first child (temp uint)
+0:205        'out_u1' (temp uint)
+0:205        imageAtomicOr (temp uint)
+0:205          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:205          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:205            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:205            Constant:
+0:205              1 (const uint)
+0:205          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:205            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:205            Constant:
+0:205              0 (const uint)
+0:206      imageAtomicXor (temp uint)
+0:206        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:206        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:206          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:206          Constant:
+0:206            1 (const uint)
+0:206        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:206          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:206          Constant:
+0:206            0 (const uint)
+0:207      move second child to first child (temp uint)
+0:207        'out_u1' (temp uint)
+0:207        imageAtomicXor (temp uint)
+0:207          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:207          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:207            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:207            Constant:
+0:207              1 (const uint)
+0:207          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:207            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:207            Constant:
+0:207              0 (const uint)
+0:210      imageAtomicAdd (temp int)
+0:210        'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:210        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:210          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:210          Constant:
+0:210            5 (const uint)
+0:210        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:210          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:210          Constant:
+0:210            8 (const uint)
+0:211      move second child to first child (temp int)
+0:211        'out_i1' (temp int)
+0:211        imageAtomicAdd (temp int)
+0:211          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:211          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:211            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:211            Constant:
+0:211              5 (const uint)
+0:211          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:211            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:211            Constant:
+0:211              5 (const uint)
+0:212      imageAtomicAnd (temp int)
+0:212        'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:212        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:212          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:212          Constant:
+0:212            5 (const uint)
+0:212        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:212          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:212          Constant:
+0:212            8 (const uint)
+0:213      move second child to first child (temp int)
+0:213        'out_i1' (temp int)
+0:213        imageAtomicAnd (temp int)
+0:213          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:213          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:213            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:213            Constant:
+0:213              5 (const uint)
+0:213          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:213            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:213            Constant:
+0:213              5 (const uint)
+0:214      move second child to first child (temp int)
+0:214        'out_i1' (temp int)
+0:214        imageAtomicCompSwap (temp int)
+0:214          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:214          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:214            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:214            Constant:
+0:214              5 (const uint)
+0:214          i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:214            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:214            Constant:
+0:214              8 (const uint)
+0:214          i1c: direct index for structure (layout(offset=64 ) uniform int)
+0:214            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:214            Constant:
+0:214              9 (const uint)
+0:215      move second child to first child (temp int)
+0:215        'out_i1' (temp int)
+0:215        imageAtomicExchange (temp int)
+0:215          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:215          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:215            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:215            Constant:
+0:215              5 (const uint)
+0:215          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:215            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:215            Constant:
+0:215              5 (const uint)
+0:216      imageAtomicMax (temp int)
+0:216        'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:216        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:216          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:216          Constant:
+0:216            5 (const uint)
+0:216        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:216          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:216          Constant:
+0:216            8 (const uint)
+0:217      move second child to first child (temp int)
+0:217        'out_i1' (temp int)
+0:217        imageAtomicMax (temp int)
+0:217          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:217          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:217            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:217            Constant:
+0:217              5 (const uint)
+0:217          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:217            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:217            Constant:
+0:217              5 (const uint)
+0:218      imageAtomicMin (temp int)
+0:218        'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:218        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:218          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:218          Constant:
+0:218            5 (const uint)
+0:218        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:218          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:218          Constant:
+0:218            8 (const uint)
+0:219      move second child to first child (temp int)
+0:219        'out_i1' (temp int)
+0:219        imageAtomicMin (temp int)
+0:219          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:219          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:219            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:219            Constant:
+0:219              5 (const uint)
+0:219          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:219            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:219            Constant:
+0:219              5 (const uint)
+0:220      imageAtomicOr (temp int)
+0:220        'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:220        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:220          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:220          Constant:
+0:220            5 (const uint)
+0:220        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:220          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:220          Constant:
+0:220            8 (const uint)
+0:221      move second child to first child (temp int)
+0:221        'out_i1' (temp int)
+0:221        imageAtomicOr (temp int)
+0:221          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:221          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:221            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:221            Constant:
+0:221              5 (const uint)
+0:221          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:221            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:221            Constant:
+0:221              5 (const uint)
+0:222      imageAtomicXor (temp int)
+0:222        'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:222        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:222          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:222          Constant:
+0:222            5 (const uint)
+0:222        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:222          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:222          Constant:
+0:222            8 (const uint)
+0:223      move second child to first child (temp int)
+0:223        'out_i1' (temp int)
+0:223        imageAtomicXor (temp int)
+0:223          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:223          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:223            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:223            Constant:
+0:223              5 (const uint)
+0:223          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:223            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:223            Constant:
+0:223              5 (const uint)
+0:226      imageAtomicAdd (temp uint)
+0:226        'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:226        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:226          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:226          Constant:
+0:226            0 (const uint)
+0:226        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:226          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:226          Constant:
+0:226            0 (const uint)
+0:227      move second child to first child (temp uint)
+0:227        'out_u1' (temp uint)
+0:227        imageAtomicAdd (temp uint)
+0:227          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:227          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:227            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:227            Constant:
+0:227              0 (const uint)
+0:227          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:227            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:227            Constant:
+0:227              0 (const uint)
+0:228      imageAtomicAnd (temp uint)
+0:228        'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:228        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:228          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:228          Constant:
+0:228            0 (const uint)
+0:228        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:228          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:228          Constant:
+0:228            0 (const uint)
+0:229      move second child to first child (temp uint)
+0:229        'out_u1' (temp uint)
+0:229        imageAtomicAnd (temp uint)
+0:229          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:229          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:229            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:229            Constant:
+0:229              0 (const uint)
+0:229          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:229            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:229            Constant:
+0:229              0 (const uint)
+0:230      move second child to first child (temp uint)
+0:230        'out_u1' (temp uint)
+0:230        imageAtomicCompSwap (temp uint)
+0:230          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:230          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:230            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:230            Constant:
+0:230              0 (const uint)
+0:230          u1b: direct index for structure (layout(offset=28 ) uniform uint)
+0:230            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:230            Constant:
+0:230              3 (const uint)
+0:230          u1c: direct index for structure (layout(offset=32 ) uniform uint)
+0:230            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:230            Constant:
+0:230              4 (const uint)
+0:231      move second child to first child (temp uint)
+0:231        'out_u1' (temp uint)
+0:231        imageAtomicExchange (temp uint)
+0:231          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:231          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:231            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:231            Constant:
+0:231              0 (const uint)
+0:231          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:231            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:231            Constant:
+0:231              0 (const uint)
+0:232      imageAtomicMax (temp uint)
+0:232        'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:232        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:232          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:232          Constant:
+0:232            0 (const uint)
+0:232        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:232          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:232          Constant:
+0:232            0 (const uint)
+0:233      move second child to first child (temp uint)
+0:233        'out_u1' (temp uint)
+0:233        imageAtomicMax (temp uint)
+0:233          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:233          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:233            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:233            Constant:
+0:233              0 (const uint)
+0:233          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:233            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:233            Constant:
+0:233              0 (const uint)
+0:234      imageAtomicMin (temp uint)
+0:234        'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:234        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:234          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:234          Constant:
+0:234            0 (const uint)
+0:234        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:234          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:234          Constant:
+0:234            0 (const uint)
+0:235      move second child to first child (temp uint)
+0:235        'out_u1' (temp uint)
+0:235        imageAtomicMin (temp uint)
+0:235          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:235          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:235            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:235            Constant:
+0:235              0 (const uint)
+0:235          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:235            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:235            Constant:
+0:235              0 (const uint)
+0:236      imageAtomicOr (temp uint)
+0:236        'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:236        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:236          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:236          Constant:
+0:236            0 (const uint)
+0:236        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:236          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:236          Constant:
+0:236            0 (const uint)
+0:237      move second child to first child (temp uint)
+0:237        'out_u1' (temp uint)
+0:237        imageAtomicOr (temp uint)
+0:237          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:237          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:237            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:237            Constant:
+0:237              0 (const uint)
+0:237          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:237            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:237            Constant:
+0:237              0 (const uint)
+0:238      imageAtomicXor (temp uint)
+0:238        'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:238        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:238          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:238          Constant:
+0:238            0 (const uint)
+0:238        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:238          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:238          Constant:
+0:238            0 (const uint)
+0:239      move second child to first child (temp uint)
+0:239        'out_u1' (temp uint)
+0:239        imageAtomicXor (temp uint)
+0:239          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:239          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:239            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:239            Constant:
+0:239              0 (const uint)
+0:239          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:239            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:239            Constant:
+0:239              0 (const uint)
+0:242      move second child to first child (temp 4-component vector of float)
+0:242        Color: direct index for structure (temp 4-component vector of float)
+0:242          'psout' (temp structure{temp 4-component vector of float Color})
+0:242          Constant:
+0:242            0 (const int)
+0:242        Constant:
+0:242          1.000000
+0:242          1.000000
+0:242          1.000000
+0:242          1.000000
+0:243      Sequence
+0:243        Sequence
+0:243          move second child to first child (temp 4-component vector of float)
+0:?             'Color' (layout(location=0 ) out 4-component vector of float)
+0:243            Color: direct index for structure (temp 4-component vector of float)
+0:243              'psout' (temp structure{temp 4-component vector of float Color})
+0:243              Constant:
+0:243                0 (const int)
+0:243        Branch: Return
+0:?   Linker Objects
+0:?     'g_sSamp' (uniform sampler)
+0:?     'g_tTex1df1' (layout(r32f ) uniform image1D)
+0:?     'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:?     'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:?     'g_tTex2df1' (layout(r32f ) uniform image2D)
+0:?     'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:?     'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:?     'g_tTex3df1' (layout(r32f ) uniform image3D)
+0:?     'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:?     'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:?     'g_tTex1df1a' (layout(r32f ) uniform image1DArray)
+0:?     'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:?     'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:?     'g_tTex2df1a' (layout(r32f ) uniform image2DArray)
+0:?     'g_tTex2di1a' (layout(r32i ) uniform iimage2DArray)
+0:?     'g_tTex2du1a' (layout(r32ui ) uniform uimage2DArray)
+0:?     'g_tBuffF' (layout(r32f ) uniform imageBuffer)
+0:?     'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:?     'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:?     'Color' (layout(location=0 ) out 4-component vector of float)
+0:?     'anon@0' (uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+
+
+Linked fragment stage:
+
+
+Shader version: 450
+gl_FragCoord origin is upper left
+0:? Sequence
+0:45  Function Definition: main( (temp structure{temp 4-component vector of float Color})
+0:45    Function Parameters: 
+0:?     Sequence
+0:50      imageAtomicAdd (temp int)
+0:50        'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:50        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:50          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:50          Constant:
+0:50            5 (const uint)
+0:50        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:50          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:50          Constant:
+0:50            8 (const uint)
+0:51      move second child to first child (temp int)
+0:51        'out_i1' (temp int)
+0:51        imageAtomicAdd (temp int)
+0:51          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:51          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:51            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:51            Constant:
+0:51              5 (const uint)
+0:51          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:51            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:51            Constant:
+0:51              5 (const uint)
+0:52      imageAtomicAnd (temp int)
+0:52        'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:52        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:52          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:52          Constant:
+0:52            5 (const uint)
+0:52        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:52          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:52          Constant:
+0:52            8 (const uint)
+0:53      move second child to first child (temp int)
+0:53        'out_i1' (temp int)
+0:53        imageAtomicAnd (temp int)
+0:53          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:53          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:53            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:53            Constant:
+0:53              5 (const uint)
+0:53          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:53            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:53            Constant:
+0:53              5 (const uint)
+0:54      move second child to first child (temp int)
+0:54        'out_i1' (temp int)
+0:54        imageAtomicCompSwap (temp int)
+0:54          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:54          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:54            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:54            Constant:
+0:54              5 (const uint)
+0:54          i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:54            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:54            Constant:
+0:54              8 (const uint)
+0:54          i1c: direct index for structure (layout(offset=64 ) uniform int)
+0:54            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:54            Constant:
+0:54              9 (const uint)
+0:55      move second child to first child (temp int)
+0:55        'out_i1' (temp int)
+0:55        imageAtomicExchange (temp int)
+0:55          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:55          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:55            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:55            Constant:
+0:55              5 (const uint)
+0:55          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:55            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:55            Constant:
+0:55              5 (const uint)
+0:56      imageAtomicMax (temp int)
+0:56        'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:56        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:56          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:56          Constant:
+0:56            5 (const uint)
+0:56        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:56          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:56          Constant:
+0:56            8 (const uint)
+0:57      move second child to first child (temp int)
+0:57        'out_i1' (temp int)
+0:57        imageAtomicMax (temp int)
+0:57          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:57          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:57            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:57            Constant:
+0:57              5 (const uint)
+0:57          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:57            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:57            Constant:
+0:57              5 (const uint)
+0:58      imageAtomicMin (temp int)
+0:58        'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:58        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:58          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:58          Constant:
+0:58            5 (const uint)
+0:58        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:58          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:58          Constant:
+0:58            8 (const uint)
+0:59      move second child to first child (temp int)
+0:59        'out_i1' (temp int)
+0:59        imageAtomicMin (temp int)
+0:59          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:59          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:59            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:59            Constant:
+0:59              5 (const uint)
+0:59          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:59            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:59            Constant:
+0:59              5 (const uint)
+0:60      imageAtomicOr (temp int)
+0:60        'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:60        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:60          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:60          Constant:
+0:60            5 (const uint)
+0:60        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:60          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:60          Constant:
+0:60            8 (const uint)
+0:61      move second child to first child (temp int)
+0:61        'out_i1' (temp int)
+0:61        imageAtomicOr (temp int)
+0:61          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:61          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:61            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:61            Constant:
+0:61              5 (const uint)
+0:61          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:61            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:61            Constant:
+0:61              5 (const uint)
+0:62      imageAtomicXor (temp int)
+0:62        'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:62        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:62          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:62          Constant:
+0:62            5 (const uint)
+0:62        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:62          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:62          Constant:
+0:62            8 (const uint)
+0:63      move second child to first child (temp int)
+0:63        'out_i1' (temp int)
+0:63        imageAtomicXor (temp int)
+0:63          'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:63          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:63            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:63            Constant:
+0:63              5 (const uint)
+0:63          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:63            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:63            Constant:
+0:63              5 (const uint)
+0:66      imageAtomicAdd (temp uint)
+0:66        'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:66        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:66          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:66          Constant:
+0:66            0 (const uint)
+0:66        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:66          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:66          Constant:
+0:66            0 (const uint)
+0:67      move second child to first child (temp uint)
+0:67        'out_u1' (temp uint)
+0:67        imageAtomicAdd (temp uint)
+0:67          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:67          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:67            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:67            Constant:
+0:67              0 (const uint)
+0:67          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:67            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:67            Constant:
+0:67              0 (const uint)
+0:68      imageAtomicAnd (temp uint)
+0:68        'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:68        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:68          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:68          Constant:
+0:68            0 (const uint)
+0:68        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:68          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:68          Constant:
+0:68            0 (const uint)
+0:69      move second child to first child (temp uint)
+0:69        'out_u1' (temp uint)
+0:69        imageAtomicAnd (temp uint)
+0:69          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:69          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:69            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:69            Constant:
+0:69              0 (const uint)
+0:69          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:69            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:69            Constant:
+0:69              0 (const uint)
+0:70      move second child to first child (temp uint)
+0:70        'out_u1' (temp uint)
+0:70        imageAtomicCompSwap (temp uint)
+0:70          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:70          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:70            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:70            Constant:
+0:70              0 (const uint)
+0:70          u1b: direct index for structure (layout(offset=28 ) uniform uint)
+0:70            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:70            Constant:
+0:70              3 (const uint)
+0:70          u1c: direct index for structure (layout(offset=32 ) uniform uint)
+0:70            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:70            Constant:
+0:70              4 (const uint)
+0:71      move second child to first child (temp uint)
+0:71        'out_u1' (temp uint)
+0:71        imageAtomicExchange (temp uint)
+0:71          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:71          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:71            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:71            Constant:
+0:71              0 (const uint)
+0:71          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:71            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:71            Constant:
+0:71              0 (const uint)
+0:72      imageAtomicMax (temp uint)
+0:72        'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:72        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:72          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:72          Constant:
+0:72            0 (const uint)
+0:72        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:72          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:72          Constant:
+0:72            0 (const uint)
+0:73      move second child to first child (temp uint)
+0:73        'out_u1' (temp uint)
+0:73        imageAtomicMax (temp uint)
+0:73          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:73          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:73            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:73            Constant:
+0:73              0 (const uint)
+0:73          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:73            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:73            Constant:
+0:73              0 (const uint)
+0:74      imageAtomicMin (temp uint)
+0:74        'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:74        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:74          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:74          Constant:
+0:74            0 (const uint)
+0:74        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:74          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:74          Constant:
+0:74            0 (const uint)
+0:75      move second child to first child (temp uint)
+0:75        'out_u1' (temp uint)
+0:75        imageAtomicMin (temp uint)
+0:75          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:75          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:75            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:75            Constant:
+0:75              0 (const uint)
+0:75          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:75            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:75            Constant:
+0:75              0 (const uint)
+0:76      imageAtomicOr (temp uint)
+0:76        'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:76        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:76          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:76          Constant:
+0:76            0 (const uint)
+0:76        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:76          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:76          Constant:
+0:76            0 (const uint)
+0:77      move second child to first child (temp uint)
+0:77        'out_u1' (temp uint)
+0:77        imageAtomicOr (temp uint)
+0:77          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:77          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:77            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:77            Constant:
+0:77              0 (const uint)
+0:77          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:77            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:77            Constant:
+0:77              0 (const uint)
+0:78      imageAtomicXor (temp uint)
+0:78        'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:78        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:78          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:78          Constant:
+0:78            0 (const uint)
+0:78        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:78          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:78          Constant:
+0:78            0 (const uint)
+0:79      move second child to first child (temp uint)
+0:79        'out_u1' (temp uint)
+0:79        imageAtomicXor (temp uint)
+0:79          'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:79          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:79            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:79            Constant:
+0:79              0 (const uint)
+0:79          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:79            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:79            Constant:
+0:79              0 (const uint)
+0:82      imageAtomicAdd (temp int)
+0:82        'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:82        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:82          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:82          Constant:
+0:82            6 (const uint)
+0:82        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:82          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:82          Constant:
+0:82            8 (const uint)
+0:83      move second child to first child (temp int)
+0:83        'out_i1' (temp int)
+0:83        imageAtomicAdd (temp int)
+0:83          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:83          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:83            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:83            Constant:
+0:83              6 (const uint)
+0:83          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:83            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:83            Constant:
+0:83              5 (const uint)
+0:84      imageAtomicAnd (temp int)
+0:84        'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:84        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:84          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:84          Constant:
+0:84            6 (const uint)
+0:84        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:84          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:84          Constant:
+0:84            8 (const uint)
+0:85      move second child to first child (temp int)
+0:85        'out_i1' (temp int)
+0:85        imageAtomicAnd (temp int)
+0:85          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:85          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:85            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:85            Constant:
+0:85              6 (const uint)
+0:85          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:85            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:85            Constant:
+0:85              5 (const uint)
+0:86      move second child to first child (temp int)
+0:86        'out_i1' (temp int)
+0:86        imageAtomicCompSwap (temp int)
+0:86          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:86          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:86            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:86            Constant:
+0:86              6 (const uint)
+0:86          i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:86            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:86            Constant:
+0:86              8 (const uint)
+0:86          i1c: direct index for structure (layout(offset=64 ) uniform int)
+0:86            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:86            Constant:
+0:86              9 (const uint)
+0:87      move second child to first child (temp int)
+0:87        'out_i1' (temp int)
+0:87        imageAtomicExchange (temp int)
+0:87          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:87          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:87            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:87            Constant:
+0:87              6 (const uint)
+0:87          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:87            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:87            Constant:
+0:87              5 (const uint)
+0:88      imageAtomicMax (temp int)
+0:88        'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:88        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:88          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:88          Constant:
+0:88            6 (const uint)
+0:88        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:88          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:88          Constant:
+0:88            8 (const uint)
+0:89      move second child to first child (temp int)
+0:89        'out_i1' (temp int)
+0:89        imageAtomicMax (temp int)
+0:89          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:89          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:89            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:89            Constant:
+0:89              6 (const uint)
+0:89          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:89            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:89            Constant:
+0:89              5 (const uint)
+0:90      imageAtomicMin (temp int)
+0:90        'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:90        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:90          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:90          Constant:
+0:90            6 (const uint)
+0:90        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:90          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:90          Constant:
+0:90            8 (const uint)
+0:91      move second child to first child (temp int)
+0:91        'out_i1' (temp int)
+0:91        imageAtomicMin (temp int)
+0:91          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:91          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:91            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:91            Constant:
+0:91              6 (const uint)
+0:91          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:91            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:91            Constant:
+0:91              5 (const uint)
+0:92      imageAtomicOr (temp int)
+0:92        'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:92        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:92          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:92          Constant:
+0:92            6 (const uint)
+0:92        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:92          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:92          Constant:
+0:92            8 (const uint)
+0:93      move second child to first child (temp int)
+0:93        'out_i1' (temp int)
+0:93        imageAtomicOr (temp int)
+0:93          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:93          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:93            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:93            Constant:
+0:93              6 (const uint)
+0:93          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:93            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:93            Constant:
+0:93              5 (const uint)
+0:94      imageAtomicXor (temp int)
+0:94        'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:94        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:94          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:94          Constant:
+0:94            6 (const uint)
+0:94        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:94          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:94          Constant:
+0:94            8 (const uint)
+0:95      move second child to first child (temp int)
+0:95        'out_i1' (temp int)
+0:95        imageAtomicXor (temp int)
+0:95          'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:95          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:95            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:95            Constant:
+0:95              6 (const uint)
+0:95          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:95            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:95            Constant:
+0:95              5 (const uint)
+0:98      imageAtomicAdd (temp uint)
+0:98        'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:98        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:98          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:98          Constant:
+0:98            1 (const uint)
+0:98        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:98          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:98          Constant:
+0:98            0 (const uint)
+0:99      move second child to first child (temp uint)
+0:99        'out_u1' (temp uint)
+0:99        imageAtomicAdd (temp uint)
+0:99          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:99          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:99            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:99            Constant:
+0:99              1 (const uint)
+0:99          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:99            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:99            Constant:
+0:99              0 (const uint)
+0:100      imageAtomicAnd (temp uint)
+0:100        'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:100        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:100          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:100          Constant:
+0:100            1 (const uint)
+0:100        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:100          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:100          Constant:
+0:100            0 (const uint)
+0:101      move second child to first child (temp uint)
+0:101        'out_u1' (temp uint)
+0:101        imageAtomicAnd (temp uint)
+0:101          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:101          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:101            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:101            Constant:
+0:101              1 (const uint)
+0:101          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:101            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:101            Constant:
+0:101              0 (const uint)
+0:102      move second child to first child (temp uint)
+0:102        'out_u1' (temp uint)
+0:102        imageAtomicCompSwap (temp uint)
+0:102          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:102          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:102            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:102            Constant:
+0:102              1 (const uint)
+0:102          u1b: direct index for structure (layout(offset=28 ) uniform uint)
+0:102            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:102            Constant:
+0:102              3 (const uint)
+0:102          u1c: direct index for structure (layout(offset=32 ) uniform uint)
+0:102            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:102            Constant:
+0:102              4 (const uint)
+0:103      move second child to first child (temp uint)
+0:103        'out_u1' (temp uint)
+0:103        imageAtomicExchange (temp uint)
+0:103          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:103          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:103            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:103            Constant:
+0:103              1 (const uint)
+0:103          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:103            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:103            Constant:
+0:103              0 (const uint)
+0:104      imageAtomicMax (temp uint)
+0:104        'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:104        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:104          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:104          Constant:
+0:104            1 (const uint)
+0:104        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:104          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:104          Constant:
+0:104            0 (const uint)
+0:105      move second child to first child (temp uint)
+0:105        'out_u1' (temp uint)
+0:105        imageAtomicMax (temp uint)
+0:105          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:105          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:105            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:105            Constant:
+0:105              1 (const uint)
+0:105          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:105            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:105            Constant:
+0:105              0 (const uint)
+0:106      imageAtomicMin (temp uint)
+0:106        'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:106        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:106          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:106          Constant:
+0:106            1 (const uint)
+0:106        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:106          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:106          Constant:
+0:106            0 (const uint)
+0:107      move second child to first child (temp uint)
+0:107        'out_u1' (temp uint)
+0:107        imageAtomicMin (temp uint)
+0:107          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:107          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:107            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:107            Constant:
+0:107              1 (const uint)
+0:107          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:107            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:107            Constant:
+0:107              0 (const uint)
+0:108      imageAtomicOr (temp uint)
+0:108        'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:108        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:108          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:108          Constant:
+0:108            1 (const uint)
+0:108        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:108          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:108          Constant:
+0:108            0 (const uint)
+0:109      move second child to first child (temp uint)
+0:109        'out_u1' (temp uint)
+0:109        imageAtomicOr (temp uint)
+0:109          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:109          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:109            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:109            Constant:
+0:109              1 (const uint)
+0:109          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:109            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:109            Constant:
+0:109              0 (const uint)
+0:110      imageAtomicXor (temp uint)
+0:110        'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:110        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:110          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:110          Constant:
+0:110            1 (const uint)
+0:110        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:110          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:110          Constant:
+0:110            0 (const uint)
+0:111      move second child to first child (temp uint)
+0:111        'out_u1' (temp uint)
+0:111        imageAtomicXor (temp uint)
+0:111          'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:111          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:111            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:111            Constant:
+0:111              1 (const uint)
+0:111          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:111            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:111            Constant:
+0:111              0 (const uint)
+0:114      imageAtomicAdd (temp int)
+0:114        'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:114        i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:114          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:114          Constant:
+0:114            7 (const uint)
+0:114        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:114          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:114          Constant:
+0:114            8 (const uint)
+0:115      move second child to first child (temp int)
+0:115        'out_i1' (temp int)
+0:115        imageAtomicAdd (temp int)
+0:115          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:115          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:115            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:115            Constant:
+0:115              7 (const uint)
+0:115          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:115            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:115            Constant:
+0:115              5 (const uint)
+0:116      imageAtomicAnd (temp int)
+0:116        'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:116        i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:116          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:116          Constant:
+0:116            7 (const uint)
+0:116        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:116          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:116          Constant:
+0:116            8 (const uint)
+0:117      move second child to first child (temp int)
+0:117        'out_i1' (temp int)
+0:117        imageAtomicAnd (temp int)
+0:117          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:117          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:117            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:117            Constant:
+0:117              7 (const uint)
+0:117          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:117            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:117            Constant:
+0:117              5 (const uint)
+0:118      move second child to first child (temp int)
+0:118        'out_i1' (temp int)
+0:118        imageAtomicCompSwap (temp int)
+0:118          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:118          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:118            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:118            Constant:
+0:118              7 (const uint)
+0:118          i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:118            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:118            Constant:
+0:118              8 (const uint)
+0:118          i1c: direct index for structure (layout(offset=64 ) uniform int)
+0:118            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:118            Constant:
+0:118              9 (const uint)
+0:119      move second child to first child (temp int)
+0:119        'out_i1' (temp int)
+0:119        imageAtomicExchange (temp int)
+0:119          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:119          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:119            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:119            Constant:
+0:119              7 (const uint)
+0:119          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:119            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:119            Constant:
+0:119              5 (const uint)
+0:120      imageAtomicMax (temp int)
+0:120        'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:120        i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:120          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:120          Constant:
+0:120            7 (const uint)
+0:120        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:120          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:120          Constant:
+0:120            8 (const uint)
+0:121      move second child to first child (temp int)
+0:121        'out_i1' (temp int)
+0:121        imageAtomicMax (temp int)
+0:121          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:121          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:121            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:121            Constant:
+0:121              7 (const uint)
+0:121          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:121            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:121            Constant:
+0:121              5 (const uint)
+0:122      imageAtomicMin (temp int)
+0:122        'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:122        i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:122          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:122          Constant:
+0:122            7 (const uint)
+0:122        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:122          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:122          Constant:
+0:122            8 (const uint)
+0:123      move second child to first child (temp int)
+0:123        'out_i1' (temp int)
+0:123        imageAtomicMin (temp int)
+0:123          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:123          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:123            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:123            Constant:
+0:123              7 (const uint)
+0:123          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:123            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:123            Constant:
+0:123              5 (const uint)
+0:124      imageAtomicOr (temp int)
+0:124        'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:124        i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:124          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:124          Constant:
+0:124            7 (const uint)
+0:124        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:124          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:124          Constant:
+0:124            8 (const uint)
+0:125      move second child to first child (temp int)
+0:125        'out_i1' (temp int)
+0:125        imageAtomicOr (temp int)
+0:125          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:125          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:125            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:125            Constant:
+0:125              7 (const uint)
+0:125          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:125            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:125            Constant:
+0:125              5 (const uint)
+0:126      imageAtomicXor (temp int)
+0:126        'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:126        i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:126          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:126          Constant:
+0:126            7 (const uint)
+0:126        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:126          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:126          Constant:
+0:126            8 (const uint)
+0:127      move second child to first child (temp int)
+0:127        'out_i1' (temp int)
+0:127        imageAtomicXor (temp int)
+0:127          'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:127          i3: direct index for structure (layout(offset=48 ) uniform 3-component vector of int)
+0:127            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:127            Constant:
+0:127              7 (const uint)
+0:127          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:127            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:127            Constant:
+0:127              5 (const uint)
+0:130      imageAtomicAdd (temp uint)
+0:130        'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:130        u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:130          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:130          Constant:
+0:130            2 (const uint)
+0:130        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:130          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:130          Constant:
+0:130            0 (const uint)
+0:131      move second child to first child (temp uint)
+0:131        'out_u1' (temp uint)
+0:131        imageAtomicAdd (temp uint)
+0:131          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:131          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:131            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:131            Constant:
+0:131              2 (const uint)
+0:131          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:131            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:131            Constant:
+0:131              0 (const uint)
+0:132      imageAtomicAnd (temp uint)
+0:132        'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:132        u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:132          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:132          Constant:
+0:132            2 (const uint)
+0:132        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:132          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:132          Constant:
+0:132            0 (const uint)
+0:133      move second child to first child (temp uint)
+0:133        'out_u1' (temp uint)
+0:133        imageAtomicAnd (temp uint)
+0:133          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:133          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:133            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:133            Constant:
+0:133              2 (const uint)
+0:133          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:133            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:133            Constant:
+0:133              0 (const uint)
+0:134      move second child to first child (temp uint)
+0:134        'out_u1' (temp uint)
+0:134        imageAtomicCompSwap (temp uint)
+0:134          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:134          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:134            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:134            Constant:
+0:134              2 (const uint)
+0:134          u1b: direct index for structure (layout(offset=28 ) uniform uint)
+0:134            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:134            Constant:
+0:134              3 (const uint)
+0:134          u1c: direct index for structure (layout(offset=32 ) uniform uint)
+0:134            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:134            Constant:
+0:134              4 (const uint)
+0:135      move second child to first child (temp uint)
+0:135        'out_u1' (temp uint)
+0:135        imageAtomicExchange (temp uint)
+0:135          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:135          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:135            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:135            Constant:
+0:135              2 (const uint)
+0:135          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:135            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:135            Constant:
+0:135              0 (const uint)
+0:136      imageAtomicMax (temp uint)
+0:136        'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:136        u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:136          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:136          Constant:
+0:136            2 (const uint)
+0:136        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:136          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:136          Constant:
+0:136            0 (const uint)
+0:137      move second child to first child (temp uint)
+0:137        'out_u1' (temp uint)
+0:137        imageAtomicMax (temp uint)
+0:137          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:137          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:137            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:137            Constant:
+0:137              2 (const uint)
+0:137          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:137            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:137            Constant:
+0:137              0 (const uint)
+0:138      imageAtomicMin (temp uint)
+0:138        'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:138        u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:138          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:138          Constant:
+0:138            2 (const uint)
+0:138        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:138          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:138          Constant:
+0:138            0 (const uint)
+0:139      move second child to first child (temp uint)
+0:139        'out_u1' (temp uint)
+0:139        imageAtomicMin (temp uint)
+0:139          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:139          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:139            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:139            Constant:
+0:139              2 (const uint)
+0:139          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:139            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:139            Constant:
+0:139              0 (const uint)
+0:140      imageAtomicOr (temp uint)
+0:140        'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:140        u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:140          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:140          Constant:
+0:140            2 (const uint)
+0:140        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:140          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:140          Constant:
+0:140            0 (const uint)
+0:141      move second child to first child (temp uint)
+0:141        'out_u1' (temp uint)
+0:141        imageAtomicOr (temp uint)
+0:141          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:141          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:141            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:141            Constant:
+0:141              2 (const uint)
+0:141          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:141            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:141            Constant:
+0:141              0 (const uint)
+0:142      imageAtomicXor (temp uint)
+0:142        'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:142        u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:142          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:142          Constant:
+0:142            2 (const uint)
+0:142        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:142          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:142          Constant:
+0:142            0 (const uint)
+0:143      move second child to first child (temp uint)
+0:143        'out_u1' (temp uint)
+0:143        imageAtomicXor (temp uint)
+0:143          'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:143          u3: direct index for structure (layout(offset=16 ) uniform 3-component vector of uint)
+0:143            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:143            Constant:
+0:143              2 (const uint)
+0:143          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:143            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:143            Constant:
+0:143              0 (const uint)
+0:146      imageAtomicAdd (temp int)
+0:146        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:146        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:146          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:146          Constant:
+0:146            6 (const uint)
+0:146        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:146          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:146          Constant:
+0:146            8 (const uint)
+0:147      move second child to first child (temp int)
+0:147        'out_i1' (temp int)
+0:147        imageAtomicAdd (temp int)
+0:147          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:147          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:147            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:147            Constant:
+0:147              6 (const uint)
+0:147          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:147            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:147            Constant:
+0:147              5 (const uint)
+0:148      imageAtomicAnd (temp int)
+0:148        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:148        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:148          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:148          Constant:
+0:148            6 (const uint)
+0:148        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:148          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:148          Constant:
+0:148            8 (const uint)
+0:149      move second child to first child (temp int)
+0:149        'out_i1' (temp int)
+0:149        imageAtomicAnd (temp int)
+0:149          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:149          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:149            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:149            Constant:
+0:149              6 (const uint)
+0:149          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:149            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:149            Constant:
+0:149              5 (const uint)
+0:150      move second child to first child (temp int)
+0:150        'out_i1' (temp int)
+0:150        imageAtomicCompSwap (temp int)
+0:150          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:150          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:150            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:150            Constant:
+0:150              6 (const uint)
+0:150          i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:150            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:150            Constant:
+0:150              8 (const uint)
+0:150          i1c: direct index for structure (layout(offset=64 ) uniform int)
+0:150            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:150            Constant:
+0:150              9 (const uint)
+0:151      move second child to first child (temp int)
+0:151        'out_i1' (temp int)
+0:151        imageAtomicExchange (temp int)
+0:151          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:151          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:151            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:151            Constant:
+0:151              6 (const uint)
+0:151          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:151            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:151            Constant:
+0:151              5 (const uint)
+0:152      imageAtomicMax (temp int)
+0:152        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:152        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:152          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:152          Constant:
+0:152            6 (const uint)
+0:152        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:152          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:152          Constant:
+0:152            8 (const uint)
+0:153      move second child to first child (temp int)
+0:153        'out_i1' (temp int)
+0:153        imageAtomicMax (temp int)
+0:153          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:153          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:153            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:153            Constant:
+0:153              6 (const uint)
+0:153          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:153            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:153            Constant:
+0:153              5 (const uint)
+0:154      imageAtomicMin (temp int)
+0:154        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:154        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:154          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:154          Constant:
+0:154            6 (const uint)
+0:154        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:154          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:154          Constant:
+0:154            8 (const uint)
+0:155      move second child to first child (temp int)
+0:155        'out_i1' (temp int)
+0:155        imageAtomicMin (temp int)
+0:155          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:155          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:155            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:155            Constant:
+0:155              6 (const uint)
+0:155          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:155            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:155            Constant:
+0:155              5 (const uint)
+0:156      imageAtomicOr (temp int)
+0:156        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:156        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:156          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:156          Constant:
+0:156            6 (const uint)
+0:156        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:156          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:156          Constant:
+0:156            8 (const uint)
+0:157      move second child to first child (temp int)
+0:157        'out_i1' (temp int)
+0:157        imageAtomicOr (temp int)
+0:157          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:157          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:157            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:157            Constant:
+0:157              6 (const uint)
+0:157          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:157            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:157            Constant:
+0:157              5 (const uint)
+0:158      imageAtomicXor (temp int)
+0:158        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:158        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:158          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:158          Constant:
+0:158            6 (const uint)
+0:158        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:158          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:158          Constant:
+0:158            8 (const uint)
+0:159      move second child to first child (temp int)
+0:159        'out_i1' (temp int)
+0:159        imageAtomicXor (temp int)
+0:159          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:159          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:159            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:159            Constant:
+0:159              6 (const uint)
+0:159          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:159            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:159            Constant:
+0:159              5 (const uint)
+0:162      imageAtomicAdd (temp uint)
+0:162        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:162        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:162          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:162          Constant:
+0:162            1 (const uint)
+0:162        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:162          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:162          Constant:
+0:162            0 (const uint)
+0:163      move second child to first child (temp uint)
+0:163        'out_u1' (temp uint)
+0:163        imageAtomicAdd (temp uint)
+0:163          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:163          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:163            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:163            Constant:
+0:163              1 (const uint)
+0:163          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:163            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:163            Constant:
+0:163              0 (const uint)
+0:164      imageAtomicAnd (temp uint)
+0:164        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:164        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:164          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:164          Constant:
+0:164            1 (const uint)
+0:164        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:164          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:164          Constant:
+0:164            0 (const uint)
+0:165      move second child to first child (temp uint)
+0:165        'out_u1' (temp uint)
+0:165        imageAtomicAnd (temp uint)
+0:165          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:165          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:165            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:165            Constant:
+0:165              1 (const uint)
+0:165          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:165            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:165            Constant:
+0:165              0 (const uint)
+0:166      move second child to first child (temp uint)
+0:166        'out_u1' (temp uint)
+0:166        imageAtomicCompSwap (temp uint)
+0:166          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:166          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:166            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:166            Constant:
+0:166              1 (const uint)
+0:166          u1b: direct index for structure (layout(offset=28 ) uniform uint)
+0:166            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:166            Constant:
+0:166              3 (const uint)
+0:166          u1c: direct index for structure (layout(offset=32 ) uniform uint)
+0:166            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:166            Constant:
+0:166              4 (const uint)
+0:167      move second child to first child (temp uint)
+0:167        'out_u1' (temp uint)
+0:167        imageAtomicExchange (temp uint)
+0:167          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:167          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:167            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:167            Constant:
+0:167              1 (const uint)
+0:167          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:167            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:167            Constant:
+0:167              0 (const uint)
+0:168      imageAtomicMax (temp uint)
+0:168        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:168        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:168          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:168          Constant:
+0:168            1 (const uint)
+0:168        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:168          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:168          Constant:
+0:168            0 (const uint)
+0:169      move second child to first child (temp uint)
+0:169        'out_u1' (temp uint)
+0:169        imageAtomicMax (temp uint)
+0:169          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:169          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:169            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:169            Constant:
+0:169              1 (const uint)
+0:169          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:169            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:169            Constant:
+0:169              0 (const uint)
+0:170      imageAtomicMin (temp uint)
+0:170        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:170        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:170          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:170          Constant:
+0:170            1 (const uint)
+0:170        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:170          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:170          Constant:
+0:170            0 (const uint)
+0:171      move second child to first child (temp uint)
+0:171        'out_u1' (temp uint)
+0:171        imageAtomicMin (temp uint)
+0:171          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:171          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:171            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:171            Constant:
+0:171              1 (const uint)
+0:171          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:171            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:171            Constant:
+0:171              0 (const uint)
+0:172      imageAtomicOr (temp uint)
+0:172        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:172        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:172          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:172          Constant:
+0:172            1 (const uint)
+0:172        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:172          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:172          Constant:
+0:172            0 (const uint)
+0:173      move second child to first child (temp uint)
+0:173        'out_u1' (temp uint)
+0:173        imageAtomicOr (temp uint)
+0:173          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:173          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:173            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:173            Constant:
+0:173              1 (const uint)
+0:173          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:173            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:173            Constant:
+0:173              0 (const uint)
+0:174      imageAtomicXor (temp uint)
+0:174        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:174        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:174          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:174          Constant:
+0:174            1 (const uint)
+0:174        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:174          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:174          Constant:
+0:174            0 (const uint)
+0:175      move second child to first child (temp uint)
+0:175        'out_u1' (temp uint)
+0:175        imageAtomicXor (temp uint)
+0:175          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:175          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:175            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:175            Constant:
+0:175              1 (const uint)
+0:175          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:175            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:175            Constant:
+0:175              0 (const uint)
+0:178      imageAtomicAdd (temp int)
+0:178        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:178        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:178          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:178          Constant:
+0:178            6 (const uint)
+0:178        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:178          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:178          Constant:
+0:178            8 (const uint)
+0:179      move second child to first child (temp int)
+0:179        'out_i1' (temp int)
+0:179        imageAtomicAdd (temp int)
+0:179          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:179          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:179            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:179            Constant:
+0:179              6 (const uint)
+0:179          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:179            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:179            Constant:
+0:179              5 (const uint)
+0:180      imageAtomicAnd (temp int)
+0:180        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:180        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:180          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:180          Constant:
+0:180            6 (const uint)
+0:180        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:180          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:180          Constant:
+0:180            8 (const uint)
+0:181      move second child to first child (temp int)
+0:181        'out_i1' (temp int)
+0:181        imageAtomicAnd (temp int)
+0:181          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:181          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:181            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:181            Constant:
+0:181              6 (const uint)
+0:181          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:181            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:181            Constant:
+0:181              5 (const uint)
+0:182      move second child to first child (temp int)
+0:182        'out_i1' (temp int)
+0:182        imageAtomicCompSwap (temp int)
+0:182          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:182          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:182            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:182            Constant:
+0:182              6 (const uint)
+0:182          i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:182            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:182            Constant:
+0:182              8 (const uint)
+0:182          i1c: direct index for structure (layout(offset=64 ) uniform int)
+0:182            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:182            Constant:
+0:182              9 (const uint)
+0:183      move second child to first child (temp int)
+0:183        'out_i1' (temp int)
+0:183        imageAtomicExchange (temp int)
+0:183          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:183          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:183            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:183            Constant:
+0:183              6 (const uint)
+0:183          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:183            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:183            Constant:
+0:183              5 (const uint)
+0:184      imageAtomicMax (temp int)
+0:184        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:184        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:184          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:184          Constant:
+0:184            6 (const uint)
+0:184        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:184          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:184          Constant:
+0:184            8 (const uint)
+0:185      move second child to first child (temp int)
+0:185        'out_i1' (temp int)
+0:185        imageAtomicMax (temp int)
+0:185          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:185          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:185            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:185            Constant:
+0:185              6 (const uint)
+0:185          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:185            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:185            Constant:
+0:185              5 (const uint)
+0:186      imageAtomicMin (temp int)
+0:186        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:186        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:186          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:186          Constant:
+0:186            6 (const uint)
+0:186        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:186          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:186          Constant:
+0:186            8 (const uint)
+0:187      move second child to first child (temp int)
+0:187        'out_i1' (temp int)
+0:187        imageAtomicMin (temp int)
+0:187          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:187          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:187            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:187            Constant:
+0:187              6 (const uint)
+0:187          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:187            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:187            Constant:
+0:187              5 (const uint)
+0:188      imageAtomicOr (temp int)
+0:188        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:188        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:188          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:188          Constant:
+0:188            6 (const uint)
+0:188        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:188          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:188          Constant:
+0:188            8 (const uint)
+0:189      move second child to first child (temp int)
+0:189        'out_i1' (temp int)
+0:189        imageAtomicOr (temp int)
+0:189          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:189          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:189            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:189            Constant:
+0:189              6 (const uint)
+0:189          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:189            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:189            Constant:
+0:189              5 (const uint)
+0:190      imageAtomicXor (temp int)
+0:190        'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:190        i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:190          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:190          Constant:
+0:190            6 (const uint)
+0:190        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:190          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:190          Constant:
+0:190            8 (const uint)
+0:191      move second child to first child (temp int)
+0:191        'out_i1' (temp int)
+0:191        imageAtomicXor (temp int)
+0:191          'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:191          i2: direct index for structure (layout(offset=40 ) uniform 2-component vector of int)
+0:191            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:191            Constant:
+0:191              6 (const uint)
+0:191          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:191            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:191            Constant:
+0:191              5 (const uint)
+0:194      imageAtomicAdd (temp uint)
+0:194        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:194        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:194          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:194          Constant:
+0:194            1 (const uint)
+0:194        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:194          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:194          Constant:
+0:194            0 (const uint)
+0:195      move second child to first child (temp uint)
+0:195        'out_u1' (temp uint)
+0:195        imageAtomicAdd (temp uint)
+0:195          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:195          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:195            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:195            Constant:
+0:195              1 (const uint)
+0:195          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:195            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:195            Constant:
+0:195              0 (const uint)
+0:196      imageAtomicAnd (temp uint)
+0:196        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:196        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:196          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:196          Constant:
+0:196            1 (const uint)
+0:196        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:196          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:196          Constant:
+0:196            0 (const uint)
+0:197      move second child to first child (temp uint)
+0:197        'out_u1' (temp uint)
+0:197        imageAtomicAnd (temp uint)
+0:197          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:197          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:197            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:197            Constant:
+0:197              1 (const uint)
+0:197          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:197            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:197            Constant:
+0:197              0 (const uint)
+0:198      move second child to first child (temp uint)
+0:198        'out_u1' (temp uint)
+0:198        imageAtomicCompSwap (temp uint)
+0:198          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:198          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:198            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:198            Constant:
+0:198              1 (const uint)
+0:198          u1b: direct index for structure (layout(offset=28 ) uniform uint)
+0:198            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:198            Constant:
+0:198              3 (const uint)
+0:198          u1c: direct index for structure (layout(offset=32 ) uniform uint)
+0:198            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:198            Constant:
+0:198              4 (const uint)
+0:199      move second child to first child (temp uint)
+0:199        'out_u1' (temp uint)
+0:199        imageAtomicExchange (temp uint)
+0:199          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:199          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:199            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:199            Constant:
+0:199              1 (const uint)
+0:199          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:199            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:199            Constant:
+0:199              0 (const uint)
+0:200      imageAtomicMax (temp uint)
+0:200        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:200        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:200          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:200          Constant:
+0:200            1 (const uint)
+0:200        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:200          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:200          Constant:
+0:200            0 (const uint)
+0:201      move second child to first child (temp uint)
+0:201        'out_u1' (temp uint)
+0:201        imageAtomicMax (temp uint)
+0:201          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:201          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:201            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:201            Constant:
+0:201              1 (const uint)
+0:201          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:201            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:201            Constant:
+0:201              0 (const uint)
+0:202      imageAtomicMin (temp uint)
+0:202        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:202        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:202          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:202          Constant:
+0:202            1 (const uint)
+0:202        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:202          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:202          Constant:
+0:202            0 (const uint)
+0:203      move second child to first child (temp uint)
+0:203        'out_u1' (temp uint)
+0:203        imageAtomicMin (temp uint)
+0:203          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:203          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:203            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:203            Constant:
+0:203              1 (const uint)
+0:203          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:203            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:203            Constant:
+0:203              0 (const uint)
+0:204      imageAtomicOr (temp uint)
+0:204        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:204        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:204          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:204          Constant:
+0:204            1 (const uint)
+0:204        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:204          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:204          Constant:
+0:204            0 (const uint)
+0:205      move second child to first child (temp uint)
+0:205        'out_u1' (temp uint)
+0:205        imageAtomicOr (temp uint)
+0:205          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:205          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:205            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:205            Constant:
+0:205              1 (const uint)
+0:205          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:205            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:205            Constant:
+0:205              0 (const uint)
+0:206      imageAtomicXor (temp uint)
+0:206        'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:206        u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:206          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:206          Constant:
+0:206            1 (const uint)
+0:206        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:206          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:206          Constant:
+0:206            0 (const uint)
+0:207      move second child to first child (temp uint)
+0:207        'out_u1' (temp uint)
+0:207        imageAtomicXor (temp uint)
+0:207          'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:207          u2: direct index for structure (layout(offset=8 ) uniform 2-component vector of uint)
+0:207            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:207            Constant:
+0:207              1 (const uint)
+0:207          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:207            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:207            Constant:
+0:207              0 (const uint)
+0:210      imageAtomicAdd (temp int)
+0:210        'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:210        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:210          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:210          Constant:
+0:210            5 (const uint)
+0:210        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:210          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:210          Constant:
+0:210            8 (const uint)
+0:211      move second child to first child (temp int)
+0:211        'out_i1' (temp int)
+0:211        imageAtomicAdd (temp int)
+0:211          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:211          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:211            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:211            Constant:
+0:211              5 (const uint)
+0:211          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:211            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:211            Constant:
+0:211              5 (const uint)
+0:212      imageAtomicAnd (temp int)
+0:212        'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:212        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:212          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:212          Constant:
+0:212            5 (const uint)
+0:212        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:212          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:212          Constant:
+0:212            8 (const uint)
+0:213      move second child to first child (temp int)
+0:213        'out_i1' (temp int)
+0:213        imageAtomicAnd (temp int)
+0:213          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:213          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:213            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:213            Constant:
+0:213              5 (const uint)
+0:213          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:213            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:213            Constant:
+0:213              5 (const uint)
+0:214      move second child to first child (temp int)
+0:214        'out_i1' (temp int)
+0:214        imageAtomicCompSwap (temp int)
+0:214          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:214          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:214            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:214            Constant:
+0:214              5 (const uint)
+0:214          i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:214            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:214            Constant:
+0:214              8 (const uint)
+0:214          i1c: direct index for structure (layout(offset=64 ) uniform int)
+0:214            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:214            Constant:
+0:214              9 (const uint)
+0:215      move second child to first child (temp int)
+0:215        'out_i1' (temp int)
+0:215        imageAtomicExchange (temp int)
+0:215          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:215          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:215            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:215            Constant:
+0:215              5 (const uint)
+0:215          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:215            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:215            Constant:
+0:215              5 (const uint)
+0:216      imageAtomicMax (temp int)
+0:216        'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:216        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:216          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:216          Constant:
+0:216            5 (const uint)
+0:216        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:216          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:216          Constant:
+0:216            8 (const uint)
+0:217      move second child to first child (temp int)
+0:217        'out_i1' (temp int)
+0:217        imageAtomicMax (temp int)
+0:217          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:217          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:217            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:217            Constant:
+0:217              5 (const uint)
+0:217          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:217            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:217            Constant:
+0:217              5 (const uint)
+0:218      imageAtomicMin (temp int)
+0:218        'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:218        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:218          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:218          Constant:
+0:218            5 (const uint)
+0:218        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:218          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:218          Constant:
+0:218            8 (const uint)
+0:219      move second child to first child (temp int)
+0:219        'out_i1' (temp int)
+0:219        imageAtomicMin (temp int)
+0:219          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:219          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:219            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:219            Constant:
+0:219              5 (const uint)
+0:219          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:219            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:219            Constant:
+0:219              5 (const uint)
+0:220      imageAtomicOr (temp int)
+0:220        'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:220        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:220          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:220          Constant:
+0:220            5 (const uint)
+0:220        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:220          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:220          Constant:
+0:220            8 (const uint)
+0:221      move second child to first child (temp int)
+0:221        'out_i1' (temp int)
+0:221        imageAtomicOr (temp int)
+0:221          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:221          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:221            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:221            Constant:
+0:221              5 (const uint)
+0:221          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:221            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:221            Constant:
+0:221              5 (const uint)
+0:222      imageAtomicXor (temp int)
+0:222        'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:222        i1: direct index for structure (layout(offset=36 ) uniform int)
+0:222          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:222          Constant:
+0:222            5 (const uint)
+0:222        i1b: direct index for structure (layout(offset=60 ) uniform int)
+0:222          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:222          Constant:
+0:222            8 (const uint)
+0:223      move second child to first child (temp int)
+0:223        'out_i1' (temp int)
+0:223        imageAtomicXor (temp int)
+0:223          'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:223          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:223            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:223            Constant:
+0:223              5 (const uint)
+0:223          i1: direct index for structure (layout(offset=36 ) uniform int)
+0:223            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:223            Constant:
+0:223              5 (const uint)
+0:226      imageAtomicAdd (temp uint)
+0:226        'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:226        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:226          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:226          Constant:
+0:226            0 (const uint)
+0:226        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:226          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:226          Constant:
+0:226            0 (const uint)
+0:227      move second child to first child (temp uint)
+0:227        'out_u1' (temp uint)
+0:227        imageAtomicAdd (temp uint)
+0:227          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:227          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:227            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:227            Constant:
+0:227              0 (const uint)
+0:227          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:227            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:227            Constant:
+0:227              0 (const uint)
+0:228      imageAtomicAnd (temp uint)
+0:228        'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:228        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:228          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:228          Constant:
+0:228            0 (const uint)
+0:228        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:228          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:228          Constant:
+0:228            0 (const uint)
+0:229      move second child to first child (temp uint)
+0:229        'out_u1' (temp uint)
+0:229        imageAtomicAnd (temp uint)
+0:229          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:229          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:229            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:229            Constant:
+0:229              0 (const uint)
+0:229          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:229            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:229            Constant:
+0:229              0 (const uint)
+0:230      move second child to first child (temp uint)
+0:230        'out_u1' (temp uint)
+0:230        imageAtomicCompSwap (temp uint)
+0:230          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:230          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:230            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:230            Constant:
+0:230              0 (const uint)
+0:230          u1b: direct index for structure (layout(offset=28 ) uniform uint)
+0:230            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:230            Constant:
+0:230              3 (const uint)
+0:230          u1c: direct index for structure (layout(offset=32 ) uniform uint)
+0:230            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:230            Constant:
+0:230              4 (const uint)
+0:231      move second child to first child (temp uint)
+0:231        'out_u1' (temp uint)
+0:231        imageAtomicExchange (temp uint)
+0:231          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:231          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:231            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:231            Constant:
+0:231              0 (const uint)
+0:231          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:231            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:231            Constant:
+0:231              0 (const uint)
+0:232      imageAtomicMax (temp uint)
+0:232        'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:232        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:232          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:232          Constant:
+0:232            0 (const uint)
+0:232        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:232          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:232          Constant:
+0:232            0 (const uint)
+0:233      move second child to first child (temp uint)
+0:233        'out_u1' (temp uint)
+0:233        imageAtomicMax (temp uint)
+0:233          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:233          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:233            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:233            Constant:
+0:233              0 (const uint)
+0:233          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:233            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:233            Constant:
+0:233              0 (const uint)
+0:234      imageAtomicMin (temp uint)
+0:234        'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:234        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:234          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:234          Constant:
+0:234            0 (const uint)
+0:234        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:234          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:234          Constant:
+0:234            0 (const uint)
+0:235      move second child to first child (temp uint)
+0:235        'out_u1' (temp uint)
+0:235        imageAtomicMin (temp uint)
+0:235          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:235          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:235            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:235            Constant:
+0:235              0 (const uint)
+0:235          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:235            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:235            Constant:
+0:235              0 (const uint)
+0:236      imageAtomicOr (temp uint)
+0:236        'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:236        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:236          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:236          Constant:
+0:236            0 (const uint)
+0:236        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:236          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:236          Constant:
+0:236            0 (const uint)
+0:237      move second child to first child (temp uint)
+0:237        'out_u1' (temp uint)
+0:237        imageAtomicOr (temp uint)
+0:237          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:237          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:237            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:237            Constant:
+0:237              0 (const uint)
+0:237          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:237            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:237            Constant:
+0:237              0 (const uint)
+0:238      imageAtomicXor (temp uint)
+0:238        'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:238        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:238          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:238          Constant:
+0:238            0 (const uint)
+0:238        u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:238          'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:238          Constant:
+0:238            0 (const uint)
+0:239      move second child to first child (temp uint)
+0:239        'out_u1' (temp uint)
+0:239        imageAtomicXor (temp uint)
+0:239          'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:239          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:239            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:239            Constant:
+0:239              0 (const uint)
+0:239          u1: direct index for structure (layout(offset=0 ) uniform uint)
+0:239            'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+0:239            Constant:
+0:239              0 (const uint)
+0:242      move second child to first child (temp 4-component vector of float)
+0:242        Color: direct index for structure (temp 4-component vector of float)
+0:242          'psout' (temp structure{temp 4-component vector of float Color})
+0:242          Constant:
+0:242            0 (const int)
+0:242        Constant:
+0:242          1.000000
+0:242          1.000000
+0:242          1.000000
+0:242          1.000000
+0:243      Sequence
+0:243        Sequence
+0:243          move second child to first child (temp 4-component vector of float)
+0:?             'Color' (layout(location=0 ) out 4-component vector of float)
+0:243            Color: direct index for structure (temp 4-component vector of float)
+0:243              'psout' (temp structure{temp 4-component vector of float Color})
+0:243              Constant:
+0:243                0 (const int)
+0:243        Branch: Return
+0:?   Linker Objects
+0:?     'g_sSamp' (uniform sampler)
+0:?     'g_tTex1df1' (layout(r32f ) uniform image1D)
+0:?     'g_tTex1di1' (layout(r32i ) uniform iimage1D)
+0:?     'g_tTex1du1' (layout(r32ui ) uniform uimage1D)
+0:?     'g_tTex2df1' (layout(r32f ) uniform image2D)
+0:?     'g_tTex2di1' (layout(r32i ) uniform iimage2D)
+0:?     'g_tTex2du1' (layout(r32ui ) uniform uimage2D)
+0:?     'g_tTex3df1' (layout(r32f ) uniform image3D)
+0:?     'g_tTex3di1' (layout(r32i ) uniform iimage3D)
+0:?     'g_tTex3du1' (layout(r32ui ) uniform uimage3D)
+0:?     'g_tTex1df1a' (layout(r32f ) uniform image1DArray)
+0:?     'g_tTex1di1a' (layout(r32i ) uniform iimage1DArray)
+0:?     'g_tTex1du1a' (layout(r32ui ) uniform uimage1DArray)
+0:?     'g_tTex2df1a' (layout(r32f ) uniform image2DArray)
+0:?     'g_tTex2di1a' (layout(r32i ) uniform iimage2DArray)
+0:?     'g_tTex2du1a' (layout(r32ui ) uniform uimage2DArray)
+0:?     'g_tBuffF' (layout(r32f ) uniform imageBuffer)
+0:?     'g_tBuffI' (layout(r32i ) uniform iimageBuffer)
+0:?     'g_tBuffU' (layout(r32ui ) uniform uimageBuffer)
+0:?     'Color' (layout(location=0 ) out 4-component vector of float)
+0:?     'anon@0' (uniform block{layout(offset=0 ) uniform uint u1, layout(offset=8 ) uniform 2-component vector of uint u2, layout(offset=16 ) uniform 3-component vector of uint u3, layout(offset=28 ) uniform uint u1b, layout(offset=32 ) uniform uint u1c, layout(offset=36 ) uniform int i1, layout(offset=40 ) uniform 2-component vector of int i2, layout(offset=48 ) uniform 3-component vector of int i3, layout(offset=60 ) uniform int i1b, layout(offset=64 ) uniform int i1c})
+
+// Module Version 10000
+// Generated by (magic number): 80001
+// Id's are bound by 1142
+
+                              Capability Shader
+                              Capability Sampled1D
+                              Capability SampledBuffer
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Fragment 4  "main" 1111
+                              ExecutionMode 4 OriginUpperLeft
+                              Name 4  "main"
+                              Name 9  "g_tTex1di1"
+                              Name 15  "$Global"
+                              MemberName 15($Global) 0  "u1"
+                              MemberName 15($Global) 1  "u2"
+                              MemberName 15($Global) 2  "u3"
+                              MemberName 15($Global) 3  "u1b"
+                              MemberName 15($Global) 4  "u1c"
+                              MemberName 15($Global) 5  "i1"
+                              MemberName 15($Global) 6  "i2"
+                              MemberName 15($Global) 7  "i3"
+                              MemberName 15($Global) 8  "i1b"
+                              MemberName 15($Global) 9  "i1c"
+                              Name 17  ""
+                              Name 31  "out_i1"
+                              Name 115  "g_tTex1du1"
+                              Name 126  "out_u1"
+                              Name 211  "g_tTex2di1"
+                              Name 302  "g_tTex2du1"
+                              Name 393  "g_tTex3di1"
+                              Name 484  "g_tTex3du1"
+                              Name 575  "g_tTex1di1a"
+                              Name 664  "g_tTex1du1a"
+                              Name 925  "g_tBuffI"
+                              Name 1014  "g_tBuffU"
+                              Name 1103  "PS_OUTPUT"
+                              MemberName 1103(PS_OUTPUT) 0  "Color"
+                              Name 1105  "psout"
+                              Name 1111  "Color"
+                              Name 1117  "g_sSamp"
+                              Name 1120  "g_tTex1df1"
+                              Name 1123  "g_tTex2df1"
+                              Name 1126  "g_tTex3df1"
+                              Name 1129  "g_tTex1df1a"
+                              Name 1132  "g_tTex2df1a"
+                              Name 1135  "g_tTex2di1a"
+                              Name 1138  "g_tTex2du1a"
+                              Name 1141  "g_tBuffF"
+                              Decorate 9(g_tTex1di1) DescriptorSet 0
+                              MemberDecorate 15($Global) 0 Offset 0
+                              MemberDecorate 15($Global) 1 Offset 8
+                              MemberDecorate 15($Global) 2 Offset 16
+                              MemberDecorate 15($Global) 3 Offset 28
+                              MemberDecorate 15($Global) 4 Offset 32
+                              MemberDecorate 15($Global) 5 Offset 36
+                              MemberDecorate 15($Global) 6 Offset 40
+                              MemberDecorate 15($Global) 7 Offset 48
+                              MemberDecorate 15($Global) 8 Offset 60
+                              MemberDecorate 15($Global) 9 Offset 64
+                              Decorate 15($Global) Block
+                              Decorate 17 DescriptorSet 0
+                              Decorate 115(g_tTex1du1) DescriptorSet 0
+                              Decorate 211(g_tTex2di1) DescriptorSet 0
+                              Decorate 302(g_tTex2du1) DescriptorSet 0
+                              Decorate 393(g_tTex3di1) DescriptorSet 0
+                              Decorate 484(g_tTex3du1) DescriptorSet 0
+                              Decorate 575(g_tTex1di1a) DescriptorSet 0
+                              Decorate 664(g_tTex1du1a) DescriptorSet 0
+                              Decorate 925(g_tBuffI) DescriptorSet 0
+                              Decorate 1014(g_tBuffU) DescriptorSet 0
+                              Decorate 1111(Color) Location 0
+                              Decorate 1117(g_sSamp) DescriptorSet 0
+                              Decorate 1120(g_tTex1df1) DescriptorSet 0
+                              Decorate 1123(g_tTex2df1) DescriptorSet 0
+                              Decorate 1126(g_tTex3df1) DescriptorSet 0
+                              Decorate 1129(g_tTex1df1a) DescriptorSet 0
+                              Decorate 1132(g_tTex2df1a) DescriptorSet 0
+                              Decorate 1135(g_tTex2di1a) DescriptorSet 0
+                              Decorate 1138(g_tTex2du1a) DescriptorSet 0
+                              Decorate 1141(g_tBuffF) DescriptorSet 0
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeInt 32 1
+               7:             TypeImage 6(int) 1D nonsampled format:R32i
+               8:             TypePointer UniformConstant 7
+   9(g_tTex1di1):      8(ptr) Variable UniformConstant
+              10:             TypeInt 32 0
+              11:             TypeVector 10(int) 2
+              12:             TypeVector 10(int) 3
+              13:             TypeVector 6(int) 2
+              14:             TypeVector 6(int) 3
+     15($Global):             TypeStruct 10(int) 11(ivec2) 12(ivec3) 10(int) 10(int) 6(int) 13(ivec2) 14(ivec3) 6(int) 6(int)
+              16:             TypePointer Uniform 15($Global)
+              17:     16(ptr) Variable Uniform
+              18:      6(int) Constant 5
+              19:             TypePointer Uniform 6(int)
+              22:      6(int) Constant 8
+              25:     10(int) Constant 0
+              26:             TypePointer Image 6(int)
+              28:     10(int) Constant 1
+              30:             TypePointer Function 6(int)
+              54:      6(int) Constant 9
+             113:             TypeImage 10(int) 1D nonsampled format:R32ui
+             114:             TypePointer UniformConstant 113
+ 115(g_tTex1du1):    114(ptr) Variable UniformConstant
+             116:      6(int) Constant 0
+             117:             TypePointer Uniform 10(int)
+             122:             TypePointer Image 10(int)
+             125:             TypePointer Function 10(int)
+             147:      6(int) Constant 3
+             150:      6(int) Constant 4
+             209:             TypeImage 6(int) 2D nonsampled format:R32i
+             210:             TypePointer UniformConstant 209
+ 211(g_tTex2di1):    210(ptr) Variable UniformConstant
+             212:      6(int) Constant 6
+             213:             TypePointer Uniform 13(ivec2)
+             300:             TypeImage 10(int) 2D nonsampled format:R32ui
+             301:             TypePointer UniformConstant 300
+ 302(g_tTex2du1):    301(ptr) Variable UniformConstant
+             303:      6(int) Constant 1
+             304:             TypePointer Uniform 11(ivec2)
+             391:             TypeImage 6(int) 3D nonsampled format:R32i
+             392:             TypePointer UniformConstant 391
+ 393(g_tTex3di1):    392(ptr) Variable UniformConstant
+             394:      6(int) Constant 7
+             395:             TypePointer Uniform 14(ivec3)
+             482:             TypeImage 10(int) 3D nonsampled format:R32ui
+             483:             TypePointer UniformConstant 482
+ 484(g_tTex3du1):    483(ptr) Variable UniformConstant
+             485:      6(int) Constant 2
+             486:             TypePointer Uniform 12(ivec3)
+             573:             TypeImage 6(int) 1D array nonsampled format:R32i
+             574:             TypePointer UniformConstant 573
+575(g_tTex1di1a):    574(ptr) Variable UniformConstant
+             662:             TypeImage 10(int) 1D array nonsampled format:R32ui
+             663:             TypePointer UniformConstant 662
+664(g_tTex1du1a):    663(ptr) Variable UniformConstant
+             923:             TypeImage 6(int) Buffer nonsampled format:R32i
+             924:             TypePointer UniformConstant 923
+   925(g_tBuffI):    924(ptr) Variable UniformConstant
+            1012:             TypeImage 10(int) Buffer nonsampled format:R32ui
+            1013:             TypePointer UniformConstant 1012
+  1014(g_tBuffU):   1013(ptr) Variable UniformConstant
+            1101:             TypeFloat 32
+            1102:             TypeVector 1101(float) 4
+ 1103(PS_OUTPUT):             TypeStruct 1102(fvec4)
+            1104:             TypePointer Function 1103(PS_OUTPUT)
+            1106: 1101(float) Constant 1065353216
+            1107: 1102(fvec4) ConstantComposite 1106 1106 1106 1106
+            1108:             TypePointer Function 1102(fvec4)
+            1110:             TypePointer Output 1102(fvec4)
+     1111(Color):   1110(ptr) Variable Output
+            1115:             TypeSampler
+            1116:             TypePointer UniformConstant 1115
+   1117(g_sSamp):   1116(ptr) Variable UniformConstant
+            1118:             TypeImage 1101(float) 1D nonsampled format:R32f
+            1119:             TypePointer UniformConstant 1118
+1120(g_tTex1df1):   1119(ptr) Variable UniformConstant
+            1121:             TypeImage 1101(float) 2D nonsampled format:R32f
+            1122:             TypePointer UniformConstant 1121
+1123(g_tTex2df1):   1122(ptr) Variable UniformConstant
+            1124:             TypeImage 1101(float) 3D nonsampled format:R32f
+            1125:             TypePointer UniformConstant 1124
+1126(g_tTex3df1):   1125(ptr) Variable UniformConstant
+            1127:             TypeImage 1101(float) 1D array nonsampled format:R32f
+            1128:             TypePointer UniformConstant 1127
+1129(g_tTex1df1a):   1128(ptr) Variable UniformConstant
+            1130:             TypeImage 1101(float) 2D array nonsampled format:R32f
+            1131:             TypePointer UniformConstant 1130
+1132(g_tTex2df1a):   1131(ptr) Variable UniformConstant
+            1133:             TypeImage 6(int) 2D array nonsampled format:R32i
+            1134:             TypePointer UniformConstant 1133
+1135(g_tTex2di1a):   1134(ptr) Variable UniformConstant
+            1136:             TypeImage 10(int) 2D array nonsampled format:R32ui
+            1137:             TypePointer UniformConstant 1136
+1138(g_tTex2du1a):   1137(ptr) Variable UniformConstant
+            1139:             TypeImage 1101(float) Buffer nonsampled format:R32f
+            1140:             TypePointer UniformConstant 1139
+  1141(g_tBuffF):   1140(ptr) Variable UniformConstant
+         4(main):           2 Function None 3
+               5:             Label
+      31(out_i1):     30(ptr) Variable Function
+     126(out_u1):    125(ptr) Variable Function
+     1105(psout):   1104(ptr) Variable Function
+              20:     19(ptr) AccessChain 17 18
+              21:      6(int) Load 20
+              23:     19(ptr) AccessChain 17 22
+              24:      6(int) Load 23
+              27:     26(ptr) ImageTexelPointer 9(g_tTex1di1) 21 25
+              29:      6(int) AtomicIAdd 27 28 25 24
+              32:     19(ptr) AccessChain 17 18
+              33:      6(int) Load 32
+              34:     19(ptr) AccessChain 17 18
+              35:      6(int) Load 34
+              36:     26(ptr) ImageTexelPointer 9(g_tTex1di1) 33 25
+              37:      6(int) AtomicIAdd 36 28 25 35
+                              Store 31(out_i1) 37
+              38:     19(ptr) AccessChain 17 18
+              39:      6(int) Load 38
+              40:     19(ptr) AccessChain 17 22
+              41:      6(int) Load 40
+              42:     26(ptr) ImageTexelPointer 9(g_tTex1di1) 39 25
+              43:      6(int) AtomicAnd 42 28 25 41
+              44:     19(ptr) AccessChain 17 18
+              45:      6(int) Load 44
+              46:     19(ptr) AccessChain 17 18
+              47:      6(int) Load 46
+              48:     26(ptr) ImageTexelPointer 9(g_tTex1di1) 45 25
+              49:      6(int) AtomicAnd 48 28 25 47
+                              Store 31(out_i1) 49
+              50:     19(ptr) AccessChain 17 18
+              51:      6(int) Load 50
+              52:     19(ptr) AccessChain 17 22
+              53:      6(int) Load 52
+              55:     19(ptr) AccessChain 17 54
+              56:      6(int) Load 55
+              57:     26(ptr) ImageTexelPointer 9(g_tTex1di1) 51 25
+              58:      6(int) AtomicCompareExchange 57 28 25 25 56 53
+                              Store 31(out_i1) 58
+              59:     19(ptr) AccessChain 17 18
+              60:      6(int) Load 59
+              61:     19(ptr) AccessChain 17 18
+              62:      6(int) Load 61
+              63:     26(ptr) ImageTexelPointer 9(g_tTex1di1) 60 25
+              64:      6(int) AtomicExchange 63 28 25 62
+                              Store 31(out_i1) 64
+              65:     19(ptr) AccessChain 17 18
+              66:      6(int) Load 65
+              67:     19(ptr) AccessChain 17 22
+              68:      6(int) Load 67
+              69:     26(ptr) ImageTexelPointer 9(g_tTex1di1) 66 25
+              70:      6(int) AtomicSMax 69 28 25 68
+              71:     19(ptr) AccessChain 17 18
+              72:      6(int) Load 71
+              73:     19(ptr) AccessChain 17 18
+              74:      6(int) Load 73
+              75:     26(ptr) ImageTexelPointer 9(g_tTex1di1) 72 25
+              76:      6(int) AtomicSMax 75 28 25 74
+                              Store 31(out_i1) 76
+              77:     19(ptr) AccessChain 17 18
+              78:      6(int) Load 77
+              79:     19(ptr) AccessChain 17 22
+              80:      6(int) Load 79
+              81:     26(ptr) ImageTexelPointer 9(g_tTex1di1) 78 25
+              82:      6(int) AtomicSMin 81 28 25 80
+              83:     19(ptr) AccessChain 17 18
+              84:      6(int) Load 83
+              85:     19(ptr) AccessChain 17 18
+              86:      6(int) Load 85
+              87:     26(ptr) ImageTexelPointer 9(g_tTex1di1) 84 25
+              88:      6(int) AtomicSMin 87 28 25 86
+                              Store 31(out_i1) 88
+              89:     19(ptr) AccessChain 17 18
+              90:      6(int) Load 89
+              91:     19(ptr) AccessChain 17 22
+              92:      6(int) Load 91
+              93:     26(ptr) ImageTexelPointer 9(g_tTex1di1) 90 25
+              94:      6(int) AtomicOr 93 28 25 92
+              95:     19(ptr) AccessChain 17 18
+              96:      6(int) Load 95
+              97:     19(ptr) AccessChain 17 18
+              98:      6(int) Load 97
+              99:     26(ptr) ImageTexelPointer 9(g_tTex1di1) 96 25
+             100:      6(int) AtomicOr 99 28 25 98
+                              Store 31(out_i1) 100
+             101:     19(ptr) AccessChain 17 18
+             102:      6(int) Load 101
+             103:     19(ptr) AccessChain 17 22
+             104:      6(int) Load 103
+             105:     26(ptr) ImageTexelPointer 9(g_tTex1di1) 102 25
+             106:      6(int) AtomicXor 105 28 25 104
+             107:     19(ptr) AccessChain 17 18
+             108:      6(int) Load 107
+             109:     19(ptr) AccessChain 17 18
+             110:      6(int) Load 109
+             111:     26(ptr) ImageTexelPointer 9(g_tTex1di1) 108 25
+             112:      6(int) AtomicXor 111 28 25 110
+                              Store 31(out_i1) 112
+             118:    117(ptr) AccessChain 17 116
+             119:     10(int) Load 118
+             120:    117(ptr) AccessChain 17 116
+             121:     10(int) Load 120
+             123:    122(ptr) ImageTexelPointer 115(g_tTex1du1) 119 25
+             124:     10(int) AtomicIAdd 123 28 25 121
+             127:    117(ptr) AccessChain 17 116
+             128:     10(int) Load 127
+             129:    117(ptr) AccessChain 17 116
+             130:     10(int) Load 129
+             131:    122(ptr) ImageTexelPointer 115(g_tTex1du1) 128 25
+             132:     10(int) AtomicIAdd 131 28 25 130
+                              Store 126(out_u1) 132
+             133:    117(ptr) AccessChain 17 116
+             134:     10(int) Load 133
+             135:    117(ptr) AccessChain 17 116
+             136:     10(int) Load 135
+             137:    122(ptr) ImageTexelPointer 115(g_tTex1du1) 134 25
+             138:     10(int) AtomicAnd 137 28 25 136
+             139:    117(ptr) AccessChain 17 116
+             140:     10(int) Load 139
+             141:    117(ptr) AccessChain 17 116
+             142:     10(int) Load 141
+             143:    122(ptr) ImageTexelPointer 115(g_tTex1du1) 140 25
+             144:     10(int) AtomicAnd 143 28 25 142
+                              Store 126(out_u1) 144
+             145:    117(ptr) AccessChain 17 116
+             146:     10(int) Load 145
+             148:    117(ptr) AccessChain 17 147
+             149:     10(int) Load 148
+             151:    117(ptr) AccessChain 17 150
+             152:     10(int) Load 151
+             153:    122(ptr) ImageTexelPointer 115(g_tTex1du1) 146 25
+             154:     10(int) AtomicCompareExchange 153 28 25 25 152 149
+                              Store 126(out_u1) 154
+             155:    117(ptr) AccessChain 17 116
+             156:     10(int) Load 155
+             157:    117(ptr) AccessChain 17 116
+             158:     10(int) Load 157
+             159:    122(ptr) ImageTexelPointer 115(g_tTex1du1) 156 25
+             160:     10(int) AtomicExchange 159 28 25 158
+                              Store 126(out_u1) 160
+             161:    117(ptr) AccessChain 17 116
+             162:     10(int) Load 161
+             163:    117(ptr) AccessChain 17 116
+             164:     10(int) Load 163
+             165:    122(ptr) ImageTexelPointer 115(g_tTex1du1) 162 25
+             166:     10(int) AtomicUMax 165 28 25 164
+             167:    117(ptr) AccessChain 17 116
+             168:     10(int) Load 167
+             169:    117(ptr) AccessChain 17 116
+             170:     10(int) Load 169
+             171:    122(ptr) ImageTexelPointer 115(g_tTex1du1) 168 25
+             172:     10(int) AtomicUMax 171 28 25 170
+                              Store 126(out_u1) 172
+             173:    117(ptr) AccessChain 17 116
+             174:     10(int) Load 173
+             175:    117(ptr) AccessChain 17 116
+             176:     10(int) Load 175
+             177:    122(ptr) ImageTexelPointer 115(g_tTex1du1) 174 25
+             178:     10(int) AtomicUMin 177 28 25 176
+             179:    117(ptr) AccessChain 17 116
+             180:     10(int) Load 179
+             181:    117(ptr) AccessChain 17 116
+             182:     10(int) Load 181
+             183:    122(ptr) ImageTexelPointer 115(g_tTex1du1) 180 25
+             184:     10(int) AtomicUMin 183 28 25 182
+                              Store 126(out_u1) 184
+             185:    117(ptr) AccessChain 17 116
+             186:     10(int) Load 185
+             187:    117(ptr) AccessChain 17 116
+             188:     10(int) Load 187
+             189:    122(ptr) ImageTexelPointer 115(g_tTex1du1) 186 25
+             190:     10(int) AtomicOr 189 28 25 188
+             191:    117(ptr) AccessChain 17 116
+             192:     10(int) Load 191
+             193:    117(ptr) AccessChain 17 116
+             194:     10(int) Load 193
+             195:    122(ptr) ImageTexelPointer 115(g_tTex1du1) 192 25
+             196:     10(int) AtomicOr 195 28 25 194
+                              Store 126(out_u1) 196
+             197:    117(ptr) AccessChain 17 116
+             198:     10(int) Load 197
+             199:    117(ptr) AccessChain 17 116
+             200:     10(int) Load 199
+             201:    122(ptr) ImageTexelPointer 115(g_tTex1du1) 198 25
+             202:     10(int) AtomicXor 201 28 25 200
+             203:    117(ptr) AccessChain 17 116
+             204:     10(int) Load 203
+             205:    117(ptr) AccessChain 17 116
+             206:     10(int) Load 205
+             207:    122(ptr) ImageTexelPointer 115(g_tTex1du1) 204 25
+             208:     10(int) AtomicXor 207 28 25 206
+                              Store 126(out_u1) 208
+             214:    213(ptr) AccessChain 17 212
+             215:   13(ivec2) Load 214
+             216:     19(ptr) AccessChain 17 22
+             217:      6(int) Load 216
+             218:     26(ptr) ImageTexelPointer 211(g_tTex2di1) 215 25
+             219:      6(int) AtomicIAdd 218 28 25 217
+             220:    213(ptr) AccessChain 17 212
+             221:   13(ivec2) Load 220
+             222:     19(ptr) AccessChain 17 18
+             223:      6(int) Load 222
+             224:     26(ptr) ImageTexelPointer 211(g_tTex2di1) 221 25
+             225:      6(int) AtomicIAdd 224 28 25 223
+                              Store 31(out_i1) 225
+             226:    213(ptr) AccessChain 17 212
+             227:   13(ivec2) Load 226
+             228:     19(ptr) AccessChain 17 22
+             229:      6(int) Load 228
+             230:     26(ptr) ImageTexelPointer 211(g_tTex2di1) 227 25
+             231:      6(int) AtomicAnd 230 28 25 229
+             232:    213(ptr) AccessChain 17 212
+             233:   13(ivec2) Load 232
+             234:     19(ptr) AccessChain 17 18
+             235:      6(int) Load 234
+             236:     26(ptr) ImageTexelPointer 211(g_tTex2di1) 233 25
+             237:      6(int) AtomicAnd 236 28 25 235
+                              Store 31(out_i1) 237
+             238:    213(ptr) AccessChain 17 212
+             239:   13(ivec2) Load 238
+             240:     19(ptr) AccessChain 17 22
+             241:      6(int) Load 240
+             242:     19(ptr) AccessChain 17 54
+             243:      6(int) Load 242
+             244:     26(ptr) ImageTexelPointer 211(g_tTex2di1) 239 25
+             245:      6(int) AtomicCompareExchange 244 28 25 25 243 241
+                              Store 31(out_i1) 245
+             246:    213(ptr) AccessChain 17 212
+             247:   13(ivec2) Load 246
+             248:     19(ptr) AccessChain 17 18
+             249:      6(int) Load 248
+             250:     26(ptr) ImageTexelPointer 211(g_tTex2di1) 247 25
+             251:      6(int) AtomicExchange 250 28 25 249
+                              Store 31(out_i1) 251
+             252:    213(ptr) AccessChain 17 212
+             253:   13(ivec2) Load 252
+             254:     19(ptr) AccessChain 17 22
+             255:      6(int) Load 254
+             256:     26(ptr) ImageTexelPointer 211(g_tTex2di1) 253 25
+             257:      6(int) AtomicSMax 256 28 25 255
+             258:    213(ptr) AccessChain 17 212
+             259:   13(ivec2) Load 258
+             260:     19(ptr) AccessChain 17 18
+             261:      6(int) Load 260
+             262:     26(ptr) ImageTexelPointer 211(g_tTex2di1) 259 25
+             263:      6(int) AtomicSMax 262 28 25 261
+                              Store 31(out_i1) 263
+             264:    213(ptr) AccessChain 17 212
+             265:   13(ivec2) Load 264
+             266:     19(ptr) AccessChain 17 22
+             267:      6(int) Load 266
+             268:     26(ptr) ImageTexelPointer 211(g_tTex2di1) 265 25
+             269:      6(int) AtomicSMin 268 28 25 267
+             270:    213(ptr) AccessChain 17 212
+             271:   13(ivec2) Load 270
+             272:     19(ptr) AccessChain 17 18
+             273:      6(int) Load 272
+             274:     26(ptr) ImageTexelPointer 211(g_tTex2di1) 271 25
+             275:      6(int) AtomicSMin 274 28 25 273
+                              Store 31(out_i1) 275
+             276:    213(ptr) AccessChain 17 212
+             277:   13(ivec2) Load 276
+             278:     19(ptr) AccessChain 17 22
+             279:      6(int) Load 278
+             280:     26(ptr) ImageTexelPointer 211(g_tTex2di1) 277 25
+             281:      6(int) AtomicOr 280 28 25 279
+             282:    213(ptr) AccessChain 17 212
+             283:   13(ivec2) Load 282
+             284:     19(ptr) AccessChain 17 18
+             285:      6(int) Load 284
+             286:     26(ptr) ImageTexelPointer 211(g_tTex2di1) 283 25
+             287:      6(int) AtomicOr 286 28 25 285
+                              Store 31(out_i1) 287
+             288:    213(ptr) AccessChain 17 212
+             289:   13(ivec2) Load 288
+             290:     19(ptr) AccessChain 17 22
+             291:      6(int) Load 290
+             292:     26(ptr) ImageTexelPointer 211(g_tTex2di1) 289 25
+             293:      6(int) AtomicXor 292 28 25 291
+             294:    213(ptr) AccessChain 17 212
+             295:   13(ivec2) Load 294
+             296:     19(ptr) AccessChain 17 18
+             297:      6(int) Load 296
+             298:     26(ptr) ImageTexelPointer 211(g_tTex2di1) 295 25
+             299:      6(int) AtomicXor 298 28 25 297
+                              Store 31(out_i1) 299
+             305:    304(ptr) AccessChain 17 303
+             306:   11(ivec2) Load 305
+             307:    117(ptr) AccessChain 17 116
+             308:     10(int) Load 307
+             309:    122(ptr) ImageTexelPointer 302(g_tTex2du1) 306 25
+             310:     10(int) AtomicIAdd 309 28 25 308
+             311:    304(ptr) AccessChain 17 303
+             312:   11(ivec2) Load 311
+             313:    117(ptr) AccessChain 17 116
+             314:     10(int) Load 313
+             315:    122(ptr) ImageTexelPointer 302(g_tTex2du1) 312 25
+             316:     10(int) AtomicIAdd 315 28 25 314
+                              Store 126(out_u1) 316
+             317:    304(ptr) AccessChain 17 303
+             318:   11(ivec2) Load 317
+             319:    117(ptr) AccessChain 17 116
+             320:     10(int) Load 319
+             321:    122(ptr) ImageTexelPointer 302(g_tTex2du1) 318 25
+             322:     10(int) AtomicAnd 321 28 25 320
+             323:    304(ptr) AccessChain 17 303
+             324:   11(ivec2) Load 323
+             325:    117(ptr) AccessChain 17 116
+             326:     10(int) Load 325
+             327:    122(ptr) ImageTexelPointer 302(g_tTex2du1) 324 25
+             328:     10(int) AtomicAnd 327 28 25 326
+                              Store 126(out_u1) 328
+             329:    304(ptr) AccessChain 17 303
+             330:   11(ivec2) Load 329
+             331:    117(ptr) AccessChain 17 147
+             332:     10(int) Load 331
+             333:    117(ptr) AccessChain 17 150
+             334:     10(int) Load 333
+             335:    122(ptr) ImageTexelPointer 302(g_tTex2du1) 330 25
+             336:     10(int) AtomicCompareExchange 335 28 25 25 334 332
+                              Store 126(out_u1) 336
+             337:    304(ptr) AccessChain 17 303
+             338:   11(ivec2) Load 337
+             339:    117(ptr) AccessChain 17 116
+             340:     10(int) Load 339
+             341:    122(ptr) ImageTexelPointer 302(g_tTex2du1) 338 25
+             342:     10(int) AtomicExchange 341 28 25 340
+                              Store 126(out_u1) 342
+             343:    304(ptr) AccessChain 17 303
+             344:   11(ivec2) Load 343
+             345:    117(ptr) AccessChain 17 116
+             346:     10(int) Load 345
+             347:    122(ptr) ImageTexelPointer 302(g_tTex2du1) 344 25
+             348:     10(int) AtomicUMax 347 28 25 346
+             349:    304(ptr) AccessChain 17 303
+             350:   11(ivec2) Load 349
+             351:    117(ptr) AccessChain 17 116
+             352:     10(int) Load 351
+             353:    122(ptr) ImageTexelPointer 302(g_tTex2du1) 350 25
+             354:     10(int) AtomicUMax 353 28 25 352
+                              Store 126(out_u1) 354
+             355:    304(ptr) AccessChain 17 303
+             356:   11(ivec2) Load 355
+             357:    117(ptr) AccessChain 17 116
+             358:     10(int) Load 357
+             359:    122(ptr) ImageTexelPointer 302(g_tTex2du1) 356 25
+             360:     10(int) AtomicUMin 359 28 25 358
+             361:    304(ptr) AccessChain 17 303
+             362:   11(ivec2) Load 361
+             363:    117(ptr) AccessChain 17 116
+             364:     10(int) Load 363
+             365:    122(ptr) ImageTexelPointer 302(g_tTex2du1) 362 25
+             366:     10(int) AtomicUMin 365 28 25 364
+                              Store 126(out_u1) 366
+             367:    304(ptr) AccessChain 17 303
+             368:   11(ivec2) Load 367
+             369:    117(ptr) AccessChain 17 116
+             370:     10(int) Load 369
+             371:    122(ptr) ImageTexelPointer 302(g_tTex2du1) 368 25
+             372:     10(int) AtomicOr 371 28 25 370
+             373:    304(ptr) AccessChain 17 303
+             374:   11(ivec2) Load 373
+             375:    117(ptr) AccessChain 17 116
+             376:     10(int) Load 375
+             377:    122(ptr) ImageTexelPointer 302(g_tTex2du1) 374 25
+             378:     10(int) AtomicOr 377 28 25 376
+                              Store 126(out_u1) 378
+             379:    304(ptr) AccessChain 17 303
+             380:   11(ivec2) Load 379
+             381:    117(ptr) AccessChain 17 116
+             382:     10(int) Load 381
+             383:    122(ptr) ImageTexelPointer 302(g_tTex2du1) 380 25
+             384:     10(int) AtomicXor 383 28 25 382
+             385:    304(ptr) AccessChain 17 303
+             386:   11(ivec2) Load 385
+             387:    117(ptr) AccessChain 17 116
+             388:     10(int) Load 387
+             389:    122(ptr) ImageTexelPointer 302(g_tTex2du1) 386 25
+             390:     10(int) AtomicXor 389 28 25 388
+                              Store 126(out_u1) 390
+             396:    395(ptr) AccessChain 17 394
+             397:   14(ivec3) Load 396
+             398:     19(ptr) AccessChain 17 22
+             399:      6(int) Load 398
+             400:     26(ptr) ImageTexelPointer 393(g_tTex3di1) 397 25
+             401:      6(int) AtomicIAdd 400 28 25 399
+             402:    395(ptr) AccessChain 17 394
+             403:   14(ivec3) Load 402
+             404:     19(ptr) AccessChain 17 18
+             405:      6(int) Load 404
+             406:     26(ptr) ImageTexelPointer 393(g_tTex3di1) 403 25
+             407:      6(int) AtomicIAdd 406 28 25 405
+                              Store 31(out_i1) 407
+             408:    395(ptr) AccessChain 17 394
+             409:   14(ivec3) Load 408
+             410:     19(ptr) AccessChain 17 22
+             411:      6(int) Load 410
+             412:     26(ptr) ImageTexelPointer 393(g_tTex3di1) 409 25
+             413:      6(int) AtomicAnd 412 28 25 411
+             414:    395(ptr) AccessChain 17 394
+             415:   14(ivec3) Load 414
+             416:     19(ptr) AccessChain 17 18
+             417:      6(int) Load 416
+             418:     26(ptr) ImageTexelPointer 393(g_tTex3di1) 415 25
+             419:      6(int) AtomicAnd 418 28 25 417
+                              Store 31(out_i1) 419
+             420:    395(ptr) AccessChain 17 394
+             421:   14(ivec3) Load 420
+             422:     19(ptr) AccessChain 17 22
+             423:      6(int) Load 422
+             424:     19(ptr) AccessChain 17 54
+             425:      6(int) Load 424
+             426:     26(ptr) ImageTexelPointer 393(g_tTex3di1) 421 25
+             427:      6(int) AtomicCompareExchange 426 28 25 25 425 423
+                              Store 31(out_i1) 427
+             428:    395(ptr) AccessChain 17 394
+             429:   14(ivec3) Load 428
+             430:     19(ptr) AccessChain 17 18
+             431:      6(int) Load 430
+             432:     26(ptr) ImageTexelPointer 393(g_tTex3di1) 429 25
+             433:      6(int) AtomicExchange 432 28 25 431
+                              Store 31(out_i1) 433
+             434:    395(ptr) AccessChain 17 394
+             435:   14(ivec3) Load 434
+             436:     19(ptr) AccessChain 17 22
+             437:      6(int) Load 436
+             438:     26(ptr) ImageTexelPointer 393(g_tTex3di1) 435 25
+             439:      6(int) AtomicSMax 438 28 25 437
+             440:    395(ptr) AccessChain 17 394
+             441:   14(ivec3) Load 440
+             442:     19(ptr) AccessChain 17 18
+             443:      6(int) Load 442
+             444:     26(ptr) ImageTexelPointer 393(g_tTex3di1) 441 25
+             445:      6(int) AtomicSMax 444 28 25 443
+                              Store 31(out_i1) 445
+             446:    395(ptr) AccessChain 17 394
+             447:   14(ivec3) Load 446
+             448:     19(ptr) AccessChain 17 22
+             449:      6(int) Load 448
+             450:     26(ptr) ImageTexelPointer 393(g_tTex3di1) 447 25
+             451:      6(int) AtomicSMin 450 28 25 449
+             452:    395(ptr) AccessChain 17 394
+             453:   14(ivec3) Load 452
+             454:     19(ptr) AccessChain 17 18
+             455:      6(int) Load 454
+             456:     26(ptr) ImageTexelPointer 393(g_tTex3di1) 453 25
+             457:      6(int) AtomicSMin 456 28 25 455
+                              Store 31(out_i1) 457
+             458:    395(ptr) AccessChain 17 394
+             459:   14(ivec3) Load 458
+             460:     19(ptr) AccessChain 17 22
+             461:      6(int) Load 460
+             462:     26(ptr) ImageTexelPointer 393(g_tTex3di1) 459 25
+             463:      6(int) AtomicOr 462 28 25 461
+             464:    395(ptr) AccessChain 17 394
+             465:   14(ivec3) Load 464
+             466:     19(ptr) AccessChain 17 18
+             467:      6(int) Load 466
+             468:     26(ptr) ImageTexelPointer 393(g_tTex3di1) 465 25
+             469:      6(int) AtomicOr 468 28 25 467
+                              Store 31(out_i1) 469
+             470:    395(ptr) AccessChain 17 394
+             471:   14(ivec3) Load 470
+             472:     19(ptr) AccessChain 17 22
+             473:      6(int) Load 472
+             474:     26(ptr) ImageTexelPointer 393(g_tTex3di1) 471 25
+             475:      6(int) AtomicXor 474 28 25 473
+             476:    395(ptr) AccessChain 17 394
+             477:   14(ivec3) Load 476
+             478:     19(ptr) AccessChain 17 18
+             479:      6(int) Load 478
+             480:     26(ptr) ImageTexelPointer 393(g_tTex3di1) 477 25
+             481:      6(int) AtomicXor 480 28 25 479
+                              Store 31(out_i1) 481
+             487:    486(ptr) AccessChain 17 485
+             488:   12(ivec3) Load 487
+             489:    117(ptr) AccessChain 17 116
+             490:     10(int) Load 489
+             491:    122(ptr) ImageTexelPointer 484(g_tTex3du1) 488 25
+             492:     10(int) AtomicIAdd 491 28 25 490
+             493:    486(ptr) AccessChain 17 485
+             494:   12(ivec3) Load 493
+             495:    117(ptr) AccessChain 17 116
+             496:     10(int) Load 495
+             497:    122(ptr) ImageTexelPointer 484(g_tTex3du1) 494 25
+             498:     10(int) AtomicIAdd 497 28 25 496
+                              Store 126(out_u1) 498
+             499:    486(ptr) AccessChain 17 485
+             500:   12(ivec3) Load 499
+             501:    117(ptr) AccessChain 17 116
+             502:     10(int) Load 501
+             503:    122(ptr) ImageTexelPointer 484(g_tTex3du1) 500 25
+             504:     10(int) AtomicAnd 503 28 25 502
+             505:    486(ptr) AccessChain 17 485
+             506:   12(ivec3) Load 505
+             507:    117(ptr) AccessChain 17 116
+             508:     10(int) Load 507
+             509:    122(ptr) ImageTexelPointer 484(g_tTex3du1) 506 25
+             510:     10(int) AtomicAnd 509 28 25 508
+                              Store 126(out_u1) 510
+             511:    486(ptr) AccessChain 17 485
+             512:   12(ivec3) Load 511
+             513:    117(ptr) AccessChain 17 147
+             514:     10(int) Load 513
+             515:    117(ptr) AccessChain 17 150
+             516:     10(int) Load 515
+             517:    122(ptr) ImageTexelPointer 484(g_tTex3du1) 512 25
+             518:     10(int) AtomicCompareExchange 517 28 25 25 516 514
+                              Store 126(out_u1) 518
+             519:    486(ptr) AccessChain 17 485
+             520:   12(ivec3) Load 519
+             521:    117(ptr) AccessChain 17 116
+             522:     10(int) Load 521
+             523:    122(ptr) ImageTexelPointer 484(g_tTex3du1) 520 25
+             524:     10(int) AtomicExchange 523 28 25 522
+                              Store 126(out_u1) 524
+             525:    486(ptr) AccessChain 17 485
+             526:   12(ivec3) Load 525
+             527:    117(ptr) AccessChain 17 116
+             528:     10(int) Load 527
+             529:    122(ptr) ImageTexelPointer 484(g_tTex3du1) 526 25
+             530:     10(int) AtomicUMax 529 28 25 528
+             531:    486(ptr) AccessChain 17 485
+             532:   12(ivec3) Load 531
+             533:    117(ptr) AccessChain 17 116
+             534:     10(int) Load 533
+             535:    122(ptr) ImageTexelPointer 484(g_tTex3du1) 532 25
+             536:     10(int) AtomicUMax 535 28 25 534
+                              Store 126(out_u1) 536
+             537:    486(ptr) AccessChain 17 485
+             538:   12(ivec3) Load 537
+             539:    117(ptr) AccessChain 17 116
+             540:     10(int) Load 539
+             541:    122(ptr) ImageTexelPointer 484(g_tTex3du1) 538 25
+             542:     10(int) AtomicUMin 541 28 25 540
+             543:    486(ptr) AccessChain 17 485
+             544:   12(ivec3) Load 543
+             545:    117(ptr) AccessChain 17 116
+             546:     10(int) Load 545
+             547:    122(ptr) ImageTexelPointer 484(g_tTex3du1) 544 25
+             548:     10(int) AtomicUMin 547 28 25 546
+                              Store 126(out_u1) 548
+             549:    486(ptr) AccessChain 17 485
+             550:   12(ivec3) Load 549
+             551:    117(ptr) AccessChain 17 116
+             552:     10(int) Load 551
+             553:    122(ptr) ImageTexelPointer 484(g_tTex3du1) 550 25
+             554:     10(int) AtomicOr 553 28 25 552
+             555:    486(ptr) AccessChain 17 485
+             556:   12(ivec3) Load 555
+             557:    117(ptr) AccessChain 17 116
+             558:     10(int) Load 557
+             559:    122(ptr) ImageTexelPointer 484(g_tTex3du1) 556 25
+             560:     10(int) AtomicOr 559 28 25 558
+                              Store 126(out_u1) 560
+             561:    486(ptr) AccessChain 17 485
+             562:   12(ivec3) Load 561
+             563:    117(ptr) AccessChain 17 116
+             564:     10(int) Load 563
+             565:    122(ptr) ImageTexelPointer 484(g_tTex3du1) 562 25
+             566:     10(int) AtomicXor 565 28 25 564
+             567:    486(ptr) AccessChain 17 485
+             568:   12(ivec3) Load 567
+             569:    117(ptr) AccessChain 17 116
+             570:     10(int) Load 569
+             571:    122(ptr) ImageTexelPointer 484(g_tTex3du1) 568 25
+             572:     10(int) AtomicXor 571 28 25 570
+                              Store 126(out_u1) 572
+             576:    213(ptr) AccessChain 17 212
+             577:   13(ivec2) Load 576
+             578:     19(ptr) AccessChain 17 22
+             579:      6(int) Load 578
+             580:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 577 25
+             581:      6(int) AtomicIAdd 580 28 25 579
+             582:    213(ptr) AccessChain 17 212
+             583:   13(ivec2) Load 582
+             584:     19(ptr) AccessChain 17 18
+             585:      6(int) Load 584
+             586:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 583 25
+             587:      6(int) AtomicIAdd 586 28 25 585
+                              Store 31(out_i1) 587
+             588:    213(ptr) AccessChain 17 212
+             589:   13(ivec2) Load 588
+             590:     19(ptr) AccessChain 17 22
+             591:      6(int) Load 590
+             592:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 589 25
+             593:      6(int) AtomicAnd 592 28 25 591
+             594:    213(ptr) AccessChain 17 212
+             595:   13(ivec2) Load 594
+             596:     19(ptr) AccessChain 17 18
+             597:      6(int) Load 596
+             598:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 595 25
+             599:      6(int) AtomicAnd 598 28 25 597
+                              Store 31(out_i1) 599
+             600:    213(ptr) AccessChain 17 212
+             601:   13(ivec2) Load 600
+             602:     19(ptr) AccessChain 17 22
+             603:      6(int) Load 602
+             604:     19(ptr) AccessChain 17 54
+             605:      6(int) Load 604
+             606:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 601 25
+             607:      6(int) AtomicCompareExchange 606 28 25 25 605 603
+                              Store 31(out_i1) 607
+             608:    213(ptr) AccessChain 17 212
+             609:   13(ivec2) Load 608
+             610:     19(ptr) AccessChain 17 18
+             611:      6(int) Load 610
+             612:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 609 25
+             613:      6(int) AtomicExchange 612 28 25 611
+                              Store 31(out_i1) 613
+             614:    213(ptr) AccessChain 17 212
+             615:   13(ivec2) Load 614
+             616:     19(ptr) AccessChain 17 22
+             617:      6(int) Load 616
+             618:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 615 25
+             619:      6(int) AtomicSMax 618 28 25 617
+             620:    213(ptr) AccessChain 17 212
+             621:   13(ivec2) Load 620
+             622:     19(ptr) AccessChain 17 18
+             623:      6(int) Load 622
+             624:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 621 25
+             625:      6(int) AtomicSMax 624 28 25 623
+                              Store 31(out_i1) 625
+             626:    213(ptr) AccessChain 17 212
+             627:   13(ivec2) Load 626
+             628:     19(ptr) AccessChain 17 22
+             629:      6(int) Load 628
+             630:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 627 25
+             631:      6(int) AtomicSMin 630 28 25 629
+             632:    213(ptr) AccessChain 17 212
+             633:   13(ivec2) Load 632
+             634:     19(ptr) AccessChain 17 18
+             635:      6(int) Load 634
+             636:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 633 25
+             637:      6(int) AtomicSMin 636 28 25 635
+                              Store 31(out_i1) 637
+             638:    213(ptr) AccessChain 17 212
+             639:   13(ivec2) Load 638
+             640:     19(ptr) AccessChain 17 22
+             641:      6(int) Load 640
+             642:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 639 25
+             643:      6(int) AtomicOr 642 28 25 641
+             644:    213(ptr) AccessChain 17 212
+             645:   13(ivec2) Load 644
+             646:     19(ptr) AccessChain 17 18
+             647:      6(int) Load 646
+             648:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 645 25
+             649:      6(int) AtomicOr 648 28 25 647
+                              Store 31(out_i1) 649
+             650:    213(ptr) AccessChain 17 212
+             651:   13(ivec2) Load 650
+             652:     19(ptr) AccessChain 17 22
+             653:      6(int) Load 652
+             654:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 651 25
+             655:      6(int) AtomicXor 654 28 25 653
+             656:    213(ptr) AccessChain 17 212
+             657:   13(ivec2) Load 656
+             658:     19(ptr) AccessChain 17 18
+             659:      6(int) Load 658
+             660:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 657 25
+             661:      6(int) AtomicXor 660 28 25 659
+                              Store 31(out_i1) 661
+             665:    304(ptr) AccessChain 17 303
+             666:   11(ivec2) Load 665
+             667:    117(ptr) AccessChain 17 116
+             668:     10(int) Load 667
+             669:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 666 25
+             670:     10(int) AtomicIAdd 669 28 25 668
+             671:    304(ptr) AccessChain 17 303
+             672:   11(ivec2) Load 671
+             673:    117(ptr) AccessChain 17 116
+             674:     10(int) Load 673
+             675:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 672 25
+             676:     10(int) AtomicIAdd 675 28 25 674
+                              Store 126(out_u1) 676
+             677:    304(ptr) AccessChain 17 303
+             678:   11(ivec2) Load 677
+             679:    117(ptr) AccessChain 17 116
+             680:     10(int) Load 679
+             681:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 678 25
+             682:     10(int) AtomicAnd 681 28 25 680
+             683:    304(ptr) AccessChain 17 303
+             684:   11(ivec2) Load 683
+             685:    117(ptr) AccessChain 17 116
+             686:     10(int) Load 685
+             687:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 684 25
+             688:     10(int) AtomicAnd 687 28 25 686
+                              Store 126(out_u1) 688
+             689:    304(ptr) AccessChain 17 303
+             690:   11(ivec2) Load 689
+             691:    117(ptr) AccessChain 17 147
+             692:     10(int) Load 691
+             693:    117(ptr) AccessChain 17 150
+             694:     10(int) Load 693
+             695:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 690 25
+             696:     10(int) AtomicCompareExchange 695 28 25 25 694 692
+                              Store 126(out_u1) 696
+             697:    304(ptr) AccessChain 17 303
+             698:   11(ivec2) Load 697
+             699:    117(ptr) AccessChain 17 116
+             700:     10(int) Load 699
+             701:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 698 25
+             702:     10(int) AtomicExchange 701 28 25 700
+                              Store 126(out_u1) 702
+             703:    304(ptr) AccessChain 17 303
+             704:   11(ivec2) Load 703
+             705:    117(ptr) AccessChain 17 116
+             706:     10(int) Load 705
+             707:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 704 25
+             708:     10(int) AtomicUMax 707 28 25 706
+             709:    304(ptr) AccessChain 17 303
+             710:   11(ivec2) Load 709
+             711:    117(ptr) AccessChain 17 116
+             712:     10(int) Load 711
+             713:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 710 25
+             714:     10(int) AtomicUMax 713 28 25 712
+                              Store 126(out_u1) 714
+             715:    304(ptr) AccessChain 17 303
+             716:   11(ivec2) Load 715
+             717:    117(ptr) AccessChain 17 116
+             718:     10(int) Load 717
+             719:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 716 25
+             720:     10(int) AtomicUMin 719 28 25 718
+             721:    304(ptr) AccessChain 17 303
+             722:   11(ivec2) Load 721
+             723:    117(ptr) AccessChain 17 116
+             724:     10(int) Load 723
+             725:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 722 25
+             726:     10(int) AtomicUMin 725 28 25 724
+                              Store 126(out_u1) 726
+             727:    304(ptr) AccessChain 17 303
+             728:   11(ivec2) Load 727
+             729:    117(ptr) AccessChain 17 116
+             730:     10(int) Load 729
+             731:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 728 25
+             732:     10(int) AtomicOr 731 28 25 730
+             733:    304(ptr) AccessChain 17 303
+             734:   11(ivec2) Load 733
+             735:    117(ptr) AccessChain 17 116
+             736:     10(int) Load 735
+             737:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 734 25
+             738:     10(int) AtomicOr 737 28 25 736
+                              Store 126(out_u1) 738
+             739:    304(ptr) AccessChain 17 303
+             740:   11(ivec2) Load 739
+             741:    117(ptr) AccessChain 17 116
+             742:     10(int) Load 741
+             743:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 740 25
+             744:     10(int) AtomicXor 743 28 25 742
+             745:    304(ptr) AccessChain 17 303
+             746:   11(ivec2) Load 745
+             747:    117(ptr) AccessChain 17 116
+             748:     10(int) Load 747
+             749:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 746 25
+             750:     10(int) AtomicXor 749 28 25 748
+                              Store 126(out_u1) 750
+             751:    213(ptr) AccessChain 17 212
+             752:   13(ivec2) Load 751
+             753:     19(ptr) AccessChain 17 22
+             754:      6(int) Load 753
+             755:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 752 25
+             756:      6(int) AtomicIAdd 755 28 25 754
+             757:    213(ptr) AccessChain 17 212
+             758:   13(ivec2) Load 757
+             759:     19(ptr) AccessChain 17 18
+             760:      6(int) Load 759
+             761:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 758 25
+             762:      6(int) AtomicIAdd 761 28 25 760
+                              Store 31(out_i1) 762
+             763:    213(ptr) AccessChain 17 212
+             764:   13(ivec2) Load 763
+             765:     19(ptr) AccessChain 17 22
+             766:      6(int) Load 765
+             767:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 764 25
+             768:      6(int) AtomicAnd 767 28 25 766
+             769:    213(ptr) AccessChain 17 212
+             770:   13(ivec2) Load 769
+             771:     19(ptr) AccessChain 17 18
+             772:      6(int) Load 771
+             773:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 770 25
+             774:      6(int) AtomicAnd 773 28 25 772
+                              Store 31(out_i1) 774
+             775:    213(ptr) AccessChain 17 212
+             776:   13(ivec2) Load 775
+             777:     19(ptr) AccessChain 17 22
+             778:      6(int) Load 777
+             779:     19(ptr) AccessChain 17 54
+             780:      6(int) Load 779
+             781:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 776 25
+             782:      6(int) AtomicCompareExchange 781 28 25 25 780 778
+                              Store 31(out_i1) 782
+             783:    213(ptr) AccessChain 17 212
+             784:   13(ivec2) Load 783
+             785:     19(ptr) AccessChain 17 18
+             786:      6(int) Load 785
+             787:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 784 25
+             788:      6(int) AtomicExchange 787 28 25 786
+                              Store 31(out_i1) 788
+             789:    213(ptr) AccessChain 17 212
+             790:   13(ivec2) Load 789
+             791:     19(ptr) AccessChain 17 22
+             792:      6(int) Load 791
+             793:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 790 25
+             794:      6(int) AtomicSMax 793 28 25 792
+             795:    213(ptr) AccessChain 17 212
+             796:   13(ivec2) Load 795
+             797:     19(ptr) AccessChain 17 18
+             798:      6(int) Load 797
+             799:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 796 25
+             800:      6(int) AtomicSMax 799 28 25 798
+                              Store 31(out_i1) 800
+             801:    213(ptr) AccessChain 17 212
+             802:   13(ivec2) Load 801
+             803:     19(ptr) AccessChain 17 22
+             804:      6(int) Load 803
+             805:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 802 25
+             806:      6(int) AtomicSMin 805 28 25 804
+             807:    213(ptr) AccessChain 17 212
+             808:   13(ivec2) Load 807
+             809:     19(ptr) AccessChain 17 18
+             810:      6(int) Load 809
+             811:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 808 25
+             812:      6(int) AtomicSMin 811 28 25 810
+                              Store 31(out_i1) 812
+             813:    213(ptr) AccessChain 17 212
+             814:   13(ivec2) Load 813
+             815:     19(ptr) AccessChain 17 22
+             816:      6(int) Load 815
+             817:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 814 25
+             818:      6(int) AtomicOr 817 28 25 816
+             819:    213(ptr) AccessChain 17 212
+             820:   13(ivec2) Load 819
+             821:     19(ptr) AccessChain 17 18
+             822:      6(int) Load 821
+             823:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 820 25
+             824:      6(int) AtomicOr 823 28 25 822
+                              Store 31(out_i1) 824
+             825:    213(ptr) AccessChain 17 212
+             826:   13(ivec2) Load 825
+             827:     19(ptr) AccessChain 17 22
+             828:      6(int) Load 827
+             829:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 826 25
+             830:      6(int) AtomicXor 829 28 25 828
+             831:    213(ptr) AccessChain 17 212
+             832:   13(ivec2) Load 831
+             833:     19(ptr) AccessChain 17 18
+             834:      6(int) Load 833
+             835:     26(ptr) ImageTexelPointer 575(g_tTex1di1a) 832 25
+             836:      6(int) AtomicXor 835 28 25 834
+                              Store 31(out_i1) 836
+             837:    304(ptr) AccessChain 17 303
+             838:   11(ivec2) Load 837
+             839:    117(ptr) AccessChain 17 116
+             840:     10(int) Load 839
+             841:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 838 25
+             842:     10(int) AtomicIAdd 841 28 25 840
+             843:    304(ptr) AccessChain 17 303
+             844:   11(ivec2) Load 843
+             845:    117(ptr) AccessChain 17 116
+             846:     10(int) Load 845
+             847:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 844 25
+             848:     10(int) AtomicIAdd 847 28 25 846
+                              Store 126(out_u1) 848
+             849:    304(ptr) AccessChain 17 303
+             850:   11(ivec2) Load 849
+             851:    117(ptr) AccessChain 17 116
+             852:     10(int) Load 851
+             853:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 850 25
+             854:     10(int) AtomicAnd 853 28 25 852
+             855:    304(ptr) AccessChain 17 303
+             856:   11(ivec2) Load 855
+             857:    117(ptr) AccessChain 17 116
+             858:     10(int) Load 857
+             859:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 856 25
+             860:     10(int) AtomicAnd 859 28 25 858
+                              Store 126(out_u1) 860
+             861:    304(ptr) AccessChain 17 303
+             862:   11(ivec2) Load 861
+             863:    117(ptr) AccessChain 17 147
+             864:     10(int) Load 863
+             865:    117(ptr) AccessChain 17 150
+             866:     10(int) Load 865
+             867:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 862 25
+             868:     10(int) AtomicCompareExchange 867 28 25 25 866 864
+                              Store 126(out_u1) 868
+             869:    304(ptr) AccessChain 17 303
+             870:   11(ivec2) Load 869
+             871:    117(ptr) AccessChain 17 116
+             872:     10(int) Load 871
+             873:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 870 25
+             874:     10(int) AtomicExchange 873 28 25 872
+                              Store 126(out_u1) 874
+             875:    304(ptr) AccessChain 17 303
+             876:   11(ivec2) Load 875
+             877:    117(ptr) AccessChain 17 116
+             878:     10(int) Load 877
+             879:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 876 25
+             880:     10(int) AtomicUMax 879 28 25 878
+             881:    304(ptr) AccessChain 17 303
+             882:   11(ivec2) Load 881
+             883:    117(ptr) AccessChain 17 116
+             884:     10(int) Load 883
+             885:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 882 25
+             886:     10(int) AtomicUMax 885 28 25 884
+                              Store 126(out_u1) 886
+             887:    304(ptr) AccessChain 17 303
+             888:   11(ivec2) Load 887
+             889:    117(ptr) AccessChain 17 116
+             890:     10(int) Load 889
+             891:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 888 25
+             892:     10(int) AtomicUMin 891 28 25 890
+             893:    304(ptr) AccessChain 17 303
+             894:   11(ivec2) Load 893
+             895:    117(ptr) AccessChain 17 116
+             896:     10(int) Load 895
+             897:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 894 25
+             898:     10(int) AtomicUMin 897 28 25 896
+                              Store 126(out_u1) 898
+             899:    304(ptr) AccessChain 17 303
+             900:   11(ivec2) Load 899
+             901:    117(ptr) AccessChain 17 116
+             902:     10(int) Load 901
+             903:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 900 25
+             904:     10(int) AtomicOr 903 28 25 902
+             905:    304(ptr) AccessChain 17 303
+             906:   11(ivec2) Load 905
+             907:    117(ptr) AccessChain 17 116
+             908:     10(int) Load 907
+             909:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 906 25
+             910:     10(int) AtomicOr 909 28 25 908
+                              Store 126(out_u1) 910
+             911:    304(ptr) AccessChain 17 303
+             912:   11(ivec2) Load 911
+             913:    117(ptr) AccessChain 17 116
+             914:     10(int) Load 913
+             915:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 912 25
+             916:     10(int) AtomicXor 915 28 25 914
+             917:    304(ptr) AccessChain 17 303
+             918:   11(ivec2) Load 917
+             919:    117(ptr) AccessChain 17 116
+             920:     10(int) Load 919
+             921:    122(ptr) ImageTexelPointer 664(g_tTex1du1a) 918 25
+             922:     10(int) AtomicXor 921 28 25 920
+                              Store 126(out_u1) 922
+             926:     19(ptr) AccessChain 17 18
+             927:      6(int) Load 926
+             928:     19(ptr) AccessChain 17 22
+             929:      6(int) Load 928
+             930:     26(ptr) ImageTexelPointer 925(g_tBuffI) 927 25
+             931:      6(int) AtomicIAdd 930 28 25 929
+             932:     19(ptr) AccessChain 17 18
+             933:      6(int) Load 932
+             934:     19(ptr) AccessChain 17 18
+             935:      6(int) Load 934
+             936:     26(ptr) ImageTexelPointer 925(g_tBuffI) 933 25
+             937:      6(int) AtomicIAdd 936 28 25 935
+                              Store 31(out_i1) 937
+             938:     19(ptr) AccessChain 17 18
+             939:      6(int) Load 938
+             940:     19(ptr) AccessChain 17 22
+             941:      6(int) Load 940
+             942:     26(ptr) ImageTexelPointer 925(g_tBuffI) 939 25
+             943:      6(int) AtomicAnd 942 28 25 941
+             944:     19(ptr) AccessChain 17 18
+             945:      6(int) Load 944
+             946:     19(ptr) AccessChain 17 18
+             947:      6(int) Load 946
+             948:     26(ptr) ImageTexelPointer 925(g_tBuffI) 945 25
+             949:      6(int) AtomicAnd 948 28 25 947
+                              Store 31(out_i1) 949
+             950:     19(ptr) AccessChain 17 18
+             951:      6(int) Load 950
+             952:     19(ptr) AccessChain 17 22
+             953:      6(int) Load 952
+             954:     19(ptr) AccessChain 17 54
+             955:      6(int) Load 954
+             956:     26(ptr) ImageTexelPointer 925(g_tBuffI) 951 25
+             957:      6(int) AtomicCompareExchange 956 28 25 25 955 953
+                              Store 31(out_i1) 957
+             958:     19(ptr) AccessChain 17 18
+             959:      6(int) Load 958
+             960:     19(ptr) AccessChain 17 18
+             961:      6(int) Load 960
+             962:     26(ptr) ImageTexelPointer 925(g_tBuffI) 959 25
+             963:      6(int) AtomicExchange 962 28 25 961
+                              Store 31(out_i1) 963
+             964:     19(ptr) AccessChain 17 18
+             965:      6(int) Load 964
+             966:     19(ptr) AccessChain 17 22
+             967:      6(int) Load 966
+             968:     26(ptr) ImageTexelPointer 925(g_tBuffI) 965 25
+             969:      6(int) AtomicSMax 968 28 25 967
+             970:     19(ptr) AccessChain 17 18
+             971:      6(int) Load 970
+             972:     19(ptr) AccessChain 17 18
+             973:      6(int) Load 972
+             974:     26(ptr) ImageTexelPointer 925(g_tBuffI) 971 25
+             975:      6(int) AtomicSMax 974 28 25 973
+                              Store 31(out_i1) 975
+             976:     19(ptr) AccessChain 17 18
+             977:      6(int) Load 976
+             978:     19(ptr) AccessChain 17 22
+             979:      6(int) Load 978
+             980:     26(ptr) ImageTexelPointer 925(g_tBuffI) 977 25
+             981:      6(int) AtomicSMin 980 28 25 979
+             982:     19(ptr) AccessChain 17 18
+             983:      6(int) Load 982
+             984:     19(ptr) AccessChain 17 18
+             985:      6(int) Load 984
+             986:     26(ptr) ImageTexelPointer 925(g_tBuffI) 983 25
+             987:      6(int) AtomicSMin 986 28 25 985
+                              Store 31(out_i1) 987
+             988:     19(ptr) AccessChain 17 18
+             989:      6(int) Load 988
+             990:     19(ptr) AccessChain 17 22
+             991:      6(int) Load 990
+             992:     26(ptr) ImageTexelPointer 925(g_tBuffI) 989 25
+             993:      6(int) AtomicOr 992 28 25 991
+             994:     19(ptr) AccessChain 17 18
+             995:      6(int) Load 994
+             996:     19(ptr) AccessChain 17 18
+             997:      6(int) Load 996
+             998:     26(ptr) ImageTexelPointer 925(g_tBuffI) 995 25
+             999:      6(int) AtomicOr 998 28 25 997
+                              Store 31(out_i1) 999
+            1000:     19(ptr) AccessChain 17 18
+            1001:      6(int) Load 1000
+            1002:     19(ptr) AccessChain 17 22
+            1003:      6(int) Load 1002
+            1004:     26(ptr) ImageTexelPointer 925(g_tBuffI) 1001 25
+            1005:      6(int) AtomicXor 1004 28 25 1003
+            1006:     19(ptr) AccessChain 17 18
+            1007:      6(int) Load 1006
+            1008:     19(ptr) AccessChain 17 18
+            1009:      6(int) Load 1008
+            1010:     26(ptr) ImageTexelPointer 925(g_tBuffI) 1007 25
+            1011:      6(int) AtomicXor 1010 28 25 1009
+                              Store 31(out_i1) 1011
+            1015:    117(ptr) AccessChain 17 116
+            1016:     10(int) Load 1015
+            1017:    117(ptr) AccessChain 17 116
+            1018:     10(int) Load 1017
+            1019:    122(ptr) ImageTexelPointer 1014(g_tBuffU) 1016 25
+            1020:     10(int) AtomicIAdd 1019 28 25 1018
+            1021:    117(ptr) AccessChain 17 116
+            1022:     10(int) Load 1021
+            1023:    117(ptr) AccessChain 17 116
+            1024:     10(int) Load 1023
+            1025:    122(ptr) ImageTexelPointer 1014(g_tBuffU) 1022 25
+            1026:     10(int) AtomicIAdd 1025 28 25 1024
+                              Store 126(out_u1) 1026
+            1027:    117(ptr) AccessChain 17 116
+            1028:     10(int) Load 1027
+            1029:    117(ptr) AccessChain 17 116
+            1030:     10(int) Load 1029
+            1031:    122(ptr) ImageTexelPointer 1014(g_tBuffU) 1028 25
+            1032:     10(int) AtomicAnd 1031 28 25 1030
+            1033:    117(ptr) AccessChain 17 116
+            1034:     10(int) Load 1033
+            1035:    117(ptr) AccessChain 17 116
+            1036:     10(int) Load 1035
+            1037:    122(ptr) ImageTexelPointer 1014(g_tBuffU) 1034 25
+            1038:     10(int) AtomicAnd 1037 28 25 1036
+                              Store 126(out_u1) 1038
+            1039:    117(ptr) AccessChain 17 116
+            1040:     10(int) Load 1039
+            1041:    117(ptr) AccessChain 17 147
+            1042:     10(int) Load 1041
+            1043:    117(ptr) AccessChain 17 150
+            1044:     10(int) Load 1043
+            1045:    122(ptr) ImageTexelPointer 1014(g_tBuffU) 1040 25
+            1046:     10(int) AtomicCompareExchange 1045 28 25 25 1044 1042
+                              Store 126(out_u1) 1046
+            1047:    117(ptr) AccessChain 17 116
+            1048:     10(int) Load 1047
+            1049:    117(ptr) AccessChain 17 116
+            1050:     10(int) Load 1049
+            1051:    122(ptr) ImageTexelPointer 1014(g_tBuffU) 1048 25
+            1052:     10(int) AtomicExchange 1051 28 25 1050
+                              Store 126(out_u1) 1052
+            1053:    117(ptr) AccessChain 17 116
+            1054:     10(int) Load 1053
+            1055:    117(ptr) AccessChain 17 116
+            1056:     10(int) Load 1055
+            1057:    122(ptr) ImageTexelPointer 1014(g_tBuffU) 1054 25
+            1058:     10(int) AtomicUMax 1057 28 25 1056
+            1059:    117(ptr) AccessChain 17 116
+            1060:     10(int) Load 1059
+            1061:    117(ptr) AccessChain 17 116
+            1062:     10(int) Load 1061
+            1063:    122(ptr) ImageTexelPointer 1014(g_tBuffU) 1060 25
+            1064:     10(int) AtomicUMax 1063 28 25 1062
+                              Store 126(out_u1) 1064
+            1065:    117(ptr) AccessChain 17 116
+            1066:     10(int) Load 1065
+            1067:    117(ptr) AccessChain 17 116
+            1068:     10(int) Load 1067
+            1069:    122(ptr) ImageTexelPointer 1014(g_tBuffU) 1066 25
+            1070:     10(int) AtomicUMin 1069 28 25 1068
+            1071:    117(ptr) AccessChain 17 116
+            1072:     10(int) Load 1071
+            1073:    117(ptr) AccessChain 17 116
+            1074:     10(int) Load 1073
+            1075:    122(ptr) ImageTexelPointer 1014(g_tBuffU) 1072 25
+            1076:     10(int) AtomicUMin 1075 28 25 1074
+                              Store 126(out_u1) 1076
+            1077:    117(ptr) AccessChain 17 116
+            1078:     10(int) Load 1077
+            1079:    117(ptr) AccessChain 17 116
+            1080:     10(int) Load 1079
+            1081:    122(ptr) ImageTexelPointer 1014(g_tBuffU) 1078 25
+            1082:     10(int) AtomicOr 1081 28 25 1080
+            1083:    117(ptr) AccessChain 17 116
+            1084:     10(int) Load 1083
+            1085:    117(ptr) AccessChain 17 116
+            1086:     10(int) Load 1085
+            1087:    122(ptr) ImageTexelPointer 1014(g_tBuffU) 1084 25
+            1088:     10(int) AtomicOr 1087 28 25 1086
+                              Store 126(out_u1) 1088
+            1089:    117(ptr) AccessChain 17 116
+            1090:     10(int) Load 1089
+            1091:    117(ptr) AccessChain 17 116
+            1092:     10(int) Load 1091
+            1093:    122(ptr) ImageTexelPointer 1014(g_tBuffU) 1090 25
+            1094:     10(int) AtomicXor 1093 28 25 1092
+            1095:    117(ptr) AccessChain 17 116
+            1096:     10(int) Load 1095
+            1097:    117(ptr) AccessChain 17 116
+            1098:     10(int) Load 1097
+            1099:    122(ptr) ImageTexelPointer 1014(g_tBuffU) 1096 25
+            1100:     10(int) AtomicXor 1099 28 25 1098
+                              Store 126(out_u1) 1100
+            1109:   1108(ptr) AccessChain 1105(psout) 116
+                              Store 1109 1107
+            1112:   1108(ptr) AccessChain 1105(psout) 116
+            1113: 1102(fvec4) Load 1112
+                              Store 1111(Color) 1113
+                              Return
+                              FunctionEnd

--- a/Test/hlsl.rw.atomics.frag
+++ b/Test/hlsl.rw.atomics.frag
@@ -1,0 +1,244 @@
+SamplerState       g_sSamp;
+
+RWTexture1D <float> g_tTex1df1;
+RWTexture1D <int>   g_tTex1di1;
+RWTexture1D <uint>  g_tTex1du1;
+
+RWTexture2D <float> g_tTex2df1;
+RWTexture2D <int>   g_tTex2di1;
+RWTexture2D <uint>  g_tTex2du1;
+
+RWTexture3D <float> g_tTex3df1;
+RWTexture3D <int>   g_tTex3di1;
+RWTexture3D <uint>  g_tTex3du1;
+
+RWTexture1DArray <float> g_tTex1df1a;
+RWTexture1DArray <int>   g_tTex1di1a;
+RWTexture1DArray <uint>  g_tTex1du1a;
+
+RWTexture2DArray <float> g_tTex2df1a;
+RWTexture2DArray <int>   g_tTex2di1a;
+RWTexture2DArray <uint>  g_tTex2du1a;
+
+RWBuffer <float> g_tBuffF;
+RWBuffer <int>   g_tBuffI;
+RWBuffer <uint>  g_tBuffU;
+
+struct PS_OUTPUT
+{
+    float4 Color : SV_Target0;
+};
+
+uniform uint  u1;
+uniform uint2 u2;
+uniform uint3 u3;
+uniform uint  u1b;
+uniform uint  u1c;
+
+uniform int   i1;
+uniform int2  i2;
+uniform int3  i3;
+uniform int   i1b;
+uniform int   i1c;
+
+PS_OUTPUT main()
+{
+    uint out_u1;
+    int out_i1;
+
+    // 1D int
+    InterlockedAdd(g_tTex1di1[i1], i1b);
+    InterlockedAdd(g_tTex1di1[i1], i1, out_i1);
+    InterlockedAnd(g_tTex1di1[i1], i1b);
+    InterlockedAnd(g_tTex1di1[i1], i1, out_i1);
+    InterlockedCompareExchange(g_tTex1di1[i1], i1b, i1c, out_i1);
+    InterlockedExchange(g_tTex1di1[i1], i1, out_i1);
+    InterlockedMax(g_tTex1di1[i1], i1b);
+    InterlockedMax(g_tTex1di1[i1], i1, out_i1);
+    InterlockedMin(g_tTex1di1[i1], i1b);
+    InterlockedMin(g_tTex1di1[i1], i1, out_i1);
+    InterlockedOr(g_tTex1di1[i1], i1b);
+    InterlockedOr(g_tTex1di1[i1], i1, out_i1);
+    InterlockedXor(g_tTex1di1[i1], i1b);
+    InterlockedXor(g_tTex1di1[i1], i1, out_i1);
+
+    // 1D uint
+    InterlockedAdd(g_tTex1du1[u1], u1);
+    InterlockedAdd(g_tTex1du1[u1], u1, out_u1);
+    InterlockedAnd(g_tTex1du1[u1], u1);
+    InterlockedAnd(g_tTex1du1[u1], u1, out_u1);
+    InterlockedCompareExchange(g_tTex1du1[u1], u1b, u1c, out_u1);
+    InterlockedExchange(g_tTex1du1[u1], u1, out_u1);
+    InterlockedMax(g_tTex1du1[u1], u1);
+    InterlockedMax(g_tTex1du1[u1], u1, out_u1);
+    InterlockedMin(g_tTex1du1[u1], u1);
+    InterlockedMin(g_tTex1du1[u1], u1, out_u1);
+    InterlockedOr(g_tTex1du1[u1], u1);
+    InterlockedOr(g_tTex1du1[u1], u1, out_u1);
+    InterlockedXor(g_tTex1du1[u1], u1);
+    InterlockedXor(g_tTex1du1[u1], u1, out_u1);
+
+    // 2D int
+    InterlockedAdd(g_tTex2di1[i2], i1b);
+    InterlockedAdd(g_tTex2di1[i2], i1, out_i1);
+    InterlockedAnd(g_tTex2di1[i2], i1b);
+    InterlockedAnd(g_tTex2di1[i2], i1, out_i1);
+    InterlockedCompareExchange(g_tTex2di1[i2], i1b, i1c, out_i1);
+    InterlockedExchange(g_tTex2di1[i2], i1, out_i1);
+    InterlockedMax(g_tTex2di1[i2], i1b);
+    InterlockedMax(g_tTex2di1[i2], i1, out_i1);
+    InterlockedMin(g_tTex2di1[i2], i1b);
+    InterlockedMin(g_tTex2di1[i2], i1, out_i1);
+    InterlockedOr(g_tTex2di1[i2], i1b);
+    InterlockedOr(g_tTex2di1[i2], i1, out_i1);
+    InterlockedXor(g_tTex2di1[i2], i1b);
+    InterlockedXor(g_tTex2di1[i2], i1, out_i1);
+
+    // 2D uint
+    InterlockedAdd(g_tTex2du1[u2], u1);
+    InterlockedAdd(g_tTex2du1[u2], u1, out_u1);
+    InterlockedAnd(g_tTex2du1[u2], u1);
+    InterlockedAnd(g_tTex2du1[u2], u1, out_u1);
+    InterlockedCompareExchange(g_tTex2du1[u2], u1b, u1c, out_u1);
+    InterlockedExchange(g_tTex2du1[u2], u1, out_u1);
+    InterlockedMax(g_tTex2du1[u2], u1);
+    InterlockedMax(g_tTex2du1[u2], u1, out_u1);
+    InterlockedMin(g_tTex2du1[u2], u1);
+    InterlockedMin(g_tTex2du1[u2], u1, out_u1);
+    InterlockedOr(g_tTex2du1[u2], u1);
+    InterlockedOr(g_tTex2du1[u2], u1, out_u1);
+    InterlockedXor(g_tTex2du1[u2], u1);
+    InterlockedXor(g_tTex2du1[u2], u1, out_u1);
+
+    // 3D int
+    InterlockedAdd(g_tTex3di1[i3], i1b);
+    InterlockedAdd(g_tTex3di1[i3], i1, out_i1);
+    InterlockedAnd(g_tTex3di1[i3], i1b);
+    InterlockedAnd(g_tTex3di1[i3], i1, out_i1);
+    InterlockedCompareExchange(g_tTex3di1[i3], i1b, i1c, out_i1);
+    InterlockedExchange(g_tTex3di1[i3], i1, out_i1);
+    InterlockedMax(g_tTex3di1[i3], i1b);
+    InterlockedMax(g_tTex3di1[i3], i1, out_i1);
+    InterlockedMin(g_tTex3di1[i3], i1b);
+    InterlockedMin(g_tTex3di1[i3], i1, out_i1);
+    InterlockedOr(g_tTex3di1[i3], i1b);
+    InterlockedOr(g_tTex3di1[i3], i1, out_i1);
+    InterlockedXor(g_tTex3di1[i3], i1b);
+    InterlockedXor(g_tTex3di1[i3], i1, out_i1);
+
+    // 3D uint
+    InterlockedAdd(g_tTex3du1[u3], u1);
+    InterlockedAdd(g_tTex3du1[u3], u1, out_u1);
+    InterlockedAnd(g_tTex3du1[u3], u1);
+    InterlockedAnd(g_tTex3du1[u3], u1, out_u1);
+    InterlockedCompareExchange(g_tTex3du1[u3], u1b, u1c, out_u1);
+    InterlockedExchange(g_tTex3du1[u3], u1, out_u1);
+    InterlockedMax(g_tTex3du1[u3], u1);
+    InterlockedMax(g_tTex3du1[u3], u1, out_u1);
+    InterlockedMin(g_tTex3du1[u3], u1);
+    InterlockedMin(g_tTex3du1[u3], u1, out_u1);
+    InterlockedOr(g_tTex3du1[u3], u1);
+    InterlockedOr(g_tTex3du1[u3], u1, out_u1);
+    InterlockedXor(g_tTex3du1[u3], u1);
+    InterlockedXor(g_tTex3du1[u3], u1, out_u1);
+
+    // 1D array int
+    InterlockedAdd(g_tTex1di1a[i2], i1b);
+    InterlockedAdd(g_tTex1di1a[i2], i1, out_i1);
+    InterlockedAnd(g_tTex1di1a[i2], i1b);
+    InterlockedAnd(g_tTex1di1a[i2], i1, out_i1);
+    InterlockedCompareExchange(g_tTex1di1a[i2], i1b, i1c, out_i1);
+    InterlockedExchange(g_tTex1di1a[i2], i1, out_i1);
+    InterlockedMax(g_tTex1di1a[i2], i1b);
+    InterlockedMax(g_tTex1di1a[i2], i1, out_i1);
+    InterlockedMin(g_tTex1di1a[i2], i1b);
+    InterlockedMin(g_tTex1di1a[i2], i1, out_i1);
+    InterlockedOr(g_tTex1di1a[i2], i1b);
+    InterlockedOr(g_tTex1di1a[i2], i1, out_i1);
+    InterlockedXor(g_tTex1di1a[i2], i1b);
+    InterlockedXor(g_tTex1di1a[i2], i1, out_i1);
+
+    // 1D array uint
+    InterlockedAdd(g_tTex1du1a[u2], u1);
+    InterlockedAdd(g_tTex1du1a[u2], u1, out_u1);
+    InterlockedAnd(g_tTex1du1a[u2], u1);
+    InterlockedAnd(g_tTex1du1a[u2], u1, out_u1);
+    InterlockedCompareExchange(g_tTex1du1a[u2], u1b, u1c, out_u1);
+    InterlockedExchange(g_tTex1du1a[u2], u1, out_u1);
+    InterlockedMax(g_tTex1du1a[u2], u1);
+    InterlockedMax(g_tTex1du1a[u2], u1, out_u1);
+    InterlockedMin(g_tTex1du1a[u2], u1);
+    InterlockedMin(g_tTex1du1a[u2], u1, out_u1);
+    InterlockedOr(g_tTex1du1a[u2], u1);
+    InterlockedOr(g_tTex1du1a[u2], u1, out_u1);
+    InterlockedXor(g_tTex1du1a[u2], u1);
+    InterlockedXor(g_tTex1du1a[u2], u1, out_u1);
+
+    // 2D array int
+    InterlockedAdd(g_tTex1di1a[i2], i1b);
+    InterlockedAdd(g_tTex1di1a[i2], i1, out_i1);
+    InterlockedAnd(g_tTex1di1a[i2], i1b);
+    InterlockedAnd(g_tTex1di1a[i2], i1, out_i1);
+    InterlockedCompareExchange(g_tTex1di1a[i2], i1b, i1c, out_i1);
+    InterlockedExchange(g_tTex1di1a[i2], i1, out_i1);
+    InterlockedMax(g_tTex1di1a[i2], i1b);
+    InterlockedMax(g_tTex1di1a[i2], i1, out_i1);
+    InterlockedMin(g_tTex1di1a[i2], i1b);
+    InterlockedMin(g_tTex1di1a[i2], i1, out_i1);
+    InterlockedOr(g_tTex1di1a[i2], i1b);
+    InterlockedOr(g_tTex1di1a[i2], i1, out_i1);
+    InterlockedXor(g_tTex1di1a[i2], i1b);
+    InterlockedXor(g_tTex1di1a[i2], i1, out_i1);
+
+    // 2D array uint
+    InterlockedAdd(g_tTex1du1a[u2], u1);
+    InterlockedAdd(g_tTex1du1a[u2], u1, out_u1);
+    InterlockedAnd(g_tTex1du1a[u2], u1);
+    InterlockedAnd(g_tTex1du1a[u2], u1, out_u1);
+    InterlockedCompareExchange(g_tTex1du1a[u2], u1b, u1c, out_u1);
+    InterlockedExchange(g_tTex1du1a[u2], u1, out_u1);
+    InterlockedMax(g_tTex1du1a[u2], u1);
+    InterlockedMax(g_tTex1du1a[u2], u1, out_u1);
+    InterlockedMin(g_tTex1du1a[u2], u1);
+    InterlockedMin(g_tTex1du1a[u2], u1, out_u1);
+    InterlockedOr(g_tTex1du1a[u2], u1);
+    InterlockedOr(g_tTex1du1a[u2], u1, out_u1);
+    InterlockedXor(g_tTex1du1a[u2], u1);
+    InterlockedXor(g_tTex1du1a[u2], u1, out_u1);
+
+    // buffer int
+    InterlockedAdd(g_tBuffI[i1], i1b);
+    InterlockedAdd(g_tBuffI[i1], i1, out_i1);
+    InterlockedAnd(g_tBuffI[i1], i1b);
+    InterlockedAnd(g_tBuffI[i1], i1, out_i1);
+    InterlockedCompareExchange(g_tBuffI[i1], i1b, i1c, out_i1);
+    InterlockedExchange(g_tBuffI[i1], i1, out_i1);
+    InterlockedMax(g_tBuffI[i1], i1b);
+    InterlockedMax(g_tBuffI[i1], i1, out_i1);
+    InterlockedMin(g_tBuffI[i1], i1b);
+    InterlockedMin(g_tBuffI[i1], i1, out_i1);
+    InterlockedOr(g_tBuffI[i1], i1b);
+    InterlockedOr(g_tBuffI[i1], i1, out_i1);
+    InterlockedXor(g_tBuffI[i1], i1b);
+    InterlockedXor(g_tBuffI[i1], i1, out_i1);
+
+    // buffer uint
+    InterlockedAdd(g_tBuffU[u1], u1);
+    InterlockedAdd(g_tBuffU[u1], u1, out_u1);
+    InterlockedAnd(g_tBuffU[u1], u1);
+    InterlockedAnd(g_tBuffU[u1], u1, out_u1);
+    InterlockedCompareExchange(g_tBuffU[u1], u1b, u1c, out_u1);
+    InterlockedExchange(g_tBuffU[u1], u1, out_u1);
+    InterlockedMax(g_tBuffU[u1], u1);
+    InterlockedMax(g_tBuffU[u1], u1, out_u1);
+    InterlockedMin(g_tBuffU[u1], u1);
+    InterlockedMin(g_tBuffU[u1], u1, out_u1);
+    InterlockedOr(g_tBuffU[u1], u1);
+    InterlockedOr(g_tBuffU[u1], u1, out_u1);
+    InterlockedXor(g_tBuffU[u1], u1);
+    InterlockedXor(g_tBuffU[u1], u1, out_u1);
+
+    PS_OUTPUT psout;
+    psout.Color = 1.0;
+    return psout;
+}

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -150,6 +150,7 @@ INSTANTIATE_TEST_CASE_P(
         {"hlsl.pp.line.frag", "main"},
         {"hlsl.precise.frag", "main"},
         {"hlsl.promotions.frag", "main"},
+        {"hlsl.rw.atomics.frag", "main"},
         {"hlsl.rw.bracket.frag", "main"},
         {"hlsl.rw.scalar.bracket.frag", "main"},
         {"hlsl.rw.vec2.bracket.frag", "main"},


### PR DESCRIPTION
This PR will turn Interlocked* intrinsics using rwtexture or rwbuffer objects as the first parameter into the proper OpImageAtomic* operations.
