### PR TITLE
Fix build warnings on some platforms

### DIFF
--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
+++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
@@ -1052,7 +1052,7 @@ int TPpContext::tMacroInput::scan(TPpToken* ppToken)
     // TODO: preprocessor:  properly handle whitespace (or lack of it) between tokens when expanding
     if (token == PpAtomIdentifier) {
         int i;
-        for (i = mac->args.size() - 1; i >= 0; i--)
+        for (i = (int)mac->args.size() - 1; i >= 0; i--)
             if (strcmp(pp->atomStrings.getString(mac->args[i]), ppToken->name) == 0)
                 break;
         if (i >= 0) {

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -2452,7 +2452,7 @@ void HlslParseContext::decomposeStructBufferMethods(const TSourceLoc& loc, TInte
 
     case EOpMethodGetDimensions:
         {
-            const int numArgs = argAggregate->getSequence().size();
+            const int numArgs = (int)argAggregate->getSequence().size();
             TIntermTyped* argNumItems = argAggregate->getSequence()[1]->getAsTyped();  // out num items
             TIntermTyped* argStride   = numArgs > 2 ? argAggregate->getSequence()[2]->getAsTyped() : nullptr;  // out stride
 
@@ -3754,7 +3754,7 @@ TIntermTyped* HlslParseContext::handleFunctionCall(const TSourceLoc& loc, TFunct
         // Find it in the symbol table.
         //
         const TFunction* fnCandidate = nullptr;
-        bool builtIn;
+        bool builtIn = false;
 
         // TODO: this needs improvement: there's no way at present to look up a signature in
         // the symbol table for an arbitrary type.  This is a temporary hack until that ability exists.


### PR DESCRIPTION
Use an explicit cast from size_t to int to avoid errors like the following:
glslang\glslang\MachineIndependent\preprocessor\Pp.cpp(1053) : error C2220: warning treated as error - no 'object' file generated
glslang\glslang\MachineIndependent\preprocessor\Pp.cpp(1053) : warning C4267: '=' : conversion from 'size_t' to 'int', possible loss of data

affects Pp.cpp, hlslParseHelper.cpp.

Initialize local variable to get rid of warnings about potentially
uninitialized variables:
glslang\hlsl\hlslparsehelper.cpp(3667) : error C2220: warning treated as error - no 'object' file generated
glslang\hlsl\hlslparsehelper.cpp(3667) : warning C4701: potentially uninitialized local variable 'builtIn' used

affects hlslParseHelper.cpp