### PR TITLE
HLSL: Enable GatherCmpRed.  Green/Blue/Alpha cannot be supported.

### DIFF
--- a/Test/baseResults/hlsl.gathercmpRGBA.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.gathercmpRGBA.offset.dx10.frag.out
@@ -1,0 +1,610 @@
+hlsl.gathercmpRGBA.offset.dx10.frag
+Shader version: 450
+gl_FragCoord origin is upper left
+0:? Sequence
+0:38  Function Definition: @main( (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:38    Function Parameters: 
+0:?     Sequence
+0:45      Sequence
+0:45        move second child to first child (temp 4-component vector of float)
+0:45          'txval001' (temp 4-component vector of float)
+0:45          textureGatherOffset (temp 4-component vector of float)
+0:45            Construct combined texture-sampler (temp sampler2DShadow)
+0:45              'g_tTex2df4' (uniform texture2D)
+0:45              'g_sSampCmp' (layout(binding=0 ) uniform sampler)
+0:45            c2: direct index for structure (layout(offset=8 ) uniform 2-component vector of float)
+0:45              'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform float c1, layout(offset=8 ) uniform 2-component vector of float c2, layout(offset=16 ) uniform 3-component vector of float c3, layout(offset=32 ) uniform 4-component vector of float c4})
+0:45              Constant:
+0:45                1 (const uint)
+0:45            Constant:
+0:45              0.750000
+0:?             Constant:
+0:?               1 (const int)
+0:?               0 (const int)
+0:45            Constant:
+0:45              0 (const int)
+0:46      Sequence
+0:46        move second child to first child (temp 4-component vector of int)
+0:46          'txval011' (temp 4-component vector of int)
+0:46          textureGatherOffset (temp 4-component vector of int)
+0:46            Construct combined texture-sampler (temp isampler2DShadow)
+0:46              'g_tTex2di4' (uniform itexture2D)
+0:46              'g_sSampCmp' (layout(binding=0 ) uniform sampler)
+0:46            c2: direct index for structure (layout(offset=8 ) uniform 2-component vector of float)
+0:46              'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform float c1, layout(offset=8 ) uniform 2-component vector of float c2, layout(offset=16 ) uniform 3-component vector of float c3, layout(offset=32 ) uniform 4-component vector of float c4})
+0:46              Constant:
+0:46                1 (const uint)
+0:46            Constant:
+0:46              0.750000
+0:?             Constant:
+0:?               1 (const int)
+0:?               -1 (const int)
+0:46            Constant:
+0:46              0 (const int)
+0:47      Sequence
+0:47        move second child to first child (temp 4-component vector of uint)
+0:47          'txval021' (temp 4-component vector of uint)
+0:47          textureGatherOffset (temp 4-component vector of uint)
+0:47            Construct combined texture-sampler (temp usampler2DShadow)
+0:47              'g_tTex2du4' (uniform utexture2D)
+0:47              'g_sSampCmp' (layout(binding=0 ) uniform sampler)
+0:47            c2: direct index for structure (layout(offset=8 ) uniform 2-component vector of float)
+0:47              'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform float c1, layout(offset=8 ) uniform 2-component vector of float c2, layout(offset=16 ) uniform 3-component vector of float c3, layout(offset=32 ) uniform 4-component vector of float c4})
+0:47              Constant:
+0:47                1 (const uint)
+0:47            Constant:
+0:47              0.750000
+0:?             Constant:
+0:?               1 (const int)
+0:?               1 (const int)
+0:47            Constant:
+0:47              0 (const int)
+0:49      Sequence
+0:49        move second child to first child (temp 4-component vector of float)
+0:49          'txval004' (temp 4-component vector of float)
+0:49          textureGatherOffsets (temp 4-component vector of float)
+0:49            Construct combined texture-sampler (temp sampler2DShadow)
+0:49              'g_tTex2df4' (uniform texture2D)
+0:49              'g_sSampCmp' (layout(binding=0 ) uniform sampler)
+0:49            c2: direct index for structure (layout(offset=8 ) uniform 2-component vector of float)
+0:49              'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform float c1, layout(offset=8 ) uniform 2-component vector of float c2, layout(offset=16 ) uniform 3-component vector of float c3, layout(offset=32 ) uniform 4-component vector of float c4})
+0:49              Constant:
+0:49                1 (const uint)
+0:49            Constant:
+0:49              0.750000
+0:49            Constant:
+0:49              1 (const int)
+0:49              0 (const int)
+0:49              1 (const int)
+0:49              0 (const int)
+0:49              1 (const int)
+0:49              0 (const int)
+0:49              1 (const int)
+0:49              0 (const int)
+0:49            Constant:
+0:49              0 (const int)
+0:50      Sequence
+0:50        move second child to first child (temp 4-component vector of int)
+0:50          'txval014' (temp 4-component vector of int)
+0:50          textureGatherOffsets (temp 4-component vector of int)
+0:50            Construct combined texture-sampler (temp isampler2DShadow)
+0:50              'g_tTex2di4' (uniform itexture2D)
+0:50              'g_sSampCmp' (layout(binding=0 ) uniform sampler)
+0:50            c2: direct index for structure (layout(offset=8 ) uniform 2-component vector of float)
+0:50              'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform float c1, layout(offset=8 ) uniform 2-component vector of float c2, layout(offset=16 ) uniform 3-component vector of float c3, layout(offset=32 ) uniform 4-component vector of float c4})
+0:50              Constant:
+0:50                1 (const uint)
+0:50            Constant:
+0:50              0.750000
+0:50            Constant:
+0:50              1 (const int)
+0:50              -1 (const int)
+0:50              1 (const int)
+0:50              -1 (const int)
+0:50              1 (const int)
+0:50              -1 (const int)
+0:50              1 (const int)
+0:50              -1 (const int)
+0:50            Constant:
+0:50              0 (const int)
+0:51      Sequence
+0:51        move second child to first child (temp 4-component vector of uint)
+0:51          'txval024' (temp 4-component vector of uint)
+0:51          textureGatherOffsets (temp 4-component vector of uint)
+0:51            Construct combined texture-sampler (temp usampler2DShadow)
+0:51              'g_tTex2du4' (uniform utexture2D)
+0:51              'g_sSampCmp' (layout(binding=0 ) uniform sampler)
+0:51            c2: direct index for structure (layout(offset=8 ) uniform 2-component vector of float)
+0:51              'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform float c1, layout(offset=8 ) uniform 2-component vector of float c2, layout(offset=16 ) uniform 3-component vector of float c3, layout(offset=32 ) uniform 4-component vector of float c4})
+0:51              Constant:
+0:51                1 (const uint)
+0:51            Constant:
+0:51              0.750000
+0:51            Constant:
+0:51              1 (const int)
+0:51              1 (const int)
+0:51              1 (const int)
+0:51              1 (const int)
+0:51              1 (const int)
+0:51              1 (const int)
+0:51              1 (const int)
+0:51              1 (const int)
+0:51            Constant:
+0:51              0 (const int)
+0:114      move second child to first child (temp 4-component vector of float)
+0:114        Color: direct index for structure (temp 4-component vector of float)
+0:114          'psout' (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:114          Constant:
+0:114            0 (const int)
+0:114        Constant:
+0:114          1.000000
+0:114          1.000000
+0:114          1.000000
+0:114          1.000000
+0:115      move second child to first child (temp float)
+0:115        Depth: direct index for structure (temp float)
+0:115          'psout' (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:115          Constant:
+0:115            1 (const int)
+0:115        Constant:
+0:115          1.000000
+0:117      Branch: Return with expression
+0:117        'psout' (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:38  Function Definition: main( (temp void)
+0:38    Function Parameters: 
+0:?     Sequence
+0:38      Sequence
+0:38        move second child to first child (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:38          'flattenTemp' (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:38          Function Call: @main( (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:38        move second child to first child (temp 4-component vector of float)
+0:?           'Color' (layout(location=0 ) out 4-component vector of float)
+0:38          Color: direct index for structure (temp 4-component vector of float)
+0:38            'flattenTemp' (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:38            Constant:
+0:38              0 (const int)
+0:38        move second child to first child (temp float)
+0:?           'Depth' (out float FragDepth)
+0:38          Depth: direct index for structure (temp float)
+0:38            'flattenTemp' (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:38            Constant:
+0:38              1 (const int)
+0:?   Linker Objects
+0:?     'g_sSampCmp' (layout(binding=0 ) uniform sampler)
+0:?     'g_tTex1df4a' (layout(binding=1 ) uniform texture1D)
+0:?     'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
+0:?     'g_tTex1di4' (uniform itexture1D)
+0:?     'g_tTex1du4' (uniform utexture1D)
+0:?     'g_tTex2df4' (uniform texture2D)
+0:?     'g_tTex2di4' (uniform itexture2D)
+0:?     'g_tTex2du4' (uniform utexture2D)
+0:?     'g_tTex3df4' (uniform texture3D)
+0:?     'g_tTex3di4' (uniform itexture3D)
+0:?     'g_tTex3du4' (uniform utexture3D)
+0:?     'g_tTexcdf4' (uniform textureCube)
+0:?     'g_tTexcdi4' (uniform itextureCube)
+0:?     'g_tTexcdu4' (uniform utextureCube)
+0:?     'Color' (layout(location=0 ) out 4-component vector of float)
+0:?     'Depth' (out float FragDepth)
+0:?     'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform float c1, layout(offset=8 ) uniform 2-component vector of float c2, layout(offset=16 ) uniform 3-component vector of float c3, layout(offset=32 ) uniform 4-component vector of float c4})
+
+
+Linked fragment stage:
+
+
+Shader version: 450
+gl_FragCoord origin is upper left
+0:? Sequence
+0:38  Function Definition: @main( (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:38    Function Parameters: 
+0:?     Sequence
+0:45      Sequence
+0:45        move second child to first child (temp 4-component vector of float)
+0:45          'txval001' (temp 4-component vector of float)
+0:45          textureGatherOffset (temp 4-component vector of float)
+0:45            Construct combined texture-sampler (temp sampler2DShadow)
+0:45              'g_tTex2df4' (uniform texture2D)
+0:45              'g_sSampCmp' (layout(binding=0 ) uniform sampler)
+0:45            c2: direct index for structure (layout(offset=8 ) uniform 2-component vector of float)
+0:45              'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform float c1, layout(offset=8 ) uniform 2-component vector of float c2, layout(offset=16 ) uniform 3-component vector of float c3, layout(offset=32 ) uniform 4-component vector of float c4})
+0:45              Constant:
+0:45                1 (const uint)
+0:45            Constant:
+0:45              0.750000
+0:?             Constant:
+0:?               1 (const int)
+0:?               0 (const int)
+0:45            Constant:
+0:45              0 (const int)
+0:46      Sequence
+0:46        move second child to first child (temp 4-component vector of int)
+0:46          'txval011' (temp 4-component vector of int)
+0:46          textureGatherOffset (temp 4-component vector of int)
+0:46            Construct combined texture-sampler (temp isampler2DShadow)
+0:46              'g_tTex2di4' (uniform itexture2D)
+0:46              'g_sSampCmp' (layout(binding=0 ) uniform sampler)
+0:46            c2: direct index for structure (layout(offset=8 ) uniform 2-component vector of float)
+0:46              'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform float c1, layout(offset=8 ) uniform 2-component vector of float c2, layout(offset=16 ) uniform 3-component vector of float c3, layout(offset=32 ) uniform 4-component vector of float c4})
+0:46              Constant:
+0:46                1 (const uint)
+0:46            Constant:
+0:46              0.750000
+0:?             Constant:
+0:?               1 (const int)
+0:?               -1 (const int)
+0:46            Constant:
+0:46              0 (const int)
+0:47      Sequence
+0:47        move second child to first child (temp 4-component vector of uint)
+0:47          'txval021' (temp 4-component vector of uint)
+0:47          textureGatherOffset (temp 4-component vector of uint)
+0:47            Construct combined texture-sampler (temp usampler2DShadow)
+0:47              'g_tTex2du4' (uniform utexture2D)
+0:47              'g_sSampCmp' (layout(binding=0 ) uniform sampler)
+0:47            c2: direct index for structure (layout(offset=8 ) uniform 2-component vector of float)
+0:47              'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform float c1, layout(offset=8 ) uniform 2-component vector of float c2, layout(offset=16 ) uniform 3-component vector of float c3, layout(offset=32 ) uniform 4-component vector of float c4})
+0:47              Constant:
+0:47                1 (const uint)
+0:47            Constant:
+0:47              0.750000
+0:?             Constant:
+0:?               1 (const int)
+0:?               1 (const int)
+0:47            Constant:
+0:47              0 (const int)
+0:49      Sequence
+0:49        move second child to first child (temp 4-component vector of float)
+0:49          'txval004' (temp 4-component vector of float)
+0:49          textureGatherOffsets (temp 4-component vector of float)
+0:49            Construct combined texture-sampler (temp sampler2DShadow)
+0:49              'g_tTex2df4' (uniform texture2D)
+0:49              'g_sSampCmp' (layout(binding=0 ) uniform sampler)
+0:49            c2: direct index for structure (layout(offset=8 ) uniform 2-component vector of float)
+0:49              'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform float c1, layout(offset=8 ) uniform 2-component vector of float c2, layout(offset=16 ) uniform 3-component vector of float c3, layout(offset=32 ) uniform 4-component vector of float c4})
+0:49              Constant:
+0:49                1 (const uint)
+0:49            Constant:
+0:49              0.750000
+0:49            Constant:
+0:49              1 (const int)
+0:49              0 (const int)
+0:49              1 (const int)
+0:49              0 (const int)
+0:49              1 (const int)
+0:49              0 (const int)
+0:49              1 (const int)
+0:49              0 (const int)
+0:49            Constant:
+0:49              0 (const int)
+0:50      Sequence
+0:50        move second child to first child (temp 4-component vector of int)
+0:50          'txval014' (temp 4-component vector of int)
+0:50          textureGatherOffsets (temp 4-component vector of int)
+0:50            Construct combined texture-sampler (temp isampler2DShadow)
+0:50              'g_tTex2di4' (uniform itexture2D)
+0:50              'g_sSampCmp' (layout(binding=0 ) uniform sampler)
+0:50            c2: direct index for structure (layout(offset=8 ) uniform 2-component vector of float)
+0:50              'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform float c1, layout(offset=8 ) uniform 2-component vector of float c2, layout(offset=16 ) uniform 3-component vector of float c3, layout(offset=32 ) uniform 4-component vector of float c4})
+0:50              Constant:
+0:50                1 (const uint)
+0:50            Constant:
+0:50              0.750000
+0:50            Constant:
+0:50              1 (const int)
+0:50              -1 (const int)
+0:50              1 (const int)
+0:50              -1 (const int)
+0:50              1 (const int)
+0:50              -1 (const int)
+0:50              1 (const int)
+0:50              -1 (const int)
+0:50            Constant:
+0:50              0 (const int)
+0:51      Sequence
+0:51        move second child to first child (temp 4-component vector of uint)
+0:51          'txval024' (temp 4-component vector of uint)
+0:51          textureGatherOffsets (temp 4-component vector of uint)
+0:51            Construct combined texture-sampler (temp usampler2DShadow)
+0:51              'g_tTex2du4' (uniform utexture2D)
+0:51              'g_sSampCmp' (layout(binding=0 ) uniform sampler)
+0:51            c2: direct index for structure (layout(offset=8 ) uniform 2-component vector of float)
+0:51              'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform float c1, layout(offset=8 ) uniform 2-component vector of float c2, layout(offset=16 ) uniform 3-component vector of float c3, layout(offset=32 ) uniform 4-component vector of float c4})
+0:51              Constant:
+0:51                1 (const uint)
+0:51            Constant:
+0:51              0.750000
+0:51            Constant:
+0:51              1 (const int)
+0:51              1 (const int)
+0:51              1 (const int)
+0:51              1 (const int)
+0:51              1 (const int)
+0:51              1 (const int)
+0:51              1 (const int)
+0:51              1 (const int)
+0:51            Constant:
+0:51              0 (const int)
+0:114      move second child to first child (temp 4-component vector of float)
+0:114        Color: direct index for structure (temp 4-component vector of float)
+0:114          'psout' (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:114          Constant:
+0:114            0 (const int)
+0:114        Constant:
+0:114          1.000000
+0:114          1.000000
+0:114          1.000000
+0:114          1.000000
+0:115      move second child to first child (temp float)
+0:115        Depth: direct index for structure (temp float)
+0:115          'psout' (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:115          Constant:
+0:115            1 (const int)
+0:115        Constant:
+0:115          1.000000
+0:117      Branch: Return with expression
+0:117        'psout' (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:38  Function Definition: main( (temp void)
+0:38    Function Parameters: 
+0:?     Sequence
+0:38      Sequence
+0:38        move second child to first child (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:38          'flattenTemp' (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:38          Function Call: @main( (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:38        move second child to first child (temp 4-component vector of float)
+0:?           'Color' (layout(location=0 ) out 4-component vector of float)
+0:38          Color: direct index for structure (temp 4-component vector of float)
+0:38            'flattenTemp' (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:38            Constant:
+0:38              0 (const int)
+0:38        move second child to first child (temp float)
+0:?           'Depth' (out float FragDepth)
+0:38          Depth: direct index for structure (temp float)
+0:38            'flattenTemp' (temp structure{temp 4-component vector of float Color, temp float Depth})
+0:38            Constant:
+0:38              1 (const int)
+0:?   Linker Objects
+0:?     'g_sSampCmp' (layout(binding=0 ) uniform sampler)
+0:?     'g_tTex1df4a' (layout(binding=1 ) uniform texture1D)
+0:?     'g_tTex1df4' (layout(binding=0 ) uniform texture1D)
+0:?     'g_tTex1di4' (uniform itexture1D)
+0:?     'g_tTex1du4' (uniform utexture1D)
+0:?     'g_tTex2df4' (uniform texture2D)
+0:?     'g_tTex2di4' (uniform itexture2D)
+0:?     'g_tTex2du4' (uniform utexture2D)
+0:?     'g_tTex3df4' (uniform texture3D)
+0:?     'g_tTex3di4' (uniform itexture3D)
+0:?     'g_tTex3du4' (uniform utexture3D)
+0:?     'g_tTexcdf4' (uniform textureCube)
+0:?     'g_tTexcdi4' (uniform itextureCube)
+0:?     'g_tTexcdu4' (uniform utextureCube)
+0:?     'Color' (layout(location=0 ) out 4-component vector of float)
+0:?     'Depth' (out float FragDepth)
+0:?     'anon@0' (layout(row_major std140 ) uniform block{layout(offset=0 ) uniform float c1, layout(offset=8 ) uniform 2-component vector of float c2, layout(offset=16 ) uniform 3-component vector of float c3, layout(offset=32 ) uniform 4-component vector of float c4})
+
+// Module Version 10000
+// Generated by (magic number): 80001
+// Id's are bound by 146
+
+                              Capability Shader
+                              Capability Sampled1D
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Fragment 4  "main" 111 115
+                              ExecutionMode 4 OriginUpperLeft
+                              Name 4  "main"
+                              Name 8  "PS_OUTPUT"
+                              MemberName 8(PS_OUTPUT) 0  "Color"
+                              MemberName 8(PS_OUTPUT) 1  "Depth"
+                              Name 10  "@main("
+                              Name 13  "txval001"
+                              Name 16  "g_tTex2df4"
+                              Name 20  "g_sSampCmp"
+                              Name 27  "$Global"
+                              MemberName 27($Global) 0  "c1"
+                              MemberName 27($Global) 1  "c2"
+                              MemberName 27($Global) 2  "c3"
+                              MemberName 27($Global) 3  "c4"
+                              Name 29  ""
+                              Name 42  "txval011"
+                              Name 45  "g_tTex2di4"
+                              Name 59  "txval021"
+                              Name 62  "g_tTex2du4"
+                              Name 72  "txval004"
+                              Name 82  "txval014"
+                              Name 90  "txval024"
+                              Name 99  "psout"
+                              Name 108  "flattenTemp"
+                              Name 111  "Color"
+                              Name 115  "Depth"
+                              Name 120  "g_tTex1df4a"
+                              Name 121  "g_tTex1df4"
+                              Name 124  "g_tTex1di4"
+                              Name 127  "g_tTex1du4"
+                              Name 130  "g_tTex3df4"
+                              Name 133  "g_tTex3di4"
+                              Name 136  "g_tTex3du4"
+                              Name 139  "g_tTexcdf4"
+                              Name 142  "g_tTexcdi4"
+                              Name 145  "g_tTexcdu4"
+                              Decorate 16(g_tTex2df4) DescriptorSet 0
+                              Decorate 20(g_sSampCmp) DescriptorSet 0
+                              Decorate 20(g_sSampCmp) Binding 0
+                              MemberDecorate 27($Global) 0 Offset 0
+                              MemberDecorate 27($Global) 1 Offset 8
+                              MemberDecorate 27($Global) 2 Offset 16
+                              MemberDecorate 27($Global) 3 Offset 32
+                              Decorate 27($Global) Block
+                              Decorate 29 DescriptorSet 0
+                              Decorate 45(g_tTex2di4) DescriptorSet 0
+                              Decorate 62(g_tTex2du4) DescriptorSet 0
+                              Decorate 111(Color) Location 0
+                              Decorate 115(Depth) BuiltIn FragDepth
+                              Decorate 120(g_tTex1df4a) DescriptorSet 0
+                              Decorate 120(g_tTex1df4a) Binding 1
+                              Decorate 121(g_tTex1df4) DescriptorSet 0
+                              Decorate 121(g_tTex1df4) Binding 0
+                              Decorate 124(g_tTex1di4) DescriptorSet 0
+                              Decorate 127(g_tTex1du4) DescriptorSet 0
+                              Decorate 130(g_tTex3df4) DescriptorSet 0
+                              Decorate 133(g_tTex3di4) DescriptorSet 0
+                              Decorate 136(g_tTex3du4) DescriptorSet 0
+                              Decorate 139(g_tTexcdf4) DescriptorSet 0
+                              Decorate 142(g_tTexcdi4) DescriptorSet 0
+                              Decorate 145(g_tTexcdu4) DescriptorSet 0
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeFloat 32
+               7:             TypeVector 6(float) 4
+    8(PS_OUTPUT):             TypeStruct 7(fvec4) 6(float)
+               9:             TypeFunction 8(PS_OUTPUT)
+              12:             TypePointer Function 7(fvec4)
+              14:             TypeImage 6(float) 2D sampled format:Unknown
+              15:             TypePointer UniformConstant 14
+  16(g_tTex2df4):     15(ptr) Variable UniformConstant
+              18:             TypeSampler
+              19:             TypePointer UniformConstant 18
+  20(g_sSampCmp):     19(ptr) Variable UniformConstant
+              22:             TypeImage 6(float) 2D depth sampled format:Unknown
+              23:             TypeSampledImage 22
+              25:             TypeVector 6(float) 2
+              26:             TypeVector 6(float) 3
+     27($Global):             TypeStruct 6(float) 25(fvec2) 26(fvec3) 7(fvec4)
+              28:             TypePointer Uniform 27($Global)
+              29:     28(ptr) Variable Uniform
+              30:             TypeInt 32 1
+              31:     30(int) Constant 1
+              32:             TypePointer Uniform 25(fvec2)
+              35:    6(float) Constant 1061158912
+              36:             TypeVector 30(int) 2
+              37:     30(int) Constant 0
+              38:   36(ivec2) ConstantComposite 31 37
+              40:             TypeVector 30(int) 4
+              41:             TypePointer Function 40(ivec4)
+              43:             TypeImage 30(int) 2D sampled format:Unknown
+              44:             TypePointer UniformConstant 43
+  45(g_tTex2di4):     44(ptr) Variable UniformConstant
+              48:             TypeImage 30(int) 2D depth sampled format:Unknown
+              49:             TypeSampledImage 48
+              53:     30(int) Constant 4294967295
+              54:   36(ivec2) ConstantComposite 31 53
+              56:             TypeInt 32 0
+              57:             TypeVector 56(int) 4
+              58:             TypePointer Function 57(ivec4)
+              60:             TypeImage 56(int) 2D sampled format:Unknown
+              61:             TypePointer UniformConstant 60
+  62(g_tTex2du4):     61(ptr) Variable UniformConstant
+              65:             TypeImage 56(int) 2D depth sampled format:Unknown
+              66:             TypeSampledImage 65
+              70:   36(ivec2) ConstantComposite 31 31
+              78:     56(int) Constant 4
+              79:             TypeArray 36(ivec2) 78
+              80:          79 ConstantComposite 38 38 38 38
+              88:          79 ConstantComposite 54 54 54 54
+              96:          79 ConstantComposite 70 70 70 70
+              98:             TypePointer Function 8(PS_OUTPUT)
+             100:    6(float) Constant 1065353216
+             101:    7(fvec4) ConstantComposite 100 100 100 100
+             103:             TypePointer Function 6(float)
+             110:             TypePointer Output 7(fvec4)
+      111(Color):    110(ptr) Variable Output
+             114:             TypePointer Output 6(float)
+      115(Depth):    114(ptr) Variable Output
+             118:             TypeImage 6(float) 1D sampled format:Unknown
+             119:             TypePointer UniformConstant 118
+120(g_tTex1df4a):    119(ptr) Variable UniformConstant
+ 121(g_tTex1df4):    119(ptr) Variable UniformConstant
+             122:             TypeImage 30(int) 1D sampled format:Unknown
+             123:             TypePointer UniformConstant 122
+ 124(g_tTex1di4):    123(ptr) Variable UniformConstant
+             125:             TypeImage 56(int) 1D sampled format:Unknown
+             126:             TypePointer UniformConstant 125
+ 127(g_tTex1du4):    126(ptr) Variable UniformConstant
+             128:             TypeImage 6(float) 3D sampled format:Unknown
+             129:             TypePointer UniformConstant 128
+ 130(g_tTex3df4):    129(ptr) Variable UniformConstant
+             131:             TypeImage 30(int) 3D sampled format:Unknown
+             132:             TypePointer UniformConstant 131
+ 133(g_tTex3di4):    132(ptr) Variable UniformConstant
+             134:             TypeImage 56(int) 3D sampled format:Unknown
+             135:             TypePointer UniformConstant 134
+ 136(g_tTex3du4):    135(ptr) Variable UniformConstant
+             137:             TypeImage 6(float) Cube sampled format:Unknown
+             138:             TypePointer UniformConstant 137
+ 139(g_tTexcdf4):    138(ptr) Variable UniformConstant
+             140:             TypeImage 30(int) Cube sampled format:Unknown
+             141:             TypePointer UniformConstant 140
+ 142(g_tTexcdi4):    141(ptr) Variable UniformConstant
+             143:             TypeImage 56(int) Cube sampled format:Unknown
+             144:             TypePointer UniformConstant 143
+ 145(g_tTexcdu4):    144(ptr) Variable UniformConstant
+         4(main):           2 Function None 3
+               5:             Label
+108(flattenTemp):     98(ptr) Variable Function
+             109:8(PS_OUTPUT) FunctionCall 10(@main()
+                              Store 108(flattenTemp) 109
+             112:     12(ptr) AccessChain 108(flattenTemp) 37
+             113:    7(fvec4) Load 112
+                              Store 111(Color) 113
+             116:    103(ptr) AccessChain 108(flattenTemp) 31
+             117:    6(float) Load 116
+                              Store 115(Depth) 117
+                              Return
+                              FunctionEnd
+      10(@main():8(PS_OUTPUT) Function None 9
+              11:             Label
+    13(txval001):     12(ptr) Variable Function
+    42(txval011):     41(ptr) Variable Function
+    59(txval021):     58(ptr) Variable Function
+    72(txval004):     12(ptr) Variable Function
+    82(txval014):     41(ptr) Variable Function
+    90(txval024):     58(ptr) Variable Function
+       99(psout):     98(ptr) Variable Function
+              17:          14 Load 16(g_tTex2df4)
+              21:          18 Load 20(g_sSampCmp)
+              24:          23 SampledImage 17 21
+              33:     32(ptr) AccessChain 29 31
+              34:   25(fvec2) Load 33
+              39:    7(fvec4) ImageDrefGather 24 34 35 ConstOffset 38
+                              Store 13(txval001) 39
+              46:          43 Load 45(g_tTex2di4)
+              47:          18 Load 20(g_sSampCmp)
+              50:          49 SampledImage 46 47
+              51:     32(ptr) AccessChain 29 31
+              52:   25(fvec2) Load 51
+              55:   40(ivec4) ImageDrefGather 50 52 35 ConstOffset 54
+                              Store 42(txval011) 55
+              63:          60 Load 62(g_tTex2du4)
+              64:          18 Load 20(g_sSampCmp)
+              67:          66 SampledImage 63 64
+              68:     32(ptr) AccessChain 29 31
+              69:   25(fvec2) Load 68
+              71:   57(ivec4) ImageDrefGather 67 69 35 ConstOffset 70
+                              Store 59(txval021) 71
+              73:          14 Load 16(g_tTex2df4)
+              74:          18 Load 20(g_sSampCmp)
+              75:          23 SampledImage 73 74
+              76:     32(ptr) AccessChain 29 31
+              77:   25(fvec2) Load 76
+              81:    7(fvec4) ImageDrefGather 75 77 35 ConstOffsets 80
+                              Store 72(txval004) 81
+              83:          43 Load 45(g_tTex2di4)
+              84:          18 Load 20(g_sSampCmp)
+              85:          49 SampledImage 83 84
+              86:     32(ptr) AccessChain 29 31
+              87:   25(fvec2) Load 86
+              89:   40(ivec4) ImageDrefGather 85 87 35 ConstOffsets 88
+                              Store 82(txval014) 89
+              91:          60 Load 62(g_tTex2du4)
+              92:          18 Load 20(g_sSampCmp)
+              93:          66 SampledImage 91 92
+              94:     32(ptr) AccessChain 29 31
+              95:   25(fvec2) Load 94
+              97:   57(ivec4) ImageDrefGather 93 95 35 ConstOffsets 96
+                              Store 90(txval024) 97
+             102:     12(ptr) AccessChain 99(psout) 37
+                              Store 102 101
+             104:    103(ptr) AccessChain 99(psout) 31
+                              Store 104 100
+             105:8(PS_OUTPUT) Load 99(psout)
+                              ReturnValue 105
+                              FunctionEnd

--- a/Test/hlsl.gathercmpRGBA.offset.dx10.frag
+++ b/Test/hlsl.gathercmpRGBA.offset.dx10.frag
@@ -29,10 +29,10 @@ uniform float2 c2;
 uniform float3 c3;
 uniform float4 c4;
 
-uniform int  o1;
-uniform int2 o2;
-uniform int3 o3;
-uniform int4 o4;
+
+
+
+
 
 PS_OUTPUT main()
 {
@@ -42,69 +42,72 @@ PS_OUTPUT main()
 
    // no 1D gathers
 
-   float4 txval001 = g_tTex2df4 . GatherCmpRed(g_sSampCmp, c2, 0.75, o2);
-   int4   txval011 = g_tTex2di4 . GatherCmpRed(g_sSampCmp, c2, 0.75, o2);
-   uint4  txval021 = g_tTex2du4 . GatherCmpRed(g_sSampCmp, c2, 0.75, o2);
+   float4 txval001 = g_tTex2df4 . GatherCmpRed(g_sSampCmp, c2, 0.75, int2(1,0));
+   int4   txval011 = g_tTex2di4 . GatherCmpRed(g_sSampCmp, c2, 0.75, int2(1,-1));
+   uint4  txval021 = g_tTex2du4 . GatherCmpRed(g_sSampCmp, c2, 0.75, int2(1,1));
 
-   float4 txval004 = g_tTex2df4 . GatherCmpRed(g_sSampCmp, c2, 0.75, o2, o2, o2, o2);
-   int4   txval014 = g_tTex2di4 . GatherCmpRed(g_sSampCmp, c2, 0.75, o2, o2, o2, o2);
-   uint4  txval024 = g_tTex2du4 . GatherCmpRed(g_sSampCmp, c2, 0.75, o2, o2, o2, o2);
+   float4 txval004 = g_tTex2df4 . GatherCmpRed(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0));
+   int4   txval014 = g_tTex2di4 . GatherCmpRed(g_sSampCmp, c2, 0.75, int2(1,-1), int2(1,-1), int2(1,-1), int2(1,-1));
+   uint4  txval024 = g_tTex2du4 . GatherCmpRed(g_sSampCmp, c2, 0.75, int2(1,1), int2(1,1), int2(1,1), int2(1,1));
    
-   // float4 txval00s = g_tTex2df4 . GatherCmpRed(g_sSampCmp, c2, 0.75, o2, status);
-   // int4   txval01s = g_tTex2di4 . GatherCmpRed(g_sSampCmp, c2, 0.75, o2, status);
-   // uint4  txval02s = g_tTex2du4 . GatherCmpRed(g_sSampCmp, c2, 0.75, o2, status);
+   // float4 txval00s = g_tTex2df4 . GatherCmpRed(g_sSampCmp, c2, 0.75, int2(1,0), status);
+   // int4   txval01s = g_tTex2di4 . GatherCmpRed(g_sSampCmp, c2, 0.75, int2(1,0), status);
+   // uint4  txval02s = g_tTex2du4 . GatherCmpRed(g_sSampCmp, c2, 0.75, int2(1,0), status);
 
-   // float4 txval004s = g_tTex2df4 . GatherCmpRed(g_sSampCmp, c2, 0.75, o2, o2, o2, o2, status);
-   // int4   txval014s = g_tTex2di4 . GatherCmpRed(g_sSampCmp, c2, 0.75, o2, o2, o2, o2, status);
-   // uint4  txval024s = g_tTex2du4 . GatherCmpRed(g_sSampCmp, c2, 0.75, o2, o2, o2, o2, status);
+   // float4 txval004s = g_tTex2df4 . GatherCmpRed(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0), status);
+   // int4   txval014s = g_tTex2di4 . GatherCmpRed(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0), status);
+   // uint4  txval024s = g_tTex2du4 . GatherCmpRed(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0), status);
 
-   float4 txval101 = g_tTex2df4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, o2);
-   int4   txval111 = g_tTex2di4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, o2);
-   uint4  txval121 = g_tTex2du4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, o2);
+   // GatherCmpGreen not implemented pending OpImageDrefGather component input
+   // float4 txval101 = g_tTex2df4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, int2(1,0));
+   // int4   txval111 = g_tTex2di4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, int2(1,0));
+   // uint4  txval121 = g_tTex2du4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, int2(1,0));
 
-   float4 txval104 = g_tTex2df4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, o2, o2, o2, o2);
-   int4   txval114 = g_tTex2di4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, o2, o2, o2, o2);
-   uint4  txval124 = g_tTex2du4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, o2, o2, o2, o2);
+   // float4 txval104 = g_tTex2df4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0));
+   // int4   txval114 = g_tTex2di4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0));
+   // uint4  txval124 = g_tTex2du4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0));
 
-   // float4 txval10s = g_tTex2df4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, o2, status);
-   // int4   txval11s = g_tTex2di4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, o2, status);
-   // uint4  txval12s = g_tTex2du4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, o2, status);
+   // float4 txval10s = g_tTex2df4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, int2(1,0), status);
+   // int4   txval11s = g_tTex2di4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, int2(1,0), status);
+   // uint4  txval12s = g_tTex2du4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, int2(1,0), status);
 
-   // float4 txval104 = g_tTex2df4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, o2, o2, o2, o2, status);
-   // int4   txval114 = g_tTex2di4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, o2, o2, o2, o2, status);
-   // uint4  txval124 = g_tTex2du4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, o2, o2, o2, o2, status);
+   // float4 txval104 = g_tTex2df4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0), status);
+   // int4   txval114 = g_tTex2di4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0), status);
+   // uint4  txval124 = g_tTex2du4 . GatherCmpGreen(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0), status);
 
-   float4 txval201 = g_tTex2df4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, o2);
-   int4   txval211 = g_tTex2di4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, o2);
-   uint4  txval221 = g_tTex2du4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, o2);
+   // GatherCmpBlue not implemented pending OpImageDrefGather component input
+   // float4 txval201 = g_tTex2df4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, int2(1,0));
+   // int4   txval211 = g_tTex2di4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, int2(1,0));
+   // uint4  txval221 = g_tTex2du4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, int2(1,0));
 
-   float4 txval204 = g_tTex2df4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, o2, o2, o2, o2);
-   int4   txval214 = g_tTex2di4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, o2, o2, o2, o2);
-   uint4  txval224 = g_tTex2du4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, o2, o2, o2, o2);
+   // float4 txval204 = g_tTex2df4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0));
+   // int4   txval214 = g_tTex2di4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0));
+   // uint4  txval224 = g_tTex2du4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0));
 
-   // float4 txval204s = g_tTex2df4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, o2, o2, o2, o2, status);
-   // int4   txval214s = g_tTex2di4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, o2, o2, o2, o2, status);
-   // uint4  txval224s = g_tTex2du4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, o2, o2, o2, o2, status);
+   // float4 txval204s = g_tTex2df4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0), status);
+   // int4   txval214s = g_tTex2di4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0), status);
+   // uint4  txval224s = g_tTex2du4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0), status);
 
-   // float4 txval20s = g_tTex2df4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, o2, status);
-   // int4   txval21s = g_tTex2di4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, o2, status);
-   // uint4  txval22s = g_tTex2du4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, o2, status);
+   // float4 txval20s = g_tTex2df4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, int2(1,0), status);
+   // int4   txval21s = g_tTex2di4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, int2(1,0), status);
+   // uint4  txval22s = g_tTex2du4 . GatherCmpBlue(g_sSampCmp, c2, 0.75, int2(1,0), status);
 
-   float4 txval301 = g_tTex2df4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, o2);
-   int4   txval311 = g_tTex2di4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, o2);
-   uint4  txval321 = g_tTex2du4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, o2);
+   // GatherCmpAlpha not implemented pending OpImageDrefGather component input
+   // float4 txval301 = g_tTex2df4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, int2(1,0));
+   // int4   txval311 = g_tTex2di4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, int2(1,0));
+   // uint4  txval321 = g_tTex2du4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, int2(1,0));
 
-   float4 txval304 = g_tTex2df4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, o2, o2, o2, o2);
-   int4   txval314 = g_tTex2di4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, o2, o2, o2, o2);
-   uint4  txval324 = g_tTex2du4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, o2, o2, o2, o2);
+   // float4 txval304 = g_tTex2df4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0));
+   // int4   txval314 = g_tTex2di4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0));
+   // uint4  txval324 = g_tTex2du4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0));
 
-   // float4 txval304s = g_tTex2df4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, o2, o2, o2, o2, status);
-   // int4   txval314s = g_tTex2di4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, o2, o2, o2, o2, status);
-   // uint4  txval324s = g_tTex2du4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, o2, o2, o2, o2, status);
+   // float4 txval304s = g_tTex2df4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0), status);
+   // int4   txval314s = g_tTex2di4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0), status);
+   // uint4  txval324s = g_tTex2du4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, int2(1,0), int2(1,0), int2(1,0), int2(1,0), status);
 
-   // float4 txval30s = g_tTex2df4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, o2, status);
-   // int4   txval31s = g_tTex2di4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, o2, status);
-   // uint4  txval32s = g_tTex2du4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, o2, status);
+   // float4 txval30s = g_tTex2df4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, int2(1,0), status);
+   // int4   txval31s = g_tTex2di4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, int2(1,0), status);
+   // uint4  txval32s = g_tTex2du4 . GatherCmpAlpha(g_sSampCmp, c2, 0.75, int2(1,0), status);
 
    // no 3D gathers with offset
 

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -111,6 +111,7 @@ INSTANTIATE_TEST_CASE_P(
         {"hlsl.gather.basic.dx10.vert", "main"},
         {"hlsl.gather.offset.dx10.frag", "main"},
         {"hlsl.gather.offsetarray.dx10.frag", "main"},
+        {"hlsl.gathercmpRGBA.offset.dx10.frag", "main"},
         {"hlsl.gatherRGBA.array.dx10.frag", "main"},
         {"hlsl.gatherRGBA.basic.dx10.frag", "main"},
         {"hlsl.gatherRGBA.offset.dx10.frag", "main"},

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -3043,8 +3043,10 @@ void HlslParseContext::decomposeSampleMethods(const TSourceLoc& loc, TIntermType
             // For now, we have nothing to map the component-wise comparison forms
             // to, because neither GLSL nor SPIR-V has such an opcode.  Issue an
             // unimplemented error instead.  Most of the machinery is here if that
-            // should ever become available.
-            if (cmpValues) {
+            // should ever become available.  However, red can be passed through
+            // to OpImageDrefGather.  G/B/A cannot, because that opcode does not
+            // accept a component.
+            if (cmpValues != 0 && op != EOpMethodGatherCmpRed) {
                 error(loc, "unimplemented: component-level gather compare", "", "");
                 return;
             }
@@ -3125,7 +3127,7 @@ void HlslParseContext::decomposeSampleMethods(const TSourceLoc& loc, TIntermType
             }
 
             // Add comparison value if we have one
-            if (argTex->getType().getSampler().isShadow())
+            if (argCmp != nullptr)
                 txgather->getSequence().push_back(argCmp);
 
             // Add offset (either 1, or an array of 4) if we have one


### PR DESCRIPTION
This implements GatherCmpRed in terms of OpImageDrefGather.

There appears to be no way to implement the Green/Blue/Apha forms: see #673.  Those still result in unimplemented errors.

