### PR TITLE
HLSL: small fix for index type in f16tof32 opcode

### DIFF
--- a/Test/baseResults/hlsl.intrinsics.f1632.frag.out
+++ b/Test/baseResults/hlsl.intrinsics.f1632.frag.out
@@ -11,7 +11,7 @@ gl_FragCoord origin is upper left
 0:3          unpackHalf2x16 (temp 2-component vector of float)
 0:3            'inF0' (in uint)
 0:3          Constant:
-0:3            0.000000
+0:3            0 (const int)
 0:7  Function Definition: PixelShaderFunction1(vu1; (temp 1-component vector of float)
 0:7    Function Parameters: 
 0:7      'inF0' (in 1-component vector of uint)
@@ -32,7 +32,7 @@ gl_FragCoord origin is upper left
 0:13                Constant:
 0:13                  0 (const int)
 0:13            Constant:
-0:13              0.000000
+0:13              0 (const int)
 0:13          direct index (temp float)
 0:13            unpackHalf2x16 (temp 2-component vector of float)
 0:13              direct index (temp uint)
@@ -40,7 +40,7 @@ gl_FragCoord origin is upper left
 0:13                Constant:
 0:13                  1 (const int)
 0:13            Constant:
-0:13              0.000000
+0:13              0 (const int)
 0:17  Function Definition: PixelShaderFunction3(vu3; (temp 3-component vector of float)
 0:17    Function Parameters: 
 0:17      'inF0' (in 3-component vector of uint)
@@ -54,7 +54,7 @@ gl_FragCoord origin is upper left
 0:18                Constant:
 0:18                  0 (const int)
 0:18            Constant:
-0:18              0.000000
+0:18              0 (const int)
 0:18          direct index (temp float)
 0:18            unpackHalf2x16 (temp 2-component vector of float)
 0:18              direct index (temp uint)
@@ -62,7 +62,7 @@ gl_FragCoord origin is upper left
 0:18                Constant:
 0:18                  1 (const int)
 0:18            Constant:
-0:18              0.000000
+0:18              0 (const int)
 0:18          direct index (temp float)
 0:18            unpackHalf2x16 (temp 2-component vector of float)
 0:18              direct index (temp uint)
@@ -70,7 +70,7 @@ gl_FragCoord origin is upper left
 0:18                Constant:
 0:18                  2 (const int)
 0:18            Constant:
-0:18              0.000000
+0:18              0 (const int)
 0:22  Function Definition: PixelShaderFunction(vu4; (temp 4-component vector of float)
 0:22    Function Parameters: 
 0:22      'inF0' (in 4-component vector of uint)
@@ -84,7 +84,7 @@ gl_FragCoord origin is upper left
 0:23                Constant:
 0:23                  0 (const int)
 0:23            Constant:
-0:23              0.000000
+0:23              0 (const int)
 0:23          direct index (temp float)
 0:23            unpackHalf2x16 (temp 2-component vector of float)
 0:23              direct index (temp uint)
@@ -92,7 +92,7 @@ gl_FragCoord origin is upper left
 0:23                Constant:
 0:23                  1 (const int)
 0:23            Constant:
-0:23              0.000000
+0:23              0 (const int)
 0:23          direct index (temp float)
 0:23            unpackHalf2x16 (temp 2-component vector of float)
 0:23              direct index (temp uint)
@@ -100,7 +100,7 @@ gl_FragCoord origin is upper left
 0:23                Constant:
 0:23                  2 (const int)
 0:23            Constant:
-0:23              0.000000
+0:23              0 (const int)
 0:23          direct index (temp float)
 0:23            unpackHalf2x16 (temp 2-component vector of float)
 0:23              direct index (temp uint)
@@ -108,7 +108,7 @@ gl_FragCoord origin is upper left
 0:23                Constant:
 0:23                  3 (const int)
 0:23            Constant:
-0:23              0.000000
+0:23              0 (const int)
 0:27  Function Definition: @main( (temp 4-component vector of float)
 0:27    Function Parameters: 
 0:?     Sequence
@@ -143,7 +143,7 @@ gl_FragCoord origin is upper left
 0:3          unpackHalf2x16 (temp 2-component vector of float)
 0:3            'inF0' (in uint)
 0:3          Constant:
-0:3            0.000000
+0:3            0 (const int)
 0:7  Function Definition: PixelShaderFunction1(vu1; (temp 1-component vector of float)
 0:7    Function Parameters: 
 0:7      'inF0' (in 1-component vector of uint)
@@ -164,7 +164,7 @@ gl_FragCoord origin is upper left
 0:13                Constant:
 0:13                  0 (const int)
 0:13            Constant:
-0:13              0.000000
+0:13              0 (const int)
 0:13          direct index (temp float)
 0:13            unpackHalf2x16 (temp 2-component vector of float)
 0:13              direct index (temp uint)
@@ -172,7 +172,7 @@ gl_FragCoord origin is upper left
 0:13                Constant:
 0:13                  1 (const int)
 0:13            Constant:
-0:13              0.000000
+0:13              0 (const int)
 0:17  Function Definition: PixelShaderFunction3(vu3; (temp 3-component vector of float)
 0:17    Function Parameters: 
 0:17      'inF0' (in 3-component vector of uint)
@@ -186,7 +186,7 @@ gl_FragCoord origin is upper left
 0:18                Constant:
 0:18                  0 (const int)
 0:18            Constant:
-0:18              0.000000
+0:18              0 (const int)
 0:18          direct index (temp float)
 0:18            unpackHalf2x16 (temp 2-component vector of float)
 0:18              direct index (temp uint)
@@ -194,7 +194,7 @@ gl_FragCoord origin is upper left
 0:18                Constant:
 0:18                  1 (const int)
 0:18            Constant:
-0:18              0.000000
+0:18              0 (const int)
 0:18          direct index (temp float)
 0:18            unpackHalf2x16 (temp 2-component vector of float)
 0:18              direct index (temp uint)
@@ -202,7 +202,7 @@ gl_FragCoord origin is upper left
 0:18                Constant:
 0:18                  2 (const int)
 0:18            Constant:
-0:18              0.000000
+0:18              0 (const int)
 0:22  Function Definition: PixelShaderFunction(vu4; (temp 4-component vector of float)
 0:22    Function Parameters: 
 0:22      'inF0' (in 4-component vector of uint)
@@ -216,7 +216,7 @@ gl_FragCoord origin is upper left
 0:23                Constant:
 0:23                  0 (const int)
 0:23            Constant:
-0:23              0.000000
+0:23              0 (const int)
 0:23          direct index (temp float)
 0:23            unpackHalf2x16 (temp 2-component vector of float)
 0:23              direct index (temp uint)
@@ -224,7 +224,7 @@ gl_FragCoord origin is upper left
 0:23                Constant:
 0:23                  1 (const int)
 0:23            Constant:
-0:23              0.000000
+0:23              0 (const int)
 0:23          direct index (temp float)
 0:23            unpackHalf2x16 (temp 2-component vector of float)
 0:23              direct index (temp uint)
@@ -232,7 +232,7 @@ gl_FragCoord origin is upper left
 0:23                Constant:
 0:23                  2 (const int)
 0:23            Constant:
-0:23              0.000000
+0:23              0 (const int)
 0:23          direct index (temp float)
 0:23            unpackHalf2x16 (temp 2-component vector of float)
 0:23              direct index (temp uint)
@@ -240,7 +240,7 @@ gl_FragCoord origin is upper left
 0:23                Constant:
 0:23                  3 (const int)
 0:23            Constant:
-0:23              0.000000
+0:23              0 (const int)
 0:27  Function Definition: @main( (temp 4-component vector of float)
 0:27    Function Parameters: 
 0:?     Sequence

--- a/Test/baseResults/hlsl.intrinsics.negative.frag.out
+++ b/Test/baseResults/hlsl.intrinsics.negative.frag.out
@@ -112,7 +112,7 @@ ERROR: node is still EOpNull!
 0:12          Convert float to uint (temp uint)
 0:12            'inF0' (in float)
 0:12        Constant:
-0:12          0.000000
+0:12          0 (const int)
 0:13      findMSB (temp uint)
 0:13        Convert float to uint (temp uint)
 0:13          'inF0' (in float)
@@ -202,7 +202,7 @@ ERROR: node is still EOpNull!
 0:52              Constant:
 0:52                0 (const int)
 0:52          Constant:
-0:52            0.000000
+0:52            0 (const int)
 0:52        direct index (temp float)
 0:52          unpackHalf2x16 (temp 2-component vector of float)
 0:52            direct index (temp uint)
@@ -211,7 +211,7 @@ ERROR: node is still EOpNull!
 0:52              Constant:
 0:52                1 (const int)
 0:52          Constant:
-0:52            0.000000
+0:52            0 (const int)
 0:53      findMSB (temp 2-component vector of uint)
 0:53        Convert float to uint (temp 2-component vector of uint)
 0:53          'inF0' (in 2-component vector of float)
@@ -252,7 +252,7 @@ ERROR: node is still EOpNull!
 0:68              Constant:
 0:68                0 (const int)
 0:68          Constant:
-0:68            0.000000
+0:68            0 (const int)
 0:68        direct index (temp float)
 0:68          unpackHalf2x16 (temp 2-component vector of float)
 0:68            direct index (temp uint)
@@ -261,7 +261,7 @@ ERROR: node is still EOpNull!
 0:68              Constant:
 0:68                1 (const int)
 0:68          Constant:
-0:68            0.000000
+0:68            0 (const int)
 0:68        direct index (temp float)
 0:68          unpackHalf2x16 (temp 2-component vector of float)
 0:68            direct index (temp uint)
@@ -270,7 +270,7 @@ ERROR: node is still EOpNull!
 0:68              Constant:
 0:68                2 (const int)
 0:68          Constant:
-0:68            0.000000
+0:68            0 (const int)
 0:69      findMSB (temp 3-component vector of uint)
 0:69        Convert float to uint (temp 3-component vector of uint)
 0:69          'inF0' (in 3-component vector of float)
@@ -315,7 +315,7 @@ ERROR: node is still EOpNull!
 0:85              Constant:
 0:85                0 (const int)
 0:85          Constant:
-0:85            0.000000
+0:85            0 (const int)
 0:85        direct index (temp float)
 0:85          unpackHalf2x16 (temp 2-component vector of float)
 0:85            direct index (temp uint)
@@ -324,7 +324,7 @@ ERROR: node is still EOpNull!
 0:85              Constant:
 0:85                1 (const int)
 0:85          Constant:
-0:85            0.000000
+0:85            0 (const int)
 0:85        direct index (temp float)
 0:85          unpackHalf2x16 (temp 2-component vector of float)
 0:85            direct index (temp uint)
@@ -333,7 +333,7 @@ ERROR: node is still EOpNull!
 0:85              Constant:
 0:85                2 (const int)
 0:85          Constant:
-0:85            0.000000
+0:85            0 (const int)
 0:85        direct index (temp float)
 0:85          unpackHalf2x16 (temp 2-component vector of float)
 0:85            direct index (temp uint)
@@ -342,7 +342,7 @@ ERROR: node is still EOpNull!
 0:85              Constant:
 0:85                3 (const int)
 0:85          Constant:
-0:85            0.000000
+0:85            0 (const int)
 0:86      findMSB (temp 4-component vector of uint)
 0:86        Convert float to uint (temp 4-component vector of uint)
 0:86          'inF0' (in 4-component vector of float)
@@ -574,7 +574,7 @@ ERROR: node is still EOpNull!
 0:12          Convert float to uint (temp uint)
 0:12            'inF0' (in float)
 0:12        Constant:
-0:12          0.000000
+0:12          0 (const int)
 0:13      findMSB (temp uint)
 0:13        Convert float to uint (temp uint)
 0:13          'inF0' (in float)
@@ -664,7 +664,7 @@ ERROR: node is still EOpNull!
 0:52              Constant:
 0:52                0 (const int)
 0:52          Constant:
-0:52            0.000000
+0:52            0 (const int)
 0:52        direct index (temp float)
 0:52          unpackHalf2x16 (temp 2-component vector of float)
 0:52            direct index (temp uint)
@@ -673,7 +673,7 @@ ERROR: node is still EOpNull!
 0:52              Constant:
 0:52                1 (const int)
 0:52          Constant:
-0:52            0.000000
+0:52            0 (const int)
 0:53      findMSB (temp 2-component vector of uint)
 0:53        Convert float to uint (temp 2-component vector of uint)
 0:53          'inF0' (in 2-component vector of float)
@@ -714,7 +714,7 @@ ERROR: node is still EOpNull!
 0:68              Constant:
 0:68                0 (const int)
 0:68          Constant:
-0:68            0.000000
+0:68            0 (const int)
 0:68        direct index (temp float)
 0:68          unpackHalf2x16 (temp 2-component vector of float)
 0:68            direct index (temp uint)
@@ -723,7 +723,7 @@ ERROR: node is still EOpNull!
 0:68              Constant:
 0:68                1 (const int)
 0:68          Constant:
-0:68            0.000000
+0:68            0 (const int)
 0:68        direct index (temp float)
 0:68          unpackHalf2x16 (temp 2-component vector of float)
 0:68            direct index (temp uint)
@@ -732,7 +732,7 @@ ERROR: node is still EOpNull!
 0:68              Constant:
 0:68                2 (const int)
 0:68          Constant:
-0:68            0.000000
+0:68            0 (const int)
 0:69      findMSB (temp 3-component vector of uint)
 0:69        Convert float to uint (temp 3-component vector of uint)
 0:69          'inF0' (in 3-component vector of float)
@@ -777,7 +777,7 @@ ERROR: node is still EOpNull!
 0:85              Constant:
 0:85                0 (const int)
 0:85          Constant:
-0:85            0.000000
+0:85            0 (const int)
 0:85        direct index (temp float)
 0:85          unpackHalf2x16 (temp 2-component vector of float)
 0:85            direct index (temp uint)
@@ -786,7 +786,7 @@ ERROR: node is still EOpNull!
 0:85              Constant:
 0:85                1 (const int)
 0:85          Constant:
-0:85            0.000000
+0:85            0 (const int)
 0:85        direct index (temp float)
 0:85          unpackHalf2x16 (temp 2-component vector of float)
 0:85            direct index (temp uint)
@@ -795,7 +795,7 @@ ERROR: node is still EOpNull!
 0:85              Constant:
 0:85                2 (const int)
 0:85          Constant:
-0:85            0.000000
+0:85            0 (const int)
 0:85        direct index (temp float)
 0:85          unpackHalf2x16 (temp 2-component vector of float)
 0:85            direct index (temp uint)
@@ -804,7 +804,7 @@ ERROR: node is still EOpNull!
 0:85              Constant:
 0:85                3 (const int)
 0:85          Constant:
-0:85            0.000000
+0:85            0 (const int)
 0:86      findMSB (temp 4-component vector of uint)
 0:86        Convert float to uint (temp 4-component vector of uint)
 0:86          'inF0' (in 4-component vector of float)

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -3587,7 +3587,7 @@ void HlslParseContext::decomposeIntrinsic(const TSourceLoc& loc, TIntermTyped*& 
         {
             // input uvecN with low 16 bits of each component holding a float16.  convert to float32.
             TIntermTyped* argValue = node->getAsUnaryNode()->getOperand();
-            TIntermTyped* zero = intermediate.addConstantUnion(0.0, EbtFloat, loc, true);
+            TIntermTyped* zero = intermediate.addConstantUnion(0, loc, true);
             const int vecSize = argValue->getType().getVectorSize();
 
             TOperator constructOp = EOpNull;


### PR DESCRIPTION
Due to a cut and paste error, the f16tof32 opcode was indexing a vector with a float 0, rather than an int 0.  It may have made no functional difference due to the identical bit pattern, but code looking at the type could be confused.
