### PR TITLE
Added 'GL_core_profile' and 'GL_compatibility_profile' to macro expansion

### DIFF
--- a/Test/150.vert
+++ b/Test/150.vert
@@ -1,5 +1,9 @@
 #version 150 core
 
+#ifndef GL_core_profile
+#	error standard macro GL_core_profile not defined
+#endif
+
 in vec4 iv4;
 
 uniform float ps;

--- a/Test/baseResults/150.vert.out
+++ b/Test/baseResults/150.vert.out
@@ -1,44 +1,44 @@
 150.vert
-ERROR: 0:22: 'a' : cannot redeclare a user-block member array 
+ERROR: 0:26: 'a' : cannot redeclare a user-block member array 
 ERROR: 0:3001: '#error' : line of this error should be 3001  
 ERROR: 2 compilation errors.  No code generated.
 
 
 Shader version: 150
 ERROR: node is still EOpNull!
-0:9  Function Definition: main( (global void)
-0:9    Function Parameters: 
-0:11    Sequence
-0:11      move second child to first child (temp 4-component vector of float)
-0:11        gl_Position: direct index for structure (invariant gl_Position 4-component vector of float Position)
-0:11          'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out implicitly-sized array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
-0:11          Constant:
-0:11            0 (const uint)
-0:11        'iv4' (in 4-component vector of float)
-0:12      move second child to first child (temp float)
-0:12        gl_PointSize: direct index for structure (gl_PointSize float PointSize)
-0:12          'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out implicitly-sized array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
-0:12          Constant:
-0:12            1 (const uint)
-0:12        'ps' (uniform float)
-0:13      move second child to first child (temp float)
-0:13        direct index (temp float ClipDistance)
-0:13          gl_ClipDistance: direct index for structure (out 4-element array of float ClipDistance)
-0:13            'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out implicitly-sized array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
-0:13            Constant:
-0:13              2 (const uint)
-0:13          Constant:
-0:13            2 (const int)
-0:13        direct index (temp float)
-0:13          'iv4' (in 4-component vector of float)
-0:13          Constant:
-0:13            0 (const int)
-0:14      move second child to first child (temp 4-component vector of float)
-0:14        gl_ClipVertex: direct index for structure (gl_ClipVertex 4-component vector of float ClipVertex)
-0:14          'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out implicitly-sized array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
-0:14          Constant:
-0:14            3 (const uint)
-0:14        'iv4' (in 4-component vector of float)
+0:13  Function Definition: main( (global void)
+0:13    Function Parameters: 
+0:15    Sequence
+0:15      move second child to first child (temp 4-component vector of float)
+0:15        gl_Position: direct index for structure (invariant gl_Position 4-component vector of float Position)
+0:15          'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out implicitly-sized array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
+0:15          Constant:
+0:15            0 (const uint)
+0:15        'iv4' (in 4-component vector of float)
+0:16      move second child to first child (temp float)
+0:16        gl_PointSize: direct index for structure (gl_PointSize float PointSize)
+0:16          'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out implicitly-sized array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
+0:16          Constant:
+0:16            1 (const uint)
+0:16        'ps' (uniform float)
+0:17      move second child to first child (temp float)
+0:17        direct index (temp float ClipDistance)
+0:17          gl_ClipDistance: direct index for structure (out 4-element array of float ClipDistance)
+0:17            'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out implicitly-sized array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
+0:17            Constant:
+0:17              2 (const uint)
+0:17          Constant:
+0:17            2 (const int)
+0:17        direct index (temp float)
+0:17          'iv4' (in 4-component vector of float)
+0:17          Constant:
+0:17            0 (const int)
+0:18      move second child to first child (temp 4-component vector of float)
+0:18        gl_ClipVertex: direct index for structure (gl_ClipVertex 4-component vector of float ClipVertex)
+0:18          'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out implicitly-sized array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
+0:18          Constant:
+0:18            3 (const uint)
+0:18        'iv4' (in 4-component vector of float)
 0:?   Linker Objects
 0:?     'iv4' (in 4-component vector of float)
 0:?     'ps' (uniform float)
@@ -53,39 +53,39 @@ ERROR: Linking vertex stage: Can only use one of gl_ClipDistance or gl_ClipVerte
 
 Shader version: 150
 ERROR: node is still EOpNull!
-0:9  Function Definition: main( (global void)
-0:9    Function Parameters: 
-0:11    Sequence
-0:11      move second child to first child (temp 4-component vector of float)
-0:11        gl_Position: direct index for structure (invariant gl_Position 4-component vector of float Position)
-0:11          'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out 1-element array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
-0:11          Constant:
-0:11            0 (const uint)
-0:11        'iv4' (in 4-component vector of float)
-0:12      move second child to first child (temp float)
-0:12        gl_PointSize: direct index for structure (gl_PointSize float PointSize)
-0:12          'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out 1-element array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
-0:12          Constant:
-0:12            1 (const uint)
-0:12        'ps' (uniform float)
-0:13      move second child to first child (temp float)
-0:13        direct index (temp float ClipDistance)
-0:13          gl_ClipDistance: direct index for structure (out 4-element array of float ClipDistance)
-0:13            'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out 1-element array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
-0:13            Constant:
-0:13              2 (const uint)
-0:13          Constant:
-0:13            2 (const int)
-0:13        direct index (temp float)
-0:13          'iv4' (in 4-component vector of float)
-0:13          Constant:
-0:13            0 (const int)
-0:14      move second child to first child (temp 4-component vector of float)
-0:14        gl_ClipVertex: direct index for structure (gl_ClipVertex 4-component vector of float ClipVertex)
-0:14          'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out 1-element array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
-0:14          Constant:
-0:14            3 (const uint)
-0:14        'iv4' (in 4-component vector of float)
+0:13  Function Definition: main( (global void)
+0:13    Function Parameters: 
+0:15    Sequence
+0:15      move second child to first child (temp 4-component vector of float)
+0:15        gl_Position: direct index for structure (invariant gl_Position 4-component vector of float Position)
+0:15          'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out 1-element array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
+0:15          Constant:
+0:15            0 (const uint)
+0:15        'iv4' (in 4-component vector of float)
+0:16      move second child to first child (temp float)
+0:16        gl_PointSize: direct index for structure (gl_PointSize float PointSize)
+0:16          'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out 1-element array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
+0:16          Constant:
+0:16            1 (const uint)
+0:16        'ps' (uniform float)
+0:17      move second child to first child (temp float)
+0:17        direct index (temp float ClipDistance)
+0:17          gl_ClipDistance: direct index for structure (out 4-element array of float ClipDistance)
+0:17            'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out 1-element array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
+0:17            Constant:
+0:17              2 (const uint)
+0:17          Constant:
+0:17            2 (const int)
+0:17        direct index (temp float)
+0:17          'iv4' (in 4-component vector of float)
+0:17          Constant:
+0:17            0 (const int)
+0:18      move second child to first child (temp 4-component vector of float)
+0:18        gl_ClipVertex: direct index for structure (gl_ClipVertex 4-component vector of float ClipVertex)
+0:18          'anon@0' (out block{invariant gl_Position 4-component vector of float Position gl_Position, gl_PointSize float PointSize gl_PointSize, out 4-element array of float ClipDistance gl_ClipDistance, gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex, out 4-component vector of float FrontColor gl_FrontColor, out 4-component vector of float BackColor gl_BackColor, out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor, out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor, out 1-element array of 4-component vector of float TexCoord gl_TexCoord, out float FogFragCoord gl_FogFragCoord})
+0:18          Constant:
+0:18            3 (const uint)
+0:18        'iv4' (in 4-component vector of float)
 0:?   Linker Objects
 0:?     'iv4' (in 4-component vector of float)
 0:?     'ps' (uniform float)

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -332,6 +332,19 @@ void TParseVersions::getPreamble(std::string& preamble)
             "#define GL_GOOGLE_include_directive 1\n"
             ;
 
+    if (version >= 150) {
+        // define GL_core_profile and GL_compatibility_profile
+        preamble +=
+                "#define GL_core_profile 1\n"
+                ;
+
+        if (profile == ECompatibilityProfile) {
+            preamble +=
+                    "#define GL_compatibility_profile 1\n"
+                    ;
+        }
+    }
+
     // #define VULKAN XXXX
     const int numberBufSize = 12;
     char numberBuf[numberBufSize];


### PR DESCRIPTION
As stated in the [OpenGL wiki](https://www.khronos.org/opengl/wiki/Core_Language_(GLSL)#Standard_macros), `GL_core_profile` is always defined as standard macro to "1", and `GL_compatibility_profile` is only defined as standard macro to "1", if the version profile was set to "compatibility".

**Note:**
All standard macros (i.e. `__VERSION__`, `__LINE__`, `__FILE__`, `GL_core_profile`, and `GL_compatibility_profile`) are still not identified in an '#ifdef' or '#if defined' directive!
I.e. the following pre-processor directives will not result in a compiler error, but it should be:
```
#ifdef __VERSION__
#error foo bar
#endif
```