### PR TITLE
Rename KHX_multiview/device_group to EXT_multiview/device to match the released specs

### DIFF
--- a/Test/baseResults/spv.deviceGroup.frag.out
+++ b/Test/baseResults/spv.deviceGroup.frag.out
@@ -13,11 +13,11 @@ Warning, version 450 is not yet complete; most version-specific features are pre
                               EntryPoint Fragment 4  "main" 9
                               ExecutionMode 4 OriginUpperLeft
                               Source GLSL 450
-                              SourceExtension  "GL_KHX_device_group"
+                              SourceExtension  "GL_EXT_device_group"
                               Name 4  "main"
                               Name 9  "color"
-                              Name 12  "gl_DeviceIndexKHR"
-                              Decorate 12(gl_DeviceIndexKHR) BuiltIn DeviceIndex
+                              Name 12  "gl_DeviceIndex"
+                              Decorate 12(gl_DeviceIndex) BuiltIn DeviceIndex
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -26,11 +26,11 @@ Warning, version 450 is not yet complete; most version-specific features are pre
         9(color):      8(ptr) Variable Output
               10:             TypeInt 32 1
               11:             TypePointer UniformConstant 10(int)
-12(gl_DeviceIndexKHR):     11(ptr) Variable UniformConstant
+12(gl_DeviceIndex):     11(ptr) Variable UniformConstant
               15:    6(float) Constant 0
          4(main):           2 Function None 3
                5:             Label
-              13:     10(int) Load 12(gl_DeviceIndexKHR)
+              13:     10(int) Load 12(gl_DeviceIndex)
               14:    6(float) ConvertSToF 13
               16:    7(fvec4) CompositeConstruct 14 15 15 15
                               Store 9(color) 16

--- a/Test/baseResults/spv.multiView.frag.out
+++ b/Test/baseResults/spv.multiView.frag.out
@@ -13,11 +13,11 @@ Warning, version 450 is not yet complete; most version-specific features are pre
                               EntryPoint Fragment 4  "main" 9
                               ExecutionMode 4 OriginUpperLeft
                               Source GLSL 450
-                              SourceExtension  "GL_KHX_multiview"
+                              SourceExtension  "GL_EXT_multiview"
                               Name 4  "main"
                               Name 9  "color"
-                              Name 12  "gl_ViewIndexKHR"
-                              Decorate 12(gl_ViewIndexKHR) BuiltIn ViewIndex
+                              Name 12  "gl_ViewIndex"
+                              Decorate 12(gl_ViewIndex) BuiltIn ViewIndex
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -26,11 +26,11 @@ Warning, version 450 is not yet complete; most version-specific features are pre
         9(color):      8(ptr) Variable Output
               10:             TypeInt 32 1
               11:             TypePointer UniformConstant 10(int)
-12(gl_ViewIndexKHR):     11(ptr) Variable UniformConstant
+12(gl_ViewIndex):     11(ptr) Variable UniformConstant
               15:    6(float) Constant 0
          4(main):           2 Function None 3
                5:             Label
-              13:     10(int) Load 12(gl_ViewIndexKHR)
+              13:     10(int) Load 12(gl_ViewIndex)
               14:    6(float) ConvertSToF 13
               16:    7(fvec4) CompositeConstruct 14 15 15 15
                               Store 9(color) 16

--- a/Test/spv.deviceGroup.frag
+++ b/Test/spv.deviceGroup.frag
@@ -1,9 +1,9 @@
 #version 450
 
-#extension GL_KHX_device_group : enable
+#extension GL_EXT_device_group : enable
 
 out vec4 color;
 
 void main() {
-    color = vec4(gl_DeviceIndexKHR, 0, 0, 0);
+    color = vec4(gl_DeviceIndex, 0, 0, 0);
 }

--- a/Test/spv.multiView.frag
+++ b/Test/spv.multiView.frag
@@ -1,9 +1,9 @@
 #version 450
 
-#extension GL_KHX_multiview : enable
+#extension GL_EXT_multiview : enable
 
 out vec4 color;
 
 void main() {
-    color = vec4(gl_ViewIndexKHR, 0, 0, 0);
+    color = vec4(gl_ViewIndex, 0, 0, 0);
 }

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -3702,8 +3702,8 @@ void TBuiltIns::initialize(int version, EProfile profile, const SpvVersion& spvV
     }
 
     if (profile != EEsProfile) {
-        commonBuiltins.append("uniform int gl_ViewIndexKHR;");
-        commonBuiltins.append("uniform int gl_DeviceIndexKHR;");  // GL_KHX_device_group
+        commonBuiltins.append("uniform int gl_ViewIndex;");
+        commonBuiltins.append("uniform int gl_DeviceIndex;");  // GL_EXT_device_group
     }
 
     // printf("%s\n", commonBuiltins.c_str());
@@ -5318,10 +5318,10 @@ void TBuiltIns::identifyBuiltIns(int version, EProfile profile, const SpvVersion
         }
 
         if (profile != EEsProfile) {
-            symbolTable.setFunctionExtensions("gl_DeviceIndexKHR",  1, &E_GL_KHX_device_group);
-            BuiltInVariable("gl_DeviceIndexKHR", EbvDeviceIndex, symbolTable);
-            symbolTable.setFunctionExtensions("gl_ViewIndexKHR", 1, &E_GL_KHX_multiview);
-            BuiltInVariable("gl_ViewIndexKHR", EbvViewIndex, symbolTable);
+            symbolTable.setFunctionExtensions("gl_DeviceIndex",  1, &E_GL_EXT_device_group);
+            BuiltInVariable("gl_DeviceIndex", EbvDeviceIndex, symbolTable);
+            symbolTable.setFunctionExtensions("gl_ViewIndex", 1, &E_GL_EXT_multiview);
+            BuiltInVariable("gl_ViewIndex", EbvViewIndex, symbolTable);
         }
         break;
 

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -233,9 +233,9 @@ void TParseVersions::initializeExtensionBehavior()
     extensionBehavior[E_GL_OES_texture_buffer]           = EBhDisable;
     extensionBehavior[E_GL_OES_texture_cube_map_array]   = EBhDisable;
 
-    // KHX extensions
-    extensionBehavior[E_GL_KHX_device_group]             = EBhDisable;
-    extensionBehavior[E_GL_KHX_multiview]                = EBhDisable;
+    // EXT extensions
+    extensionBehavior[E_GL_EXT_device_group]             = EBhDisable;
+    extensionBehavior[E_GL_EXT_multiview]                = EBhDisable;
 }
 
 // Get code that is not part of a shared symbol table, is specific to this shader,

--- a/glslang/MachineIndependent/Versions.h
+++ b/glslang/MachineIndependent/Versions.h
@@ -132,9 +132,9 @@ const char* const E_GL_ARB_sparse_texture_clamp         = "GL_ARB_sparse_texture
 const char* const E_GL_EXT_shader_non_constant_global_initializers = "GL_EXT_shader_non_constant_global_initializers";
 const char* const E_GL_EXT_shader_image_load_formatted = "GL_EXT_shader_image_load_formatted";
 
-// KHX extensions
-const char* const E_GL_KHX_device_group                 = "GL_KHX_device_group";
-const char* const E_GL_KHX_multiview                    = "GL_KHX_multiview";
+// EXT extensions
+const char* const E_GL_EXT_device_group                 = "GL_EXT_device_group";
+const char* const E_GL_EXT_multiview                    = "GL_EXT_multiview";
 
 // #line and #include
 const char* const E_GL_GOOGLE_cpp_style_line_directive          = "GL_GOOGLE_cpp_style_line_directive";


### PR DESCRIPTION
GL_KHX_multiview and GL_KHX_device_group don't exist,
they were released as GL_EXT_multiview and GL_EXT_device_group.

https://www.khronos.org/registry/vulkan/specs/misc/GL_EXT_device_group.txt
https://www.khronos.org/registry/vulkan/specs/misc/GL_EXT_multiview.txt