### PR TITLE
CMake: add target_link_libraries internally

### DIFF
--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -40,6 +40,7 @@ endif(ENABLE_NV_EXTENSIONS)
 
 add_library(SPIRV STATIC ${SOURCES} ${HEADERS})
 set_property(TARGET SPIRV PROPERTY FOLDER glslang)
+target_link_libraries(SPIRV glslang)
 
 add_library(SPVRemapper STATIC ${SPVREMAP_SOURCES} ${SPVREMAP_HEADERS})
 set_property(TARGET SPVRemapper PROPERTY FOLDER glslang)

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -20,15 +20,10 @@ glslang_set_link_args(spirv-remap)
 
 set(LIBRARIES
     glslang
-    OGLCompiler
-    OSDependent
     SPIRV
     SPVRemapper
     glslang-default-resource-limits)
 
-if(ENABLE_HLSL)
-    set(LIBRARIES ${LIBRARIES} HLSL)
-endif(ENABLE_HLSL)
 
 if(WIN32)
     set(LIBRARIES ${LIBRARIES} psapi)

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -82,6 +82,10 @@ set(HEADERS
 
 add_library(glslang STATIC ${BISON_GLSLParser_OUTPUT_SOURCE} ${SOURCES} ${HEADERS})
 set_property(TARGET glslang PROPERTY FOLDER glslang)
+target_link_libraries(glslang OGLCompiler OSDependent)
+if(ENABLE_HLSL)
+	target_link_libraries(glslang HLSL)
+endif()
 
 if(WIN32)
     source_group("Public" REGULAR_EXPRESSION "Public/*")


### PR DESCRIPTION
Makes it easier to include glslang in a larger CMake project: instead of having to call `target_link_libraries(glslang OSDependent OGLCompiler HLSL)`, for example, you only need to call `target_link_libraries(glslang)` and it will pull in the helpers it needs.

This is also better in terms of cleaning up the "public interface", of sorts, for building glslang: end-users probably shouldn't need to know or be explicitly dependent on internal targets.