### PR TITLE
WIP: apply unused variable

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -1216,7 +1216,7 @@ void TParseContext::computeBuiltinPrecisions(TIntermTyped& node, const TFunction
                                         function.getType().getQualifier().precision;
     } else if (TIntermAggregate* agg = node.getAsAggregate()) {
         TIntermSequence& sequence = agg->getSequence();
-        int numArgs = (int)sequence.size();
+        unsigned int numArgs = (unsigned int)sequence.size();
         switch (agg->getOp()) {
         case EOpBitfieldExtract:
             numArgs = 1;
@@ -1233,7 +1233,7 @@ void TParseContext::computeBuiltinPrecisions(TIntermTyped& node, const TFunction
             break;
         }
         // find the maximum precision from the arguments and parameters
-        for (unsigned int arg = 0; arg < sequence.size(); ++arg) {
+        for (unsigned int arg = 0; arg < numArgs; ++arg) {
             operationPrecision = std::max(operationPrecision, sequence[arg]->getAsTyped()->getQualifier().precision);
             operationPrecision = std::max(operationPrecision, function[arg].type->getQualifier().precision);
         }


### PR DESCRIPTION
I happened upon numArgs while hunting for unused variables. I suspect
the intent was to apply it as shown in this patch. However, I am not a
compiler dude. Someone more appropriate should grok this change.