### PR TITLE
Use std::atoi instead of std::stoi

### DIFF
--- a/StandAlone/ResourceLimits.cpp
+++ b/StandAlone/ResourceLimits.cpp
@@ -263,7 +263,7 @@ void DecodeResourceLimits(TBuiltInResource* resources, char* config)
             return;
         }
 
-        const int value = std::stoi(valueStr);
+        const int value = std::atoi(valueStr.c_str());
 
         if (tokenStr == "MaxLights")
             resources->maxLights = value;


### PR DESCRIPTION
Some Android cross cross-compilers don't have std::stoi.

E.g. i686-linux-android-g++ from Android NDK r10e don't have std::stoi.