### PR TITLE
Unbreak build on FreeBSD with GCC/libstdc++ 6.2.0

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.h
+++ b/glslang/MachineIndependent/ParseHelper.h
@@ -49,8 +49,7 @@
 #include "SymbolTable.h"
 #include "localintermediate.h"
 #include "Scan.h"
-#include <functional>
-
+#include <cstdarg>
 #include <functional>
 
 namespace glslang {


### PR DESCRIPTION
Probably affects Linux as well with non-standard libc that doesn't bootleg `<stdarg.h>`.
```c++
In file included from C:/Projects/glslang/glslang/MachineIndependent/glslang.y:59:0:
glslang/MachineIndependent/ParseHelper.h:276:24: error: 'va_list' has not been declared
                        va_list args);
                        ^~~~~~~
```