### PR TITLE
SPV: Emit names of specialization constants, fixes #710

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -4971,7 +4971,9 @@ spv::Id TGlslangToSpvTraverser::createSpvConstant(const glslang::TIntermTyped& n
             return accessChainLoad(sub_tree->getType());
         } else if (auto* const_union_array = &sn->getConstArray()){
             int nextConst = 0;
-            return createSpvConstantFromConstUnionArray(sn->getType(), *const_union_array, nextConst, true);
+            spv::Id id = createSpvConstantFromConstUnionArray(sn->getType(), *const_union_array, nextConst, true);
+            builder.addName(id, sn->getName().c_str());
+            return id;
         }
     }
 

--- a/Test/baseResults/hlsl.layout.frag.out
+++ b/Test/baseResults/hlsl.layout.frag.out
@@ -87,6 +87,7 @@ gl_FragCoord origin is upper left
                               Name 30  "tbufName2"
                               MemberName 30(tbufName2) 0  "v1PostLayout"
                               Name 32  ""
+                              Name 38  "specConst"
                               MemberDecorate 14(tbufName) 0 Offset 16
                               Decorate 14(tbufName) BufferBlock
                               Decorate 16 DescriptorSet 3
@@ -97,7 +98,7 @@ gl_FragCoord origin is upper left
                               Decorate 30(tbufName2) BufferBlock
                               Decorate 32 DescriptorSet 4
                               Decorate 32 Binding 7
-                              Decorate 38 SpecId 17
+                              Decorate 38(specConst) SpecId 17
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -117,7 +118,7 @@ gl_FragCoord origin is upper left
    30(tbufName2):             TypeStruct 7(fvec4)
               31:             TypePointer Uniform 30(tbufName2)
               32:     31(ptr) Variable Uniform
-              38:     17(int) SpecConstant 10
+   38(specConst):     17(int) SpecConstant 10
          4(main):           2 Function None 3
                5:             Label
                               Return

--- a/Test/baseResults/spv.float16.frag.out
+++ b/Test/baseResults/spv.float16.frag.out
@@ -105,6 +105,9 @@ Warning, version 450 is not yet complete; most version-specific features are pre
                               MemberName 523(B2) 6  "u"
                               MemberName 523(B2) 7  "v"
                               Name 525  ""
+                              Name 526  "sf16"
+                              Name 527  "sf"
+                              Name 528  "sd"
                               Decorate 512 ArrayStride 16
                               Decorate 513 ArrayStride 32
                               MemberDecorate 514(S) 0 Offset 0
@@ -145,9 +148,9 @@ Warning, version 450 is not yet complete; most version-specific features are pre
                               MemberDecorate 523(B2) 7 Offset 72
                               Decorate 523(B2) BufferBlock
                               Decorate 525 DescriptorSet 0
-                              Decorate 526 SpecId 100
-                              Decorate 527 SpecId 101
-                              Decorate 528 SpecId 102
+                              Decorate 526(sf16) SpecId 100
+                              Decorate 527(sf) SpecId 101
+                              Decorate 528(sd) SpecId 102
                2:             TypeVoid
                3:             TypeFunction 2
               28:             TypeFloat 16
@@ -223,14 +226,14 @@ Warning, version 450 is not yet complete; most version-specific features are pre
          523(B2):             TypeStruct 28(float) 29(fvec2) 151(fvec3) 519 406 520 521(S) 522
              524:             TypePointer Uniform 523(B2)
              525:    524(ptr) Variable Uniform
-             526:   28(float) SpecConstant 12288
-             527:  164(float) SpecConstant 1048576000
-             528:  172(float) SpecConstant 0 1071644672
-             529:  164(float) SpecConstantOp 115 526
-             530:  164(float) SpecConstantOp 115 526
+       526(sf16):   28(float) SpecConstant 12288
+         527(sf):  164(float) SpecConstant 1048576000
+         528(sd):  172(float) SpecConstant 0 1071644672
+             529:  164(float) SpecConstantOp 115 526(sf16)
+             530:  164(float) SpecConstantOp 115 526(sf16)
              531:  172(float) SpecConstantOp 115 530
-             532:   28(float) SpecConstantOp 115 527
-             533:   28(float) SpecConstantOp 115 528
+             532:   28(float) SpecConstantOp 115 527(sf)
+             533:   28(float) SpecConstantOp 115 528(sd)
          4(main):           2 Function None 3
                5:             Label
                               Return

--- a/Test/baseResults/spv.int64.frag.out
+++ b/Test/baseResults/spv.int64.frag.out
@@ -51,6 +51,11 @@ Warning, version 450 is not yet complete; most version-specific features are pre
                               MemberName 454(Block) 0  "i64v"
                               MemberName 454(Block) 1  "u64"
                               Name 456  "block"
+                              Name 457  "si64"
+                              Name 458  "su64"
+                              Name 459  "si"
+                              Name 460  "su"
+                              Name 461  "sb"
                               MemberDecorate 28(Uniforms) 0 Offset 0
                               Decorate 28(Uniforms) Block
                               Decorate 30 DescriptorSet 0
@@ -60,11 +65,11 @@ Warning, version 450 is not yet complete; most version-specific features are pre
                               Decorate 454(Block) Block
                               Decorate 456(block) DescriptorSet 0
                               Decorate 456(block) Binding 1
-                              Decorate 457 SpecId 100
-                              Decorate 458 SpecId 101
-                              Decorate 459 SpecId 102
-                              Decorate 460 SpecId 103
-                              Decorate 461 SpecId 104
+                              Decorate 457(si64) SpecId 100
+                              Decorate 458(su64) SpecId 101
+                              Decorate 459(si) SpecId 102
+                              Decorate 460(su) SpecId 103
+                              Decorate 461(sb) SpecId 104
                2:             TypeVoid
                3:             TypeFunction 2
               14:             TypeInt 64 0
@@ -148,28 +153,28 @@ Warning, version 450 is not yet complete; most version-specific features are pre
       454(Block):             TypeStruct 136(ivec3) 14(int)
              455:             TypePointer Uniform 454(Block)
       456(block):    455(ptr) Variable Uniform
-             457:     18(int) SpecConstant 4294967286 4294967295
-             458:     14(int) SpecConstant 20 0
-             459:     31(int) SpecConstant 4294967291
-             460:     21(int) SpecConstant 4
-             461:    55(bool) SpecConstantTrue
-             462:    55(bool) SpecConstantOp 171 457 69
-             463:    55(bool) SpecConstantOp 171 458 69
-             464:     18(int) SpecConstantOp 169 461 61 60
-             465:     14(int) SpecConstantOp 169 461 70 69
-             466:     31(int) SpecConstantOp 114 457
-             467:     18(int) SpecConstantOp 114 459
-             468:     21(int) SpecConstantOp 113 458
-             469:     14(int) SpecConstantOp 113 460
-             470:     18(int) SpecConstantOp 128 458 69
-             471:     14(int) SpecConstantOp 128 457 69
-             472:     21(int) SpecConstantOp 113 458
+       457(si64):     18(int) SpecConstant 4294967286 4294967295
+       458(su64):     14(int) SpecConstant 20 0
+         459(si):     31(int) SpecConstant 4294967291
+         460(su):     21(int) SpecConstant 4
+         461(sb):    55(bool) SpecConstantTrue
+             462:    55(bool) SpecConstantOp 171 457(si64) 69
+             463:    55(bool) SpecConstantOp 171 458(su64) 69
+             464:     18(int) SpecConstantOp 169 461(sb) 61 60
+             465:     14(int) SpecConstantOp 169 461(sb) 70 69
+             466:     31(int) SpecConstantOp 114 457(si64)
+             467:     18(int) SpecConstantOp 114 459(si)
+             468:     21(int) SpecConstantOp 113 458(su64)
+             469:     14(int) SpecConstantOp 113 460(su)
+             470:     18(int) SpecConstantOp 128 458(su64) 69
+             471:     14(int) SpecConstantOp 128 457(si64) 69
+             472:     21(int) SpecConstantOp 113 458(su64)
              473:     31(int) SpecConstantOp 128 472 219
-             474:     18(int) SpecConstantOp 114 459
+             474:     18(int) SpecConstantOp 114 459(si)
              475:     14(int) SpecConstantOp 128 474 69
-             476:     31(int) SpecConstantOp 114 457
+             476:     31(int) SpecConstantOp 114 457(si64)
              477:     21(int) SpecConstantOp 128 476 219
-             478:     14(int) SpecConstantOp 113 460
+             478:     14(int) SpecConstantOp 113 460(su)
              479:     18(int) SpecConstantOp 128 478 69
          4(main):           2 Function None 3
                5:             Label

--- a/Test/baseResults/spv.specConst.vert.out
+++ b/Test/baseResults/spv.specConst.vert.out
@@ -17,6 +17,7 @@ Warning, version 450 is not yet complete; most version-specific features are pre
                               MemberName 11(gl_PerVertex) 2  "gl_ClipDistance"
                               MemberName 11(gl_PerVertex) 3  "gl_CullDistance"
                               Name 13  ""
+                              Name 18  "a"
                               Name 25  "gl_VertexID"
                               Name 26  "gl_InstanceID"
                               MemberDecorate 11(gl_PerVertex) 0 BuiltIn Position
@@ -24,7 +25,7 @@ Warning, version 450 is not yet complete; most version-specific features are pre
                               MemberDecorate 11(gl_PerVertex) 2 BuiltIn ClipDistance
                               MemberDecorate 11(gl_PerVertex) 3 BuiltIn CullDistance
                               Decorate 11(gl_PerVertex) Block
-                              Decorate 18 SpecId 11
+                              Decorate 18(a) SpecId 11
                               Decorate 25(gl_VertexID) BuiltIn VertexId
                               Decorate 26(gl_InstanceID) BuiltIn InstanceId
                2:             TypeVoid
@@ -41,14 +42,14 @@ Warning, version 450 is not yet complete; most version-specific features are pre
               15:     14(int) Constant 0
               16:    6(float) Constant 1065353216
               17:    7(fvec4) ConstantComposite 16 16 16 16
-              18:     14(int) SpecConstant 8
+           18(a):     14(int) SpecConstant 8
               22:             TypePointer Output 7(fvec4)
               24:             TypePointer Input 14(int)
  25(gl_VertexID):     24(ptr) Variable Input
 26(gl_InstanceID):     24(ptr) Variable Input
          4(main):           2 Function None 3
                5:             Label
-              19:    6(float) ConvertSToF 18
+              19:    6(float) ConvertSToF 18(a)
               20:    7(fvec4) CompositeConstruct 19 19 19 19
               21:    7(fvec4) FDiv 17 20
               23:     22(ptr) AccessChain 13 15

--- a/Test/baseResults/spv.specConstant.vert.out
+++ b/Test/baseResults/spv.specConstant.vert.out
@@ -12,33 +12,44 @@ Warning, version 400 is not yet complete; most version-specific features are pre
                               EntryPoint Vertex 4  "main" 20 22 28 53
                               Source GLSL 400
                               Name 4  "main"
+                              Name 9  "arraySize"
                               Name 14  "foo(vf4[s1516];"
                               Name 13  "p"
                               Name 17  "builtin_spec_constant("
                               Name 20  "color"
                               Name 22  "ucol"
                               Name 28  "size"
+                              Name 30  "spBool"
+                              Name 34  "scale"
+                              Name 39  "spDouble"
+                              Name 40  "spFloat"
                               Name 47  "param"
+                              Name 50  "dupArraySize"
                               Name 53  "dupUcol"
+                              Name 60  "spDupBool"
+                              Name 63  "dupScale"
+                              Name 67  "spDupDouble"
+                              Name 68  "spDupFloat"
                               Name 76  "result"
-                              Decorate 9 SpecId 16
-                              Decorate 30 SpecId 17
-                              Decorate 34 SpecId 22
-                              Decorate 39 SpecId 19
-                              Decorate 40 SpecId 18
-                              Decorate 50 SpecId 116
-                              Decorate 60 SpecId 117
-                              Decorate 63 SpecId 122
-                              Decorate 67 SpecId 119
-                              Decorate 68 SpecId 118
-                              Decorate 77 SpecId 24
+                              Name 77  "gl_MaxImageUnits"
+                              Decorate 9(arraySize) SpecId 16
+                              Decorate 30(spBool) SpecId 17
+                              Decorate 34(scale) SpecId 22
+                              Decorate 39(spDouble) SpecId 19
+                              Decorate 40(spFloat) SpecId 18
+                              Decorate 50(dupArraySize) SpecId 116
+                              Decorate 60(spDupBool) SpecId 117
+                              Decorate 63(dupScale) SpecId 122
+                              Decorate 67(spDupDouble) SpecId 119
+                              Decorate 68(spDupFloat) SpecId 118
+                              Decorate 77(gl_MaxImageUnits) SpecId 24
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
                7:             TypeVector 6(float) 4
                8:             TypeInt 32 1
-               9:      8(int) SpecConstant 5
-              10:             TypeArray 7(fvec4) 9
+    9(arraySize):      8(int) SpecConstant 5
+              10:             TypeArray 7(fvec4) 9(arraySize)
               11:             TypePointer Function 10
               12:             TypeFunction 2 11(ptr)
               16:             TypeFunction 8(int)
@@ -51,41 +62,41 @@ Warning, version 400 is not yet complete; most version-specific features are pre
               27:             TypePointer Output 8(int)
         28(size):     27(ptr) Variable Output
               29:             TypeBool
-              30:    29(bool) SpecConstantTrue
+      30(spBool):    29(bool) SpecConstantTrue
               33:             TypeInt 32 0
-              34:     33(int) SpecConstant 2
+       34(scale):     33(int) SpecConstant 2
               38:             TypeFloat 64
-              39:   38(float) SpecConstant 1413754136 1074340347
-              40:    6(float) SpecConstant 1078523331
-              41:   38(float) SpecConstantOp 115 40
-              50:      8(int) SpecConstant 12
-              51:             TypeArray 7(fvec4) 50
+    39(spDouble):   38(float) SpecConstant 1413754136 1074340347
+     40(spFloat):    6(float) SpecConstant 1078523331
+              41:   38(float) SpecConstantOp 115 40(spFloat)
+50(dupArraySize):      8(int) SpecConstant 12
+              51:             TypeArray 7(fvec4) 50(dupArraySize)
               52:             TypePointer Input 51
      53(dupUcol):     52(ptr) Variable Input
-              60:    29(bool) SpecConstantTrue
-              63:     33(int) SpecConstant 2
-              67:   38(float) SpecConstant 1413754136 1074340347
-              68:    6(float) SpecConstant 1078523331
-              69:   38(float) SpecConstantOp 115 68
+   60(spDupBool):    29(bool) SpecConstantTrue
+    63(dupScale):     33(int) SpecConstant 2
+ 67(spDupDouble):   38(float) SpecConstant 1413754136 1074340347
+  68(spDupFloat):    6(float) SpecConstant 1078523331
+              69:   38(float) SpecConstantOp 115 68(spDupFloat)
               75:             TypePointer Function 8(int)
-              77:      8(int) SpecConstant 8
+77(gl_MaxImageUnits):      8(int) SpecConstant 8
          4(main):           2 Function None 3
                5:             Label
        47(param):     11(ptr) Variable Function
               25:     24(ptr) AccessChain 22(ucol) 23
               26:    7(fvec4) Load 25
                               Store 20(color) 26
-                              Store 28(size) 9
+                              Store 28(size) 9(arraySize)
                               SelectionMerge 32 None
-                              BranchConditional 30 31 32
+                              BranchConditional 30(spBool) 31 32
               31:               Label
-              35:    6(float)   ConvertUToF 34
+              35:    6(float)   ConvertUToF 34(scale)
               36:    7(fvec4)   Load 20(color)
               37:    7(fvec4)   VectorTimesScalar 36 35
                                 Store 20(color) 37
                                 Branch 32
               32:             Label
-              42:   38(float) FDiv 39 41
+              42:   38(float) FDiv 39(spDouble) 41
               43:    6(float) FConvert 42
               44:    7(fvec4) Load 20(color)
               45:    7(fvec4) CompositeConstruct 43 43 43 43
@@ -105,18 +116,18 @@ Warning, version 400 is not yet complete; most version-specific features are pre
               57:    7(fvec4) FAdd 56 55
                               Store 20(color) 57
               58:      8(int) Load 28(size)
-              59:      8(int) IAdd 58 50
+              59:      8(int) IAdd 58 50(dupArraySize)
                               Store 28(size) 59
                               SelectionMerge 62 None
-                              BranchConditional 60 61 62
+                              BranchConditional 60(spDupBool) 61 62
               61:               Label
-              64:    6(float)   ConvertUToF 63
+              64:    6(float)   ConvertUToF 63(dupScale)
               65:    7(fvec4)   Load 20(color)
               66:    7(fvec4)   VectorTimesScalar 65 64
                                 Store 20(color) 66
                                 Branch 62
               62:             Label
-              70:   38(float) FDiv 67 69
+              70:   38(float) FDiv 67(spDupDouble) 69
               71:    6(float) FConvert 70
               72:    7(fvec4) Load 20(color)
               73:    7(fvec4) CompositeConstruct 71 71 71 71
@@ -127,7 +138,7 @@ Warning, version 400 is not yet complete; most version-specific features are pre
 17(builtin_spec_constant():      8(int) Function None 16
               18:             Label
       76(result):     75(ptr) Variable Function
-                              Store 76(result) 77
+                              Store 76(result) 77(gl_MaxImageUnits)
               78:      8(int) Load 76(result)
                               ReturnValue 78
                               FunctionEnd

--- a/Test/baseResults/spv.specConstantComposite.vert.out
+++ b/Test/baseResults/spv.specConstantComposite.vert.out
@@ -18,29 +18,33 @@ Warning, version 450 is not yet complete; most version-specific features are pre
                               Name 12  "refer_composite_bracket_dereference("
                               Name 16  "refer_spec_const_array_length("
                               Name 18  "declare_spec_const_in_func("
+                              Name 21  "spec_bool"
                               Name 27  "color"
+                              Name 28  "spec_int"
                               Name 33  "len"
+                              Name 37  "spec_float"
+                              Name 39  "spec_double"
                               Name 42  "global_vec4_array_with_spec_length"
-                              Decorate 21 SpecId 203
-                              Decorate 28 SpecId 200
-                              Decorate 37 SpecId 201
-                              Decorate 39 SpecId 202
+                              Decorate 21(spec_bool) SpecId 203
+                              Decorate 28(spec_int) SpecId 200
+                              Decorate 37(spec_float) SpecId 201
+                              Decorate 39(spec_double) SpecId 202
                2:             TypeVoid
                3:             TypeFunction 2
               14:             TypeInt 32 1
               15:             TypeFunction 14(int)
               20:             TypeBool
-              21:    20(bool) SpecConstantTrue
+   21(spec_bool):    20(bool) SpecConstantTrue
               24:             TypeFloat 32
               25:             TypeVector 24(float) 4
               26:             TypePointer Output 25(fvec4)
        27(color):     26(ptr) Variable Output
-              28:     14(int) SpecConstant 3
+    28(spec_int):     14(int) SpecConstant 3
               32:             TypePointer Function 14(int)
-              37:   24(float) SpecConstant 1078523331
+  37(spec_float):   24(float) SpecConstant 1078523331
               38:             TypeFloat 64
-              39:   38(float) SpecConstant 1413754136 1074340347
-              40:             TypeArray 25(fvec4) 28
+ 39(spec_double):   38(float) SpecConstant 1413754136 1074340347
+              40:             TypeArray 25(fvec4) 28(spec_int)
               41:             TypePointer Input 40
 42(global_vec4_array_with_spec_length):     41(ptr) Variable Input
          4(main):           2 Function None 3
@@ -50,9 +54,9 @@ Warning, version 450 is not yet complete; most version-specific features are pre
 6(refer_primary_spec_const():           2 Function None 3
                7:             Label
                               SelectionMerge 23 None
-                              BranchConditional 21 22 23
+                              BranchConditional 21(spec_bool) 22 23
               22:               Label
-              29:   24(float)   ConvertSToF 28
+              29:   24(float)   ConvertSToF 28(spec_int)
               30:   25(fvec4)   Load 27(color)
               31:   25(fvec4)   VectorTimesScalar 30 29
                                 Store 27(color) 31
@@ -75,7 +79,7 @@ Warning, version 450 is not yet complete; most version-specific features are pre
 16(refer_spec_const_array_length():     14(int) Function None 15
               17:             Label
          33(len):     32(ptr) Variable Function
-                              Store 33(len) 28
+                              Store 33(len) 28(spec_int)
               34:     14(int) Load 33(len)
                               ReturnValue 34
                               FunctionEnd

--- a/Test/baseResults/spv.specConstantOperations.vert.out
+++ b/Test/baseResults/spv.specConstantOperations.vert.out
@@ -14,85 +14,90 @@ Warning, version 450 is not yet complete; most version-specific features are pre
                               Name 4  "main"
                               Name 8  "non_const_array_size_from_spec_const("
                               Name 11  "i"
+                              Name 19  "sp_int"
                               Name 27  "array"
-                              Decorate 19 SpecId 201
-                              Decorate 40 SpecId 200
-                              Decorate 42 SpecId 202
-                              Decorate 43 SpecId 203
-                              Decorate 45 SpecId 204
+                              Name 40  "sp_float"
+                              Name 42  "sp_uint"
+                              Name 43  "sp_sint"
+                              Name 45  "sp_double"
+                              Decorate 19(sp_int) SpecId 201
+                              Decorate 40(sp_float) SpecId 200
+                              Decorate 42(sp_uint) SpecId 202
+                              Decorate 43(sp_sint) SpecId 203
+                              Decorate 45(sp_double) SpecId 204
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeInt 32 1
                7:             TypeFunction 6(int)
               10:             TypePointer Function 6(int)
               12:      6(int) Constant 0
-              19:      6(int) SpecConstant 10
+      19(sp_int):      6(int) SpecConstant 10
               20:      6(int) Constant 2
-              21:      6(int) SpecConstantOp 128 19 20
+              21:      6(int) SpecConstantOp 128 19(sp_int) 20
               22:             TypeBool
-              24:      6(int) SpecConstantOp 128 19 20
+              24:      6(int) SpecConstantOp 128 19(sp_int) 20
               25:             TypeArray 6(int) 24
               26:             TypePointer Function 25
               29:      6(int) Constant 1023
               32:      6(int) Constant 1
-              34:      6(int) SpecConstantOp 128 19 32
+              34:      6(int) SpecConstantOp 128 19(sp_int) 32
               39:             TypeFloat 32
-              40:   39(float) SpecConstant 1078530010
+    40(sp_float):   39(float) SpecConstant 1078530010
               41:             TypeInt 32 0
-              42:     41(int) SpecConstant 100
-              43:      6(int) SpecConstant 4294967286
+     42(sp_uint):     41(int) SpecConstant 100
+     43(sp_sint):      6(int) SpecConstant 4294967286
               44:             TypeFloat 64
-              45:   44(float) SpecConstant 2333366019 1074118410
-              46:   39(float) SpecConstantOp 115 45
-              47:   44(float) SpecConstantOp 115 40
+   45(sp_double):   44(float) SpecConstant 2333366019 1074118410
+              46:   39(float) SpecConstantOp 115 45(sp_double)
+              47:   44(float) SpecConstantOp 115 40(sp_float)
               48:     41(int) Constant 0
-              49:    22(bool) SpecConstantOp 171 19 48
-              50:    22(bool) SpecConstantOp 171 42 48
+              49:    22(bool) SpecConstantOp 171 19(sp_int) 48
+              50:    22(bool) SpecConstantOp 171 42(sp_uint) 48
               51:      6(int) SpecConstantOp 169 49 32 12
               52:     41(int) Constant 1
               53:     41(int) SpecConstantOp 169 49 52 48
-              54:     41(int) SpecConstantOp 128 43 48
-              55:      6(int) SpecConstantOp 128 42 48
-              56:      6(int) SpecConstantOp 126 19
-              57:      6(int) SpecConstantOp 200 19
-              58:      6(int) SpecConstantOp 128 19 20
-              59:      6(int) SpecConstantOp 128 19 20
+              54:     41(int) SpecConstantOp 128 43(sp_sint) 48
+              55:      6(int) SpecConstantOp 128 42(sp_uint) 48
+              56:      6(int) SpecConstantOp 126 19(sp_int)
+              57:      6(int) SpecConstantOp 200 19(sp_int)
+              58:      6(int) SpecConstantOp 128 19(sp_int) 20
+              59:      6(int) SpecConstantOp 128 19(sp_int) 20
               60:      6(int) Constant 3
               61:      6(int) SpecConstantOp 130 59 60
               62:      6(int) Constant 4
               63:      6(int) SpecConstantOp 130 58 62
-              64:      6(int) SpecConstantOp 132 43 20
+              64:      6(int) SpecConstantOp 132 43(sp_sint) 20
               65:     41(int) Constant 2
-              66:     41(int) SpecConstantOp 132 42 65
+              66:     41(int) SpecConstantOp 132 42(sp_uint) 65
               67:      6(int) Constant 5
               68:      6(int) SpecConstantOp 135 64 67
               69:     41(int) Constant 5
               70:     41(int) SpecConstantOp 134 66 69
-              71:      6(int) SpecConstantOp 139 43 62
+              71:      6(int) SpecConstantOp 139 43(sp_sint) 62
               72:     41(int) Constant 4
-              73:     41(int) SpecConstantOp 137 42 72
-              74:      6(int) SpecConstantOp 132 43 60
+              73:     41(int) SpecConstantOp 137 42(sp_uint) 72
+              74:      6(int) SpecConstantOp 132 43(sp_sint) 60
               75:      6(int) SpecConstantOp 135 74 67
               76:      6(int) Constant 10
-              77:      6(int) SpecConstantOp 195 43 76
+              77:      6(int) SpecConstantOp 195 43(sp_sint) 76
               78:      6(int) Constant 20
-              79:     41(int) SpecConstantOp 194 42 78
-              80:      6(int) SpecConstantOp 196 43 32
-              81:     41(int) SpecConstantOp 196 42 20
+              79:     41(int) SpecConstantOp 194 42(sp_uint) 78
+              80:      6(int) SpecConstantOp 196 43(sp_sint) 32
+              81:     41(int) SpecConstantOp 196 42(sp_uint) 20
               82:      6(int) Constant 256
-              83:      6(int) SpecConstantOp 197 43 82
+              83:      6(int) SpecConstantOp 197 43(sp_sint) 82
               84:     41(int) Constant 512
-              85:     41(int) SpecConstantOp 198 42 84
-              86:    22(bool) SpecConstantOp 177 19 43
-              87:    22(bool) SpecConstantOp 170 42 42
-              88:    22(bool) SpecConstantOp 173 19 43
+              85:     41(int) SpecConstantOp 198 42(sp_uint) 84
+              86:    22(bool) SpecConstantOp 177 19(sp_int) 43(sp_sint)
+              87:    22(bool) SpecConstantOp 170 42(sp_uint) 42(sp_uint)
+              88:    22(bool) SpecConstantOp 173 19(sp_int) 43(sp_sint)
               89:      6(int) Constant 30
               90:             TypeVector 6(int) 4
-              91:   90(ivec4) SpecConstantComposite 78 89 19 19
+              91:   90(ivec4) SpecConstantComposite 78 89 19(sp_int) 19(sp_int)
               92:     41(int) Constant 4294967295
               93:     41(int) Constant 4294967294
               94:             TypeVector 41(int) 4
-              95:   94(ivec4) SpecConstantComposite 42 42 92 93
+              95:   94(ivec4) SpecConstantComposite 42(sp_uint) 42(sp_uint) 92 93
               96:             TypeVector 22(bool) 4
               97:   94(ivec4) ConstantComposite 48 48 48 48
               98:   96(bvec4) SpecConstantOp 171 91 97

--- a/Test/baseResults/vulkan.ast.vert.out
+++ b/Test/baseResults/vulkan.ast.vert.out
@@ -269,56 +269,59 @@ Shader version: 450
                               EntryPoint Vertex 4  "main"
                               Source GLSL 450
                               Name 4  "main"
-                              Decorate 7 SpecId 200
-                              Decorate 11 SpecId 201
-                              Decorate 13 SpecId 202
+                              Name 7  "scf1"
+                              Name 11  "scbt"
+                              Name 13  "sci2"
+                              Decorate 7(scf1) SpecId 200
+                              Decorate 11(scbt) SpecId 201
+                              Decorate 13(sci2) SpecId 202
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
-               7:    6(float) SpecConstant 1065353216
+         7(scf1):    6(float) SpecConstant 1065353216
                8:             TypeBool
                9:    6(float) Constant 0
-              11:     8(bool) SpecConstantTrue
+        11(scbt):     8(bool) SpecConstantTrue
               12:             TypeInt 32 1
-              13:     12(int) SpecConstant 2
+        13(sci2):     12(int) SpecConstant 2
               14:             TypeInt 32 0
               15:     14(int) Constant 0
-              16:     8(bool) SpecConstantOp 171 13 15
+              16:     8(bool) SpecConstantOp 171 13(sci2) 15
               17:    6(float) Constant 1065353216
               21:     12(int) Constant 0
               22:     12(int) Constant 1
-              23:     12(int) SpecConstantOp 169 11 22 21
-              25:     8(bool) SpecConstantOp 166 11 11
-              26:     12(int) SpecConstantOp 132 13 13
-              30:     8(bool) SpecConstantOp 168 11
-              31:     12(int) SpecConstantOp 126 13
-              33:     8(bool) SpecConstantOp 173 13 13
-              35:     8(bool) SpecConstantOp 165 11 11
-              36:     8(bool) SpecConstantOp 171 13 13
+              23:     12(int) SpecConstantOp 169 11(scbt) 22 21
+              25:     8(bool) SpecConstantOp 166 11(scbt) 11(scbt)
+              26:     12(int) SpecConstantOp 132 13(sci2) 13(sci2)
+              30:     8(bool) SpecConstantOp 168 11(scbt)
+              31:     12(int) SpecConstantOp 126 13(sci2)
+              33:     8(bool) SpecConstantOp 173 13(sci2) 13(sci2)
+              35:     8(bool) SpecConstantOp 165 11(scbt) 11(scbt)
+              36:     8(bool) SpecConstantOp 171 13(sci2) 13(sci2)
               37:             TypeVector 12(int) 2
-              38:   37(ivec2) SpecConstantComposite 13 13
-              39:   37(ivec2) SpecConstantComposite 13 13
-              40:   37(ivec2) SpecConstantComposite 13 13
+              38:   37(ivec2) SpecConstantComposite 13(sci2) 13(sci2)
+              39:   37(ivec2) SpecConstantComposite 13(sci2) 13(sci2)
+              40:   37(ivec2) SpecConstantComposite 13(sci2) 13(sci2)
               41:     14(int) Constant 2
               42:             TypeArray 37(ivec2) 41
               44:             TypeVector 6(float) 2
               48:             TypeArray 44(fvec2) 41
          4(main):           2 Function None 3
                5:             Label
-              10:     8(bool) FOrdNotEqual 7 9
-              18:    6(float) Select 11 17 9
-              19:    6(float) ConvertSToF 13
-              20:     12(int) ConvertFToS 7
-              24:    6(float) FMul 7 7
-              27:    6(float) ConvertSToF 13
-              28:    6(float) FAdd 7 27
-              29:    6(float) FNegate 7
-              32:     8(bool) FOrdGreaterThan 7 7
-              34:     8(bool) FOrdNotEqual 7 7
+              10:     8(bool) FOrdNotEqual 7(scf1) 9
+              18:    6(float) Select 11(scbt) 17 9
+              19:    6(float) ConvertSToF 13(sci2)
+              20:     12(int) ConvertFToS 7(scf1)
+              24:    6(float) FMul 7(scf1) 7(scf1)
+              27:    6(float) ConvertSToF 13(sci2)
+              28:    6(float) FAdd 7(scf1) 27
+              29:    6(float) FNegate 7(scf1)
+              32:     8(bool) FOrdGreaterThan 7(scf1) 7(scf1)
+              34:     8(bool) FOrdNotEqual 7(scf1) 7(scf1)
               43:          42 CompositeConstruct 39 40
-              45:   44(fvec2) CompositeConstruct 7 7
-              46:   44(fvec2) CompositeConstruct 7 7
-              47:   44(fvec2) CompositeConstruct 7 7
+              45:   44(fvec2) CompositeConstruct 7(scf1) 7(scf1)
+              46:   44(fvec2) CompositeConstruct 7(scf1) 7(scf1)
+              47:   44(fvec2) CompositeConstruct 7(scf1) 7(scf1)
               49:          48 CompositeConstruct 46 47
                               Return
                               FunctionEnd


### PR DESCRIPTION
A somewhat naive attempt at making GlslangToSpv emit friendly names of specialization constants.