### PR TITLE
Fix build if NV_EXTENSIONS is not set

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -3969,6 +3969,8 @@ void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publi
             return;
         }
     }
+#else
+    }
 #endif
     error(loc, "unrecognized layout identifier, or qualifier requires assignment (e.g., binding = 4)", id.c_str(), "");
 }


### PR DESCRIPTION
Also, maybe it would be better to have a NO_NV_EXTENSIONS define instead... why would you want to turn them off anyway?