### PR TITLE
HLSL: fix copies between arrays of structs of builtins, and arrayed b…

### DIFF
--- a/Test/baseResults/hlsl.struct.split.assign.frag.out
+++ b/Test/baseResults/hlsl.struct.split.assign.frag.out
@@ -37,6 +37,18 @@ gl_FragCoord origin is upper left
 0:7                0 (const int)
 0:7            Constant:
 0:7              0 (const int)
+0:7        move second child to first child (temp 4-component vector of float)
+0:7          pos: direct index for structure (temp 4-component vector of float)
+0:7            direct index (temp structure{temp float f, temp 4-component vector of float pos})
+0:?               'input' (temp 3-element array of structure{temp float f, temp 4-component vector of float pos})
+0:7              Constant:
+0:7                0 (const int)
+0:7            Constant:
+0:7              1 (const int)
+0:7          direct index (in 4-component vector of float FragCoord)
+0:?             'input_pos' (in 3-element array of 4-component vector of float FragCoord)
+0:7            Constant:
+0:7              0 (const int)
 0:7        move second child to first child (temp float)
 0:7          f: direct index for structure (temp float)
 0:7            direct index (temp structure{temp float f, temp 4-component vector of float pos})
@@ -52,6 +64,18 @@ gl_FragCoord origin is upper left
 0:7                1 (const int)
 0:7            Constant:
 0:7              0 (const int)
+0:7        move second child to first child (temp 4-component vector of float)
+0:7          pos: direct index for structure (temp 4-component vector of float)
+0:7            direct index (temp structure{temp float f, temp 4-component vector of float pos})
+0:?               'input' (temp 3-element array of structure{temp float f, temp 4-component vector of float pos})
+0:7              Constant:
+0:7                1 (const int)
+0:7            Constant:
+0:7              1 (const int)
+0:7          direct index (in 4-component vector of float FragCoord)
+0:?             'input_pos' (in 3-element array of 4-component vector of float FragCoord)
+0:7            Constant:
+0:7              1 (const int)
 0:7        move second child to first child (temp float)
 0:7          f: direct index for structure (temp float)
 0:7            direct index (temp structure{temp float f, temp 4-component vector of float pos})
@@ -67,6 +91,18 @@ gl_FragCoord origin is upper left
 0:7                2 (const int)
 0:7            Constant:
 0:7              0 (const int)
+0:7        move second child to first child (temp 4-component vector of float)
+0:7          pos: direct index for structure (temp 4-component vector of float)
+0:7            direct index (temp structure{temp float f, temp 4-component vector of float pos})
+0:?               'input' (temp 3-element array of structure{temp float f, temp 4-component vector of float pos})
+0:7              Constant:
+0:7                2 (const int)
+0:7            Constant:
+0:7              1 (const int)
+0:7          direct index (in 4-component vector of float FragCoord)
+0:?             'input_pos' (in 3-element array of 4-component vector of float FragCoord)
+0:7            Constant:
+0:7              2 (const int)
 0:7      move second child to first child (temp 4-component vector of float)
 0:?         '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
 0:7        Function Call: @main(i1;struct-S-f1-vf41[3]; (temp 4-component vector of float)
@@ -120,6 +156,18 @@ gl_FragCoord origin is upper left
 0:7                0 (const int)
 0:7            Constant:
 0:7              0 (const int)
+0:7        move second child to first child (temp 4-component vector of float)
+0:7          pos: direct index for structure (temp 4-component vector of float)
+0:7            direct index (temp structure{temp float f, temp 4-component vector of float pos})
+0:?               'input' (temp 3-element array of structure{temp float f, temp 4-component vector of float pos})
+0:7              Constant:
+0:7                0 (const int)
+0:7            Constant:
+0:7              1 (const int)
+0:7          direct index (in 4-component vector of float FragCoord)
+0:?             'input_pos' (in 3-element array of 4-component vector of float FragCoord)
+0:7            Constant:
+0:7              0 (const int)
 0:7        move second child to first child (temp float)
 0:7          f: direct index for structure (temp float)
 0:7            direct index (temp structure{temp float f, temp 4-component vector of float pos})
@@ -135,6 +183,18 @@ gl_FragCoord origin is upper left
 0:7                1 (const int)
 0:7            Constant:
 0:7              0 (const int)
+0:7        move second child to first child (temp 4-component vector of float)
+0:7          pos: direct index for structure (temp 4-component vector of float)
+0:7            direct index (temp structure{temp float f, temp 4-component vector of float pos})
+0:?               'input' (temp 3-element array of structure{temp float f, temp 4-component vector of float pos})
+0:7              Constant:
+0:7                1 (const int)
+0:7            Constant:
+0:7              1 (const int)
+0:7          direct index (in 4-component vector of float FragCoord)
+0:?             'input_pos' (in 3-element array of 4-component vector of float FragCoord)
+0:7            Constant:
+0:7              1 (const int)
 0:7        move second child to first child (temp float)
 0:7          f: direct index for structure (temp float)
 0:7            direct index (temp structure{temp float f, temp 4-component vector of float pos})
@@ -150,6 +210,18 @@ gl_FragCoord origin is upper left
 0:7                2 (const int)
 0:7            Constant:
 0:7              0 (const int)
+0:7        move second child to first child (temp 4-component vector of float)
+0:7          pos: direct index for structure (temp 4-component vector of float)
+0:7            direct index (temp structure{temp float f, temp 4-component vector of float pos})
+0:?               'input' (temp 3-element array of structure{temp float f, temp 4-component vector of float pos})
+0:7              Constant:
+0:7                2 (const int)
+0:7            Constant:
+0:7              1 (const int)
+0:7          direct index (in 4-component vector of float FragCoord)
+0:?             'input_pos' (in 3-element array of 4-component vector of float FragCoord)
+0:7            Constant:
+0:7              2 (const int)
 0:7      move second child to first child (temp 4-component vector of float)
 0:?         '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
 0:7        Function Call: @main(i1;struct-S-f1-vf41[3]; (temp 4-component vector of float)
@@ -163,12 +235,12 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 63
+// Id's are bound by 73
 
                               Capability Shader
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 32 39 54 62
+                              EntryPoint Fragment 4  "main" 32 39 48 67
                               ExecutionMode 4 OriginUpperLeft
                               Name 4  "main"
                               Name 10  "S"
@@ -184,14 +256,14 @@ gl_FragCoord origin is upper left
                               Name 36  "S"
                               MemberName 36(S) 0  "f"
                               Name 39  "input"
-                              Name 54  "@entryPointOutput"
-                              Name 55  "param"
-                              Name 57  "param"
-                              Name 62  "input_pos"
+                              Name 48  "input_pos"
+                              Name 67  "@entryPointOutput"
+                              Name 68  "param"
+                              Name 70  "param"
                               Decorate 32(i) Location 0
                               Decorate 39(input) Location 1
-                              Decorate 54(@entryPointOutput) Location 0
-                              Decorate 62(input_pos) BuiltIn FragCoord
+                              Decorate 48(input_pos) BuiltIn FragCoord
+                              Decorate 67(@entryPointOutput) Location 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeInt 32 1
@@ -218,38 +290,51 @@ gl_FragCoord origin is upper left
               40:             TypePointer Input 8(float)
               43:             TypePointer Function 8(float)
               45:      6(int) Constant 1
-              49:      6(int) Constant 2
-              53:             TypePointer Output 9(fvec4)
-54(@entryPointOutput):     53(ptr) Variable Output
-              60:             TypeArray 9(fvec4) 12
-              61:             TypePointer Input 60
-   62(input_pos):     61(ptr) Variable Input
+              46:             TypeArray 9(fvec4) 12
+              47:             TypePointer Input 46
+   48(input_pos):     47(ptr) Variable Input
+              49:             TypePointer Input 9(fvec4)
+              59:      6(int) Constant 2
+              66:             TypePointer Output 9(fvec4)
+67(@entryPointOutput):     66(ptr) Variable Output
          4(main):           2 Function None 3
                5:             Label
            30(i):      7(ptr) Variable Function
        34(input):     14(ptr) Variable Function
-       55(param):      7(ptr) Variable Function
-       57(param):     14(ptr) Variable Function
+       68(param):      7(ptr) Variable Function
+       70(param):     14(ptr) Variable Function
               33:      6(int) Load 32(i)
                               Store 30(i) 33
               41:     40(ptr) AccessChain 39(input) 35 35
               42:    8(float) Load 41
               44:     43(ptr) AccessChain 34(input) 35 35
                               Store 44 42
-              46:     40(ptr) AccessChain 39(input) 45 35
-              47:    8(float) Load 46
-              48:     43(ptr) AccessChain 34(input) 45 35
-                              Store 48 47
-              50:     40(ptr) AccessChain 39(input) 49 35
-              51:    8(float) Load 50
-              52:     43(ptr) AccessChain 34(input) 49 35
+              50:     49(ptr) AccessChain 48(input_pos) 35
+              51:    9(fvec4) Load 50
+              52:     25(ptr) AccessChain 34(input) 35 45
                               Store 52 51
-              56:      6(int) Load 30(i)
-                              Store 55(param) 56
-              58:          13 Load 34(input)
-                              Store 57(param) 58
-              59:    9(fvec4) FunctionCall 18(@main(i1;struct-S-f1-vf41[3];) 55(param) 57(param)
-                              Store 54(@entryPointOutput) 59
+              53:     40(ptr) AccessChain 39(input) 45 35
+              54:    8(float) Load 53
+              55:     43(ptr) AccessChain 34(input) 45 35
+                              Store 55 54
+              56:     49(ptr) AccessChain 48(input_pos) 45
+              57:    9(fvec4) Load 56
+              58:     25(ptr) AccessChain 34(input) 45 45
+                              Store 58 57
+              60:     40(ptr) AccessChain 39(input) 59 35
+              61:    8(float) Load 60
+              62:     43(ptr) AccessChain 34(input) 59 35
+                              Store 62 61
+              63:     49(ptr) AccessChain 48(input_pos) 59
+              64:    9(fvec4) Load 63
+              65:     25(ptr) AccessChain 34(input) 59 45
+                              Store 65 64
+              69:      6(int) Load 30(i)
+                              Store 68(param) 69
+              71:          13 Load 34(input)
+                              Store 70(param) 71
+              72:    9(fvec4) FunctionCall 18(@main(i1;struct-S-f1-vf41[3];) 68(param) 70(param)
+                              Store 67(@entryPointOutput) 72
                               Return
                               FunctionEnd
 18(@main(i1;struct-S-f1-vf41[3];):    9(fvec4) Function None 15

--- a/Test/baseResults/hlsl.struct.split.nested.geom.out
+++ b/Test/baseResults/hlsl.struct.split.nested.geom.out
@@ -43,6 +43,18 @@ output primitive = triangle_strip
 0:24    Function Parameters: 
 0:?     Sequence
 0:24      Sequence
+0:24        move second child to first child (temp 4-component vector of float)
+0:24          pos: direct index for structure (temp 4-component vector of float)
+0:24            direct index (temp structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
+0:?               'tin' (temp 3-element array of structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
+0:24              Constant:
+0:24                0 (const int)
+0:24            Constant:
+0:24              0 (const int)
+0:24          direct index (in 4-component vector of float Position)
+0:?             'tin_pos' (in 3-element array of 4-component vector of float Position)
+0:24            Constant:
+0:24              0 (const int)
 0:24        move second child to first child (temp 2-component vector of float)
 0:24          tc: direct index for structure (temp 2-component vector of float)
 0:24            direct index (temp structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
@@ -58,6 +70,18 @@ output primitive = triangle_strip
 0:24                0 (const int)
 0:24            Constant:
 0:24              0 (const int)
+0:24        move second child to first child (temp 4-component vector of float)
+0:24          pos: direct index for structure (temp 4-component vector of float)
+0:24            direct index (temp structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
+0:?               'tin' (temp 3-element array of structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
+0:24              Constant:
+0:24                1 (const int)
+0:24            Constant:
+0:24              0 (const int)
+0:24          direct index (in 4-component vector of float Position)
+0:?             'tin_pos' (in 3-element array of 4-component vector of float Position)
+0:24            Constant:
+0:24              1 (const int)
 0:24        move second child to first child (temp 2-component vector of float)
 0:24          tc: direct index for structure (temp 2-component vector of float)
 0:24            direct index (temp structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
@@ -73,6 +97,18 @@ output primitive = triangle_strip
 0:24                1 (const int)
 0:24            Constant:
 0:24              0 (const int)
+0:24        move second child to first child (temp 4-component vector of float)
+0:24          pos: direct index for structure (temp 4-component vector of float)
+0:24            direct index (temp structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
+0:?               'tin' (temp 3-element array of structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
+0:24              Constant:
+0:24                2 (const int)
+0:24            Constant:
+0:24              0 (const int)
+0:24          direct index (in 4-component vector of float Position)
+0:?             'tin_pos' (in 3-element array of 4-component vector of float Position)
+0:24            Constant:
+0:24              2 (const int)
 0:24        move second child to first child (temp 2-component vector of float)
 0:24          tc: direct index for structure (temp 2-component vector of float)
 0:24            direct index (temp structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
@@ -143,6 +179,18 @@ output primitive = triangle_strip
 0:24    Function Parameters: 
 0:?     Sequence
 0:24      Sequence
+0:24        move second child to first child (temp 4-component vector of float)
+0:24          pos: direct index for structure (temp 4-component vector of float)
+0:24            direct index (temp structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
+0:?               'tin' (temp 3-element array of structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
+0:24              Constant:
+0:24                0 (const int)
+0:24            Constant:
+0:24              0 (const int)
+0:24          direct index (in 4-component vector of float Position)
+0:?             'tin_pos' (in 3-element array of 4-component vector of float Position)
+0:24            Constant:
+0:24              0 (const int)
 0:24        move second child to first child (temp 2-component vector of float)
 0:24          tc: direct index for structure (temp 2-component vector of float)
 0:24            direct index (temp structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
@@ -158,6 +206,18 @@ output primitive = triangle_strip
 0:24                0 (const int)
 0:24            Constant:
 0:24              0 (const int)
+0:24        move second child to first child (temp 4-component vector of float)
+0:24          pos: direct index for structure (temp 4-component vector of float)
+0:24            direct index (temp structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
+0:?               'tin' (temp 3-element array of structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
+0:24              Constant:
+0:24                1 (const int)
+0:24            Constant:
+0:24              0 (const int)
+0:24          direct index (in 4-component vector of float Position)
+0:?             'tin_pos' (in 3-element array of 4-component vector of float Position)
+0:24            Constant:
+0:24              1 (const int)
 0:24        move second child to first child (temp 2-component vector of float)
 0:24          tc: direct index for structure (temp 2-component vector of float)
 0:24            direct index (temp structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
@@ -173,6 +233,18 @@ output primitive = triangle_strip
 0:24                1 (const int)
 0:24            Constant:
 0:24              0 (const int)
+0:24        move second child to first child (temp 4-component vector of float)
+0:24          pos: direct index for structure (temp 4-component vector of float)
+0:24            direct index (temp structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
+0:?               'tin' (temp 3-element array of structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
+0:24              Constant:
+0:24                2 (const int)
+0:24            Constant:
+0:24              0 (const int)
+0:24          direct index (in 4-component vector of float Position)
+0:?             'tin_pos' (in 3-element array of 4-component vector of float Position)
+0:24            Constant:
+0:24              2 (const int)
 0:24        move second child to first child (temp 2-component vector of float)
 0:24          tc: direct index for structure (temp 2-component vector of float)
 0:24            direct index (temp structure{temp 4-component vector of float pos, temp 2-component vector of float tc})
@@ -197,12 +269,12 @@ output primitive = triangle_strip
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 67
+// Id's are bound by 80
 
                               Capability Geometry
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Geometry 4  "main" 46 66
+                              EntryPoint Geometry 4  "main" 45 53 79
                               ExecutionMode 4 Triangles
                               ExecutionMode 4 Invocations 1
                               ExecutionMode 4 OutputTriangleStrip
@@ -225,18 +297,20 @@ output primitive = triangle_strip
                               Name 23  "ts"
                               Name 26  "o"
                               Name 42  "tin"
-                              Name 43  "PS_IN"
-                              MemberName 43(PS_IN) 0  "tc"
-                              Name 46  "tin"
-                              Name 58  "ts"
-                              Name 59  "param"
-                              Name 61  "param"
-                              Name 63  "PerVertex_in"
-                              MemberName 63(PerVertex_in) 0  "tin_pos"
-                              Name 66  "PerVertex_in"
-                              Decorate 46(tin) Location 0
-                              MemberDecorate 63(PerVertex_in) 0 BuiltIn Position
-                              Decorate 63(PerVertex_in) Block
+                              Name 45  "tin_pos"
+                              Name 50  "PS_IN"
+                              MemberName 50(PS_IN) 0  "tc"
+                              Name 53  "tin"
+                              Name 71  "ts"
+                              Name 72  "param"
+                              Name 74  "param"
+                              Name 76  "PerVertex_in"
+                              MemberName 76(PerVertex_in) 0  "tin_pos"
+                              Name 79  "PerVertex_in"
+                              Decorate 45(tin_pos) BuiltIn Position
+                              Decorate 53(tin) Location 0
+                              MemberDecorate 76(PerVertex_in) 0 BuiltIn Position
+                              Decorate 76(PerVertex_in) Block
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -267,37 +341,53 @@ output primitive = triangle_strip
               37:    6(float) Constant 1086324736
               38:    8(fvec2) ConstantComposite 36 37
               39:             TypePointer Function 8(fvec2)
-       43(PS_IN):             TypeStruct 8(fvec2)
-              44:             TypeArray 43(PS_IN) 11
-              45:             TypePointer Input 44
-         46(tin):     45(ptr) Variable Input
-              47:             TypePointer Input 8(fvec2)
-              54:     17(int) Constant 2
-63(PerVertex_in):             TypeStruct 7(fvec4)
-              64:             TypeArray 63(PerVertex_in) 11
-              65:             TypePointer Input 64
-66(PerVertex_in):     65(ptr) Variable Input
+              43:             TypeArray 7(fvec4) 11
+              44:             TypePointer Input 43
+     45(tin_pos):     44(ptr) Variable Input
+              46:             TypePointer Input 7(fvec4)
+       50(PS_IN):             TypeStruct 8(fvec2)
+              51:             TypeArray 50(PS_IN) 11
+              52:             TypePointer Input 51
+         53(tin):     52(ptr) Variable Input
+              54:             TypePointer Input 8(fvec2)
+              64:     17(int) Constant 2
+76(PerVertex_in):             TypeStruct 7(fvec4)
+              77:             TypeArray 76(PerVertex_in) 11
+              78:             TypePointer Input 77
+79(PerVertex_in):     78(ptr) Variable Input
          4(main):           2 Function None 3
                5:             Label
          42(tin):     13(ptr) Variable Function
-          58(ts):     20(ptr) Variable Function
-       59(param):     13(ptr) Variable Function
-       61(param):     20(ptr) Variable Function
-              48:     47(ptr) AccessChain 46(tin) 27 27
-              49:    8(fvec2) Load 48
-              50:     39(ptr) AccessChain 42(tin) 27 35
-                              Store 50 49
-              51:     47(ptr) AccessChain 46(tin) 35 27
-              52:    8(fvec2) Load 51
-              53:     39(ptr) AccessChain 42(tin) 35 35
-                              Store 53 52
-              55:     47(ptr) AccessChain 46(tin) 54 27
+          71(ts):     20(ptr) Variable Function
+       72(param):     13(ptr) Variable Function
+       74(param):     20(ptr) Variable Function
+              47:     46(ptr) AccessChain 45(tin_pos) 27
+              48:    7(fvec4) Load 47
+              49:     33(ptr) AccessChain 42(tin) 27 27
+                              Store 49 48
+              55:     54(ptr) AccessChain 53(tin) 27 27
               56:    8(fvec2) Load 55
-              57:     39(ptr) AccessChain 42(tin) 54 35
+              57:     39(ptr) AccessChain 42(tin) 27 35
                               Store 57 56
-              60:          12 Load 42(tin)
-                              Store 59(param) 60
-              62:           2 FunctionCall 24(@main(struct-PS_IN-vf4-vf21[3];struct-GS_OUT-struct-PS_IN-vf4-vf21-struct-STRUCT_WITH_NO_BUILTIN_INTERSTAGE_IO-f1[2]-i111;) 59(param) 61(param)
+              58:     46(ptr) AccessChain 45(tin_pos) 35
+              59:    7(fvec4) Load 58
+              60:     33(ptr) AccessChain 42(tin) 35 27
+                              Store 60 59
+              61:     54(ptr) AccessChain 53(tin) 35 27
+              62:    8(fvec2) Load 61
+              63:     39(ptr) AccessChain 42(tin) 35 35
+                              Store 63 62
+              65:     46(ptr) AccessChain 45(tin_pos) 64
+              66:    7(fvec4) Load 65
+              67:     33(ptr) AccessChain 42(tin) 64 27
+                              Store 67 66
+              68:     54(ptr) AccessChain 53(tin) 64 27
+              69:    8(fvec2) Load 68
+              70:     39(ptr) AccessChain 42(tin) 64 35
+                              Store 70 69
+              73:          12 Load 42(tin)
+                              Store 72(param) 73
+              75:           2 FunctionCall 24(@main(struct-PS_IN-vf4-vf21[3];struct-GS_OUT-struct-PS_IN-vf4-vf21-struct-STRUCT_WITH_NO_BUILTIN_INTERSTAGE_IO-f1[2]-i111;) 72(param) 74(param)
                               Return
                               FunctionEnd
 24(@main(struct-PS_IN-vf4-vf21[3];struct-GS_OUT-struct-PS_IN-vf4-vf21-struct-STRUCT_WITH_NO_BUILTIN_INTERSTAGE_IO-f1[2]-i111;):           2 Function None 21

--- a/Test/baseResults/hlsl.struct.split.trivial.geom.out
+++ b/Test/baseResults/hlsl.struct.split.trivial.geom.out
@@ -5,10 +5,10 @@ max_vertices = 3
 input primitive = triangles
 output primitive = triangle_strip
 0:? Sequence
-0:14  Function Definition: main(struct-PS_IN-vf41[3];struct-GS_OUT-vf41; (temp void)
+0:14  Function Definition: @main(struct-PS_IN-vf41[3];struct-GS_OUT-vf41; (temp void)
 0:14    Function Parameters: 
-0:14      'i' (in 3-element array of structure{temp 4-component vector of float Position pos})
-0:14      'ts' (out structure{temp 4-component vector of float Position pos})
+0:14      'i' (in 3-element array of structure{temp 4-component vector of float pos})
+0:14      'ts' (out structure{temp 4-component vector of float pos})
 0:?     Sequence
 0:17      Sequence
 0:17        move second child to first child (temp int)
@@ -28,24 +28,65 @@ output primitive = triangle_strip
 0:18                'o' (temp structure{temp 4-component vector of float pos})
 0:18                Constant:
 0:18                  0 (const int)
-0:18              indirect index (temp 4-component vector of float Position)
-0:18                'i_pos' (in 3-element array of 4-component vector of float Position)
-0:18                'x' (temp int)
+0:18              pos: direct index for structure (temp 4-component vector of float)
+0:18                indirect index (temp structure{temp 4-component vector of float pos})
+0:18                  'i' (in 3-element array of structure{temp 4-component vector of float pos})
+0:18                  'x' (temp int)
+0:18                Constant:
+0:18                  0 (const int)
 0:19            Sequence
-0:19              Sequence
-0:19                move second child to first child (temp 4-component vector of float)
-0:?                   'ts_pos' (out 4-component vector of float Position)
-0:19                  pos: direct index for structure (temp 4-component vector of float)
-0:19                    'o' (temp structure{temp 4-component vector of float pos})
-0:19                    Constant:
-0:19                      0 (const int)
+0:19              move second child to first child (temp structure{temp 4-component vector of float pos})
+0:19                'ts' (out structure{temp 4-component vector of float pos})
+0:19                'o' (temp structure{temp 4-component vector of float pos})
 0:19              EmitVertex (temp void)
 0:17          Loop Terminal Expression
 0:17          Pre-Increment (temp int)
 0:17            'x' (temp int)
+0:14  Function Definition: main( (temp void)
+0:14    Function Parameters: 
+0:?     Sequence
+0:14      Sequence
+0:14        move second child to first child (temp 4-component vector of float)
+0:14          pos: direct index for structure (temp 4-component vector of float)
+0:14            direct index (temp structure{temp 4-component vector of float pos})
+0:?               'i' (temp 3-element array of structure{temp 4-component vector of float pos})
+0:14              Constant:
+0:14                0 (const int)
+0:14            Constant:
+0:14              0 (const int)
+0:14          direct index (in 4-component vector of float Position)
+0:?             'i_pos' (in 3-element array of 4-component vector of float Position)
+0:14            Constant:
+0:14              0 (const int)
+0:14        move second child to first child (temp 4-component vector of float)
+0:14          pos: direct index for structure (temp 4-component vector of float)
+0:14            direct index (temp structure{temp 4-component vector of float pos})
+0:?               'i' (temp 3-element array of structure{temp 4-component vector of float pos})
+0:14              Constant:
+0:14                1 (const int)
+0:14            Constant:
+0:14              0 (const int)
+0:14          direct index (in 4-component vector of float Position)
+0:?             'i_pos' (in 3-element array of 4-component vector of float Position)
+0:14            Constant:
+0:14              1 (const int)
+0:14        move second child to first child (temp 4-component vector of float)
+0:14          pos: direct index for structure (temp 4-component vector of float)
+0:14            direct index (temp structure{temp 4-component vector of float pos})
+0:?               'i' (temp 3-element array of structure{temp 4-component vector of float pos})
+0:14              Constant:
+0:14                2 (const int)
+0:14            Constant:
+0:14              0 (const int)
+0:14          direct index (in 4-component vector of float Position)
+0:?             'i_pos' (in 3-element array of 4-component vector of float Position)
+0:14            Constant:
+0:14              2 (const int)
+0:14      Function Call: @main(struct-PS_IN-vf41[3];struct-GS_OUT-vf41; (temp void)
+0:?         'i' (temp 3-element array of structure{temp 4-component vector of float pos})
+0:?         'ts' (temp structure{temp 4-component vector of float pos})
 0:?   Linker Objects
 0:?     'PerVertex_in' (in 3-element array of block{in 4-component vector of float Position i_pos})
-0:?     'PerVertex_out' (out block{out 4-component vector of float Position ts_pos})
 
 
 Linked geometry stage:
@@ -57,10 +98,10 @@ max_vertices = 3
 input primitive = triangles
 output primitive = triangle_strip
 0:? Sequence
-0:14  Function Definition: main(struct-PS_IN-vf41[3];struct-GS_OUT-vf41; (temp void)
+0:14  Function Definition: @main(struct-PS_IN-vf41[3];struct-GS_OUT-vf41; (temp void)
 0:14    Function Parameters: 
-0:14      'i' (in 3-element array of structure{temp 4-component vector of float Position pos})
-0:14      'ts' (out structure{temp 4-component vector of float Position pos})
+0:14      'i' (in 3-element array of structure{temp 4-component vector of float pos})
+0:14      'ts' (out structure{temp 4-component vector of float pos})
 0:?     Sequence
 0:17      Sequence
 0:17        move second child to first child (temp int)
@@ -80,113 +121,180 @@ output primitive = triangle_strip
 0:18                'o' (temp structure{temp 4-component vector of float pos})
 0:18                Constant:
 0:18                  0 (const int)
-0:18              indirect index (temp 4-component vector of float Position)
-0:18                'i_pos' (in 3-element array of 4-component vector of float Position)
-0:18                'x' (temp int)
+0:18              pos: direct index for structure (temp 4-component vector of float)
+0:18                indirect index (temp structure{temp 4-component vector of float pos})
+0:18                  'i' (in 3-element array of structure{temp 4-component vector of float pos})
+0:18                  'x' (temp int)
+0:18                Constant:
+0:18                  0 (const int)
 0:19            Sequence
-0:19              Sequence
-0:19                move second child to first child (temp 4-component vector of float)
-0:?                   'ts_pos' (out 4-component vector of float Position)
-0:19                  pos: direct index for structure (temp 4-component vector of float)
-0:19                    'o' (temp structure{temp 4-component vector of float pos})
-0:19                    Constant:
-0:19                      0 (const int)
+0:19              move second child to first child (temp structure{temp 4-component vector of float pos})
+0:19                'ts' (out structure{temp 4-component vector of float pos})
+0:19                'o' (temp structure{temp 4-component vector of float pos})
 0:19              EmitVertex (temp void)
 0:17          Loop Terminal Expression
 0:17          Pre-Increment (temp int)
 0:17            'x' (temp int)
+0:14  Function Definition: main( (temp void)
+0:14    Function Parameters: 
+0:?     Sequence
+0:14      Sequence
+0:14        move second child to first child (temp 4-component vector of float)
+0:14          pos: direct index for structure (temp 4-component vector of float)
+0:14            direct index (temp structure{temp 4-component vector of float pos})
+0:?               'i' (temp 3-element array of structure{temp 4-component vector of float pos})
+0:14              Constant:
+0:14                0 (const int)
+0:14            Constant:
+0:14              0 (const int)
+0:14          direct index (in 4-component vector of float Position)
+0:?             'i_pos' (in 3-element array of 4-component vector of float Position)
+0:14            Constant:
+0:14              0 (const int)
+0:14        move second child to first child (temp 4-component vector of float)
+0:14          pos: direct index for structure (temp 4-component vector of float)
+0:14            direct index (temp structure{temp 4-component vector of float pos})
+0:?               'i' (temp 3-element array of structure{temp 4-component vector of float pos})
+0:14              Constant:
+0:14                1 (const int)
+0:14            Constant:
+0:14              0 (const int)
+0:14          direct index (in 4-component vector of float Position)
+0:?             'i_pos' (in 3-element array of 4-component vector of float Position)
+0:14            Constant:
+0:14              1 (const int)
+0:14        move second child to first child (temp 4-component vector of float)
+0:14          pos: direct index for structure (temp 4-component vector of float)
+0:14            direct index (temp structure{temp 4-component vector of float pos})
+0:?               'i' (temp 3-element array of structure{temp 4-component vector of float pos})
+0:14              Constant:
+0:14                2 (const int)
+0:14            Constant:
+0:14              0 (const int)
+0:14          direct index (in 4-component vector of float Position)
+0:?             'i_pos' (in 3-element array of 4-component vector of float Position)
+0:14            Constant:
+0:14              2 (const int)
+0:14      Function Call: @main(struct-PS_IN-vf41[3];struct-GS_OUT-vf41; (temp void)
+0:?         'i' (temp 3-element array of structure{temp 4-component vector of float pos})
+0:?         'ts' (temp structure{temp 4-component vector of float pos})
 0:?   Linker Objects
 0:?     'PerVertex_in' (in 3-element array of block{in 4-component vector of float Position i_pos})
-0:?     'PerVertex_out' (out block{out 4-component vector of float Position ts_pos})
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 49
+// Id's are bound by 67
 
                               Capability Geometry
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Geometry 4  "main" 28 36 45 48
+                              EntryPoint Geometry 4  "main" 46 66
                               ExecutionMode 4 Triangles
                               ExecutionMode 4 Invocations 1
                               ExecutionMode 4 OutputTriangleStrip
                               ExecutionMode 4 OutputVertices 3
                               Name 4  "main"
-                              Name 8  "x"
-                              Name 21  "GS_OUT"
-                              MemberName 21(GS_OUT) 0  "pos"
-                              Name 23  "o"
-                              Name 28  "i_pos"
-                              Name 36  "ts_pos"
-                              Name 42  "PerVertex_in"
-                              MemberName 42(PerVertex_in) 0  "i_pos"
-                              Name 45  "PerVertex_in"
-                              Name 46  "PerVertex_out"
-                              MemberName 46(PerVertex_out) 0  "ts_pos"
-                              Name 48  "PerVertex_out"
-                              Decorate 28(i_pos) BuiltIn Position
-                              Decorate 36(ts_pos) BuiltIn Position
-                              MemberDecorate 42(PerVertex_in) 0 BuiltIn Position
-                              Decorate 42(PerVertex_in) Block
-                              MemberDecorate 46(PerVertex_out) 0 BuiltIn Position
-                              Decorate 46(PerVertex_out) Block
+                              Name 8  "PS_IN"
+                              MemberName 8(PS_IN) 0  "pos"
+                              Name 13  "GS_OUT"
+                              MemberName 13(GS_OUT) 0  "pos"
+                              Name 18  "@main(struct-PS_IN-vf41[3];struct-GS_OUT-vf41;"
+                              Name 16  "i"
+                              Name 17  "ts"
+                              Name 22  "x"
+                              Name 33  "o"
+                              Name 43  "i"
+                              Name 46  "i_pos"
+                              Name 58  "ts"
+                              Name 59  "param"
+                              Name 61  "param"
+                              Name 63  "PerVertex_in"
+                              MemberName 63(PerVertex_in) 0  "i_pos"
+                              Name 66  "PerVertex_in"
+                              Decorate 46(i_pos) BuiltIn Position
+                              MemberDecorate 63(PerVertex_in) 0 BuiltIn Position
+                              Decorate 63(PerVertex_in) Block
                2:             TypeVoid
                3:             TypeFunction 2
-               6:             TypeInt 32 1
-               7:             TypePointer Function 6(int)
-               9:      6(int) Constant 0
-              16:      6(int) Constant 3
-              17:             TypeBool
-              19:             TypeFloat 32
-              20:             TypeVector 19(float) 4
-      21(GS_OUT):             TypeStruct 20(fvec4)
-              22:             TypePointer Function 21(GS_OUT)
-              24:             TypeInt 32 0
-              25:     24(int) Constant 3
-              26:             TypeArray 20(fvec4) 25
-              27:             TypePointer Input 26
-       28(i_pos):     27(ptr) Variable Input
-              30:             TypePointer Input 20(fvec4)
-              33:             TypePointer Function 20(fvec4)
-              35:             TypePointer Output 20(fvec4)
-      36(ts_pos):     35(ptr) Variable Output
-              40:      6(int) Constant 1
-42(PerVertex_in):             TypeStruct 20(fvec4)
-              43:             TypeArray 42(PerVertex_in) 25
-              44:             TypePointer Input 43
-45(PerVertex_in):     44(ptr) Variable Input
-46(PerVertex_out):             TypeStruct 20(fvec4)
-              47:             TypePointer Output 46(PerVertex_out)
-48(PerVertex_out):     47(ptr) Variable Output
+               6:             TypeFloat 32
+               7:             TypeVector 6(float) 4
+        8(PS_IN):             TypeStruct 7(fvec4)
+               9:             TypeInt 32 0
+              10:      9(int) Constant 3
+              11:             TypeArray 8(PS_IN) 10
+              12:             TypePointer Function 11
+      13(GS_OUT):             TypeStruct 7(fvec4)
+              14:             TypePointer Function 13(GS_OUT)
+              15:             TypeFunction 2 12(ptr) 14(ptr)
+              20:             TypeInt 32 1
+              21:             TypePointer Function 20(int)
+              23:     20(int) Constant 0
+              30:     20(int) Constant 3
+              31:             TypeBool
+              35:             TypePointer Function 7(fvec4)
+              41:     20(int) Constant 1
+              44:             TypeArray 7(fvec4) 10
+              45:             TypePointer Input 44
+       46(i_pos):     45(ptr) Variable Input
+              47:             TypePointer Input 7(fvec4)
+              54:     20(int) Constant 2
+63(PerVertex_in):             TypeStruct 7(fvec4)
+              64:             TypeArray 63(PerVertex_in) 10
+              65:             TypePointer Input 64
+66(PerVertex_in):     65(ptr) Variable Input
          4(main):           2 Function None 3
                5:             Label
-            8(x):      7(ptr) Variable Function
-           23(o):     22(ptr) Variable Function
-                              Store 8(x) 9
-                              Branch 10
-              10:             Label
-                              LoopMerge 12 13 None
-                              Branch 14
-              14:             Label
-              15:      6(int) Load 8(x)
-              18:    17(bool) SLessThan 15 16
-                              BranchConditional 18 11 12
-              11:               Label
-              29:      6(int)   Load 8(x)
-              31:     30(ptr)   AccessChain 28(i_pos) 29
-              32:   20(fvec4)   Load 31
-              34:     33(ptr)   AccessChain 23(o) 9
-                                Store 34 32
-              37:     33(ptr)   AccessChain 23(o) 9
-              38:   20(fvec4)   Load 37
-                                Store 36(ts_pos) 38
+           43(i):     12(ptr) Variable Function
+          58(ts):     14(ptr) Variable Function
+       59(param):     12(ptr) Variable Function
+       61(param):     14(ptr) Variable Function
+              48:     47(ptr) AccessChain 46(i_pos) 23
+              49:    7(fvec4) Load 48
+              50:     35(ptr) AccessChain 43(i) 23 23
+                              Store 50 49
+              51:     47(ptr) AccessChain 46(i_pos) 41
+              52:    7(fvec4) Load 51
+              53:     35(ptr) AccessChain 43(i) 41 23
+                              Store 53 52
+              55:     47(ptr) AccessChain 46(i_pos) 54
+              56:    7(fvec4) Load 55
+              57:     35(ptr) AccessChain 43(i) 54 23
+                              Store 57 56
+              60:          11 Load 43(i)
+                              Store 59(param) 60
+              62:           2 FunctionCall 18(@main(struct-PS_IN-vf41[3];struct-GS_OUT-vf41;) 59(param) 61(param)
+                              Return
+                              FunctionEnd
+18(@main(struct-PS_IN-vf41[3];struct-GS_OUT-vf41;):           2 Function None 15
+           16(i):     12(ptr) FunctionParameter
+          17(ts):     14(ptr) FunctionParameter
+              19:             Label
+           22(x):     21(ptr) Variable Function
+           33(o):     14(ptr) Variable Function
+                              Store 22(x) 23
+                              Branch 24
+              24:             Label
+                              LoopMerge 26 27 None
+                              Branch 28
+              28:             Label
+              29:     20(int) Load 22(x)
+              32:    31(bool) SLessThan 29 30
+                              BranchConditional 32 25 26
+              25:               Label
+              34:     20(int)   Load 22(x)
+              36:     35(ptr)   AccessChain 16(i) 34 23
+              37:    7(fvec4)   Load 36
+              38:     35(ptr)   AccessChain 33(o) 23
+                                Store 38 37
+              39:  13(GS_OUT)   Load 33(o)
+                                Store 17(ts) 39
                                 EmitVertex
-                                Branch 13
-              13:               Label
-              39:      6(int)   Load 8(x)
-              41:      6(int)   IAdd 39 40
-                                Store 8(x) 41
-                                Branch 10
-              12:             Label
+                                Branch 27
+              27:               Label
+              40:     20(int)   Load 22(x)
+              42:     20(int)   IAdd 40 41
+                                Store 22(x) 42
+                                Branch 24
+              26:             Label
                               Return
                               FunctionEnd

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -214,7 +214,7 @@ INSTANTIATE_TEST_CASE_P(
         {"hlsl.struct.split.assign.frag", "main"},
         {"hlsl.struct.split.call.vert", "main"},
         {"hlsl.struct.split.nested.geom", "main"},
-        //{"hlsl.struct.split.trivial.geom", "main"},
+        {"hlsl.struct.split.trivial.geom", "main"},
         {"hlsl.struct.split.trivial.vert", "main"},
         {"hlsl.structarray.flatten.frag", "main"},
         {"hlsl.structarray.flatten.geom", "main"},

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -1919,6 +1919,11 @@ TIntermTyped* HlslParseContext::handleAssign(const TSourceLoc& loc, TOperator op
 
     int memberIdx = 0;
 
+    // When dealing with split arrayed structures of builtins, the arrayness is moved to the extracted builtin
+    // variables, which is awkward when copying between split and unsplit structures.  This variable tracks
+    // array indirections so they can be percolated from outer structs to inner variables.
+    std::vector <int> arrayElement;
+
     // We track the outer-most aggregate, so that we can use its storage class later.
     const TIntermTyped* outerLeft  = left;
     const TIntermTyped* outerRight = right;
@@ -1936,6 +1941,14 @@ TIntermTyped* HlslParseContext::handleAssign(const TSourceLoc& loc, TOperator op
         if (split && derefType.isBuiltInInterstageIO(language)) {
             // copy from interstage IO builtin if needed
             subTree = intermediate.addSymbol(*interstageBuiltInIo.find(tInterstageIoData(derefType, outer->getType()))->second);
+
+            // Arrayness of builtIn symbols isn't handled by the normal recursion: it's been extracted and moved to the builtin.
+            if (subTree->getType().isArray() && !arrayElement.empty()) {
+                const TType splitDerefType(subTree->getType(), arrayElement.back());
+                subTree = intermediate.addIndex(EOpIndexDirect, subTree, intermediate.addConstantUnion(arrayElement.back(), loc), loc);
+                subTree->setType(splitDerefType);
+            }
+
         } else if (flattened && isFinalFlattening(derefType)) {
             subTree = intermediate.addSymbol(*flatVariables[memberIdx++]);
         } else {
@@ -1966,17 +1979,21 @@ TIntermTyped* HlslParseContext::handleAssign(const TSourceLoc& loc, TOperator op
 
             // array case
             for (int element=0; element < left->getType().getOuterArraySize(); ++element) {
-                    // Add a new AST symbol node if we have a temp variable holding a complex RHS.
+                // Add a new AST symbol node if we have a temp variable holding a complex RHS.
                 TIntermTyped* subLeft  = getMember(true,  left,  element, left, element);
                 TIntermTyped* subRight = getMember(false, right, element, right, element);
 
                 TIntermTyped* subSplitLeft =  isSplitLeft  ? getMember(true,  left,  element, splitLeft, element) : subLeft;
                 TIntermTyped* subSplitRight = isSplitRight ? getMember(false, right, element, splitRight, element) : subRight; 
 
+                arrayElement.push_back(element);
+
                 if (isFinalFlattening(dereferencedType))
                     assignList = intermediate.growAggregate(assignList, intermediate.addAssign(op, subLeft, subRight, loc), loc);
                 else
                     traverse(subLeft, subRight, subSplitLeft, subSplitRight);
+
+                arrayElement.pop_back();
             }
         } else if (left->getType().isStruct()) {
             // struct case


### PR DESCRIPTION
…uiltins.

Structs are split to remove builtin members to create valid SPIR-V.  In this process, an outer structure array dimension may be propegated onto the now-removed builtin variables.  For example, a mystruct[3].position ->
position[3].  The copy between the split and unsplit forms would handle this in some cases, but not if the array dimension was at different levels of aggregate.

It now does this, but may not handle arbitrary composite types.  Unclear if that has any semantic meaning for builtins anyway.