### PR TITLE
Sanitize ShaderLang.h

### DIFF
--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -203,14 +203,6 @@ SH_IMPORT_EXPORT int ShCompile(
     EShMessages messages = EShMsgDefault // warnings and errors
     );
 
-SH_IMPORT_EXPORT int ShLink(
-    const ShHandle,               // linker object
-    const ShHandle h[],           // compiler objects to link together
-    const int numHandles,
-    ShHandle uniformMap,          // updated with new uniforms
-    short int** uniformsAccessed,  // returned with indexes of uniforms accessed
-    int* numUniformsAccessed);
-
 SH_IMPORT_EXPORT int ShLinkExt(
     const ShHandle,               // linker object
     const ShHandle h[],           // compiler objects to link together


### PR DESCRIPTION
`ShaderLang.h` contains declaration for `ShLink` function which is never
defined.

See this grep output:

```
$ grep -Hrn 'ShLink'
glslang/Public/ShaderLang.h:206:SH_IMPORT_EXPORT int ShLink(
glslang/Public/ShaderLang.h:214:SH_IMPORT_EXPORT int ShLinkExt(
glslang/MachineIndependent/ShaderLang.cpp:1268:int ShLinkExt(
```