### PR TITLE
HLSL: fix defect in EOpMethodSampleCmp* texture decomposition

### DIFF
--- a/Test/baseResults/hlsl.samplecmp.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmp.array.dx10.frag.out
@@ -12,7 +12,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DArrayShadow)
 0:42              'g_tTex1df4a' (uniform texture1DArray)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec3 (temp float)
+0:42            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -25,7 +25,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DArrayShadow)
 0:43              'g_tTex1di4a' (uniform itexture1DArray)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec3 (temp float)
+0:43            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -38,7 +38,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DArrayShadow)
 0:44              'g_tTex1du4a' (uniform utexture1DArray)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec3 (temp float)
+0:44            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -51,7 +51,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DArrayShadow)
 0:47              'g_tTex2df4a' (uniform texture2DArray)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec4 (temp float)
+0:47            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -65,7 +65,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DArrayShadow)
 0:48              'g_tTex2di4a' (uniform itexture2DArray)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec4 (temp float)
+0:48            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -79,7 +79,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DArrayShadow)
 0:49              'g_tTex2du4a' (uniform utexture2DArray)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec4 (temp float)
+0:49            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -93,7 +93,7 @@ gl_FragCoord origin is upper left
 0:52            Construct combined texture-sampler (temp samplerCubeArrayShadow)
 0:52              'g_tTexcdf4a' (uniform textureCubeArray)
 0:52              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:52            Construct vec4 (temp float)
+0:52            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -108,7 +108,7 @@ gl_FragCoord origin is upper left
 0:53            Construct combined texture-sampler (temp isamplerCubeArrayShadow)
 0:53              'g_tTexcdi4a' (uniform itextureCubeArray)
 0:53              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:53            Construct vec4 (temp float)
+0:53            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -123,7 +123,7 @@ gl_FragCoord origin is upper left
 0:54            Construct combined texture-sampler (temp usamplerCubeArrayShadow)
 0:54              'g_tTexcdu4a' (uniform utextureCubeArray)
 0:54              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:54            Construct vec4 (temp float)
+0:54            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -206,7 +206,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DArrayShadow)
 0:42              'g_tTex1df4a' (uniform texture1DArray)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec3 (temp float)
+0:42            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -219,7 +219,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DArrayShadow)
 0:43              'g_tTex1di4a' (uniform itexture1DArray)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec3 (temp float)
+0:43            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -232,7 +232,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DArrayShadow)
 0:44              'g_tTex1du4a' (uniform utexture1DArray)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec3 (temp float)
+0:44            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -245,7 +245,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DArrayShadow)
 0:47              'g_tTex2df4a' (uniform texture2DArray)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec4 (temp float)
+0:47            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -259,7 +259,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DArrayShadow)
 0:48              'g_tTex2di4a' (uniform itexture2DArray)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec4 (temp float)
+0:48            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -273,7 +273,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DArrayShadow)
 0:49              'g_tTex2du4a' (uniform utexture2DArray)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec4 (temp float)
+0:49            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -287,7 +287,7 @@ gl_FragCoord origin is upper left
 0:52            Construct combined texture-sampler (temp samplerCubeArrayShadow)
 0:52              'g_tTexcdf4a' (uniform textureCubeArray)
 0:52              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:52            Construct vec4 (temp float)
+0:52            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -302,7 +302,7 @@ gl_FragCoord origin is upper left
 0:53            Construct combined texture-sampler (temp isamplerCubeArrayShadow)
 0:53              'g_tTexcdi4a' (uniform itextureCubeArray)
 0:53              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:53            Construct vec4 (temp float)
+0:53            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -317,7 +317,7 @@ gl_FragCoord origin is upper left
 0:54            Construct combined texture-sampler (temp usamplerCubeArrayShadow)
 0:54              'g_tTexcdu4a' (uniform utextureCubeArray)
 0:54              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:54            Construct vec4 (temp float)
+0:54            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -385,79 +385,79 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 184
+// Id's are bound by 211
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 140 144
+                              EntryPoint Fragment 4  "main" 167 171
                               ExecutionMode 4 OriginUpperLeft
                               Name 4  "main"
                               Name 8  "r10"
                               Name 11  "g_tTex1df4a"
                               Name 15  "g_sSamp"
-                              Name 28  "r12"
-                              Name 32  "g_tTex1di4a"
-                              Name 41  "r14"
-                              Name 45  "g_tTex1du4a"
-                              Name 54  "r30"
-                              Name 57  "g_tTex2df4a"
-                              Name 69  "r32"
-                              Name 72  "g_tTex2di4a"
-                              Name 81  "r34"
-                              Name 84  "g_tTex2du4a"
-                              Name 93  "r60"
-                              Name 96  "g_tTexcdf4a"
-                              Name 107  "r62"
-                              Name 110  "g_tTexcdi4a"
-                              Name 118  "r64"
-                              Name 121  "g_tTexcdu4a"
-                              Name 129  "PS_OUTPUT"
-                              MemberName 129(PS_OUTPUT) 0  "Color"
-                              MemberName 129(PS_OUTPUT) 1  "Depth"
-                              Name 131  "psout"
-                              Name 140  "Color"
-                              Name 144  "Depth"
-                              Name 150  "g_tTex1df4"
-                              Name 153  "g_tTex1di4"
-                              Name 156  "g_tTex1du4"
-                              Name 159  "g_tTex2df4"
-                              Name 162  "g_tTex2di4"
-                              Name 165  "g_tTex2du4"
-                              Name 168  "g_tTex3df4"
-                              Name 171  "g_tTex3di4"
-                              Name 174  "g_tTex3du4"
-                              Name 177  "g_tTexcdf4"
-                              Name 180  "g_tTexcdi4"
-                              Name 183  "g_tTexcdu4"
+                              Name 31  "r12"
+                              Name 35  "g_tTex1di4a"
+                              Name 46  "r14"
+                              Name 50  "g_tTex1du4a"
+                              Name 61  "r30"
+                              Name 64  "g_tTex2df4a"
+                              Name 79  "r32"
+                              Name 82  "g_tTex2di4a"
+                              Name 94  "r34"
+                              Name 97  "g_tTex2du4a"
+                              Name 109  "r60"
+                              Name 112  "g_tTexcdf4a"
+                              Name 126  "r62"
+                              Name 129  "g_tTexcdi4a"
+                              Name 141  "r64"
+                              Name 144  "g_tTexcdu4a"
+                              Name 156  "PS_OUTPUT"
+                              MemberName 156(PS_OUTPUT) 0  "Color"
+                              MemberName 156(PS_OUTPUT) 1  "Depth"
+                              Name 158  "psout"
+                              Name 167  "Color"
+                              Name 171  "Depth"
+                              Name 177  "g_tTex1df4"
+                              Name 180  "g_tTex1di4"
+                              Name 183  "g_tTex1du4"
+                              Name 186  "g_tTex2df4"
+                              Name 189  "g_tTex2di4"
+                              Name 192  "g_tTex2du4"
+                              Name 195  "g_tTex3df4"
+                              Name 198  "g_tTex3di4"
+                              Name 201  "g_tTex3du4"
+                              Name 204  "g_tTexcdf4"
+                              Name 207  "g_tTexcdi4"
+                              Name 210  "g_tTexcdu4"
                               Decorate 11(g_tTex1df4a) DescriptorSet 0
                               Decorate 15(g_sSamp) DescriptorSet 0
                               Decorate 15(g_sSamp) Binding 0
-                              Decorate 32(g_tTex1di4a) DescriptorSet 0
-                              Decorate 45(g_tTex1du4a) DescriptorSet 0
-                              Decorate 57(g_tTex2df4a) DescriptorSet 0
-                              Decorate 72(g_tTex2di4a) DescriptorSet 0
-                              Decorate 84(g_tTex2du4a) DescriptorSet 0
-                              Decorate 96(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 110(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 121(g_tTexcdu4a) DescriptorSet 0
-                              Decorate 140(Color) Location 0
-                              Decorate 144(Depth) BuiltIn FragDepth
-                              Decorate 150(g_tTex1df4) DescriptorSet 0
-                              Decorate 150(g_tTex1df4) Binding 0
-                              Decorate 153(g_tTex1di4) DescriptorSet 0
-                              Decorate 156(g_tTex1du4) DescriptorSet 0
-                              Decorate 159(g_tTex2df4) DescriptorSet 0
-                              Decorate 162(g_tTex2di4) DescriptorSet 0
-                              Decorate 165(g_tTex2du4) DescriptorSet 0
-                              Decorate 168(g_tTex3df4) DescriptorSet 0
-                              Decorate 171(g_tTex3di4) DescriptorSet 0
-                              Decorate 174(g_tTex3du4) DescriptorSet 0
-                              Decorate 177(g_tTexcdf4) DescriptorSet 0
-                              Decorate 180(g_tTexcdi4) DescriptorSet 0
-                              Decorate 183(g_tTexcdu4) DescriptorSet 0
+                              Decorate 35(g_tTex1di4a) DescriptorSet 0
+                              Decorate 50(g_tTex1du4a) DescriptorSet 0
+                              Decorate 64(g_tTex2df4a) DescriptorSet 0
+                              Decorate 82(g_tTex2di4a) DescriptorSet 0
+                              Decorate 97(g_tTex2du4a) DescriptorSet 0
+                              Decorate 112(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 129(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 144(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 167(Color) Location 0
+                              Decorate 171(Depth) BuiltIn FragDepth
+                              Decorate 177(g_tTex1df4) DescriptorSet 0
+                              Decorate 177(g_tTex1df4) Binding 0
+                              Decorate 180(g_tTex1di4) DescriptorSet 0
+                              Decorate 183(g_tTex1du4) DescriptorSet 0
+                              Decorate 186(g_tTex2df4) DescriptorSet 0
+                              Decorate 189(g_tTex2di4) DescriptorSet 0
+                              Decorate 192(g_tTex2du4) DescriptorSet 0
+                              Decorate 195(g_tTex3df4) DescriptorSet 0
+                              Decorate 198(g_tTex3di4) DescriptorSet 0
+                              Decorate 201(g_tTex3du4) DescriptorSet 0
+                              Decorate 204(g_tTexcdf4) DescriptorSet 0
+                              Decorate 207(g_tTexcdi4) DescriptorSet 0
+                              Decorate 210(g_tTexcdu4) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -475,182 +475,209 @@ gl_FragCoord origin is upper left
               22:    6(float) Constant 1045220557
               23:   20(fvec2) ConstantComposite 21 22
               24:    6(float) Constant 1061158912
-              29:             TypeInt 32 1
-              30:             TypeImage 29(int) 1D array sampled format:Unknown
-              31:             TypePointer UniformConstant 30
- 32(g_tTex1di4a):     31(ptr) Variable UniformConstant
-              35:             TypeImage 29(int) 1D depth array sampled format:Unknown
-              36:             TypeSampledImage 35
-              42:             TypeInt 32 0
-              43:             TypeImage 42(int) 1D array sampled format:Unknown
-              44:             TypePointer UniformConstant 43
- 45(g_tTex1du4a):     44(ptr) Variable UniformConstant
-              48:             TypeImage 42(int) 1D depth array sampled format:Unknown
-              49:             TypeSampledImage 48
-              55:             TypeImage 6(float) 2D array sampled format:Unknown
-              56:             TypePointer UniformConstant 55
- 57(g_tTex2df4a):     56(ptr) Variable UniformConstant
-              60:             TypeImage 6(float) 2D depth array sampled format:Unknown
-              61:             TypeSampledImage 60
-              63:             TypeVector 6(float) 3
-              64:    6(float) Constant 1050253722
-              65:   63(fvec3) ConstantComposite 21 22 64
-              70:             TypeImage 29(int) 2D array sampled format:Unknown
-              71:             TypePointer UniformConstant 70
- 72(g_tTex2di4a):     71(ptr) Variable UniformConstant
-              75:             TypeImage 29(int) 2D depth array sampled format:Unknown
-              76:             TypeSampledImage 75
-              82:             TypeImage 42(int) 2D array sampled format:Unknown
-              83:             TypePointer UniformConstant 82
- 84(g_tTex2du4a):     83(ptr) Variable UniformConstant
-              87:             TypeImage 42(int) 2D depth array sampled format:Unknown
-              88:             TypeSampledImage 87
-              94:             TypeImage 6(float) Cube array sampled format:Unknown
-              95:             TypePointer UniformConstant 94
- 96(g_tTexcdf4a):     95(ptr) Variable UniformConstant
-              99:             TypeImage 6(float) Cube depth array sampled format:Unknown
-             100:             TypeSampledImage 99
-             102:             TypeVector 6(float) 4
-             103:    6(float) Constant 1053609165
-             104:  102(fvec4) ConstantComposite 21 22 64 103
-             108:             TypeImage 29(int) Cube array sampled format:Unknown
-             109:             TypePointer UniformConstant 108
-110(g_tTexcdi4a):    109(ptr) Variable UniformConstant
-             113:             TypeImage 29(int) Cube depth array sampled format:Unknown
-             114:             TypeSampledImage 113
-             119:             TypeImage 42(int) Cube array sampled format:Unknown
-             120:             TypePointer UniformConstant 119
-121(g_tTexcdu4a):    120(ptr) Variable UniformConstant
-             124:             TypeImage 42(int) Cube depth array sampled format:Unknown
-             125:             TypeSampledImage 124
-  129(PS_OUTPUT):             TypeStruct 102(fvec4) 6(float)
-             130:             TypePointer Function 129(PS_OUTPUT)
-             132:     29(int) Constant 0
-             133:    6(float) Constant 1065353216
-             134:  102(fvec4) ConstantComposite 133 133 133 133
-             135:             TypePointer Function 102(fvec4)
-             137:     29(int) Constant 1
-             139:             TypePointer Output 102(fvec4)
-      140(Color):    139(ptr) Variable Output
-             143:             TypePointer Output 6(float)
-      144(Depth):    143(ptr) Variable Output
-             148:             TypeImage 6(float) 1D sampled format:Unknown
-             149:             TypePointer UniformConstant 148
- 150(g_tTex1df4):    149(ptr) Variable UniformConstant
-             151:             TypeImage 29(int) 1D sampled format:Unknown
-             152:             TypePointer UniformConstant 151
- 153(g_tTex1di4):    152(ptr) Variable UniformConstant
-             154:             TypeImage 42(int) 1D sampled format:Unknown
-             155:             TypePointer UniformConstant 154
- 156(g_tTex1du4):    155(ptr) Variable UniformConstant
-             157:             TypeImage 6(float) 2D sampled format:Unknown
-             158:             TypePointer UniformConstant 157
- 159(g_tTex2df4):    158(ptr) Variable UniformConstant
-             160:             TypeImage 29(int) 2D sampled format:Unknown
-             161:             TypePointer UniformConstant 160
- 162(g_tTex2di4):    161(ptr) Variable UniformConstant
-             163:             TypeImage 42(int) 2D sampled format:Unknown
-             164:             TypePointer UniformConstant 163
- 165(g_tTex2du4):    164(ptr) Variable UniformConstant
-             166:             TypeImage 6(float) 3D sampled format:Unknown
-             167:             TypePointer UniformConstant 166
- 168(g_tTex3df4):    167(ptr) Variable UniformConstant
-             169:             TypeImage 29(int) 3D sampled format:Unknown
-             170:             TypePointer UniformConstant 169
- 171(g_tTex3di4):    170(ptr) Variable UniformConstant
-             172:             TypeImage 42(int) 3D sampled format:Unknown
-             173:             TypePointer UniformConstant 172
- 174(g_tTex3du4):    173(ptr) Variable UniformConstant
-             175:             TypeImage 6(float) Cube sampled format:Unknown
+              25:             TypeVector 6(float) 3
+              32:             TypeInt 32 1
+              33:             TypeImage 32(int) 1D array sampled format:Unknown
+              34:             TypePointer UniformConstant 33
+ 35(g_tTex1di4a):     34(ptr) Variable UniformConstant
+              38:             TypeImage 32(int) 1D depth array sampled format:Unknown
+              39:             TypeSampledImage 38
+              47:             TypeInt 32 0
+              48:             TypeImage 47(int) 1D array sampled format:Unknown
+              49:             TypePointer UniformConstant 48
+ 50(g_tTex1du4a):     49(ptr) Variable UniformConstant
+              53:             TypeImage 47(int) 1D depth array sampled format:Unknown
+              54:             TypeSampledImage 53
+              62:             TypeImage 6(float) 2D array sampled format:Unknown
+              63:             TypePointer UniformConstant 62
+ 64(g_tTex2df4a):     63(ptr) Variable UniformConstant
+              67:             TypeImage 6(float) 2D depth array sampled format:Unknown
+              68:             TypeSampledImage 67
+              70:    6(float) Constant 1050253722
+              71:   25(fvec3) ConstantComposite 21 22 70
+              72:             TypeVector 6(float) 4
+              80:             TypeImage 32(int) 2D array sampled format:Unknown
+              81:             TypePointer UniformConstant 80
+ 82(g_tTex2di4a):     81(ptr) Variable UniformConstant
+              85:             TypeImage 32(int) 2D depth array sampled format:Unknown
+              86:             TypeSampledImage 85
+              95:             TypeImage 47(int) 2D array sampled format:Unknown
+              96:             TypePointer UniformConstant 95
+ 97(g_tTex2du4a):     96(ptr) Variable UniformConstant
+             100:             TypeImage 47(int) 2D depth array sampled format:Unknown
+             101:             TypeSampledImage 100
+             110:             TypeImage 6(float) Cube array sampled format:Unknown
+             111:             TypePointer UniformConstant 110
+112(g_tTexcdf4a):    111(ptr) Variable UniformConstant
+             115:             TypeImage 6(float) Cube depth array sampled format:Unknown
+             116:             TypeSampledImage 115
+             118:    6(float) Constant 1053609165
+             119:   72(fvec4) ConstantComposite 21 22 70 118
+             127:             TypeImage 32(int) Cube array sampled format:Unknown
+             128:             TypePointer UniformConstant 127
+129(g_tTexcdi4a):    128(ptr) Variable UniformConstant
+             132:             TypeImage 32(int) Cube depth array sampled format:Unknown
+             133:             TypeSampledImage 132
+             142:             TypeImage 47(int) Cube array sampled format:Unknown
+             143:             TypePointer UniformConstant 142
+144(g_tTexcdu4a):    143(ptr) Variable UniformConstant
+             147:             TypeImage 47(int) Cube depth array sampled format:Unknown
+             148:             TypeSampledImage 147
+  156(PS_OUTPUT):             TypeStruct 72(fvec4) 6(float)
+             157:             TypePointer Function 156(PS_OUTPUT)
+             159:     32(int) Constant 0
+             160:    6(float) Constant 1065353216
+             161:   72(fvec4) ConstantComposite 160 160 160 160
+             162:             TypePointer Function 72(fvec4)
+             164:     32(int) Constant 1
+             166:             TypePointer Output 72(fvec4)
+      167(Color):    166(ptr) Variable Output
+             170:             TypePointer Output 6(float)
+      171(Depth):    170(ptr) Variable Output
+             175:             TypeImage 6(float) 1D sampled format:Unknown
              176:             TypePointer UniformConstant 175
- 177(g_tTexcdf4):    176(ptr) Variable UniformConstant
-             178:             TypeImage 29(int) Cube sampled format:Unknown
+ 177(g_tTex1df4):    176(ptr) Variable UniformConstant
+             178:             TypeImage 32(int) 1D sampled format:Unknown
              179:             TypePointer UniformConstant 178
- 180(g_tTexcdi4):    179(ptr) Variable UniformConstant
-             181:             TypeImage 42(int) Cube sampled format:Unknown
+ 180(g_tTex1di4):    179(ptr) Variable UniformConstant
+             181:             TypeImage 47(int) 1D sampled format:Unknown
              182:             TypePointer UniformConstant 181
- 183(g_tTexcdu4):    182(ptr) Variable UniformConstant
+ 183(g_tTex1du4):    182(ptr) Variable UniformConstant
+             184:             TypeImage 6(float) 2D sampled format:Unknown
+             185:             TypePointer UniformConstant 184
+ 186(g_tTex2df4):    185(ptr) Variable UniformConstant
+             187:             TypeImage 32(int) 2D sampled format:Unknown
+             188:             TypePointer UniformConstant 187
+ 189(g_tTex2di4):    188(ptr) Variable UniformConstant
+             190:             TypeImage 47(int) 2D sampled format:Unknown
+             191:             TypePointer UniformConstant 190
+ 192(g_tTex2du4):    191(ptr) Variable UniformConstant
+             193:             TypeImage 6(float) 3D sampled format:Unknown
+             194:             TypePointer UniformConstant 193
+ 195(g_tTex3df4):    194(ptr) Variable UniformConstant
+             196:             TypeImage 32(int) 3D sampled format:Unknown
+             197:             TypePointer UniformConstant 196
+ 198(g_tTex3di4):    197(ptr) Variable UniformConstant
+             199:             TypeImage 47(int) 3D sampled format:Unknown
+             200:             TypePointer UniformConstant 199
+ 201(g_tTex3du4):    200(ptr) Variable UniformConstant
+             202:             TypeImage 6(float) Cube sampled format:Unknown
+             203:             TypePointer UniformConstant 202
+ 204(g_tTexcdf4):    203(ptr) Variable UniformConstant
+             205:             TypeImage 32(int) Cube sampled format:Unknown
+             206:             TypePointer UniformConstant 205
+ 207(g_tTexcdi4):    206(ptr) Variable UniformConstant
+             208:             TypeImage 47(int) Cube sampled format:Unknown
+             209:             TypePointer UniformConstant 208
+ 210(g_tTexcdu4):    209(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
           8(r10):      7(ptr) Variable Function
-         28(r12):      7(ptr) Variable Function
-         41(r14):      7(ptr) Variable Function
-         54(r30):      7(ptr) Variable Function
-         69(r32):      7(ptr) Variable Function
-         81(r34):      7(ptr) Variable Function
-         93(r60):      7(ptr) Variable Function
-        107(r62):      7(ptr) Variable Function
-        118(r64):      7(ptr) Variable Function
-      131(psout):    130(ptr) Variable Function
+         31(r12):      7(ptr) Variable Function
+         46(r14):      7(ptr) Variable Function
+         61(r30):      7(ptr) Variable Function
+         79(r32):      7(ptr) Variable Function
+         94(r34):      7(ptr) Variable Function
+        109(r60):      7(ptr) Variable Function
+        126(r62):      7(ptr) Variable Function
+        141(r64):      7(ptr) Variable Function
+      158(psout):    157(ptr) Variable Function
               12:           9 Load 11(g_tTex1df4a)
               16:          13 Load 15(g_sSamp)
               19:          18 SampledImage 12 16
-              25:    6(float) CompositeExtract 23 0
-              26:    6(float) CompositeExtract 25 0
-              27:    6(float) ImageSampleDrefImplicitLod 19 25 26
-                              Store 8(r10) 27
-              33:          30 Load 32(g_tTex1di4a)
-              34:          13 Load 15(g_sSamp)
-              37:          36 SampledImage 33 34
-              38:    6(float) CompositeExtract 23 0
-              39:    6(float) CompositeExtract 38 0
-              40:    6(float) ImageSampleDrefImplicitLod 37 38 39
-                              Store 28(r12) 40
-              46:          43 Load 45(g_tTex1du4a)
-              47:          13 Load 15(g_sSamp)
-              50:          49 SampledImage 46 47
-              51:    6(float) CompositeExtract 23 0
-              52:    6(float) CompositeExtract 51 0
-              53:    6(float) ImageSampleDrefImplicitLod 50 51 52
-                              Store 41(r14) 53
-              58:          55 Load 57(g_tTex2df4a)
-              59:          13 Load 15(g_sSamp)
-              62:          61 SampledImage 58 59
-              66:    6(float) CompositeExtract 65 0
-              67:    6(float) CompositeExtract 66 0
-              68:    6(float) ImageSampleDrefImplicitLod 62 66 67
-                              Store 54(r30) 68
-              73:          70 Load 72(g_tTex2di4a)
-              74:          13 Load 15(g_sSamp)
-              77:          76 SampledImage 73 74
-              78:    6(float) CompositeExtract 65 0
-              79:    6(float) CompositeExtract 78 0
-              80:    6(float) ImageSampleDrefImplicitLod 77 78 79
-                              Store 69(r32) 80
-              85:          82 Load 84(g_tTex2du4a)
-              86:          13 Load 15(g_sSamp)
-              89:          88 SampledImage 85 86
-              90:    6(float) CompositeExtract 65 0
-              91:    6(float) CompositeExtract 90 0
-              92:    6(float) ImageSampleDrefImplicitLod 89 90 91
-                              Store 81(r34) 92
-              97:          94 Load 96(g_tTexcdf4a)
-              98:          13 Load 15(g_sSamp)
-             101:         100 SampledImage 97 98
-             105:    6(float) CompositeExtract 104 0
-             106:    6(float) ImageSampleDrefImplicitLod 101 105 24
-                              Store 93(r60) 106
-             111:         108 Load 110(g_tTexcdi4a)
-             112:          13 Load 15(g_sSamp)
-             115:         114 SampledImage 111 112
-             116:    6(float) CompositeExtract 104 0
-             117:    6(float) ImageSampleDrefImplicitLod 115 116 24
-                              Store 107(r62) 117
-             122:         119 Load 121(g_tTexcdu4a)
-             123:          13 Load 15(g_sSamp)
-             126:         125 SampledImage 122 123
-             127:    6(float) CompositeExtract 104 0
-             128:    6(float) ImageSampleDrefImplicitLod 126 127 24
-                              Store 118(r64) 128
-             136:    135(ptr) AccessChain 131(psout) 132
-                              Store 136 134
-             138:      7(ptr) AccessChain 131(psout) 137
-                              Store 138 133
-             141:    135(ptr) AccessChain 131(psout) 132
-             142:  102(fvec4) Load 141
-                              Store 140(Color) 142
-             145:      7(ptr) AccessChain 131(psout) 137
-             146:    6(float) Load 145
-                              Store 144(Depth) 146
+              26:    6(float) CompositeExtract 23 0
+              27:    6(float) CompositeExtract 23 1
+              28:   25(fvec3) CompositeConstruct 26 27 24
+              29:    6(float) CompositeExtract 28 2
+              30:    6(float) ImageSampleDrefImplicitLod 19 28 29
+                              Store 8(r10) 30
+              36:          33 Load 35(g_tTex1di4a)
+              37:          13 Load 15(g_sSamp)
+              40:          39 SampledImage 36 37
+              41:    6(float) CompositeExtract 23 0
+              42:    6(float) CompositeExtract 23 1
+              43:   25(fvec3) CompositeConstruct 41 42 24
+              44:    6(float) CompositeExtract 43 2
+              45:    6(float) ImageSampleDrefImplicitLod 40 43 44
+                              Store 31(r12) 45
+              51:          48 Load 50(g_tTex1du4a)
+              52:          13 Load 15(g_sSamp)
+              55:          54 SampledImage 51 52
+              56:    6(float) CompositeExtract 23 0
+              57:    6(float) CompositeExtract 23 1
+              58:   25(fvec3) CompositeConstruct 56 57 24
+              59:    6(float) CompositeExtract 58 2
+              60:    6(float) ImageSampleDrefImplicitLod 55 58 59
+                              Store 46(r14) 60
+              65:          62 Load 64(g_tTex2df4a)
+              66:          13 Load 15(g_sSamp)
+              69:          68 SampledImage 65 66
+              73:    6(float) CompositeExtract 71 0
+              74:    6(float) CompositeExtract 71 1
+              75:    6(float) CompositeExtract 71 2
+              76:   72(fvec4) CompositeConstruct 73 74 75 24
+              77:    6(float) CompositeExtract 76 3
+              78:    6(float) ImageSampleDrefImplicitLod 69 76 77
+                              Store 61(r30) 78
+              83:          80 Load 82(g_tTex2di4a)
+              84:          13 Load 15(g_sSamp)
+              87:          86 SampledImage 83 84
+              88:    6(float) CompositeExtract 71 0
+              89:    6(float) CompositeExtract 71 1
+              90:    6(float) CompositeExtract 71 2
+              91:   72(fvec4) CompositeConstruct 88 89 90 24
+              92:    6(float) CompositeExtract 91 3
+              93:    6(float) ImageSampleDrefImplicitLod 87 91 92
+                              Store 79(r32) 93
+              98:          95 Load 97(g_tTex2du4a)
+              99:          13 Load 15(g_sSamp)
+             102:         101 SampledImage 98 99
+             103:    6(float) CompositeExtract 71 0
+             104:    6(float) CompositeExtract 71 1
+             105:    6(float) CompositeExtract 71 2
+             106:   72(fvec4) CompositeConstruct 103 104 105 24
+             107:    6(float) CompositeExtract 106 3
+             108:    6(float) ImageSampleDrefImplicitLod 102 106 107
+                              Store 94(r34) 108
+             113:         110 Load 112(g_tTexcdf4a)
+             114:          13 Load 15(g_sSamp)
+             117:         116 SampledImage 113 114
+             120:    6(float) CompositeExtract 119 0
+             121:    6(float) CompositeExtract 119 1
+             122:    6(float) CompositeExtract 119 2
+             123:    6(float) CompositeExtract 119 3
+             124:   72(fvec4) CompositeConstruct 120 121 122 123
+             125:    6(float) ImageSampleDrefImplicitLod 117 124 24
+                              Store 109(r60) 125
+             130:         127 Load 129(g_tTexcdi4a)
+             131:          13 Load 15(g_sSamp)
+             134:         133 SampledImage 130 131
+             135:    6(float) CompositeExtract 119 0
+             136:    6(float) CompositeExtract 119 1
+             137:    6(float) CompositeExtract 119 2
+             138:    6(float) CompositeExtract 119 3
+             139:   72(fvec4) CompositeConstruct 135 136 137 138
+             140:    6(float) ImageSampleDrefImplicitLod 134 139 24
+                              Store 126(r62) 140
+             145:         142 Load 144(g_tTexcdu4a)
+             146:          13 Load 15(g_sSamp)
+             149:         148 SampledImage 145 146
+             150:    6(float) CompositeExtract 119 0
+             151:    6(float) CompositeExtract 119 1
+             152:    6(float) CompositeExtract 119 2
+             153:    6(float) CompositeExtract 119 3
+             154:   72(fvec4) CompositeConstruct 150 151 152 153
+             155:    6(float) ImageSampleDrefImplicitLod 149 154 24
+                              Store 141(r64) 155
+             163:    162(ptr) AccessChain 158(psout) 159
+                              Store 163 161
+             165:      7(ptr) AccessChain 158(psout) 164
+                              Store 165 160
+             168:    162(ptr) AccessChain 158(psout) 159
+             169:   72(fvec4) Load 168
+                              Store 167(Color) 169
+             172:      7(ptr) AccessChain 158(psout) 164
+             173:    6(float) Load 172
+                              Store 171(Depth) 173
                               Return
                               FunctionEnd

--- a/Test/baseResults/hlsl.samplecmp.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmp.basic.dx10.frag.out
@@ -12,7 +12,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DShadow)
 0:42              'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec2 (temp float)
+0:42            Construct vec2 (temp 2-component vector of float)
 0:42              Constant:
 0:42                0.100000
 0:42              Constant:
@@ -24,7 +24,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DShadow)
 0:43              'g_tTex1di4' (uniform itexture1D)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec2 (temp float)
+0:43            Construct vec2 (temp 2-component vector of float)
 0:43              Constant:
 0:43                0.100000
 0:43              Constant:
@@ -36,7 +36,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DShadow)
 0:44              'g_tTex1du4' (uniform utexture1D)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec2 (temp float)
+0:44            Construct vec2 (temp 2-component vector of float)
 0:44              Constant:
 0:44                0.100000
 0:44              Constant:
@@ -48,7 +48,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DShadow)
 0:47              'g_tTex2df4' (uniform texture2D)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec3 (temp float)
+0:47            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -61,7 +61,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DShadow)
 0:48              'g_tTex2di4' (uniform itexture2D)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec3 (temp float)
+0:48            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -74,7 +74,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DShadow)
 0:49              'g_tTex2du4' (uniform utexture2D)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec3 (temp float)
+0:49            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -87,7 +87,7 @@ gl_FragCoord origin is upper left
 0:53            Construct combined texture-sampler (temp samplerCubeShadow)
 0:53              'g_tTexcdf4' (uniform textureCube)
 0:53              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:53            Construct vec4 (temp float)
+0:53            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -101,7 +101,7 @@ gl_FragCoord origin is upper left
 0:54            Construct combined texture-sampler (temp isamplerCubeShadow)
 0:54              'g_tTexcdi4' (uniform itextureCube)
 0:54              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:54            Construct vec4 (temp float)
+0:54            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -115,7 +115,7 @@ gl_FragCoord origin is upper left
 0:55            Construct combined texture-sampler (temp usamplerCubeShadow)
 0:55              'g_tTexcdu4' (uniform utextureCube)
 0:55              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:55            Construct vec4 (temp float)
+0:55            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -197,7 +197,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DShadow)
 0:42              'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec2 (temp float)
+0:42            Construct vec2 (temp 2-component vector of float)
 0:42              Constant:
 0:42                0.100000
 0:42              Constant:
@@ -209,7 +209,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DShadow)
 0:43              'g_tTex1di4' (uniform itexture1D)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec2 (temp float)
+0:43            Construct vec2 (temp 2-component vector of float)
 0:43              Constant:
 0:43                0.100000
 0:43              Constant:
@@ -221,7 +221,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DShadow)
 0:44              'g_tTex1du4' (uniform utexture1D)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec2 (temp float)
+0:44            Construct vec2 (temp 2-component vector of float)
 0:44              Constant:
 0:44                0.100000
 0:44              Constant:
@@ -233,7 +233,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DShadow)
 0:47              'g_tTex2df4' (uniform texture2D)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec3 (temp float)
+0:47            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -246,7 +246,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DShadow)
 0:48              'g_tTex2di4' (uniform itexture2D)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec3 (temp float)
+0:48            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -259,7 +259,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DShadow)
 0:49              'g_tTex2du4' (uniform utexture2D)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec3 (temp float)
+0:49            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -272,7 +272,7 @@ gl_FragCoord origin is upper left
 0:53            Construct combined texture-sampler (temp samplerCubeShadow)
 0:53              'g_tTexcdf4' (uniform textureCube)
 0:53              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:53            Construct vec4 (temp float)
+0:53            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -286,7 +286,7 @@ gl_FragCoord origin is upper left
 0:54            Construct combined texture-sampler (temp isamplerCubeShadow)
 0:54              'g_tTexcdi4' (uniform itextureCube)
 0:54              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:54            Construct vec4 (temp float)
+0:54            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -300,7 +300,7 @@ gl_FragCoord origin is upper left
 0:55            Construct combined texture-sampler (temp usamplerCubeShadow)
 0:55              'g_tTexcdu4' (uniform utextureCube)
 0:55              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:55            Construct vec4 (temp float)
+0:55            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -367,79 +367,79 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 182
+// Id's are bound by 200
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 138 142
+                              EntryPoint Fragment 4  "main" 156 160
                               ExecutionMode 4 OriginUpperLeft
                               Name 4  "main"
                               Name 8  "r00"
                               Name 11  "g_tTex1df4"
                               Name 15  "g_sSamp"
-                              Name 24  "r02"
-                              Name 28  "g_tTex1di4"
-                              Name 36  "r04"
-                              Name 40  "g_tTex1du4"
-                              Name 48  "r20"
-                              Name 51  "g_tTex2df4"
-                              Name 63  "r22"
-                              Name 66  "g_tTex2di4"
-                              Name 75  "r24"
-                              Name 78  "g_tTex2du4"
-                              Name 87  "r50"
-                              Name 90  "g_tTexcdf4"
-                              Name 102  "r52"
-                              Name 105  "g_tTexcdi4"
-                              Name 114  "r54"
-                              Name 117  "g_tTexcdu4"
-                              Name 127  "PS_OUTPUT"
-                              MemberName 127(PS_OUTPUT) 0  "Color"
-                              MemberName 127(PS_OUTPUT) 1  "Depth"
-                              Name 129  "psout"
-                              Name 138  "Color"
-                              Name 142  "Depth"
-                              Name 148  "g_tTex3df4"
-                              Name 151  "g_tTex3di4"
-                              Name 154  "g_tTex3du4"
-                              Name 157  "g_tTex1df4a"
-                              Name 160  "g_tTex1di4a"
-                              Name 163  "g_tTex1du4a"
-                              Name 166  "g_tTex2df4a"
-                              Name 169  "g_tTex2di4a"
-                              Name 172  "g_tTex2du4a"
-                              Name 175  "g_tTexcdf4a"
-                              Name 178  "g_tTexcdi4a"
-                              Name 181  "g_tTexcdu4a"
+                              Name 26  "r02"
+                              Name 30  "g_tTex1di4"
+                              Name 39  "r04"
+                              Name 43  "g_tTex1du4"
+                              Name 52  "r20"
+                              Name 55  "g_tTex2df4"
+                              Name 69  "r22"
+                              Name 72  "g_tTex2di4"
+                              Name 83  "r24"
+                              Name 86  "g_tTex2du4"
+                              Name 97  "r50"
+                              Name 100  "g_tTexcdf4"
+                              Name 115  "r52"
+                              Name 118  "g_tTexcdi4"
+                              Name 130  "r54"
+                              Name 133  "g_tTexcdu4"
+                              Name 145  "PS_OUTPUT"
+                              MemberName 145(PS_OUTPUT) 0  "Color"
+                              MemberName 145(PS_OUTPUT) 1  "Depth"
+                              Name 147  "psout"
+                              Name 156  "Color"
+                              Name 160  "Depth"
+                              Name 166  "g_tTex3df4"
+                              Name 169  "g_tTex3di4"
+                              Name 172  "g_tTex3du4"
+                              Name 175  "g_tTex1df4a"
+                              Name 178  "g_tTex1di4a"
+                              Name 181  "g_tTex1du4a"
+                              Name 184  "g_tTex2df4a"
+                              Name 187  "g_tTex2di4a"
+                              Name 190  "g_tTex2du4a"
+                              Name 193  "g_tTexcdf4a"
+                              Name 196  "g_tTexcdi4a"
+                              Name 199  "g_tTexcdu4a"
                               Decorate 11(g_tTex1df4) DescriptorSet 0
                               Decorate 11(g_tTex1df4) Binding 0
                               Decorate 15(g_sSamp) DescriptorSet 0
                               Decorate 15(g_sSamp) Binding 0
-                              Decorate 28(g_tTex1di4) DescriptorSet 0
-                              Decorate 40(g_tTex1du4) DescriptorSet 0
-                              Decorate 51(g_tTex2df4) DescriptorSet 0
-                              Decorate 66(g_tTex2di4) DescriptorSet 0
-                              Decorate 78(g_tTex2du4) DescriptorSet 0
-                              Decorate 90(g_tTexcdf4) DescriptorSet 0
-                              Decorate 105(g_tTexcdi4) DescriptorSet 0
-                              Decorate 117(g_tTexcdu4) DescriptorSet 0
-                              Decorate 138(Color) Location 0
-                              Decorate 142(Depth) BuiltIn FragDepth
-                              Decorate 148(g_tTex3df4) DescriptorSet 0
-                              Decorate 151(g_tTex3di4) DescriptorSet 0
-                              Decorate 154(g_tTex3du4) DescriptorSet 0
-                              Decorate 157(g_tTex1df4a) DescriptorSet 0
-                              Decorate 160(g_tTex1di4a) DescriptorSet 0
-                              Decorate 163(g_tTex1du4a) DescriptorSet 0
-                              Decorate 166(g_tTex2df4a) DescriptorSet 0
-                              Decorate 169(g_tTex2di4a) DescriptorSet 0
-                              Decorate 172(g_tTex2du4a) DescriptorSet 0
-                              Decorate 175(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 178(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 181(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 30(g_tTex1di4) DescriptorSet 0
+                              Decorate 43(g_tTex1du4) DescriptorSet 0
+                              Decorate 55(g_tTex2df4) DescriptorSet 0
+                              Decorate 72(g_tTex2di4) DescriptorSet 0
+                              Decorate 86(g_tTex2du4) DescriptorSet 0
+                              Decorate 100(g_tTexcdf4) DescriptorSet 0
+                              Decorate 118(g_tTexcdi4) DescriptorSet 0
+                              Decorate 133(g_tTexcdu4) DescriptorSet 0
+                              Decorate 156(Color) Location 0
+                              Decorate 160(Depth) BuiltIn FragDepth
+                              Decorate 166(g_tTex3df4) DescriptorSet 0
+                              Decorate 169(g_tTex3di4) DescriptorSet 0
+                              Decorate 172(g_tTex3du4) DescriptorSet 0
+                              Decorate 175(g_tTex1df4a) DescriptorSet 0
+                              Decorate 178(g_tTex1di4a) DescriptorSet 0
+                              Decorate 181(g_tTex1du4a) DescriptorSet 0
+                              Decorate 184(g_tTex2df4a) DescriptorSet 0
+                              Decorate 187(g_tTex2di4a) DescriptorSet 0
+                              Decorate 190(g_tTex2du4a) DescriptorSet 0
+                              Decorate 193(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 196(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 199(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -454,183 +454,201 @@ gl_FragCoord origin is upper left
               18:             TypeSampledImage 17
               20:    6(float) Constant 1036831949
               21:    6(float) Constant 1061158912
-              25:             TypeInt 32 1
-              26:             TypeImage 25(int) 1D sampled format:Unknown
-              27:             TypePointer UniformConstant 26
-  28(g_tTex1di4):     27(ptr) Variable UniformConstant
-              31:             TypeImage 25(int) 1D depth sampled format:Unknown
-              32:             TypeSampledImage 31
-              37:             TypeInt 32 0
-              38:             TypeImage 37(int) 1D sampled format:Unknown
-              39:             TypePointer UniformConstant 38
-  40(g_tTex1du4):     39(ptr) Variable UniformConstant
-              43:             TypeImage 37(int) 1D depth sampled format:Unknown
-              44:             TypeSampledImage 43
-              49:             TypeImage 6(float) 2D sampled format:Unknown
-              50:             TypePointer UniformConstant 49
-  51(g_tTex2df4):     50(ptr) Variable UniformConstant
-              54:             TypeImage 6(float) 2D depth sampled format:Unknown
-              55:             TypeSampledImage 54
-              57:             TypeVector 6(float) 2
-              58:    6(float) Constant 1045220557
-              59:   57(fvec2) ConstantComposite 20 58
-              64:             TypeImage 25(int) 2D sampled format:Unknown
-              65:             TypePointer UniformConstant 64
-  66(g_tTex2di4):     65(ptr) Variable UniformConstant
-              69:             TypeImage 25(int) 2D depth sampled format:Unknown
-              70:             TypeSampledImage 69
-              76:             TypeImage 37(int) 2D sampled format:Unknown
-              77:             TypePointer UniformConstant 76
-  78(g_tTex2du4):     77(ptr) Variable UniformConstant
-              81:             TypeImage 37(int) 2D depth sampled format:Unknown
-              82:             TypeSampledImage 81
-              88:             TypeImage 6(float) Cube sampled format:Unknown
-              89:             TypePointer UniformConstant 88
-  90(g_tTexcdf4):     89(ptr) Variable UniformConstant
-              93:             TypeImage 6(float) Cube depth sampled format:Unknown
-              94:             TypeSampledImage 93
-              96:             TypeVector 6(float) 3
-              97:    6(float) Constant 1050253722
-              98:   96(fvec3) ConstantComposite 20 58 97
-             103:             TypeImage 25(int) Cube sampled format:Unknown
-             104:             TypePointer UniformConstant 103
- 105(g_tTexcdi4):    104(ptr) Variable UniformConstant
-             108:             TypeImage 25(int) Cube depth sampled format:Unknown
-             109:             TypeSampledImage 108
-             115:             TypeImage 37(int) Cube sampled format:Unknown
-             116:             TypePointer UniformConstant 115
- 117(g_tTexcdu4):    116(ptr) Variable UniformConstant
-             120:             TypeImage 37(int) Cube depth sampled format:Unknown
-             121:             TypeSampledImage 120
-             126:             TypeVector 6(float) 4
-  127(PS_OUTPUT):             TypeStruct 126(fvec4) 6(float)
-             128:             TypePointer Function 127(PS_OUTPUT)
-             130:     25(int) Constant 0
-             131:    6(float) Constant 1065353216
-             132:  126(fvec4) ConstantComposite 131 131 131 131
-             133:             TypePointer Function 126(fvec4)
-             135:     25(int) Constant 1
-             137:             TypePointer Output 126(fvec4)
-      138(Color):    137(ptr) Variable Output
-             141:             TypePointer Output 6(float)
-      142(Depth):    141(ptr) Variable Output
-             146:             TypeImage 6(float) 3D sampled format:Unknown
-             147:             TypePointer UniformConstant 146
- 148(g_tTex3df4):    147(ptr) Variable UniformConstant
-             149:             TypeImage 25(int) 3D sampled format:Unknown
-             150:             TypePointer UniformConstant 149
- 151(g_tTex3di4):    150(ptr) Variable UniformConstant
-             152:             TypeImage 37(int) 3D sampled format:Unknown
-             153:             TypePointer UniformConstant 152
- 154(g_tTex3du4):    153(ptr) Variable UniformConstant
-             155:             TypeImage 6(float) 1D array sampled format:Unknown
-             156:             TypePointer UniformConstant 155
-157(g_tTex1df4a):    156(ptr) Variable UniformConstant
-             158:             TypeImage 25(int) 1D array sampled format:Unknown
-             159:             TypePointer UniformConstant 158
-160(g_tTex1di4a):    159(ptr) Variable UniformConstant
-             161:             TypeImage 37(int) 1D array sampled format:Unknown
-             162:             TypePointer UniformConstant 161
-163(g_tTex1du4a):    162(ptr) Variable UniformConstant
-             164:             TypeImage 6(float) 2D array sampled format:Unknown
+              22:             TypeVector 6(float) 2
+              27:             TypeInt 32 1
+              28:             TypeImage 27(int) 1D sampled format:Unknown
+              29:             TypePointer UniformConstant 28
+  30(g_tTex1di4):     29(ptr) Variable UniformConstant
+              33:             TypeImage 27(int) 1D depth sampled format:Unknown
+              34:             TypeSampledImage 33
+              40:             TypeInt 32 0
+              41:             TypeImage 40(int) 1D sampled format:Unknown
+              42:             TypePointer UniformConstant 41
+  43(g_tTex1du4):     42(ptr) Variable UniformConstant
+              46:             TypeImage 40(int) 1D depth sampled format:Unknown
+              47:             TypeSampledImage 46
+              53:             TypeImage 6(float) 2D sampled format:Unknown
+              54:             TypePointer UniformConstant 53
+  55(g_tTex2df4):     54(ptr) Variable UniformConstant
+              58:             TypeImage 6(float) 2D depth sampled format:Unknown
+              59:             TypeSampledImage 58
+              61:    6(float) Constant 1045220557
+              62:   22(fvec2) ConstantComposite 20 61
+              63:             TypeVector 6(float) 3
+              70:             TypeImage 27(int) 2D sampled format:Unknown
+              71:             TypePointer UniformConstant 70
+  72(g_tTex2di4):     71(ptr) Variable UniformConstant
+              75:             TypeImage 27(int) 2D depth sampled format:Unknown
+              76:             TypeSampledImage 75
+              84:             TypeImage 40(int) 2D sampled format:Unknown
+              85:             TypePointer UniformConstant 84
+  86(g_tTex2du4):     85(ptr) Variable UniformConstant
+              89:             TypeImage 40(int) 2D depth sampled format:Unknown
+              90:             TypeSampledImage 89
+              98:             TypeImage 6(float) Cube sampled format:Unknown
+              99:             TypePointer UniformConstant 98
+ 100(g_tTexcdf4):     99(ptr) Variable UniformConstant
+             103:             TypeImage 6(float) Cube depth sampled format:Unknown
+             104:             TypeSampledImage 103
+             106:    6(float) Constant 1050253722
+             107:   63(fvec3) ConstantComposite 20 61 106
+             108:             TypeVector 6(float) 4
+             116:             TypeImage 27(int) Cube sampled format:Unknown
+             117:             TypePointer UniformConstant 116
+ 118(g_tTexcdi4):    117(ptr) Variable UniformConstant
+             121:             TypeImage 27(int) Cube depth sampled format:Unknown
+             122:             TypeSampledImage 121
+             131:             TypeImage 40(int) Cube sampled format:Unknown
+             132:             TypePointer UniformConstant 131
+ 133(g_tTexcdu4):    132(ptr) Variable UniformConstant
+             136:             TypeImage 40(int) Cube depth sampled format:Unknown
+             137:             TypeSampledImage 136
+  145(PS_OUTPUT):             TypeStruct 108(fvec4) 6(float)
+             146:             TypePointer Function 145(PS_OUTPUT)
+             148:     27(int) Constant 0
+             149:    6(float) Constant 1065353216
+             150:  108(fvec4) ConstantComposite 149 149 149 149
+             151:             TypePointer Function 108(fvec4)
+             153:     27(int) Constant 1
+             155:             TypePointer Output 108(fvec4)
+      156(Color):    155(ptr) Variable Output
+             159:             TypePointer Output 6(float)
+      160(Depth):    159(ptr) Variable Output
+             164:             TypeImage 6(float) 3D sampled format:Unknown
              165:             TypePointer UniformConstant 164
-166(g_tTex2df4a):    165(ptr) Variable UniformConstant
-             167:             TypeImage 25(int) 2D array sampled format:Unknown
+ 166(g_tTex3df4):    165(ptr) Variable UniformConstant
+             167:             TypeImage 27(int) 3D sampled format:Unknown
              168:             TypePointer UniformConstant 167
-169(g_tTex2di4a):    168(ptr) Variable UniformConstant
-             170:             TypeImage 37(int) 2D array sampled format:Unknown
+ 169(g_tTex3di4):    168(ptr) Variable UniformConstant
+             170:             TypeImage 40(int) 3D sampled format:Unknown
              171:             TypePointer UniformConstant 170
-172(g_tTex2du4a):    171(ptr) Variable UniformConstant
-             173:             TypeImage 6(float) Cube array sampled format:Unknown
+ 172(g_tTex3du4):    171(ptr) Variable UniformConstant
+             173:             TypeImage 6(float) 1D array sampled format:Unknown
              174:             TypePointer UniformConstant 173
-175(g_tTexcdf4a):    174(ptr) Variable UniformConstant
-             176:             TypeImage 25(int) Cube array sampled format:Unknown
+175(g_tTex1df4a):    174(ptr) Variable UniformConstant
+             176:             TypeImage 27(int) 1D array sampled format:Unknown
              177:             TypePointer UniformConstant 176
-178(g_tTexcdi4a):    177(ptr) Variable UniformConstant
-             179:             TypeImage 37(int) Cube array sampled format:Unknown
+178(g_tTex1di4a):    177(ptr) Variable UniformConstant
+             179:             TypeImage 40(int) 1D array sampled format:Unknown
              180:             TypePointer UniformConstant 179
-181(g_tTexcdu4a):    180(ptr) Variable UniformConstant
+181(g_tTex1du4a):    180(ptr) Variable UniformConstant
+             182:             TypeImage 6(float) 2D array sampled format:Unknown
+             183:             TypePointer UniformConstant 182
+184(g_tTex2df4a):    183(ptr) Variable UniformConstant
+             185:             TypeImage 27(int) 2D array sampled format:Unknown
+             186:             TypePointer UniformConstant 185
+187(g_tTex2di4a):    186(ptr) Variable UniformConstant
+             188:             TypeImage 40(int) 2D array sampled format:Unknown
+             189:             TypePointer UniformConstant 188
+190(g_tTex2du4a):    189(ptr) Variable UniformConstant
+             191:             TypeImage 6(float) Cube array sampled format:Unknown
+             192:             TypePointer UniformConstant 191
+193(g_tTexcdf4a):    192(ptr) Variable UniformConstant
+             194:             TypeImage 27(int) Cube array sampled format:Unknown
+             195:             TypePointer UniformConstant 194
+196(g_tTexcdi4a):    195(ptr) Variable UniformConstant
+             197:             TypeImage 40(int) Cube array sampled format:Unknown
+             198:             TypePointer UniformConstant 197
+199(g_tTexcdu4a):    198(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
           8(r00):      7(ptr) Variable Function
-         24(r02):      7(ptr) Variable Function
-         36(r04):      7(ptr) Variable Function
-         48(r20):      7(ptr) Variable Function
-         63(r22):      7(ptr) Variable Function
-         75(r24):      7(ptr) Variable Function
-         87(r50):      7(ptr) Variable Function
-        102(r52):      7(ptr) Variable Function
-        114(r54):      7(ptr) Variable Function
-      129(psout):    128(ptr) Variable Function
+         26(r02):      7(ptr) Variable Function
+         39(r04):      7(ptr) Variable Function
+         52(r20):      7(ptr) Variable Function
+         69(r22):      7(ptr) Variable Function
+         83(r24):      7(ptr) Variable Function
+         97(r50):      7(ptr) Variable Function
+        115(r52):      7(ptr) Variable Function
+        130(r54):      7(ptr) Variable Function
+      147(psout):    146(ptr) Variable Function
               12:           9 Load 11(g_tTex1df4)
               16:          13 Load 15(g_sSamp)
               19:          18 SampledImage 12 16
-              22:    6(float) CompositeExtract 20 0
-              23:    6(float) ImageSampleDrefImplicitLod 19 20 22
-                              Store 8(r00) 23
-              29:          26 Load 28(g_tTex1di4)
-              30:          13 Load 15(g_sSamp)
-              33:          32 SampledImage 29 30
-              34:    6(float) CompositeExtract 20 0
-              35:    6(float) ImageSampleDrefImplicitLod 33 20 34
-                              Store 24(r02) 35
-              41:          38 Load 40(g_tTex1du4)
-              42:          13 Load 15(g_sSamp)
-              45:          44 SampledImage 41 42
-              46:    6(float) CompositeExtract 20 0
-              47:    6(float) ImageSampleDrefImplicitLod 45 20 46
-                              Store 36(r04) 47
-              52:          49 Load 51(g_tTex2df4)
-              53:          13 Load 15(g_sSamp)
-              56:          55 SampledImage 52 53
-              60:    6(float) CompositeExtract 59 0
-              61:    6(float) CompositeExtract 60 0
-              62:    6(float) ImageSampleDrefImplicitLod 56 60 61
-                              Store 48(r20) 62
-              67:          64 Load 66(g_tTex2di4)
-              68:          13 Load 15(g_sSamp)
-              71:          70 SampledImage 67 68
-              72:    6(float) CompositeExtract 59 0
-              73:    6(float) CompositeExtract 72 0
-              74:    6(float) ImageSampleDrefImplicitLod 71 72 73
-                              Store 63(r22) 74
-              79:          76 Load 78(g_tTex2du4)
-              80:          13 Load 15(g_sSamp)
-              83:          82 SampledImage 79 80
-              84:    6(float) CompositeExtract 59 0
-              85:    6(float) CompositeExtract 84 0
-              86:    6(float) ImageSampleDrefImplicitLod 83 84 85
-                              Store 75(r24) 86
-              91:          88 Load 90(g_tTexcdf4)
-              92:          13 Load 15(g_sSamp)
-              95:          94 SampledImage 91 92
-              99:    6(float) CompositeExtract 98 0
-             100:    6(float) CompositeExtract 99 0
-             101:    6(float) ImageSampleDrefImplicitLod 95 99 100
-                              Store 87(r50) 101
-             106:         103 Load 105(g_tTexcdi4)
-             107:          13 Load 15(g_sSamp)
-             110:         109 SampledImage 106 107
-             111:    6(float) CompositeExtract 98 0
-             112:    6(float) CompositeExtract 111 0
-             113:    6(float) ImageSampleDrefImplicitLod 110 111 112
-                              Store 102(r52) 113
-             118:         115 Load 117(g_tTexcdu4)
-             119:          13 Load 15(g_sSamp)
-             122:         121 SampledImage 118 119
-             123:    6(float) CompositeExtract 98 0
-             124:    6(float) CompositeExtract 123 0
-             125:    6(float) ImageSampleDrefImplicitLod 122 123 124
-                              Store 114(r54) 125
-             134:    133(ptr) AccessChain 129(psout) 130
-                              Store 134 132
-             136:      7(ptr) AccessChain 129(psout) 135
-                              Store 136 131
-             139:    133(ptr) AccessChain 129(psout) 130
-             140:  126(fvec4) Load 139
-                              Store 138(Color) 140
-             143:      7(ptr) AccessChain 129(psout) 135
-             144:    6(float) Load 143
-                              Store 142(Depth) 144
+              23:   22(fvec2) CompositeConstruct 20 21
+              24:    6(float) CompositeExtract 23 1
+              25:    6(float) ImageSampleDrefImplicitLod 19 23 24
+                              Store 8(r00) 25
+              31:          28 Load 30(g_tTex1di4)
+              32:          13 Load 15(g_sSamp)
+              35:          34 SampledImage 31 32
+              36:   22(fvec2) CompositeConstruct 20 21
+              37:    6(float) CompositeExtract 36 1
+              38:    6(float) ImageSampleDrefImplicitLod 35 36 37
+                              Store 26(r02) 38
+              44:          41 Load 43(g_tTex1du4)
+              45:          13 Load 15(g_sSamp)
+              48:          47 SampledImage 44 45
+              49:   22(fvec2) CompositeConstruct 20 21
+              50:    6(float) CompositeExtract 49 1
+              51:    6(float) ImageSampleDrefImplicitLod 48 49 50
+                              Store 39(r04) 51
+              56:          53 Load 55(g_tTex2df4)
+              57:          13 Load 15(g_sSamp)
+              60:          59 SampledImage 56 57
+              64:    6(float) CompositeExtract 62 0
+              65:    6(float) CompositeExtract 62 1
+              66:   63(fvec3) CompositeConstruct 64 65 21
+              67:    6(float) CompositeExtract 66 2
+              68:    6(float) ImageSampleDrefImplicitLod 60 66 67
+                              Store 52(r20) 68
+              73:          70 Load 72(g_tTex2di4)
+              74:          13 Load 15(g_sSamp)
+              77:          76 SampledImage 73 74
+              78:    6(float) CompositeExtract 62 0
+              79:    6(float) CompositeExtract 62 1
+              80:   63(fvec3) CompositeConstruct 78 79 21
+              81:    6(float) CompositeExtract 80 2
+              82:    6(float) ImageSampleDrefImplicitLod 77 80 81
+                              Store 69(r22) 82
+              87:          84 Load 86(g_tTex2du4)
+              88:          13 Load 15(g_sSamp)
+              91:          90 SampledImage 87 88
+              92:    6(float) CompositeExtract 62 0
+              93:    6(float) CompositeExtract 62 1
+              94:   63(fvec3) CompositeConstruct 92 93 21
+              95:    6(float) CompositeExtract 94 2
+              96:    6(float) ImageSampleDrefImplicitLod 91 94 95
+                              Store 83(r24) 96
+             101:          98 Load 100(g_tTexcdf4)
+             102:          13 Load 15(g_sSamp)
+             105:         104 SampledImage 101 102
+             109:    6(float) CompositeExtract 107 0
+             110:    6(float) CompositeExtract 107 1
+             111:    6(float) CompositeExtract 107 2
+             112:  108(fvec4) CompositeConstruct 109 110 111 21
+             113:    6(float) CompositeExtract 112 3
+             114:    6(float) ImageSampleDrefImplicitLod 105 112 113
+                              Store 97(r50) 114
+             119:         116 Load 118(g_tTexcdi4)
+             120:          13 Load 15(g_sSamp)
+             123:         122 SampledImage 119 120
+             124:    6(float) CompositeExtract 107 0
+             125:    6(float) CompositeExtract 107 1
+             126:    6(float) CompositeExtract 107 2
+             127:  108(fvec4) CompositeConstruct 124 125 126 21
+             128:    6(float) CompositeExtract 127 3
+             129:    6(float) ImageSampleDrefImplicitLod 123 127 128
+                              Store 115(r52) 129
+             134:         131 Load 133(g_tTexcdu4)
+             135:          13 Load 15(g_sSamp)
+             138:         137 SampledImage 134 135
+             139:    6(float) CompositeExtract 107 0
+             140:    6(float) CompositeExtract 107 1
+             141:    6(float) CompositeExtract 107 2
+             142:  108(fvec4) CompositeConstruct 139 140 141 21
+             143:    6(float) CompositeExtract 142 3
+             144:    6(float) ImageSampleDrefImplicitLod 138 142 143
+                              Store 130(r54) 144
+             152:    151(ptr) AccessChain 147(psout) 148
+                              Store 152 150
+             154:      7(ptr) AccessChain 147(psout) 153
+                              Store 154 149
+             157:    151(ptr) AccessChain 147(psout) 148
+             158:  108(fvec4) Load 157
+                              Store 156(Color) 158
+             161:      7(ptr) AccessChain 147(psout) 153
+             162:    6(float) Load 161
+                              Store 160(Depth) 162
                               Return
                               FunctionEnd

--- a/Test/baseResults/hlsl.samplecmp.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmp.offset.dx10.frag.out
@@ -12,7 +12,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DShadow)
 0:42              'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec2 (temp float)
+0:42            Construct vec2 (temp 2-component vector of float)
 0:42              Constant:
 0:42                0.100000
 0:42              Constant:
@@ -26,7 +26,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DShadow)
 0:43              'g_tTex1di4' (uniform itexture1D)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec2 (temp float)
+0:43            Construct vec2 (temp 2-component vector of float)
 0:43              Constant:
 0:43                0.100000
 0:43              Constant:
@@ -40,7 +40,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DShadow)
 0:44              'g_tTex1du4' (uniform utexture1D)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec2 (temp float)
+0:44            Construct vec2 (temp 2-component vector of float)
 0:44              Constant:
 0:44                0.100000
 0:44              Constant:
@@ -54,7 +54,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DShadow)
 0:47              'g_tTex2df4' (uniform texture2D)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec3 (temp float)
+0:47            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -70,7 +70,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DShadow)
 0:48              'g_tTex2di4' (uniform itexture2D)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec3 (temp float)
+0:48            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -86,7 +86,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DShadow)
 0:49              'g_tTex2du4' (uniform utexture2D)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec3 (temp float)
+0:49            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -170,7 +170,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DShadow)
 0:42              'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec2 (temp float)
+0:42            Construct vec2 (temp 2-component vector of float)
 0:42              Constant:
 0:42                0.100000
 0:42              Constant:
@@ -184,7 +184,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DShadow)
 0:43              'g_tTex1di4' (uniform itexture1D)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec2 (temp float)
+0:43            Construct vec2 (temp 2-component vector of float)
 0:43              Constant:
 0:43                0.100000
 0:43              Constant:
@@ -198,7 +198,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DShadow)
 0:44              'g_tTex1du4' (uniform utexture1D)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec2 (temp float)
+0:44            Construct vec2 (temp 2-component vector of float)
 0:44              Constant:
 0:44                0.100000
 0:44              Constant:
@@ -212,7 +212,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DShadow)
 0:47              'g_tTex2df4' (uniform texture2D)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec3 (temp float)
+0:47            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -228,7 +228,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DShadow)
 0:48              'g_tTex2di4' (uniform itexture2D)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec3 (temp float)
+0:48            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -244,7 +244,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DShadow)
 0:49              'g_tTex2du4' (uniform utexture2D)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec3 (temp float)
+0:49            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -313,76 +313,76 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 156
+// Id's are bound by 166
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 103 107
+                              EntryPoint Fragment 4  "main" 113 117
                               ExecutionMode 4 OriginUpperLeft
                               Name 4  "main"
                               Name 8  "r01"
                               Name 11  "g_tTex1df4"
                               Name 15  "g_sSamp"
-                              Name 26  "r03"
-                              Name 29  "g_tTex1di4"
-                              Name 37  "r05"
-                              Name 41  "g_tTex1du4"
-                              Name 49  "r21"
-                              Name 52  "g_tTex2df4"
-                              Name 67  "r23"
-                              Name 70  "g_tTex2di4"
-                              Name 79  "r25"
-                              Name 82  "g_tTex2du4"
-                              Name 92  "PS_OUTPUT"
-                              MemberName 92(PS_OUTPUT) 0  "Color"
-                              MemberName 92(PS_OUTPUT) 1  "Depth"
-                              Name 94  "psout"
-                              Name 103  "Color"
-                              Name 107  "Depth"
-                              Name 113  "g_tTex3df4"
-                              Name 116  "g_tTex3di4"
-                              Name 119  "g_tTex3du4"
-                              Name 122  "g_tTexcdf4"
-                              Name 125  "g_tTexcdi4"
-                              Name 128  "g_tTexcdu4"
-                              Name 131  "g_tTex1df4a"
-                              Name 134  "g_tTex1di4a"
-                              Name 137  "g_tTex1du4a"
-                              Name 140  "g_tTex2df4a"
-                              Name 143  "g_tTex2di4a"
-                              Name 146  "g_tTex2du4a"
-                              Name 149  "g_tTexcdf4a"
-                              Name 152  "g_tTexcdi4a"
-                              Name 155  "g_tTexcdu4a"
+                              Name 28  "r03"
+                              Name 31  "g_tTex1di4"
+                              Name 40  "r05"
+                              Name 44  "g_tTex1du4"
+                              Name 53  "r21"
+                              Name 56  "g_tTex2df4"
+                              Name 73  "r23"
+                              Name 76  "g_tTex2di4"
+                              Name 87  "r25"
+                              Name 90  "g_tTex2du4"
+                              Name 102  "PS_OUTPUT"
+                              MemberName 102(PS_OUTPUT) 0  "Color"
+                              MemberName 102(PS_OUTPUT) 1  "Depth"
+                              Name 104  "psout"
+                              Name 113  "Color"
+                              Name 117  "Depth"
+                              Name 123  "g_tTex3df4"
+                              Name 126  "g_tTex3di4"
+                              Name 129  "g_tTex3du4"
+                              Name 132  "g_tTexcdf4"
+                              Name 135  "g_tTexcdi4"
+                              Name 138  "g_tTexcdu4"
+                              Name 141  "g_tTex1df4a"
+                              Name 144  "g_tTex1di4a"
+                              Name 147  "g_tTex1du4a"
+                              Name 150  "g_tTex2df4a"
+                              Name 153  "g_tTex2di4a"
+                              Name 156  "g_tTex2du4a"
+                              Name 159  "g_tTexcdf4a"
+                              Name 162  "g_tTexcdi4a"
+                              Name 165  "g_tTexcdu4a"
                               Decorate 11(g_tTex1df4) DescriptorSet 0
                               Decorate 11(g_tTex1df4) Binding 0
                               Decorate 15(g_sSamp) DescriptorSet 0
                               Decorate 15(g_sSamp) Binding 0
-                              Decorate 29(g_tTex1di4) DescriptorSet 0
-                              Decorate 41(g_tTex1du4) DescriptorSet 0
-                              Decorate 52(g_tTex2df4) DescriptorSet 0
-                              Decorate 70(g_tTex2di4) DescriptorSet 0
-                              Decorate 82(g_tTex2du4) DescriptorSet 0
-                              Decorate 103(Color) Location 0
-                              Decorate 107(Depth) BuiltIn FragDepth
-                              Decorate 113(g_tTex3df4) DescriptorSet 0
-                              Decorate 116(g_tTex3di4) DescriptorSet 0
-                              Decorate 119(g_tTex3du4) DescriptorSet 0
-                              Decorate 122(g_tTexcdf4) DescriptorSet 0
-                              Decorate 125(g_tTexcdi4) DescriptorSet 0
-                              Decorate 128(g_tTexcdu4) DescriptorSet 0
-                              Decorate 131(g_tTex1df4a) DescriptorSet 0
-                              Decorate 134(g_tTex1di4a) DescriptorSet 0
-                              Decorate 137(g_tTex1du4a) DescriptorSet 0
-                              Decorate 140(g_tTex2df4a) DescriptorSet 0
-                              Decorate 143(g_tTex2di4a) DescriptorSet 0
-                              Decorate 146(g_tTex2du4a) DescriptorSet 0
-                              Decorate 149(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 152(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 155(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 31(g_tTex1di4) DescriptorSet 0
+                              Decorate 44(g_tTex1du4) DescriptorSet 0
+                              Decorate 56(g_tTex2df4) DescriptorSet 0
+                              Decorate 76(g_tTex2di4) DescriptorSet 0
+                              Decorate 90(g_tTex2du4) DescriptorSet 0
+                              Decorate 113(Color) Location 0
+                              Decorate 117(Depth) BuiltIn FragDepth
+                              Decorate 123(g_tTex3df4) DescriptorSet 0
+                              Decorate 126(g_tTex3di4) DescriptorSet 0
+                              Decorate 129(g_tTex3du4) DescriptorSet 0
+                              Decorate 132(g_tTexcdf4) DescriptorSet 0
+                              Decorate 135(g_tTexcdi4) DescriptorSet 0
+                              Decorate 138(g_tTexcdu4) DescriptorSet 0
+                              Decorate 141(g_tTex1df4a) DescriptorSet 0
+                              Decorate 144(g_tTex1di4a) DescriptorSet 0
+                              Decorate 147(g_tTex1du4a) DescriptorSet 0
+                              Decorate 150(g_tTex2df4a) DescriptorSet 0
+                              Decorate 153(g_tTex2di4a) DescriptorSet 0
+                              Decorate 156(g_tTex2du4a) DescriptorSet 0
+                              Decorate 159(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 162(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 165(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -397,154 +397,164 @@ gl_FragCoord origin is upper left
               18:             TypeSampledImage 17
               20:    6(float) Constant 1036831949
               21:    6(float) Constant 1061158912
-              22:             TypeInt 32 1
-              23:     22(int) Constant 2
-              27:             TypeImage 22(int) 1D sampled format:Unknown
-              28:             TypePointer UniformConstant 27
-  29(g_tTex1di4):     28(ptr) Variable UniformConstant
-              32:             TypeImage 22(int) 1D depth sampled format:Unknown
-              33:             TypeSampledImage 32
-              38:             TypeInt 32 0
-              39:             TypeImage 38(int) 1D sampled format:Unknown
-              40:             TypePointer UniformConstant 39
-  41(g_tTex1du4):     40(ptr) Variable UniformConstant
-              44:             TypeImage 38(int) 1D depth sampled format:Unknown
-              45:             TypeSampledImage 44
-              50:             TypeImage 6(float) 2D sampled format:Unknown
-              51:             TypePointer UniformConstant 50
-  52(g_tTex2df4):     51(ptr) Variable UniformConstant
-              55:             TypeImage 6(float) 2D depth sampled format:Unknown
-              56:             TypeSampledImage 55
-              58:             TypeVector 6(float) 2
-              59:    6(float) Constant 1045220557
-              60:   58(fvec2) ConstantComposite 20 59
-              62:             TypeVector 22(int) 2
-              63:     22(int) Constant 3
-              64:   62(ivec2) ConstantComposite 23 63
-              68:             TypeImage 22(int) 2D sampled format:Unknown
-              69:             TypePointer UniformConstant 68
-  70(g_tTex2di4):     69(ptr) Variable UniformConstant
-              73:             TypeImage 22(int) 2D depth sampled format:Unknown
-              74:             TypeSampledImage 73
-              80:             TypeImage 38(int) 2D sampled format:Unknown
-              81:             TypePointer UniformConstant 80
-  82(g_tTex2du4):     81(ptr) Variable UniformConstant
-              85:             TypeImage 38(int) 2D depth sampled format:Unknown
-              86:             TypeSampledImage 85
-              91:             TypeVector 6(float) 4
-   92(PS_OUTPUT):             TypeStruct 91(fvec4) 6(float)
-              93:             TypePointer Function 92(PS_OUTPUT)
-              95:     22(int) Constant 0
-              96:    6(float) Constant 1065353216
-              97:   91(fvec4) ConstantComposite 96 96 96 96
-              98:             TypePointer Function 91(fvec4)
-             100:     22(int) Constant 1
-             102:             TypePointer Output 91(fvec4)
-      103(Color):    102(ptr) Variable Output
-             106:             TypePointer Output 6(float)
-      107(Depth):    106(ptr) Variable Output
-             111:             TypeImage 6(float) 3D sampled format:Unknown
-             112:             TypePointer UniformConstant 111
- 113(g_tTex3df4):    112(ptr) Variable UniformConstant
-             114:             TypeImage 22(int) 3D sampled format:Unknown
-             115:             TypePointer UniformConstant 114
- 116(g_tTex3di4):    115(ptr) Variable UniformConstant
-             117:             TypeImage 38(int) 3D sampled format:Unknown
-             118:             TypePointer UniformConstant 117
- 119(g_tTex3du4):    118(ptr) Variable UniformConstant
-             120:             TypeImage 6(float) Cube sampled format:Unknown
-             121:             TypePointer UniformConstant 120
- 122(g_tTexcdf4):    121(ptr) Variable UniformConstant
-             123:             TypeImage 22(int) Cube sampled format:Unknown
-             124:             TypePointer UniformConstant 123
- 125(g_tTexcdi4):    124(ptr) Variable UniformConstant
-             126:             TypeImage 38(int) Cube sampled format:Unknown
-             127:             TypePointer UniformConstant 126
- 128(g_tTexcdu4):    127(ptr) Variable UniformConstant
-             129:             TypeImage 6(float) 1D array sampled format:Unknown
-             130:             TypePointer UniformConstant 129
-131(g_tTex1df4a):    130(ptr) Variable UniformConstant
-             132:             TypeImage 22(int) 1D array sampled format:Unknown
-             133:             TypePointer UniformConstant 132
-134(g_tTex1di4a):    133(ptr) Variable UniformConstant
-             135:             TypeImage 38(int) 1D array sampled format:Unknown
-             136:             TypePointer UniformConstant 135
-137(g_tTex1du4a):    136(ptr) Variable UniformConstant
-             138:             TypeImage 6(float) 2D array sampled format:Unknown
-             139:             TypePointer UniformConstant 138
-140(g_tTex2df4a):    139(ptr) Variable UniformConstant
-             141:             TypeImage 22(int) 2D array sampled format:Unknown
-             142:             TypePointer UniformConstant 141
-143(g_tTex2di4a):    142(ptr) Variable UniformConstant
-             144:             TypeImage 38(int) 2D array sampled format:Unknown
-             145:             TypePointer UniformConstant 144
-146(g_tTex2du4a):    145(ptr) Variable UniformConstant
-             147:             TypeImage 6(float) Cube array sampled format:Unknown
-             148:             TypePointer UniformConstant 147
-149(g_tTexcdf4a):    148(ptr) Variable UniformConstant
-             150:             TypeImage 22(int) Cube array sampled format:Unknown
-             151:             TypePointer UniformConstant 150
-152(g_tTexcdi4a):    151(ptr) Variable UniformConstant
-             153:             TypeImage 38(int) Cube array sampled format:Unknown
-             154:             TypePointer UniformConstant 153
-155(g_tTexcdu4a):    154(ptr) Variable UniformConstant
+              22:             TypeVector 6(float) 2
+              24:             TypeInt 32 1
+              25:     24(int) Constant 2
+              29:             TypeImage 24(int) 1D sampled format:Unknown
+              30:             TypePointer UniformConstant 29
+  31(g_tTex1di4):     30(ptr) Variable UniformConstant
+              34:             TypeImage 24(int) 1D depth sampled format:Unknown
+              35:             TypeSampledImage 34
+              41:             TypeInt 32 0
+              42:             TypeImage 41(int) 1D sampled format:Unknown
+              43:             TypePointer UniformConstant 42
+  44(g_tTex1du4):     43(ptr) Variable UniformConstant
+              47:             TypeImage 41(int) 1D depth sampled format:Unknown
+              48:             TypeSampledImage 47
+              54:             TypeImage 6(float) 2D sampled format:Unknown
+              55:             TypePointer UniformConstant 54
+  56(g_tTex2df4):     55(ptr) Variable UniformConstant
+              59:             TypeImage 6(float) 2D depth sampled format:Unknown
+              60:             TypeSampledImage 59
+              62:    6(float) Constant 1045220557
+              63:   22(fvec2) ConstantComposite 20 62
+              64:             TypeVector 6(float) 3
+              68:             TypeVector 24(int) 2
+              69:     24(int) Constant 3
+              70:   68(ivec2) ConstantComposite 25 69
+              74:             TypeImage 24(int) 2D sampled format:Unknown
+              75:             TypePointer UniformConstant 74
+  76(g_tTex2di4):     75(ptr) Variable UniformConstant
+              79:             TypeImage 24(int) 2D depth sampled format:Unknown
+              80:             TypeSampledImage 79
+              88:             TypeImage 41(int) 2D sampled format:Unknown
+              89:             TypePointer UniformConstant 88
+  90(g_tTex2du4):     89(ptr) Variable UniformConstant
+              93:             TypeImage 41(int) 2D depth sampled format:Unknown
+              94:             TypeSampledImage 93
+             101:             TypeVector 6(float) 4
+  102(PS_OUTPUT):             TypeStruct 101(fvec4) 6(float)
+             103:             TypePointer Function 102(PS_OUTPUT)
+             105:     24(int) Constant 0
+             106:    6(float) Constant 1065353216
+             107:  101(fvec4) ConstantComposite 106 106 106 106
+             108:             TypePointer Function 101(fvec4)
+             110:     24(int) Constant 1
+             112:             TypePointer Output 101(fvec4)
+      113(Color):    112(ptr) Variable Output
+             116:             TypePointer Output 6(float)
+      117(Depth):    116(ptr) Variable Output
+             121:             TypeImage 6(float) 3D sampled format:Unknown
+             122:             TypePointer UniformConstant 121
+ 123(g_tTex3df4):    122(ptr) Variable UniformConstant
+             124:             TypeImage 24(int) 3D sampled format:Unknown
+             125:             TypePointer UniformConstant 124
+ 126(g_tTex3di4):    125(ptr) Variable UniformConstant
+             127:             TypeImage 41(int) 3D sampled format:Unknown
+             128:             TypePointer UniformConstant 127
+ 129(g_tTex3du4):    128(ptr) Variable UniformConstant
+             130:             TypeImage 6(float) Cube sampled format:Unknown
+             131:             TypePointer UniformConstant 130
+ 132(g_tTexcdf4):    131(ptr) Variable UniformConstant
+             133:             TypeImage 24(int) Cube sampled format:Unknown
+             134:             TypePointer UniformConstant 133
+ 135(g_tTexcdi4):    134(ptr) Variable UniformConstant
+             136:             TypeImage 41(int) Cube sampled format:Unknown
+             137:             TypePointer UniformConstant 136
+ 138(g_tTexcdu4):    137(ptr) Variable UniformConstant
+             139:             TypeImage 6(float) 1D array sampled format:Unknown
+             140:             TypePointer UniformConstant 139
+141(g_tTex1df4a):    140(ptr) Variable UniformConstant
+             142:             TypeImage 24(int) 1D array sampled format:Unknown
+             143:             TypePointer UniformConstant 142
+144(g_tTex1di4a):    143(ptr) Variable UniformConstant
+             145:             TypeImage 41(int) 1D array sampled format:Unknown
+             146:             TypePointer UniformConstant 145
+147(g_tTex1du4a):    146(ptr) Variable UniformConstant
+             148:             TypeImage 6(float) 2D array sampled format:Unknown
+             149:             TypePointer UniformConstant 148
+150(g_tTex2df4a):    149(ptr) Variable UniformConstant
+             151:             TypeImage 24(int) 2D array sampled format:Unknown
+             152:             TypePointer UniformConstant 151
+153(g_tTex2di4a):    152(ptr) Variable UniformConstant
+             154:             TypeImage 41(int) 2D array sampled format:Unknown
+             155:             TypePointer UniformConstant 154
+156(g_tTex2du4a):    155(ptr) Variable UniformConstant
+             157:             TypeImage 6(float) Cube array sampled format:Unknown
+             158:             TypePointer UniformConstant 157
+159(g_tTexcdf4a):    158(ptr) Variable UniformConstant
+             160:             TypeImage 24(int) Cube array sampled format:Unknown
+             161:             TypePointer UniformConstant 160
+162(g_tTexcdi4a):    161(ptr) Variable UniformConstant
+             163:             TypeImage 41(int) Cube array sampled format:Unknown
+             164:             TypePointer UniformConstant 163
+165(g_tTexcdu4a):    164(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
           8(r01):      7(ptr) Variable Function
-         26(r03):      7(ptr) Variable Function
-         37(r05):      7(ptr) Variable Function
-         49(r21):      7(ptr) Variable Function
-         67(r23):      7(ptr) Variable Function
-         79(r25):      7(ptr) Variable Function
-       94(psout):     93(ptr) Variable Function
+         28(r03):      7(ptr) Variable Function
+         40(r05):      7(ptr) Variable Function
+         53(r21):      7(ptr) Variable Function
+         73(r23):      7(ptr) Variable Function
+         87(r25):      7(ptr) Variable Function
+      104(psout):    103(ptr) Variable Function
               12:           9 Load 11(g_tTex1df4)
               16:          13 Load 15(g_sSamp)
               19:          18 SampledImage 12 16
-              24:    6(float) CompositeExtract 20 0
-              25:    6(float) ImageSampleDrefImplicitLod 19 20 24 ConstOffset 23
-                              Store 8(r01) 25
-              30:          27 Load 29(g_tTex1di4)
-              31:          13 Load 15(g_sSamp)
-              34:          33 SampledImage 30 31
-              35:    6(float) CompositeExtract 20 0
-              36:    6(float) ImageSampleDrefImplicitLod 34 20 35 ConstOffset 23
-                              Store 26(r03) 36
-              42:          39 Load 41(g_tTex1du4)
-              43:          13 Load 15(g_sSamp)
-              46:          45 SampledImage 42 43
-              47:    6(float) CompositeExtract 20 0
-              48:    6(float) ImageSampleDrefImplicitLod 46 20 47 ConstOffset 23
-                              Store 37(r05) 48
-              53:          50 Load 52(g_tTex2df4)
-              54:          13 Load 15(g_sSamp)
-              57:          56 SampledImage 53 54
-              61:    6(float) CompositeExtract 60 0
-              65:    6(float) CompositeExtract 61 0
-              66:    6(float) ImageSampleDrefImplicitLod 57 61 65 ConstOffset 64
-                              Store 49(r21) 66
-              71:          68 Load 70(g_tTex2di4)
-              72:          13 Load 15(g_sSamp)
-              75:          74 SampledImage 71 72
-              76:    6(float) CompositeExtract 60 0
-              77:    6(float) CompositeExtract 76 0
-              78:    6(float) ImageSampleDrefImplicitLod 75 76 77 ConstOffset 64
-                              Store 67(r23) 78
-              83:          80 Load 82(g_tTex2du4)
-              84:          13 Load 15(g_sSamp)
-              87:          86 SampledImage 83 84
-              88:    6(float) CompositeExtract 60 0
-              89:    6(float) CompositeExtract 88 0
-              90:    6(float) ImageSampleDrefImplicitLod 87 88 89 ConstOffset 64
-                              Store 79(r25) 90
-              99:     98(ptr) AccessChain 94(psout) 95
-                              Store 99 97
-             101:      7(ptr) AccessChain 94(psout) 100
-                              Store 101 96
-             104:     98(ptr) AccessChain 94(psout) 95
-             105:   91(fvec4) Load 104
-                              Store 103(Color) 105
-             108:      7(ptr) AccessChain 94(psout) 100
-             109:    6(float) Load 108
-                              Store 107(Depth) 109
+              23:   22(fvec2) CompositeConstruct 20 21
+              26:    6(float) CompositeExtract 23 1
+              27:    6(float) ImageSampleDrefImplicitLod 19 23 26 ConstOffset 25
+                              Store 8(r01) 27
+              32:          29 Load 31(g_tTex1di4)
+              33:          13 Load 15(g_sSamp)
+              36:          35 SampledImage 32 33
+              37:   22(fvec2) CompositeConstruct 20 21
+              38:    6(float) CompositeExtract 37 1
+              39:    6(float) ImageSampleDrefImplicitLod 36 37 38 ConstOffset 25
+                              Store 28(r03) 39
+              45:          42 Load 44(g_tTex1du4)
+              46:          13 Load 15(g_sSamp)
+              49:          48 SampledImage 45 46
+              50:   22(fvec2) CompositeConstruct 20 21
+              51:    6(float) CompositeExtract 50 1
+              52:    6(float) ImageSampleDrefImplicitLod 49 50 51 ConstOffset 25
+                              Store 40(r05) 52
+              57:          54 Load 56(g_tTex2df4)
+              58:          13 Load 15(g_sSamp)
+              61:          60 SampledImage 57 58
+              65:    6(float) CompositeExtract 63 0
+              66:    6(float) CompositeExtract 63 1
+              67:   64(fvec3) CompositeConstruct 65 66 21
+              71:    6(float) CompositeExtract 67 2
+              72:    6(float) ImageSampleDrefImplicitLod 61 67 71 ConstOffset 70
+                              Store 53(r21) 72
+              77:          74 Load 76(g_tTex2di4)
+              78:          13 Load 15(g_sSamp)
+              81:          80 SampledImage 77 78
+              82:    6(float) CompositeExtract 63 0
+              83:    6(float) CompositeExtract 63 1
+              84:   64(fvec3) CompositeConstruct 82 83 21
+              85:    6(float) CompositeExtract 84 2
+              86:    6(float) ImageSampleDrefImplicitLod 81 84 85 ConstOffset 70
+                              Store 73(r23) 86
+              91:          88 Load 90(g_tTex2du4)
+              92:          13 Load 15(g_sSamp)
+              95:          94 SampledImage 91 92
+              96:    6(float) CompositeExtract 63 0
+              97:    6(float) CompositeExtract 63 1
+              98:   64(fvec3) CompositeConstruct 96 97 21
+              99:    6(float) CompositeExtract 98 2
+             100:    6(float) ImageSampleDrefImplicitLod 95 98 99 ConstOffset 70
+                              Store 87(r25) 100
+             109:    108(ptr) AccessChain 104(psout) 105
+                              Store 109 107
+             111:      7(ptr) AccessChain 104(psout) 110
+                              Store 111 106
+             114:    108(ptr) AccessChain 104(psout) 105
+             115:  101(fvec4) Load 114
+                              Store 113(Color) 115
+             118:      7(ptr) AccessChain 104(psout) 110
+             119:    6(float) Load 118
+                              Store 117(Depth) 119
                               Return
                               FunctionEnd

--- a/Test/baseResults/hlsl.samplecmp.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmp.offsetarray.dx10.frag.out
@@ -12,7 +12,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DArrayShadow)
 0:42              'g_tTex1df4a' (uniform texture1DArray)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec3 (temp float)
+0:42            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -27,7 +27,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DArrayShadow)
 0:43              'g_tTex1di4a' (uniform itexture1DArray)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec3 (temp float)
+0:43            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -42,7 +42,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DArrayShadow)
 0:44              'g_tTex1du4a' (uniform utexture1DArray)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec3 (temp float)
+0:44            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -57,7 +57,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DArrayShadow)
 0:47              'g_tTex2df4a' (uniform texture2DArray)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec4 (temp float)
+0:47            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -74,7 +74,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DArrayShadow)
 0:48              'g_tTex2di4a' (uniform itexture2DArray)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec4 (temp float)
+0:48            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -91,7 +91,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DArrayShadow)
 0:49              'g_tTex2du4a' (uniform utexture2DArray)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec4 (temp float)
+0:49            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -176,7 +176,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DArrayShadow)
 0:42              'g_tTex1df4a' (uniform texture1DArray)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec3 (temp float)
+0:42            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -191,7 +191,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DArrayShadow)
 0:43              'g_tTex1di4a' (uniform itexture1DArray)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec3 (temp float)
+0:43            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -206,7 +206,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DArrayShadow)
 0:44              'g_tTex1du4a' (uniform utexture1DArray)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec3 (temp float)
+0:44            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -221,7 +221,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DArrayShadow)
 0:47              'g_tTex2df4a' (uniform texture2DArray)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec4 (temp float)
+0:47            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -238,7 +238,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DArrayShadow)
 0:48              'g_tTex2di4a' (uniform itexture2DArray)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec4 (temp float)
+0:48            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -255,7 +255,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DArrayShadow)
 0:49              'g_tTex2du4a' (uniform utexture2DArray)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec4 (temp float)
+0:49            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -325,76 +325,76 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 162
+// Id's are bound by 177
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 109 113
+                              EntryPoint Fragment 4  "main" 124 128
                               ExecutionMode 4 OriginUpperLeft
                               Name 4  "main"
                               Name 8  "r11"
                               Name 11  "g_tTex1df4a"
                               Name 15  "g_sSamp"
-                              Name 30  "r13"
-                              Name 33  "g_tTex1di4a"
-                              Name 42  "r15"
-                              Name 46  "g_tTex1du4a"
-                              Name 55  "r31"
-                              Name 58  "g_tTex2df4a"
-                              Name 73  "r33"
-                              Name 76  "g_tTex2di4a"
-                              Name 85  "r35"
-                              Name 88  "g_tTex2du4a"
-                              Name 98  "PS_OUTPUT"
-                              MemberName 98(PS_OUTPUT) 0  "Color"
-                              MemberName 98(PS_OUTPUT) 1  "Depth"
-                              Name 100  "psout"
-                              Name 109  "Color"
-                              Name 113  "Depth"
-                              Name 119  "g_tTex1df4"
-                              Name 122  "g_tTex1di4"
-                              Name 125  "g_tTex1du4"
-                              Name 128  "g_tTex2df4"
-                              Name 131  "g_tTex2di4"
-                              Name 134  "g_tTex2du4"
-                              Name 137  "g_tTex3df4"
-                              Name 140  "g_tTex3di4"
-                              Name 143  "g_tTex3du4"
-                              Name 146  "g_tTexcdf4"
-                              Name 149  "g_tTexcdi4"
-                              Name 152  "g_tTexcdu4"
-                              Name 155  "g_tTexcdf4a"
-                              Name 158  "g_tTexcdi4a"
-                              Name 161  "g_tTexcdu4a"
+                              Name 33  "r13"
+                              Name 36  "g_tTex1di4a"
+                              Name 47  "r15"
+                              Name 51  "g_tTex1du4a"
+                              Name 62  "r31"
+                              Name 65  "g_tTex2df4a"
+                              Name 83  "r33"
+                              Name 86  "g_tTex2di4a"
+                              Name 98  "r35"
+                              Name 101  "g_tTex2du4a"
+                              Name 113  "PS_OUTPUT"
+                              MemberName 113(PS_OUTPUT) 0  "Color"
+                              MemberName 113(PS_OUTPUT) 1  "Depth"
+                              Name 115  "psout"
+                              Name 124  "Color"
+                              Name 128  "Depth"
+                              Name 134  "g_tTex1df4"
+                              Name 137  "g_tTex1di4"
+                              Name 140  "g_tTex1du4"
+                              Name 143  "g_tTex2df4"
+                              Name 146  "g_tTex2di4"
+                              Name 149  "g_tTex2du4"
+                              Name 152  "g_tTex3df4"
+                              Name 155  "g_tTex3di4"
+                              Name 158  "g_tTex3du4"
+                              Name 161  "g_tTexcdf4"
+                              Name 164  "g_tTexcdi4"
+                              Name 167  "g_tTexcdu4"
+                              Name 170  "g_tTexcdf4a"
+                              Name 173  "g_tTexcdi4a"
+                              Name 176  "g_tTexcdu4a"
                               Decorate 11(g_tTex1df4a) DescriptorSet 0
                               Decorate 15(g_sSamp) DescriptorSet 0
                               Decorate 15(g_sSamp) Binding 0
-                              Decorate 33(g_tTex1di4a) DescriptorSet 0
-                              Decorate 46(g_tTex1du4a) DescriptorSet 0
-                              Decorate 58(g_tTex2df4a) DescriptorSet 0
-                              Decorate 76(g_tTex2di4a) DescriptorSet 0
-                              Decorate 88(g_tTex2du4a) DescriptorSet 0
-                              Decorate 109(Color) Location 0
-                              Decorate 113(Depth) BuiltIn FragDepth
-                              Decorate 119(g_tTex1df4) DescriptorSet 0
-                              Decorate 119(g_tTex1df4) Binding 0
-                              Decorate 122(g_tTex1di4) DescriptorSet 0
-                              Decorate 125(g_tTex1du4) DescriptorSet 0
-                              Decorate 128(g_tTex2df4) DescriptorSet 0
-                              Decorate 131(g_tTex2di4) DescriptorSet 0
-                              Decorate 134(g_tTex2du4) DescriptorSet 0
-                              Decorate 137(g_tTex3df4) DescriptorSet 0
-                              Decorate 140(g_tTex3di4) DescriptorSet 0
-                              Decorate 143(g_tTex3du4) DescriptorSet 0
-                              Decorate 146(g_tTexcdf4) DescriptorSet 0
-                              Decorate 149(g_tTexcdi4) DescriptorSet 0
-                              Decorate 152(g_tTexcdu4) DescriptorSet 0
-                              Decorate 155(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 158(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 161(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 36(g_tTex1di4a) DescriptorSet 0
+                              Decorate 51(g_tTex1du4a) DescriptorSet 0
+                              Decorate 65(g_tTex2df4a) DescriptorSet 0
+                              Decorate 86(g_tTex2di4a) DescriptorSet 0
+                              Decorate 101(g_tTex2du4a) DescriptorSet 0
+                              Decorate 124(Color) Location 0
+                              Decorate 128(Depth) BuiltIn FragDepth
+                              Decorate 134(g_tTex1df4) DescriptorSet 0
+                              Decorate 134(g_tTex1df4) Binding 0
+                              Decorate 137(g_tTex1di4) DescriptorSet 0
+                              Decorate 140(g_tTex1du4) DescriptorSet 0
+                              Decorate 143(g_tTex2df4) DescriptorSet 0
+                              Decorate 146(g_tTex2di4) DescriptorSet 0
+                              Decorate 149(g_tTex2du4) DescriptorSet 0
+                              Decorate 152(g_tTex3df4) DescriptorSet 0
+                              Decorate 155(g_tTex3di4) DescriptorSet 0
+                              Decorate 158(g_tTex3du4) DescriptorSet 0
+                              Decorate 161(g_tTexcdf4) DescriptorSet 0
+                              Decorate 164(g_tTexcdi4) DescriptorSet 0
+                              Decorate 167(g_tTexcdu4) DescriptorSet 0
+                              Decorate 170(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 173(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 176(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -412,157 +412,172 @@ gl_FragCoord origin is upper left
               22:    6(float) Constant 1045220557
               23:   20(fvec2) ConstantComposite 21 22
               24:    6(float) Constant 1061158912
-              26:             TypeInt 32 1
-              27:     26(int) Constant 2
-              31:             TypeImage 26(int) 1D array sampled format:Unknown
-              32:             TypePointer UniformConstant 31
- 33(g_tTex1di4a):     32(ptr) Variable UniformConstant
-              36:             TypeImage 26(int) 1D depth array sampled format:Unknown
-              37:             TypeSampledImage 36
-              43:             TypeInt 32 0
-              44:             TypeImage 43(int) 1D array sampled format:Unknown
-              45:             TypePointer UniformConstant 44
- 46(g_tTex1du4a):     45(ptr) Variable UniformConstant
-              49:             TypeImage 43(int) 1D depth array sampled format:Unknown
-              50:             TypeSampledImage 49
-              56:             TypeImage 6(float) 2D array sampled format:Unknown
-              57:             TypePointer UniformConstant 56
- 58(g_tTex2df4a):     57(ptr) Variable UniformConstant
-              61:             TypeImage 6(float) 2D depth array sampled format:Unknown
-              62:             TypeSampledImage 61
-              64:             TypeVector 6(float) 3
-              65:    6(float) Constant 1050253722
-              66:   64(fvec3) ConstantComposite 21 22 65
-              68:             TypeVector 26(int) 2
-              69:     26(int) Constant 3
-              70:   68(ivec2) ConstantComposite 27 69
-              74:             TypeImage 26(int) 2D array sampled format:Unknown
-              75:             TypePointer UniformConstant 74
- 76(g_tTex2di4a):     75(ptr) Variable UniformConstant
-              79:             TypeImage 26(int) 2D depth array sampled format:Unknown
-              80:             TypeSampledImage 79
-              86:             TypeImage 43(int) 2D array sampled format:Unknown
-              87:             TypePointer UniformConstant 86
- 88(g_tTex2du4a):     87(ptr) Variable UniformConstant
-              91:             TypeImage 43(int) 2D depth array sampled format:Unknown
-              92:             TypeSampledImage 91
-              97:             TypeVector 6(float) 4
-   98(PS_OUTPUT):             TypeStruct 97(fvec4) 6(float)
-              99:             TypePointer Function 98(PS_OUTPUT)
-             101:     26(int) Constant 0
-             102:    6(float) Constant 1065353216
-             103:   97(fvec4) ConstantComposite 102 102 102 102
-             104:             TypePointer Function 97(fvec4)
-             106:     26(int) Constant 1
-             108:             TypePointer Output 97(fvec4)
-      109(Color):    108(ptr) Variable Output
-             112:             TypePointer Output 6(float)
-      113(Depth):    112(ptr) Variable Output
-             117:             TypeImage 6(float) 1D sampled format:Unknown
-             118:             TypePointer UniformConstant 117
- 119(g_tTex1df4):    118(ptr) Variable UniformConstant
-             120:             TypeImage 26(int) 1D sampled format:Unknown
-             121:             TypePointer UniformConstant 120
- 122(g_tTex1di4):    121(ptr) Variable UniformConstant
-             123:             TypeImage 43(int) 1D sampled format:Unknown
-             124:             TypePointer UniformConstant 123
- 125(g_tTex1du4):    124(ptr) Variable UniformConstant
-             126:             TypeImage 6(float) 2D sampled format:Unknown
-             127:             TypePointer UniformConstant 126
- 128(g_tTex2df4):    127(ptr) Variable UniformConstant
-             129:             TypeImage 26(int) 2D sampled format:Unknown
-             130:             TypePointer UniformConstant 129
- 131(g_tTex2di4):    130(ptr) Variable UniformConstant
-             132:             TypeImage 43(int) 2D sampled format:Unknown
+              25:             TypeVector 6(float) 3
+              29:             TypeInt 32 1
+              30:     29(int) Constant 2
+              34:             TypeImage 29(int) 1D array sampled format:Unknown
+              35:             TypePointer UniformConstant 34
+ 36(g_tTex1di4a):     35(ptr) Variable UniformConstant
+              39:             TypeImage 29(int) 1D depth array sampled format:Unknown
+              40:             TypeSampledImage 39
+              48:             TypeInt 32 0
+              49:             TypeImage 48(int) 1D array sampled format:Unknown
+              50:             TypePointer UniformConstant 49
+ 51(g_tTex1du4a):     50(ptr) Variable UniformConstant
+              54:             TypeImage 48(int) 1D depth array sampled format:Unknown
+              55:             TypeSampledImage 54
+              63:             TypeImage 6(float) 2D array sampled format:Unknown
+              64:             TypePointer UniformConstant 63
+ 65(g_tTex2df4a):     64(ptr) Variable UniformConstant
+              68:             TypeImage 6(float) 2D depth array sampled format:Unknown
+              69:             TypeSampledImage 68
+              71:    6(float) Constant 1050253722
+              72:   25(fvec3) ConstantComposite 21 22 71
+              73:             TypeVector 6(float) 4
+              78:             TypeVector 29(int) 2
+              79:     29(int) Constant 3
+              80:   78(ivec2) ConstantComposite 30 79
+              84:             TypeImage 29(int) 2D array sampled format:Unknown
+              85:             TypePointer UniformConstant 84
+ 86(g_tTex2di4a):     85(ptr) Variable UniformConstant
+              89:             TypeImage 29(int) 2D depth array sampled format:Unknown
+              90:             TypeSampledImage 89
+              99:             TypeImage 48(int) 2D array sampled format:Unknown
+             100:             TypePointer UniformConstant 99
+101(g_tTex2du4a):    100(ptr) Variable UniformConstant
+             104:             TypeImage 48(int) 2D depth array sampled format:Unknown
+             105:             TypeSampledImage 104
+  113(PS_OUTPUT):             TypeStruct 73(fvec4) 6(float)
+             114:             TypePointer Function 113(PS_OUTPUT)
+             116:     29(int) Constant 0
+             117:    6(float) Constant 1065353216
+             118:   73(fvec4) ConstantComposite 117 117 117 117
+             119:             TypePointer Function 73(fvec4)
+             121:     29(int) Constant 1
+             123:             TypePointer Output 73(fvec4)
+      124(Color):    123(ptr) Variable Output
+             127:             TypePointer Output 6(float)
+      128(Depth):    127(ptr) Variable Output
+             132:             TypeImage 6(float) 1D sampled format:Unknown
              133:             TypePointer UniformConstant 132
- 134(g_tTex2du4):    133(ptr) Variable UniformConstant
-             135:             TypeImage 6(float) 3D sampled format:Unknown
+ 134(g_tTex1df4):    133(ptr) Variable UniformConstant
+             135:             TypeImage 29(int) 1D sampled format:Unknown
              136:             TypePointer UniformConstant 135
- 137(g_tTex3df4):    136(ptr) Variable UniformConstant
-             138:             TypeImage 26(int) 3D sampled format:Unknown
+ 137(g_tTex1di4):    136(ptr) Variable UniformConstant
+             138:             TypeImage 48(int) 1D sampled format:Unknown
              139:             TypePointer UniformConstant 138
- 140(g_tTex3di4):    139(ptr) Variable UniformConstant
-             141:             TypeImage 43(int) 3D sampled format:Unknown
+ 140(g_tTex1du4):    139(ptr) Variable UniformConstant
+             141:             TypeImage 6(float) 2D sampled format:Unknown
              142:             TypePointer UniformConstant 141
- 143(g_tTex3du4):    142(ptr) Variable UniformConstant
-             144:             TypeImage 6(float) Cube sampled format:Unknown
+ 143(g_tTex2df4):    142(ptr) Variable UniformConstant
+             144:             TypeImage 29(int) 2D sampled format:Unknown
              145:             TypePointer UniformConstant 144
- 146(g_tTexcdf4):    145(ptr) Variable UniformConstant
-             147:             TypeImage 26(int) Cube sampled format:Unknown
+ 146(g_tTex2di4):    145(ptr) Variable UniformConstant
+             147:             TypeImage 48(int) 2D sampled format:Unknown
              148:             TypePointer UniformConstant 147
- 149(g_tTexcdi4):    148(ptr) Variable UniformConstant
-             150:             TypeImage 43(int) Cube sampled format:Unknown
+ 149(g_tTex2du4):    148(ptr) Variable UniformConstant
+             150:             TypeImage 6(float) 3D sampled format:Unknown
              151:             TypePointer UniformConstant 150
- 152(g_tTexcdu4):    151(ptr) Variable UniformConstant
-             153:             TypeImage 6(float) Cube array sampled format:Unknown
+ 152(g_tTex3df4):    151(ptr) Variable UniformConstant
+             153:             TypeImage 29(int) 3D sampled format:Unknown
              154:             TypePointer UniformConstant 153
-155(g_tTexcdf4a):    154(ptr) Variable UniformConstant
-             156:             TypeImage 26(int) Cube array sampled format:Unknown
+ 155(g_tTex3di4):    154(ptr) Variable UniformConstant
+             156:             TypeImage 48(int) 3D sampled format:Unknown
              157:             TypePointer UniformConstant 156
-158(g_tTexcdi4a):    157(ptr) Variable UniformConstant
-             159:             TypeImage 43(int) Cube array sampled format:Unknown
+ 158(g_tTex3du4):    157(ptr) Variable UniformConstant
+             159:             TypeImage 6(float) Cube sampled format:Unknown
              160:             TypePointer UniformConstant 159
-161(g_tTexcdu4a):    160(ptr) Variable UniformConstant
+ 161(g_tTexcdf4):    160(ptr) Variable UniformConstant
+             162:             TypeImage 29(int) Cube sampled format:Unknown
+             163:             TypePointer UniformConstant 162
+ 164(g_tTexcdi4):    163(ptr) Variable UniformConstant
+             165:             TypeImage 48(int) Cube sampled format:Unknown
+             166:             TypePointer UniformConstant 165
+ 167(g_tTexcdu4):    166(ptr) Variable UniformConstant
+             168:             TypeImage 6(float) Cube array sampled format:Unknown
+             169:             TypePointer UniformConstant 168
+170(g_tTexcdf4a):    169(ptr) Variable UniformConstant
+             171:             TypeImage 29(int) Cube array sampled format:Unknown
+             172:             TypePointer UniformConstant 171
+173(g_tTexcdi4a):    172(ptr) Variable UniformConstant
+             174:             TypeImage 48(int) Cube array sampled format:Unknown
+             175:             TypePointer UniformConstant 174
+176(g_tTexcdu4a):    175(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
           8(r11):      7(ptr) Variable Function
-         30(r13):      7(ptr) Variable Function
-         42(r15):      7(ptr) Variable Function
-         55(r31):      7(ptr) Variable Function
-         73(r33):      7(ptr) Variable Function
-         85(r35):      7(ptr) Variable Function
-      100(psout):     99(ptr) Variable Function
+         33(r13):      7(ptr) Variable Function
+         47(r15):      7(ptr) Variable Function
+         62(r31):      7(ptr) Variable Function
+         83(r33):      7(ptr) Variable Function
+         98(r35):      7(ptr) Variable Function
+      115(psout):    114(ptr) Variable Function
               12:           9 Load 11(g_tTex1df4a)
               16:          13 Load 15(g_sSamp)
               19:          18 SampledImage 12 16
-              25:    6(float) CompositeExtract 23 0
-              28:    6(float) CompositeExtract 25 0
-              29:    6(float) ImageSampleDrefImplicitLod 19 25 28 ConstOffset 27
-                              Store 8(r11) 29
-              34:          31 Load 33(g_tTex1di4a)
-              35:          13 Load 15(g_sSamp)
-              38:          37 SampledImage 34 35
-              39:    6(float) CompositeExtract 23 0
-              40:    6(float) CompositeExtract 39 0
-              41:    6(float) ImageSampleDrefImplicitLod 38 39 40 ConstOffset 27
-                              Store 30(r13) 41
-              47:          44 Load 46(g_tTex1du4a)
-              48:          13 Load 15(g_sSamp)
-              51:          50 SampledImage 47 48
-              52:    6(float) CompositeExtract 23 0
-              53:    6(float) CompositeExtract 52 0
-              54:    6(float) ImageSampleDrefImplicitLod 51 52 53 ConstOffset 27
-                              Store 42(r15) 54
-              59:          56 Load 58(g_tTex2df4a)
-              60:          13 Load 15(g_sSamp)
-              63:          62 SampledImage 59 60
-              67:    6(float) CompositeExtract 66 0
-              71:    6(float) CompositeExtract 67 0
-              72:    6(float) ImageSampleDrefImplicitLod 63 67 71 ConstOffset 70
-                              Store 55(r31) 72
-              77:          74 Load 76(g_tTex2di4a)
-              78:          13 Load 15(g_sSamp)
-              81:          80 SampledImage 77 78
-              82:    6(float) CompositeExtract 66 0
-              83:    6(float) CompositeExtract 82 0
-              84:    6(float) ImageSampleDrefImplicitLod 81 82 83 ConstOffset 70
-                              Store 73(r33) 84
-              89:          86 Load 88(g_tTex2du4a)
-              90:          13 Load 15(g_sSamp)
-              93:          92 SampledImage 89 90
-              94:    6(float) CompositeExtract 66 0
-              95:    6(float) CompositeExtract 94 0
-              96:    6(float) ImageSampleDrefImplicitLod 93 94 95 ConstOffset 70
-                              Store 85(r35) 96
-             105:    104(ptr) AccessChain 100(psout) 101
-                              Store 105 103
-             107:      7(ptr) AccessChain 100(psout) 106
-                              Store 107 102
-             110:    104(ptr) AccessChain 100(psout) 101
-             111:   97(fvec4) Load 110
-                              Store 109(Color) 111
-             114:      7(ptr) AccessChain 100(psout) 106
-             115:    6(float) Load 114
-                              Store 113(Depth) 115
+              26:    6(float) CompositeExtract 23 0
+              27:    6(float) CompositeExtract 23 1
+              28:   25(fvec3) CompositeConstruct 26 27 24
+              31:    6(float) CompositeExtract 28 2
+              32:    6(float) ImageSampleDrefImplicitLod 19 28 31 ConstOffset 30
+                              Store 8(r11) 32
+              37:          34 Load 36(g_tTex1di4a)
+              38:          13 Load 15(g_sSamp)
+              41:          40 SampledImage 37 38
+              42:    6(float) CompositeExtract 23 0
+              43:    6(float) CompositeExtract 23 1
+              44:   25(fvec3) CompositeConstruct 42 43 24
+              45:    6(float) CompositeExtract 44 2
+              46:    6(float) ImageSampleDrefImplicitLod 41 44 45 ConstOffset 30
+                              Store 33(r13) 46
+              52:          49 Load 51(g_tTex1du4a)
+              53:          13 Load 15(g_sSamp)
+              56:          55 SampledImage 52 53
+              57:    6(float) CompositeExtract 23 0
+              58:    6(float) CompositeExtract 23 1
+              59:   25(fvec3) CompositeConstruct 57 58 24
+              60:    6(float) CompositeExtract 59 2
+              61:    6(float) ImageSampleDrefImplicitLod 56 59 60 ConstOffset 30
+                              Store 47(r15) 61
+              66:          63 Load 65(g_tTex2df4a)
+              67:          13 Load 15(g_sSamp)
+              70:          69 SampledImage 66 67
+              74:    6(float) CompositeExtract 72 0
+              75:    6(float) CompositeExtract 72 1
+              76:    6(float) CompositeExtract 72 2
+              77:   73(fvec4) CompositeConstruct 74 75 76 24
+              81:    6(float) CompositeExtract 77 3
+              82:    6(float) ImageSampleDrefImplicitLod 70 77 81 ConstOffset 80
+                              Store 62(r31) 82
+              87:          84 Load 86(g_tTex2di4a)
+              88:          13 Load 15(g_sSamp)
+              91:          90 SampledImage 87 88
+              92:    6(float) CompositeExtract 72 0
+              93:    6(float) CompositeExtract 72 1
+              94:    6(float) CompositeExtract 72 2
+              95:   73(fvec4) CompositeConstruct 92 93 94 24
+              96:    6(float) CompositeExtract 95 3
+              97:    6(float) ImageSampleDrefImplicitLod 91 95 96 ConstOffset 80
+                              Store 83(r33) 97
+             102:          99 Load 101(g_tTex2du4a)
+             103:          13 Load 15(g_sSamp)
+             106:         105 SampledImage 102 103
+             107:    6(float) CompositeExtract 72 0
+             108:    6(float) CompositeExtract 72 1
+             109:    6(float) CompositeExtract 72 2
+             110:   73(fvec4) CompositeConstruct 107 108 109 24
+             111:    6(float) CompositeExtract 110 3
+             112:    6(float) ImageSampleDrefImplicitLod 106 110 111 ConstOffset 80
+                              Store 98(r35) 112
+             120:    119(ptr) AccessChain 115(psout) 116
+                              Store 120 118
+             122:      7(ptr) AccessChain 115(psout) 121
+                              Store 122 117
+             125:    119(ptr) AccessChain 115(psout) 116
+             126:   73(fvec4) Load 125
+                              Store 124(Color) 126
+             129:      7(ptr) AccessChain 115(psout) 121
+             130:    6(float) Load 129
+                              Store 128(Depth) 130
                               Return
                               FunctionEnd

--- a/Test/baseResults/hlsl.samplecmplevelzero.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmplevelzero.array.dx10.frag.out
@@ -12,7 +12,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DArrayShadow)
 0:42              'g_tTex1df4a' (uniform texture1DArray)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec3 (temp float)
+0:42            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -27,7 +27,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DArrayShadow)
 0:43              'g_tTex1di4a' (uniform itexture1DArray)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec3 (temp float)
+0:43            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -42,7 +42,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DArrayShadow)
 0:44              'g_tTex1du4a' (uniform utexture1DArray)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec3 (temp float)
+0:44            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -57,7 +57,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DArrayShadow)
 0:47              'g_tTex2df4a' (uniform texture2DArray)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec4 (temp float)
+0:47            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -73,7 +73,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DArrayShadow)
 0:48              'g_tTex2di4a' (uniform itexture2DArray)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec4 (temp float)
+0:48            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -89,7 +89,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DArrayShadow)
 0:49              'g_tTex2du4a' (uniform utexture2DArray)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec4 (temp float)
+0:49            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -105,7 +105,7 @@ gl_FragCoord origin is upper left
 0:52            Construct combined texture-sampler (temp samplerCubeArrayShadow)
 0:52              'g_tTexcdf4a' (uniform textureCubeArray)
 0:52              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:52            Construct vec4 (temp float)
+0:52            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -122,7 +122,7 @@ gl_FragCoord origin is upper left
 0:53            Construct combined texture-sampler (temp isamplerCubeArrayShadow)
 0:53              'g_tTexcdi4a' (uniform itextureCubeArray)
 0:53              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:53            Construct vec4 (temp float)
+0:53            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -139,7 +139,7 @@ gl_FragCoord origin is upper left
 0:54            Construct combined texture-sampler (temp usamplerCubeArrayShadow)
 0:54              'g_tTexcdu4a' (uniform utextureCubeArray)
 0:54              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:54            Construct vec4 (temp float)
+0:54            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -224,7 +224,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DArrayShadow)
 0:42              'g_tTex1df4a' (uniform texture1DArray)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec3 (temp float)
+0:42            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -239,7 +239,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DArrayShadow)
 0:43              'g_tTex1di4a' (uniform itexture1DArray)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec3 (temp float)
+0:43            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -254,7 +254,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DArrayShadow)
 0:44              'g_tTex1du4a' (uniform utexture1DArray)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec3 (temp float)
+0:44            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -269,7 +269,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DArrayShadow)
 0:47              'g_tTex2df4a' (uniform texture2DArray)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec4 (temp float)
+0:47            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -285,7 +285,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DArrayShadow)
 0:48              'g_tTex2di4a' (uniform itexture2DArray)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec4 (temp float)
+0:48            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -301,7 +301,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DArrayShadow)
 0:49              'g_tTex2du4a' (uniform utexture2DArray)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec4 (temp float)
+0:49            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -317,7 +317,7 @@ gl_FragCoord origin is upper left
 0:52            Construct combined texture-sampler (temp samplerCubeArrayShadow)
 0:52              'g_tTexcdf4a' (uniform textureCubeArray)
 0:52              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:52            Construct vec4 (temp float)
+0:52            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -334,7 +334,7 @@ gl_FragCoord origin is upper left
 0:53            Construct combined texture-sampler (temp isamplerCubeArrayShadow)
 0:53              'g_tTexcdi4a' (uniform itextureCubeArray)
 0:53              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:53            Construct vec4 (temp float)
+0:53            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -351,7 +351,7 @@ gl_FragCoord origin is upper left
 0:54            Construct combined texture-sampler (temp usamplerCubeArrayShadow)
 0:54              'g_tTexcdu4a' (uniform utextureCubeArray)
 0:54              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:54            Construct vec4 (temp float)
+0:54            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -421,79 +421,79 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 185
+// Id's are bound by 212
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 141 145
+                              EntryPoint Fragment 4  "main" 168 172
                               ExecutionMode 4 OriginUpperLeft
                               Name 4  "main"
                               Name 8  "r10"
                               Name 11  "g_tTex1df4a"
                               Name 15  "g_sSamp"
-                              Name 29  "r12"
-                              Name 33  "g_tTex1di4a"
-                              Name 42  "r14"
-                              Name 46  "g_tTex1du4a"
-                              Name 55  "r30"
-                              Name 58  "g_tTex2df4a"
-                              Name 70  "r32"
-                              Name 73  "g_tTex2di4a"
-                              Name 82  "r34"
-                              Name 85  "g_tTex2du4a"
-                              Name 94  "r60"
-                              Name 97  "g_tTexcdf4a"
-                              Name 108  "r62"
-                              Name 111  "g_tTexcdi4a"
-                              Name 119  "r64"
-                              Name 122  "g_tTexcdu4a"
-                              Name 130  "PS_OUTPUT"
-                              MemberName 130(PS_OUTPUT) 0  "Color"
-                              MemberName 130(PS_OUTPUT) 1  "Depth"
-                              Name 132  "psout"
-                              Name 141  "Color"
-                              Name 145  "Depth"
-                              Name 151  "g_tTex1df4"
-                              Name 154  "g_tTex1di4"
-                              Name 157  "g_tTex1du4"
-                              Name 160  "g_tTex2df4"
-                              Name 163  "g_tTex2di4"
-                              Name 166  "g_tTex2du4"
-                              Name 169  "g_tTex3df4"
-                              Name 172  "g_tTex3di4"
-                              Name 175  "g_tTex3du4"
-                              Name 178  "g_tTexcdf4"
-                              Name 181  "g_tTexcdi4"
-                              Name 184  "g_tTexcdu4"
+                              Name 32  "r12"
+                              Name 36  "g_tTex1di4a"
+                              Name 47  "r14"
+                              Name 51  "g_tTex1du4a"
+                              Name 62  "r30"
+                              Name 65  "g_tTex2df4a"
+                              Name 80  "r32"
+                              Name 83  "g_tTex2di4a"
+                              Name 95  "r34"
+                              Name 98  "g_tTex2du4a"
+                              Name 110  "r60"
+                              Name 113  "g_tTexcdf4a"
+                              Name 127  "r62"
+                              Name 130  "g_tTexcdi4a"
+                              Name 142  "r64"
+                              Name 145  "g_tTexcdu4a"
+                              Name 157  "PS_OUTPUT"
+                              MemberName 157(PS_OUTPUT) 0  "Color"
+                              MemberName 157(PS_OUTPUT) 1  "Depth"
+                              Name 159  "psout"
+                              Name 168  "Color"
+                              Name 172  "Depth"
+                              Name 178  "g_tTex1df4"
+                              Name 181  "g_tTex1di4"
+                              Name 184  "g_tTex1du4"
+                              Name 187  "g_tTex2df4"
+                              Name 190  "g_tTex2di4"
+                              Name 193  "g_tTex2du4"
+                              Name 196  "g_tTex3df4"
+                              Name 199  "g_tTex3di4"
+                              Name 202  "g_tTex3du4"
+                              Name 205  "g_tTexcdf4"
+                              Name 208  "g_tTexcdi4"
+                              Name 211  "g_tTexcdu4"
                               Decorate 11(g_tTex1df4a) DescriptorSet 0
                               Decorate 15(g_sSamp) DescriptorSet 0
                               Decorate 15(g_sSamp) Binding 0
-                              Decorate 33(g_tTex1di4a) DescriptorSet 0
-                              Decorate 46(g_tTex1du4a) DescriptorSet 0
-                              Decorate 58(g_tTex2df4a) DescriptorSet 0
-                              Decorate 73(g_tTex2di4a) DescriptorSet 0
-                              Decorate 85(g_tTex2du4a) DescriptorSet 0
-                              Decorate 97(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 111(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 122(g_tTexcdu4a) DescriptorSet 0
-                              Decorate 141(Color) Location 0
-                              Decorate 145(Depth) BuiltIn FragDepth
-                              Decorate 151(g_tTex1df4) DescriptorSet 0
-                              Decorate 151(g_tTex1df4) Binding 0
-                              Decorate 154(g_tTex1di4) DescriptorSet 0
-                              Decorate 157(g_tTex1du4) DescriptorSet 0
-                              Decorate 160(g_tTex2df4) DescriptorSet 0
-                              Decorate 163(g_tTex2di4) DescriptorSet 0
-                              Decorate 166(g_tTex2du4) DescriptorSet 0
-                              Decorate 169(g_tTex3df4) DescriptorSet 0
-                              Decorate 172(g_tTex3di4) DescriptorSet 0
-                              Decorate 175(g_tTex3du4) DescriptorSet 0
-                              Decorate 178(g_tTexcdf4) DescriptorSet 0
-                              Decorate 181(g_tTexcdi4) DescriptorSet 0
-                              Decorate 184(g_tTexcdu4) DescriptorSet 0
+                              Decorate 36(g_tTex1di4a) DescriptorSet 0
+                              Decorate 51(g_tTex1du4a) DescriptorSet 0
+                              Decorate 65(g_tTex2df4a) DescriptorSet 0
+                              Decorate 83(g_tTex2di4a) DescriptorSet 0
+                              Decorate 98(g_tTex2du4a) DescriptorSet 0
+                              Decorate 113(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 130(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 145(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 168(Color) Location 0
+                              Decorate 172(Depth) BuiltIn FragDepth
+                              Decorate 178(g_tTex1df4) DescriptorSet 0
+                              Decorate 178(g_tTex1df4) Binding 0
+                              Decorate 181(g_tTex1di4) DescriptorSet 0
+                              Decorate 184(g_tTex1du4) DescriptorSet 0
+                              Decorate 187(g_tTex2df4) DescriptorSet 0
+                              Decorate 190(g_tTex2di4) DescriptorSet 0
+                              Decorate 193(g_tTex2du4) DescriptorSet 0
+                              Decorate 196(g_tTex3df4) DescriptorSet 0
+                              Decorate 199(g_tTex3di4) DescriptorSet 0
+                              Decorate 202(g_tTex3du4) DescriptorSet 0
+                              Decorate 205(g_tTexcdf4) DescriptorSet 0
+                              Decorate 208(g_tTexcdi4) DescriptorSet 0
+                              Decorate 211(g_tTexcdu4) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -511,183 +511,210 @@ gl_FragCoord origin is upper left
               22:    6(float) Constant 1045220557
               23:   20(fvec2) ConstantComposite 21 22
               24:    6(float) Constant 1061158912
-              26:    6(float) Constant 0
-              30:             TypeInt 32 1
-              31:             TypeImage 30(int) 1D array sampled format:Unknown
-              32:             TypePointer UniformConstant 31
- 33(g_tTex1di4a):     32(ptr) Variable UniformConstant
-              36:             TypeImage 30(int) 1D depth array sampled format:Unknown
-              37:             TypeSampledImage 36
-              43:             TypeInt 32 0
-              44:             TypeImage 43(int) 1D array sampled format:Unknown
-              45:             TypePointer UniformConstant 44
- 46(g_tTex1du4a):     45(ptr) Variable UniformConstant
-              49:             TypeImage 43(int) 1D depth array sampled format:Unknown
-              50:             TypeSampledImage 49
-              56:             TypeImage 6(float) 2D array sampled format:Unknown
-              57:             TypePointer UniformConstant 56
- 58(g_tTex2df4a):     57(ptr) Variable UniformConstant
-              61:             TypeImage 6(float) 2D depth array sampled format:Unknown
-              62:             TypeSampledImage 61
-              64:             TypeVector 6(float) 3
-              65:    6(float) Constant 1050253722
-              66:   64(fvec3) ConstantComposite 21 22 65
-              71:             TypeImage 30(int) 2D array sampled format:Unknown
-              72:             TypePointer UniformConstant 71
- 73(g_tTex2di4a):     72(ptr) Variable UniformConstant
-              76:             TypeImage 30(int) 2D depth array sampled format:Unknown
-              77:             TypeSampledImage 76
-              83:             TypeImage 43(int) 2D array sampled format:Unknown
-              84:             TypePointer UniformConstant 83
- 85(g_tTex2du4a):     84(ptr) Variable UniformConstant
-              88:             TypeImage 43(int) 2D depth array sampled format:Unknown
-              89:             TypeSampledImage 88
-              95:             TypeImage 6(float) Cube array sampled format:Unknown
-              96:             TypePointer UniformConstant 95
- 97(g_tTexcdf4a):     96(ptr) Variable UniformConstant
-             100:             TypeImage 6(float) Cube depth array sampled format:Unknown
-             101:             TypeSampledImage 100
-             103:             TypeVector 6(float) 4
-             104:    6(float) Constant 1053609165
-             105:  103(fvec4) ConstantComposite 21 22 65 104
-             109:             TypeImage 30(int) Cube array sampled format:Unknown
-             110:             TypePointer UniformConstant 109
-111(g_tTexcdi4a):    110(ptr) Variable UniformConstant
-             114:             TypeImage 30(int) Cube depth array sampled format:Unknown
-             115:             TypeSampledImage 114
-             120:             TypeImage 43(int) Cube array sampled format:Unknown
-             121:             TypePointer UniformConstant 120
-122(g_tTexcdu4a):    121(ptr) Variable UniformConstant
-             125:             TypeImage 43(int) Cube depth array sampled format:Unknown
-             126:             TypeSampledImage 125
-  130(PS_OUTPUT):             TypeStruct 103(fvec4) 6(float)
-             131:             TypePointer Function 130(PS_OUTPUT)
-             133:     30(int) Constant 0
-             134:    6(float) Constant 1065353216
-             135:  103(fvec4) ConstantComposite 134 134 134 134
-             136:             TypePointer Function 103(fvec4)
-             138:     30(int) Constant 1
-             140:             TypePointer Output 103(fvec4)
-      141(Color):    140(ptr) Variable Output
-             144:             TypePointer Output 6(float)
-      145(Depth):    144(ptr) Variable Output
-             149:             TypeImage 6(float) 1D sampled format:Unknown
-             150:             TypePointer UniformConstant 149
- 151(g_tTex1df4):    150(ptr) Variable UniformConstant
-             152:             TypeImage 30(int) 1D sampled format:Unknown
-             153:             TypePointer UniformConstant 152
- 154(g_tTex1di4):    153(ptr) Variable UniformConstant
-             155:             TypeImage 43(int) 1D sampled format:Unknown
-             156:             TypePointer UniformConstant 155
- 157(g_tTex1du4):    156(ptr) Variable UniformConstant
-             158:             TypeImage 6(float) 2D sampled format:Unknown
-             159:             TypePointer UniformConstant 158
- 160(g_tTex2df4):    159(ptr) Variable UniformConstant
-             161:             TypeImage 30(int) 2D sampled format:Unknown
-             162:             TypePointer UniformConstant 161
- 163(g_tTex2di4):    162(ptr) Variable UniformConstant
-             164:             TypeImage 43(int) 2D sampled format:Unknown
-             165:             TypePointer UniformConstant 164
- 166(g_tTex2du4):    165(ptr) Variable UniformConstant
-             167:             TypeImage 6(float) 3D sampled format:Unknown
-             168:             TypePointer UniformConstant 167
- 169(g_tTex3df4):    168(ptr) Variable UniformConstant
-             170:             TypeImage 30(int) 3D sampled format:Unknown
-             171:             TypePointer UniformConstant 170
- 172(g_tTex3di4):    171(ptr) Variable UniformConstant
-             173:             TypeImage 43(int) 3D sampled format:Unknown
-             174:             TypePointer UniformConstant 173
- 175(g_tTex3du4):    174(ptr) Variable UniformConstant
-             176:             TypeImage 6(float) Cube sampled format:Unknown
+              25:             TypeVector 6(float) 3
+              29:    6(float) Constant 0
+              33:             TypeInt 32 1
+              34:             TypeImage 33(int) 1D array sampled format:Unknown
+              35:             TypePointer UniformConstant 34
+ 36(g_tTex1di4a):     35(ptr) Variable UniformConstant
+              39:             TypeImage 33(int) 1D depth array sampled format:Unknown
+              40:             TypeSampledImage 39
+              48:             TypeInt 32 0
+              49:             TypeImage 48(int) 1D array sampled format:Unknown
+              50:             TypePointer UniformConstant 49
+ 51(g_tTex1du4a):     50(ptr) Variable UniformConstant
+              54:             TypeImage 48(int) 1D depth array sampled format:Unknown
+              55:             TypeSampledImage 54
+              63:             TypeImage 6(float) 2D array sampled format:Unknown
+              64:             TypePointer UniformConstant 63
+ 65(g_tTex2df4a):     64(ptr) Variable UniformConstant
+              68:             TypeImage 6(float) 2D depth array sampled format:Unknown
+              69:             TypeSampledImage 68
+              71:    6(float) Constant 1050253722
+              72:   25(fvec3) ConstantComposite 21 22 71
+              73:             TypeVector 6(float) 4
+              81:             TypeImage 33(int) 2D array sampled format:Unknown
+              82:             TypePointer UniformConstant 81
+ 83(g_tTex2di4a):     82(ptr) Variable UniformConstant
+              86:             TypeImage 33(int) 2D depth array sampled format:Unknown
+              87:             TypeSampledImage 86
+              96:             TypeImage 48(int) 2D array sampled format:Unknown
+              97:             TypePointer UniformConstant 96
+ 98(g_tTex2du4a):     97(ptr) Variable UniformConstant
+             101:             TypeImage 48(int) 2D depth array sampled format:Unknown
+             102:             TypeSampledImage 101
+             111:             TypeImage 6(float) Cube array sampled format:Unknown
+             112:             TypePointer UniformConstant 111
+113(g_tTexcdf4a):    112(ptr) Variable UniformConstant
+             116:             TypeImage 6(float) Cube depth array sampled format:Unknown
+             117:             TypeSampledImage 116
+             119:    6(float) Constant 1053609165
+             120:   73(fvec4) ConstantComposite 21 22 71 119
+             128:             TypeImage 33(int) Cube array sampled format:Unknown
+             129:             TypePointer UniformConstant 128
+130(g_tTexcdi4a):    129(ptr) Variable UniformConstant
+             133:             TypeImage 33(int) Cube depth array sampled format:Unknown
+             134:             TypeSampledImage 133
+             143:             TypeImage 48(int) Cube array sampled format:Unknown
+             144:             TypePointer UniformConstant 143
+145(g_tTexcdu4a):    144(ptr) Variable UniformConstant
+             148:             TypeImage 48(int) Cube depth array sampled format:Unknown
+             149:             TypeSampledImage 148
+  157(PS_OUTPUT):             TypeStruct 73(fvec4) 6(float)
+             158:             TypePointer Function 157(PS_OUTPUT)
+             160:     33(int) Constant 0
+             161:    6(float) Constant 1065353216
+             162:   73(fvec4) ConstantComposite 161 161 161 161
+             163:             TypePointer Function 73(fvec4)
+             165:     33(int) Constant 1
+             167:             TypePointer Output 73(fvec4)
+      168(Color):    167(ptr) Variable Output
+             171:             TypePointer Output 6(float)
+      172(Depth):    171(ptr) Variable Output
+             176:             TypeImage 6(float) 1D sampled format:Unknown
              177:             TypePointer UniformConstant 176
- 178(g_tTexcdf4):    177(ptr) Variable UniformConstant
-             179:             TypeImage 30(int) Cube sampled format:Unknown
+ 178(g_tTex1df4):    177(ptr) Variable UniformConstant
+             179:             TypeImage 33(int) 1D sampled format:Unknown
              180:             TypePointer UniformConstant 179
- 181(g_tTexcdi4):    180(ptr) Variable UniformConstant
-             182:             TypeImage 43(int) Cube sampled format:Unknown
+ 181(g_tTex1di4):    180(ptr) Variable UniformConstant
+             182:             TypeImage 48(int) 1D sampled format:Unknown
              183:             TypePointer UniformConstant 182
- 184(g_tTexcdu4):    183(ptr) Variable UniformConstant
+ 184(g_tTex1du4):    183(ptr) Variable UniformConstant
+             185:             TypeImage 6(float) 2D sampled format:Unknown
+             186:             TypePointer UniformConstant 185
+ 187(g_tTex2df4):    186(ptr) Variable UniformConstant
+             188:             TypeImage 33(int) 2D sampled format:Unknown
+             189:             TypePointer UniformConstant 188
+ 190(g_tTex2di4):    189(ptr) Variable UniformConstant
+             191:             TypeImage 48(int) 2D sampled format:Unknown
+             192:             TypePointer UniformConstant 191
+ 193(g_tTex2du4):    192(ptr) Variable UniformConstant
+             194:             TypeImage 6(float) 3D sampled format:Unknown
+             195:             TypePointer UniformConstant 194
+ 196(g_tTex3df4):    195(ptr) Variable UniformConstant
+             197:             TypeImage 33(int) 3D sampled format:Unknown
+             198:             TypePointer UniformConstant 197
+ 199(g_tTex3di4):    198(ptr) Variable UniformConstant
+             200:             TypeImage 48(int) 3D sampled format:Unknown
+             201:             TypePointer UniformConstant 200
+ 202(g_tTex3du4):    201(ptr) Variable UniformConstant
+             203:             TypeImage 6(float) Cube sampled format:Unknown
+             204:             TypePointer UniformConstant 203
+ 205(g_tTexcdf4):    204(ptr) Variable UniformConstant
+             206:             TypeImage 33(int) Cube sampled format:Unknown
+             207:             TypePointer UniformConstant 206
+ 208(g_tTexcdi4):    207(ptr) Variable UniformConstant
+             209:             TypeImage 48(int) Cube sampled format:Unknown
+             210:             TypePointer UniformConstant 209
+ 211(g_tTexcdu4):    210(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
           8(r10):      7(ptr) Variable Function
-         29(r12):      7(ptr) Variable Function
-         42(r14):      7(ptr) Variable Function
-         55(r30):      7(ptr) Variable Function
-         70(r32):      7(ptr) Variable Function
-         82(r34):      7(ptr) Variable Function
-         94(r60):      7(ptr) Variable Function
-        108(r62):      7(ptr) Variable Function
-        119(r64):      7(ptr) Variable Function
-      132(psout):    131(ptr) Variable Function
+         32(r12):      7(ptr) Variable Function
+         47(r14):      7(ptr) Variable Function
+         62(r30):      7(ptr) Variable Function
+         80(r32):      7(ptr) Variable Function
+         95(r34):      7(ptr) Variable Function
+        110(r60):      7(ptr) Variable Function
+        127(r62):      7(ptr) Variable Function
+        142(r64):      7(ptr) Variable Function
+      159(psout):    158(ptr) Variable Function
               12:           9 Load 11(g_tTex1df4a)
               16:          13 Load 15(g_sSamp)
               19:          18 SampledImage 12 16
-              25:    6(float) CompositeExtract 23 0
-              27:    6(float) CompositeExtract 25 0
-              28:    6(float) ImageSampleDrefExplicitLod 19 25 27 Lod 26
-                              Store 8(r10) 28
-              34:          31 Load 33(g_tTex1di4a)
-              35:          13 Load 15(g_sSamp)
-              38:          37 SampledImage 34 35
-              39:    6(float) CompositeExtract 23 0
-              40:    6(float) CompositeExtract 39 0
-              41:    6(float) ImageSampleDrefExplicitLod 38 39 40 Lod 26
-                              Store 29(r12) 41
-              47:          44 Load 46(g_tTex1du4a)
-              48:          13 Load 15(g_sSamp)
-              51:          50 SampledImage 47 48
-              52:    6(float) CompositeExtract 23 0
-              53:    6(float) CompositeExtract 52 0
-              54:    6(float) ImageSampleDrefExplicitLod 51 52 53 Lod 26
-                              Store 42(r14) 54
-              59:          56 Load 58(g_tTex2df4a)
-              60:          13 Load 15(g_sSamp)
-              63:          62 SampledImage 59 60
-              67:    6(float) CompositeExtract 66 0
-              68:    6(float) CompositeExtract 67 0
-              69:    6(float) ImageSampleDrefExplicitLod 63 67 68 Lod 26
-                              Store 55(r30) 69
-              74:          71 Load 73(g_tTex2di4a)
-              75:          13 Load 15(g_sSamp)
-              78:          77 SampledImage 74 75
-              79:    6(float) CompositeExtract 66 0
-              80:    6(float) CompositeExtract 79 0
-              81:    6(float) ImageSampleDrefExplicitLod 78 79 80 Lod 26
-                              Store 70(r32) 81
-              86:          83 Load 85(g_tTex2du4a)
-              87:          13 Load 15(g_sSamp)
-              90:          89 SampledImage 86 87
-              91:    6(float) CompositeExtract 66 0
-              92:    6(float) CompositeExtract 91 0
-              93:    6(float) ImageSampleDrefExplicitLod 90 91 92 Lod 26
-                              Store 82(r34) 93
-              98:          95 Load 97(g_tTexcdf4a)
-              99:          13 Load 15(g_sSamp)
-             102:         101 SampledImage 98 99
-             106:    6(float) CompositeExtract 105 0
-             107:    6(float) ImageSampleDrefExplicitLod 102 106 24 Lod 24
-                              Store 94(r60) 107
-             112:         109 Load 111(g_tTexcdi4a)
-             113:          13 Load 15(g_sSamp)
-             116:         115 SampledImage 112 113
-             117:    6(float) CompositeExtract 105 0
-             118:    6(float) ImageSampleDrefExplicitLod 116 117 24 Lod 24
-                              Store 108(r62) 118
-             123:         120 Load 122(g_tTexcdu4a)
-             124:          13 Load 15(g_sSamp)
-             127:         126 SampledImage 123 124
-             128:    6(float) CompositeExtract 105 0
-             129:    6(float) ImageSampleDrefExplicitLod 127 128 24 Lod 24
-                              Store 119(r64) 129
-             137:    136(ptr) AccessChain 132(psout) 133
-                              Store 137 135
-             139:      7(ptr) AccessChain 132(psout) 138
-                              Store 139 134
-             142:    136(ptr) AccessChain 132(psout) 133
-             143:  103(fvec4) Load 142
-                              Store 141(Color) 143
-             146:      7(ptr) AccessChain 132(psout) 138
-             147:    6(float) Load 146
-                              Store 145(Depth) 147
+              26:    6(float) CompositeExtract 23 0
+              27:    6(float) CompositeExtract 23 1
+              28:   25(fvec3) CompositeConstruct 26 27 24
+              30:    6(float) CompositeExtract 28 2
+              31:    6(float) ImageSampleDrefExplicitLod 19 28 30 Lod 29
+                              Store 8(r10) 31
+              37:          34 Load 36(g_tTex1di4a)
+              38:          13 Load 15(g_sSamp)
+              41:          40 SampledImage 37 38
+              42:    6(float) CompositeExtract 23 0
+              43:    6(float) CompositeExtract 23 1
+              44:   25(fvec3) CompositeConstruct 42 43 24
+              45:    6(float) CompositeExtract 44 2
+              46:    6(float) ImageSampleDrefExplicitLod 41 44 45 Lod 29
+                              Store 32(r12) 46
+              52:          49 Load 51(g_tTex1du4a)
+              53:          13 Load 15(g_sSamp)
+              56:          55 SampledImage 52 53
+              57:    6(float) CompositeExtract 23 0
+              58:    6(float) CompositeExtract 23 1
+              59:   25(fvec3) CompositeConstruct 57 58 24
+              60:    6(float) CompositeExtract 59 2
+              61:    6(float) ImageSampleDrefExplicitLod 56 59 60 Lod 29
+                              Store 47(r14) 61
+              66:          63 Load 65(g_tTex2df4a)
+              67:          13 Load 15(g_sSamp)
+              70:          69 SampledImage 66 67
+              74:    6(float) CompositeExtract 72 0
+              75:    6(float) CompositeExtract 72 1
+              76:    6(float) CompositeExtract 72 2
+              77:   73(fvec4) CompositeConstruct 74 75 76 24
+              78:    6(float) CompositeExtract 77 3
+              79:    6(float) ImageSampleDrefExplicitLod 70 77 78 Lod 29
+                              Store 62(r30) 79
+              84:          81 Load 83(g_tTex2di4a)
+              85:          13 Load 15(g_sSamp)
+              88:          87 SampledImage 84 85
+              89:    6(float) CompositeExtract 72 0
+              90:    6(float) CompositeExtract 72 1
+              91:    6(float) CompositeExtract 72 2
+              92:   73(fvec4) CompositeConstruct 89 90 91 24
+              93:    6(float) CompositeExtract 92 3
+              94:    6(float) ImageSampleDrefExplicitLod 88 92 93 Lod 29
+                              Store 80(r32) 94
+              99:          96 Load 98(g_tTex2du4a)
+             100:          13 Load 15(g_sSamp)
+             103:         102 SampledImage 99 100
+             104:    6(float) CompositeExtract 72 0
+             105:    6(float) CompositeExtract 72 1
+             106:    6(float) CompositeExtract 72 2
+             107:   73(fvec4) CompositeConstruct 104 105 106 24
+             108:    6(float) CompositeExtract 107 3
+             109:    6(float) ImageSampleDrefExplicitLod 103 107 108 Lod 29
+                              Store 95(r34) 109
+             114:         111 Load 113(g_tTexcdf4a)
+             115:          13 Load 15(g_sSamp)
+             118:         117 SampledImage 114 115
+             121:    6(float) CompositeExtract 120 0
+             122:    6(float) CompositeExtract 120 1
+             123:    6(float) CompositeExtract 120 2
+             124:    6(float) CompositeExtract 120 3
+             125:   73(fvec4) CompositeConstruct 121 122 123 124
+             126:    6(float) ImageSampleDrefExplicitLod 118 125 24 Lod 24
+                              Store 110(r60) 126
+             131:         128 Load 130(g_tTexcdi4a)
+             132:          13 Load 15(g_sSamp)
+             135:         134 SampledImage 131 132
+             136:    6(float) CompositeExtract 120 0
+             137:    6(float) CompositeExtract 120 1
+             138:    6(float) CompositeExtract 120 2
+             139:    6(float) CompositeExtract 120 3
+             140:   73(fvec4) CompositeConstruct 136 137 138 139
+             141:    6(float) ImageSampleDrefExplicitLod 135 140 24 Lod 24
+                              Store 127(r62) 141
+             146:         143 Load 145(g_tTexcdu4a)
+             147:          13 Load 15(g_sSamp)
+             150:         149 SampledImage 146 147
+             151:    6(float) CompositeExtract 120 0
+             152:    6(float) CompositeExtract 120 1
+             153:    6(float) CompositeExtract 120 2
+             154:    6(float) CompositeExtract 120 3
+             155:   73(fvec4) CompositeConstruct 151 152 153 154
+             156:    6(float) ImageSampleDrefExplicitLod 150 155 24 Lod 24
+                              Store 142(r64) 156
+             164:    163(ptr) AccessChain 159(psout) 160
+                              Store 164 162
+             166:      7(ptr) AccessChain 159(psout) 165
+                              Store 166 161
+             169:    163(ptr) AccessChain 159(psout) 160
+             170:   73(fvec4) Load 169
+                              Store 168(Color) 170
+             173:      7(ptr) AccessChain 159(psout) 165
+             174:    6(float) Load 173
+                              Store 172(Depth) 174
                               Return
                               FunctionEnd

--- a/Test/baseResults/hlsl.samplecmplevelzero.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmplevelzero.basic.dx10.frag.out
@@ -12,7 +12,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DShadow)
 0:42              'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec2 (temp float)
+0:42            Construct vec2 (temp 2-component vector of float)
 0:42              Constant:
 0:42                0.100000
 0:42              Constant:
@@ -26,7 +26,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DShadow)
 0:43              'g_tTex1di4' (uniform itexture1D)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec2 (temp float)
+0:43            Construct vec2 (temp 2-component vector of float)
 0:43              Constant:
 0:43                0.100000
 0:43              Constant:
@@ -40,7 +40,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DShadow)
 0:44              'g_tTex1du4' (uniform utexture1D)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec2 (temp float)
+0:44            Construct vec2 (temp 2-component vector of float)
 0:44              Constant:
 0:44                0.100000
 0:44              Constant:
@@ -54,7 +54,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DShadow)
 0:47              'g_tTex2df4' (uniform texture2D)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec3 (temp float)
+0:47            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -69,7 +69,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DShadow)
 0:48              'g_tTex2di4' (uniform itexture2D)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec3 (temp float)
+0:48            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -84,7 +84,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DShadow)
 0:49              'g_tTex2du4' (uniform utexture2D)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec3 (temp float)
+0:49            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -99,7 +99,7 @@ gl_FragCoord origin is upper left
 0:53            Construct combined texture-sampler (temp samplerCubeShadow)
 0:53              'g_tTexcdf4' (uniform textureCube)
 0:53              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:53            Construct vec4 (temp float)
+0:53            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -115,7 +115,7 @@ gl_FragCoord origin is upper left
 0:54            Construct combined texture-sampler (temp isamplerCubeShadow)
 0:54              'g_tTexcdi4' (uniform itextureCube)
 0:54              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:54            Construct vec4 (temp float)
+0:54            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -131,7 +131,7 @@ gl_FragCoord origin is upper left
 0:55            Construct combined texture-sampler (temp usamplerCubeShadow)
 0:55              'g_tTexcdu4' (uniform utextureCube)
 0:55              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:55            Construct vec4 (temp float)
+0:55            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -215,7 +215,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DShadow)
 0:42              'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec2 (temp float)
+0:42            Construct vec2 (temp 2-component vector of float)
 0:42              Constant:
 0:42                0.100000
 0:42              Constant:
@@ -229,7 +229,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DShadow)
 0:43              'g_tTex1di4' (uniform itexture1D)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec2 (temp float)
+0:43            Construct vec2 (temp 2-component vector of float)
 0:43              Constant:
 0:43                0.100000
 0:43              Constant:
@@ -243,7 +243,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DShadow)
 0:44              'g_tTex1du4' (uniform utexture1D)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec2 (temp float)
+0:44            Construct vec2 (temp 2-component vector of float)
 0:44              Constant:
 0:44                0.100000
 0:44              Constant:
@@ -257,7 +257,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DShadow)
 0:47              'g_tTex2df4' (uniform texture2D)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec3 (temp float)
+0:47            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -272,7 +272,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DShadow)
 0:48              'g_tTex2di4' (uniform itexture2D)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec3 (temp float)
+0:48            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -287,7 +287,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DShadow)
 0:49              'g_tTex2du4' (uniform utexture2D)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec3 (temp float)
+0:49            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -302,7 +302,7 @@ gl_FragCoord origin is upper left
 0:53            Construct combined texture-sampler (temp samplerCubeShadow)
 0:53              'g_tTexcdf4' (uniform textureCube)
 0:53              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:53            Construct vec4 (temp float)
+0:53            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -318,7 +318,7 @@ gl_FragCoord origin is upper left
 0:54            Construct combined texture-sampler (temp isamplerCubeShadow)
 0:54              'g_tTexcdi4' (uniform itextureCube)
 0:54              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:54            Construct vec4 (temp float)
+0:54            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -334,7 +334,7 @@ gl_FragCoord origin is upper left
 0:55            Construct combined texture-sampler (temp usamplerCubeShadow)
 0:55              'g_tTexcdu4' (uniform utextureCube)
 0:55              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:55            Construct vec4 (temp float)
+0:55            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -403,79 +403,79 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 183
+// Id's are bound by 201
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 139 143
+                              EntryPoint Fragment 4  "main" 157 161
                               ExecutionMode 4 OriginUpperLeft
                               Name 4  "main"
                               Name 8  "r00"
                               Name 11  "g_tTex1df4"
                               Name 15  "g_sSamp"
-                              Name 25  "r02"
-                              Name 29  "g_tTex1di4"
-                              Name 37  "r04"
-                              Name 41  "g_tTex1du4"
-                              Name 49  "r20"
-                              Name 52  "g_tTex2df4"
-                              Name 64  "r22"
-                              Name 67  "g_tTex2di4"
-                              Name 76  "r24"
-                              Name 79  "g_tTex2du4"
-                              Name 88  "r50"
-                              Name 91  "g_tTexcdf4"
-                              Name 103  "r52"
-                              Name 106  "g_tTexcdi4"
-                              Name 115  "r54"
-                              Name 118  "g_tTexcdu4"
-                              Name 128  "PS_OUTPUT"
-                              MemberName 128(PS_OUTPUT) 0  "Color"
-                              MemberName 128(PS_OUTPUT) 1  "Depth"
-                              Name 130  "psout"
-                              Name 139  "Color"
-                              Name 143  "Depth"
-                              Name 149  "g_tTex3df4"
-                              Name 152  "g_tTex3di4"
-                              Name 155  "g_tTex3du4"
-                              Name 158  "g_tTex1df4a"
-                              Name 161  "g_tTex1di4a"
-                              Name 164  "g_tTex1du4a"
-                              Name 167  "g_tTex2df4a"
-                              Name 170  "g_tTex2di4a"
-                              Name 173  "g_tTex2du4a"
-                              Name 176  "g_tTexcdf4a"
-                              Name 179  "g_tTexcdi4a"
-                              Name 182  "g_tTexcdu4a"
+                              Name 27  "r02"
+                              Name 31  "g_tTex1di4"
+                              Name 40  "r04"
+                              Name 44  "g_tTex1du4"
+                              Name 53  "r20"
+                              Name 56  "g_tTex2df4"
+                              Name 70  "r22"
+                              Name 73  "g_tTex2di4"
+                              Name 84  "r24"
+                              Name 87  "g_tTex2du4"
+                              Name 98  "r50"
+                              Name 101  "g_tTexcdf4"
+                              Name 116  "r52"
+                              Name 119  "g_tTexcdi4"
+                              Name 131  "r54"
+                              Name 134  "g_tTexcdu4"
+                              Name 146  "PS_OUTPUT"
+                              MemberName 146(PS_OUTPUT) 0  "Color"
+                              MemberName 146(PS_OUTPUT) 1  "Depth"
+                              Name 148  "psout"
+                              Name 157  "Color"
+                              Name 161  "Depth"
+                              Name 167  "g_tTex3df4"
+                              Name 170  "g_tTex3di4"
+                              Name 173  "g_tTex3du4"
+                              Name 176  "g_tTex1df4a"
+                              Name 179  "g_tTex1di4a"
+                              Name 182  "g_tTex1du4a"
+                              Name 185  "g_tTex2df4a"
+                              Name 188  "g_tTex2di4a"
+                              Name 191  "g_tTex2du4a"
+                              Name 194  "g_tTexcdf4a"
+                              Name 197  "g_tTexcdi4a"
+                              Name 200  "g_tTexcdu4a"
                               Decorate 11(g_tTex1df4) DescriptorSet 0
                               Decorate 11(g_tTex1df4) Binding 0
                               Decorate 15(g_sSamp) DescriptorSet 0
                               Decorate 15(g_sSamp) Binding 0
-                              Decorate 29(g_tTex1di4) DescriptorSet 0
-                              Decorate 41(g_tTex1du4) DescriptorSet 0
-                              Decorate 52(g_tTex2df4) DescriptorSet 0
-                              Decorate 67(g_tTex2di4) DescriptorSet 0
-                              Decorate 79(g_tTex2du4) DescriptorSet 0
-                              Decorate 91(g_tTexcdf4) DescriptorSet 0
-                              Decorate 106(g_tTexcdi4) DescriptorSet 0
-                              Decorate 118(g_tTexcdu4) DescriptorSet 0
-                              Decorate 139(Color) Location 0
-                              Decorate 143(Depth) BuiltIn FragDepth
-                              Decorate 149(g_tTex3df4) DescriptorSet 0
-                              Decorate 152(g_tTex3di4) DescriptorSet 0
-                              Decorate 155(g_tTex3du4) DescriptorSet 0
-                              Decorate 158(g_tTex1df4a) DescriptorSet 0
-                              Decorate 161(g_tTex1di4a) DescriptorSet 0
-                              Decorate 164(g_tTex1du4a) DescriptorSet 0
-                              Decorate 167(g_tTex2df4a) DescriptorSet 0
-                              Decorate 170(g_tTex2di4a) DescriptorSet 0
-                              Decorate 173(g_tTex2du4a) DescriptorSet 0
-                              Decorate 176(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 179(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 182(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 31(g_tTex1di4) DescriptorSet 0
+                              Decorate 44(g_tTex1du4) DescriptorSet 0
+                              Decorate 56(g_tTex2df4) DescriptorSet 0
+                              Decorate 73(g_tTex2di4) DescriptorSet 0
+                              Decorate 87(g_tTex2du4) DescriptorSet 0
+                              Decorate 101(g_tTexcdf4) DescriptorSet 0
+                              Decorate 119(g_tTexcdi4) DescriptorSet 0
+                              Decorate 134(g_tTexcdu4) DescriptorSet 0
+                              Decorate 157(Color) Location 0
+                              Decorate 161(Depth) BuiltIn FragDepth
+                              Decorate 167(g_tTex3df4) DescriptorSet 0
+                              Decorate 170(g_tTex3di4) DescriptorSet 0
+                              Decorate 173(g_tTex3du4) DescriptorSet 0
+                              Decorate 176(g_tTex1df4a) DescriptorSet 0
+                              Decorate 179(g_tTex1di4a) DescriptorSet 0
+                              Decorate 182(g_tTex1du4a) DescriptorSet 0
+                              Decorate 185(g_tTex2df4a) DescriptorSet 0
+                              Decorate 188(g_tTex2di4a) DescriptorSet 0
+                              Decorate 191(g_tTex2du4a) DescriptorSet 0
+                              Decorate 194(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 197(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 200(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -490,184 +490,202 @@ gl_FragCoord origin is upper left
               18:             TypeSampledImage 17
               20:    6(float) Constant 1036831949
               21:    6(float) Constant 1061158912
-              22:    6(float) Constant 0
-              26:             TypeInt 32 1
-              27:             TypeImage 26(int) 1D sampled format:Unknown
-              28:             TypePointer UniformConstant 27
-  29(g_tTex1di4):     28(ptr) Variable UniformConstant
-              32:             TypeImage 26(int) 1D depth sampled format:Unknown
-              33:             TypeSampledImage 32
-              38:             TypeInt 32 0
-              39:             TypeImage 38(int) 1D sampled format:Unknown
-              40:             TypePointer UniformConstant 39
-  41(g_tTex1du4):     40(ptr) Variable UniformConstant
-              44:             TypeImage 38(int) 1D depth sampled format:Unknown
-              45:             TypeSampledImage 44
-              50:             TypeImage 6(float) 2D sampled format:Unknown
-              51:             TypePointer UniformConstant 50
-  52(g_tTex2df4):     51(ptr) Variable UniformConstant
-              55:             TypeImage 6(float) 2D depth sampled format:Unknown
-              56:             TypeSampledImage 55
-              58:             TypeVector 6(float) 2
-              59:    6(float) Constant 1045220557
-              60:   58(fvec2) ConstantComposite 20 59
-              65:             TypeImage 26(int) 2D sampled format:Unknown
-              66:             TypePointer UniformConstant 65
-  67(g_tTex2di4):     66(ptr) Variable UniformConstant
-              70:             TypeImage 26(int) 2D depth sampled format:Unknown
-              71:             TypeSampledImage 70
-              77:             TypeImage 38(int) 2D sampled format:Unknown
-              78:             TypePointer UniformConstant 77
-  79(g_tTex2du4):     78(ptr) Variable UniformConstant
-              82:             TypeImage 38(int) 2D depth sampled format:Unknown
-              83:             TypeSampledImage 82
-              89:             TypeImage 6(float) Cube sampled format:Unknown
-              90:             TypePointer UniformConstant 89
-  91(g_tTexcdf4):     90(ptr) Variable UniformConstant
-              94:             TypeImage 6(float) Cube depth sampled format:Unknown
-              95:             TypeSampledImage 94
-              97:             TypeVector 6(float) 3
-              98:    6(float) Constant 1050253722
-              99:   97(fvec3) ConstantComposite 20 59 98
-             104:             TypeImage 26(int) Cube sampled format:Unknown
-             105:             TypePointer UniformConstant 104
- 106(g_tTexcdi4):    105(ptr) Variable UniformConstant
-             109:             TypeImage 26(int) Cube depth sampled format:Unknown
-             110:             TypeSampledImage 109
-             116:             TypeImage 38(int) Cube sampled format:Unknown
-             117:             TypePointer UniformConstant 116
- 118(g_tTexcdu4):    117(ptr) Variable UniformConstant
-             121:             TypeImage 38(int) Cube depth sampled format:Unknown
-             122:             TypeSampledImage 121
-             127:             TypeVector 6(float) 4
-  128(PS_OUTPUT):             TypeStruct 127(fvec4) 6(float)
-             129:             TypePointer Function 128(PS_OUTPUT)
-             131:     26(int) Constant 0
-             132:    6(float) Constant 1065353216
-             133:  127(fvec4) ConstantComposite 132 132 132 132
-             134:             TypePointer Function 127(fvec4)
-             136:     26(int) Constant 1
-             138:             TypePointer Output 127(fvec4)
-      139(Color):    138(ptr) Variable Output
-             142:             TypePointer Output 6(float)
-      143(Depth):    142(ptr) Variable Output
-             147:             TypeImage 6(float) 3D sampled format:Unknown
-             148:             TypePointer UniformConstant 147
- 149(g_tTex3df4):    148(ptr) Variable UniformConstant
-             150:             TypeImage 26(int) 3D sampled format:Unknown
-             151:             TypePointer UniformConstant 150
- 152(g_tTex3di4):    151(ptr) Variable UniformConstant
-             153:             TypeImage 38(int) 3D sampled format:Unknown
-             154:             TypePointer UniformConstant 153
- 155(g_tTex3du4):    154(ptr) Variable UniformConstant
-             156:             TypeImage 6(float) 1D array sampled format:Unknown
-             157:             TypePointer UniformConstant 156
-158(g_tTex1df4a):    157(ptr) Variable UniformConstant
-             159:             TypeImage 26(int) 1D array sampled format:Unknown
-             160:             TypePointer UniformConstant 159
-161(g_tTex1di4a):    160(ptr) Variable UniformConstant
-             162:             TypeImage 38(int) 1D array sampled format:Unknown
-             163:             TypePointer UniformConstant 162
-164(g_tTex1du4a):    163(ptr) Variable UniformConstant
-             165:             TypeImage 6(float) 2D array sampled format:Unknown
+              22:             TypeVector 6(float) 2
+              24:    6(float) Constant 0
+              28:             TypeInt 32 1
+              29:             TypeImage 28(int) 1D sampled format:Unknown
+              30:             TypePointer UniformConstant 29
+  31(g_tTex1di4):     30(ptr) Variable UniformConstant
+              34:             TypeImage 28(int) 1D depth sampled format:Unknown
+              35:             TypeSampledImage 34
+              41:             TypeInt 32 0
+              42:             TypeImage 41(int) 1D sampled format:Unknown
+              43:             TypePointer UniformConstant 42
+  44(g_tTex1du4):     43(ptr) Variable UniformConstant
+              47:             TypeImage 41(int) 1D depth sampled format:Unknown
+              48:             TypeSampledImage 47
+              54:             TypeImage 6(float) 2D sampled format:Unknown
+              55:             TypePointer UniformConstant 54
+  56(g_tTex2df4):     55(ptr) Variable UniformConstant
+              59:             TypeImage 6(float) 2D depth sampled format:Unknown
+              60:             TypeSampledImage 59
+              62:    6(float) Constant 1045220557
+              63:   22(fvec2) ConstantComposite 20 62
+              64:             TypeVector 6(float) 3
+              71:             TypeImage 28(int) 2D sampled format:Unknown
+              72:             TypePointer UniformConstant 71
+  73(g_tTex2di4):     72(ptr) Variable UniformConstant
+              76:             TypeImage 28(int) 2D depth sampled format:Unknown
+              77:             TypeSampledImage 76
+              85:             TypeImage 41(int) 2D sampled format:Unknown
+              86:             TypePointer UniformConstant 85
+  87(g_tTex2du4):     86(ptr) Variable UniformConstant
+              90:             TypeImage 41(int) 2D depth sampled format:Unknown
+              91:             TypeSampledImage 90
+              99:             TypeImage 6(float) Cube sampled format:Unknown
+             100:             TypePointer UniformConstant 99
+ 101(g_tTexcdf4):    100(ptr) Variable UniformConstant
+             104:             TypeImage 6(float) Cube depth sampled format:Unknown
+             105:             TypeSampledImage 104
+             107:    6(float) Constant 1050253722
+             108:   64(fvec3) ConstantComposite 20 62 107
+             109:             TypeVector 6(float) 4
+             117:             TypeImage 28(int) Cube sampled format:Unknown
+             118:             TypePointer UniformConstant 117
+ 119(g_tTexcdi4):    118(ptr) Variable UniformConstant
+             122:             TypeImage 28(int) Cube depth sampled format:Unknown
+             123:             TypeSampledImage 122
+             132:             TypeImage 41(int) Cube sampled format:Unknown
+             133:             TypePointer UniformConstant 132
+ 134(g_tTexcdu4):    133(ptr) Variable UniformConstant
+             137:             TypeImage 41(int) Cube depth sampled format:Unknown
+             138:             TypeSampledImage 137
+  146(PS_OUTPUT):             TypeStruct 109(fvec4) 6(float)
+             147:             TypePointer Function 146(PS_OUTPUT)
+             149:     28(int) Constant 0
+             150:    6(float) Constant 1065353216
+             151:  109(fvec4) ConstantComposite 150 150 150 150
+             152:             TypePointer Function 109(fvec4)
+             154:     28(int) Constant 1
+             156:             TypePointer Output 109(fvec4)
+      157(Color):    156(ptr) Variable Output
+             160:             TypePointer Output 6(float)
+      161(Depth):    160(ptr) Variable Output
+             165:             TypeImage 6(float) 3D sampled format:Unknown
              166:             TypePointer UniformConstant 165
-167(g_tTex2df4a):    166(ptr) Variable UniformConstant
-             168:             TypeImage 26(int) 2D array sampled format:Unknown
+ 167(g_tTex3df4):    166(ptr) Variable UniformConstant
+             168:             TypeImage 28(int) 3D sampled format:Unknown
              169:             TypePointer UniformConstant 168
-170(g_tTex2di4a):    169(ptr) Variable UniformConstant
-             171:             TypeImage 38(int) 2D array sampled format:Unknown
+ 170(g_tTex3di4):    169(ptr) Variable UniformConstant
+             171:             TypeImage 41(int) 3D sampled format:Unknown
              172:             TypePointer UniformConstant 171
-173(g_tTex2du4a):    172(ptr) Variable UniformConstant
-             174:             TypeImage 6(float) Cube array sampled format:Unknown
+ 173(g_tTex3du4):    172(ptr) Variable UniformConstant
+             174:             TypeImage 6(float) 1D array sampled format:Unknown
              175:             TypePointer UniformConstant 174
-176(g_tTexcdf4a):    175(ptr) Variable UniformConstant
-             177:             TypeImage 26(int) Cube array sampled format:Unknown
+176(g_tTex1df4a):    175(ptr) Variable UniformConstant
+             177:             TypeImage 28(int) 1D array sampled format:Unknown
              178:             TypePointer UniformConstant 177
-179(g_tTexcdi4a):    178(ptr) Variable UniformConstant
-             180:             TypeImage 38(int) Cube array sampled format:Unknown
+179(g_tTex1di4a):    178(ptr) Variable UniformConstant
+             180:             TypeImage 41(int) 1D array sampled format:Unknown
              181:             TypePointer UniformConstant 180
-182(g_tTexcdu4a):    181(ptr) Variable UniformConstant
+182(g_tTex1du4a):    181(ptr) Variable UniformConstant
+             183:             TypeImage 6(float) 2D array sampled format:Unknown
+             184:             TypePointer UniformConstant 183
+185(g_tTex2df4a):    184(ptr) Variable UniformConstant
+             186:             TypeImage 28(int) 2D array sampled format:Unknown
+             187:             TypePointer UniformConstant 186
+188(g_tTex2di4a):    187(ptr) Variable UniformConstant
+             189:             TypeImage 41(int) 2D array sampled format:Unknown
+             190:             TypePointer UniformConstant 189
+191(g_tTex2du4a):    190(ptr) Variable UniformConstant
+             192:             TypeImage 6(float) Cube array sampled format:Unknown
+             193:             TypePointer UniformConstant 192
+194(g_tTexcdf4a):    193(ptr) Variable UniformConstant
+             195:             TypeImage 28(int) Cube array sampled format:Unknown
+             196:             TypePointer UniformConstant 195
+197(g_tTexcdi4a):    196(ptr) Variable UniformConstant
+             198:             TypeImage 41(int) Cube array sampled format:Unknown
+             199:             TypePointer UniformConstant 198
+200(g_tTexcdu4a):    199(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
           8(r00):      7(ptr) Variable Function
-         25(r02):      7(ptr) Variable Function
-         37(r04):      7(ptr) Variable Function
-         49(r20):      7(ptr) Variable Function
-         64(r22):      7(ptr) Variable Function
-         76(r24):      7(ptr) Variable Function
-         88(r50):      7(ptr) Variable Function
-        103(r52):      7(ptr) Variable Function
-        115(r54):      7(ptr) Variable Function
-      130(psout):    129(ptr) Variable Function
+         27(r02):      7(ptr) Variable Function
+         40(r04):      7(ptr) Variable Function
+         53(r20):      7(ptr) Variable Function
+         70(r22):      7(ptr) Variable Function
+         84(r24):      7(ptr) Variable Function
+         98(r50):      7(ptr) Variable Function
+        116(r52):      7(ptr) Variable Function
+        131(r54):      7(ptr) Variable Function
+      148(psout):    147(ptr) Variable Function
               12:           9 Load 11(g_tTex1df4)
               16:          13 Load 15(g_sSamp)
               19:          18 SampledImage 12 16
-              23:    6(float) CompositeExtract 20 0
-              24:    6(float) ImageSampleDrefExplicitLod 19 20 23 Lod 22
-                              Store 8(r00) 24
-              30:          27 Load 29(g_tTex1di4)
-              31:          13 Load 15(g_sSamp)
-              34:          33 SampledImage 30 31
-              35:    6(float) CompositeExtract 20 0
-              36:    6(float) ImageSampleDrefExplicitLod 34 20 35 Lod 22
-                              Store 25(r02) 36
-              42:          39 Load 41(g_tTex1du4)
-              43:          13 Load 15(g_sSamp)
-              46:          45 SampledImage 42 43
-              47:    6(float) CompositeExtract 20 0
-              48:    6(float) ImageSampleDrefExplicitLod 46 20 47 Lod 22
-                              Store 37(r04) 48
-              53:          50 Load 52(g_tTex2df4)
-              54:          13 Load 15(g_sSamp)
-              57:          56 SampledImage 53 54
-              61:    6(float) CompositeExtract 60 0
-              62:    6(float) CompositeExtract 61 0
-              63:    6(float) ImageSampleDrefExplicitLod 57 61 62 Lod 22
-                              Store 49(r20) 63
-              68:          65 Load 67(g_tTex2di4)
-              69:          13 Load 15(g_sSamp)
-              72:          71 SampledImage 68 69
-              73:    6(float) CompositeExtract 60 0
-              74:    6(float) CompositeExtract 73 0
-              75:    6(float) ImageSampleDrefExplicitLod 72 73 74 Lod 22
-                              Store 64(r22) 75
-              80:          77 Load 79(g_tTex2du4)
-              81:          13 Load 15(g_sSamp)
-              84:          83 SampledImage 80 81
-              85:    6(float) CompositeExtract 60 0
-              86:    6(float) CompositeExtract 85 0
-              87:    6(float) ImageSampleDrefExplicitLod 84 85 86 Lod 22
-                              Store 76(r24) 87
-              92:          89 Load 91(g_tTexcdf4)
-              93:          13 Load 15(g_sSamp)
-              96:          95 SampledImage 92 93
-             100:    6(float) CompositeExtract 99 0
-             101:    6(float) CompositeExtract 100 0
-             102:    6(float) ImageSampleDrefExplicitLod 96 100 101 Lod 22
-                              Store 88(r50) 102
-             107:         104 Load 106(g_tTexcdi4)
-             108:          13 Load 15(g_sSamp)
-             111:         110 SampledImage 107 108
-             112:    6(float) CompositeExtract 99 0
-             113:    6(float) CompositeExtract 112 0
-             114:    6(float) ImageSampleDrefExplicitLod 111 112 113 Lod 22
-                              Store 103(r52) 114
-             119:         116 Load 118(g_tTexcdu4)
-             120:          13 Load 15(g_sSamp)
-             123:         122 SampledImage 119 120
-             124:    6(float) CompositeExtract 99 0
-             125:    6(float) CompositeExtract 124 0
-             126:    6(float) ImageSampleDrefExplicitLod 123 124 125 Lod 22
-                              Store 115(r54) 126
-             135:    134(ptr) AccessChain 130(psout) 131
-                              Store 135 133
-             137:      7(ptr) AccessChain 130(psout) 136
-                              Store 137 132
-             140:    134(ptr) AccessChain 130(psout) 131
-             141:  127(fvec4) Load 140
-                              Store 139(Color) 141
-             144:      7(ptr) AccessChain 130(psout) 136
-             145:    6(float) Load 144
-                              Store 143(Depth) 145
+              23:   22(fvec2) CompositeConstruct 20 21
+              25:    6(float) CompositeExtract 23 1
+              26:    6(float) ImageSampleDrefExplicitLod 19 23 25 Lod 24
+                              Store 8(r00) 26
+              32:          29 Load 31(g_tTex1di4)
+              33:          13 Load 15(g_sSamp)
+              36:          35 SampledImage 32 33
+              37:   22(fvec2) CompositeConstruct 20 21
+              38:    6(float) CompositeExtract 37 1
+              39:    6(float) ImageSampleDrefExplicitLod 36 37 38 Lod 24
+                              Store 27(r02) 39
+              45:          42 Load 44(g_tTex1du4)
+              46:          13 Load 15(g_sSamp)
+              49:          48 SampledImage 45 46
+              50:   22(fvec2) CompositeConstruct 20 21
+              51:    6(float) CompositeExtract 50 1
+              52:    6(float) ImageSampleDrefExplicitLod 49 50 51 Lod 24
+                              Store 40(r04) 52
+              57:          54 Load 56(g_tTex2df4)
+              58:          13 Load 15(g_sSamp)
+              61:          60 SampledImage 57 58
+              65:    6(float) CompositeExtract 63 0
+              66:    6(float) CompositeExtract 63 1
+              67:   64(fvec3) CompositeConstruct 65 66 21
+              68:    6(float) CompositeExtract 67 2
+              69:    6(float) ImageSampleDrefExplicitLod 61 67 68 Lod 24
+                              Store 53(r20) 69
+              74:          71 Load 73(g_tTex2di4)
+              75:          13 Load 15(g_sSamp)
+              78:          77 SampledImage 74 75
+              79:    6(float) CompositeExtract 63 0
+              80:    6(float) CompositeExtract 63 1
+              81:   64(fvec3) CompositeConstruct 79 80 21
+              82:    6(float) CompositeExtract 81 2
+              83:    6(float) ImageSampleDrefExplicitLod 78 81 82 Lod 24
+                              Store 70(r22) 83
+              88:          85 Load 87(g_tTex2du4)
+              89:          13 Load 15(g_sSamp)
+              92:          91 SampledImage 88 89
+              93:    6(float) CompositeExtract 63 0
+              94:    6(float) CompositeExtract 63 1
+              95:   64(fvec3) CompositeConstruct 93 94 21
+              96:    6(float) CompositeExtract 95 2
+              97:    6(float) ImageSampleDrefExplicitLod 92 95 96 Lod 24
+                              Store 84(r24) 97
+             102:          99 Load 101(g_tTexcdf4)
+             103:          13 Load 15(g_sSamp)
+             106:         105 SampledImage 102 103
+             110:    6(float) CompositeExtract 108 0
+             111:    6(float) CompositeExtract 108 1
+             112:    6(float) CompositeExtract 108 2
+             113:  109(fvec4) CompositeConstruct 110 111 112 21
+             114:    6(float) CompositeExtract 113 3
+             115:    6(float) ImageSampleDrefExplicitLod 106 113 114 Lod 24
+                              Store 98(r50) 115
+             120:         117 Load 119(g_tTexcdi4)
+             121:          13 Load 15(g_sSamp)
+             124:         123 SampledImage 120 121
+             125:    6(float) CompositeExtract 108 0
+             126:    6(float) CompositeExtract 108 1
+             127:    6(float) CompositeExtract 108 2
+             128:  109(fvec4) CompositeConstruct 125 126 127 21
+             129:    6(float) CompositeExtract 128 3
+             130:    6(float) ImageSampleDrefExplicitLod 124 128 129 Lod 24
+                              Store 116(r52) 130
+             135:         132 Load 134(g_tTexcdu4)
+             136:          13 Load 15(g_sSamp)
+             139:         138 SampledImage 135 136
+             140:    6(float) CompositeExtract 108 0
+             141:    6(float) CompositeExtract 108 1
+             142:    6(float) CompositeExtract 108 2
+             143:  109(fvec4) CompositeConstruct 140 141 142 21
+             144:    6(float) CompositeExtract 143 3
+             145:    6(float) ImageSampleDrefExplicitLod 139 143 144 Lod 24
+                              Store 131(r54) 145
+             153:    152(ptr) AccessChain 148(psout) 149
+                              Store 153 151
+             155:      7(ptr) AccessChain 148(psout) 154
+                              Store 155 150
+             158:    152(ptr) AccessChain 148(psout) 149
+             159:  109(fvec4) Load 158
+                              Store 157(Color) 159
+             162:      7(ptr) AccessChain 148(psout) 154
+             163:    6(float) Load 162
+                              Store 161(Depth) 163
                               Return
                               FunctionEnd

--- a/Test/baseResults/hlsl.samplecmplevelzero.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmplevelzero.offset.dx10.frag.out
@@ -12,7 +12,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DShadow)
 0:42              'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec2 (temp float)
+0:42            Construct vec2 (temp 2-component vector of float)
 0:42              Constant:
 0:42                0.100000
 0:42              Constant:
@@ -28,7 +28,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DShadow)
 0:43              'g_tTex1di4' (uniform itexture1D)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec2 (temp float)
+0:43            Construct vec2 (temp 2-component vector of float)
 0:43              Constant:
 0:43                0.100000
 0:43              Constant:
@@ -44,7 +44,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DShadow)
 0:44              'g_tTex1du4' (uniform utexture1D)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec2 (temp float)
+0:44            Construct vec2 (temp 2-component vector of float)
 0:44              Constant:
 0:44                0.100000
 0:44              Constant:
@@ -60,7 +60,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DShadow)
 0:47              'g_tTex2df4' (uniform texture2D)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec3 (temp float)
+0:47            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -78,7 +78,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DShadow)
 0:48              'g_tTex2di4' (uniform itexture2D)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec3 (temp float)
+0:48            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -96,7 +96,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DShadow)
 0:49              'g_tTex2du4' (uniform utexture2D)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec3 (temp float)
+0:49            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -182,7 +182,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DShadow)
 0:42              'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec2 (temp float)
+0:42            Construct vec2 (temp 2-component vector of float)
 0:42              Constant:
 0:42                0.100000
 0:42              Constant:
@@ -198,7 +198,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DShadow)
 0:43              'g_tTex1di4' (uniform itexture1D)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec2 (temp float)
+0:43            Construct vec2 (temp 2-component vector of float)
 0:43              Constant:
 0:43                0.100000
 0:43              Constant:
@@ -214,7 +214,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DShadow)
 0:44              'g_tTex1du4' (uniform utexture1D)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec2 (temp float)
+0:44            Construct vec2 (temp 2-component vector of float)
 0:44              Constant:
 0:44                0.100000
 0:44              Constant:
@@ -230,7 +230,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DShadow)
 0:47              'g_tTex2df4' (uniform texture2D)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec3 (temp float)
+0:47            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -248,7 +248,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DShadow)
 0:48              'g_tTex2di4' (uniform itexture2D)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec3 (temp float)
+0:48            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -266,7 +266,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DShadow)
 0:49              'g_tTex2du4' (uniform utexture2D)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec3 (temp float)
+0:49            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -337,76 +337,76 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 157
+// Id's are bound by 167
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 104 108
+                              EntryPoint Fragment 4  "main" 114 118
                               ExecutionMode 4 OriginUpperLeft
                               Name 4  "main"
                               Name 8  "r01"
                               Name 11  "g_tTex1df4"
                               Name 15  "g_sSamp"
-                              Name 27  "r03"
-                              Name 30  "g_tTex1di4"
-                              Name 38  "r05"
-                              Name 42  "g_tTex1du4"
-                              Name 50  "r21"
-                              Name 53  "g_tTex2df4"
-                              Name 68  "r23"
-                              Name 71  "g_tTex2di4"
-                              Name 80  "r25"
-                              Name 83  "g_tTex2du4"
-                              Name 93  "PS_OUTPUT"
-                              MemberName 93(PS_OUTPUT) 0  "Color"
-                              MemberName 93(PS_OUTPUT) 1  "Depth"
-                              Name 95  "psout"
-                              Name 104  "Color"
-                              Name 108  "Depth"
-                              Name 114  "g_tTex3df4"
-                              Name 117  "g_tTex3di4"
-                              Name 120  "g_tTex3du4"
-                              Name 123  "g_tTexcdf4"
-                              Name 126  "g_tTexcdi4"
-                              Name 129  "g_tTexcdu4"
-                              Name 132  "g_tTex1df4a"
-                              Name 135  "g_tTex1di4a"
-                              Name 138  "g_tTex1du4a"
-                              Name 141  "g_tTex2df4a"
-                              Name 144  "g_tTex2di4a"
-                              Name 147  "g_tTex2du4a"
-                              Name 150  "g_tTexcdf4a"
-                              Name 153  "g_tTexcdi4a"
-                              Name 156  "g_tTexcdu4a"
+                              Name 29  "r03"
+                              Name 32  "g_tTex1di4"
+                              Name 41  "r05"
+                              Name 45  "g_tTex1du4"
+                              Name 54  "r21"
+                              Name 57  "g_tTex2df4"
+                              Name 74  "r23"
+                              Name 77  "g_tTex2di4"
+                              Name 88  "r25"
+                              Name 91  "g_tTex2du4"
+                              Name 103  "PS_OUTPUT"
+                              MemberName 103(PS_OUTPUT) 0  "Color"
+                              MemberName 103(PS_OUTPUT) 1  "Depth"
+                              Name 105  "psout"
+                              Name 114  "Color"
+                              Name 118  "Depth"
+                              Name 124  "g_tTex3df4"
+                              Name 127  "g_tTex3di4"
+                              Name 130  "g_tTex3du4"
+                              Name 133  "g_tTexcdf4"
+                              Name 136  "g_tTexcdi4"
+                              Name 139  "g_tTexcdu4"
+                              Name 142  "g_tTex1df4a"
+                              Name 145  "g_tTex1di4a"
+                              Name 148  "g_tTex1du4a"
+                              Name 151  "g_tTex2df4a"
+                              Name 154  "g_tTex2di4a"
+                              Name 157  "g_tTex2du4a"
+                              Name 160  "g_tTexcdf4a"
+                              Name 163  "g_tTexcdi4a"
+                              Name 166  "g_tTexcdu4a"
                               Decorate 11(g_tTex1df4) DescriptorSet 0
                               Decorate 11(g_tTex1df4) Binding 0
                               Decorate 15(g_sSamp) DescriptorSet 0
                               Decorate 15(g_sSamp) Binding 0
-                              Decorate 30(g_tTex1di4) DescriptorSet 0
-                              Decorate 42(g_tTex1du4) DescriptorSet 0
-                              Decorate 53(g_tTex2df4) DescriptorSet 0
-                              Decorate 71(g_tTex2di4) DescriptorSet 0
-                              Decorate 83(g_tTex2du4) DescriptorSet 0
-                              Decorate 104(Color) Location 0
-                              Decorate 108(Depth) BuiltIn FragDepth
-                              Decorate 114(g_tTex3df4) DescriptorSet 0
-                              Decorate 117(g_tTex3di4) DescriptorSet 0
-                              Decorate 120(g_tTex3du4) DescriptorSet 0
-                              Decorate 123(g_tTexcdf4) DescriptorSet 0
-                              Decorate 126(g_tTexcdi4) DescriptorSet 0
-                              Decorate 129(g_tTexcdu4) DescriptorSet 0
-                              Decorate 132(g_tTex1df4a) DescriptorSet 0
-                              Decorate 135(g_tTex1di4a) DescriptorSet 0
-                              Decorate 138(g_tTex1du4a) DescriptorSet 0
-                              Decorate 141(g_tTex2df4a) DescriptorSet 0
-                              Decorate 144(g_tTex2di4a) DescriptorSet 0
-                              Decorate 147(g_tTex2du4a) DescriptorSet 0
-                              Decorate 150(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 153(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 156(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 32(g_tTex1di4) DescriptorSet 0
+                              Decorate 45(g_tTex1du4) DescriptorSet 0
+                              Decorate 57(g_tTex2df4) DescriptorSet 0
+                              Decorate 77(g_tTex2di4) DescriptorSet 0
+                              Decorate 91(g_tTex2du4) DescriptorSet 0
+                              Decorate 114(Color) Location 0
+                              Decorate 118(Depth) BuiltIn FragDepth
+                              Decorate 124(g_tTex3df4) DescriptorSet 0
+                              Decorate 127(g_tTex3di4) DescriptorSet 0
+                              Decorate 130(g_tTex3du4) DescriptorSet 0
+                              Decorate 133(g_tTexcdf4) DescriptorSet 0
+                              Decorate 136(g_tTexcdi4) DescriptorSet 0
+                              Decorate 139(g_tTexcdu4) DescriptorSet 0
+                              Decorate 142(g_tTex1df4a) DescriptorSet 0
+                              Decorate 145(g_tTex1di4a) DescriptorSet 0
+                              Decorate 148(g_tTex1du4a) DescriptorSet 0
+                              Decorate 151(g_tTex2df4a) DescriptorSet 0
+                              Decorate 154(g_tTex2di4a) DescriptorSet 0
+                              Decorate 157(g_tTex2du4a) DescriptorSet 0
+                              Decorate 160(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 163(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 166(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -421,155 +421,165 @@ gl_FragCoord origin is upper left
               18:             TypeSampledImage 17
               20:    6(float) Constant 1036831949
               21:    6(float) Constant 1061158912
-              22:    6(float) Constant 0
-              23:             TypeInt 32 1
-              24:     23(int) Constant 2
-              28:             TypeImage 23(int) 1D sampled format:Unknown
-              29:             TypePointer UniformConstant 28
-  30(g_tTex1di4):     29(ptr) Variable UniformConstant
-              33:             TypeImage 23(int) 1D depth sampled format:Unknown
-              34:             TypeSampledImage 33
-              39:             TypeInt 32 0
-              40:             TypeImage 39(int) 1D sampled format:Unknown
-              41:             TypePointer UniformConstant 40
-  42(g_tTex1du4):     41(ptr) Variable UniformConstant
-              45:             TypeImage 39(int) 1D depth sampled format:Unknown
-              46:             TypeSampledImage 45
-              51:             TypeImage 6(float) 2D sampled format:Unknown
-              52:             TypePointer UniformConstant 51
-  53(g_tTex2df4):     52(ptr) Variable UniformConstant
-              56:             TypeImage 6(float) 2D depth sampled format:Unknown
-              57:             TypeSampledImage 56
-              59:             TypeVector 6(float) 2
-              60:    6(float) Constant 1045220557
-              61:   59(fvec2) ConstantComposite 20 60
-              63:             TypeVector 23(int) 2
-              64:     23(int) Constant 3
-              65:   63(ivec2) ConstantComposite 24 64
-              69:             TypeImage 23(int) 2D sampled format:Unknown
-              70:             TypePointer UniformConstant 69
-  71(g_tTex2di4):     70(ptr) Variable UniformConstant
-              74:             TypeImage 23(int) 2D depth sampled format:Unknown
-              75:             TypeSampledImage 74
-              81:             TypeImage 39(int) 2D sampled format:Unknown
-              82:             TypePointer UniformConstant 81
-  83(g_tTex2du4):     82(ptr) Variable UniformConstant
-              86:             TypeImage 39(int) 2D depth sampled format:Unknown
-              87:             TypeSampledImage 86
-              92:             TypeVector 6(float) 4
-   93(PS_OUTPUT):             TypeStruct 92(fvec4) 6(float)
-              94:             TypePointer Function 93(PS_OUTPUT)
-              96:     23(int) Constant 0
-              97:    6(float) Constant 1065353216
-              98:   92(fvec4) ConstantComposite 97 97 97 97
-              99:             TypePointer Function 92(fvec4)
-             101:     23(int) Constant 1
-             103:             TypePointer Output 92(fvec4)
-      104(Color):    103(ptr) Variable Output
-             107:             TypePointer Output 6(float)
-      108(Depth):    107(ptr) Variable Output
-             112:             TypeImage 6(float) 3D sampled format:Unknown
-             113:             TypePointer UniformConstant 112
- 114(g_tTex3df4):    113(ptr) Variable UniformConstant
-             115:             TypeImage 23(int) 3D sampled format:Unknown
-             116:             TypePointer UniformConstant 115
- 117(g_tTex3di4):    116(ptr) Variable UniformConstant
-             118:             TypeImage 39(int) 3D sampled format:Unknown
-             119:             TypePointer UniformConstant 118
- 120(g_tTex3du4):    119(ptr) Variable UniformConstant
-             121:             TypeImage 6(float) Cube sampled format:Unknown
-             122:             TypePointer UniformConstant 121
- 123(g_tTexcdf4):    122(ptr) Variable UniformConstant
-             124:             TypeImage 23(int) Cube sampled format:Unknown
-             125:             TypePointer UniformConstant 124
- 126(g_tTexcdi4):    125(ptr) Variable UniformConstant
-             127:             TypeImage 39(int) Cube sampled format:Unknown
-             128:             TypePointer UniformConstant 127
- 129(g_tTexcdu4):    128(ptr) Variable UniformConstant
-             130:             TypeImage 6(float) 1D array sampled format:Unknown
-             131:             TypePointer UniformConstant 130
-132(g_tTex1df4a):    131(ptr) Variable UniformConstant
-             133:             TypeImage 23(int) 1D array sampled format:Unknown
-             134:             TypePointer UniformConstant 133
-135(g_tTex1di4a):    134(ptr) Variable UniformConstant
-             136:             TypeImage 39(int) 1D array sampled format:Unknown
-             137:             TypePointer UniformConstant 136
-138(g_tTex1du4a):    137(ptr) Variable UniformConstant
-             139:             TypeImage 6(float) 2D array sampled format:Unknown
-             140:             TypePointer UniformConstant 139
-141(g_tTex2df4a):    140(ptr) Variable UniformConstant
-             142:             TypeImage 23(int) 2D array sampled format:Unknown
-             143:             TypePointer UniformConstant 142
-144(g_tTex2di4a):    143(ptr) Variable UniformConstant
-             145:             TypeImage 39(int) 2D array sampled format:Unknown
-             146:             TypePointer UniformConstant 145
-147(g_tTex2du4a):    146(ptr) Variable UniformConstant
-             148:             TypeImage 6(float) Cube array sampled format:Unknown
-             149:             TypePointer UniformConstant 148
-150(g_tTexcdf4a):    149(ptr) Variable UniformConstant
-             151:             TypeImage 23(int) Cube array sampled format:Unknown
-             152:             TypePointer UniformConstant 151
-153(g_tTexcdi4a):    152(ptr) Variable UniformConstant
-             154:             TypeImage 39(int) Cube array sampled format:Unknown
-             155:             TypePointer UniformConstant 154
-156(g_tTexcdu4a):    155(ptr) Variable UniformConstant
+              22:             TypeVector 6(float) 2
+              24:    6(float) Constant 0
+              25:             TypeInt 32 1
+              26:     25(int) Constant 2
+              30:             TypeImage 25(int) 1D sampled format:Unknown
+              31:             TypePointer UniformConstant 30
+  32(g_tTex1di4):     31(ptr) Variable UniformConstant
+              35:             TypeImage 25(int) 1D depth sampled format:Unknown
+              36:             TypeSampledImage 35
+              42:             TypeInt 32 0
+              43:             TypeImage 42(int) 1D sampled format:Unknown
+              44:             TypePointer UniformConstant 43
+  45(g_tTex1du4):     44(ptr) Variable UniformConstant
+              48:             TypeImage 42(int) 1D depth sampled format:Unknown
+              49:             TypeSampledImage 48
+              55:             TypeImage 6(float) 2D sampled format:Unknown
+              56:             TypePointer UniformConstant 55
+  57(g_tTex2df4):     56(ptr) Variable UniformConstant
+              60:             TypeImage 6(float) 2D depth sampled format:Unknown
+              61:             TypeSampledImage 60
+              63:    6(float) Constant 1045220557
+              64:   22(fvec2) ConstantComposite 20 63
+              65:             TypeVector 6(float) 3
+              69:             TypeVector 25(int) 2
+              70:     25(int) Constant 3
+              71:   69(ivec2) ConstantComposite 26 70
+              75:             TypeImage 25(int) 2D sampled format:Unknown
+              76:             TypePointer UniformConstant 75
+  77(g_tTex2di4):     76(ptr) Variable UniformConstant
+              80:             TypeImage 25(int) 2D depth sampled format:Unknown
+              81:             TypeSampledImage 80
+              89:             TypeImage 42(int) 2D sampled format:Unknown
+              90:             TypePointer UniformConstant 89
+  91(g_tTex2du4):     90(ptr) Variable UniformConstant
+              94:             TypeImage 42(int) 2D depth sampled format:Unknown
+              95:             TypeSampledImage 94
+             102:             TypeVector 6(float) 4
+  103(PS_OUTPUT):             TypeStruct 102(fvec4) 6(float)
+             104:             TypePointer Function 103(PS_OUTPUT)
+             106:     25(int) Constant 0
+             107:    6(float) Constant 1065353216
+             108:  102(fvec4) ConstantComposite 107 107 107 107
+             109:             TypePointer Function 102(fvec4)
+             111:     25(int) Constant 1
+             113:             TypePointer Output 102(fvec4)
+      114(Color):    113(ptr) Variable Output
+             117:             TypePointer Output 6(float)
+      118(Depth):    117(ptr) Variable Output
+             122:             TypeImage 6(float) 3D sampled format:Unknown
+             123:             TypePointer UniformConstant 122
+ 124(g_tTex3df4):    123(ptr) Variable UniformConstant
+             125:             TypeImage 25(int) 3D sampled format:Unknown
+             126:             TypePointer UniformConstant 125
+ 127(g_tTex3di4):    126(ptr) Variable UniformConstant
+             128:             TypeImage 42(int) 3D sampled format:Unknown
+             129:             TypePointer UniformConstant 128
+ 130(g_tTex3du4):    129(ptr) Variable UniformConstant
+             131:             TypeImage 6(float) Cube sampled format:Unknown
+             132:             TypePointer UniformConstant 131
+ 133(g_tTexcdf4):    132(ptr) Variable UniformConstant
+             134:             TypeImage 25(int) Cube sampled format:Unknown
+             135:             TypePointer UniformConstant 134
+ 136(g_tTexcdi4):    135(ptr) Variable UniformConstant
+             137:             TypeImage 42(int) Cube sampled format:Unknown
+             138:             TypePointer UniformConstant 137
+ 139(g_tTexcdu4):    138(ptr) Variable UniformConstant
+             140:             TypeImage 6(float) 1D array sampled format:Unknown
+             141:             TypePointer UniformConstant 140
+142(g_tTex1df4a):    141(ptr) Variable UniformConstant
+             143:             TypeImage 25(int) 1D array sampled format:Unknown
+             144:             TypePointer UniformConstant 143
+145(g_tTex1di4a):    144(ptr) Variable UniformConstant
+             146:             TypeImage 42(int) 1D array sampled format:Unknown
+             147:             TypePointer UniformConstant 146
+148(g_tTex1du4a):    147(ptr) Variable UniformConstant
+             149:             TypeImage 6(float) 2D array sampled format:Unknown
+             150:             TypePointer UniformConstant 149
+151(g_tTex2df4a):    150(ptr) Variable UniformConstant
+             152:             TypeImage 25(int) 2D array sampled format:Unknown
+             153:             TypePointer UniformConstant 152
+154(g_tTex2di4a):    153(ptr) Variable UniformConstant
+             155:             TypeImage 42(int) 2D array sampled format:Unknown
+             156:             TypePointer UniformConstant 155
+157(g_tTex2du4a):    156(ptr) Variable UniformConstant
+             158:             TypeImage 6(float) Cube array sampled format:Unknown
+             159:             TypePointer UniformConstant 158
+160(g_tTexcdf4a):    159(ptr) Variable UniformConstant
+             161:             TypeImage 25(int) Cube array sampled format:Unknown
+             162:             TypePointer UniformConstant 161
+163(g_tTexcdi4a):    162(ptr) Variable UniformConstant
+             164:             TypeImage 42(int) Cube array sampled format:Unknown
+             165:             TypePointer UniformConstant 164
+166(g_tTexcdu4a):    165(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
           8(r01):      7(ptr) Variable Function
-         27(r03):      7(ptr) Variable Function
-         38(r05):      7(ptr) Variable Function
-         50(r21):      7(ptr) Variable Function
-         68(r23):      7(ptr) Variable Function
-         80(r25):      7(ptr) Variable Function
-       95(psout):     94(ptr) Variable Function
+         29(r03):      7(ptr) Variable Function
+         41(r05):      7(ptr) Variable Function
+         54(r21):      7(ptr) Variable Function
+         74(r23):      7(ptr) Variable Function
+         88(r25):      7(ptr) Variable Function
+      105(psout):    104(ptr) Variable Function
               12:           9 Load 11(g_tTex1df4)
               16:          13 Load 15(g_sSamp)
               19:          18 SampledImage 12 16
-              25:    6(float) CompositeExtract 20 0
-              26:    6(float) ImageSampleDrefExplicitLod 19 20 25 Lod ConstOffset 22 24
-                              Store 8(r01) 26
-              31:          28 Load 30(g_tTex1di4)
-              32:          13 Load 15(g_sSamp)
-              35:          34 SampledImage 31 32
-              36:    6(float) CompositeExtract 20 0
-              37:    6(float) ImageSampleDrefExplicitLod 35 20 36 Lod ConstOffset 22 24
-                              Store 27(r03) 37
-              43:          40 Load 42(g_tTex1du4)
-              44:          13 Load 15(g_sSamp)
-              47:          46 SampledImage 43 44
-              48:    6(float) CompositeExtract 20 0
-              49:    6(float) ImageSampleDrefExplicitLod 47 20 48 Lod ConstOffset 22 24
-                              Store 38(r05) 49
-              54:          51 Load 53(g_tTex2df4)
-              55:          13 Load 15(g_sSamp)
-              58:          57 SampledImage 54 55
-              62:    6(float) CompositeExtract 61 0
-              66:    6(float) CompositeExtract 62 0
-              67:    6(float) ImageSampleDrefExplicitLod 58 62 66 Lod ConstOffset 22 65
-                              Store 50(r21) 67
-              72:          69 Load 71(g_tTex2di4)
-              73:          13 Load 15(g_sSamp)
-              76:          75 SampledImage 72 73
-              77:    6(float) CompositeExtract 61 0
-              78:    6(float) CompositeExtract 77 0
-              79:    6(float) ImageSampleDrefExplicitLod 76 77 78 Lod ConstOffset 22 65
-                              Store 68(r23) 79
-              84:          81 Load 83(g_tTex2du4)
-              85:          13 Load 15(g_sSamp)
-              88:          87 SampledImage 84 85
-              89:    6(float) CompositeExtract 61 0
-              90:    6(float) CompositeExtract 89 0
-              91:    6(float) ImageSampleDrefExplicitLod 88 89 90 Lod ConstOffset 22 65
-                              Store 80(r25) 91
-             100:     99(ptr) AccessChain 95(psout) 96
-                              Store 100 98
-             102:      7(ptr) AccessChain 95(psout) 101
-                              Store 102 97
-             105:     99(ptr) AccessChain 95(psout) 96
-             106:   92(fvec4) Load 105
-                              Store 104(Color) 106
-             109:      7(ptr) AccessChain 95(psout) 101
-             110:    6(float) Load 109
-                              Store 108(Depth) 110
+              23:   22(fvec2) CompositeConstruct 20 21
+              27:    6(float) CompositeExtract 23 1
+              28:    6(float) ImageSampleDrefExplicitLod 19 23 27 Lod ConstOffset 24 26
+                              Store 8(r01) 28
+              33:          30 Load 32(g_tTex1di4)
+              34:          13 Load 15(g_sSamp)
+              37:          36 SampledImage 33 34
+              38:   22(fvec2) CompositeConstruct 20 21
+              39:    6(float) CompositeExtract 38 1
+              40:    6(float) ImageSampleDrefExplicitLod 37 38 39 Lod ConstOffset 24 26
+                              Store 29(r03) 40
+              46:          43 Load 45(g_tTex1du4)
+              47:          13 Load 15(g_sSamp)
+              50:          49 SampledImage 46 47
+              51:   22(fvec2) CompositeConstruct 20 21
+              52:    6(float) CompositeExtract 51 1
+              53:    6(float) ImageSampleDrefExplicitLod 50 51 52 Lod ConstOffset 24 26
+                              Store 41(r05) 53
+              58:          55 Load 57(g_tTex2df4)
+              59:          13 Load 15(g_sSamp)
+              62:          61 SampledImage 58 59
+              66:    6(float) CompositeExtract 64 0
+              67:    6(float) CompositeExtract 64 1
+              68:   65(fvec3) CompositeConstruct 66 67 21
+              72:    6(float) CompositeExtract 68 2
+              73:    6(float) ImageSampleDrefExplicitLod 62 68 72 Lod ConstOffset 24 71
+                              Store 54(r21) 73
+              78:          75 Load 77(g_tTex2di4)
+              79:          13 Load 15(g_sSamp)
+              82:          81 SampledImage 78 79
+              83:    6(float) CompositeExtract 64 0
+              84:    6(float) CompositeExtract 64 1
+              85:   65(fvec3) CompositeConstruct 83 84 21
+              86:    6(float) CompositeExtract 85 2
+              87:    6(float) ImageSampleDrefExplicitLod 82 85 86 Lod ConstOffset 24 71
+                              Store 74(r23) 87
+              92:          89 Load 91(g_tTex2du4)
+              93:          13 Load 15(g_sSamp)
+              96:          95 SampledImage 92 93
+              97:    6(float) CompositeExtract 64 0
+              98:    6(float) CompositeExtract 64 1
+              99:   65(fvec3) CompositeConstruct 97 98 21
+             100:    6(float) CompositeExtract 99 2
+             101:    6(float) ImageSampleDrefExplicitLod 96 99 100 Lod ConstOffset 24 71
+                              Store 88(r25) 101
+             110:    109(ptr) AccessChain 105(psout) 106
+                              Store 110 108
+             112:      7(ptr) AccessChain 105(psout) 111
+                              Store 112 107
+             115:    109(ptr) AccessChain 105(psout) 106
+             116:  102(fvec4) Load 115
+                              Store 114(Color) 116
+             119:      7(ptr) AccessChain 105(psout) 111
+             120:    6(float) Load 119
+                              Store 118(Depth) 120
                               Return
                               FunctionEnd

--- a/Test/baseResults/hlsl.samplecmplevelzero.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmplevelzero.offsetarray.dx10.frag.out
@@ -12,7 +12,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DArrayShadow)
 0:42              'g_tTex1df4a' (uniform texture1DArray)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec3 (temp float)
+0:42            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -29,7 +29,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DArrayShadow)
 0:43              'g_tTex1di4a' (uniform itexture1DArray)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec3 (temp float)
+0:43            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -46,7 +46,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DArrayShadow)
 0:44              'g_tTex1du4a' (uniform utexture1DArray)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec3 (temp float)
+0:44            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -63,7 +63,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DArrayShadow)
 0:47              'g_tTex2df4a' (uniform texture2DArray)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec4 (temp float)
+0:47            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -82,7 +82,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DArrayShadow)
 0:48              'g_tTex2di4a' (uniform itexture2DArray)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec4 (temp float)
+0:48            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -101,7 +101,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DArrayShadow)
 0:49              'g_tTex2du4a' (uniform utexture2DArray)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec4 (temp float)
+0:49            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -188,7 +188,7 @@ gl_FragCoord origin is upper left
 0:42            Construct combined texture-sampler (temp sampler1DArrayShadow)
 0:42              'g_tTex1df4a' (uniform texture1DArray)
 0:42              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:42            Construct vec3 (temp float)
+0:42            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -205,7 +205,7 @@ gl_FragCoord origin is upper left
 0:43            Construct combined texture-sampler (temp isampler1DArrayShadow)
 0:43              'g_tTex1di4a' (uniform itexture1DArray)
 0:43              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:43            Construct vec3 (temp float)
+0:43            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -222,7 +222,7 @@ gl_FragCoord origin is upper left
 0:44            Construct combined texture-sampler (temp usampler1DArrayShadow)
 0:44              'g_tTex1du4a' (uniform utexture1DArray)
 0:44              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:44            Construct vec3 (temp float)
+0:44            Construct vec3 (temp 3-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -239,7 +239,7 @@ gl_FragCoord origin is upper left
 0:47            Construct combined texture-sampler (temp sampler2DArrayShadow)
 0:47              'g_tTex2df4a' (uniform texture2DArray)
 0:47              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:47            Construct vec4 (temp float)
+0:47            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -258,7 +258,7 @@ gl_FragCoord origin is upper left
 0:48            Construct combined texture-sampler (temp isampler2DArrayShadow)
 0:48              'g_tTex2di4a' (uniform itexture2DArray)
 0:48              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:48            Construct vec4 (temp float)
+0:48            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -277,7 +277,7 @@ gl_FragCoord origin is upper left
 0:49            Construct combined texture-sampler (temp usampler2DArrayShadow)
 0:49              'g_tTex2du4a' (uniform utexture2DArray)
 0:49              'g_sSamp' (layout(binding=0 ) uniform sampler)
-0:49            Construct vec4 (temp float)
+0:49            Construct vec4 (temp 4-component vector of float)
 0:?               Constant:
 0:?                 0.100000
 0:?                 0.200000
@@ -349,76 +349,76 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 163
+// Id's are bound by 178
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 110 114
+                              EntryPoint Fragment 4  "main" 125 129
                               ExecutionMode 4 OriginUpperLeft
                               Name 4  "main"
                               Name 8  "r11"
                               Name 11  "g_tTex1df4a"
                               Name 15  "g_sSamp"
-                              Name 31  "r13"
-                              Name 34  "g_tTex1di4a"
-                              Name 43  "r15"
-                              Name 47  "g_tTex1du4a"
-                              Name 56  "r31"
-                              Name 59  "g_tTex2df4a"
-                              Name 74  "r33"
-                              Name 77  "g_tTex2di4a"
-                              Name 86  "r35"
-                              Name 89  "g_tTex2du4a"
-                              Name 99  "PS_OUTPUT"
-                              MemberName 99(PS_OUTPUT) 0  "Color"
-                              MemberName 99(PS_OUTPUT) 1  "Depth"
-                              Name 101  "psout"
-                              Name 110  "Color"
-                              Name 114  "Depth"
-                              Name 120  "g_tTex1df4"
-                              Name 123  "g_tTex1di4"
-                              Name 126  "g_tTex1du4"
-                              Name 129  "g_tTex2df4"
-                              Name 132  "g_tTex2di4"
-                              Name 135  "g_tTex2du4"
-                              Name 138  "g_tTex3df4"
-                              Name 141  "g_tTex3di4"
-                              Name 144  "g_tTex3du4"
-                              Name 147  "g_tTexcdf4"
-                              Name 150  "g_tTexcdi4"
-                              Name 153  "g_tTexcdu4"
-                              Name 156  "g_tTexcdf4a"
-                              Name 159  "g_tTexcdi4a"
-                              Name 162  "g_tTexcdu4a"
+                              Name 34  "r13"
+                              Name 37  "g_tTex1di4a"
+                              Name 48  "r15"
+                              Name 52  "g_tTex1du4a"
+                              Name 63  "r31"
+                              Name 66  "g_tTex2df4a"
+                              Name 84  "r33"
+                              Name 87  "g_tTex2di4a"
+                              Name 99  "r35"
+                              Name 102  "g_tTex2du4a"
+                              Name 114  "PS_OUTPUT"
+                              MemberName 114(PS_OUTPUT) 0  "Color"
+                              MemberName 114(PS_OUTPUT) 1  "Depth"
+                              Name 116  "psout"
+                              Name 125  "Color"
+                              Name 129  "Depth"
+                              Name 135  "g_tTex1df4"
+                              Name 138  "g_tTex1di4"
+                              Name 141  "g_tTex1du4"
+                              Name 144  "g_tTex2df4"
+                              Name 147  "g_tTex2di4"
+                              Name 150  "g_tTex2du4"
+                              Name 153  "g_tTex3df4"
+                              Name 156  "g_tTex3di4"
+                              Name 159  "g_tTex3du4"
+                              Name 162  "g_tTexcdf4"
+                              Name 165  "g_tTexcdi4"
+                              Name 168  "g_tTexcdu4"
+                              Name 171  "g_tTexcdf4a"
+                              Name 174  "g_tTexcdi4a"
+                              Name 177  "g_tTexcdu4a"
                               Decorate 11(g_tTex1df4a) DescriptorSet 0
                               Decorate 15(g_sSamp) DescriptorSet 0
                               Decorate 15(g_sSamp) Binding 0
-                              Decorate 34(g_tTex1di4a) DescriptorSet 0
-                              Decorate 47(g_tTex1du4a) DescriptorSet 0
-                              Decorate 59(g_tTex2df4a) DescriptorSet 0
-                              Decorate 77(g_tTex2di4a) DescriptorSet 0
-                              Decorate 89(g_tTex2du4a) DescriptorSet 0
-                              Decorate 110(Color) Location 0
-                              Decorate 114(Depth) BuiltIn FragDepth
-                              Decorate 120(g_tTex1df4) DescriptorSet 0
-                              Decorate 120(g_tTex1df4) Binding 0
-                              Decorate 123(g_tTex1di4) DescriptorSet 0
-                              Decorate 126(g_tTex1du4) DescriptorSet 0
-                              Decorate 129(g_tTex2df4) DescriptorSet 0
-                              Decorate 132(g_tTex2di4) DescriptorSet 0
-                              Decorate 135(g_tTex2du4) DescriptorSet 0
-                              Decorate 138(g_tTex3df4) DescriptorSet 0
-                              Decorate 141(g_tTex3di4) DescriptorSet 0
-                              Decorate 144(g_tTex3du4) DescriptorSet 0
-                              Decorate 147(g_tTexcdf4) DescriptorSet 0
-                              Decorate 150(g_tTexcdi4) DescriptorSet 0
-                              Decorate 153(g_tTexcdu4) DescriptorSet 0
-                              Decorate 156(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 159(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 162(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 37(g_tTex1di4a) DescriptorSet 0
+                              Decorate 52(g_tTex1du4a) DescriptorSet 0
+                              Decorate 66(g_tTex2df4a) DescriptorSet 0
+                              Decorate 87(g_tTex2di4a) DescriptorSet 0
+                              Decorate 102(g_tTex2du4a) DescriptorSet 0
+                              Decorate 125(Color) Location 0
+                              Decorate 129(Depth) BuiltIn FragDepth
+                              Decorate 135(g_tTex1df4) DescriptorSet 0
+                              Decorate 135(g_tTex1df4) Binding 0
+                              Decorate 138(g_tTex1di4) DescriptorSet 0
+                              Decorate 141(g_tTex1du4) DescriptorSet 0
+                              Decorate 144(g_tTex2df4) DescriptorSet 0
+                              Decorate 147(g_tTex2di4) DescriptorSet 0
+                              Decorate 150(g_tTex2du4) DescriptorSet 0
+                              Decorate 153(g_tTex3df4) DescriptorSet 0
+                              Decorate 156(g_tTex3di4) DescriptorSet 0
+                              Decorate 159(g_tTex3du4) DescriptorSet 0
+                              Decorate 162(g_tTexcdf4) DescriptorSet 0
+                              Decorate 165(g_tTexcdi4) DescriptorSet 0
+                              Decorate 168(g_tTexcdu4) DescriptorSet 0
+                              Decorate 171(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 174(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 177(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -436,158 +436,173 @@ gl_FragCoord origin is upper left
               22:    6(float) Constant 1045220557
               23:   20(fvec2) ConstantComposite 21 22
               24:    6(float) Constant 1061158912
-              26:    6(float) Constant 0
-              27:             TypeInt 32 1
-              28:     27(int) Constant 2
-              32:             TypeImage 27(int) 1D array sampled format:Unknown
-              33:             TypePointer UniformConstant 32
- 34(g_tTex1di4a):     33(ptr) Variable UniformConstant
-              37:             TypeImage 27(int) 1D depth array sampled format:Unknown
-              38:             TypeSampledImage 37
-              44:             TypeInt 32 0
-              45:             TypeImage 44(int) 1D array sampled format:Unknown
-              46:             TypePointer UniformConstant 45
- 47(g_tTex1du4a):     46(ptr) Variable UniformConstant
-              50:             TypeImage 44(int) 1D depth array sampled format:Unknown
-              51:             TypeSampledImage 50
-              57:             TypeImage 6(float) 2D array sampled format:Unknown
-              58:             TypePointer UniformConstant 57
- 59(g_tTex2df4a):     58(ptr) Variable UniformConstant
-              62:             TypeImage 6(float) 2D depth array sampled format:Unknown
-              63:             TypeSampledImage 62
-              65:             TypeVector 6(float) 3
-              66:    6(float) Constant 1050253722
-              67:   65(fvec3) ConstantComposite 21 22 66
-              69:             TypeVector 27(int) 2
-              70:     27(int) Constant 3
-              71:   69(ivec2) ConstantComposite 28 70
-              75:             TypeImage 27(int) 2D array sampled format:Unknown
-              76:             TypePointer UniformConstant 75
- 77(g_tTex2di4a):     76(ptr) Variable UniformConstant
-              80:             TypeImage 27(int) 2D depth array sampled format:Unknown
-              81:             TypeSampledImage 80
-              87:             TypeImage 44(int) 2D array sampled format:Unknown
-              88:             TypePointer UniformConstant 87
- 89(g_tTex2du4a):     88(ptr) Variable UniformConstant
-              92:             TypeImage 44(int) 2D depth array sampled format:Unknown
-              93:             TypeSampledImage 92
-              98:             TypeVector 6(float) 4
-   99(PS_OUTPUT):             TypeStruct 98(fvec4) 6(float)
-             100:             TypePointer Function 99(PS_OUTPUT)
-             102:     27(int) Constant 0
-             103:    6(float) Constant 1065353216
-             104:   98(fvec4) ConstantComposite 103 103 103 103
-             105:             TypePointer Function 98(fvec4)
-             107:     27(int) Constant 1
-             109:             TypePointer Output 98(fvec4)
-      110(Color):    109(ptr) Variable Output
-             113:             TypePointer Output 6(float)
-      114(Depth):    113(ptr) Variable Output
-             118:             TypeImage 6(float) 1D sampled format:Unknown
-             119:             TypePointer UniformConstant 118
- 120(g_tTex1df4):    119(ptr) Variable UniformConstant
-             121:             TypeImage 27(int) 1D sampled format:Unknown
-             122:             TypePointer UniformConstant 121
- 123(g_tTex1di4):    122(ptr) Variable UniformConstant
-             124:             TypeImage 44(int) 1D sampled format:Unknown
-             125:             TypePointer UniformConstant 124
- 126(g_tTex1du4):    125(ptr) Variable UniformConstant
-             127:             TypeImage 6(float) 2D sampled format:Unknown
-             128:             TypePointer UniformConstant 127
- 129(g_tTex2df4):    128(ptr) Variable UniformConstant
-             130:             TypeImage 27(int) 2D sampled format:Unknown
-             131:             TypePointer UniformConstant 130
- 132(g_tTex2di4):    131(ptr) Variable UniformConstant
-             133:             TypeImage 44(int) 2D sampled format:Unknown
+              25:             TypeVector 6(float) 3
+              29:    6(float) Constant 0
+              30:             TypeInt 32 1
+              31:     30(int) Constant 2
+              35:             TypeImage 30(int) 1D array sampled format:Unknown
+              36:             TypePointer UniformConstant 35
+ 37(g_tTex1di4a):     36(ptr) Variable UniformConstant
+              40:             TypeImage 30(int) 1D depth array sampled format:Unknown
+              41:             TypeSampledImage 40
+              49:             TypeInt 32 0
+              50:             TypeImage 49(int) 1D array sampled format:Unknown
+              51:             TypePointer UniformConstant 50
+ 52(g_tTex1du4a):     51(ptr) Variable UniformConstant
+              55:             TypeImage 49(int) 1D depth array sampled format:Unknown
+              56:             TypeSampledImage 55
+              64:             TypeImage 6(float) 2D array sampled format:Unknown
+              65:             TypePointer UniformConstant 64
+ 66(g_tTex2df4a):     65(ptr) Variable UniformConstant
+              69:             TypeImage 6(float) 2D depth array sampled format:Unknown
+              70:             TypeSampledImage 69
+              72:    6(float) Constant 1050253722
+              73:   25(fvec3) ConstantComposite 21 22 72
+              74:             TypeVector 6(float) 4
+              79:             TypeVector 30(int) 2
+              80:     30(int) Constant 3
+              81:   79(ivec2) ConstantComposite 31 80
+              85:             TypeImage 30(int) 2D array sampled format:Unknown
+              86:             TypePointer UniformConstant 85
+ 87(g_tTex2di4a):     86(ptr) Variable UniformConstant
+              90:             TypeImage 30(int) 2D depth array sampled format:Unknown
+              91:             TypeSampledImage 90
+             100:             TypeImage 49(int) 2D array sampled format:Unknown
+             101:             TypePointer UniformConstant 100
+102(g_tTex2du4a):    101(ptr) Variable UniformConstant
+             105:             TypeImage 49(int) 2D depth array sampled format:Unknown
+             106:             TypeSampledImage 105
+  114(PS_OUTPUT):             TypeStruct 74(fvec4) 6(float)
+             115:             TypePointer Function 114(PS_OUTPUT)
+             117:     30(int) Constant 0
+             118:    6(float) Constant 1065353216
+             119:   74(fvec4) ConstantComposite 118 118 118 118
+             120:             TypePointer Function 74(fvec4)
+             122:     30(int) Constant 1
+             124:             TypePointer Output 74(fvec4)
+      125(Color):    124(ptr) Variable Output
+             128:             TypePointer Output 6(float)
+      129(Depth):    128(ptr) Variable Output
+             133:             TypeImage 6(float) 1D sampled format:Unknown
              134:             TypePointer UniformConstant 133
- 135(g_tTex2du4):    134(ptr) Variable UniformConstant
-             136:             TypeImage 6(float) 3D sampled format:Unknown
+ 135(g_tTex1df4):    134(ptr) Variable UniformConstant
+             136:             TypeImage 30(int) 1D sampled format:Unknown
              137:             TypePointer UniformConstant 136
- 138(g_tTex3df4):    137(ptr) Variable UniformConstant
-             139:             TypeImage 27(int) 3D sampled format:Unknown
+ 138(g_tTex1di4):    137(ptr) Variable UniformConstant
+             139:             TypeImage 49(int) 1D sampled format:Unknown
              140:             TypePointer UniformConstant 139
- 141(g_tTex3di4):    140(ptr) Variable UniformConstant
-             142:             TypeImage 44(int) 3D sampled format:Unknown
+ 141(g_tTex1du4):    140(ptr) Variable UniformConstant
+             142:             TypeImage 6(float) 2D sampled format:Unknown
              143:             TypePointer UniformConstant 142
- 144(g_tTex3du4):    143(ptr) Variable UniformConstant
-             145:             TypeImage 6(float) Cube sampled format:Unknown
+ 144(g_tTex2df4):    143(ptr) Variable UniformConstant
+             145:             TypeImage 30(int) 2D sampled format:Unknown
              146:             TypePointer UniformConstant 145
- 147(g_tTexcdf4):    146(ptr) Variable UniformConstant
-             148:             TypeImage 27(int) Cube sampled format:Unknown
+ 147(g_tTex2di4):    146(ptr) Variable UniformConstant
+             148:             TypeImage 49(int) 2D sampled format:Unknown
              149:             TypePointer UniformConstant 148
- 150(g_tTexcdi4):    149(ptr) Variable UniformConstant
-             151:             TypeImage 44(int) Cube sampled format:Unknown
+ 150(g_tTex2du4):    149(ptr) Variable UniformConstant
+             151:             TypeImage 6(float) 3D sampled format:Unknown
              152:             TypePointer UniformConstant 151
- 153(g_tTexcdu4):    152(ptr) Variable UniformConstant
-             154:             TypeImage 6(float) Cube array sampled format:Unknown
+ 153(g_tTex3df4):    152(ptr) Variable UniformConstant
+             154:             TypeImage 30(int) 3D sampled format:Unknown
              155:             TypePointer UniformConstant 154
-156(g_tTexcdf4a):    155(ptr) Variable UniformConstant
-             157:             TypeImage 27(int) Cube array sampled format:Unknown
+ 156(g_tTex3di4):    155(ptr) Variable UniformConstant
+             157:             TypeImage 49(int) 3D sampled format:Unknown
              158:             TypePointer UniformConstant 157
-159(g_tTexcdi4a):    158(ptr) Variable UniformConstant
-             160:             TypeImage 44(int) Cube array sampled format:Unknown
+ 159(g_tTex3du4):    158(ptr) Variable UniformConstant
+             160:             TypeImage 6(float) Cube sampled format:Unknown
              161:             TypePointer UniformConstant 160
-162(g_tTexcdu4a):    161(ptr) Variable UniformConstant
+ 162(g_tTexcdf4):    161(ptr) Variable UniformConstant
+             163:             TypeImage 30(int) Cube sampled format:Unknown
+             164:             TypePointer UniformConstant 163
+ 165(g_tTexcdi4):    164(ptr) Variable UniformConstant
+             166:             TypeImage 49(int) Cube sampled format:Unknown
+             167:             TypePointer UniformConstant 166
+ 168(g_tTexcdu4):    167(ptr) Variable UniformConstant
+             169:             TypeImage 6(float) Cube array sampled format:Unknown
+             170:             TypePointer UniformConstant 169
+171(g_tTexcdf4a):    170(ptr) Variable UniformConstant
+             172:             TypeImage 30(int) Cube array sampled format:Unknown
+             173:             TypePointer UniformConstant 172
+174(g_tTexcdi4a):    173(ptr) Variable UniformConstant
+             175:             TypeImage 49(int) Cube array sampled format:Unknown
+             176:             TypePointer UniformConstant 175
+177(g_tTexcdu4a):    176(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
           8(r11):      7(ptr) Variable Function
-         31(r13):      7(ptr) Variable Function
-         43(r15):      7(ptr) Variable Function
-         56(r31):      7(ptr) Variable Function
-         74(r33):      7(ptr) Variable Function
-         86(r35):      7(ptr) Variable Function
-      101(psout):    100(ptr) Variable Function
+         34(r13):      7(ptr) Variable Function
+         48(r15):      7(ptr) Variable Function
+         63(r31):      7(ptr) Variable Function
+         84(r33):      7(ptr) Variable Function
+         99(r35):      7(ptr) Variable Function
+      116(psout):    115(ptr) Variable Function
               12:           9 Load 11(g_tTex1df4a)
               16:          13 Load 15(g_sSamp)
               19:          18 SampledImage 12 16
-              25:    6(float) CompositeExtract 23 0
-              29:    6(float) CompositeExtract 25 0
-              30:    6(float) ImageSampleDrefExplicitLod 19 25 29 Lod ConstOffset 26 28
-                              Store 8(r11) 30
-              35:          32 Load 34(g_tTex1di4a)
-              36:          13 Load 15(g_sSamp)
-              39:          38 SampledImage 35 36
-              40:    6(float) CompositeExtract 23 0
-              41:    6(float) CompositeExtract 40 0
-              42:    6(float) ImageSampleDrefExplicitLod 39 40 41 Lod ConstOffset 26 28
-                              Store 31(r13) 42
-              48:          45 Load 47(g_tTex1du4a)
-              49:          13 Load 15(g_sSamp)
-              52:          51 SampledImage 48 49
-              53:    6(float) CompositeExtract 23 0
-              54:    6(float) CompositeExtract 53 0
-              55:    6(float) ImageSampleDrefExplicitLod 52 53 54 Lod ConstOffset 26 28
-                              Store 43(r15) 55
-              60:          57 Load 59(g_tTex2df4a)
-              61:          13 Load 15(g_sSamp)
-              64:          63 SampledImage 60 61
-              68:    6(float) CompositeExtract 67 0
-              72:    6(float) CompositeExtract 68 0
-              73:    6(float) ImageSampleDrefExplicitLod 64 68 72 Lod ConstOffset 26 71
-                              Store 56(r31) 73
-              78:          75 Load 77(g_tTex2di4a)
-              79:          13 Load 15(g_sSamp)
-              82:          81 SampledImage 78 79
-              83:    6(float) CompositeExtract 67 0
-              84:    6(float) CompositeExtract 83 0
-              85:    6(float) ImageSampleDrefExplicitLod 82 83 84 Lod ConstOffset 26 71
-                              Store 74(r33) 85
-              90:          87 Load 89(g_tTex2du4a)
-              91:          13 Load 15(g_sSamp)
-              94:          93 SampledImage 90 91
-              95:    6(float) CompositeExtract 67 0
-              96:    6(float) CompositeExtract 95 0
-              97:    6(float) ImageSampleDrefExplicitLod 94 95 96 Lod ConstOffset 26 71
-                              Store 86(r35) 97
-             106:    105(ptr) AccessChain 101(psout) 102
-                              Store 106 104
-             108:      7(ptr) AccessChain 101(psout) 107
-                              Store 108 103
-             111:    105(ptr) AccessChain 101(psout) 102
-             112:   98(fvec4) Load 111
-                              Store 110(Color) 112
-             115:      7(ptr) AccessChain 101(psout) 107
-             116:    6(float) Load 115
-                              Store 114(Depth) 116
+              26:    6(float) CompositeExtract 23 0
+              27:    6(float) CompositeExtract 23 1
+              28:   25(fvec3) CompositeConstruct 26 27 24
+              32:    6(float) CompositeExtract 28 2
+              33:    6(float) ImageSampleDrefExplicitLod 19 28 32 Lod ConstOffset 29 31
+                              Store 8(r11) 33
+              38:          35 Load 37(g_tTex1di4a)
+              39:          13 Load 15(g_sSamp)
+              42:          41 SampledImage 38 39
+              43:    6(float) CompositeExtract 23 0
+              44:    6(float) CompositeExtract 23 1
+              45:   25(fvec3) CompositeConstruct 43 44 24
+              46:    6(float) CompositeExtract 45 2
+              47:    6(float) ImageSampleDrefExplicitLod 42 45 46 Lod ConstOffset 29 31
+                              Store 34(r13) 47
+              53:          50 Load 52(g_tTex1du4a)
+              54:          13 Load 15(g_sSamp)
+              57:          56 SampledImage 53 54
+              58:    6(float) CompositeExtract 23 0
+              59:    6(float) CompositeExtract 23 1
+              60:   25(fvec3) CompositeConstruct 58 59 24
+              61:    6(float) CompositeExtract 60 2
+              62:    6(float) ImageSampleDrefExplicitLod 57 60 61 Lod ConstOffset 29 31
+                              Store 48(r15) 62
+              67:          64 Load 66(g_tTex2df4a)
+              68:          13 Load 15(g_sSamp)
+              71:          70 SampledImage 67 68
+              75:    6(float) CompositeExtract 73 0
+              76:    6(float) CompositeExtract 73 1
+              77:    6(float) CompositeExtract 73 2
+              78:   74(fvec4) CompositeConstruct 75 76 77 24
+              82:    6(float) CompositeExtract 78 3
+              83:    6(float) ImageSampleDrefExplicitLod 71 78 82 Lod ConstOffset 29 81
+                              Store 63(r31) 83
+              88:          85 Load 87(g_tTex2di4a)
+              89:          13 Load 15(g_sSamp)
+              92:          91 SampledImage 88 89
+              93:    6(float) CompositeExtract 73 0
+              94:    6(float) CompositeExtract 73 1
+              95:    6(float) CompositeExtract 73 2
+              96:   74(fvec4) CompositeConstruct 93 94 95 24
+              97:    6(float) CompositeExtract 96 3
+              98:    6(float) ImageSampleDrefExplicitLod 92 96 97 Lod ConstOffset 29 81
+                              Store 84(r33) 98
+             103:         100 Load 102(g_tTex2du4a)
+             104:          13 Load 15(g_sSamp)
+             107:         106 SampledImage 103 104
+             108:    6(float) CompositeExtract 73 0
+             109:    6(float) CompositeExtract 73 1
+             110:    6(float) CompositeExtract 73 2
+             111:   74(fvec4) CompositeConstruct 108 109 110 24
+             112:    6(float) CompositeExtract 111 3
+             113:    6(float) ImageSampleDrefExplicitLod 107 111 112 Lod ConstOffset 29 81
+                              Store 99(r35) 113
+             121:    120(ptr) AccessChain 116(psout) 117
+                              Store 121 119
+             123:      7(ptr) AccessChain 116(psout) 122
+                              Store 123 118
+             126:    120(ptr) AccessChain 116(psout) 117
+             127:   74(fvec4) Load 126
+                              Store 125(Color) 127
+             130:      7(ptr) AccessChain 116(psout) 122
+             131:    6(float) Load 130
+                              Store 129(Depth) 131
                               Return
                               FunctionEnd

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -1496,6 +1496,10 @@ void HlslParseContext::decomposeSampleMethods(const TSourceLoc& loc, TIntermType
             constructCoord->getSequence().push_back(arg1);
             constructCoord->setLoc(loc);
 
+            // The input vector should never be less than 2, since there's always a bias.
+            // The max is for safety, and should be a no-op.
+            constructCoord->setType(TType(arg1->getBasicType(), EvqTemporary, std::max(arg1->getVectorSize() - 1, 0)));
+
             TIntermAggregate* tex = new TIntermAggregate(EOpTexture);
             tex->getSequence().push_back(arg0);           // sampler
             tex->getSequence().push_back(constructCoord); // coordinate
@@ -1725,6 +1729,7 @@ void HlslParseContext::decomposeSampleMethods(const TSourceLoc& loc, TIntermType
             if (coordDimWithCmpVal != 5) // cube array shadow is special.
                 coordWithCmp->getSequence().push_back(argCmpVal);
             coordWithCmp->setLoc(loc);
+            coordWithCmp->setType(TType(argCoord->getBasicType(), EvqTemporary, std::min(coordDimWithCmpVal, 4)));
 
             TOperator textureOp = (op == EOpMethodSampleCmpLevelZero ? EOpTextureLod : EOpTexture);
             if (argOffset != nullptr)


### PR DESCRIPTION
HLSL holds the compare value in a separate intrinsic arg, but the AST wants a vector including the cmp val, except in the 4-dim coord case, where it doesn't fit and is in fact a separate AST parameter.   This is awkward but necessary, given AST semantics.  In the process, a new vector is constructed for the combined result, but this vector was not being given the correct TType, so was causing some downstream troubles.

Now it is.  A similar defect existed in OpTextureBias, and has also been fixed.
