### PR TITLE
HLSL: Enable component-wise vector comparisons from operators

### DIFF
--- a/Test/baseResults/hlsl.comparison.vec.frag.out
+++ b/Test/baseResults/hlsl.comparison.vec.frag.out
@@ -1,0 +1,401 @@
+hlsl.comparison.vec.frag
+Shader version: 450
+gl_FragCoord origin is upper left
+0:? Sequence
+0:4  Function Definition: Bug1(vf4; (temp void)
+0:4    Function Parameters: 
+0:4      'a' (in 4-component vector of float)
+0:?     Sequence
+0:5      Sequence
+0:5        move second child to first child (temp 4-component vector of float)
+0:5          'v04' (temp 4-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:6      Sequence
+0:6        move second child to first child (temp float)
+0:6          'v01' (temp float)
+0:6          Constant:
+0:6            0.000000
+0:8      Sequence
+0:8        move second child to first child (temp 4-component vector of bool)
+0:8          'r00' (temp 4-component vector of bool)
+0:8          Equal (temp 4-component vector of bool)
+0:8            'a' (in 4-component vector of float)
+0:8            'v04' (temp 4-component vector of float)
+0:9      Sequence
+0:9        move second child to first child (temp 4-component vector of bool)
+0:9          'r01' (temp 4-component vector of bool)
+0:9          NotEqual (temp 4-component vector of bool)
+0:9            'a' (in 4-component vector of float)
+0:9            'v04' (temp 4-component vector of float)
+0:10      Sequence
+0:10        move second child to first child (temp 4-component vector of bool)
+0:10          'r02' (temp 4-component vector of bool)
+0:10          Compare Less Than (temp 4-component vector of bool)
+0:10            'a' (in 4-component vector of float)
+0:10            'v04' (temp 4-component vector of float)
+0:11      Sequence
+0:11        move second child to first child (temp 4-component vector of bool)
+0:11          'r03' (temp 4-component vector of bool)
+0:11          Compare Greater Than (temp 4-component vector of bool)
+0:11            'a' (in 4-component vector of float)
+0:11            'v04' (temp 4-component vector of float)
+0:13      Sequence
+0:13        move second child to first child (temp 4-component vector of bool)
+0:13          'r10' (temp 4-component vector of bool)
+0:13          Equal (temp 4-component vector of bool)
+0:13            'a' (in 4-component vector of float)
+0:13            Construct vec4 (in 4-component vector of float)
+0:13              'v01' (temp float)
+0:14      Sequence
+0:14        move second child to first child (temp 4-component vector of bool)
+0:14          'r11' (temp 4-component vector of bool)
+0:14          NotEqual (temp 4-component vector of bool)
+0:14            'a' (in 4-component vector of float)
+0:14            Construct vec4 (in 4-component vector of float)
+0:14              'v01' (temp float)
+0:15      Sequence
+0:15        move second child to first child (temp 4-component vector of bool)
+0:15          'r12' (temp 4-component vector of bool)
+0:15          Compare Less Than (temp 4-component vector of bool)
+0:15            'a' (in 4-component vector of float)
+0:15            Construct vec4 (in 4-component vector of float)
+0:15              'v01' (temp float)
+0:16      Sequence
+0:16        move second child to first child (temp 4-component vector of bool)
+0:16          'r13' (temp 4-component vector of bool)
+0:16          Compare Greater Than (temp 4-component vector of bool)
+0:16            'a' (in 4-component vector of float)
+0:16            Construct vec4 (in 4-component vector of float)
+0:16              'v01' (temp float)
+0:18      Sequence
+0:18        move second child to first child (temp 4-component vector of bool)
+0:18          'r20' (temp 4-component vector of bool)
+0:18          Equal (temp 4-component vector of bool)
+0:18            Construct vec4 (in 4-component vector of float)
+0:18              'v01' (temp float)
+0:18            'a' (in 4-component vector of float)
+0:19      Sequence
+0:19        move second child to first child (temp 4-component vector of bool)
+0:19          'r21' (temp 4-component vector of bool)
+0:19          NotEqual (temp 4-component vector of bool)
+0:19            Construct vec4 (in 4-component vector of float)
+0:19              'v01' (temp float)
+0:19            'a' (in 4-component vector of float)
+0:20      Sequence
+0:20        move second child to first child (temp 4-component vector of bool)
+0:20          'r22' (temp 4-component vector of bool)
+0:20          Compare Less Than (temp 4-component vector of bool)
+0:20            Construct vec4 (in 4-component vector of float)
+0:20              'v01' (temp float)
+0:20            'a' (in 4-component vector of float)
+0:21      Sequence
+0:21        move second child to first child (temp 4-component vector of bool)
+0:21          'r23' (temp 4-component vector of bool)
+0:21          Compare Greater Than (temp 4-component vector of bool)
+0:21            Construct vec4 (in 4-component vector of float)
+0:21              'v01' (temp float)
+0:21            'a' (in 4-component vector of float)
+0:30  Function Definition: main( (temp structure{temp 4-component vector of float Color})
+0:30    Function Parameters: 
+0:?     Sequence
+0:32      move second child to first child (temp 4-component vector of float)
+0:32        Color: direct index for structure (temp 4-component vector of float)
+0:32          'psout' (temp structure{temp 4-component vector of float Color})
+0:32          Constant:
+0:32            0 (const int)
+0:32        Constant:
+0:32          0.000000
+0:32          0.000000
+0:32          0.000000
+0:32          0.000000
+0:33      Sequence
+0:33        Sequence
+0:33          move second child to first child (temp 4-component vector of float)
+0:?             'Color' (layout(location=0 ) out 4-component vector of float)
+0:33            Color: direct index for structure (temp 4-component vector of float)
+0:33              'psout' (temp structure{temp 4-component vector of float Color})
+0:33              Constant:
+0:33                0 (const int)
+0:33        Branch: Return
+0:?   Linker Objects
+0:?     'anon@0' (uniform block{layout(offset=0 ) uniform 4-component vector of float uf4})
+0:?     'Color' (layout(location=0 ) out 4-component vector of float)
+
+
+Linked fragment stage:
+
+
+Shader version: 450
+gl_FragCoord origin is upper left
+0:? Sequence
+0:4  Function Definition: Bug1(vf4; (temp void)
+0:4    Function Parameters: 
+0:4      'a' (in 4-component vector of float)
+0:?     Sequence
+0:5      Sequence
+0:5        move second child to first child (temp 4-component vector of float)
+0:5          'v04' (temp 4-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:6      Sequence
+0:6        move second child to first child (temp float)
+0:6          'v01' (temp float)
+0:6          Constant:
+0:6            0.000000
+0:8      Sequence
+0:8        move second child to first child (temp 4-component vector of bool)
+0:8          'r00' (temp 4-component vector of bool)
+0:8          Equal (temp 4-component vector of bool)
+0:8            'a' (in 4-component vector of float)
+0:8            'v04' (temp 4-component vector of float)
+0:9      Sequence
+0:9        move second child to first child (temp 4-component vector of bool)
+0:9          'r01' (temp 4-component vector of bool)
+0:9          NotEqual (temp 4-component vector of bool)
+0:9            'a' (in 4-component vector of float)
+0:9            'v04' (temp 4-component vector of float)
+0:10      Sequence
+0:10        move second child to first child (temp 4-component vector of bool)
+0:10          'r02' (temp 4-component vector of bool)
+0:10          Compare Less Than (temp 4-component vector of bool)
+0:10            'a' (in 4-component vector of float)
+0:10            'v04' (temp 4-component vector of float)
+0:11      Sequence
+0:11        move second child to first child (temp 4-component vector of bool)
+0:11          'r03' (temp 4-component vector of bool)
+0:11          Compare Greater Than (temp 4-component vector of bool)
+0:11            'a' (in 4-component vector of float)
+0:11            'v04' (temp 4-component vector of float)
+0:13      Sequence
+0:13        move second child to first child (temp 4-component vector of bool)
+0:13          'r10' (temp 4-component vector of bool)
+0:13          Equal (temp 4-component vector of bool)
+0:13            'a' (in 4-component vector of float)
+0:13            Construct vec4 (in 4-component vector of float)
+0:13              'v01' (temp float)
+0:14      Sequence
+0:14        move second child to first child (temp 4-component vector of bool)
+0:14          'r11' (temp 4-component vector of bool)
+0:14          NotEqual (temp 4-component vector of bool)
+0:14            'a' (in 4-component vector of float)
+0:14            Construct vec4 (in 4-component vector of float)
+0:14              'v01' (temp float)
+0:15      Sequence
+0:15        move second child to first child (temp 4-component vector of bool)
+0:15          'r12' (temp 4-component vector of bool)
+0:15          Compare Less Than (temp 4-component vector of bool)
+0:15            'a' (in 4-component vector of float)
+0:15            Construct vec4 (in 4-component vector of float)
+0:15              'v01' (temp float)
+0:16      Sequence
+0:16        move second child to first child (temp 4-component vector of bool)
+0:16          'r13' (temp 4-component vector of bool)
+0:16          Compare Greater Than (temp 4-component vector of bool)
+0:16            'a' (in 4-component vector of float)
+0:16            Construct vec4 (in 4-component vector of float)
+0:16              'v01' (temp float)
+0:18      Sequence
+0:18        move second child to first child (temp 4-component vector of bool)
+0:18          'r20' (temp 4-component vector of bool)
+0:18          Equal (temp 4-component vector of bool)
+0:18            Construct vec4 (in 4-component vector of float)
+0:18              'v01' (temp float)
+0:18            'a' (in 4-component vector of float)
+0:19      Sequence
+0:19        move second child to first child (temp 4-component vector of bool)
+0:19          'r21' (temp 4-component vector of bool)
+0:19          NotEqual (temp 4-component vector of bool)
+0:19            Construct vec4 (in 4-component vector of float)
+0:19              'v01' (temp float)
+0:19            'a' (in 4-component vector of float)
+0:20      Sequence
+0:20        move second child to first child (temp 4-component vector of bool)
+0:20          'r22' (temp 4-component vector of bool)
+0:20          Compare Less Than (temp 4-component vector of bool)
+0:20            Construct vec4 (in 4-component vector of float)
+0:20              'v01' (temp float)
+0:20            'a' (in 4-component vector of float)
+0:21      Sequence
+0:21        move second child to first child (temp 4-component vector of bool)
+0:21          'r23' (temp 4-component vector of bool)
+0:21          Compare Greater Than (temp 4-component vector of bool)
+0:21            Construct vec4 (in 4-component vector of float)
+0:21              'v01' (temp float)
+0:21            'a' (in 4-component vector of float)
+0:30  Function Definition: main( (temp structure{temp 4-component vector of float Color})
+0:30    Function Parameters: 
+0:?     Sequence
+0:32      move second child to first child (temp 4-component vector of float)
+0:32        Color: direct index for structure (temp 4-component vector of float)
+0:32          'psout' (temp structure{temp 4-component vector of float Color})
+0:32          Constant:
+0:32            0 (const int)
+0:32        Constant:
+0:32          0.000000
+0:32          0.000000
+0:32          0.000000
+0:32          0.000000
+0:33      Sequence
+0:33        Sequence
+0:33          move second child to first child (temp 4-component vector of float)
+0:?             'Color' (layout(location=0 ) out 4-component vector of float)
+0:33            Color: direct index for structure (temp 4-component vector of float)
+0:33              'psout' (temp structure{temp 4-component vector of float Color})
+0:33              Constant:
+0:33                0 (const int)
+0:33        Branch: Return
+0:?   Linker Objects
+0:?     'anon@0' (uniform block{layout(offset=0 ) uniform 4-component vector of float uf4})
+0:?     'Color' (layout(location=0 ) out 4-component vector of float)
+
+// Module Version 10000
+// Generated by (magic number): 80001
+// Id's are bound by 91
+
+                              Capability Shader
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Fragment 4  "main" 84
+                              ExecutionMode 4 OriginUpperLeft
+                              Name 4  "main"
+                              Name 11  "Bug1(vf4;"
+                              Name 10  "a"
+                              Name 13  "v04"
+                              Name 17  "v01"
+                              Name 21  "r00"
+                              Name 25  "r01"
+                              Name 29  "r02"
+                              Name 33  "r03"
+                              Name 37  "r10"
+                              Name 42  "r11"
+                              Name 47  "r12"
+                              Name 52  "r13"
+                              Name 57  "r20"
+                              Name 62  "r21"
+                              Name 67  "r22"
+                              Name 72  "r23"
+                              Name 77  "PS_OUTPUT"
+                              MemberName 77(PS_OUTPUT) 0  "Color"
+                              Name 79  "psout"
+                              Name 84  "Color"
+                              Name 88  "$Global"
+                              MemberName 88($Global) 0  "uf4"
+                              Name 90  ""
+                              Decorate 84(Color) Location 0
+                              Decorate 88($Global) Block
+                              Decorate 90 DescriptorSet 0
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeFloat 32
+               7:             TypeVector 6(float) 4
+               8:             TypePointer Function 7(fvec4)
+               9:             TypeFunction 2 8(ptr)
+              14:    6(float) Constant 0
+              15:    7(fvec4) ConstantComposite 14 14 14 14
+              16:             TypePointer Function 6(float)
+              18:             TypeBool
+              19:             TypeVector 18(bool) 4
+              20:             TypePointer Function 19(bvec4)
+   77(PS_OUTPUT):             TypeStruct 7(fvec4)
+              78:             TypePointer Function 77(PS_OUTPUT)
+              80:             TypeInt 32 1
+              81:     80(int) Constant 0
+              83:             TypePointer Output 7(fvec4)
+       84(Color):     83(ptr) Variable Output
+     88($Global):             TypeStruct 7(fvec4)
+              89:             TypePointer Uniform 88($Global)
+              90:     89(ptr) Variable Uniform
+         4(main):           2 Function None 3
+               5:             Label
+       79(psout):     78(ptr) Variable Function
+              82:      8(ptr) AccessChain 79(psout) 81
+                              Store 82 15
+              85:      8(ptr) AccessChain 79(psout) 81
+              86:    7(fvec4) Load 85
+                              Store 84(Color) 86
+                              Return
+                              FunctionEnd
+   11(Bug1(vf4;):           2 Function None 9
+           10(a):      8(ptr) FunctionParameter
+              12:             Label
+         13(v04):      8(ptr) Variable Function
+         17(v01):     16(ptr) Variable Function
+         21(r00):     20(ptr) Variable Function
+         25(r01):     20(ptr) Variable Function
+         29(r02):     20(ptr) Variable Function
+         33(r03):     20(ptr) Variable Function
+         37(r10):     20(ptr) Variable Function
+         42(r11):     20(ptr) Variable Function
+         47(r12):     20(ptr) Variable Function
+         52(r13):     20(ptr) Variable Function
+         57(r20):     20(ptr) Variable Function
+         62(r21):     20(ptr) Variable Function
+         67(r22):     20(ptr) Variable Function
+         72(r23):     20(ptr) Variable Function
+                              Store 13(v04) 15
+                              Store 17(v01) 14
+              22:    7(fvec4) Load 10(a)
+              23:    7(fvec4) Load 13(v04)
+              24:   19(bvec4) FOrdEqual 22 23
+                              Store 21(r00) 24
+              26:    7(fvec4) Load 10(a)
+              27:    7(fvec4) Load 13(v04)
+              28:   19(bvec4) FOrdNotEqual 26 27
+                              Store 25(r01) 28
+              30:    7(fvec4) Load 10(a)
+              31:    7(fvec4) Load 13(v04)
+              32:   19(bvec4) FOrdLessThan 30 31
+                              Store 29(r02) 32
+              34:    7(fvec4) Load 10(a)
+              35:    7(fvec4) Load 13(v04)
+              36:   19(bvec4) FOrdGreaterThan 34 35
+                              Store 33(r03) 36
+              38:    7(fvec4) Load 10(a)
+              39:    6(float) Load 17(v01)
+              40:    7(fvec4) CompositeConstruct 39 39 39 39
+              41:   19(bvec4) FOrdEqual 38 40
+                              Store 37(r10) 41
+              43:    7(fvec4) Load 10(a)
+              44:    6(float) Load 17(v01)
+              45:    7(fvec4) CompositeConstruct 44 44 44 44
+              46:   19(bvec4) FOrdNotEqual 43 45
+                              Store 42(r11) 46
+              48:    7(fvec4) Load 10(a)
+              49:    6(float) Load 17(v01)
+              50:    7(fvec4) CompositeConstruct 49 49 49 49
+              51:   19(bvec4) FOrdLessThan 48 50
+                              Store 47(r12) 51
+              53:    7(fvec4) Load 10(a)
+              54:    6(float) Load 17(v01)
+              55:    7(fvec4) CompositeConstruct 54 54 54 54
+              56:   19(bvec4) FOrdGreaterThan 53 55
+                              Store 52(r13) 56
+              58:    6(float) Load 17(v01)
+              59:    7(fvec4) CompositeConstruct 58 58 58 58
+              60:    7(fvec4) Load 10(a)
+              61:   19(bvec4) FOrdEqual 59 60
+                              Store 57(r20) 61
+              63:    6(float) Load 17(v01)
+              64:    7(fvec4) CompositeConstruct 63 63 63 63
+              65:    7(fvec4) Load 10(a)
+              66:   19(bvec4) FOrdNotEqual 64 65
+                              Store 62(r21) 66
+              68:    6(float) Load 17(v01)
+              69:    7(fvec4) CompositeConstruct 68 68 68 68
+              70:    7(fvec4) Load 10(a)
+              71:   19(bvec4) FOrdLessThan 69 70
+                              Store 67(r22) 71
+              73:    6(float) Load 17(v01)
+              74:    7(fvec4) CompositeConstruct 73 73 73 73
+              75:    7(fvec4) Load 10(a)
+              76:   19(bvec4) FOrdGreaterThan 74 75
+                              Store 72(r23) 76
+                              Return
+                              FunctionEnd

--- a/Test/baseResults/hlsl.doLoop.frag.out
+++ b/Test/baseResults/hlsl.doLoop.frag.out
@@ -18,9 +18,10 @@ gl_FragCoord origin is upper left
 0:4        No loop body
 0:5      Loop with condition not tested first
 0:5        Loop Condition
-0:5        Compare Equal (temp bool)
-0:5          'input' (layout(location=0 ) in 4-component vector of float)
-0:5          'input' (layout(location=0 ) in 4-component vector of float)
+0:5        all (global bool)
+0:5          Equal (temp 4-component vector of bool)
+0:5            'input' (layout(location=0 ) in 4-component vector of float)
+0:5            'input' (layout(location=0 ) in 4-component vector of float)
 0:5        Loop Body
 0:5        Sequence
 0:5          move second child to first child (temp 4-component vector of float)
@@ -54,9 +55,10 @@ gl_FragCoord origin is upper left
 0:4        No loop body
 0:5      Loop with condition not tested first
 0:5        Loop Condition
-0:5        Compare Equal (temp bool)
-0:5          'input' (layout(location=0 ) in 4-component vector of float)
-0:5          'input' (layout(location=0 ) in 4-component vector of float)
+0:5        all (global bool)
+0:5          Equal (temp 4-component vector of bool)
+0:5            'input' (layout(location=0 ) in 4-component vector of float)
+0:5            'input' (layout(location=0 ) in 4-component vector of float)
 0:5        Loop Body
 0:5        Sequence
 0:5          move second child to first child (temp 4-component vector of float)

--- a/Test/baseResults/hlsl.forLoop.frag.out
+++ b/Test/baseResults/hlsl.forLoop.frag.out
@@ -19,16 +19,18 @@ gl_FragCoord origin is upper left
 0:?       Sequence
 0:5        Loop with condition tested first
 0:5          Loop Condition
-0:5          Compare Not Equal (temp bool)
-0:5            'input' (layout(location=0 ) in 4-component vector of float)
-0:5            'input' (layout(location=0 ) in 4-component vector of float)
+0:5          any (global bool)
+0:5            NotEqual (temp 4-component vector of bool)
+0:5              'input' (layout(location=0 ) in 4-component vector of float)
+0:5              'input' (layout(location=0 ) in 4-component vector of float)
 0:5          No loop body
 0:?       Sequence
 0:6        Loop with condition tested first
 0:6          Loop Condition
-0:6          Compare Not Equal (temp bool)
-0:6            'input' (layout(location=0 ) in 4-component vector of float)
-0:6            'input' (layout(location=0 ) in 4-component vector of float)
+0:6          any (global bool)
+0:6            NotEqual (temp 4-component vector of bool)
+0:6              'input' (layout(location=0 ) in 4-component vector of float)
+0:6              'input' (layout(location=0 ) in 4-component vector of float)
 0:6          Loop Body
 0:?           Sequence
 0:6            Sequence
@@ -42,9 +44,10 @@ gl_FragCoord origin is upper left
 0:7          'input' (layout(location=0 ) in 4-component vector of float)
 0:7        Loop with condition tested first
 0:7          Loop Condition
-0:7          Compare Not Equal (temp bool)
-0:7            'input' (layout(location=0 ) in 4-component vector of float)
-0:7            'input' (layout(location=0 ) in 4-component vector of float)
+0:7          any (global bool)
+0:7            NotEqual (temp 4-component vector of bool)
+0:7              'input' (layout(location=0 ) in 4-component vector of float)
+0:7              'input' (layout(location=0 ) in 4-component vector of float)
 0:7          Loop Body
 0:?           Sequence
 0:7            Sequence
@@ -141,16 +144,18 @@ gl_FragCoord origin is upper left
 0:?       Sequence
 0:5        Loop with condition tested first
 0:5          Loop Condition
-0:5          Compare Not Equal (temp bool)
-0:5            'input' (layout(location=0 ) in 4-component vector of float)
-0:5            'input' (layout(location=0 ) in 4-component vector of float)
+0:5          any (global bool)
+0:5            NotEqual (temp 4-component vector of bool)
+0:5              'input' (layout(location=0 ) in 4-component vector of float)
+0:5              'input' (layout(location=0 ) in 4-component vector of float)
 0:5          No loop body
 0:?       Sequence
 0:6        Loop with condition tested first
 0:6          Loop Condition
-0:6          Compare Not Equal (temp bool)
-0:6            'input' (layout(location=0 ) in 4-component vector of float)
-0:6            'input' (layout(location=0 ) in 4-component vector of float)
+0:6          any (global bool)
+0:6            NotEqual (temp 4-component vector of bool)
+0:6              'input' (layout(location=0 ) in 4-component vector of float)
+0:6              'input' (layout(location=0 ) in 4-component vector of float)
 0:6          Loop Body
 0:?           Sequence
 0:6            Sequence
@@ -164,9 +169,10 @@ gl_FragCoord origin is upper left
 0:7          'input' (layout(location=0 ) in 4-component vector of float)
 0:7        Loop with condition tested first
 0:7          Loop Condition
-0:7          Compare Not Equal (temp bool)
-0:7            'input' (layout(location=0 ) in 4-component vector of float)
-0:7            'input' (layout(location=0 ) in 4-component vector of float)
+0:7          any (global bool)
+0:7            NotEqual (temp 4-component vector of bool)
+0:7              'input' (layout(location=0 ) in 4-component vector of float)
+0:7              'input' (layout(location=0 ) in 4-component vector of float)
 0:7          Loop Body
 0:?           Sequence
 0:7            Sequence

--- a/Test/baseResults/hlsl.if.frag.out
+++ b/Test/baseResults/hlsl.if.frag.out
@@ -8,9 +8,10 @@ gl_FragCoord origin is upper left
 0:?     Sequence
 0:3      Test condition and select (temp void)
 0:3        Condition
-0:3        Compare Equal (temp bool)
-0:3          'input' (layout(location=0 ) in 4-component vector of float)
-0:3          'input' (layout(location=0 ) in 4-component vector of float)
+0:3        all (global bool)
+0:3          Equal (temp 4-component vector of bool)
+0:3            'input' (layout(location=0 ) in 4-component vector of float)
+0:3            'input' (layout(location=0 ) in 4-component vector of float)
 0:3        true case
 0:4        Sequence
 0:4          move second child to first child (temp 4-component vector of float)
@@ -19,9 +20,10 @@ gl_FragCoord origin is upper left
 0:4          Branch: Return
 0:6      Test condition and select (temp void)
 0:6        Condition
-0:6        Compare Equal (temp bool)
-0:6          'input' (layout(location=0 ) in 4-component vector of float)
-0:6          'input' (layout(location=0 ) in 4-component vector of float)
+0:6        all (global bool)
+0:6          Equal (temp 4-component vector of bool)
+0:6            'input' (layout(location=0 ) in 4-component vector of float)
+0:6            'input' (layout(location=0 ) in 4-component vector of float)
 0:6        true case
 0:7        Sequence
 0:7          move second child to first child (temp 4-component vector of float)
@@ -37,21 +39,24 @@ gl_FragCoord origin is upper left
 0:9          Branch: Return
 0:11      Test condition and select (temp void)
 0:11        Condition
-0:11        Compare Equal (temp bool)
-0:11          'input' (layout(location=0 ) in 4-component vector of float)
-0:11          'input' (layout(location=0 ) in 4-component vector of float)
+0:11        all (global bool)
+0:11          Equal (temp 4-component vector of bool)
+0:11            'input' (layout(location=0 ) in 4-component vector of float)
+0:11            'input' (layout(location=0 ) in 4-component vector of float)
 0:11        true case is null
 0:14      Test condition and select (temp void)
 0:14        Condition
-0:14        Compare Equal (temp bool)
-0:14          'input' (layout(location=0 ) in 4-component vector of float)
-0:14          'input' (layout(location=0 ) in 4-component vector of float)
+0:14        all (global bool)
+0:14          Equal (temp 4-component vector of bool)
+0:14            'input' (layout(location=0 ) in 4-component vector of float)
+0:14            'input' (layout(location=0 ) in 4-component vector of float)
 0:14        true case is null
 0:19      Test condition and select (temp void)
 0:19        Condition
-0:19        Compare Equal (temp bool)
-0:19          'input' (layout(location=0 ) in 4-component vector of float)
-0:19          'input' (layout(location=0 ) in 4-component vector of float)
+0:19        all (global bool)
+0:19          Equal (temp 4-component vector of bool)
+0:19            'input' (layout(location=0 ) in 4-component vector of float)
+0:19            'input' (layout(location=0 ) in 4-component vector of float)
 0:19        true case
 0:?         Sequence
 0:20          Sequence
@@ -61,9 +66,10 @@ gl_FragCoord origin is upper left
 0:20            Branch: Return
 0:23      Test condition and select (temp void)
 0:23        Condition
-0:23        Compare Equal (temp bool)
-0:23          'input' (layout(location=0 ) in 4-component vector of float)
-0:23          'input' (layout(location=0 ) in 4-component vector of float)
+0:23        all (global bool)
+0:23          Equal (temp 4-component vector of bool)
+0:23            'input' (layout(location=0 ) in 4-component vector of float)
+0:23            'input' (layout(location=0 ) in 4-component vector of float)
 0:23        true case
 0:?         Sequence
 0:24          Sequence
@@ -109,9 +115,10 @@ gl_FragCoord origin is upper left
 0:?     Sequence
 0:3      Test condition and select (temp void)
 0:3        Condition
-0:3        Compare Equal (temp bool)
-0:3          'input' (layout(location=0 ) in 4-component vector of float)
-0:3          'input' (layout(location=0 ) in 4-component vector of float)
+0:3        all (global bool)
+0:3          Equal (temp 4-component vector of bool)
+0:3            'input' (layout(location=0 ) in 4-component vector of float)
+0:3            'input' (layout(location=0 ) in 4-component vector of float)
 0:3        true case
 0:4        Sequence
 0:4          move second child to first child (temp 4-component vector of float)
@@ -120,9 +127,10 @@ gl_FragCoord origin is upper left
 0:4          Branch: Return
 0:6      Test condition and select (temp void)
 0:6        Condition
-0:6        Compare Equal (temp bool)
-0:6          'input' (layout(location=0 ) in 4-component vector of float)
-0:6          'input' (layout(location=0 ) in 4-component vector of float)
+0:6        all (global bool)
+0:6          Equal (temp 4-component vector of bool)
+0:6            'input' (layout(location=0 ) in 4-component vector of float)
+0:6            'input' (layout(location=0 ) in 4-component vector of float)
 0:6        true case
 0:7        Sequence
 0:7          move second child to first child (temp 4-component vector of float)
@@ -138,21 +146,24 @@ gl_FragCoord origin is upper left
 0:9          Branch: Return
 0:11      Test condition and select (temp void)
 0:11        Condition
-0:11        Compare Equal (temp bool)
-0:11          'input' (layout(location=0 ) in 4-component vector of float)
-0:11          'input' (layout(location=0 ) in 4-component vector of float)
+0:11        all (global bool)
+0:11          Equal (temp 4-component vector of bool)
+0:11            'input' (layout(location=0 ) in 4-component vector of float)
+0:11            'input' (layout(location=0 ) in 4-component vector of float)
 0:11        true case is null
 0:14      Test condition and select (temp void)
 0:14        Condition
-0:14        Compare Equal (temp bool)
-0:14          'input' (layout(location=0 ) in 4-component vector of float)
-0:14          'input' (layout(location=0 ) in 4-component vector of float)
+0:14        all (global bool)
+0:14          Equal (temp 4-component vector of bool)
+0:14            'input' (layout(location=0 ) in 4-component vector of float)
+0:14            'input' (layout(location=0 ) in 4-component vector of float)
 0:14        true case is null
 0:19      Test condition and select (temp void)
 0:19        Condition
-0:19        Compare Equal (temp bool)
-0:19          'input' (layout(location=0 ) in 4-component vector of float)
-0:19          'input' (layout(location=0 ) in 4-component vector of float)
+0:19        all (global bool)
+0:19          Equal (temp 4-component vector of bool)
+0:19            'input' (layout(location=0 ) in 4-component vector of float)
+0:19            'input' (layout(location=0 ) in 4-component vector of float)
 0:19        true case
 0:?         Sequence
 0:20          Sequence
@@ -162,9 +173,10 @@ gl_FragCoord origin is upper left
 0:20            Branch: Return
 0:23      Test condition and select (temp void)
 0:23        Condition
-0:23        Compare Equal (temp bool)
-0:23          'input' (layout(location=0 ) in 4-component vector of float)
-0:23          'input' (layout(location=0 ) in 4-component vector of float)
+0:23        all (global bool)
+0:23          Equal (temp 4-component vector of bool)
+0:23            'input' (layout(location=0 ) in 4-component vector of float)
+0:23            'input' (layout(location=0 ) in 4-component vector of float)
 0:23        true case
 0:?         Sequence
 0:24          Sequence

--- a/Test/baseResults/hlsl.shapeConv.frag.out
+++ b/Test/baseResults/hlsl.shapeConv.frag.out
@@ -58,41 +58,43 @@ gl_FragCoord origin is upper left
 0:13          'MyVal' (temp 3-component vector of float)
 0:13          Construct vec3 (temp 3-component vector of float)
 0:13            'V' (temp float)
-0:16      Compare Greater Than (temp bool)
+0:16      Compare Greater Than (temp 3-component vector of bool)
 0:16        'foo' (temp 3-component vector of float)
 0:16        Constant:
 0:16          4.000000
 0:16          4.000000
 0:16          4.000000
-0:17      Compare Greater Than or Equal (temp bool)
+0:17      Compare Greater Than or Equal (temp 3-component vector of bool)
 0:17        'foo' (temp 3-component vector of float)
 0:17        Constant:
 0:17          5.000000
 0:17          5.000000
 0:17          5.000000
-0:18      Compare Less Than (temp bool)
+0:18      Compare Less Than (temp 3-component vector of bool)
 0:18        Constant:
 0:18          6.000000
 0:18          6.000000
 0:18          6.000000
 0:18        'foo' (temp 3-component vector of float)
-0:19      Compare Less Than or Equal (temp bool)
+0:19      Compare Less Than or Equal (temp 3-component vector of bool)
 0:19        Constant:
 0:19          7.000000
 0:19          7.000000
 0:19          7.000000
 0:19        'foo' (temp 3-component vector of float)
-0:21      Compare Equal (temp bool)
-0:21        Construct vec4 (temp 4-component vector of float)
-0:21          direct index (temp float)
-0:21            'v' (temp 4-component vector of float)
-0:21            Constant:
-0:21              0 (const int)
-0:21        'v' (temp 4-component vector of float)
-0:22      Compare Not Equal (temp bool)
-0:22        Construct vec4 (temp 4-component vector of float)
-0:22          'f' (in float)
-0:22        'v' (temp 4-component vector of float)
+0:21      all (global bool)
+0:21        Equal (temp 4-component vector of bool)
+0:21          Construct vec4 (temp 4-component vector of float)
+0:21            direct index (temp float)
+0:21              'v' (temp 4-component vector of float)
+0:21              Constant:
+0:21                0 (const int)
+0:21          'v' (temp 4-component vector of float)
+0:22      any (global bool)
+0:22        NotEqual (temp 4-component vector of bool)
+0:22          Construct vec4 (temp 4-component vector of float)
+0:22            'f' (in float)
+0:22          'v' (temp 4-component vector of float)
 0:26      Compare Equal (temp bool)
 0:26        'f1' (temp 1-component vector of float)
 0:26        Construct float (temp 1-component vector of float)
@@ -173,41 +175,43 @@ gl_FragCoord origin is upper left
 0:13          'MyVal' (temp 3-component vector of float)
 0:13          Construct vec3 (temp 3-component vector of float)
 0:13            'V' (temp float)
-0:16      Compare Greater Than (temp bool)
+0:16      Compare Greater Than (temp 3-component vector of bool)
 0:16        'foo' (temp 3-component vector of float)
 0:16        Constant:
 0:16          4.000000
 0:16          4.000000
 0:16          4.000000
-0:17      Compare Greater Than or Equal (temp bool)
+0:17      Compare Greater Than or Equal (temp 3-component vector of bool)
 0:17        'foo' (temp 3-component vector of float)
 0:17        Constant:
 0:17          5.000000
 0:17          5.000000
 0:17          5.000000
-0:18      Compare Less Than (temp bool)
+0:18      Compare Less Than (temp 3-component vector of bool)
 0:18        Constant:
 0:18          6.000000
 0:18          6.000000
 0:18          6.000000
 0:18        'foo' (temp 3-component vector of float)
-0:19      Compare Less Than or Equal (temp bool)
+0:19      Compare Less Than or Equal (temp 3-component vector of bool)
 0:19        Constant:
 0:19          7.000000
 0:19          7.000000
 0:19          7.000000
 0:19        'foo' (temp 3-component vector of float)
-0:21      Compare Equal (temp bool)
-0:21        Construct vec4 (temp 4-component vector of float)
-0:21          direct index (temp float)
-0:21            'v' (temp 4-component vector of float)
-0:21            Constant:
-0:21              0 (const int)
-0:21        'v' (temp 4-component vector of float)
-0:22      Compare Not Equal (temp bool)
-0:22        Construct vec4 (temp 4-component vector of float)
-0:22          'f' (in float)
-0:22        'v' (temp 4-component vector of float)
+0:21      all (global bool)
+0:21        Equal (temp 4-component vector of bool)
+0:21          Construct vec4 (temp 4-component vector of float)
+0:21            direct index (temp float)
+0:21              'v' (temp 4-component vector of float)
+0:21              Constant:
+0:21                0 (const int)
+0:21          'v' (temp 4-component vector of float)
+0:22      any (global bool)
+0:22        NotEqual (temp 4-component vector of bool)
+0:22          Construct vec4 (temp 4-component vector of float)
+0:22            'f' (in float)
+0:22          'v' (temp 4-component vector of float)
 0:26      Compare Equal (temp bool)
 0:26        'f1' (temp 1-component vector of float)
 0:26        Construct float (temp 1-component vector of float)
@@ -227,7 +231,7 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 84
+// Id's are bound by 85
 
                               Capability Shader
                1:             ExtInstImport  "GLSL.std.450"
@@ -244,7 +248,7 @@ gl_FragCoord origin is upper left
                               Name 33  "V"
                               Name 34  "MyVal"
                               Name 37  "foo"
-                              Name 69  "f1"
+                              Name 70  "f1"
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -266,15 +270,16 @@ gl_FragCoord origin is upper left
               39:    6(float) Constant 1082130432
               40:   22(fvec3) ConstantComposite 39 39 39
               41:             TypeBool
-              44:    6(float) Constant 1084227584
-              45:   22(fvec3) ConstantComposite 44 44 44
-              47:    6(float) Constant 1086324736
-              48:   22(fvec3) ConstantComposite 47 47 47
-              51:    6(float) Constant 1088421888
-              52:   22(fvec3) ConstantComposite 51 51 51
-              55:             TypeInt 32 0
-              56:     55(int) Constant 0
-              61:             TypeVector 41(bool) 4
+              42:             TypeVector 41(bool) 3
+              45:    6(float) Constant 1084227584
+              46:   22(fvec3) ConstantComposite 45 45 45
+              48:    6(float) Constant 1086324736
+              49:   22(fvec3) ConstantComposite 48 48 48
+              52:    6(float) Constant 1088421888
+              53:   22(fvec3) ConstantComposite 52 52 52
+              56:             TypeInt 32 0
+              57:     56(int) Constant 0
+              62:             TypeVector 41(bool) 4
          4(main):           2 Function None 3
                5:             Label
                               FunctionEnd
@@ -288,7 +293,7 @@ gl_FragCoord origin is upper left
            33(V):      9(ptr) Variable Function
        34(MyVal):     23(ptr) Variable Function
          37(foo):     23(ptr) Variable Function
-          69(f1):      9(ptr) Variable Function
+          70(f1):      9(ptr) Variable Function
                               Store 15(v) 17
                               Store 15(v) 19
               20:    6(float) Load 12(f)
@@ -305,35 +310,35 @@ gl_FragCoord origin is upper left
               36:   22(fvec3) CompositeConstruct 35 35 35
                               Store 34(MyVal) 36
               38:   22(fvec3) Load 37(foo)
-              42:    41(bool) FOrdGreaterThan 38 40
-              43:   22(fvec3) Load 37(foo)
-              46:    41(bool) FOrdGreaterThanEqual 43 45
-              49:   22(fvec3) Load 37(foo)
-              50:    41(bool) FOrdLessThan 48 49
-              53:   22(fvec3) Load 37(foo)
-              54:    41(bool) FOrdLessThanEqual 52 53
-              57:      9(ptr) AccessChain 15(v) 56
-              58:    6(float) Load 57
-              59:    7(fvec4) CompositeConstruct 58 58 58 58
-              60:    7(fvec4) Load 15(v)
-              62:   61(bvec4) FOrdEqual 59 60
-              63:    41(bool) All 62
-              64:    6(float) Load 12(f)
-              65:    7(fvec4) CompositeConstruct 64 64 64 64
-              66:    7(fvec4) Load 15(v)
-              67:   61(bvec4) FOrdNotEqual 65 66
-              68:    41(bool) Any 67
-              70:    6(float) Load 69(f1)
-              71:    7(fvec4) Load 15(v)
-              72:    6(float) CompositeExtract 71 0
-              73:    41(bool) FOrdEqual 70 72
-              74:    7(fvec4) Load 15(v)
-              75:    6(float) CompositeExtract 74 0
-              76:    6(float) Load 69(f1)
-              77:    41(bool) FOrdLessThan 75 76
-              78:    6(float) Load 69(f1)
-              79:    6(float) Load 69(f1)
-              80:   22(fvec3) CompositeConstruct 79 79 79
-              81:    7(fvec4) Load 11(input)
-                              ReturnValue 81
+              43:   42(bvec3) FOrdGreaterThan 38 40
+              44:   22(fvec3) Load 37(foo)
+              47:   42(bvec3) FOrdGreaterThanEqual 44 46
+              50:   22(fvec3) Load 37(foo)
+              51:   42(bvec3) FOrdLessThan 49 50
+              54:   22(fvec3) Load 37(foo)
+              55:   42(bvec3) FOrdLessThanEqual 53 54
+              58:      9(ptr) AccessChain 15(v) 57
+              59:    6(float) Load 58
+              60:    7(fvec4) CompositeConstruct 59 59 59 59
+              61:    7(fvec4) Load 15(v)
+              63:   62(bvec4) FOrdEqual 60 61
+              64:    41(bool) All 63
+              65:    6(float) Load 12(f)
+              66:    7(fvec4) CompositeConstruct 65 65 65 65
+              67:    7(fvec4) Load 15(v)
+              68:   62(bvec4) FOrdNotEqual 66 67
+              69:    41(bool) Any 68
+              71:    6(float) Load 70(f1)
+              72:    7(fvec4) Load 15(v)
+              73:    6(float) CompositeExtract 72 0
+              74:    41(bool) FOrdEqual 71 73
+              75:    7(fvec4) Load 15(v)
+              76:    6(float) CompositeExtract 75 0
+              77:    6(float) Load 70(f1)
+              78:    41(bool) FOrdLessThan 76 77
+              79:    6(float) Load 70(f1)
+              80:    6(float) Load 70(f1)
+              81:   22(fvec3) CompositeConstruct 80 80 80
+              82:    7(fvec4) Load 11(input)
+                              ReturnValue 82
                               FunctionEnd

--- a/Test/baseResults/hlsl.whileLoop.frag.out
+++ b/Test/baseResults/hlsl.whileLoop.frag.out
@@ -8,9 +8,10 @@ gl_FragCoord origin is upper left
 0:?     Sequence
 0:3      Loop with condition tested first
 0:3        Loop Condition
-0:3        Compare Not Equal (temp bool)
-0:3          'input' (layout(location=0 ) in 4-component vector of float)
-0:3          'input' (layout(location=0 ) in 4-component vector of float)
+0:3        any (global bool)
+0:3          NotEqual (temp 4-component vector of bool)
+0:3            'input' (layout(location=0 ) in 4-component vector of float)
+0:3            'input' (layout(location=0 ) in 4-component vector of float)
 0:3        Loop Body
 0:?         Sequence
 0:3          Sequence
@@ -50,9 +51,10 @@ gl_FragCoord origin is upper left
 0:?     Sequence
 0:3      Loop with condition tested first
 0:3        Loop Condition
-0:3        Compare Not Equal (temp bool)
-0:3          'input' (layout(location=0 ) in 4-component vector of float)
-0:3          'input' (layout(location=0 ) in 4-component vector of float)
+0:3        any (global bool)
+0:3          NotEqual (temp 4-component vector of bool)
+0:3            'input' (layout(location=0 ) in 4-component vector of float)
+0:3            'input' (layout(location=0 ) in 4-component vector of float)
 0:3        Loop Body
 0:?         Sequence
 0:3          Sequence

--- a/Test/hlsl.comparison.vec.frag
+++ b/Test/hlsl.comparison.vec.frag
@@ -1,0 +1,34 @@
+uniform float4 uf4;
+
+void Bug1( float4 a )
+{
+    float4 v04 = float4( 0.0, 0.0, 0.0, 0.0 );
+    float  v01 = 0.0; 
+
+    bool4 r00 = a == v04;
+    bool4 r01 = a != v04;
+    bool4 r02 = a < v04;
+    bool4 r03 = a > v04;
+    
+    bool4 r10 = a == v01;
+    bool4 r11 = a != v01;
+    bool4 r12 = a < v01;
+    bool4 r13 = a > v01;
+    
+    bool4 r20 = v01 == a;
+    bool4 r21 = v01 != a;
+    bool4 r22 = v01 < a;
+    bool4 r23 = v01 > a;
+}
+
+struct PS_OUTPUT
+{
+    float4 Color : SV_Target0;
+};
+
+PS_OUTPUT main()
+{
+   PS_OUTPUT psout;
+   psout.Color = 0;
+   return psout;
+}

--- a/Test/hlsl.doLoop.frag
+++ b/Test/hlsl.doLoop.frag
@@ -2,5 +2,5 @@ float4 PixelShaderFunction(float4 input) : COLOR0
 {
     [unroll] do {} while (false);
     [unroll] do {;} while (false);
-    do { return input; } while (input == input);
+    do { return input; } while (all(input == input));
 }

--- a/Test/hlsl.forLoop.frag
+++ b/Test/hlsl.forLoop.frag
@@ -2,9 +2,9 @@ float4 PixelShaderFunction(float4 input) : COLOR0
 {
     for (;;) ;
     for (++input; ; ) ;
-    [unroll] for (; input != input; ) {}
-    for (; input != input; ) { return -input; }
-    for (--input; input != input; input += 2) { return -input; }
+    [unroll] for (; any(input != input); ) {}
+    for (; any(input != input); ) { return -input; }
+    for (--input; any(input != input); input += 2) { return -input; }
 	for (;;) if (input.x > 2.0) break;
 	for (;;) if (input.x > 2.0) continue;
 	float ii;

--- a/Test/hlsl.if.frag
+++ b/Test/hlsl.if.frag
@@ -1,26 +1,26 @@
 float4 PixelShaderFunction(float4 input) : COLOR0
 {
-    if (input == input)
+    if (all(input == input))
         return input;
 
-    if (input == input)
+    if (all(input == input))
         return input;
     else
         return -input;
 
-    if (input == input)
+    if (all(input == input))
         ;
 
-    if (input == input)
+    if (all(input == input))
         ;
     else
         ;
 
-    [flatten] if (input == input) {
+    [flatten] if (all(input == input)) {
         return input;
     }
 
-    if (input == input) {
+    if (all(input == input)) {
         return input;
     } else {
         return -input;

--- a/Test/hlsl.shapeConv.frag
+++ b/Test/hlsl.shapeConv.frag
@@ -18,8 +18,8 @@ float4 PixelShaderFunction(float4 input, float f) : COLOR0
     6.0 < foo;
     7.0 <= foo;
 
-    v.x == v;
-    f != v;
+    all(v.x == v);
+    any(f != v);
 
     float1 f1;
 

--- a/Test/hlsl.whileLoop.frag
+++ b/Test/hlsl.whileLoop.frag
@@ -1,6 +1,6 @@
 float4 PixelShaderFunction(float4 input) : COLOR0
 {
-    while (input != input) { return input; }
+    while (any(input != input)) { return input; }
     while (false) ;
     [unroll] while (false) { }
     while ((false)) { }

--- a/glslang/MachineIndependent/intermOut.cpp
+++ b/glslang/MachineIndependent/intermOut.cpp
@@ -163,6 +163,8 @@ bool TOutputTraverser::visitBinary(TVisit /* visit */, TIntermBinary* node)
     case EOpGreaterThan:      out.debug << "Compare Greater Than";          break;
     case EOpLessThanEqual:    out.debug << "Compare Less Than or Equal";    break;
     case EOpGreaterThanEqual: out.debug << "Compare Greater Than or Equal"; break;
+    case EOpVectorEqual:      out.debug << "Equal";                         break;
+    case EOpVectorNotEqual:   out.debug << "NotEqual";                      break;
 
     case EOpVectorTimesScalar: out.debug << "vector-scale";          break;
     case EOpVectorTimesMatrix: out.debug << "vector-times-matrix";   break;

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -91,6 +91,7 @@ INSTANTIATE_TEST_CASE_P(
         {"hlsl.calculatelod.dx10.frag", "main"},
         {"hlsl.calculatelodunclamped.dx10.frag", "main"},
         {"hlsl.cast.frag", "PixelShaderFunction"},
+        {"hlsl.comparison.vec.frag", "main"},
         {"hlsl.conditional.frag", "PixelShaderFunction"},
         {"hlsl.constructexpr.frag", "main"},
         {"hlsl.depthGreater.frag", "PixelShaderFunction"},


### PR DESCRIPTION
This PR only changes a few lines of non-test code, but it's subtle, hence long explanation:

In HLSL, comparison operators (<,>,<=,>=,==,!=) operate component-wise when given a vector operand.  If a whole vector equality or inequality is desired, then all() or any() can be used on the resulting bool vector.

This PR enables this.  Previously, these were producing a scalar bool result, even for vector args.  Existing shape conversion is used when one of the two arguments is a vector and one is a scalar.

Some existing HLSL tests had assumed == and != meant vector-wise instead of component-wise comparisons.  These tests have been changed to add an explicit any() or all() to the test source, thus preserving their original semantic (and in all but one case, also their original SPIR-V).  This verifably does not change the final SPIR-V binary relative to the old behavior for == and !=, e.g, in *forLoop* or *doLoop*.  The AST does change due to the (now explicit, formerly implicit) any() and all().  Also, one test (shapeConv) has SPIR-V changes where it previously had the return type wrong, e.g, from a vec < vec comparison.

Promotion of comparison opcodes to vector forms (EOpEqual->EOpVectorEqual) is handled in promoteBinary(), as is setting the proper vector type of the result.

EOpVectorEqual and EOpVectorNotEqual are now accepted as either aggregate or binary nodes, similar to how the other operators are handled.  Partial support already existed for this: it has been
fleshed out in the printing functions in intermOut.cpp.

There is an existing defect around shape conversion with 1-vectors, but that is orthogonal to this PR and not addressed by it.
