### PR TITLE
HLSL: Fix ordering defect if global SB decl after fn param

### DIFF
--- a/Test/baseResults/hlsl.structbuffer.fn.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.fn.frag.out
@@ -2,59 +2,59 @@ hlsl.structbuffer.fn.frag
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:9  Function Definition: get(block--vu4[0]1;u1; (temp 4-component vector of uint)
-0:9    Function Parameters: 
-0:9      'sb' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
-0:9      'bufferOffset' (in uint)
+0:5  Function Definition: get(block--vu4[0]1;u1; (temp 4-component vector of uint)
+0:5    Function Parameters: 
+0:5      'sb' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:5      'bufferOffset' (in uint)
 0:?     Sequence
-0:10      Branch: Return with expression
-0:10        indirect index (layout(row_major std430 ) buffer 4-component vector of uint)
-0:10          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint)
-0:10            'sb' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
-0:10            Constant:
-0:10              0 (const uint)
-0:10          'bufferOffset' (in uint)
-0:14  Function Definition: set(block--vu4[0]1;u1;vu4; (temp void)
-0:14    Function Parameters: 
-0:14      'sb' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
-0:14      'bufferOffset' (in uint)
-0:14      'data' (in 4-component vector of uint)
+0:6      Branch: Return with expression
+0:6        indirect index (layout(row_major std430 ) buffer 4-component vector of uint)
+0:6          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint)
+0:6            'sb' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:6            Constant:
+0:6              0 (const uint)
+0:6          'bufferOffset' (in uint)
+0:10  Function Definition: set(block--vu4[0]1;u1;vu4; (temp void)
+0:10    Function Parameters: 
+0:10      'sb' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:10      'bufferOffset' (in uint)
+0:10      'data' (in 4-component vector of uint)
 0:?     Sequence
-0:15      move second child to first child (temp 4-component vector of uint)
-0:15        indirect index (layout(row_major std430 ) buffer 4-component vector of uint)
-0:15          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint)
-0:15            'sb' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
-0:15            Constant:
-0:15              0 (const uint)
-0:15          'bufferOffset' (in uint)
-0:15        'data' (in 4-component vector of uint)
-0:19  Function Definition: @main(u1; (temp 4-component vector of float)
-0:19    Function Parameters: 
-0:19      'pos' (in uint)
+0:11      move second child to first child (temp 4-component vector of uint)
+0:11        indirect index (buffer 4-component vector of uint)
+0:11          @data: direct index for structure (buffer implicitly-sized array of 4-component vector of uint)
+0:11            'sb' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:11            Constant:
+0:11              0 (const uint)
+0:11          'bufferOffset' (in uint)
+0:11        'data' (in 4-component vector of uint)
+0:20  Function Definition: @main(u1; (temp 4-component vector of float)
+0:20    Function Parameters: 
+0:20      'pos' (in uint)
 0:?     Sequence
-0:20      Function Call: set(block--vu4[0]1;u1;vu4; (temp void)
-0:20        'sbuf2' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
-0:20        Constant:
-0:20          2 (const uint)
-0:20        Function Call: get(block--vu4[0]1;u1; (temp 4-component vector of uint)
-0:20          'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
-0:20          Constant:
-0:20            3 (const uint)
-0:22      Branch: Return with expression
-0:22        Constant:
-0:22          0.000000
-0:22          0.000000
-0:22          0.000000
-0:22          0.000000
-0:19  Function Definition: main( (temp void)
-0:19    Function Parameters: 
+0:21      Function Call: set(block--vu4[0]1;u1;vu4; (temp void)
+0:21        'sbuf2' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:21        Constant:
+0:21          2 (const uint)
+0:21        Function Call: get(block--vu4[0]1;u1; (temp 4-component vector of uint)
+0:21          'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:21          Constant:
+0:21            3 (const uint)
+0:23      Branch: Return with expression
+0:23        Constant:
+0:23          0.000000
+0:23          0.000000
+0:23          0.000000
+0:23          0.000000
+0:20  Function Definition: main( (temp void)
+0:20    Function Parameters: 
 0:?     Sequence
-0:19      move second child to first child (temp uint)
+0:20      move second child to first child (temp uint)
 0:?         'pos' (temp uint)
 0:?         'pos' (layout(location=0 ) in uint)
-0:19      move second child to first child (temp 4-component vector of float)
+0:20      move second child to first child (temp 4-component vector of float)
 0:?         '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
-0:19        Function Call: @main(u1; (temp 4-component vector of float)
+0:20        Function Call: @main(u1; (temp 4-component vector of float)
 0:?           'pos' (temp uint)
 0:?   Linker Objects
 0:?     'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
@@ -70,59 +70,59 @@ Linked fragment stage:
 Shader version: 450
 gl_FragCoord origin is upper left
 0:? Sequence
-0:9  Function Definition: get(block--vu4[0]1;u1; (temp 4-component vector of uint)
-0:9    Function Parameters: 
-0:9      'sb' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
-0:9      'bufferOffset' (in uint)
+0:5  Function Definition: get(block--vu4[0]1;u1; (temp 4-component vector of uint)
+0:5    Function Parameters: 
+0:5      'sb' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:5      'bufferOffset' (in uint)
 0:?     Sequence
-0:10      Branch: Return with expression
-0:10        indirect index (layout(row_major std430 ) buffer 4-component vector of uint)
-0:10          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint)
-0:10            'sb' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
-0:10            Constant:
-0:10              0 (const uint)
-0:10          'bufferOffset' (in uint)
-0:14  Function Definition: set(block--vu4[0]1;u1;vu4; (temp void)
-0:14    Function Parameters: 
-0:14      'sb' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
-0:14      'bufferOffset' (in uint)
-0:14      'data' (in 4-component vector of uint)
+0:6      Branch: Return with expression
+0:6        indirect index (layout(row_major std430 ) buffer 4-component vector of uint)
+0:6          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint)
+0:6            'sb' (layout(row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:6            Constant:
+0:6              0 (const uint)
+0:6          'bufferOffset' (in uint)
+0:10  Function Definition: set(block--vu4[0]1;u1;vu4; (temp void)
+0:10    Function Parameters: 
+0:10      'sb' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:10      'bufferOffset' (in uint)
+0:10      'data' (in 4-component vector of uint)
 0:?     Sequence
-0:15      move second child to first child (temp 4-component vector of uint)
-0:15        indirect index (layout(row_major std430 ) buffer 4-component vector of uint)
-0:15          @data: direct index for structure (layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint)
-0:15            'sb' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
-0:15            Constant:
-0:15              0 (const uint)
-0:15          'bufferOffset' (in uint)
-0:15        'data' (in 4-component vector of uint)
-0:19  Function Definition: @main(u1; (temp 4-component vector of float)
-0:19    Function Parameters: 
-0:19      'pos' (in uint)
+0:11      move second child to first child (temp 4-component vector of uint)
+0:11        indirect index (buffer 4-component vector of uint)
+0:11          @data: direct index for structure (buffer implicitly-sized array of 4-component vector of uint)
+0:11            'sb' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:11            Constant:
+0:11              0 (const uint)
+0:11          'bufferOffset' (in uint)
+0:11        'data' (in 4-component vector of uint)
+0:20  Function Definition: @main(u1; (temp 4-component vector of float)
+0:20    Function Parameters: 
+0:20      'pos' (in uint)
 0:?     Sequence
-0:20      Function Call: set(block--vu4[0]1;u1;vu4; (temp void)
-0:20        'sbuf2' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
-0:20        Constant:
-0:20          2 (const uint)
-0:20        Function Call: get(block--vu4[0]1;u1; (temp 4-component vector of uint)
-0:20          'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
-0:20          Constant:
-0:20            3 (const uint)
-0:22      Branch: Return with expression
-0:22        Constant:
-0:22          0.000000
-0:22          0.000000
-0:22          0.000000
-0:22          0.000000
-0:19  Function Definition: main( (temp void)
-0:19    Function Parameters: 
+0:21      Function Call: set(block--vu4[0]1;u1;vu4; (temp void)
+0:21        'sbuf2' (layout(row_major std430 ) buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:21        Constant:
+0:21          2 (const uint)
+0:21        Function Call: get(block--vu4[0]1;u1; (temp 4-component vector of uint)
+0:21          'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})
+0:21          Constant:
+0:21            3 (const uint)
+0:23      Branch: Return with expression
+0:23        Constant:
+0:23          0.000000
+0:23          0.000000
+0:23          0.000000
+0:23          0.000000
+0:20  Function Definition: main( (temp void)
+0:20    Function Parameters: 
 0:?     Sequence
-0:19      move second child to first child (temp uint)
+0:20      move second child to first child (temp uint)
 0:?         'pos' (temp uint)
 0:?         'pos' (layout(location=0 ) in uint)
-0:19      move second child to first child (temp 4-component vector of float)
+0:20      move second child to first child (temp 4-component vector of float)
 0:?         '@entryPointOutput' (layout(location=0 ) out 4-component vector of float)
-0:19        Function Call: @main(u1; (temp 4-component vector of float)
+0:20        Function Call: @main(u1; (temp 4-component vector of float)
 0:?           'pos' (temp uint)
 0:?   Linker Objects
 0:?     'sbuf' (layout(binding=10 row_major std430 ) readonly buffer block{layout(row_major std430 ) buffer implicitly-sized array of 4-component vector of uint @data})

--- a/Test/hlsl.structbuffer.fn.frag
+++ b/Test/hlsl.structbuffer.fn.frag
@@ -1,9 +1,5 @@
 
 StructuredBuffer<uint4>  sbuf : register(t10);
-RWStructuredBuffer<uint4> sbuf2;
-
-// Not shared, because of type difference.
-StructuredBuffer<uint3>  sbuf3 : register(t12);
 
 uint4 get(in StructuredBuffer<uint4> sb, uint bufferOffset)
 {
@@ -14,6 +10,11 @@ void set(in RWStructuredBuffer<uint4> sb, uint bufferOffset, uint4 data)
 {
     sb[bufferOffset] = data;
 }
+
+RWStructuredBuffer<uint4> sbuf2;
+
+// Not shared, because of type difference.
+StructuredBuffer<uint3>  sbuf3 : register(t12);
 
 float4 main(uint pos : FOO) : SV_Target0
 {

--- a/hlsl/hlslGrammar.cpp
+++ b/hlsl/hlslGrammar.cpp
@@ -1874,6 +1874,7 @@ bool HlslGrammar::acceptStructBufferType(TType& type)
     TArraySizes unsizedArray;
     unsizedArray.addInnerSize(UnsizedArraySize);
     templateType->newArraySizes(unsizedArray);
+    templateType->getQualifier().storage = storage;
 
     // field name is canonical for all structbuffers
     templateType->setFieldName("@data");

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -5223,10 +5223,6 @@ void HlslParseContext::shareStructBufferType(TType& type)
         return compareQualifiers(lhs, rhs) && lhs == rhs;
     };
 
-    // TString typeName;
-    // type.appendMangledName(typeName);
-    // type.setTypeName(typeName);
-
     // This is an exhaustive O(N) search, but real world shaders have
     // only a small number of these.
     for (int idx = 0; idx < int(structBufferTypes.size()); ++idx) {
@@ -5241,8 +5237,6 @@ void HlslParseContext::shareStructBufferType(TType& type)
     TType* typeCopy = new TType;
     typeCopy->shallowCopy(type);
     structBufferTypes.push_back(typeCopy);
-
-    // structBuffTypes.push_back(type.getWritableStruct());
 }
 
 void HlslParseContext::paramFix(TType& type)


### PR DESCRIPTION
This change propagates the storage qualifier from the buffer object to its contained array type so that isStructBufferType() realizes it is one.  That propagation was happening before only for global variable declarations, so compilation defects would result if the use of a function parameter happened before a global declaration.

This fixes that case, whether or not there ever is a global declaration, and regardless of the relative order.

This changes the hlsl.structbuffer.fn.frag test to exercise the alternate order.

There are no differences to generated SPIR-V for the cases which successfully compiled before.