### PR TITLE
Added --vn option to generate a C header file containing a variable a…

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -5254,11 +5254,15 @@ void OutputSpvBin(const std::vector<unsigned int>& spirv, const char* baseName)
 }
 
 // Write SPIR-V out to a text file with 32-bit hexadecimal words
-void OutputSpvHex(const std::vector<unsigned int>& spirv, const char* baseName)
+void OutputSpvHex(const std::vector<unsigned int>& spirv, const char* baseName, const char* varName)
 {
     std::ofstream out;
     out.open(baseName, std::ios::binary | std::ios::out);
     out << "\t// " GLSLANG_REVISION " " GLSLANG_DATE << std::endl;
+	if (varName != nullptr) {
+		out << "\t #pragma once" << std::endl;
+		out << "const uint32_t " << varName << "[] = {" << std::endl;
+	}
     const int WORDS_PER_LINE = 8;
     for (int i = 0; i < (int)spirv.size(); i += WORDS_PER_LINE) {
         out << "\t";
@@ -5271,6 +5275,9 @@ void OutputSpvHex(const std::vector<unsigned int>& spirv, const char* baseName)
         }
         out << std::endl;
     }
+	if (varName != nullptr) {
+		out << "};";
+	}
     out.close();
 }
 

--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -5259,10 +5259,10 @@ void OutputSpvHex(const std::vector<unsigned int>& spirv, const char* baseName, 
     std::ofstream out;
     out.open(baseName, std::ios::binary | std::ios::out);
     out << "\t// " GLSLANG_REVISION " " GLSLANG_DATE << std::endl;
-	if (varName != nullptr) {
-		out << "\t #pragma once" << std::endl;
-		out << "const uint32_t " << varName << "[] = {" << std::endl;
-	}
+    if (varName != nullptr) {
+        out << "\t #pragma once" << std::endl;
+        out << "const uint32_t " << varName << "[] = {" << std::endl;
+    }
     const int WORDS_PER_LINE = 8;
     for (int i = 0; i < (int)spirv.size(); i += WORDS_PER_LINE) {
         out << "\t";
@@ -5275,9 +5275,9 @@ void OutputSpvHex(const std::vector<unsigned int>& spirv, const char* baseName, 
         }
         out << std::endl;
     }
-	if (varName != nullptr) {
-		out << "};";
-	}
+    if (varName != nullptr) {
+        out << "};";
+    }
     out.close();
 }
 

--- a/SPIRV/GlslangToSpv.h
+++ b/SPIRV/GlslangToSpv.h
@@ -49,6 +49,6 @@ void GetSpirvVersion(std::string&);
 void GlslangToSpv(const glslang::TIntermediate& intermediate, std::vector<unsigned int>& spirv);
 void GlslangToSpv(const glslang::TIntermediate& intermediate, std::vector<unsigned int>& spirv, spv::SpvBuildLogger* logger);
 void OutputSpvBin(const std::vector<unsigned int>& spirv, const char* baseName);
-void OutputSpvHex(const std::vector<unsigned int>& spirv, const char* baseName);
+void OutputSpvHex(const std::vector<unsigned int>& spirv, const char* baseName, const char* varName);
 
 }

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -303,20 +303,18 @@ void ProcessArguments(int argc, char* argv[])
                     } else if (lowerword == "no-storage-format" || // synonyms
                                lowerword == "nsf") {
                         Options |= EOptionNoStorageFormat;
-					}
-					else if (lowerword == "variable-name" || // synonyms
-						lowerword == "vn") {
-						Options |= EOptionOutputHexadecimal;
-						variableName = argv[1];
-						if (argc > 0) {
-							argc--;
-							argv++;
-						}
-						else
-							Error("no <C-variable-name> provided for --variable-name");
-						break;
-					}
-					else if (lowerword == "source-entrypoint" || // synonyms
+                    } else if (lowerword == "variable-name" || // synonyms
+                        lowerword == "vn") {
+                        Options |= EOptionOutputHexadecimal;
+                        variableName = argv[1];
+                        if (argc > 0) {
+                            argc--;
+                            argv++;
+                        } else
+                            Error("no <C-variable-name> provided for --variable-name");
+                        break;
+                    }
+                    else if (lowerword == "source-entrypoint" || // synonyms
                                lowerword == "sep") {
                         sourceEntryPointName = argv[1];
                         if (argc > 0) {

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -163,6 +163,7 @@ const char* binaryFileName = nullptr;
 const char* entryPointName = nullptr;
 const char* sourceEntryPointName = nullptr;
 const char* shaderStageName = nullptr;
+const char* variableName = nullptr;
 
 std::array<unsigned int, EShLangCount> baseSamplerBinding;
 std::array<unsigned int, EShLangCount> baseTextureBinding;
@@ -302,7 +303,20 @@ void ProcessArguments(int argc, char* argv[])
                     } else if (lowerword == "no-storage-format" || // synonyms
                                lowerword == "nsf") {
                         Options |= EOptionNoStorageFormat;
-                    } else if (lowerword == "source-entrypoint" || // synonyms
+					}
+					else if (lowerword == "variable-name" || // synonyms
+						lowerword == "vn") {
+						Options |= EOptionOutputHexadecimal;
+						variableName = argv[1];
+						if (argc > 0) {
+							argc--;
+							argv++;
+						}
+						else
+							Error("no <C-variable-name> provided for --variable-name");
+						break;
+					}
+					else if (lowerword == "source-entrypoint" || // synonyms
                                lowerword == "sep") {
                         sourceEntryPointName = argv[1];
                         if (argc > 0) {
@@ -650,7 +664,7 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
                     if (! (Options & EOptionMemoryLeakMode)) {
                         printf("%s", logger.getAllMessages().c_str());
                         if (Options & EOptionOutputHexadecimal) {
-                            glslang::OutputSpvHex(spirv, GetBinaryName((EShLanguage)stage));
+							glslang::OutputSpvHex(spirv, GetBinaryName((EShLanguage)stage), variableName);
                         } else {
                             glslang::OutputSpvBin(spirv, GetBinaryName((EShLanguage)stage));
                         }
@@ -987,6 +1001,8 @@ void usage()
            "\n"
            "  --keep-uncalled                         don't eliminate uncalled functions when linking\n"
            "  --ku                                    synonym for --keep-uncalled\n"
+		   "  --variable-name <name>                  Creates a C header file that contains a uint32_t array named <name> initialized with the shader binary code.\n"
+		   "  --vn <name>                             synonym for --variable-name <name>.\n"
            );
 
     exit(EFailUsage);


### PR DESCRIPTION
…ssigned to the hex representation of the shader. This is a standard feature on Microsoft's HLSL compiler and it allows developers to include pre-compiled shaders directly into the code. This option enables "Hex output", so it is NOT required to specify -x as well. The output file name is preserved, so no ".h" extension is added. If you want the output file to have ".h" extension then you have to specify it on the output file name. The generated header file uses the "#pragma once" pragma to avoid multiple inclusions.