### PR TITLE
runtests should refer to test files in current directory

### DIFF
--- a/Test/baseResults/hlsl.entry.rename.frag.out
+++ b/Test/baseResults/hlsl.entry.rename.frag.out
@@ -1,4 +1,4 @@
-../Test/hlsl.entry.rename.frag
+hlsl.entry.rename.frag
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence

--- a/Test/runtests
+++ b/Test/runtests
@@ -49,7 +49,7 @@ diff singleThread.out multiThread.out || HASERROR=1
 #
 # entry point renaming tests
 #
-$EXE -i -H -V -D -e main_in_spv --source-entrypoint main ../Test/hlsl.entry.rename.frag > $TARGETDIR/hlsl.entry.rename.frag.out
+$EXE -i -H -V -D -e main_in_spv --source-entrypoint main hlsl.entry.rename.frag > $TARGETDIR/hlsl.entry.rename.frag.out
 diff -b $BASEDIR/hlsl.entry.rename.frag.out $TARGETDIR/hlsl.entry.rename.frag.out || HASERROR=1
 
 if [ $HASERROR -eq 0 ]


### PR DESCRIPTION
Recently added entry point renaming file referred to
test source file hlsl.entry.rename.frag via relative directory.

Change it to be consistent with other tests: assume test
sources are in the current directory.