### PR TITLE
CMake: Add option to make it possible to not build the executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.11)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 option(ENABLE_AMD_EXTENSIONS "Enables support of AMD-specific extensions" ON)
+option(ENABLE_GLSLANG_BINARIES "Builds glslangValidator and spirv-remap" ON)
 
 enable_testing()
 
@@ -52,7 +53,9 @@ add_subdirectory(External)
 
 add_subdirectory(glslang)
 add_subdirectory(OGLCompilersDLL)
-add_subdirectory(StandAlone)
+if(ENABLE_GLSLANG_BINARIES)
+	add_subdirectory(StandAlone)
+endif()
 add_subdirectory(SPIRV)
 add_subdirectory(hlsl)
 add_subdirectory(gtests)


### PR DESCRIPTION
Sometimes it's nice to not build the executables when building through CMake, for example when building static libraries for platforms where the executables aren't really useful anyway like Android/iOS.

This creates an option that defaults to ON that builds them, but can be easily set to OFF to avoid building the executables.