### PR TITLE
Fix out-of-bounds array access, caught by AddressSanitizer

### DIFF
--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -2144,7 +2144,8 @@ void Builder::accessChainPushSwizzle(std::vector<unsigned>& swizzle, Id preSwizz
         std::vector<unsigned> oldSwizzle = accessChain.swizzle;
         accessChain.swizzle.resize(0);
         for (unsigned int i = 0; i < swizzle.size(); ++i) {
-            accessChain.swizzle.push_back(oldSwizzle[swizzle[i]]);
+            if (swizzle[i] < oldSwizzle.size())
+                accessChain.swizzle.push_back(oldSwizzle[swizzle[i]]);
         }
     } else
         accessChain.swizzle = swizzle;


### PR DESCRIPTION
Not entirely clear why this happens, but it does, compiling some simple HLSL shaders. Doesn't seem to have any ill effects and causes no warnings under Visual Studio's debug mode, but I get this using AddressSanitizer on the Mac.

I can provide shader examples if needed, but they are very simple and do validate using D3DCompile without issues.

ASAN log:

```
ASAN:DEADLYSIGNAL
=================================================================
==35026==ERROR: AddressSanitizer: SEGV on unknown address 0x000600000004 (pc 0x00010674024f bp 0x7fff59b5db00 sp 0x7fff59b5da70 T0)
    #0 0x10674024e in std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >::__annotate_shrink(unsigned long) const vector:858
    #1 0x1062ebab4 in std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >::__RAII_IncreaseAnnotator::~__RAII_IncreaseAnnotator() vector:872
    #2 0x1062eb5a4 in std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >::__RAII_IncreaseAnnotator::~__RAII_IncreaseAnnotator() vector:870
    #3 0x1063036c9 in std::__1::enable_if<__is_forward_iterator<unsigned int*>::value, void>::type std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >::__construct_at_end<unsigned int*>(unsigned int*, unsigned int*, unsigned long) vector:1025
    #4 0x1067d97a9 in std::__1::enable_if<(__is_forward_iterator<unsigned int*>::value) && (is_constructible<unsigned int, std::__1::iterator_traits<unsigned int*>::reference>::value), void>::type std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >::assign<unsigned int*>(unsigned int*, unsigned int*) vector:1405
    #5 0x106377b2c in spv::Builder::accessChainPushSwizzle(std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >&, unsigned int) vector:1357
    #6 0x106310c20 in (anonymous namespace)::TGlslangToSpvTraverser::visitBinary(glslang::TVisit, glslang::TIntermBinary*) GlslangToSpv.cpp:1056
    #7 0x1061a1cec in glslang::TIntermBinary::traverse(glslang::TIntermTraverser*) IntermTraverse.cpp:85
    #8 0x106340848 in (anonymous namespace)::TGlslangToSpvTraverser::handleUserFunctionCall(glslang::TIntermAggregate const*) GlslangToSpv.cpp:3048
    #9 0x1063137c5 in (anonymous namespace)::TGlslangToSpvTraverser::visitAggregate(glslang::TVisit, glslang::TIntermAggregate*) GlslangToSpv.cpp:1408
    #10 0x1061a1fb7 in glslang::TIntermAggregate::traverse(glslang::TIntermTraverser*) IntermTraverse.cpp:152
    #11 0x1063362da in (anonymous namespace)::TGlslangToSpvTraverser::translateArguments(glslang::TIntermAggregate const&, std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >&) GlslangToSpv.cpp:2664
    #12 0x106313a25 in (anonymous namespace)::TGlslangToSpvTraverser::visitAggregate(glslang::TVisit, glslang::TIntermAggregate*) GlslangToSpv.cpp:1487
    #13 0x1061a1fb7 in glslang::TIntermAggregate::traverse(glslang::TIntermTraverser*) IntermTraverse.cpp:152
    #14 0x10631624c in (anonymous namespace)::TGlslangToSpvTraverser::visitBranch(glslang::TVisit, glslang::TIntermBranch*) GlslangToSpv.cpp:1880
    #15 0x1061a2a8c in glslang::TIntermBranch::traverse(glslang::TIntermTraverser*) IntermTraverse.cpp:264
    #16 0x1061a25b8 in glslang::TIntermAggregate::traverse(glslang::TIntermTraverser*) IntermTraverse.cpp:168
    #17 0x1061a25b8 in glslang::TIntermAggregate::traverse(glslang::TIntermTraverser*) IntermTraverse.cpp:168
    #18 0x10633fe0d in (anonymous namespace)::TGlslangToSpvTraverser::visitFunctions(glslang::TVector<TIntermNode*> const&) GlslangToSpv.cpp:2638
    #19 0x1063134de in (anonymous namespace)::TGlslangToSpvTraverser::visitAggregate(glslang::TVisit, glslang::TIntermAggregate*) GlslangToSpv.cpp:1357
    #20 0x1061a1fb7 in glslang::TIntermAggregate::traverse(glslang::TIntermTraverser*) IntermTraverse.cpp:152
    #21 0x10630bf75 in glslang::GlslangToSpv(glslang::TIntermediate const&, std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >&, spv::SpvBuildLogger*) GlslangToSpv.cpp:5124
    #22 0x10630bea9 in glslang::GlslangToSpv(glslang::TIntermediate const&, std::__1::vector<unsigned int, std::__1::allocator<unsigned int> >&) GlslangToSpv.cpp:5111
    #23 0x1062e0f4a in SLtoSPV(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, Draw::ShaderStage, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, bool) ShaderConvert.cpp:246
    #24 0x1060a283d in ConvertShader(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, Draw::ShaderStage, bool) Convert.cpp:233
    #25 0x10609fb45 in ConvertShaders(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, bool) Convert.cpp:167
    #26 0x10609c7e3 in main Convert.cpp:99
    #27 0x7fff96296254 in start (libdyld.dylib+0x5254)
```