### PR TITLE
WIP: HLSL: Support for vector truncation for vector multiply

### DIFF
--- a/Test/baseResults/hlsl.float1.frag.out
+++ b/Test/baseResults/hlsl.float1.frag.out
@@ -18,13 +18,16 @@ gl_FragCoord origin is upper left
 0:5      'inScalar' (in float)
 0:?     Sequence
 0:6      Branch: Return with expression
-0:6        add (temp 1-component vector of float)
-0:6          vector-scale (temp 1-component vector of float)
-0:6            'f1' (global 1-component vector of float)
-0:6            'scalar' (global float)
-0:6          vector-scale (temp 1-component vector of float)
-0:6            'inFloat1' (in 1-component vector of float)
-0:6            'inScalar' (in float)
+0:6        Construct float (temp 1-component vector of float)
+0:6          add (temp float)
+0:6            component-wise multiply (temp float)
+0:6              Construct float (global float)
+0:6                'f1' (global 1-component vector of float)
+0:6              'scalar' (global float)
+0:6            component-wise multiply (temp float)
+0:6              Construct float (in float)
+0:6                'inFloat1' (in 1-component vector of float)
+0:6              'inScalar' (in float)
 0:?   Linker Objects
 0:?     'f1' (global 1-component vector of float)
 0:?     'scalar' (global float)
@@ -53,13 +56,16 @@ gl_FragCoord origin is upper left
 0:5      'inScalar' (in float)
 0:?     Sequence
 0:6      Branch: Return with expression
-0:6        add (temp 1-component vector of float)
-0:6          vector-scale (temp 1-component vector of float)
-0:6            'f1' (global 1-component vector of float)
-0:6            'scalar' (global float)
-0:6          vector-scale (temp 1-component vector of float)
-0:6            'inFloat1' (in 1-component vector of float)
-0:6            'inScalar' (in float)
+0:6        Construct float (temp 1-component vector of float)
+0:6          add (temp float)
+0:6            component-wise multiply (temp float)
+0:6              Construct float (global float)
+0:6                'f1' (global 1-component vector of float)
+0:6              'scalar' (global float)
+0:6            component-wise multiply (temp float)
+0:6              Construct float (in float)
+0:6                'inFloat1' (in 1-component vector of float)
+0:6              'inScalar' (in float)
 0:?   Linker Objects
 0:?     'f1' (global 1-component vector of float)
 0:?     'scalar' (global float)
@@ -101,10 +107,10 @@ gl_FragCoord origin is upper left
               12:             Label
               18:    6(float) Load 14(f1)
               19:    6(float) Load 16(scalar)
-              20:    6(float) IMul 18 19
+              20:    6(float) FMul 18 19
               21:    6(float) Load 9(inFloat1)
               22:    6(float) Load 10(inScalar)
-              23:    6(float) IMul 21 22
+              23:    6(float) FMul 21 22
               24:    6(float) FAdd 20 23
                               ReturnValue 24
                               FunctionEnd


### PR DESCRIPTION
Adds support for vector truncation for vector multiply (e.g float3 = float3 * float4).

also seems to accidentally fixes a spir-v gen bug (turns imul of floats in correct fmul of floats)

Change-Id: Iad18b280c96a601e2e33f2276e66e97dd3571e3e