### PR TITLE
Remove redundant output for successful link attempts

### DIFF
--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1687,8 +1687,6 @@ bool TProgram::linkStage(EShLanguage stage, EShMessages messages)
         newedIntermediate[stage] = true;
     }
 
-    infoSink->info << "\nLinked " << StageName(stage) << " stage:\n\n";
-
     if (stages[stage].size() > 1) {
         std::list<TShader*>::const_iterator it;
         for (it = stages[stage].begin(); it != stages[stage].end(); ++it)


### PR DESCRIPTION
The presence of non-warning/error output is bad since the callers have
to filter out warning/error messages with regular expressions or the
like to keep messages that are actually important.

TIntermediate::warn/error prefix their messages with the stage the issue
is with so this message appears completely redundant.