### PR TITLE
Fix for not-handled-in-switch warnings

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -4198,6 +4198,8 @@ spv::Id TGlslangToSpvTraverser::createInvocationsOperation(glslang::TOperator op
             groupOperation = spv::GroupOperationExclusiveScan;
             spvGroupOperands.push_back(groupOperation);
             break;
+        default:
+            break;
         }
 #endif
     }


### PR DESCRIPTION
Added default to the switch() for AMD_EXTENSIONS to avoid a spew
of warning messages.