### PR TITLE
SPV: Unexpected declarations of capabilities from NV extensions.

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -472,12 +472,12 @@ spv::BuiltIn TGlslangToSpvTraverser::TranslateBuiltInDecoration(glslang::TBuiltI
     //
     case glslang::EbvClipDistance:
         if (!memberDeclaration)
-        builder.addCapability(spv::CapabilityClipDistance);
+            builder.addCapability(spv::CapabilityClipDistance);
         return spv::BuiltInClipDistance;
 
     case glslang::EbvCullDistance:
         if (!memberDeclaration)
-        builder.addCapability(spv::CapabilityCullDistance);
+            builder.addCapability(spv::CapabilityCullDistance);
         return spv::BuiltInCullDistance;
 
     case glslang::EbvViewportIndex:
@@ -635,23 +635,32 @@ spv::BuiltIn TGlslangToSpvTraverser::TranslateBuiltInDecoration(glslang::TBuiltI
         builder.addCapability(spv::CapabilityShaderViewportMaskNV);
         return spv::BuiltInViewportMaskNV;
     case glslang::EbvSecondaryPositionNV:
-        builder.addExtension(spv::E_SPV_NV_stereo_view_rendering);
-        builder.addCapability(spv::CapabilityShaderStereoViewNV);
+        if (!memberDeclaration) {
+            builder.addExtension(spv::E_SPV_NV_stereo_view_rendering);
+            builder.addCapability(spv::CapabilityShaderStereoViewNV);
+        }
         return spv::BuiltInSecondaryPositionNV;
     case glslang::EbvSecondaryViewportMaskNV:
-        builder.addExtension(spv::E_SPV_NV_stereo_view_rendering);
-        builder.addCapability(spv::CapabilityShaderStereoViewNV);
+        if (!memberDeclaration) {
+            builder.addExtension(spv::E_SPV_NV_stereo_view_rendering);
+            builder.addCapability(spv::CapabilityShaderStereoViewNV);
+        }
         return spv::BuiltInSecondaryViewportMaskNV;
     case glslang::EbvPositionPerViewNV:
-        builder.addExtension(spv::E_SPV_NVX_multiview_per_view_attributes);
-        builder.addCapability(spv::CapabilityPerViewAttributesNV);
+        if (!memberDeclaration) {
+            builder.addExtension(spv::E_SPV_NVX_multiview_per_view_attributes);
+            builder.addCapability(spv::CapabilityPerViewAttributesNV);
+        }
         return spv::BuiltInPositionPerViewNV;
     case glslang::EbvViewportMaskPerViewNV:
-        builder.addExtension(spv::E_SPV_NVX_multiview_per_view_attributes);
-        builder.addCapability(spv::CapabilityPerViewAttributesNV);
+        if (!memberDeclaration) {
+            builder.addExtension(spv::E_SPV_NVX_multiview_per_view_attributes);
+            builder.addCapability(spv::CapabilityPerViewAttributesNV);
+        }
         return spv::BuiltInViewportMaskPerViewNV;
 #endif 
-    default:                               return spv::BuiltInMax;
+    default:
+        return spv::BuiltInMax;
     }
 }
 

--- a/SPIRV/doc.cpp
+++ b/SPIRV/doc.cpp
@@ -835,6 +835,7 @@ const char* CapabilityString(int info)
     case 5254: return "ShaderViewportIndexLayerNV";
     case 5255: return "ShaderViewportMaskNV";
     case 5259: return "ShaderStereoViewNV";
+    case 5262: return "PerViewAttributesNV";
 #endif
 
     }

--- a/Test/baseResults/spv.multiviewPerViewAttributes.tesc.out
+++ b/Test/baseResults/spv.multiviewPerViewAttributes.tesc.out
@@ -6,7 +6,7 @@ Warning, version 450 is not yet complete; most version-specific features are pre
 // Id's are bound by 37
 
                               Capability Tessellation
-                              Capability Bad
+                              Capability PerViewAttributesNV
                               Extension  "SPV_NVX_multiview_per_view_attributes"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.multiviewPerViewAttributes.vert.out
+++ b/Test/baseResults/spv.multiviewPerViewAttributes.vert.out
@@ -6,7 +6,7 @@ Warning, version 450 is not yet complete; most version-specific features are pre
 // Id's are bound by 29
 
                               Capability Shader
-                              Capability Bad
+                              Capability PerViewAttributesNV
                               Extension  "SPV_NVX_multiview_per_view_attributes"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450


### PR DESCRIPTION
We have a very simple geometry shader like this:

```
#version 450 core

layout(triangles)                        in;
layout(triangle_strip, max_vertices = 3) out;

void main()
{
    for (int n_vertex = 0;
             n_vertex < 3;
           ++n_vertex)
    {
        gl_Position = gl_in[n_vertex].gl_Position;

        EmitVertex();
    }

    EndPrimitive();
}
```
But the SPV will generate unexpected capabilities, such as 
```
Capability PerViewAttributesNV
Extension "SPV_NVX_multiview_per_view_attributes"
```
Those capabilities are similar to `ClipDistance `and `CullDistance`. The reasonable behavior is that they should be disabled if they are not used (just declare in `gl_PerVertex`).