### PR TITLE
Fixed processing #include's when preprocessing HLSL

### DIFF
--- a/glslang/MachineIndependent/parseVersions.h
+++ b/glslang/MachineIndependent/parseVersions.h
@@ -110,6 +110,7 @@ public:
     void getPreamble(std::string&);
     bool relaxedErrors()    const { return (messages & EShMsgRelaxedErrors) != 0; }
     bool suppressWarnings() const { return (messages & EShMsgSuppressWarnings) != 0; }
+    bool isReadingHLSL()    const { return (messages & EShMsgReadHlsl) == EShMsgReadHlsl; }
 
     TInfoSink& infoSink;
 

--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
+++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
@@ -897,7 +897,9 @@ int TPpContext::readCPPline(TPpToken* ppToken)
             token = CPPifdef(0, ppToken);
             break;
         case PpAtomInclude:
-            parseContext.ppRequireExtensions(ppToken->loc, 1, &E_GL_GOOGLE_include_directive, "#include");
+            if(!parseContext.isReadingHLSL()) {
+                parseContext.ppRequireExtensions(ppToken->loc, 1, &E_GL_GOOGLE_include_directive, "#include");
+            }
             token = CPPinclude(ppToken);
             break;
         case PpAtomLine:


### PR DESCRIPTION
Preprocessing HLSL would fail due to missing extension `GL_GOOGLE_include_directive`. It seems that HLSL parsing ignores the shader preamble which is, with GLSL, what implicitly enables `GL_GOOGLE_include_directive` for the desktop profile.