### PR TITLE
A way to query "location" qualifier for vertex attributes, using TProgram reflection API

### DIFF
--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1708,6 +1708,7 @@ int TProgram::getUniformArraySize(int index) const           { return reflection
 int TProgram::getNumLiveAttributes() const                   { return reflection->getNumAttributes(); }
 const char* TProgram::getAttributeName(int index) const      { return reflection->getAttribute(index).name.c_str(); }
 int TProgram::getAttributeType(int index) const              { return reflection->getAttribute(index).glDefineType; }
+const TType* TProgram::getAttributeTType(int index) const    { return reflection->getAttribute(index).getType(); }
 const TType* TProgram::getUniformTType(int index) const      { return reflection->getUniform(index).getType(); }
 const TType* TProgram::getUniformBlockTType(int index) const { return reflection->getUniformBlock(index).getType(); }
 

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -511,6 +511,7 @@ public:
     int getAttributeType(int index) const;                 // can be used for glGetActiveAttrib()
     const TType* getUniformTType(int index) const;         // returns a TType*
     const TType* getUniformBlockTType(int index) const;    // returns a TType*    
+    const TType* getAttributeTType(int index) const;       // returns a TType*
 
     void dumpReflection();
 


### PR DESCRIPTION
I'm using glslang to retrieve information about GLSL uniforms and vertex attributes for the Vulkan implementation in Banshee Engine (https://github.com/bearishsun/bansheeengine). 

However the current interface seems to be missing a way to retrieve the "location" qualifier from vertex attributes. I exposed a method that returns a TType for attribute to get around that problem (similar to existing methods for uniforms and uniform blocks).