### PR TITLE
HLSL: add structuredbuffer pass by reference in fn params

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -2730,7 +2730,8 @@ void TGlslangToSpvTraverser::makeFunctions(const glslang::TIntermSequence& glslF
         for (int p = 0; p < (int)parameters.size(); ++p) {
             const glslang::TType& paramType = parameters[p]->getAsTyped()->getType();
             spv::Id typeId = convertGlslangToSpvType(paramType);
-            if (paramType.containsOpaque())
+            if (paramType.containsOpaque() ||
+                (paramType.getBasicType() == glslang::EbtBlock && paramType.getQualifier().storage == glslang::EvqBuffer))
                 typeId = builder.makePointer(TranslateStorageClass(paramType), typeId);
             else if (paramType.getQualifier().storage != glslang::EvqConstReadOnly)
                 typeId = builder.makePointer(spv::StorageClassFunction, typeId);
@@ -3210,7 +3211,8 @@ spv::Id TGlslangToSpvTraverser::handleUserFunctionCall(const glslang::TIntermAgg
     for (int a = 0; a < (int)glslangArgs.size(); ++a) {
         const glslang::TType& paramType = glslangArgs[a]->getAsTyped()->getType();
         spv::Id arg;
-        if (paramType.containsOpaque()) {
+        if (paramType.containsOpaque() ||
+            (paramType.getBasicType() == glslang::EbtBlock && qualifiers[a] == glslang::EvqBuffer)) {
             builder.setAccessChain(lValues[lValueCount]);
             arg = builder.accessChainGetLValue();
             ++lValueCount;

--- a/Test/baseResults/hlsl.structbuffer.atomics.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.atomics.frag.out
@@ -8,8 +8,8 @@ gl_FragCoord origin is upper left
 0:?     Sequence
 0:8      AtomicAdd (temp void)
 0:8        indirect index (layout(row_major std430 ) buffer uint)
-0:8          sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:8            'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:8          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:8            'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:8            Constant:
 0:8              0 (const uint)
 0:8          right-shift (temp int)
@@ -23,8 +23,8 @@ gl_FragCoord origin is upper left
 0:9        'u' (temp uint)
 0:9        AtomicAdd (temp uint)
 0:9          indirect index (layout(row_major std430 ) buffer uint)
-0:9            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:9              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:9            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:9              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:9              Constant:
 0:9                0 (const uint)
 0:9            right-shift (temp int)
@@ -36,8 +36,8 @@ gl_FragCoord origin is upper left
 0:9            1 (const int)
 0:10      AtomicAnd (temp void)
 0:10        indirect index (layout(row_major std430 ) buffer uint)
-0:10          sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:10            'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:10          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10            'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10            Constant:
 0:10              0 (const uint)
 0:10          right-shift (temp int)
@@ -51,8 +51,8 @@ gl_FragCoord origin is upper left
 0:11        'u' (temp uint)
 0:11        AtomicAnd (temp uint)
 0:11          indirect index (layout(row_major std430 ) buffer uint)
-0:11            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11              Constant:
 0:11                0 (const uint)
 0:11            right-shift (temp int)
@@ -67,8 +67,8 @@ gl_FragCoord origin is upper left
 0:12        Convert int to uint (temp uint)
 0:12          AtomicCompSwap (temp int)
 0:12            indirect index (layout(row_major std430 ) buffer uint)
-0:12              sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12              @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                Constant:
 0:12                  0 (const uint)
 0:12              right-shift (temp int)
@@ -84,8 +84,8 @@ gl_FragCoord origin is upper left
 0:14        'u' (temp uint)
 0:14        AtomicExchange (temp uint)
 0:14          indirect index (layout(row_major std430 ) buffer uint)
-0:14            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:14              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:14            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:14              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:14              Constant:
 0:14                0 (const uint)
 0:14            right-shift (temp int)
@@ -97,8 +97,8 @@ gl_FragCoord origin is upper left
 0:14            1 (const int)
 0:15      AtomicMax (temp void)
 0:15        indirect index (layout(row_major std430 ) buffer uint)
-0:15          sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:15            'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:15          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:15            'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:15            Constant:
 0:15              0 (const uint)
 0:15          right-shift (temp int)
@@ -112,8 +112,8 @@ gl_FragCoord origin is upper left
 0:16        'u' (temp uint)
 0:16        AtomicMax (temp uint)
 0:16          indirect index (layout(row_major std430 ) buffer uint)
-0:16            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:16              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:16            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:16              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:16              Constant:
 0:16                0 (const uint)
 0:16            right-shift (temp int)
@@ -125,8 +125,8 @@ gl_FragCoord origin is upper left
 0:16            1 (const int)
 0:17      AtomicMin (temp void)
 0:17        indirect index (layout(row_major std430 ) buffer uint)
-0:17          sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:17            'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:17          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:17            'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:17            Constant:
 0:17              0 (const uint)
 0:17          right-shift (temp int)
@@ -140,8 +140,8 @@ gl_FragCoord origin is upper left
 0:18        'u' (temp uint)
 0:18        AtomicMin (temp uint)
 0:18          indirect index (layout(row_major std430 ) buffer uint)
-0:18            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:18              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:18            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:18              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:18              Constant:
 0:18                0 (const uint)
 0:18            right-shift (temp int)
@@ -153,8 +153,8 @@ gl_FragCoord origin is upper left
 0:18            1 (const int)
 0:19      AtomicOr (temp void)
 0:19        indirect index (layout(row_major std430 ) buffer uint)
-0:19          sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:19            'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:19          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:19            'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:19            Constant:
 0:19              0 (const uint)
 0:19          right-shift (temp int)
@@ -168,8 +168,8 @@ gl_FragCoord origin is upper left
 0:20        'u' (temp uint)
 0:20        AtomicOr (temp uint)
 0:20          indirect index (layout(row_major std430 ) buffer uint)
-0:20            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:20              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:20            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:20              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:20              Constant:
 0:20                0 (const uint)
 0:20            right-shift (temp int)
@@ -181,8 +181,8 @@ gl_FragCoord origin is upper left
 0:20            1 (const int)
 0:21      AtomicXor (temp void)
 0:21        indirect index (layout(row_major std430 ) buffer uint)
-0:21          sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:21            'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:21          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:21            'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:21            Constant:
 0:21              0 (const uint)
 0:21          right-shift (temp int)
@@ -196,8 +196,8 @@ gl_FragCoord origin is upper left
 0:22        'u' (temp uint)
 0:22        AtomicXor (temp uint)
 0:22          indirect index (layout(row_major std430 ) buffer uint)
-0:22            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:22              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:22            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:22              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:22              Constant:
 0:22                0 (const uint)
 0:22            right-shift (temp int)
@@ -211,8 +211,8 @@ gl_FragCoord origin is upper left
 0:24        Construct vec4 (temp 4-component vector of float)
 0:24          Convert uint to float (temp float)
 0:24            indirect index (layout(row_major std430 ) buffer uint)
-0:24              sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:24                'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:24              @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:24                'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:24                Constant:
 0:24                  0 (const uint)
 0:24              right-shift (temp int)
@@ -230,7 +230,7 @@ gl_FragCoord origin is upper left
 0:5        Function Call: @main(u1; (temp 4-component vector of float)
 0:?           'pos' (temp uint)
 0:?   Linker Objects
-0:?     'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:?     'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:?     '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
 0:?     'pos' (layout(location=0 ) in uint)
 
@@ -247,8 +247,8 @@ gl_FragCoord origin is upper left
 0:?     Sequence
 0:8      AtomicAdd (temp void)
 0:8        indirect index (layout(row_major std430 ) buffer uint)
-0:8          sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:8            'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:8          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:8            'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:8            Constant:
 0:8              0 (const uint)
 0:8          right-shift (temp int)
@@ -262,8 +262,8 @@ gl_FragCoord origin is upper left
 0:9        'u' (temp uint)
 0:9        AtomicAdd (temp uint)
 0:9          indirect index (layout(row_major std430 ) buffer uint)
-0:9            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:9              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:9            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:9              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:9              Constant:
 0:9                0 (const uint)
 0:9            right-shift (temp int)
@@ -275,8 +275,8 @@ gl_FragCoord origin is upper left
 0:9            1 (const int)
 0:10      AtomicAnd (temp void)
 0:10        indirect index (layout(row_major std430 ) buffer uint)
-0:10          sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:10            'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:10          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10            'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10            Constant:
 0:10              0 (const uint)
 0:10          right-shift (temp int)
@@ -290,8 +290,8 @@ gl_FragCoord origin is upper left
 0:11        'u' (temp uint)
 0:11        AtomicAnd (temp uint)
 0:11          indirect index (layout(row_major std430 ) buffer uint)
-0:11            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11              Constant:
 0:11                0 (const uint)
 0:11            right-shift (temp int)
@@ -306,8 +306,8 @@ gl_FragCoord origin is upper left
 0:12        Convert int to uint (temp uint)
 0:12          AtomicCompSwap (temp int)
 0:12            indirect index (layout(row_major std430 ) buffer uint)
-0:12              sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12              @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                Constant:
 0:12                  0 (const uint)
 0:12              right-shift (temp int)
@@ -323,8 +323,8 @@ gl_FragCoord origin is upper left
 0:14        'u' (temp uint)
 0:14        AtomicExchange (temp uint)
 0:14          indirect index (layout(row_major std430 ) buffer uint)
-0:14            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:14              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:14            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:14              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:14              Constant:
 0:14                0 (const uint)
 0:14            right-shift (temp int)
@@ -336,8 +336,8 @@ gl_FragCoord origin is upper left
 0:14            1 (const int)
 0:15      AtomicMax (temp void)
 0:15        indirect index (layout(row_major std430 ) buffer uint)
-0:15          sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:15            'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:15          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:15            'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:15            Constant:
 0:15              0 (const uint)
 0:15          right-shift (temp int)
@@ -351,8 +351,8 @@ gl_FragCoord origin is upper left
 0:16        'u' (temp uint)
 0:16        AtomicMax (temp uint)
 0:16          indirect index (layout(row_major std430 ) buffer uint)
-0:16            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:16              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:16            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:16              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:16              Constant:
 0:16                0 (const uint)
 0:16            right-shift (temp int)
@@ -364,8 +364,8 @@ gl_FragCoord origin is upper left
 0:16            1 (const int)
 0:17      AtomicMin (temp void)
 0:17        indirect index (layout(row_major std430 ) buffer uint)
-0:17          sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:17            'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:17          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:17            'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:17            Constant:
 0:17              0 (const uint)
 0:17          right-shift (temp int)
@@ -379,8 +379,8 @@ gl_FragCoord origin is upper left
 0:18        'u' (temp uint)
 0:18        AtomicMin (temp uint)
 0:18          indirect index (layout(row_major std430 ) buffer uint)
-0:18            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:18              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:18            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:18              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:18              Constant:
 0:18                0 (const uint)
 0:18            right-shift (temp int)
@@ -392,8 +392,8 @@ gl_FragCoord origin is upper left
 0:18            1 (const int)
 0:19      AtomicOr (temp void)
 0:19        indirect index (layout(row_major std430 ) buffer uint)
-0:19          sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:19            'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:19          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:19            'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:19            Constant:
 0:19              0 (const uint)
 0:19          right-shift (temp int)
@@ -407,8 +407,8 @@ gl_FragCoord origin is upper left
 0:20        'u' (temp uint)
 0:20        AtomicOr (temp uint)
 0:20          indirect index (layout(row_major std430 ) buffer uint)
-0:20            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:20              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:20            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:20              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:20              Constant:
 0:20                0 (const uint)
 0:20            right-shift (temp int)
@@ -420,8 +420,8 @@ gl_FragCoord origin is upper left
 0:20            1 (const int)
 0:21      AtomicXor (temp void)
 0:21        indirect index (layout(row_major std430 ) buffer uint)
-0:21          sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:21            'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:21          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:21            'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:21            Constant:
 0:21              0 (const uint)
 0:21          right-shift (temp int)
@@ -435,8 +435,8 @@ gl_FragCoord origin is upper left
 0:22        'u' (temp uint)
 0:22        AtomicXor (temp uint)
 0:22          indirect index (layout(row_major std430 ) buffer uint)
-0:22            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:22              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:22            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:22              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:22              Constant:
 0:22                0 (const uint)
 0:22            right-shift (temp int)
@@ -450,8 +450,8 @@ gl_FragCoord origin is upper left
 0:24        Construct vec4 (temp 4-component vector of float)
 0:24          Convert uint to float (temp float)
 0:24            indirect index (layout(row_major std430 ) buffer uint)
-0:24              sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:24                'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:24              @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:24                'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:24                Constant:
 0:24                  0 (const uint)
 0:24              right-shift (temp int)
@@ -469,7 +469,7 @@ gl_FragCoord origin is upper left
 0:5        Function Call: @main(u1; (temp 4-component vector of float)
 0:?           'pos' (temp uint)
 0:?   Linker Objects
-0:?     'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:?     'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:?     '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
 0:?     'pos' (layout(location=0 ) in uint)
 
@@ -486,8 +486,8 @@ gl_FragCoord origin is upper left
                               Name 12  "@main(u1;"
                               Name 11  "pos"
                               Name 15  "sbuf"
-                              MemberName 15(sbuf) 0  "sbuf"
-                              Name 17  ""
+                              MemberName 15(sbuf) 0  "@data"
+                              Name 17  "sbuf"
                               Name 29  "u"
                               Name 78  "pos"
                               Name 80  "pos"
@@ -496,7 +496,7 @@ gl_FragCoord origin is upper left
                               Decorate 14 ArrayStride 4
                               MemberDecorate 15(sbuf) 0 Offset 0
                               Decorate 15(sbuf) BufferBlock
-                              Decorate 17 DescriptorSet 0
+                              Decorate 17(sbuf) DescriptorSet 0
                               Decorate 80(pos) Location 0
                               Decorate 83(@entryPointOutput) Location 0
                2:             TypeVoid
@@ -509,7 +509,7 @@ gl_FragCoord origin is upper left
               14:             TypeRuntimeArray 6(int)
         15(sbuf):             TypeStruct 14
               16:             TypePointer Uniform 15(sbuf)
-              17:     16(ptr) Variable Uniform
+        17(sbuf):     16(ptr) Variable Uniform
               18:             TypeInt 32 1
               19:     18(int) Constant 0
               20:     18(int) Constant 8
@@ -539,59 +539,59 @@ gl_FragCoord origin is upper left
               13:             Label
            29(u):      7(ptr) Variable Function
               22:     18(int) ShiftRightArithmetic 20 21
-              24:     23(ptr) AccessChain 17 19 22
+              24:     23(ptr) AccessChain 17(sbuf) 19 22
               28:           2 AtomicIAdd 24 26 27 25
               30:     18(int) ShiftRightArithmetic 20 21
-              31:     23(ptr) AccessChain 17 19 30
+              31:     23(ptr) AccessChain 17(sbuf) 19 30
               32:      6(int) AtomicIAdd 31 26 27 25
                               Store 29(u) 32
               33:     18(int) ShiftRightArithmetic 20 21
-              34:     23(ptr) AccessChain 17 19 33
+              34:     23(ptr) AccessChain 17(sbuf) 19 33
               35:           2 AtomicAnd 34 26 27 25
               36:     18(int) ShiftRightArithmetic 20 21
-              37:     23(ptr) AccessChain 17 19 36
+              37:     23(ptr) AccessChain 17(sbuf) 19 36
               38:      6(int) AtomicAnd 37 26 27 25
                               Store 29(u) 38
               39:     18(int) ShiftRightArithmetic 20 21
-              40:     23(ptr) AccessChain 17 19 39
+              40:     23(ptr) AccessChain 17(sbuf) 19 39
               41:     18(int) AtomicCompareExchange 40 26 27 27 21 25
               42:      6(int) Bitcast 41
                               Store 29(u) 42
               43:     18(int) ShiftRightArithmetic 20 21
-              44:     23(ptr) AccessChain 17 19 43
+              44:     23(ptr) AccessChain 17(sbuf) 19 43
               45:      6(int) AtomicExchange 44 26 27 25
                               Store 29(u) 45
               46:     18(int) ShiftRightArithmetic 20 21
-              47:     23(ptr) AccessChain 17 19 46
+              47:     23(ptr) AccessChain 17(sbuf) 19 46
               48:           2 AtomicSMax 47 26 27 25
               49:     18(int) ShiftRightArithmetic 20 21
-              50:     23(ptr) AccessChain 17 19 49
+              50:     23(ptr) AccessChain 17(sbuf) 19 49
               51:      6(int) AtomicUMax 50 26 27 25
                               Store 29(u) 51
               52:     18(int) ShiftRightArithmetic 20 21
-              53:     23(ptr) AccessChain 17 19 52
+              53:     23(ptr) AccessChain 17(sbuf) 19 52
               54:           2 AtomicSMin 53 26 27 25
               55:     18(int) ShiftRightArithmetic 20 21
-              56:     23(ptr) AccessChain 17 19 55
+              56:     23(ptr) AccessChain 17(sbuf) 19 55
               57:      6(int) AtomicUMin 56 26 27 25
                               Store 29(u) 57
               58:     18(int) ShiftRightArithmetic 20 21
-              59:     23(ptr) AccessChain 17 19 58
+              59:     23(ptr) AccessChain 17(sbuf) 19 58
               60:           2 AtomicOr 59 26 27 25
               61:     18(int) ShiftRightArithmetic 20 21
-              62:     23(ptr) AccessChain 17 19 61
+              62:     23(ptr) AccessChain 17(sbuf) 19 61
               63:      6(int) AtomicOr 62 26 27 25
                               Store 29(u) 63
               64:     18(int) ShiftRightArithmetic 20 21
-              65:     23(ptr) AccessChain 17 19 64
+              65:     23(ptr) AccessChain 17(sbuf) 19 64
               66:           2 AtomicXor 65 26 27 25
               67:     18(int) ShiftRightArithmetic 20 21
-              68:     23(ptr) AccessChain 17 19 67
+              68:     23(ptr) AccessChain 17(sbuf) 19 67
               69:      6(int) AtomicXor 68 26 27 25
                               Store 29(u) 69
               70:      6(int) Load 11(pos)
               71:     18(int) ShiftRightLogical 70 21
-              72:     23(ptr) AccessChain 17 19 71
+              72:     23(ptr) AccessChain 17(sbuf) 19 71
               73:      6(int) Load 72
               74:    8(float) ConvertUToF 73
               75:    9(fvec4) CompositeConstruct 74 74 74 74

--- a/Test/baseResults/hlsl.structbuffer.byte.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.byte.frag.out
@@ -10,8 +10,8 @@ gl_FragCoord origin is upper left
 0:7        move second child to first child (temp uint)
 0:7          'size' (temp uint)
 0:7          array length (temp uint)
-0:7            sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:7              'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:7            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:7              'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:7              Constant:
 0:7                0 (const uint)
 0:12      Branch: Return with expression
@@ -19,9 +19,9 @@ gl_FragCoord origin is upper left
 0:10          add (temp 4-component vector of float)
 0:9            add (temp 4-component vector of float)
 0:9              Convert uint to float (temp float)
-0:9                indirect index (layout(row_major std430 ) readonly buffer uint)
-0:9                  sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:9                    'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:9                indirect index (layout(row_major std430 ) buffer uint)
+0:9                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:9                    'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:9                    Constant:
 0:9                      0 (const uint)
 0:9                  right-shift (temp int)
@@ -42,14 +42,14 @@ gl_FragCoord origin is upper left
 0:10                          2 (const int)
 0:?                     Construct vec2 (temp 2-component vector of uint)
 0:10                      indirect index (temp float)
-0:10                        sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:10                          'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:10                        @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10                          'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10                          Constant:
 0:10                            0 (const uint)
 0:10                        'byteAddrTemp' (temp int)
 0:10                      indirect index (temp float)
-0:10                        sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:10                          'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:10                        @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10                          'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10                          Constant:
 0:10                            0 (const uint)
 0:10                        add (temp int)
@@ -74,14 +74,14 @@ gl_FragCoord origin is upper left
 0:11                        2 (const int)
 0:?                   Construct vec3 (temp 3-component vector of uint)
 0:11                    indirect index (temp float)
-0:11                      sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:11                        'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:11                      @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                        'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                        Constant:
 0:11                          0 (const uint)
 0:11                      'byteAddrTemp' (temp int)
 0:11                    indirect index (temp float)
-0:11                      sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:11                        'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:11                      @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                        'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                        Constant:
 0:11                          0 (const uint)
 0:11                      add (temp int)
@@ -89,8 +89,8 @@ gl_FragCoord origin is upper left
 0:11                        Constant:
 0:11                          1 (const int)
 0:11                    indirect index (temp float)
-0:11                      sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:11                        'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:11                      @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                        'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                        Constant:
 0:11                          0 (const uint)
 0:11                      add (temp int)
@@ -112,14 +112,14 @@ gl_FragCoord origin is upper left
 0:12                    2 (const int)
 0:?               Construct vec4 (temp 4-component vector of uint)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  'byteAddrTemp' (temp int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -127,8 +127,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      1 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -136,8 +136,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      2 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -155,7 +155,7 @@ gl_FragCoord origin is upper left
 0:5        Function Call: @main(u1; (temp 4-component vector of float)
 0:?           'pos' (temp uint)
 0:?   Linker Objects
-0:?     'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:?     'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:?     '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
 0:?     'pos' (layout(location=0 ) in uint)
 
@@ -174,8 +174,8 @@ gl_FragCoord origin is upper left
 0:7        move second child to first child (temp uint)
 0:7          'size' (temp uint)
 0:7          array length (temp uint)
-0:7            sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:7              'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:7            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:7              'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:7              Constant:
 0:7                0 (const uint)
 0:12      Branch: Return with expression
@@ -183,9 +183,9 @@ gl_FragCoord origin is upper left
 0:10          add (temp 4-component vector of float)
 0:9            add (temp 4-component vector of float)
 0:9              Convert uint to float (temp float)
-0:9                indirect index (layout(row_major std430 ) readonly buffer uint)
-0:9                  sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:9                    'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:9                indirect index (layout(row_major std430 ) buffer uint)
+0:9                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:9                    'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:9                    Constant:
 0:9                      0 (const uint)
 0:9                  right-shift (temp int)
@@ -206,14 +206,14 @@ gl_FragCoord origin is upper left
 0:10                          2 (const int)
 0:?                     Construct vec2 (temp 2-component vector of uint)
 0:10                      indirect index (temp float)
-0:10                        sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:10                          'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:10                        @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10                          'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10                          Constant:
 0:10                            0 (const uint)
 0:10                        'byteAddrTemp' (temp int)
 0:10                      indirect index (temp float)
-0:10                        sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:10                          'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:10                        @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10                          'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10                          Constant:
 0:10                            0 (const uint)
 0:10                        add (temp int)
@@ -238,14 +238,14 @@ gl_FragCoord origin is upper left
 0:11                        2 (const int)
 0:?                   Construct vec3 (temp 3-component vector of uint)
 0:11                    indirect index (temp float)
-0:11                      sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:11                        'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:11                      @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                        'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                        Constant:
 0:11                          0 (const uint)
 0:11                      'byteAddrTemp' (temp int)
 0:11                    indirect index (temp float)
-0:11                      sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:11                        'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:11                      @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                        'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                        Constant:
 0:11                          0 (const uint)
 0:11                      add (temp int)
@@ -253,8 +253,8 @@ gl_FragCoord origin is upper left
 0:11                        Constant:
 0:11                          1 (const int)
 0:11                    indirect index (temp float)
-0:11                      sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:11                        'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:11                      @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                        'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                        Constant:
 0:11                          0 (const uint)
 0:11                      add (temp int)
@@ -276,14 +276,14 @@ gl_FragCoord origin is upper left
 0:12                    2 (const int)
 0:?               Construct vec4 (temp 4-component vector of uint)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  'byteAddrTemp' (temp int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -291,8 +291,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      1 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -300,8 +300,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      2 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -319,7 +319,7 @@ gl_FragCoord origin is upper left
 0:5        Function Call: @main(u1; (temp 4-component vector of float)
 0:?           'pos' (temp uint)
 0:?   Linker Objects
-0:?     'anon@0' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of uint sbuf})
+0:?     'sbuf' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:?     '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
 0:?     'pos' (layout(location=0 ) in uint)
 
@@ -337,8 +337,8 @@ gl_FragCoord origin is upper left
                               Name 11  "pos"
                               Name 14  "size"
                               Name 16  "sbuf"
-                              MemberName 16(sbuf) 0  "sbuf"
-                              Name 18  ""
+                              MemberName 16(sbuf) 0  "@data"
+                              Name 18  "sbuf"
                               Name 30  "byteAddrTemp"
                               Name 53  "byteAddrTemp"
                               Name 78  "byteAddrTemp"
@@ -350,7 +350,7 @@ gl_FragCoord origin is upper left
                               MemberDecorate 16(sbuf) 0 NonWritable
                               MemberDecorate 16(sbuf) 0 Offset 0
                               Decorate 16(sbuf) BufferBlock
-                              Decorate 18 DescriptorSet 0
+                              Decorate 18(sbuf) DescriptorSet 0
                               Decorate 107(pos) Location 0
                               Decorate 110(@entryPointOutput) Location 0
                2:             TypeVoid
@@ -363,7 +363,7 @@ gl_FragCoord origin is upper left
               15:             TypeRuntimeArray 6(int)
         16(sbuf):             TypeStruct 15
               17:             TypePointer Uniform 16(sbuf)
-              18:     17(ptr) Variable Uniform
+        18(sbuf):     17(ptr) Variable Uniform
               19:             TypeInt 32 1
               21:     19(int) Constant 0
               23:     19(int) Constant 2
@@ -403,11 +403,11 @@ gl_FragCoord origin is upper left
 30(byteAddrTemp):     29(ptr) Variable Function
 53(byteAddrTemp):     29(ptr) Variable Function
 78(byteAddrTemp):     29(ptr) Variable Function
-              20:     19(int) ArrayLength 18 0
+              20:     19(int) ArrayLength 18(sbuf) 0
                               Store 14(size) 20
               22:      6(int) Load 11(pos)
               24:     19(int) ShiftRightLogical 22 23
-              26:     25(ptr) AccessChain 18 21 24
+              26:     25(ptr) AccessChain 18(sbuf) 21 24
               27:      6(int) Load 26
               28:    8(float) ConvertUToF 27
               31:      6(int) Load 11(pos)
@@ -415,11 +415,11 @@ gl_FragCoord origin is upper left
               34:     19(int) ShiftRightLogical 33 23
                               Store 30(byteAddrTemp) 34
               35:     19(int) Load 30(byteAddrTemp)
-              36:     25(ptr) AccessChain 18 21 35
+              36:     25(ptr) AccessChain 18(sbuf) 21 35
               37:      6(int) Load 36
               38:     19(int) Load 30(byteAddrTemp)
               40:     19(int) IAdd 38 39
-              41:     25(ptr) AccessChain 18 21 40
+              41:     25(ptr) AccessChain 18(sbuf) 21 40
               42:      6(int) Load 41
               44:   43(ivec2) CompositeConstruct 37 42
               46:   45(fvec2) ConvertUToF 44
@@ -433,15 +433,15 @@ gl_FragCoord origin is upper left
               57:     19(int) ShiftRightLogical 56 23
                               Store 53(byteAddrTemp) 57
               58:     19(int) Load 53(byteAddrTemp)
-              59:     25(ptr) AccessChain 18 21 58
+              59:     25(ptr) AccessChain 18(sbuf) 21 58
               60:      6(int) Load 59
               61:     19(int) Load 53(byteAddrTemp)
               62:     19(int) IAdd 61 39
-              63:     25(ptr) AccessChain 18 21 62
+              63:     25(ptr) AccessChain 18(sbuf) 21 62
               64:      6(int) Load 63
               65:     19(int) Load 53(byteAddrTemp)
               66:     19(int) IAdd 65 23
-              67:     25(ptr) AccessChain 18 21 66
+              67:     25(ptr) AccessChain 18(sbuf) 21 66
               68:      6(int) Load 67
               70:   69(ivec3) CompositeConstruct 60 64 68
               72:   71(fvec3) ConvertUToF 70
@@ -455,19 +455,19 @@ gl_FragCoord origin is upper left
               82:     19(int) ShiftRightLogical 81 23
                               Store 78(byteAddrTemp) 82
               83:     19(int) Load 78(byteAddrTemp)
-              84:     25(ptr) AccessChain 18 21 83
+              84:     25(ptr) AccessChain 18(sbuf) 21 83
               85:      6(int) Load 84
               86:     19(int) Load 78(byteAddrTemp)
               87:     19(int) IAdd 86 39
-              88:     25(ptr) AccessChain 18 21 87
+              88:     25(ptr) AccessChain 18(sbuf) 21 87
               89:      6(int) Load 88
               90:     19(int) Load 78(byteAddrTemp)
               91:     19(int) IAdd 90 23
-              92:     25(ptr) AccessChain 18 21 91
+              92:     25(ptr) AccessChain 18(sbuf) 21 91
               93:      6(int) Load 92
               94:     19(int) Load 78(byteAddrTemp)
               96:     19(int) IAdd 94 95
-              97:     25(ptr) AccessChain 18 21 96
+              97:     25(ptr) AccessChain 18(sbuf) 21 96
               98:      6(int) Load 97
              100:   99(ivec4) CompositeConstruct 85 89 93 98
              101:    9(fvec4) ConvertUToF 100

--- a/Test/baseResults/hlsl.structbuffer.coherent.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.coherent.frag.out
@@ -7,9 +7,9 @@ gl_FragCoord origin is upper left
 0:12      'pos' (in uint)
 0:?     Sequence
 0:13      move second child to first child (temp float)
-0:13        indirect index (layout(row_major std430 ) coherent temp float)
-0:13          sbuf2: direct index for structure (layout(row_major std430 ) coherent buffer implicitly-sized array of float)
-0:13            'anon@1' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) coherent buffer implicitly-sized array of float sbuf2})
+0:13        indirect index (layout(row_major std430 ) buffer float)
+0:13          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of float)
+0:13            'sbuf2' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:13            Constant:
 0:13              0 (const uint)
 0:13          add (temp uint)
@@ -22,8 +22,8 @@ gl_FragCoord origin is upper left
 0:17        move second child to first child (temp uint)
 0:17          'size' (temp uint)
 0:17          array length (temp uint)
-0:17            sbuf: direct index for structure (layout(row_major std430 ) coherent buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
-0:17              'anon@0' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) coherent buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
+0:17            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
+0:17              'sbuf' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
 0:17              Constant:
 0:17                0 (const uint)
 0:17        move second child to first child (temp uint)
@@ -33,9 +33,9 @@ gl_FragCoord origin is upper left
 0:19      Test condition and select (temp void)
 0:19        Condition
 0:19        test: direct index for structure (temp bool)
-0:19          indirect index (layout(row_major std430 ) coherent temp structure{temp 3-component vector of float color, temp bool test})
-0:19            sbuf: direct index for structure (layout(row_major std430 ) coherent buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
-0:19              'anon@0' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) coherent buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
+0:19          indirect index (layout(row_major std430 ) buffer structure{temp 3-component vector of float color, temp bool test})
+0:19            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
+0:19              'sbuf' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
 0:19              Constant:
 0:19                0 (const uint)
 0:19            'pos' (in uint)
@@ -46,17 +46,17 @@ gl_FragCoord origin is upper left
 0:?           Construct vec4 (temp 4-component vector of float)
 0:20            add (temp 3-component vector of float)
 0:20              color: direct index for structure (temp 3-component vector of float)
-0:20                indirect index (layout(row_major std430 ) coherent temp structure{temp 3-component vector of float color, temp bool test})
-0:20                  sbuf: direct index for structure (layout(row_major std430 ) coherent buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
-0:20                    'anon@0' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) coherent buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
+0:20                indirect index (layout(row_major std430 ) buffer structure{temp 3-component vector of float color, temp bool test})
+0:20                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
+0:20                    'sbuf' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
 0:20                    Constant:
 0:20                      0 (const uint)
 0:20                  'pos' (in uint)
 0:20                Constant:
 0:20                  0 (const int)
-0:20              indirect index (layout(row_major std430 ) coherent temp float)
-0:20                sbuf2: direct index for structure (layout(row_major std430 ) coherent buffer implicitly-sized array of float)
-0:20                  'anon@1' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) coherent buffer implicitly-sized array of float sbuf2})
+0:20              indirect index (layout(row_major std430 ) buffer float)
+0:20                @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of float)
+0:20                  'sbuf2' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:20                  Constant:
 0:20                    0 (const uint)
 0:20                'pos' (in uint)
@@ -80,8 +80,8 @@ gl_FragCoord origin is upper left
 0:12        Function Call: @main(u1; (temp 4-component vector of float)
 0:?           'pos' (temp uint)
 0:?   Linker Objects
-0:?     'anon@0' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) coherent buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
-0:?     'anon@1' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) coherent buffer implicitly-sized array of float sbuf2})
+0:?     'sbuf' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
+0:?     'sbuf2' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:?     '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
 0:?     'pos' (layout(location=0 ) in uint)
 
@@ -97,9 +97,9 @@ gl_FragCoord origin is upper left
 0:12      'pos' (in uint)
 0:?     Sequence
 0:13      move second child to first child (temp float)
-0:13        indirect index (layout(row_major std430 ) coherent temp float)
-0:13          sbuf2: direct index for structure (layout(row_major std430 ) coherent buffer implicitly-sized array of float)
-0:13            'anon@1' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) coherent buffer implicitly-sized array of float sbuf2})
+0:13        indirect index (layout(row_major std430 ) buffer float)
+0:13          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of float)
+0:13            'sbuf2' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:13            Constant:
 0:13              0 (const uint)
 0:13          add (temp uint)
@@ -112,8 +112,8 @@ gl_FragCoord origin is upper left
 0:17        move second child to first child (temp uint)
 0:17          'size' (temp uint)
 0:17          array length (temp uint)
-0:17            sbuf: direct index for structure (layout(row_major std430 ) coherent buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
-0:17              'anon@0' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) coherent buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
+0:17            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
+0:17              'sbuf' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
 0:17              Constant:
 0:17                0 (const uint)
 0:17        move second child to first child (temp uint)
@@ -123,9 +123,9 @@ gl_FragCoord origin is upper left
 0:19      Test condition and select (temp void)
 0:19        Condition
 0:19        test: direct index for structure (temp bool)
-0:19          indirect index (layout(row_major std430 ) coherent temp structure{temp 3-component vector of float color, temp bool test})
-0:19            sbuf: direct index for structure (layout(row_major std430 ) coherent buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
-0:19              'anon@0' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) coherent buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
+0:19          indirect index (layout(row_major std430 ) buffer structure{temp 3-component vector of float color, temp bool test})
+0:19            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
+0:19              'sbuf' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
 0:19              Constant:
 0:19                0 (const uint)
 0:19            'pos' (in uint)
@@ -136,17 +136,17 @@ gl_FragCoord origin is upper left
 0:?           Construct vec4 (temp 4-component vector of float)
 0:20            add (temp 3-component vector of float)
 0:20              color: direct index for structure (temp 3-component vector of float)
-0:20                indirect index (layout(row_major std430 ) coherent temp structure{temp 3-component vector of float color, temp bool test})
-0:20                  sbuf: direct index for structure (layout(row_major std430 ) coherent buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
-0:20                    'anon@0' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) coherent buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
+0:20                indirect index (layout(row_major std430 ) buffer structure{temp 3-component vector of float color, temp bool test})
+0:20                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
+0:20                    'sbuf' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
 0:20                    Constant:
 0:20                      0 (const uint)
 0:20                  'pos' (in uint)
 0:20                Constant:
 0:20                  0 (const int)
-0:20              indirect index (layout(row_major std430 ) coherent temp float)
-0:20                sbuf2: direct index for structure (layout(row_major std430 ) coherent buffer implicitly-sized array of float)
-0:20                  'anon@1' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) coherent buffer implicitly-sized array of float sbuf2})
+0:20              indirect index (layout(row_major std430 ) buffer float)
+0:20                @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of float)
+0:20                  'sbuf2' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:20                  Constant:
 0:20                    0 (const uint)
 0:20                'pos' (in uint)
@@ -170,8 +170,8 @@ gl_FragCoord origin is upper left
 0:12        Function Call: @main(u1; (temp 4-component vector of float)
 0:?           'pos' (temp uint)
 0:?   Linker Objects
-0:?     'anon@0' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) coherent buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
-0:?     'anon@1' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) coherent buffer implicitly-sized array of float sbuf2})
+0:?     'sbuf' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
+0:?     'sbuf2' (layout(row_major std430 ) coherent buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:?     '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
 0:?     'pos' (layout(location=0 ) in uint)
 
@@ -188,15 +188,15 @@ gl_FragCoord origin is upper left
                               Name 12  "@main(u1;"
                               Name 11  "pos"
                               Name 15  "sbuf2"
-                              MemberName 15(sbuf2) 0  "sbuf2"
-                              Name 17  ""
+                              MemberName 15(sbuf2) 0  "@data"
+                              Name 17  "sbuf2"
                               Name 26  "size"
                               Name 28  "sb_t"
                               MemberName 28(sb_t) 0  "color"
                               MemberName 28(sb_t) 1  "test"
                               Name 30  "sbuf"
-                              MemberName 30(sbuf) 0  "sbuf"
-                              Name 32  ""
+                              MemberName 30(sbuf) 0  "@data"
+                              Name 32  "sbuf"
                               Name 34  "stride"
                               Name 69  "pos"
                               Name 71  "pos"
@@ -206,7 +206,7 @@ gl_FragCoord origin is upper left
                               MemberDecorate 15(sbuf2) 0 Coherent
                               MemberDecorate 15(sbuf2) 0 Offset 0
                               Decorate 15(sbuf2) BufferBlock
-                              Decorate 17 DescriptorSet 0
+                              Decorate 17(sbuf2) DescriptorSet 0
                               MemberDecorate 28(sb_t) 0 Coherent
                               MemberDecorate 28(sb_t) 0 Offset 0
                               MemberDecorate 28(sb_t) 1 Coherent
@@ -215,7 +215,7 @@ gl_FragCoord origin is upper left
                               MemberDecorate 30(sbuf) 0 Coherent
                               MemberDecorate 30(sbuf) 0 Offset 0
                               Decorate 30(sbuf) BufferBlock
-                              Decorate 32 DescriptorSet 0
+                              Decorate 32(sbuf) DescriptorSet 0
                               Decorate 71(pos) Location 0
                               Decorate 74(@entryPointOutput) Location 0
                2:             TypeVoid
@@ -228,7 +228,7 @@ gl_FragCoord origin is upper left
               14:             TypeRuntimeArray 8(float)
        15(sbuf2):             TypeStruct 14
               16:             TypePointer Uniform 15(sbuf2)
-              17:     16(ptr) Variable Uniform
+       17(sbuf2):     16(ptr) Variable Uniform
               18:             TypeInt 32 1
               19:     18(int) Constant 0
               21:      6(int) Constant 1
@@ -239,7 +239,7 @@ gl_FragCoord origin is upper left
               29:             TypeRuntimeArray 28(sb_t)
         30(sbuf):             TypeStruct 29
               31:             TypePointer Uniform 30(sbuf)
-              32:     31(ptr) Variable Uniform
+        32(sbuf):     31(ptr) Variable Uniform
               35:      6(int) Constant 16
               37:     18(int) Constant 1
               38:             TypePointer Uniform 6(int)
@@ -270,23 +270,23 @@ gl_FragCoord origin is upper left
       34(stride):      7(ptr) Variable Function
               20:      6(int) Load 11(pos)
               22:      6(int) IAdd 20 21
-              25:     24(ptr) AccessChain 17 19 22
+              25:     24(ptr) AccessChain 17(sbuf2) 19 22
                               Store 25 23
-              33:     18(int) ArrayLength 32 0
+              33:     18(int) ArrayLength 32(sbuf) 0
                               Store 26(size) 33
                               Store 34(stride) 35
               36:      6(int) Load 11(pos)
-              39:     38(ptr) AccessChain 32 19 36 37
+              39:     38(ptr) AccessChain 32(sbuf) 19 36 37
               40:      6(int) Load 39
               43:    41(bool) INotEqual 40 42
                               SelectionMerge 45 None
                               BranchConditional 43 44 61
               44:               Label
               46:      6(int)   Load 11(pos)
-              48:     47(ptr)   AccessChain 32 19 46 19
+              48:     47(ptr)   AccessChain 32(sbuf) 19 46 19
               49:   27(fvec3)   Load 48
               50:      6(int)   Load 11(pos)
-              51:     24(ptr)   AccessChain 17 19 50
+              51:     24(ptr)   AccessChain 17(sbuf2) 19 50
               52:    8(float)   Load 51
               53:   27(fvec3)   CompositeConstruct 52 52 52
               54:   27(fvec3)   FAdd 49 53

--- a/Test/baseResults/hlsl.structbuffer.fn.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.fn.frag.out
@@ -1,0 +1,266 @@
+hlsl.structbuffer.fn.frag
+Shader version: 450
+gl_FragCoord origin is upper left
+0:? Sequence
+0:9  Function Definition: get(block--vu4[0]1;u1; (temp 4-component vector of uint)
+0:9    Function Parameters: 
+0:9      'sb' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:9      'bufferOffset' (in uint)
+0:?     Sequence
+0:10      Branch: Return with expression
+0:10        indirect index (layout(row_major std430 ) buffer 4-component vector of uint)
+0:10          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint)
+0:10            'sb' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:10            Constant:
+0:10              0 (const uint)
+0:10          'bufferOffset' (in uint)
+0:14  Function Definition: set(block--vu4[0]1;u1;vu4; (temp void)
+0:14    Function Parameters: 
+0:14      'sb' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:14      'bufferOffset' (in uint)
+0:14      'data' (in 4-component vector of uint)
+0:?     Sequence
+0:15      move second child to first child (temp 4-component vector of uint)
+0:15        indirect index (layout(row_major std430 ) buffer 4-component vector of uint)
+0:15          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint)
+0:15            'sb' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:15            Constant:
+0:15              0 (const uint)
+0:15          'bufferOffset' (in uint)
+0:15        'data' (in 4-component vector of uint)
+0:19  Function Definition: @main(u1; (temp 4-component vector of float)
+0:19    Function Parameters: 
+0:19      'pos' (in uint)
+0:?     Sequence
+0:20      Function Call: set(block--vu4[0]1;u1;vu4; (temp void)
+0:20        'sbuf2' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:20        Constant:
+0:20          2 (const uint)
+0:20        Function Call: get(block--vu4[0]1;u1; (temp 4-component vector of uint)
+0:20          'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:20          Constant:
+0:20            3 (const uint)
+0:22      Branch: Return with expression
+0:22        Constant:
+0:22          0.000000
+0:22          0.000000
+0:22          0.000000
+0:22          0.000000
+0:19  Function Definition: main( (temp void)
+0:19    Function Parameters: 
+0:?     Sequence
+0:19      move second child to first child (temp uint)
+0:?         'pos' (temp uint)
+0:?         'pos' (layout(location=0 ) in uint)
+0:19      move second child to first child (temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
+0:19        Function Call: @main(u1; (temp 4-component vector of float)
+0:?           'pos' (temp uint)
+0:?   Linker Objects
+0:?     'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:?     'sbuf2' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:?     'sbuf3' (layout(binding=12 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 3-component vector of uint @data})
+0:?     '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
+0:?     'pos' (layout(location=0 ) in uint)
+
+
+Linked fragment stage:
+
+
+Shader version: 450
+gl_FragCoord origin is upper left
+0:? Sequence
+0:9  Function Definition: get(block--vu4[0]1;u1; (temp 4-component vector of uint)
+0:9    Function Parameters: 
+0:9      'sb' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:9      'bufferOffset' (in uint)
+0:?     Sequence
+0:10      Branch: Return with expression
+0:10        indirect index (layout(row_major std430 ) buffer 4-component vector of uint)
+0:10          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint)
+0:10            'sb' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:10            Constant:
+0:10              0 (const uint)
+0:10          'bufferOffset' (in uint)
+0:14  Function Definition: set(block--vu4[0]1;u1;vu4; (temp void)
+0:14    Function Parameters: 
+0:14      'sb' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:14      'bufferOffset' (in uint)
+0:14      'data' (in 4-component vector of uint)
+0:?     Sequence
+0:15      move second child to first child (temp 4-component vector of uint)
+0:15        indirect index (layout(row_major std430 ) buffer 4-component vector of uint)
+0:15          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint)
+0:15            'sb' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:15            Constant:
+0:15              0 (const uint)
+0:15          'bufferOffset' (in uint)
+0:15        'data' (in 4-component vector of uint)
+0:19  Function Definition: @main(u1; (temp 4-component vector of float)
+0:19    Function Parameters: 
+0:19      'pos' (in uint)
+0:?     Sequence
+0:20      Function Call: set(block--vu4[0]1;u1;vu4; (temp void)
+0:20        'sbuf2' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:20        Constant:
+0:20          2 (const uint)
+0:20        Function Call: get(block--vu4[0]1;u1; (temp 4-component vector of uint)
+0:20          'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:20          Constant:
+0:20            3 (const uint)
+0:22      Branch: Return with expression
+0:22        Constant:
+0:22          0.000000
+0:22          0.000000
+0:22          0.000000
+0:22          0.000000
+0:19  Function Definition: main( (temp void)
+0:19    Function Parameters: 
+0:?     Sequence
+0:19      move second child to first child (temp uint)
+0:?         'pos' (temp uint)
+0:?         'pos' (layout(location=0 ) in uint)
+0:19      move second child to first child (temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
+0:19        Function Call: @main(u1; (temp 4-component vector of float)
+0:?           'pos' (temp uint)
+0:?   Linker Objects
+0:?     'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:?     'sbuf2' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:?     'sbuf3' (layout(binding=12 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 3-component vector of uint @data})
+0:?     '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
+0:?     'pos' (layout(location=0 ) in uint)
+
+// Module Version 10000
+// Generated by (magic number): 80001
+// Id's are bound by 71
+
+                              Capability Shader
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Fragment 4  "main" 59 62
+                              ExecutionMode 4 OriginUpperLeft
+                              Name 4  "main"
+                              Name 9  ""
+                              MemberName 9 0  "@data"
+                              Name 15  "get(block--vu4[0]1;u1;"
+                              Name 13  "sb"
+                              Name 14  "bufferOffset"
+                              Name 18  ""
+                              MemberName 18 0  "@data"
+                              Name 25  "set(block--vu4[0]1;u1;vu4;"
+                              Name 22  "sb"
+                              Name 23  "bufferOffset"
+                              Name 24  "data"
+                              Name 31  "@main(u1;"
+                              Name 30  "pos"
+                              Name 44  "sbuf2"
+                              Name 46  "sbuf"
+                              Name 48  "param"
+                              Name 50  "param"
+                              Name 51  "param"
+                              Name 57  "pos"
+                              Name 59  "pos"
+                              Name 62  "@entryPointOutput"
+                              Name 63  "param"
+                              Name 68  "sbuf3"
+                              MemberName 68(sbuf3) 0  "@data"
+                              Name 70  "sbuf3"
+                              Decorate 8 ArrayStride 16
+                              MemberDecorate 9 0 NonWritable
+                              MemberDecorate 9 0 Offset 0
+                              Decorate 9 BufferBlock
+                              Decorate 17 ArrayStride 16
+                              MemberDecorate 18 0 Offset 0
+                              Decorate 18 BufferBlock
+                              Decorate 44(sbuf2) DescriptorSet 0
+                              Decorate 46(sbuf) DescriptorSet 0
+                              Decorate 46(sbuf) Binding 10
+                              Decorate 59(pos) Location 0
+                              Decorate 62(@entryPointOutput) Location 0
+                              Decorate 67 ArrayStride 16
+                              MemberDecorate 68(sbuf3) 0 NonWritable
+                              MemberDecorate 68(sbuf3) 0 Offset 0
+                              Decorate 68(sbuf3) BufferBlock
+                              Decorate 70(sbuf3) DescriptorSet 0
+                              Decorate 70(sbuf3) Binding 12
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeInt 32 0
+               7:             TypeVector 6(int) 4
+               8:             TypeRuntimeArray 7(ivec4)
+               9:             TypeStruct 8
+              10:             TypePointer Uniform 9(struct)
+              11:             TypePointer Function 6(int)
+              12:             TypeFunction 7(ivec4) 10(ptr) 11(ptr)
+              17:             TypeRuntimeArray 7(ivec4)
+              18:             TypeStruct 17
+              19:             TypePointer Uniform 18(struct)
+              20:             TypePointer Function 7(ivec4)
+              21:             TypeFunction 2 19(ptr) 11(ptr) 20(ptr)
+              27:             TypeFloat 32
+              28:             TypeVector 27(float) 4
+              29:             TypeFunction 28(fvec4) 11(ptr)
+              33:             TypeInt 32 1
+              34:     33(int) Constant 0
+              36:             TypePointer Uniform 7(ivec4)
+       44(sbuf2):     19(ptr) Variable Uniform
+              45:      6(int) Constant 2
+        46(sbuf):     10(ptr) Variable Uniform
+              47:      6(int) Constant 3
+              53:   27(float) Constant 0
+              54:   28(fvec4) ConstantComposite 53 53 53 53
+              58:             TypePointer Input 6(int)
+         59(pos):     58(ptr) Variable Input
+              61:             TypePointer Output 28(fvec4)
+62(@entryPointOutput):     61(ptr) Variable Output
+              66:             TypeVector 6(int) 3
+              67:             TypeRuntimeArray 66(ivec3)
+       68(sbuf3):             TypeStruct 67
+              69:             TypePointer Uniform 68(sbuf3)
+       70(sbuf3):     69(ptr) Variable Uniform
+         4(main):           2 Function None 3
+               5:             Label
+         57(pos):     11(ptr) Variable Function
+       63(param):     11(ptr) Variable Function
+              60:      6(int) Load 59(pos)
+                              Store 57(pos) 60
+              64:      6(int) Load 57(pos)
+                              Store 63(param) 64
+              65:   28(fvec4) FunctionCall 31(@main(u1;) 63(param)
+                              Store 62(@entryPointOutput) 65
+                              Return
+                              FunctionEnd
+15(get(block--vu4[0]1;u1;):    7(ivec4) Function None 12
+          13(sb):     10(ptr) FunctionParameter
+14(bufferOffset):     11(ptr) FunctionParameter
+              16:             Label
+              35:      6(int) Load 14(bufferOffset)
+              37:     36(ptr) AccessChain 13(sb) 34 35
+              38:    7(ivec4) Load 37
+                              ReturnValue 38
+                              FunctionEnd
+25(set(block--vu4[0]1;u1;vu4;):           2 Function None 21
+          22(sb):     19(ptr) FunctionParameter
+23(bufferOffset):     11(ptr) FunctionParameter
+        24(data):     20(ptr) FunctionParameter
+              26:             Label
+              41:      6(int) Load 23(bufferOffset)
+              42:    7(ivec4) Load 24(data)
+              43:     36(ptr) AccessChain 22(sb) 34 41
+                              Store 43 42
+                              Return
+                              FunctionEnd
+   31(@main(u1;):   28(fvec4) Function None 29
+         30(pos):     11(ptr) FunctionParameter
+              32:             Label
+       48(param):     11(ptr) Variable Function
+       50(param):     11(ptr) Variable Function
+       51(param):     20(ptr) Variable Function
+                              Store 48(param) 47
+              49:    7(ivec4) FunctionCall 15(get(block--vu4[0]1;u1;) 46(sbuf) 48(param)
+                              Store 50(param) 45
+                              Store 51(param) 49
+              52:           2 FunctionCall 25(set(block--vu4[0]1;u1;vu4;) 44(sbuf2) 50(param) 51(param)
+                              ReturnValue 54
+                              FunctionEnd

--- a/Test/baseResults/hlsl.structbuffer.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.frag.out
@@ -9,9 +9,9 @@ gl_FragCoord origin is upper left
 0:13      Sequence
 0:13        move second child to first child (temp structure{temp 3-component vector of float color, temp bool test, temp bool test2})
 0:13          'mydata' (temp structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:13          indirect index (layout(binding=10 row_major std430 ) readonly buffer structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:13            sbuf: direct index for structure (layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:13              'anon@0' (layout(binding=10 row_major std430 ) readonly buffer block{layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} sbuf})
+0:13          indirect index (layout(row_major std430 ) buffer structure{temp 3-component vector of float color, temp bool test, temp bool test2})
+0:13            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
+0:13              'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} @data})
 0:13              Constant:
 0:13                0 (const uint)
 0:13            'pos' (in uint)
@@ -19,8 +19,8 @@ gl_FragCoord origin is upper left
 0:17        move second child to first child (temp uint)
 0:17          'size' (temp uint)
 0:17          array length (temp uint)
-0:17            sbuf: direct index for structure (layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:17              'anon@0' (layout(binding=10 row_major std430 ) readonly buffer block{layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} sbuf})
+0:17            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
+0:17              'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} @data})
 0:17              Constant:
 0:17                0 (const uint)
 0:17        move second child to first child (temp uint)
@@ -30,9 +30,9 @@ gl_FragCoord origin is upper left
 0:19      Test condition and select (temp void)
 0:19        Condition
 0:19        test: direct index for structure (temp bool)
-0:19          indirect index (layout(binding=10 row_major std430 ) readonly temp structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:19            sbuf: direct index for structure (layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:19              'anon@0' (layout(binding=10 row_major std430 ) readonly buffer block{layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} sbuf})
+0:19          indirect index (layout(row_major std430 ) buffer structure{temp 3-component vector of float color, temp bool test, temp bool test2})
+0:19            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
+0:19              'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} @data})
 0:19              Constant:
 0:19                0 (const uint)
 0:19            'pos' (in uint)
@@ -43,17 +43,17 @@ gl_FragCoord origin is upper left
 0:?           Construct vec4 (temp 4-component vector of float)
 0:20            add (temp 3-component vector of float)
 0:20              color: direct index for structure (temp 3-component vector of float)
-0:20                indirect index (layout(binding=10 row_major std430 ) readonly temp structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:20                  sbuf: direct index for structure (layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:20                    'anon@0' (layout(binding=10 row_major std430 ) readonly buffer block{layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} sbuf})
+0:20                indirect index (layout(row_major std430 ) buffer structure{temp 3-component vector of float color, temp bool test, temp bool test2})
+0:20                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
+0:20                    'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} @data})
 0:20                    Constant:
 0:20                      0 (const uint)
 0:20                  'pos' (in uint)
 0:20                Constant:
 0:20                  0 (const int)
-0:20              indirect index (layout(row_major std430 ) readonly temp float)
-0:20                sbuf2: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of float)
-0:20                  'anon@1' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of float sbuf2})
+0:20              indirect index (layout(row_major std430 ) buffer float)
+0:20                @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of float)
+0:20                  'sbuf2' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:20                  Constant:
 0:20                    0 (const uint)
 0:20                'pos' (in uint)
@@ -86,8 +86,8 @@ gl_FragCoord origin is upper left
 0:12        Function Call: @main(u1; (temp 4-component vector of float)
 0:?           'pos' (temp uint)
 0:?   Linker Objects
-0:?     'anon@0' (layout(binding=10 row_major std430 ) readonly buffer block{layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} sbuf})
-0:?     'anon@1' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of float sbuf2})
+0:?     'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} @data})
+0:?     'sbuf2' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:?     '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
 0:?     'pos' (layout(location=0 ) in uint)
 
@@ -105,9 +105,9 @@ gl_FragCoord origin is upper left
 0:13      Sequence
 0:13        move second child to first child (temp structure{temp 3-component vector of float color, temp bool test, temp bool test2})
 0:13          'mydata' (temp structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:13          indirect index (layout(binding=10 row_major std430 ) readonly buffer structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:13            sbuf: direct index for structure (layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:13              'anon@0' (layout(binding=10 row_major std430 ) readonly buffer block{layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} sbuf})
+0:13          indirect index (layout(row_major std430 ) buffer structure{temp 3-component vector of float color, temp bool test, temp bool test2})
+0:13            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
+0:13              'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} @data})
 0:13              Constant:
 0:13                0 (const uint)
 0:13            'pos' (in uint)
@@ -115,8 +115,8 @@ gl_FragCoord origin is upper left
 0:17        move second child to first child (temp uint)
 0:17          'size' (temp uint)
 0:17          array length (temp uint)
-0:17            sbuf: direct index for structure (layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:17              'anon@0' (layout(binding=10 row_major std430 ) readonly buffer block{layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} sbuf})
+0:17            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
+0:17              'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} @data})
 0:17              Constant:
 0:17                0 (const uint)
 0:17        move second child to first child (temp uint)
@@ -126,9 +126,9 @@ gl_FragCoord origin is upper left
 0:19      Test condition and select (temp void)
 0:19        Condition
 0:19        test: direct index for structure (temp bool)
-0:19          indirect index (layout(binding=10 row_major std430 ) readonly temp structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:19            sbuf: direct index for structure (layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:19              'anon@0' (layout(binding=10 row_major std430 ) readonly buffer block{layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} sbuf})
+0:19          indirect index (layout(row_major std430 ) buffer structure{temp 3-component vector of float color, temp bool test, temp bool test2})
+0:19            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
+0:19              'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} @data})
 0:19              Constant:
 0:19                0 (const uint)
 0:19            'pos' (in uint)
@@ -139,17 +139,17 @@ gl_FragCoord origin is upper left
 0:?           Construct vec4 (temp 4-component vector of float)
 0:20            add (temp 3-component vector of float)
 0:20              color: direct index for structure (temp 3-component vector of float)
-0:20                indirect index (layout(binding=10 row_major std430 ) readonly temp structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:20                  sbuf: direct index for structure (layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
-0:20                    'anon@0' (layout(binding=10 row_major std430 ) readonly buffer block{layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} sbuf})
+0:20                indirect index (layout(row_major std430 ) buffer structure{temp 3-component vector of float color, temp bool test, temp bool test2})
+0:20                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2})
+0:20                    'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} @data})
 0:20                    Constant:
 0:20                      0 (const uint)
 0:20                  'pos' (in uint)
 0:20                Constant:
 0:20                  0 (const int)
-0:20              indirect index (layout(row_major std430 ) readonly temp float)
-0:20                sbuf2: direct index for structure (layout(row_major std430 ) readonly buffer implicitly-sized array of float)
-0:20                  'anon@1' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of float sbuf2})
+0:20              indirect index (layout(row_major std430 ) buffer float)
+0:20                @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of float)
+0:20                  'sbuf2' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:20                  Constant:
 0:20                    0 (const uint)
 0:20                'pos' (in uint)
@@ -182,8 +182,8 @@ gl_FragCoord origin is upper left
 0:12        Function Call: @main(u1; (temp 4-component vector of float)
 0:?           'pos' (temp uint)
 0:?   Linker Objects
-0:?     'anon@0' (layout(binding=10 row_major std430 ) readonly buffer block{layout(binding=10 row_major std430 ) readonly buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} sbuf})
-0:?     'anon@1' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) readonly buffer implicitly-sized array of float sbuf2})
+0:?     'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test, temp bool test2} @data})
+0:?     'sbuf2' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:?     '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
 0:?     'pos' (layout(location=0 ) in uint)
 
@@ -209,13 +209,13 @@ gl_FragCoord origin is upper left
                               MemberName 19(sb_t) 1  "test"
                               MemberName 19(sb_t) 2  "test2"
                               Name 21  "sbuf"
-                              MemberName 21(sbuf) 0  "sbuf"
-                              Name 23  ""
+                              MemberName 21(sbuf) 0  "@data"
+                              Name 23  "sbuf"
                               Name 40  "size"
                               Name 42  "stride"
                               Name 57  "sbuf2"
-                              MemberName 57(sbuf2) 0  "sbuf2"
-                              Name 59  ""
+                              MemberName 57(sbuf2) 0  "@data"
+                              Name 59  "sbuf2"
                               Name 85  "pos"
                               Name 87  "pos"
                               Name 90  "@entryPointOutput"
@@ -230,13 +230,13 @@ gl_FragCoord origin is upper left
                               MemberDecorate 21(sbuf) 0 NonWritable
                               MemberDecorate 21(sbuf) 0 Offset 0
                               Decorate 21(sbuf) BufferBlock
-                              Decorate 23 DescriptorSet 0
-                              Decorate 23 Binding 10
+                              Decorate 23(sbuf) DescriptorSet 0
+                              Decorate 23(sbuf) Binding 10
                               Decorate 56 ArrayStride 4
                               MemberDecorate 57(sbuf2) 0 NonWritable
                               MemberDecorate 57(sbuf2) 0 Offset 0
                               Decorate 57(sbuf2) BufferBlock
-                              Decorate 59 DescriptorSet 0
+                              Decorate 59(sbuf2) DescriptorSet 0
                               Decorate 87(pos) Location 0
                               Decorate 90(@entryPointOutput) Location 0
                2:             TypeVoid
@@ -254,7 +254,7 @@ gl_FragCoord origin is upper left
               20:             TypeRuntimeArray 19(sb_t)
         21(sbuf):             TypeStruct 20
               22:             TypePointer Uniform 21(sbuf)
-              23:     22(ptr) Variable Uniform
+        23(sbuf):     22(ptr) Variable Uniform
               24:             TypeInt 32 1
               25:     24(int) Constant 0
               27:             TypePointer Uniform 19(sb_t)
@@ -269,7 +269,7 @@ gl_FragCoord origin is upper left
               56:             TypeRuntimeArray 8(float)
        57(sbuf2):             TypeStruct 56
               58:             TypePointer Uniform 57(sbuf2)
-              59:     58(ptr) Variable Uniform
+       59(sbuf2):     58(ptr) Variable Uniform
               61:             TypePointer Uniform 8(float)
               66:    8(float) Constant 0
               73:             TypePointer Function 8(float)
@@ -296,7 +296,7 @@ gl_FragCoord origin is upper left
         40(size):      7(ptr) Variable Function
       42(stride):      7(ptr) Variable Function
               26:      6(int) Load 11(pos)
-              28:     27(ptr) AccessChain 23 25 26
+              28:     27(ptr) AccessChain 23(sbuf) 25 26
               29:    19(sb_t) Load 28
               30:   14(fvec3) CompositeExtract 29 0
               32:     31(ptr) AccessChain 18(mydata) 25
@@ -307,21 +307,21 @@ gl_FragCoord origin is upper left
               37:      6(int) CompositeExtract 29 2
               39:     35(ptr) AccessChain 18(mydata) 38
                               Store 39 37
-              41:     24(int) ArrayLength 23 0
+              41:     24(int) ArrayLength 23(sbuf) 0
                               Store 40(size) 41
                               Store 42(stride) 43
               44:      6(int) Load 11(pos)
-              46:     45(ptr) AccessChain 23 25 44 34
+              46:     45(ptr) AccessChain 23(sbuf) 25 44 34
               47:      6(int) Load 46
               49:    15(bool) INotEqual 47 48
                               SelectionMerge 51 None
                               BranchConditional 49 50 72
               50:               Label
               52:      6(int)   Load 11(pos)
-              54:     53(ptr)   AccessChain 23 25 52 25
+              54:     53(ptr)   AccessChain 23(sbuf) 25 52 25
               55:   14(fvec3)   Load 54
               60:      6(int)   Load 11(pos)
-              62:     61(ptr)   AccessChain 59 25 60
+              62:     61(ptr)   AccessChain 59(sbuf2) 25 60
               63:    8(float)   Load 62
               64:   14(fvec3)   CompositeConstruct 63 63 63
               65:   14(fvec3)   FAdd 55 64

--- a/Test/baseResults/hlsl.structbuffer.rw.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.rw.frag.out
@@ -7,9 +7,9 @@ gl_FragCoord origin is upper left
 0:12      'pos' (in uint)
 0:?     Sequence
 0:13      move second child to first child (temp float)
-0:13        indirect index (layout(row_major std430 ) temp float)
-0:13          sbuf2: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of float)
-0:13            'anon@1' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of float sbuf2})
+0:13        indirect index (layout(row_major std430 ) buffer float)
+0:13          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of float)
+0:13            'sbuf2' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:13            Constant:
 0:13              0 (const uint)
 0:13          add (temp uint)
@@ -22,8 +22,8 @@ gl_FragCoord origin is upper left
 0:17        move second child to first child (temp uint)
 0:17          'size' (temp uint)
 0:17          array length (temp uint)
-0:17            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
-0:17              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
+0:17            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
+0:17              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
 0:17              Constant:
 0:17                0 (const uint)
 0:17        move second child to first child (temp uint)
@@ -33,9 +33,9 @@ gl_FragCoord origin is upper left
 0:19      Test condition and select (temp void)
 0:19        Condition
 0:19        test: direct index for structure (temp bool)
-0:19          indirect index (layout(row_major std430 ) temp structure{temp 3-component vector of float color, temp bool test})
-0:19            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
-0:19              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
+0:19          indirect index (layout(row_major std430 ) buffer structure{temp 3-component vector of float color, temp bool test})
+0:19            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
+0:19              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
 0:19              Constant:
 0:19                0 (const uint)
 0:19            'pos' (in uint)
@@ -46,17 +46,17 @@ gl_FragCoord origin is upper left
 0:?           Construct vec4 (temp 4-component vector of float)
 0:20            add (temp 3-component vector of float)
 0:20              color: direct index for structure (temp 3-component vector of float)
-0:20                indirect index (layout(row_major std430 ) temp structure{temp 3-component vector of float color, temp bool test})
-0:20                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
-0:20                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
+0:20                indirect index (layout(row_major std430 ) buffer structure{temp 3-component vector of float color, temp bool test})
+0:20                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
+0:20                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
 0:20                    Constant:
 0:20                      0 (const uint)
 0:20                  'pos' (in uint)
 0:20                Constant:
 0:20                  0 (const int)
-0:20              indirect index (layout(row_major std430 ) temp float)
-0:20                sbuf2: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of float)
-0:20                  'anon@1' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of float sbuf2})
+0:20              indirect index (layout(row_major std430 ) buffer float)
+0:20                @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of float)
+0:20                  'sbuf2' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:20                  Constant:
 0:20                    0 (const uint)
 0:20                'pos' (in uint)
@@ -80,8 +80,8 @@ gl_FragCoord origin is upper left
 0:12        Function Call: @main(u1; (temp 4-component vector of float)
 0:?           'pos' (temp uint)
 0:?   Linker Objects
-0:?     'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
-0:?     'anon@1' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of float sbuf2})
+0:?     'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
+0:?     'sbuf2' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:?     '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
 0:?     'pos' (layout(location=0 ) in uint)
 
@@ -97,9 +97,9 @@ gl_FragCoord origin is upper left
 0:12      'pos' (in uint)
 0:?     Sequence
 0:13      move second child to first child (temp float)
-0:13        indirect index (layout(row_major std430 ) temp float)
-0:13          sbuf2: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of float)
-0:13            'anon@1' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of float sbuf2})
+0:13        indirect index (layout(row_major std430 ) buffer float)
+0:13          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of float)
+0:13            'sbuf2' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:13            Constant:
 0:13              0 (const uint)
 0:13          add (temp uint)
@@ -112,8 +112,8 @@ gl_FragCoord origin is upper left
 0:17        move second child to first child (temp uint)
 0:17          'size' (temp uint)
 0:17          array length (temp uint)
-0:17            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
-0:17              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
+0:17            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
+0:17              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
 0:17              Constant:
 0:17                0 (const uint)
 0:17        move second child to first child (temp uint)
@@ -123,9 +123,9 @@ gl_FragCoord origin is upper left
 0:19      Test condition and select (temp void)
 0:19        Condition
 0:19        test: direct index for structure (temp bool)
-0:19          indirect index (layout(row_major std430 ) temp structure{temp 3-component vector of float color, temp bool test})
-0:19            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
-0:19              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
+0:19          indirect index (layout(row_major std430 ) buffer structure{temp 3-component vector of float color, temp bool test})
+0:19            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
+0:19              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
 0:19              Constant:
 0:19                0 (const uint)
 0:19            'pos' (in uint)
@@ -136,17 +136,17 @@ gl_FragCoord origin is upper left
 0:?           Construct vec4 (temp 4-component vector of float)
 0:20            add (temp 3-component vector of float)
 0:20              color: direct index for structure (temp 3-component vector of float)
-0:20                indirect index (layout(row_major std430 ) temp structure{temp 3-component vector of float color, temp bool test})
-0:20                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
-0:20                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
+0:20                indirect index (layout(row_major std430 ) buffer structure{temp 3-component vector of float color, temp bool test})
+0:20                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test})
+0:20                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
 0:20                    Constant:
 0:20                      0 (const uint)
 0:20                  'pos' (in uint)
 0:20                Constant:
 0:20                  0 (const int)
-0:20              indirect index (layout(row_major std430 ) temp float)
-0:20                sbuf2: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of float)
-0:20                  'anon@1' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of float sbuf2})
+0:20              indirect index (layout(row_major std430 ) buffer float)
+0:20                @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of float)
+0:20                  'sbuf2' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:20                  Constant:
 0:20                    0 (const uint)
 0:20                'pos' (in uint)
@@ -170,8 +170,8 @@ gl_FragCoord origin is upper left
 0:12        Function Call: @main(u1; (temp 4-component vector of float)
 0:?           'pos' (temp uint)
 0:?   Linker Objects
-0:?     'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} sbuf})
-0:?     'anon@1' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of float sbuf2})
+0:?     'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of structure{temp 3-component vector of float color, temp bool test} @data})
+0:?     'sbuf2' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of float @data})
 0:?     '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
 0:?     'pos' (layout(location=0 ) in uint)
 
@@ -188,15 +188,15 @@ gl_FragCoord origin is upper left
                               Name 12  "@main(u1;"
                               Name 11  "pos"
                               Name 15  "sbuf2"
-                              MemberName 15(sbuf2) 0  "sbuf2"
-                              Name 17  ""
+                              MemberName 15(sbuf2) 0  "@data"
+                              Name 17  "sbuf2"
                               Name 26  "size"
                               Name 28  "sb_t"
                               MemberName 28(sb_t) 0  "color"
                               MemberName 28(sb_t) 1  "test"
                               Name 30  "sbuf"
-                              MemberName 30(sbuf) 0  "sbuf"
-                              Name 32  ""
+                              MemberName 30(sbuf) 0  "@data"
+                              Name 32  "sbuf"
                               Name 34  "stride"
                               Name 69  "pos"
                               Name 71  "pos"
@@ -205,13 +205,13 @@ gl_FragCoord origin is upper left
                               Decorate 14 ArrayStride 4
                               MemberDecorate 15(sbuf2) 0 Offset 0
                               Decorate 15(sbuf2) BufferBlock
-                              Decorate 17 DescriptorSet 0
+                              Decorate 17(sbuf2) DescriptorSet 0
                               MemberDecorate 28(sb_t) 0 Offset 0
                               MemberDecorate 28(sb_t) 1 Offset 12
                               Decorate 29 ArrayStride 16
                               MemberDecorate 30(sbuf) 0 Offset 0
                               Decorate 30(sbuf) BufferBlock
-                              Decorate 32 DescriptorSet 0
+                              Decorate 32(sbuf) DescriptorSet 0
                               Decorate 71(pos) Location 0
                               Decorate 74(@entryPointOutput) Location 0
                2:             TypeVoid
@@ -224,7 +224,7 @@ gl_FragCoord origin is upper left
               14:             TypeRuntimeArray 8(float)
        15(sbuf2):             TypeStruct 14
               16:             TypePointer Uniform 15(sbuf2)
-              17:     16(ptr) Variable Uniform
+       17(sbuf2):     16(ptr) Variable Uniform
               18:             TypeInt 32 1
               19:     18(int) Constant 0
               21:      6(int) Constant 1
@@ -235,7 +235,7 @@ gl_FragCoord origin is upper left
               29:             TypeRuntimeArray 28(sb_t)
         30(sbuf):             TypeStruct 29
               31:             TypePointer Uniform 30(sbuf)
-              32:     31(ptr) Variable Uniform
+        32(sbuf):     31(ptr) Variable Uniform
               35:      6(int) Constant 16
               37:     18(int) Constant 1
               38:             TypePointer Uniform 6(int)
@@ -266,23 +266,23 @@ gl_FragCoord origin is upper left
       34(stride):      7(ptr) Variable Function
               20:      6(int) Load 11(pos)
               22:      6(int) IAdd 20 21
-              25:     24(ptr) AccessChain 17 19 22
+              25:     24(ptr) AccessChain 17(sbuf2) 19 22
                               Store 25 23
-              33:     18(int) ArrayLength 32 0
+              33:     18(int) ArrayLength 32(sbuf) 0
                               Store 26(size) 33
                               Store 34(stride) 35
               36:      6(int) Load 11(pos)
-              39:     38(ptr) AccessChain 32 19 36 37
+              39:     38(ptr) AccessChain 32(sbuf) 19 36 37
               40:      6(int) Load 39
               43:    41(bool) INotEqual 40 42
                               SelectionMerge 45 None
                               BranchConditional 43 44 61
               44:               Label
               46:      6(int)   Load 11(pos)
-              48:     47(ptr)   AccessChain 32 19 46 19
+              48:     47(ptr)   AccessChain 32(sbuf) 19 46 19
               49:   27(fvec3)   Load 48
               50:      6(int)   Load 11(pos)
-              51:     24(ptr)   AccessChain 17 19 50
+              51:     24(ptr)   AccessChain 17(sbuf2) 19 50
               52:    8(float)   Load 51
               53:   27(fvec3)   CompositeConstruct 52 52 52
               54:   27(fvec3)   FAdd 49 53

--- a/Test/baseResults/hlsl.structbuffer.rwbyte.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.rwbyte.frag.out
@@ -10,8 +10,8 @@ gl_FragCoord origin is upper left
 0:7        move second child to first child (temp uint)
 0:7          'size' (temp uint)
 0:7          array length (temp uint)
-0:7            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:7              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:7            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:7              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:7              Constant:
 0:7                0 (const uint)
 0:?       Sequence
@@ -23,15 +23,15 @@ gl_FragCoord origin is upper left
 0:9              2 (const int)
 0:9        move second child to first child (temp float)
 0:9          indirect index (temp float)
-0:9            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:9              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:9            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:9              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:9              Constant:
 0:9                0 (const uint)
 0:9            'byteAddrTemp' (temp int)
 0:9          Convert uint to float (temp float)
 0:9            indirect index (layout(row_major std430 ) buffer uint)
-0:9              sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:9                'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:9              @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:9                'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:9                Constant:
 0:9                  0 (const uint)
 0:9              right-shift (temp int)
@@ -47,8 +47,8 @@ gl_FragCoord origin is upper left
 0:10              2 (const int)
 0:10        move second child to first child (temp float)
 0:10          indirect index (temp float)
-0:10            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:10              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:10            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10              Constant:
 0:10                0 (const uint)
 0:10            'byteAddrTemp' (temp int)
@@ -62,14 +62,14 @@ gl_FragCoord origin is upper left
 0:10                    2 (const int)
 0:?               Construct vec2 (temp 2-component vector of uint)
 0:10                indirect index (temp float)
-0:10                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:10                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:10                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10                    Constant:
 0:10                      0 (const uint)
 0:10                  'byteAddrTemp' (temp int)
 0:10                indirect index (temp float)
-0:10                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:10                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:10                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10                    Constant:
 0:10                      0 (const uint)
 0:10                  add (temp int)
@@ -80,8 +80,8 @@ gl_FragCoord origin is upper left
 0:10              0 (const int)
 0:10        move second child to first child (temp float)
 0:10          indirect index (temp float)
-0:10            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:10              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:10            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10              Constant:
 0:10                0 (const uint)
 0:10            add (temp int)
@@ -98,14 +98,14 @@ gl_FragCoord origin is upper left
 0:10                    2 (const int)
 0:?               Construct vec2 (temp 2-component vector of uint)
 0:10                indirect index (temp float)
-0:10                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:10                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:10                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10                    Constant:
 0:10                      0 (const uint)
 0:10                  'byteAddrTemp' (temp int)
 0:10                indirect index (temp float)
-0:10                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:10                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:10                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10                    Constant:
 0:10                      0 (const uint)
 0:10                  add (temp int)
@@ -123,8 +123,8 @@ gl_FragCoord origin is upper left
 0:11              2 (const int)
 0:11        move second child to first child (temp float)
 0:11          indirect index (temp float)
-0:11            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11              Constant:
 0:11                0 (const uint)
 0:11            'byteAddrTemp' (temp int)
@@ -138,14 +138,14 @@ gl_FragCoord origin is upper left
 0:11                    2 (const int)
 0:?               Construct vec3 (temp 3-component vector of uint)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  'byteAddrTemp' (temp int)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  add (temp int)
@@ -153,8 +153,8 @@ gl_FragCoord origin is upper left
 0:11                    Constant:
 0:11                      1 (const int)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  add (temp int)
@@ -165,8 +165,8 @@ gl_FragCoord origin is upper left
 0:11              0 (const int)
 0:11        move second child to first child (temp float)
 0:11          indirect index (temp float)
-0:11            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11              Constant:
 0:11                0 (const uint)
 0:11            add (temp int)
@@ -183,14 +183,14 @@ gl_FragCoord origin is upper left
 0:11                    2 (const int)
 0:?               Construct vec3 (temp 3-component vector of uint)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  'byteAddrTemp' (temp int)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  add (temp int)
@@ -198,8 +198,8 @@ gl_FragCoord origin is upper left
 0:11                    Constant:
 0:11                      1 (const int)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  add (temp int)
@@ -210,8 +210,8 @@ gl_FragCoord origin is upper left
 0:11              1 (const int)
 0:11        move second child to first child (temp float)
 0:11          indirect index (temp float)
-0:11            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11              Constant:
 0:11                0 (const uint)
 0:11            add (temp int)
@@ -228,14 +228,14 @@ gl_FragCoord origin is upper left
 0:11                    2 (const int)
 0:?               Construct vec3 (temp 3-component vector of uint)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  'byteAddrTemp' (temp int)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  add (temp int)
@@ -243,8 +243,8 @@ gl_FragCoord origin is upper left
 0:11                    Constant:
 0:11                      1 (const int)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  add (temp int)
@@ -262,8 +262,8 @@ gl_FragCoord origin is upper left
 0:12              2 (const int)
 0:12        move second child to first child (temp float)
 0:12          indirect index (temp float)
-0:12            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12              Constant:
 0:12                0 (const uint)
 0:12            'byteAddrTemp' (temp int)
@@ -277,14 +277,14 @@ gl_FragCoord origin is upper left
 0:12                    2 (const int)
 0:?               Construct vec4 (temp 4-component vector of uint)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  'byteAddrTemp' (temp int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -292,8 +292,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      1 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -301,8 +301,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      2 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -313,8 +313,8 @@ gl_FragCoord origin is upper left
 0:12              0 (const int)
 0:12        move second child to first child (temp float)
 0:12          indirect index (temp float)
-0:12            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12              Constant:
 0:12                0 (const uint)
 0:12            add (temp int)
@@ -331,14 +331,14 @@ gl_FragCoord origin is upper left
 0:12                    2 (const int)
 0:?               Construct vec4 (temp 4-component vector of uint)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  'byteAddrTemp' (temp int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -346,8 +346,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      1 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -355,8 +355,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      2 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -367,8 +367,8 @@ gl_FragCoord origin is upper left
 0:12              1 (const int)
 0:12        move second child to first child (temp float)
 0:12          indirect index (temp float)
-0:12            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12              Constant:
 0:12                0 (const uint)
 0:12            add (temp int)
@@ -385,14 +385,14 @@ gl_FragCoord origin is upper left
 0:12                    2 (const int)
 0:?               Construct vec4 (temp 4-component vector of uint)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  'byteAddrTemp' (temp int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -400,8 +400,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      1 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -409,8 +409,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      2 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -421,8 +421,8 @@ gl_FragCoord origin is upper left
 0:12              2 (const int)
 0:12        move second child to first child (temp float)
 0:12          indirect index (temp float)
-0:12            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12              Constant:
 0:12                0 (const uint)
 0:12            add (temp int)
@@ -439,14 +439,14 @@ gl_FragCoord origin is upper left
 0:12                    2 (const int)
 0:?               Construct vec4 (temp 4-component vector of uint)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  'byteAddrTemp' (temp int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -454,8 +454,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      1 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -463,8 +463,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      2 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -477,8 +477,8 @@ gl_FragCoord origin is upper left
 0:14        Construct vec4 (temp 4-component vector of float)
 0:14          Convert uint to float (temp float)
 0:14            indirect index (layout(row_major std430 ) buffer uint)
-0:14              sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:14                'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:14              @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:14                'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:14                Constant:
 0:14                  0 (const uint)
 0:14              right-shift (temp int)
@@ -496,7 +496,7 @@ gl_FragCoord origin is upper left
 0:5        Function Call: @main(u1; (temp 4-component vector of float)
 0:?           'pos' (temp uint)
 0:?   Linker Objects
-0:?     'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:?     'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:?     '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
 0:?     'pos' (layout(location=0 ) in uint)
 
@@ -515,8 +515,8 @@ gl_FragCoord origin is upper left
 0:7        move second child to first child (temp uint)
 0:7          'size' (temp uint)
 0:7          array length (temp uint)
-0:7            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:7              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:7            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:7              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:7              Constant:
 0:7                0 (const uint)
 0:?       Sequence
@@ -528,15 +528,15 @@ gl_FragCoord origin is upper left
 0:9              2 (const int)
 0:9        move second child to first child (temp float)
 0:9          indirect index (temp float)
-0:9            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:9              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:9            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:9              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:9              Constant:
 0:9                0 (const uint)
 0:9            'byteAddrTemp' (temp int)
 0:9          Convert uint to float (temp float)
 0:9            indirect index (layout(row_major std430 ) buffer uint)
-0:9              sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:9                'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:9              @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:9                'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:9                Constant:
 0:9                  0 (const uint)
 0:9              right-shift (temp int)
@@ -552,8 +552,8 @@ gl_FragCoord origin is upper left
 0:10              2 (const int)
 0:10        move second child to first child (temp float)
 0:10          indirect index (temp float)
-0:10            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:10              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:10            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10              Constant:
 0:10                0 (const uint)
 0:10            'byteAddrTemp' (temp int)
@@ -567,14 +567,14 @@ gl_FragCoord origin is upper left
 0:10                    2 (const int)
 0:?               Construct vec2 (temp 2-component vector of uint)
 0:10                indirect index (temp float)
-0:10                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:10                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:10                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10                    Constant:
 0:10                      0 (const uint)
 0:10                  'byteAddrTemp' (temp int)
 0:10                indirect index (temp float)
-0:10                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:10                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:10                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10                    Constant:
 0:10                      0 (const uint)
 0:10                  add (temp int)
@@ -585,8 +585,8 @@ gl_FragCoord origin is upper left
 0:10              0 (const int)
 0:10        move second child to first child (temp float)
 0:10          indirect index (temp float)
-0:10            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:10              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:10            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10              Constant:
 0:10                0 (const uint)
 0:10            add (temp int)
@@ -603,14 +603,14 @@ gl_FragCoord origin is upper left
 0:10                    2 (const int)
 0:?               Construct vec2 (temp 2-component vector of uint)
 0:10                indirect index (temp float)
-0:10                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:10                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:10                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10                    Constant:
 0:10                      0 (const uint)
 0:10                  'byteAddrTemp' (temp int)
 0:10                indirect index (temp float)
-0:10                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:10                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:10                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:10                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:10                    Constant:
 0:10                      0 (const uint)
 0:10                  add (temp int)
@@ -628,8 +628,8 @@ gl_FragCoord origin is upper left
 0:11              2 (const int)
 0:11        move second child to first child (temp float)
 0:11          indirect index (temp float)
-0:11            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11              Constant:
 0:11                0 (const uint)
 0:11            'byteAddrTemp' (temp int)
@@ -643,14 +643,14 @@ gl_FragCoord origin is upper left
 0:11                    2 (const int)
 0:?               Construct vec3 (temp 3-component vector of uint)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  'byteAddrTemp' (temp int)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  add (temp int)
@@ -658,8 +658,8 @@ gl_FragCoord origin is upper left
 0:11                    Constant:
 0:11                      1 (const int)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  add (temp int)
@@ -670,8 +670,8 @@ gl_FragCoord origin is upper left
 0:11              0 (const int)
 0:11        move second child to first child (temp float)
 0:11          indirect index (temp float)
-0:11            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11              Constant:
 0:11                0 (const uint)
 0:11            add (temp int)
@@ -688,14 +688,14 @@ gl_FragCoord origin is upper left
 0:11                    2 (const int)
 0:?               Construct vec3 (temp 3-component vector of uint)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  'byteAddrTemp' (temp int)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  add (temp int)
@@ -703,8 +703,8 @@ gl_FragCoord origin is upper left
 0:11                    Constant:
 0:11                      1 (const int)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  add (temp int)
@@ -715,8 +715,8 @@ gl_FragCoord origin is upper left
 0:11              1 (const int)
 0:11        move second child to first child (temp float)
 0:11          indirect index (temp float)
-0:11            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11              Constant:
 0:11                0 (const uint)
 0:11            add (temp int)
@@ -733,14 +733,14 @@ gl_FragCoord origin is upper left
 0:11                    2 (const int)
 0:?               Construct vec3 (temp 3-component vector of uint)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  'byteAddrTemp' (temp int)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  add (temp int)
@@ -748,8 +748,8 @@ gl_FragCoord origin is upper left
 0:11                    Constant:
 0:11                      1 (const int)
 0:11                indirect index (temp float)
-0:11                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:11                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:11                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:11                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:11                    Constant:
 0:11                      0 (const uint)
 0:11                  add (temp int)
@@ -767,8 +767,8 @@ gl_FragCoord origin is upper left
 0:12              2 (const int)
 0:12        move second child to first child (temp float)
 0:12          indirect index (temp float)
-0:12            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12              Constant:
 0:12                0 (const uint)
 0:12            'byteAddrTemp' (temp int)
@@ -782,14 +782,14 @@ gl_FragCoord origin is upper left
 0:12                    2 (const int)
 0:?               Construct vec4 (temp 4-component vector of uint)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  'byteAddrTemp' (temp int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -797,8 +797,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      1 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -806,8 +806,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      2 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -818,8 +818,8 @@ gl_FragCoord origin is upper left
 0:12              0 (const int)
 0:12        move second child to first child (temp float)
 0:12          indirect index (temp float)
-0:12            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12              Constant:
 0:12                0 (const uint)
 0:12            add (temp int)
@@ -836,14 +836,14 @@ gl_FragCoord origin is upper left
 0:12                    2 (const int)
 0:?               Construct vec4 (temp 4-component vector of uint)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  'byteAddrTemp' (temp int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -851,8 +851,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      1 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -860,8 +860,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      2 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -872,8 +872,8 @@ gl_FragCoord origin is upper left
 0:12              1 (const int)
 0:12        move second child to first child (temp float)
 0:12          indirect index (temp float)
-0:12            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12              Constant:
 0:12                0 (const uint)
 0:12            add (temp int)
@@ -890,14 +890,14 @@ gl_FragCoord origin is upper left
 0:12                    2 (const int)
 0:?               Construct vec4 (temp 4-component vector of uint)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  'byteAddrTemp' (temp int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -905,8 +905,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      1 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -914,8 +914,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      2 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -926,8 +926,8 @@ gl_FragCoord origin is upper left
 0:12              2 (const int)
 0:12        move second child to first child (temp float)
 0:12          indirect index (temp float)
-0:12            sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12              'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12            @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12              'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12              Constant:
 0:12                0 (const uint)
 0:12            add (temp int)
@@ -944,14 +944,14 @@ gl_FragCoord origin is upper left
 0:12                    2 (const int)
 0:?               Construct vec4 (temp 4-component vector of uint)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  'byteAddrTemp' (temp int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -959,8 +959,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      1 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -968,8 +968,8 @@ gl_FragCoord origin is upper left
 0:12                    Constant:
 0:12                      2 (const int)
 0:12                indirect index (temp float)
-0:12                  sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:12                    'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:12                  @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:12                    'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:12                    Constant:
 0:12                      0 (const uint)
 0:12                  add (temp int)
@@ -982,8 +982,8 @@ gl_FragCoord origin is upper left
 0:14        Construct vec4 (temp 4-component vector of float)
 0:14          Convert uint to float (temp float)
 0:14            indirect index (layout(row_major std430 ) buffer uint)
-0:14              sbuf: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
-0:14                'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:14              @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of uint)
+0:14                'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:14                Constant:
 0:14                  0 (const uint)
 0:14              right-shift (temp int)
@@ -1001,7 +1001,7 @@ gl_FragCoord origin is upper left
 0:5        Function Call: @main(u1; (temp 4-component vector of float)
 0:?           'pos' (temp uint)
 0:?   Linker Objects
-0:?     'anon@0' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint sbuf})
+0:?     'sbuf' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of uint @data})
 0:?     '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
 0:?     'pos' (layout(location=0 ) in uint)
 
@@ -1019,8 +1019,8 @@ gl_FragCoord origin is upper left
                               Name 11  "pos"
                               Name 14  "size"
                               Name 16  "sbuf"
-                              MemberName 16(sbuf) 0  "sbuf"
-                              Name 18  ""
+                              MemberName 16(sbuf) 0  "@data"
+                              Name 18  "sbuf"
                               Name 22  "byteAddrTemp"
                               Name 35  "byteAddrTemp"
                               Name 39  "byteAddrTemp"
@@ -1035,7 +1035,7 @@ gl_FragCoord origin is upper left
                               Decorate 15 ArrayStride 4
                               MemberDecorate 16(sbuf) 0 Offset 0
                               Decorate 16(sbuf) BufferBlock
-                              Decorate 18 DescriptorSet 0
+                              Decorate 18(sbuf) DescriptorSet 0
                               Decorate 233(pos) Location 0
                               Decorate 236(@entryPointOutput) Location 0
                2:             TypeVoid
@@ -1048,7 +1048,7 @@ gl_FragCoord origin is upper left
               15:             TypeRuntimeArray 6(int)
         16(sbuf):             TypeStruct 15
               17:             TypePointer Uniform 16(sbuf)
-              18:     17(ptr) Variable Uniform
+        18(sbuf):     17(ptr) Variable Uniform
               19:             TypeInt 32 1
               21:             TypePointer Function 19(int)
               24:     19(int) Constant 2
@@ -1090,7 +1090,7 @@ gl_FragCoord origin is upper left
 74(byteAddrTemp):     21(ptr) Variable Function
 129(byteAddrTemp):     21(ptr) Variable Function
 133(byteAddrTemp):     21(ptr) Variable Function
-              20:     19(int) ArrayLength 18 0
+              20:     19(int) ArrayLength 18(sbuf) 0
                               Store 14(size) 20
               23:      6(int) Load 11(pos)
               25:     19(int) ShiftRightLogical 23 24
@@ -1098,10 +1098,10 @@ gl_FragCoord origin is upper left
               27:     19(int) Load 22(byteAddrTemp)
               28:      6(int) Load 11(pos)
               29:     19(int) ShiftRightLogical 28 24
-              31:     30(ptr) AccessChain 18 26 29
+              31:     30(ptr) AccessChain 18(sbuf) 26 29
               32:      6(int) Load 31
               33:    8(float) ConvertUToF 32
-              34:     30(ptr) AccessChain 18 26 27
+              34:     30(ptr) AccessChain 18(sbuf) 26 27
                               Store 34 33
               36:      6(int) Load 11(pos)
               37:     19(int) ShiftRightLogical 36 24
@@ -1111,15 +1111,15 @@ gl_FragCoord origin is upper left
               41:     19(int) ShiftRightLogical 40 24
                               Store 39(byteAddrTemp) 41
               42:     19(int) Load 39(byteAddrTemp)
-              43:     30(ptr) AccessChain 18 26 42
+              43:     30(ptr) AccessChain 18(sbuf) 26 42
               44:      6(int) Load 43
               45:     19(int) Load 39(byteAddrTemp)
               47:     19(int) IAdd 45 46
-              48:     30(ptr) AccessChain 18 26 47
+              48:     30(ptr) AccessChain 18(sbuf) 26 47
               49:      6(int) Load 48
               51:   50(ivec2) CompositeConstruct 44 49
               53:      6(int) CompositeExtract 51 0
-              54:     30(ptr) AccessChain 18 26 38
+              54:     30(ptr) AccessChain 18(sbuf) 26 38
                               Store 54 53
               55:     19(int) Load 35(byteAddrTemp)
               56:     19(int) IAdd 55 46
@@ -1127,15 +1127,15 @@ gl_FragCoord origin is upper left
               58:     19(int) ShiftRightLogical 57 24
                               Store 39(byteAddrTemp) 58
               59:     19(int) Load 39(byteAddrTemp)
-              60:     30(ptr) AccessChain 18 26 59
+              60:     30(ptr) AccessChain 18(sbuf) 26 59
               61:      6(int) Load 60
               62:     19(int) Load 39(byteAddrTemp)
               63:     19(int) IAdd 62 46
-              64:     30(ptr) AccessChain 18 26 63
+              64:     30(ptr) AccessChain 18(sbuf) 26 63
               65:      6(int) Load 64
               66:   50(ivec2) CompositeConstruct 61 65
               68:      6(int) CompositeExtract 66 1
-              69:     30(ptr) AccessChain 18 26 56
+              69:     30(ptr) AccessChain 18(sbuf) 26 56
                               Store 69 68
               71:      6(int) Load 11(pos)
               72:     19(int) ShiftRightLogical 71 24
@@ -1145,19 +1145,19 @@ gl_FragCoord origin is upper left
               76:     19(int) ShiftRightLogical 75 24
                               Store 74(byteAddrTemp) 76
               77:     19(int) Load 74(byteAddrTemp)
-              78:     30(ptr) AccessChain 18 26 77
+              78:     30(ptr) AccessChain 18(sbuf) 26 77
               79:      6(int) Load 78
               80:     19(int) Load 74(byteAddrTemp)
               81:     19(int) IAdd 80 46
-              82:     30(ptr) AccessChain 18 26 81
+              82:     30(ptr) AccessChain 18(sbuf) 26 81
               83:      6(int) Load 82
               84:     19(int) Load 74(byteAddrTemp)
               85:     19(int) IAdd 84 24
-              86:     30(ptr) AccessChain 18 26 85
+              86:     30(ptr) AccessChain 18(sbuf) 26 85
               87:      6(int) Load 86
               89:   88(ivec3) CompositeConstruct 79 83 87
               90:      6(int) CompositeExtract 89 0
-              91:     30(ptr) AccessChain 18 26 73
+              91:     30(ptr) AccessChain 18(sbuf) 26 73
                               Store 91 90
               92:     19(int) Load 70(byteAddrTemp)
               93:     19(int) IAdd 92 46
@@ -1165,19 +1165,19 @@ gl_FragCoord origin is upper left
               95:     19(int) ShiftRightLogical 94 24
                               Store 74(byteAddrTemp) 95
               96:     19(int) Load 74(byteAddrTemp)
-              97:     30(ptr) AccessChain 18 26 96
+              97:     30(ptr) AccessChain 18(sbuf) 26 96
               98:      6(int) Load 97
               99:     19(int) Load 74(byteAddrTemp)
              100:     19(int) IAdd 99 46
-             101:     30(ptr) AccessChain 18 26 100
+             101:     30(ptr) AccessChain 18(sbuf) 26 100
              102:      6(int) Load 101
              103:     19(int) Load 74(byteAddrTemp)
              104:     19(int) IAdd 103 24
-             105:     30(ptr) AccessChain 18 26 104
+             105:     30(ptr) AccessChain 18(sbuf) 26 104
              106:      6(int) Load 105
              107:   88(ivec3) CompositeConstruct 98 102 106
              108:      6(int) CompositeExtract 107 1
-             109:     30(ptr) AccessChain 18 26 93
+             109:     30(ptr) AccessChain 18(sbuf) 26 93
                               Store 109 108
              110:     19(int) Load 70(byteAddrTemp)
              111:     19(int) IAdd 110 24
@@ -1185,19 +1185,19 @@ gl_FragCoord origin is upper left
              113:     19(int) ShiftRightLogical 112 24
                               Store 74(byteAddrTemp) 113
              114:     19(int) Load 74(byteAddrTemp)
-             115:     30(ptr) AccessChain 18 26 114
+             115:     30(ptr) AccessChain 18(sbuf) 26 114
              116:      6(int) Load 115
              117:     19(int) Load 74(byteAddrTemp)
              118:     19(int) IAdd 117 46
-             119:     30(ptr) AccessChain 18 26 118
+             119:     30(ptr) AccessChain 18(sbuf) 26 118
              120:      6(int) Load 119
              121:     19(int) Load 74(byteAddrTemp)
              122:     19(int) IAdd 121 24
-             123:     30(ptr) AccessChain 18 26 122
+             123:     30(ptr) AccessChain 18(sbuf) 26 122
              124:      6(int) Load 123
              125:   88(ivec3) CompositeConstruct 116 120 124
              127:      6(int) CompositeExtract 125 2
-             128:     30(ptr) AccessChain 18 26 111
+             128:     30(ptr) AccessChain 18(sbuf) 26 111
                               Store 128 127
              130:      6(int) Load 11(pos)
              131:     19(int) ShiftRightLogical 130 24
@@ -1207,23 +1207,23 @@ gl_FragCoord origin is upper left
              135:     19(int) ShiftRightLogical 134 24
                               Store 133(byteAddrTemp) 135
              136:     19(int) Load 133(byteAddrTemp)
-             137:     30(ptr) AccessChain 18 26 136
+             137:     30(ptr) AccessChain 18(sbuf) 26 136
              138:      6(int) Load 137
              139:     19(int) Load 133(byteAddrTemp)
              140:     19(int) IAdd 139 46
-             141:     30(ptr) AccessChain 18 26 140
+             141:     30(ptr) AccessChain 18(sbuf) 26 140
              142:      6(int) Load 141
              143:     19(int) Load 133(byteAddrTemp)
              144:     19(int) IAdd 143 24
-             145:     30(ptr) AccessChain 18 26 144
+             145:     30(ptr) AccessChain 18(sbuf) 26 144
              146:      6(int) Load 145
              147:     19(int) Load 133(byteAddrTemp)
              149:     19(int) IAdd 147 148
-             150:     30(ptr) AccessChain 18 26 149
+             150:     30(ptr) AccessChain 18(sbuf) 26 149
              151:      6(int) Load 150
              153:  152(ivec4) CompositeConstruct 138 142 146 151
              154:      6(int) CompositeExtract 153 0
-             155:     30(ptr) AccessChain 18 26 132
+             155:     30(ptr) AccessChain 18(sbuf) 26 132
                               Store 155 154
              156:     19(int) Load 129(byteAddrTemp)
              157:     19(int) IAdd 156 46
@@ -1231,23 +1231,23 @@ gl_FragCoord origin is upper left
              159:     19(int) ShiftRightLogical 158 24
                               Store 133(byteAddrTemp) 159
              160:     19(int) Load 133(byteAddrTemp)
-             161:     30(ptr) AccessChain 18 26 160
+             161:     30(ptr) AccessChain 18(sbuf) 26 160
              162:      6(int) Load 161
              163:     19(int) Load 133(byteAddrTemp)
              164:     19(int) IAdd 163 46
-             165:     30(ptr) AccessChain 18 26 164
+             165:     30(ptr) AccessChain 18(sbuf) 26 164
              166:      6(int) Load 165
              167:     19(int) Load 133(byteAddrTemp)
              168:     19(int) IAdd 167 24
-             169:     30(ptr) AccessChain 18 26 168
+             169:     30(ptr) AccessChain 18(sbuf) 26 168
              170:      6(int) Load 169
              171:     19(int) Load 133(byteAddrTemp)
              172:     19(int) IAdd 171 148
-             173:     30(ptr) AccessChain 18 26 172
+             173:     30(ptr) AccessChain 18(sbuf) 26 172
              174:      6(int) Load 173
              175:  152(ivec4) CompositeConstruct 162 166 170 174
              176:      6(int) CompositeExtract 175 1
-             177:     30(ptr) AccessChain 18 26 157
+             177:     30(ptr) AccessChain 18(sbuf) 26 157
                               Store 177 176
              178:     19(int) Load 129(byteAddrTemp)
              179:     19(int) IAdd 178 24
@@ -1255,23 +1255,23 @@ gl_FragCoord origin is upper left
              181:     19(int) ShiftRightLogical 180 24
                               Store 133(byteAddrTemp) 181
              182:     19(int) Load 133(byteAddrTemp)
-             183:     30(ptr) AccessChain 18 26 182
+             183:     30(ptr) AccessChain 18(sbuf) 26 182
              184:      6(int) Load 183
              185:     19(int) Load 133(byteAddrTemp)
              186:     19(int) IAdd 185 46
-             187:     30(ptr) AccessChain 18 26 186
+             187:     30(ptr) AccessChain 18(sbuf) 26 186
              188:      6(int) Load 187
              189:     19(int) Load 133(byteAddrTemp)
              190:     19(int) IAdd 189 24
-             191:     30(ptr) AccessChain 18 26 190
+             191:     30(ptr) AccessChain 18(sbuf) 26 190
              192:      6(int) Load 191
              193:     19(int) Load 133(byteAddrTemp)
              194:     19(int) IAdd 193 148
-             195:     30(ptr) AccessChain 18 26 194
+             195:     30(ptr) AccessChain 18(sbuf) 26 194
              196:      6(int) Load 195
              197:  152(ivec4) CompositeConstruct 184 188 192 196
              198:      6(int) CompositeExtract 197 2
-             199:     30(ptr) AccessChain 18 26 179
+             199:     30(ptr) AccessChain 18(sbuf) 26 179
                               Store 199 198
              200:     19(int) Load 129(byteAddrTemp)
              201:     19(int) IAdd 200 148
@@ -1279,27 +1279,27 @@ gl_FragCoord origin is upper left
              203:     19(int) ShiftRightLogical 202 24
                               Store 133(byteAddrTemp) 203
              204:     19(int) Load 133(byteAddrTemp)
-             205:     30(ptr) AccessChain 18 26 204
+             205:     30(ptr) AccessChain 18(sbuf) 26 204
              206:      6(int) Load 205
              207:     19(int) Load 133(byteAddrTemp)
              208:     19(int) IAdd 207 46
-             209:     30(ptr) AccessChain 18 26 208
+             209:     30(ptr) AccessChain 18(sbuf) 26 208
              210:      6(int) Load 209
              211:     19(int) Load 133(byteAddrTemp)
              212:     19(int) IAdd 211 24
-             213:     30(ptr) AccessChain 18 26 212
+             213:     30(ptr) AccessChain 18(sbuf) 26 212
              214:      6(int) Load 213
              215:     19(int) Load 133(byteAddrTemp)
              216:     19(int) IAdd 215 148
-             217:     30(ptr) AccessChain 18 26 216
+             217:     30(ptr) AccessChain 18(sbuf) 26 216
              218:      6(int) Load 217
              219:  152(ivec4) CompositeConstruct 206 210 214 218
              221:      6(int) CompositeExtract 219 3
-             222:     30(ptr) AccessChain 18 26 201
+             222:     30(ptr) AccessChain 18(sbuf) 26 201
                               Store 222 221
              223:      6(int) Load 11(pos)
              224:     19(int) ShiftRightLogical 223 24
-             225:     30(ptr) AccessChain 18 26 224
+             225:     30(ptr) AccessChain 18(sbuf) 26 224
              226:      6(int) Load 225
              227:    8(float) ConvertUToF 226
              228:    9(fvec4) CompositeConstruct 227 227 227 227

--- a/Test/baseResults/spv.ssbo.autoassign.frag.out
+++ b/Test/baseResults/spv.ssbo.autoassign.frag.out
@@ -16,15 +16,15 @@ spv.ssbo.autoassign.frag
                               MemberName 14(BufType) 0  "va"
                               MemberName 14(BufType) 1  "vb"
                               Name 16  "SB0"
-                              MemberName 16(SB0) 0  "SB0"
-                              Name 18  ""
+                              MemberName 16(SB0) 0  "@data"
+                              Name 18  "SB0"
                               Name 26  "TestCB"
                               MemberName 26(TestCB) 0  "W"
                               MemberName 26(TestCB) 1  "H"
                               Name 28  ""
                               Name 55  "SB1"
-                              MemberName 55(SB1) 0  "SB1"
-                              Name 57  ""
+                              MemberName 55(SB1) 0  "@data"
+                              Name 57  "SB1"
                               Name 86  "pos"
                               Name 88  "pos"
                               Name 91  "@entryPointOutput"
@@ -37,8 +37,8 @@ spv.ssbo.autoassign.frag
                               MemberDecorate 16(SB0) 0 NonWritable
                               MemberDecorate 16(SB0) 0 Offset 0
                               Decorate 16(SB0) BufferBlock
-                              Decorate 18 DescriptorSet 0
-                              Decorate 18 Binding 30
+                              Decorate 18(SB0) DescriptorSet 0
+                              Decorate 18(SB0) Binding 30
                               MemberDecorate 26(TestCB) 0 Offset 0
                               MemberDecorate 26(TestCB) 1 Offset 4
                               Decorate 26(TestCB) Block
@@ -47,8 +47,8 @@ spv.ssbo.autoassign.frag
                               Decorate 54 ArrayStride 32
                               MemberDecorate 55(SB1) 0 Offset 0
                               Decorate 55(SB1) BufferBlock
-                              Decorate 57 DescriptorSet 0
-                              Decorate 57 Binding 31
+                              Decorate 57(SB1) DescriptorSet 0
+                              Decorate 57(SB1) Binding 31
                               Decorate 88(pos) Location 0
                               Decorate 91(@entryPointOutput) Location 0
                2:             TypeVoid
@@ -61,7 +61,7 @@ spv.ssbo.autoassign.frag
               15:             TypeRuntimeArray 14(BufType)
          16(SB0):             TypeStruct 15
               17:             TypePointer Uniform 16(SB0)
-              18:     17(ptr) Variable Uniform
+         18(SB0):     17(ptr) Variable Uniform
               19:             TypeInt 32 1
               20:     19(int) Constant 0
               21:             TypeInt 32 0
@@ -77,7 +77,7 @@ spv.ssbo.autoassign.frag
               54:             TypeRuntimeArray 14(BufType)
          55(SB1):             TypeStruct 54
               56:             TypePointer Uniform 55(SB1)
-              57:     56(ptr) Variable Uniform
+         57(SB1):     56(ptr) Variable Uniform
               87:             TypePointer Input 7(fvec4)
          88(pos):     87(ptr) Variable Input
               90:             TypePointer Output 7(fvec4)
@@ -107,7 +107,7 @@ spv.ssbo.autoassign.frag
               35:     23(ptr) AccessChain 10(pos) 34
               36:    6(float) Load 35
               37:    6(float) FAdd 33 36
-              39:     38(ptr) AccessChain 18 20 37 20
+              39:     38(ptr) AccessChain 18(SB0) 20 37 20
               40:    7(fvec4) Load 39
               41:     23(ptr) AccessChain 10(pos) 22
               42:    6(float) Load 41
@@ -118,7 +118,7 @@ spv.ssbo.autoassign.frag
               47:     23(ptr) AccessChain 10(pos) 34
               48:    6(float) Load 47
               49:    6(float) FAdd 46 48
-              51:     38(ptr) AccessChain 18 20 49 50
+              51:     38(ptr) AccessChain 18(SB0) 20 49 50
               52:    7(fvec4) Load 51
               53:    7(fvec4) FAdd 40 52
                               Store 13(vTmp) 53
@@ -131,7 +131,7 @@ spv.ssbo.autoassign.frag
               64:     23(ptr) AccessChain 10(pos) 34
               65:    6(float) Load 64
               66:    6(float) FAdd 63 65
-              67:     38(ptr) AccessChain 57 20 66 20
+              67:     38(ptr) AccessChain 57(SB1) 20 66 20
               68:    7(fvec4) Load 67
               69:     23(ptr) AccessChain 10(pos) 22
               70:    6(float) Load 69
@@ -142,7 +142,7 @@ spv.ssbo.autoassign.frag
               75:     23(ptr) AccessChain 10(pos) 34
               76:    6(float) Load 75
               77:    6(float) FAdd 74 76
-              78:     38(ptr) AccessChain 57 20 77 50
+              78:     38(ptr) AccessChain 57(SB1) 20 77 50
               79:    7(fvec4) Load 78
               80:    7(fvec4) FAdd 68 79
               81:    7(fvec4) Load 13(vTmp)

--- a/Test/hlsl.structbuffer.fn.frag
+++ b/Test/hlsl.structbuffer.fn.frag
@@ -1,0 +1,23 @@
+
+StructuredBuffer<uint4>  sbuf : register(t10);
+RWStructuredBuffer<uint4> sbuf2;
+
+// Not shared, because of type difference.
+StructuredBuffer<uint3>  sbuf3 : register(t12);
+
+uint4 get(in StructuredBuffer<uint4> sb, uint bufferOffset)
+{
+    return sb[bufferOffset];
+}
+
+void set(in RWStructuredBuffer<uint4> sb, uint bufferOffset, uint4 data)
+{
+    sb[bufferOffset] = data;
+}
+
+float4 main(uint pos : FOO) : SV_Target0
+{
+    set(sbuf2, 2, get(sbuf, 3));
+
+    return 0;
+}

--- a/glslang/MachineIndependent/SymbolTable.cpp
+++ b/glslang/MachineIndependent/SymbolTable.cpp
@@ -103,7 +103,11 @@ void TType::buildMangledName(TString& mangledName)
             mangledName += "M";
         break;
     case EbtStruct:
-        mangledName += "struct-";
+    case EbtBlock:
+        if (basicType == EbtStruct)
+            mangledName += "struct-";
+        else
+            mangledName += "block-";
         if (typeName)
             mangledName += *typeName;
         for (unsigned int i = 0; i < structure->size(); ++i) {

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -225,6 +225,7 @@ INSTANTIATE_TEST_CASE_P(
         {"hlsl.structbuffer.atomics.frag", "main"},
         {"hlsl.structbuffer.byte.frag", "main"},
         {"hlsl.structbuffer.coherent.frag", "main"},
+        {"hlsl.structbuffer.fn.frag", "main"},
         {"hlsl.structbuffer.rw.frag", "main"},
         {"hlsl.structbuffer.rwbyte.frag", "main"},
         {"hlsl.structin.vert", "main"},

--- a/hlsl/hlslParseHelper.h
+++ b/hlsl/hlslParseHelper.h
@@ -180,6 +180,9 @@ public:
     void initFlattening() { flattenLevel.push_back(0); flattenOffset.push_back(0); }
     void finalizeFlattening() { flattenLevel.pop_back(); flattenOffset.pop_back(); }
 
+    // Share struct buffer deep types
+    void shareStructBufferType(TType&);
+
 protected:
     struct TFlattenData {
         TFlattenData() : nextBinding(TQualifier::layoutBindingEnd) { }
@@ -247,6 +250,14 @@ protected:
     // Test method names
     bool isSamplerMethod(const TString& name) const;
     bool isStructBufferMethod(const TString& name) const;
+
+    TType* getStructBufferContentType(const TType& type) const;
+    bool isStructBufferType(const TType& type) const { return getStructBufferContentType(type) != nullptr; }
+    TIntermTyped* indexStructBufferContent(const TSourceLoc& loc, TIntermTyped* buffer) const;
+
+    // Return true if this type is a reference.  This is not currently a type method in case that's
+    // a language specific answer.
+    bool isReference(const TType& type) const { return isStructBufferType(type); }
 
     // Pass through to base class after remembering builtin mappings.
     using TParseContextBase::trackLinkage;
@@ -329,6 +340,9 @@ protected:
 
     // Structure splitting data:
     TMap<int, TVariable*>              splitIoVars;  // variables with the builtin interstage IO removed, indexed by unique ID.
+
+    // Structuredbuffer shared types.  Typically there are only a few.
+    TVector<TType*> structBufferTypes;
 
     // The builtin interstage IO map considers e.g, EvqPosition on input and output separately, so that we
     // can build the linkage correctly if position appears on both sides.  Otherwise, multiple positions


### PR DESCRIPTION
This PR adds the ability to pass structuredbuffer types by reference as function parameters.

It also changes the representation of structuredbuffers from anonymous blocks with named members, to named blocks with pseudonymous members. That should not be an externally visible change.

Local copies of struct buffer references are not currently handled, as in:
   StructuredBuffer&lt;uint4&gt; sbuf_copy = sbuf;
