### PR TITLE
HLSL: use prefix for builtin functions names to avoid namespace colli…

### DIFF
--- a/hlsl/hlslGrammar.cpp
+++ b/hlsl/hlslGrammar.cpp
@@ -2785,11 +2785,13 @@ bool HlslGrammar::acceptFunctionCall(HlslToken callToken, TIntermTyped*& node, T
 {
     // name
     TString* functionName = nullptr;
-    if ((baseObject == nullptr && scope == nullptr) ||
-        parseContext.isBuiltInMethod(callToken.loc, baseObject, *callToken.string)) {
+    if ((baseObject == nullptr && scope == nullptr)) {
+        functionName = callToken.string;
+    } else if (parseContext.isBuiltInMethod(callToken.loc, baseObject, *callToken.string)) {
         // Built-in methods are not in the symbol table as methods, but as global functions
         // taking an explicit 'this' as the first argument.
-        functionName = callToken.string;
+        functionName = NewPoolTString(BUILTIN_PREFIX);
+        functionName->append(*callToken.string);
     } else {
         functionName = NewPoolTString("");
         if (baseObject != nullptr)

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -956,7 +956,7 @@ TIntermTyped* HlslParseContext::handleDotDereference(const TSourceLoc& loc, TInt
 // Return true if the field should be treated as a built-in method.
 // Return false otherwise.
 //
-bool HlslParseContext::isBuiltInMethod(const TSourceLoc& loc, TIntermTyped* base, const TString& field)
+bool HlslParseContext::isBuiltInMethod(const TSourceLoc&, TIntermTyped* base, const TString& field)
 {
     if (base == nullptr)
         return false;
@@ -3734,7 +3734,10 @@ TIntermTyped* HlslParseContext::handleFunctionCall(const TSourceLoc& loc, TFunct
         // It will have false positives, since it doesn't check arg counts or types.
         if (arguments && arguments->getAsAggregate()) {
             if (isStructBufferType(arguments->getAsAggregate()->getSequence()[0]->getAsTyped()->getType())) {
-                if (isStructBufferMethod(function->getName())) {
+                static const int methodPrefixSize = sizeof(BUILTIN_PREFIX)-1;
+
+                if (function->getName().length() > methodPrefixSize &&
+                    isStructBufferMethod(function->getName().substr(methodPrefixSize))) {
                     const TString mangle = function->getName() + "(";
                     TSymbol* symbol = symbolTable.find(mangle, &builtIn);
 

--- a/hlsl/hlslParseHelper.h
+++ b/hlsl/hlslParseHelper.h
@@ -390,6 +390,12 @@ protected:
     TVector<TString> currentTypePrefix;
 };
 
+// This is the prefix we use for builtin methods to avoid namespace collisions with
+// global scope user functions.
+// TODO: this would be better as a nonparseable character, but that would
+// require changing the scanner.
+#define BUILTIN_PREFIX "__BI_"
+
 } // end namespace glslang
 
 #endif // HLSL_PARSE_INCLUDED_


### PR DESCRIPTION
…sions

It would have been possible for globally scoped user functions to collide with builtin method names.  This adds a prefix to avoid polluting the namespace.  (This hasn't happened yet in a real shader, but could).

Ideally the prefix would be an invalid character to use in user identifiers, but as that requires changing the scanner, which is shared with GLSL, so for the moment it's an unlikely yet valid prefix.
