### PR TITLE
Add a CMake option to disable compilation of HLSL input support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ option(ENABLE_GLSLANG_BINARIES "Builds glslangValidator and spirv-remap" ON)
 
 option(ENABLE_NV_EXTENSIONS "Enables support of Nvidia-specific extensions" ON)
 
+option(DISABLE_HLSL "Disables HLSL input support" OFF)
+
 enable_testing()
 
 set(CMAKE_INSTALL_PREFIX "install" CACHE STRING "prefix")
@@ -19,6 +21,10 @@ endif(ENABLE_AMD_EXTENSIONS)
 if(ENABLE_NV_EXTENSIONS)
     add_definitions(-DNV_EXTENSIONS)
 endif(ENABLE_NV_EXTENSIONS)
+
+if(DISABLE_HLSL)
+    add_definitions(-DDISABLE_HLSL)
+endif(DISABLE_HLSL)
 
 if(WIN32)
     set(CMAKE_DEBUG_POSTFIX "d")
@@ -63,5 +69,7 @@ if(ENABLE_GLSLANG_BINARIES)
 	add_subdirectory(StandAlone)
 endif()
 add_subdirectory(SPIRV)
-add_subdirectory(hlsl)
+if(NOT DISABLE_HLSL)
+    add_subdirectory(hlsl)
+endif()
 add_subdirectory(gtests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ option(ENABLE_GLSLANG_BINARIES "Builds glslangValidator and spirv-remap" ON)
 
 option(ENABLE_NV_EXTENSIONS "Enables support of Nvidia-specific extensions" ON)
 
-option(DISABLE_HLSL "Disables HLSL input support" OFF)
+option(ENABLE_HLSL "Enables HLSL input support" ON)
 
 enable_testing()
 
@@ -22,9 +22,9 @@ if(ENABLE_NV_EXTENSIONS)
     add_definitions(-DNV_EXTENSIONS)
 endif(ENABLE_NV_EXTENSIONS)
 
-if(DISABLE_HLSL)
-    add_definitions(-DDISABLE_HLSL)
-endif(DISABLE_HLSL)
+if(ENABLE_HLSL)
+    add_definitions(-DENABLE_HLSL)
+endif(ENABLE_HLSL)
 
 if(WIN32)
     set(CMAKE_DEBUG_POSTFIX "d")
@@ -69,7 +69,7 @@ if(ENABLE_GLSLANG_BINARIES)
 	add_subdirectory(StandAlone)
 endif()
 add_subdirectory(SPIRV)
-if(NOT DISABLE_HLSL)
+if(ENABLE_HLSL)
     add_subdirectory(hlsl)
 endif()
 add_subdirectory(gtests)

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -22,10 +22,13 @@ set(LIBRARIES
     glslang
     OGLCompiler
     OSDependent
-    HLSL
     SPIRV
     SPVRemapper
     glslang-default-resource-limits)
+
+if(NOT DISABLE_HLSL)
+    set(LIBRARIES ${LIBRARIES} HLSL)
+endif()
 
 if(WIN32)
     set(LIBRARIES ${LIBRARIES} psapi)

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -26,7 +26,7 @@ set(LIBRARIES
     SPVRemapper
     glslang-default-resource-limits)
 
-if(NOT DISABLE_HLSL)
+if(ENABLE_HLSL)
     set(LIBRARIES ${LIBRARIES} HLSL)
 endif()
 

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -50,7 +50,7 @@
 #include "Scan.h"
 #include "ScanContext.h"
 
-#ifndef DISABLE_HLSL
+#ifdef ENABLE_HLSL
 #include "../../hlsl/hlslParseHelper.h"
 #include "../../hlsl/hlslParseables.h"
 #include "../../hlsl/hlslScanContext.h"
@@ -76,7 +76,7 @@ TBuiltInParseables* CreateBuiltInParseables(TInfoSink& infoSink, EShSource sourc
 {
     switch (source) {
     case EShSourceGlsl: return new TBuiltIns();              // GLSL builtIns
-#ifndef DISABLE_HLSL
+#ifdef ENABLE_HLSL
     case EShSourceHlsl: return new TBuiltInParseablesHlsl(); // HLSL intrinsics
 #endif
 
@@ -93,7 +93,7 @@ TParseContextBase* CreateParseContext(TSymbolTable& symbolTable, TIntermediate& 
                                       SpvVersion spvVersion, bool forwardCompatible, EShMessages messages,
                                       bool parsingBuiltIns, const std::string sourceEntryPointName = "")
 {
-#ifdef DISABLE_HLSL
+#ifndef ENABLE_HLSL
     (void)sourceEntryPointName; // Unused argument.
 #endif
 
@@ -103,7 +103,7 @@ TParseContextBase* CreateParseContext(TSymbolTable& symbolTable, TIntermediate& 
         return new TParseContext(symbolTable, intermediate, parsingBuiltIns, version, profile, spvVersion,
                                  language, infoSink, forwardCompatible, messages);
 
-#ifndef DISABLE_HLSL
+#ifdef ENABLE_HLSL
     case EShSourceHlsl:
         return new HlslParseContext(symbolTable, intermediate, parsingBuiltIns, version, profile, spvVersion,
                                     language, infoSink, sourceEntryPointName.c_str(), forwardCompatible, messages);
@@ -1096,7 +1096,7 @@ int ShInitialize()
         PerProcessGPA = new TPoolAllocator();
 
     glslang::TScanContext::fillInKeywordMap();
-#ifndef DISABLE_HLSL
+#ifdef ENABLE_HLSL
     glslang::HlslScanContext::fillInKeywordMap();
 #endif
 
@@ -1191,7 +1191,7 @@ int __fastcall ShFinalize()
     }
 
     glslang::TScanContext::deleteKeywordMap();
-#ifndef DISABLE_HLSL
+#ifdef ENABLE_HLSL
     glslang::HlslScanContext::deleteKeywordMap();
 #endif
 


### PR DESCRIPTION
This adds the ability to build glslang without support for HLSL input, which reduces the size of the binary.

Resolves isssue #666