### PR TITLE
Semantics: Texture clamp functions are available for fragment shader only

### DIFF
--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -4203,7 +4203,7 @@ void TBuiltIns::addSamplingFunctions(TSampler sampler, TString& typeName, int ve
 
                                         // Add to the per-language set of built-ins
 
-                                        if (bias)
+                                        if (bias || lodClamp)
                                             stageBuiltins[EShLangFragment].append(s);
                                         else
                                             commonBuiltins.append(s);


### PR DESCRIPTION
GLSL texture clamp functions introduced by ARB_sparse_texture_clamp are only available for fragment shader according to the spec.