### PR TITLE
Fix variable shadowing warnings.

### DIFF
--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -1460,7 +1460,7 @@ bool TIntermediate::postProcess(TIntermNode* root, EShLanguage /*language*/)
     return true;
 }
 
-void TIntermediate::addSymbolLinkageNodes(TIntermAggregate*& linkage, EShLanguage language, TSymbolTable& symbolTable)
+void TIntermediate::addSymbolLinkageNodes(TIntermAggregate*& linkage, EShLanguage languageIn, TSymbolTable& symbolTable)
 {
     // Add top-level nodes for declarations that must be checked cross
     // compilation unit by a linker, yet might not have been referenced
@@ -1483,7 +1483,7 @@ void TIntermediate::addSymbolLinkageNodes(TIntermAggregate*& linkage, EShLanguag
     //    addSymbolLinkageNode(root, symbolTable, "gl_ModelViewProjectionMatrix");
     //}
 
-    if (language == EShLangVertex) {
+    if (languageIn == EShLangVertex) {
         // the names won't be found in the symbol table unless the versions are right,
         // so version logic does not need to be repeated here
         addSymbolLinkageNode(linkage, symbolTable, "gl_VertexID");

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -179,10 +179,10 @@ void TParseContext::setLimits(const TBuiltInResource& r)
 //
 // Returns true for successful acceptance of the shader, false if any errors.
 //
-bool TParseContext::parseShaderStrings(TPpContext& ppContext, TInputScanner& input, bool versionWillBeError)
+bool TParseContext::parseShaderStrings(TPpContext& ppContextIn, TInputScanner& input, bool versionWillBeError)
 {
     currentScanner = &input;
-    ppContext.setInput(input, versionWillBeError);
+    ppContextIn.setInput(input, versionWillBeError);
     yyparse(this);
     if (! parsingBuiltins)
         finalErrorCheck();
@@ -3398,14 +3398,14 @@ TSymbol* TParseContext::redeclareBuiltinVariable(const TSourceLoc& loc, const TS
 // Either redeclare the requested block, or give an error message why it can't be done.
 //
 // TODO: functionality: explicitly sizing members of redeclared blocks is not giving them an explicit size
-void TParseContext::redeclareBuiltinBlock(const TSourceLoc& loc, TTypeList& newTypeList, const TString& blockName, const TString* instanceName, TArraySizes* arraySizes)
+void TParseContext::redeclareBuiltinBlock(const TSourceLoc& loc, TTypeList& newTypeList, const TString& blockNameIn, const TString* instanceName, TArraySizes* arraySizes)
 {
     const char* feature = "built-in block redeclaration";
     profileRequires(loc, EEsProfile, 0, Num_AEP_shader_io_blocks, AEP_shader_io_blocks, feature);
     profileRequires(loc, ~EEsProfile, 410, E_GL_ARB_separate_shader_objects, feature);
 
-    if (blockName != "gl_PerVertex" && blockName != "gl_PerFragment") {
-        error(loc, "cannot redeclare block: ", "block declaration", blockName.c_str());
+    if (blockNameIn != "gl_PerVertex" && blockNameIn != "gl_PerFragment") {
+        error(loc, "cannot redeclare block: ", "block declaration", blockNameIn.c_str());
         return;
     }
 
@@ -3435,7 +3435,7 @@ void TParseContext::redeclareBuiltinBlock(const TSourceLoc& loc, TTypeList& newT
     // Built-in blocks cannot be redeclared more than once, which if happened,
     // we'd be finding the already redeclared one here, rather than the built in.
     if (! builtIn) {
-        error(loc, "can only redeclare a built-in block once, and before any use", blockName.c_str(), "");
+        error(loc, "can only redeclare a built-in block once, and before any use", blockNameIn.c_str(), "");
         return;
     }
 
@@ -3515,14 +3515,14 @@ void TParseContext::redeclareBuiltinBlock(const TSourceLoc& loc, TTypeList& newT
     }
 
     if (numOriginalMembersFound < newTypeList.size())
-        error(loc, "block redeclaration has extra members", blockName.c_str(), "");
+        error(loc, "block redeclaration has extra members", blockNameIn.c_str(), "");
     if (type.isArray() != (arraySizes != nullptr))
-        error(loc, "cannot change arrayness of redeclared block", blockName.c_str(), "");
+        error(loc, "cannot change arrayness of redeclared block", blockNameIn.c_str(), "");
     else if (type.isArray()) {
         if (type.isExplicitlySizedArray() && arraySizes->getOuterSize() == UnsizedArraySize)
-            error(loc, "block already declared with size, can't redeclare as implicitly-sized", blockName.c_str(), "");
+            error(loc, "block already declared with size, can't redeclare as implicitly-sized", blockNameIn.c_str(), "");
         else if (type.isExplicitlySizedArray() && type.getArraySizes() != *arraySizes)
-            error(loc, "cannot change array size of redeclared block", blockName.c_str(), "");
+            error(loc, "cannot change array size of redeclared block", blockNameIn.c_str(), "");
         else if (type.isImplicitlySizedArray() && arraySizes->getOuterSize() != UnsizedArraySize)
             type.changeOuterArraySize(arraySizes->getOuterSize());
     }
@@ -4039,17 +4039,17 @@ void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publi
         // "offset" can be for either
         //  - uniform offsets
         //  - atomic_uint offsets
-        const char* feature = "offset";
-        requireProfile(loc, EEsProfile | ECoreProfile | ECompatibilityProfile, feature);
+        const char* featureVar = "offset";
+        requireProfile(loc, EEsProfile | ECoreProfile | ECompatibilityProfile, featureVar);
         const char* exts[2] = { E_GL_ARB_enhanced_layouts, E_GL_ARB_shader_atomic_counters };
-        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 420, 2, exts, feature);
-        profileRequires(loc, EEsProfile, 310, nullptr, feature);
+        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 420, 2, exts, featureVar);
+        profileRequires(loc, EEsProfile, 310, nullptr, featureVar);
         publicType.qualifier.layoutOffset = value;
         return;
     } else if (id == "align") {
-        const char* feature = "uniform buffer-member align";
-        requireProfile(loc, ECoreProfile | ECompatibilityProfile, feature);
-        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 440, E_GL_ARB_enhanced_layouts, feature);
+        const char* featureVar = "uniform buffer-member align";
+        requireProfile(loc, ECoreProfile | ECompatibilityProfile, featureVar);
+        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 440, E_GL_ARB_enhanced_layouts, featureVar);
         // "The specified alignment must be a power of 2, or a compile-time error results."
         if (! IsPow2(value))
             error(loc, "must be a power of 2", "align", "");
@@ -4095,10 +4095,10 @@ void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publi
         // capturing mode and hence responsible for describing the transform feedback 
         // setup."
         intermediate.setXfbMode();
-        const char* feature = "transform feedback qualifier";
-        requireStage(loc, (EShLanguageMask)(EShLangVertexMask | EShLangGeometryMask | EShLangTessControlMask | EShLangTessEvaluationMask), feature);
-        requireProfile(loc, ECoreProfile | ECompatibilityProfile, feature);
-        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 440, E_GL_ARB_enhanced_layouts, feature);
+        const char* featureVar = "transform feedback qualifier";
+        requireStage(loc, (EShLanguageMask)(EShLangVertexMask | EShLangGeometryMask | EShLangTessControlMask | EShLangTessEvaluationMask), featureVar);
+        requireProfile(loc, ECoreProfile | ECompatibilityProfile, featureVar);
+        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 440, E_GL_ARB_enhanced_layouts, featureVar);
         if (id == "xfb_buffer") {
             // "It is a compile-time error to specify an *xfb_buffer* that is greater than
             // the implementation-dependent constant gl_MaxTransformFeedbackBuffers."

--- a/glslang/MachineIndependent/ParseHelper.h
+++ b/glslang/MachineIndependent/ParseHelper.h
@@ -113,10 +113,10 @@ public:
 
     virtual bool parseShaderStrings(TPpContext&, TInputScanner& input, bool versionWillBeError = false) = 0;
 
-    virtual void notifyVersion(int line, int version, const char* type_string)
+    virtual void notifyVersion(int line, int versionIn, const char* type_string)
     {
         if (versionCallback)
-            versionCallback(line, version, type_string);
+            versionCallback(line, versionIn, type_string);
     }
     virtual void notifyErrorDirective(int line, const char* error_message)
     {

--- a/glslang/MachineIndependent/Scan.cpp
+++ b/glslang/MachineIndependent/Scan.cpp
@@ -637,14 +637,14 @@ int TScanContext::tokenize(TPpContext* pp, TParserToken& token)
 {
     do {
         parserToken = &token;
-        TPpToken ppToken;
-        tokenText = pp->tokenize(&ppToken);
+        TPpToken ppTokenVar;
+        tokenText = pp->tokenize(&ppTokenVar);
         if (tokenText == nullptr || tokenText[0] == 0)
             return 0;
 
-        loc = ppToken.loc;
+        loc = ppTokenVar.loc;
         parserToken->sType.lex.loc = loc;
-        switch (ppToken.token) {
+        switch (ppTokenVar.token) {
         case ';':  afterType = false;   return SEMICOLON;
         case ',':  afterType = false;   return COMMA;
         case ':':                       return COLON;
@@ -700,27 +700,27 @@ int TScanContext::tokenize(TPpContext* pp, TParserToken& token)
         case PpAtomDecrement:          return DEC_OP;
         case PpAtomIncrement:          return INC_OP;
 
-        case PpAtomConstInt:           parserToken->sType.lex.i   = ppToken.ival;       return INTCONSTANT;
-        case PpAtomConstUint:          parserToken->sType.lex.i   = ppToken.ival;       return UINTCONSTANT;
-        case PpAtomConstInt64:         parserToken->sType.lex.i64 = ppToken.i64val;     return INT64CONSTANT;
-        case PpAtomConstUint64:        parserToken->sType.lex.i64 = ppToken.i64val;     return UINT64CONSTANT;
-        case PpAtomConstFloat:         parserToken->sType.lex.d   = ppToken.dval;       return FLOATCONSTANT;
-        case PpAtomConstDouble:        parserToken->sType.lex.d   = ppToken.dval;       return DOUBLECONSTANT;
+        case PpAtomConstInt:           parserToken->sType.lex.i   = ppTokenVar.ival;       return INTCONSTANT;
+        case PpAtomConstUint:          parserToken->sType.lex.i   = ppTokenVar.ival;       return UINTCONSTANT;
+        case PpAtomConstInt64:         parserToken->sType.lex.i64 = ppTokenVar.i64val;     return INT64CONSTANT;
+        case PpAtomConstUint64:        parserToken->sType.lex.i64 = ppTokenVar.i64val;     return UINT64CONSTANT;
+        case PpAtomConstFloat:         parserToken->sType.lex.d   = ppTokenVar.dval;       return FLOATCONSTANT;
+        case PpAtomConstDouble:        parserToken->sType.lex.d   = ppTokenVar.dval;       return DOUBLECONSTANT;
 #ifdef AMD_EXTENSIONS
         case PpAtomConstFloat16:       parserToken->sType.lex.d   = ppToken.dval;       return FLOAT16CONSTANT;
 #endif
         case PpAtomIdentifier:
         {
-            int token = tokenizeIdentifier();
+            int tokenVar = tokenizeIdentifier();
             field = false;
-            return token;
+            return tokenVar;
         }
 
         case EndOfInput:               return 0;
 
         default:
             char buf[2];
-            buf[0] = (char)ppToken.token;
+            buf[0] = (char)ppTokenVar.token;
             buf[1] = 0;
             parseContext.error(loc, "unexpected token", buf, "");
             break;

--- a/glslang/MachineIndependent/limits.cpp
+++ b/glslang/MachineIndependent/limits.cpp
@@ -129,9 +129,9 @@ bool TInductiveTraverser::visitAggregate(TVisit /* visit */, TIntermAggregate* n
 //
 // External function to call for loop check.
 //
-void TParseContext::inductiveLoopBodyCheck(TIntermNode* body, int loopId, TSymbolTable& symbolTable)
+void TParseContext::inductiveLoopBodyCheck(TIntermNode* body, int loopId, TSymbolTable& symbolTableIn)
 {
-    TInductiveTraverser it(loopId, symbolTable);
+    TInductiveTraverser it(loopId, symbolTableIn);
 
     if (body == nullptr)
         return;

--- a/hlsl/hlslGrammar.cpp
+++ b/hlsl/hlslGrammar.cpp
@@ -2627,8 +2627,8 @@ bool HlslGrammar::acceptIterationStatement(TIntermNode*& statement)
         }
 
         // LEFT_PAREN condition RIGHT_PAREN
-        TIntermTyped* condition;
-        if (! acceptParenExpression(condition))
+        TIntermTyped* conditionVar;
+        if (! acceptParenExpression(conditionVar))
             return false;
 
         if (! acceptTokenClass(EHTokSemicolon))
@@ -2636,7 +2636,7 @@ bool HlslGrammar::acceptIterationStatement(TIntermNode*& statement)
 
         parseContext.unnestLooping();
 
-        statement = intermediate.addLoop(statement, condition, 0, false, loc);
+        statement = intermediate.addLoop(statement, conditionVar, 0, false, loc);
 
         return true;
 

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -112,13 +112,13 @@ void HlslParseContext::setLimits(const TBuiltInResource& r)
 //
 // Returns true for successful acceptance of the shader, false if any errors.
 //
-bool HlslParseContext::parseShaderStrings(TPpContext& ppContext, TInputScanner& input, bool versionWillBeError)
+bool HlslParseContext::parseShaderStrings(TPpContext& ppContextIn, TInputScanner& input, bool versionWillBeError)
 {
     currentScanner = &input;
-    ppContext.setInput(input, versionWillBeError);
+    ppContextIn.setInput(input, versionWillBeError);
 
-    HlslScanContext scanContext(*this, ppContext);
-    HlslGrammar grammar(scanContext, *this);
+    HlslScanContext scanContextVar(*this, ppContextIn);
+    HlslGrammar grammar(scanContextVar, *this);
     if (!grammar.parse()) {
         // Print a message formated such that if you click on the message it will take you right to
         // the line through most UIs.
@@ -3063,10 +3063,10 @@ void HlslParseContext::handlePackOffset(const TSourceLoc& loc, TQualifier& quali
 // 'profile' points to the shader_profile part, or nullptr if not present.
 // 'desc' is the type# part.
 //
-void HlslParseContext::handleRegister(const TSourceLoc& loc, TQualifier& qualifier, const glslang::TString* profile,
+void HlslParseContext::handleRegister(const TSourceLoc& loc, TQualifier& qualifier, const glslang::TString* profileIn,
                                       const glslang::TString& desc, int subComponent, const glslang::TString* spaceDesc)
 {
-    if (profile != nullptr)
+    if (profileIn != nullptr)
         warn(loc, "ignoring shader_profile", "register", "");
 
     if (desc.size() < 1) {

--- a/hlsl/hlslScanContext.cpp
+++ b/hlsl/hlslScanContext.cpp
@@ -367,14 +367,14 @@ EHlslTokenClass HlslScanContext::tokenizeClass(HlslToken& token)
 {
     do {
         parserToken = &token;
-        TPpToken ppToken;
-        tokenText = ppContext.tokenize(&ppToken);
+        TPpToken ppTokenVar;
+        tokenText = ppContext.tokenize(&ppTokenVar);
         if (tokenText == nullptr)
             return EHTokNone;
 
-        loc = ppToken.loc;
+        loc = ppTokenVar.loc;
         parserToken->loc = loc;
-        switch (ppToken.token) {
+        switch (ppTokenVar.token) {
         case ';':                       return EHTokSemicolon;
         case ',':                       return EHTokComma;
         case ':':                       return EHTokColon;
@@ -430,18 +430,18 @@ EHlslTokenClass HlslScanContext::tokenizeClass(HlslToken& token)
         case PpAtomDecrement:          return EHTokDecOp;
         case PpAtomIncrement:          return EHTokIncOp;
 
-        case PpAtomConstInt:           parserToken->i = ppToken.ival;       return EHTokIntConstant;
-        case PpAtomConstUint:          parserToken->i = ppToken.ival;       return EHTokUintConstant;
-        case PpAtomConstFloat:         parserToken->d = ppToken.dval;       return EHTokFloatConstant;
-        case PpAtomConstDouble:        parserToken->d = ppToken.dval;       return EHTokDoubleConstant;
+        case PpAtomConstInt:           parserToken->i = ppTokenVar.ival;       return EHTokIntConstant;
+        case PpAtomConstUint:          parserToken->i = ppTokenVar.ival;       return EHTokUintConstant;
+        case PpAtomConstFloat:         parserToken->d = ppTokenVar.dval;       return EHTokFloatConstant;
+        case PpAtomConstDouble:        parserToken->d = ppTokenVar.dval;       return EHTokDoubleConstant;
         case PpAtomIdentifier:
         {
-            EHlslTokenClass token = tokenizeIdentifier();
-            return token;
+            EHlslTokenClass tokenVar = tokenizeIdentifier();
+            return tokenVar;
         }
 
         case PpAtomConstString: {
-            parserToken->string = NewPoolTString(ppToken.name);
+            parserToken->string = NewPoolTString(ppTokenVar.name);
             return EHTokStringConstant;
         }
 
@@ -449,7 +449,7 @@ EHlslTokenClass HlslScanContext::tokenizeClass(HlslToken& token)
 
         default:
             char buf[2];
-            buf[0] = (char)ppToken.token;
+            buf[0] = (char)ppTokenVar.token;
             buf[1] = 0;
             parseContext.error(loc, "unexpected token", buf, "");
             break;


### PR DESCRIPTION
These were showing up in a Visual Studio compile.

Also curious if there's a way to enable specific warnings for the Visual Studio build in CMake. These were caught using a different build system.