### PR TITLE
Fix mismatched doc string for SPV_KHR_subgroup_vote

### DIFF
--- a/SPIRV/doc.cpp
+++ b/SPIRV/doc.cpp
@@ -1171,8 +1171,8 @@ const char* OpcodeString(int op)
 
     case 4421: return "OpSubgroupBallotKHR";
     case 4422: return "OpSubgroupFirstInvocationKHR";
-    case 4428: return "OpSubgroupAnyKHR";
-    case 4429: return "OpSubgroupAllKHR";
+    case 4428: return "OpSubgroupAllKHR";
+    case 4429: return "OpSubgroupAnyKHR";
     case 4430: return "OpSubgroupAllEqualKHR";
     case 4432: return "OpSubgroupReadInvocationKHR";
 

--- a/Test/baseResults/spv.shaderGroupVote.comp.out
+++ b/Test/baseResults/spv.shaderGroupVote.comp.out
@@ -48,10 +48,10 @@ Warning, version 450 is not yet complete; most version-specific features are pre
               19:     6(bool) INotEqual 17 18
                               Store 8(b1) 19
               20:     6(bool) Load 8(b1)
-              21:     6(bool) SubgroupAllKHR 20
+              21:     6(bool) SubgroupAnyKHR 20
                               Store 8(b1) 21
               22:     6(bool) Load 8(b1)
-              23:     6(bool) SubgroupAnyKHR 22
+              23:     6(bool) SubgroupAllKHR 22
                               Store 8(b1) 23
               24:     6(bool) Load 8(b1)
               25:     6(bool) SubgroupAllEqualKHR 24


### PR DESCRIPTION
Text for opcodes OpSubgroupAllKHR and OpSubgroupAnyKHR was swapped.