### PR TITLE
Install headers

### DIFF
--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -53,3 +53,5 @@ endif(WIN32)
 
 install(TARGETS SPIRV SPVRemapper
         ARCHIVE DESTINATION lib)
+
+install(FILES ${HEADERS} ${SPVREMAP_HEADERS} DESTINATION include/SPIRV/)

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -97,3 +97,8 @@ endif(WIN32)
 
 install(TARGETS glslang 
         ARCHIVE DESTINATION lib)
+
+foreach(file ${HEADERS})
+    get_filename_component(dir ${file} DIRECTORY)
+    install(FILES ${file} DESTINATION include/glslang/${dir})
+endforeach()


### PR DESCRIPTION
This enables the vulkan loader to be built against an installed glslang.