### PR TITLE
HLSL: Support for vec -> scalar conversion on assignments

### DIFF
--- a/Test/baseResults/hlsl.forLoop.frag.out
+++ b/Test/baseResults/hlsl.forLoop.frag.out
@@ -61,6 +61,9 @@ gl_FragCoord origin is upper left
 0:7            'input' (layout(location=0 ) in 4-component vector of float)
 0:7            Constant:
 0:7              2.000000
+0:7              2.000000
+0:7              2.000000
+0:7              2.000000
 0:?       Sequence
 0:8        Loop with condition tested first
 0:8          No loop condition
@@ -186,6 +189,9 @@ gl_FragCoord origin is upper left
 0:7            'input' (layout(location=0 ) in 4-component vector of float)
 0:7            Constant:
 0:7              2.000000
+0:7              2.000000
+0:7              2.000000
+0:7              2.000000
 0:?       Sequence
 0:8        Loop with condition tested first
 0:8          No loop condition
@@ -273,6 +279,7 @@ gl_FragCoord origin is upper left
               42:             TypePointer Output 11(fvec4)
 43(@entryPointOutput):     42(ptr) Variable Output
               62:   10(float) Constant 1073741824
+              63:   11(fvec4) ConstantComposite 62 62 62 62
               70:             TypeInt 32 0
               71:     70(int) Constant 0
               72:             TypePointer Input 10(float)
@@ -362,9 +369,8 @@ gl_FragCoord origin is upper left
                                 Store 43(@entryPointOutput) 60
                                 Return
               53:               Label
-              63:   11(fvec4)   Load 13(input)
-              64:   11(fvec4)   CompositeConstruct 62 62 62 62
-              65:   11(fvec4)   FAdd 63 64
+              64:   11(fvec4)   Load 13(input)
+              65:   11(fvec4)   FAdd 64 63
                                 Store 13(input) 65
                                 Branch 50
               52:             Label

--- a/Test/baseResults/hlsl.rw.bracket.frag.out
+++ b/Test/baseResults/hlsl.rw.bracket.frag.out
@@ -252,6 +252,9 @@ gl_FragCoord origin is upper left
 0:84          'storeTemp' (temp 4-component vector of float)
 0:84          Constant:
 0:84            3.000000
+0:84            3.000000
+0:84            3.000000
+0:84            3.000000
 0:84        imageStore (temp void)
 0:84          'g_tTex1df4' (layout(binding=0 rgba32f ) uniform image1D)
 0:84          'coordTemp' (temp int)
@@ -272,6 +275,9 @@ gl_FragCoord origin is upper left
 0:85        add second child into first child (temp 4-component vector of float)
 0:85          'storeTemp' (temp 4-component vector of float)
 0:85          Constant:
+0:85            4.000000
+0:85            4.000000
+0:85            4.000000
 0:85            4.000000
 0:85        imageStore (temp void)
 0:85          'g_tTex1df4' (layout(binding=0 rgba32f ) uniform image1D)
@@ -1123,6 +1129,9 @@ gl_FragCoord origin is upper left
 0:84          'storeTemp' (temp 4-component vector of float)
 0:84          Constant:
 0:84            3.000000
+0:84            3.000000
+0:84            3.000000
+0:84            3.000000
 0:84        imageStore (temp void)
 0:84          'g_tTex1df4' (layout(binding=0 rgba32f ) uniform image1D)
 0:84          'coordTemp' (temp int)
@@ -1143,6 +1152,9 @@ gl_FragCoord origin is upper left
 0:85        add second child into first child (temp 4-component vector of float)
 0:85          'storeTemp' (temp 4-component vector of float)
 0:85          Constant:
+0:85            4.000000
+0:85            4.000000
+0:85            4.000000
 0:85            4.000000
 0:85        imageStore (temp void)
 0:85          'g_tTex1df4' (layout(binding=0 rgba32f ) uniform image1D)
@@ -1978,7 +1990,9 @@ gl_FragCoord origin is upper left
              182:             TypePointer Function 6(int)
              190:   20(float) Constant 1073741824
              204:   20(float) Constant 1077936128
+             205:   21(fvec4) ConstantComposite 204 204 204 204
              218:   20(float) Constant 1082130432
+             219:   21(fvec4) ConstantComposite 218 218 218 218
              258:      6(int) Constant 65535
              272:      6(int) Constant 61680
              316:      6(int) Constant 5
@@ -2198,9 +2212,8 @@ gl_FragCoord origin is upper left
              202:      6(int) Load 197(coordTemp)
              203:   21(fvec4) ImageRead 201 202
                               Store 200(storeTemp) 203
-             205:   21(fvec4) Load 200(storeTemp)
-             206:   21(fvec4) CompositeConstruct 204 204 204 204
-             207:   21(fvec4) FSub 205 206
+             206:   21(fvec4) Load 200(storeTemp)
+             207:   21(fvec4) FSub 206 205
                               Store 200(storeTemp) 207
              208:          69 Load 71(g_tTex1df4)
              209:      6(int) Load 197(coordTemp)
@@ -2213,9 +2226,8 @@ gl_FragCoord origin is upper left
              216:      6(int) Load 211(coordTemp)
              217:   21(fvec4) ImageRead 215 216
                               Store 214(storeTemp) 217
-             219:   21(fvec4) Load 214(storeTemp)
-             220:   21(fvec4) CompositeConstruct 218 218 218 218
-             221:   21(fvec4) FAdd 219 220
+             220:   21(fvec4) Load 214(storeTemp)
+             221:   21(fvec4) FAdd 220 219
                               Store 214(storeTemp) 221
              222:          69 Load 71(g_tTex1df4)
              223:      6(int) Load 211(coordTemp)

--- a/Test/baseResults/hlsl.rw.vec2.bracket.frag.out
+++ b/Test/baseResults/hlsl.rw.vec2.bracket.frag.out
@@ -242,6 +242,7 @@ gl_FragCoord origin is upper left
 0:84          'storeTemp' (temp 2-component vector of float)
 0:84          Constant:
 0:84            3.000000
+0:84            3.000000
 0:84        imageStore (temp void)
 0:84          'g_tTex1df2' (layout(rg32f ) uniform image1D)
 0:84          'coordTemp' (temp int)
@@ -262,6 +263,7 @@ gl_FragCoord origin is upper left
 0:85        add second child into first child (temp 2-component vector of float)
 0:85          'storeTemp' (temp 2-component vector of float)
 0:85          Constant:
+0:85            4.000000
 0:85            4.000000
 0:85        imageStore (temp void)
 0:85          'g_tTex1df2' (layout(rg32f ) uniform image1D)
@@ -1095,6 +1097,7 @@ gl_FragCoord origin is upper left
 0:84          'storeTemp' (temp 2-component vector of float)
 0:84          Constant:
 0:84            3.000000
+0:84            3.000000
 0:84        imageStore (temp void)
 0:84          'g_tTex1df2' (layout(rg32f ) uniform image1D)
 0:84          'coordTemp' (temp int)
@@ -1115,6 +1118,7 @@ gl_FragCoord origin is upper left
 0:85        add second child into first child (temp 2-component vector of float)
 0:85          'storeTemp' (temp 2-component vector of float)
 0:85          Constant:
+0:85            4.000000
 0:85            4.000000
 0:85        imageStore (temp void)
 0:85          'g_tTex1df2' (layout(rg32f ) uniform image1D)
@@ -1938,7 +1942,9 @@ gl_FragCoord origin is upper left
              178:             TypePointer Function 6(int)
              186:   20(float) Constant 1073741824
              200:   20(float) Constant 1077936128
+             201:   21(fvec2) ConstantComposite 200 200
              214:   20(float) Constant 1082130432
+             215:   21(fvec2) ConstantComposite 214 214
              254:      6(int) Constant 65535
              268:      6(int) Constant 61680
              312:      6(int) Constant 5
@@ -2160,9 +2166,8 @@ gl_FragCoord origin is upper left
              198:      6(int) Load 193(coordTemp)
              199:   21(fvec2) ImageRead 197 198
                               Store 196(storeTemp) 199
-             201:   21(fvec2) Load 196(storeTemp)
-             202:   21(fvec2) CompositeConstruct 200 200
-             203:   21(fvec2) FSub 201 202
+             202:   21(fvec2) Load 196(storeTemp)
+             203:   21(fvec2) FSub 202 201
                               Store 196(storeTemp) 203
              204:          69 Load 71(g_tTex1df2)
              205:      6(int) Load 193(coordTemp)
@@ -2175,9 +2180,8 @@ gl_FragCoord origin is upper left
              212:      6(int) Load 207(coordTemp)
              213:   21(fvec2) ImageRead 211 212
                               Store 210(storeTemp) 213
-             215:   21(fvec2) Load 210(storeTemp)
-             216:   21(fvec2) CompositeConstruct 214 214
-             217:   21(fvec2) FAdd 215 216
+             216:   21(fvec2) Load 210(storeTemp)
+             217:   21(fvec2) FAdd 216 215
                               Store 210(storeTemp) 217
              218:          69 Load 71(g_tTex1df2)
              219:      6(int) Load 207(coordTemp)

--- a/Test/baseResults/hlsl.switch.frag.out
+++ b/Test/baseResults/hlsl.switch.frag.out
@@ -65,6 +65,9 @@ gl_FragCoord origin is upper left
 0:28                    'input' (layout(location=0 ) in 4-component vector of float)
 0:28                    Constant:
 0:28                      2.000000
+0:28                      2.000000
+0:28                      2.000000
+0:28                      2.000000
 0:29                  Branch: Break
 0:30                case:  with expression
 0:30                  Constant:
@@ -74,6 +77,9 @@ gl_FragCoord origin is upper left
 0:31                    'input' (layout(location=0 ) in 4-component vector of float)
 0:31                    Constant:
 0:31                      3.000000
+0:31                      3.000000
+0:31                      3.000000
+0:31                      3.000000
 0:32                  Branch: Break
 0:34            Branch: Break
 0:35          default: 
@@ -81,6 +87,9 @@ gl_FragCoord origin is upper left
 0:36            add second child into first child (temp 4-component vector of float)
 0:36              'input' (layout(location=0 ) in 4-component vector of float)
 0:36              Constant:
+0:36                4.000000
+0:36                4.000000
+0:36                4.000000
 0:36                4.000000
 0:39      switch
 0:39      condition
@@ -200,6 +209,9 @@ gl_FragCoord origin is upper left
 0:28                    'input' (layout(location=0 ) in 4-component vector of float)
 0:28                    Constant:
 0:28                      2.000000
+0:28                      2.000000
+0:28                      2.000000
+0:28                      2.000000
 0:29                  Branch: Break
 0:30                case:  with expression
 0:30                  Constant:
@@ -209,6 +221,9 @@ gl_FragCoord origin is upper left
 0:31                    'input' (layout(location=0 ) in 4-component vector of float)
 0:31                    Constant:
 0:31                      3.000000
+0:31                      3.000000
+0:31                      3.000000
+0:31                      3.000000
 0:32                  Branch: Break
 0:34            Branch: Break
 0:35          default: 
@@ -216,6 +231,9 @@ gl_FragCoord origin is upper left
 0:36            add second child into first child (temp 4-component vector of float)
 0:36              'input' (layout(location=0 ) in 4-component vector of float)
 0:36              Constant:
+0:36                4.000000
+0:36                4.000000
+0:36                4.000000
 0:36                4.000000
 0:39      switch
 0:39      condition
@@ -295,8 +313,11 @@ gl_FragCoord origin is upper left
               23:   18(float) Constant 1065353216
            41(d):      7(ptr) Variable Input
               46:   18(float) Constant 1073741824
+              47:   19(fvec4) ConstantComposite 46 46 46 46
               51:   18(float) Constant 1077936128
+              52:   19(fvec4) ConstantComposite 51 51 51 51
               58:   18(float) Constant 1082130432
+              59:   19(fvec4) ConstantComposite 58 58 58 58
               80:             TypePointer Output 19(fvec4)
 81(@entryPointOutput):     80(ptr) Variable Output
 4(PixelShaderFunction):           2 Function None 3
@@ -331,9 +352,8 @@ gl_FragCoord origin is upper left
                                      case 1: 33
                                      case 2: 34
               35:               Label
-              59:   19(fvec4)   Load 21(input)
-              60:   19(fvec4)   CompositeConstruct 58 58 58 58
-              61:   19(fvec4)   FAdd 59 60
+              60:   19(fvec4)   Load 21(input)
+              61:   19(fvec4)   FAdd 60 59
                                 Store 21(input) 61
                                 Branch 36
               33:               Label
@@ -349,15 +369,13 @@ gl_FragCoord origin is upper left
                                        case 2: 43
                                        case 3: 44
               43:                 Label
-              47:   19(fvec4)     Load 21(input)
-              48:   19(fvec4)     CompositeConstruct 46 46 46 46
-              49:   19(fvec4)     FAdd 47 48
+              48:   19(fvec4)     Load 21(input)
+              49:   19(fvec4)     FAdd 48 47
                                   Store 21(input) 49
                                   Branch 45
               44:                 Label
-              52:   19(fvec4)     Load 21(input)
-              53:   19(fvec4)     CompositeConstruct 51 51 51 51
-              54:   19(fvec4)     FAdd 52 53
+              53:   19(fvec4)     Load 21(input)
+              54:   19(fvec4)     FAdd 53 52
                                   Store 21(input) 54
                                   Branch 45
               45:               Label

--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -155,7 +155,7 @@ TIntermTyped* TIntermediate::addBinaryMath(TOperator op, TIntermTyped* left, TIn
             return folded;
     }
 
-    // If either is a specialization constant, while the other is 
+    // If either is a specialization constant, while the other is
     // a constant (or specialization constant), the result is still
     // a specialization constant, if the operation is an allowed
     // specialization-constant operation.
@@ -192,7 +192,7 @@ TIntermBinary* TIntermediate::addBinaryNode(TOperator op, TIntermTyped* left, TI
     node->setType(type);
     return node;
 }
-    
+
 //
 // Low level: add unary node (no promotions or other argument modifications)
 //
@@ -286,7 +286,7 @@ TIntermTyped* TIntermediate::addUnaryMath(TOperator op, TIntermTyped* child, TSo
         if (source == EShSourceHlsl) {
             break; // HLSL can promote logical not
         }
- 
+
         if (child->getType().getBasicType() != EbtBool || child->getType().isMatrix() || child->getType().isArray() || child->getType().isVector()) {
             return nullptr;
         }
@@ -474,7 +474,7 @@ TIntermTyped* TIntermediate::addConversion(TOperator op, const TType& type, TInt
 
         // samplers can get assigned via a sampler constructor
         // (well, not yet, but code in the rest of this function is ready for it)
-        if (node->getBasicType() == EbtSampler && op == EOpAssign && 
+        if (node->getBasicType() == EbtSampler && op == EOpAssign &&
             node->getAsOperator() != nullptr && node->getAsOperator()->getOp() == EOpConstructTextureSampler)
             break;
 
@@ -808,9 +808,13 @@ TIntermTyped* TIntermediate::addShapeConversion(TOperator op, const TType& type,
         return node;
     }
 
+    bool allowVecToScalar = false;
     // some operations don't do this
     switch (op) {
     case EOpAssign:
+    case EOpSubAssign:
+    case EOpAddAssign:
+        allowVecToScalar = true;
     case EOpLessThan:
     case EOpGreaterThan:
     case EOpLessThanEqual:
@@ -836,10 +840,11 @@ TIntermTyped* TIntermediate::addShapeConversion(TOperator op, const TType& type,
     TOperator constructorOp = mapTypeToConstructorOp(type);
 
     // scalar -> smeared -> vector, or
-    // vec1 -> scalar, or
-    // bigger vector -> smaller vector or scalar
+    // vector -> scalar, or
+    // bigger vector -> smaller vector
     if ((type.isVector() && node->getType().isScalar()) ||
         (node->getType().isVector() && node->getVectorSize() == 1 && type.isScalar()) ||
+        (node->getType().isVector() && type.isScalar() && allowVecToScalar) ||
         (node->getVectorSize() > type.getVectorSize() && type.isVector()))
         return setAggregateOperator(makeAggregate(node), constructorOp, type, node->getLoc());
 
@@ -867,16 +872,16 @@ bool TIntermediate::canImplicitlyPromote(TBasicType from, TBasicType to, TOperat
         if (fromConvertable && toConvertable) {
             switch (op) {
             case EOpAndAssign:               // assignments can perform arbitrary conversions
-            case EOpInclusiveOrAssign:       // ... 
-            case EOpExclusiveOrAssign:       // ... 
-            case EOpAssign:                  // ... 
-            case EOpAddAssign:               // ... 
-            case EOpSubAssign:               // ... 
-            case EOpMulAssign:               // ... 
-            case EOpVectorTimesScalarAssign: // ... 
-            case EOpMatrixTimesScalarAssign: // ... 
-            case EOpDivAssign:               // ... 
-            case EOpModAssign:               // ... 
+            case EOpInclusiveOrAssign:       // ...
+            case EOpExclusiveOrAssign:       // ...
+            case EOpAssign:                  // ...
+            case EOpAddAssign:               // ...
+            case EOpSubAssign:               // ...
+            case EOpMulAssign:               // ...
+            case EOpVectorTimesScalarAssign: // ...
+            case EOpMatrixTimesScalarAssign: // ...
+            case EOpDivAssign:               // ...
+            case EOpModAssign:               // ...
             case EOpReturn:                  // function returns can also perform arbitrary conversions
             case EOpFunctionCall:            // conversion of a calling parameter
             case EOpLogicalNot:
@@ -2256,7 +2261,7 @@ bool TIntermediate::promoteAggregate(TIntermAggregate& node)
     case EOpDot:
     case EOpDst:
     case EOpFaceForward:
-        // case EOpFindMSB: TODO: ?? 
+        // case EOpFindMSB: TODO: ??
         // case EOpFindLSB: TODO: ??
     case EOpFma:
     case EOpMod:


### PR DESCRIPTION
Enables automatic conversion from any vector type to a scalar type on asignment