### PR TITLE
HLSL: Additional channel value for textureGatherXXX().

### DIFF
--- a/Test/baseResults/hlsl.gathercmpRGBA.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.gathercmpRGBA.offset.dx10.frag.out
@@ -21,8 +21,6 @@ gl_FragCoord origin is upper left
 0:?             Constant:
 0:?               1 (const int)
 0:?               0 (const int)
-0:45            Constant:
-0:45              0 (const int)
 0:46      Sequence
 0:46        move second child to first child (temp 4-component vector of int)
 0:46          'txval011' (temp 4-component vector of int)
@@ -39,8 +37,6 @@ gl_FragCoord origin is upper left
 0:?             Constant:
 0:?               1 (const int)
 0:?               -1 (const int)
-0:46            Constant:
-0:46              0 (const int)
 0:47      Sequence
 0:47        move second child to first child (temp 4-component vector of uint)
 0:47          'txval021' (temp 4-component vector of uint)
@@ -57,8 +53,6 @@ gl_FragCoord origin is upper left
 0:?             Constant:
 0:?               1 (const int)
 0:?               1 (const int)
-0:47            Constant:
-0:47              0 (const int)
 0:49      Sequence
 0:49        move second child to first child (temp 4-component vector of float)
 0:49          'txval004' (temp 4-component vector of float)
@@ -80,8 +74,6 @@ gl_FragCoord origin is upper left
 0:49              1 (const int)
 0:49              0 (const int)
 0:49              1 (const int)
-0:49              0 (const int)
-0:49            Constant:
 0:49              0 (const int)
 0:50      Sequence
 0:50        move second child to first child (temp 4-component vector of int)
@@ -105,8 +97,6 @@ gl_FragCoord origin is upper left
 0:50              -1 (const int)
 0:50              1 (const int)
 0:50              -1 (const int)
-0:50            Constant:
-0:50              0 (const int)
 0:51      Sequence
 0:51        move second child to first child (temp 4-component vector of uint)
 0:51          'txval024' (temp 4-component vector of uint)
@@ -129,8 +119,6 @@ gl_FragCoord origin is upper left
 0:51              1 (const int)
 0:51              1 (const int)
 0:51              1 (const int)
-0:51            Constant:
-0:51              0 (const int)
 0:114      move second child to first child (temp 4-component vector of float)
 0:114        Color: direct index for structure (temp 4-component vector of float)
 0:114          'psout' (temp structure{temp 4-component vector of float Color, temp float Depth})
@@ -214,8 +202,6 @@ gl_FragCoord origin is upper left
 0:?             Constant:
 0:?               1 (const int)
 0:?               0 (const int)
-0:45            Constant:
-0:45              0 (const int)
 0:46      Sequence
 0:46        move second child to first child (temp 4-component vector of int)
 0:46          'txval011' (temp 4-component vector of int)
@@ -232,8 +218,6 @@ gl_FragCoord origin is upper left
 0:?             Constant:
 0:?               1 (const int)
 0:?               -1 (const int)
-0:46            Constant:
-0:46              0 (const int)
 0:47      Sequence
 0:47        move second child to first child (temp 4-component vector of uint)
 0:47          'txval021' (temp 4-component vector of uint)
@@ -250,8 +234,6 @@ gl_FragCoord origin is upper left
 0:?             Constant:
 0:?               1 (const int)
 0:?               1 (const int)
-0:47            Constant:
-0:47              0 (const int)
 0:49      Sequence
 0:49        move second child to first child (temp 4-component vector of float)
 0:49          'txval004' (temp 4-component vector of float)
@@ -273,8 +255,6 @@ gl_FragCoord origin is upper left
 0:49              1 (const int)
 0:49              0 (const int)
 0:49              1 (const int)
-0:49              0 (const int)
-0:49            Constant:
 0:49              0 (const int)
 0:50      Sequence
 0:50        move second child to first child (temp 4-component vector of int)
@@ -298,8 +278,6 @@ gl_FragCoord origin is upper left
 0:50              -1 (const int)
 0:50              1 (const int)
 0:50              -1 (const int)
-0:50            Constant:
-0:50              0 (const int)
 0:51      Sequence
 0:51        move second child to first child (temp 4-component vector of uint)
 0:51          'txval024' (temp 4-component vector of uint)
@@ -322,8 +300,6 @@ gl_FragCoord origin is upper left
 0:51              1 (const int)
 0:51              1 (const int)
 0:51              1 (const int)
-0:51            Constant:
-0:51              0 (const int)
 0:114      move second child to first child (temp 4-component vector of float)
 0:114        Color: direct index for structure (temp 4-component vector of float)
 0:114          'psout' (temp structure{temp 4-component vector of float Color, temp float Depth})

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -3082,7 +3082,9 @@ void HlslParseContext::decomposeSampleMethods(const TSourceLoc& loc, TIntermType
             if (argOffset != nullptr)
                 txgather->getSequence().push_back(argOffset);
 
-            txgather->getSequence().push_back(argChannel);
+            // Add channel value if the sampler is not shadow
+            if (! argSamp->getType().getSampler().isShadow())
+                txgather->getSequence().push_back(argChannel);
 
             txgather->setType(node->getType());
             txgather->setLoc(loc);


### PR DESCRIPTION
When mapping HLSL gather intrinsics to GLSL textureGatherXXX() built-in functions, the channel selection value is only valid for non-shadow samplers.