### PR TITLE
HLSL: handle PCF input to DS in arbitrary argument position

### DIFF
--- a/Test/baseResults/hlsl.domain.2.tese.out
+++ b/Test/baseResults/hlsl.domain.2.tese.out
@@ -1,0 +1,418 @@
+hlsl.domain.2.tese
+Shader version: 450
+input primitive = triangles
+vertex spacing = none
+triangle order = none
+0:? Sequence
+0:25  Function Definition: @main(struct-pcf_in_t-f1[3]-f1-f11;struct-ds_in_t-vf4-vf31[3];vf3; ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:25    Function Parameters: 
+0:25      'pcf_data' ( in structure{ temp 3-element array of float flTessFactor,  temp float flInsideTessFactor,  temp float foo})
+0:25      'i' ( const (read only) 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:25      'tesscoord' ( in 3-component vector of float)
+0:?     Sequence
+0:28      move second child to first child ( temp 4-component vector of float)
+0:28        pos: direct index for structure ( temp 4-component vector of float)
+0:28          'o' ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:28          Constant:
+0:28            0 (const int)
+0:28        add ( temp 4-component vector of float)
+0:28          pos: direct index for structure ( temp 4-component vector of float)
+0:28            direct index ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:28              'i' ( const (read only) 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:28              Constant:
+0:28                0 (const int)
+0:28            Constant:
+0:28              0 (const int)
+0:28          direct index ( temp float)
+0:28            'tesscoord' ( in 3-component vector of float)
+0:28            Constant:
+0:28              0 (const int)
+0:29      move second child to first child ( temp 3-component vector of float)
+0:29        norm: direct index for structure ( temp 3-component vector of float)
+0:29          'o' ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:29          Constant:
+0:29            1 (const int)
+0:29        add ( temp 3-component vector of float)
+0:29          norm: direct index for structure ( temp 3-component vector of float)
+0:29            direct index ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:29              'i' ( const (read only) 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:29              Constant:
+0:29                0 (const int)
+0:29            Constant:
+0:29              1 (const int)
+0:29          direct index ( temp float)
+0:29            'tesscoord' ( in 3-component vector of float)
+0:29            Constant:
+0:29              1 (const int)
+0:31      direct index ( temp float)
+0:31        'tesscoord' ( in 3-component vector of float)
+0:31        Constant:
+0:31          2 (const int)
+0:33      Branch: Return with expression
+0:33        'o' ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:25  Function Definition: main( ( temp void)
+0:25    Function Parameters: 
+0:?     Sequence
+0:25      Sequence
+0:25        move second child to first child ( temp float)
+0:25          direct index ( temp float)
+0:25            flTessFactor: direct index for structure ( temp 3-element array of float)
+0:?               'pcf_data' ( temp structure{ temp 3-element array of float flTessFactor,  temp float flInsideTessFactor,  temp float foo})
+0:25              Constant:
+0:25                0 (const int)
+0:25            Constant:
+0:25              0 (const int)
+0:25          direct index ( patch in float TessLevelOuter)
+0:?             'pcf_data_flTessFactor' ( patch in 4-element array of float TessLevelOuter)
+0:25            Constant:
+0:25              0 (const int)
+0:25        move second child to first child ( temp float)
+0:25          direct index ( temp float)
+0:25            flTessFactor: direct index for structure ( temp 3-element array of float)
+0:?               'pcf_data' ( temp structure{ temp 3-element array of float flTessFactor,  temp float flInsideTessFactor,  temp float foo})
+0:25              Constant:
+0:25                0 (const int)
+0:25            Constant:
+0:25              1 (const int)
+0:25          direct index ( patch in float TessLevelOuter)
+0:?             'pcf_data_flTessFactor' ( patch in 4-element array of float TessLevelOuter)
+0:25            Constant:
+0:25              1 (const int)
+0:25        move second child to first child ( temp float)
+0:25          direct index ( temp float)
+0:25            flTessFactor: direct index for structure ( temp 3-element array of float)
+0:?               'pcf_data' ( temp structure{ temp 3-element array of float flTessFactor,  temp float flInsideTessFactor,  temp float foo})
+0:25              Constant:
+0:25                0 (const int)
+0:25            Constant:
+0:25              2 (const int)
+0:25          direct index ( patch in float TessLevelOuter)
+0:?             'pcf_data_flTessFactor' ( patch in 4-element array of float TessLevelOuter)
+0:25            Constant:
+0:25              2 (const int)
+0:25        move second child to first child ( temp float)
+0:25          flInsideTessFactor: direct index for structure ( temp float)
+0:?             'pcf_data' ( temp structure{ temp 3-element array of float flTessFactor,  temp float flInsideTessFactor,  temp float foo})
+0:25            Constant:
+0:25              1 (const int)
+0:25          direct index ( patch in float TessLevelInner)
+0:?             'pcf_data_flInsideTessFactor' ( patch in 2-element array of float TessLevelInner)
+0:25            Constant:
+0:25              0 (const int)
+0:25        move second child to first child ( temp float)
+0:25          foo: direct index for structure ( temp float)
+0:?             'pcf_data' ( temp structure{ temp 3-element array of float flTessFactor,  temp float flInsideTessFactor,  temp float foo})
+0:25            Constant:
+0:25              2 (const int)
+0:25          foo: direct index for structure ( temp float)
+0:25            'pcf_data' (layout( location=2) patch in structure{ temp float foo})
+0:25            Constant:
+0:25              0 (const int)
+0:25      move second child to first child ( temp 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:?         'i' ( temp 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:?         'i' (layout( location=0) in 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:25      move second child to first child ( temp 3-component vector of float)
+0:?         'tesscoord' ( temp 3-component vector of float)
+0:?         'tesscoord' ( patch in 3-component vector of float TessCoord)
+0:25      move second child to first child ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:?         '@entryPointOutput' (layout( location=0) out structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:25        Function Call: @main(struct-pcf_in_t-f1[3]-f1-f11;struct-ds_in_t-vf4-vf31[3];vf3; ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:?           'pcf_data' ( temp structure{ temp 3-element array of float flTessFactor,  temp float flInsideTessFactor,  temp float foo})
+0:?           'i' ( temp 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:?           'tesscoord' ( temp 3-component vector of float)
+0:?   Linker Objects
+0:?     '@entryPointOutput' (layout( location=0) out structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:?     'i' (layout( location=0) in 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:?     'tesscoord' ( patch in 3-component vector of float TessCoord)
+0:?     'pcf_data' (layout( location=2) patch in structure{ temp float foo})
+0:?     'pcf_data_flTessFactor' ( patch in 4-element array of float TessLevelOuter)
+0:?     'pcf_data_flInsideTessFactor' ( patch in 2-element array of float TessLevelInner)
+
+
+Linked tessellation evaluation stage:
+
+
+Shader version: 450
+input primitive = triangles
+vertex spacing = none
+triangle order = none
+0:? Sequence
+0:25  Function Definition: @main(struct-pcf_in_t-f1[3]-f1-f11;struct-ds_in_t-vf4-vf31[3];vf3; ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:25    Function Parameters: 
+0:25      'pcf_data' ( in structure{ temp 3-element array of float flTessFactor,  temp float flInsideTessFactor,  temp float foo})
+0:25      'i' ( const (read only) 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:25      'tesscoord' ( in 3-component vector of float)
+0:?     Sequence
+0:28      move second child to first child ( temp 4-component vector of float)
+0:28        pos: direct index for structure ( temp 4-component vector of float)
+0:28          'o' ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:28          Constant:
+0:28            0 (const int)
+0:28        add ( temp 4-component vector of float)
+0:28          pos: direct index for structure ( temp 4-component vector of float)
+0:28            direct index ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:28              'i' ( const (read only) 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:28              Constant:
+0:28                0 (const int)
+0:28            Constant:
+0:28              0 (const int)
+0:28          direct index ( temp float)
+0:28            'tesscoord' ( in 3-component vector of float)
+0:28            Constant:
+0:28              0 (const int)
+0:29      move second child to first child ( temp 3-component vector of float)
+0:29        norm: direct index for structure ( temp 3-component vector of float)
+0:29          'o' ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:29          Constant:
+0:29            1 (const int)
+0:29        add ( temp 3-component vector of float)
+0:29          norm: direct index for structure ( temp 3-component vector of float)
+0:29            direct index ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:29              'i' ( const (read only) 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:29              Constant:
+0:29                0 (const int)
+0:29            Constant:
+0:29              1 (const int)
+0:29          direct index ( temp float)
+0:29            'tesscoord' ( in 3-component vector of float)
+0:29            Constant:
+0:29              1 (const int)
+0:31      direct index ( temp float)
+0:31        'tesscoord' ( in 3-component vector of float)
+0:31        Constant:
+0:31          2 (const int)
+0:33      Branch: Return with expression
+0:33        'o' ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:25  Function Definition: main( ( temp void)
+0:25    Function Parameters: 
+0:?     Sequence
+0:25      Sequence
+0:25        move second child to first child ( temp float)
+0:25          direct index ( temp float)
+0:25            flTessFactor: direct index for structure ( temp 3-element array of float)
+0:?               'pcf_data' ( temp structure{ temp 3-element array of float flTessFactor,  temp float flInsideTessFactor,  temp float foo})
+0:25              Constant:
+0:25                0 (const int)
+0:25            Constant:
+0:25              0 (const int)
+0:25          direct index ( patch in float TessLevelOuter)
+0:?             'pcf_data_flTessFactor' ( patch in 4-element array of float TessLevelOuter)
+0:25            Constant:
+0:25              0 (const int)
+0:25        move second child to first child ( temp float)
+0:25          direct index ( temp float)
+0:25            flTessFactor: direct index for structure ( temp 3-element array of float)
+0:?               'pcf_data' ( temp structure{ temp 3-element array of float flTessFactor,  temp float flInsideTessFactor,  temp float foo})
+0:25              Constant:
+0:25                0 (const int)
+0:25            Constant:
+0:25              1 (const int)
+0:25          direct index ( patch in float TessLevelOuter)
+0:?             'pcf_data_flTessFactor' ( patch in 4-element array of float TessLevelOuter)
+0:25            Constant:
+0:25              1 (const int)
+0:25        move second child to first child ( temp float)
+0:25          direct index ( temp float)
+0:25            flTessFactor: direct index for structure ( temp 3-element array of float)
+0:?               'pcf_data' ( temp structure{ temp 3-element array of float flTessFactor,  temp float flInsideTessFactor,  temp float foo})
+0:25              Constant:
+0:25                0 (const int)
+0:25            Constant:
+0:25              2 (const int)
+0:25          direct index ( patch in float TessLevelOuter)
+0:?             'pcf_data_flTessFactor' ( patch in 4-element array of float TessLevelOuter)
+0:25            Constant:
+0:25              2 (const int)
+0:25        move second child to first child ( temp float)
+0:25          flInsideTessFactor: direct index for structure ( temp float)
+0:?             'pcf_data' ( temp structure{ temp 3-element array of float flTessFactor,  temp float flInsideTessFactor,  temp float foo})
+0:25            Constant:
+0:25              1 (const int)
+0:25          direct index ( patch in float TessLevelInner)
+0:?             'pcf_data_flInsideTessFactor' ( patch in 2-element array of float TessLevelInner)
+0:25            Constant:
+0:25              0 (const int)
+0:25        move second child to first child ( temp float)
+0:25          foo: direct index for structure ( temp float)
+0:?             'pcf_data' ( temp structure{ temp 3-element array of float flTessFactor,  temp float flInsideTessFactor,  temp float foo})
+0:25            Constant:
+0:25              2 (const int)
+0:25          foo: direct index for structure ( temp float)
+0:25            'pcf_data' (layout( location=2) patch in structure{ temp float foo})
+0:25            Constant:
+0:25              0 (const int)
+0:25      move second child to first child ( temp 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:?         'i' ( temp 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:?         'i' (layout( location=0) in 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:25      move second child to first child ( temp 3-component vector of float)
+0:?         'tesscoord' ( temp 3-component vector of float)
+0:?         'tesscoord' ( patch in 3-component vector of float TessCoord)
+0:25      move second child to first child ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:?         '@entryPointOutput' (layout( location=0) out structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:25        Function Call: @main(struct-pcf_in_t-f1[3]-f1-f11;struct-ds_in_t-vf4-vf31[3];vf3; ( temp structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:?           'pcf_data' ( temp structure{ temp 3-element array of float flTessFactor,  temp float flInsideTessFactor,  temp float foo})
+0:?           'i' ( temp 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:?           'tesscoord' ( temp 3-component vector of float)
+0:?   Linker Objects
+0:?     '@entryPointOutput' (layout( location=0) out structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:?     'i' (layout( location=0) in 3-element array of structure{ temp 4-component vector of float pos,  temp 3-component vector of float norm})
+0:?     'tesscoord' ( patch in 3-component vector of float TessCoord)
+0:?     'pcf_data' (layout( location=2) patch in structure{ temp float foo})
+0:?     'pcf_data_flTessFactor' ( patch in 4-element array of float TessLevelOuter)
+0:?     'pcf_data_flInsideTessFactor' ( patch in 2-element array of float TessLevelInner)
+
+// Module Version 10000
+// Generated by (magic number): 80001
+// Id's are bound by 94
+
+                              Capability Tessellation
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint TessellationEvaluation 4  "main" 52 67 73 80 84 87
+                              ExecutionMode 4 Triangles
+                              Name 4  "main"
+                              Name 10  "pcf_in_t"
+                              MemberName 10(pcf_in_t) 0  "flTessFactor"
+                              MemberName 10(pcf_in_t) 1  "flInsideTessFactor"
+                              MemberName 10(pcf_in_t) 2  "foo"
+                              Name 14  "ds_in_t"
+                              MemberName 14(ds_in_t) 0  "pos"
+                              MemberName 14(ds_in_t) 1  "norm"
+                              Name 17  "gs_in_t"
+                              MemberName 17(gs_in_t) 0  "pos"
+                              MemberName 17(gs_in_t) 1  "norm"
+                              Name 22  "@main(struct-pcf_in_t-f1[3]-f1-f11;struct-ds_in_t-vf4-vf31[3];vf3;"
+                              Name 19  "pcf_data"
+                              Name 20  "i"
+                              Name 21  "tesscoord"
+                              Name 25  "o"
+                              Name 48  "pcf_data"
+                              Name 52  "pcf_data_flTessFactor"
+                              Name 67  "pcf_data_flInsideTessFactor"
+                              Name 71  "pcf_in_t"
+                              MemberName 71(pcf_in_t) 0  "foo"
+                              Name 73  "pcf_data"
+                              Name 78  "i"
+                              Name 80  "i"
+                              Name 82  "tesscoord"
+                              Name 84  "tesscoord"
+                              Name 87  "@entryPointOutput"
+                              Name 89  "param"
+                              Name 91  "param"
+                              Decorate 52(pcf_data_flTessFactor) Patch
+                              Decorate 52(pcf_data_flTessFactor) BuiltIn TessLevelOuter
+                              Decorate 67(pcf_data_flInsideTessFactor) Patch
+                              Decorate 67(pcf_data_flInsideTessFactor) BuiltIn TessLevelInner
+                              MemberDecorate 71(pcf_in_t) 0 Patch
+                              Decorate 73(pcf_data) Patch
+                              Decorate 73(pcf_data) Location 2
+                              Decorate 80(i) Location 0
+                              Decorate 84(tesscoord) Patch
+                              Decorate 84(tesscoord) BuiltIn TessCoord
+                              Decorate 87(@entryPointOutput) Location 0
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeFloat 32
+               7:             TypeInt 32 0
+               8:      7(int) Constant 3
+               9:             TypeArray 6(float) 8
+    10(pcf_in_t):             TypeStruct 9 6(float) 6(float)
+              11:             TypePointer Function 10(pcf_in_t)
+              12:             TypeVector 6(float) 4
+              13:             TypeVector 6(float) 3
+     14(ds_in_t):             TypeStruct 12(fvec4) 13(fvec3)
+              15:             TypeArray 14(ds_in_t) 8
+              16:             TypePointer Function 13(fvec3)
+     17(gs_in_t):             TypeStruct 12(fvec4) 13(fvec3)
+              18:             TypeFunction 17(gs_in_t) 11(ptr) 15 16(ptr)
+              24:             TypePointer Function 17(gs_in_t)
+              26:             TypeInt 32 1
+              27:     26(int) Constant 0
+              29:      7(int) Constant 0
+              30:             TypePointer Function 6(float)
+              35:             TypePointer Function 12(fvec4)
+              37:     26(int) Constant 1
+              39:      7(int) Constant 1
+              49:      7(int) Constant 4
+              50:             TypeArray 6(float) 49
+              51:             TypePointer Input 50
+52(pcf_data_flTessFactor):     51(ptr) Variable Input
+              53:             TypePointer Input 6(float)
+              60:     26(int) Constant 2
+              64:      7(int) Constant 2
+              65:             TypeArray 6(float) 64
+              66:             TypePointer Input 65
+67(pcf_data_flInsideTessFactor):     66(ptr) Variable Input
+    71(pcf_in_t):             TypeStruct 6(float)
+              72:             TypePointer Input 71(pcf_in_t)
+    73(pcf_data):     72(ptr) Variable Input
+              77:             TypePointer Function 15
+              79:             TypePointer Input 15
+           80(i):     79(ptr) Variable Input
+              83:             TypePointer Input 13(fvec3)
+   84(tesscoord):     83(ptr) Variable Input
+              86:             TypePointer Output 17(gs_in_t)
+87(@entryPointOutput):     86(ptr) Variable Output
+         4(main):           2 Function None 3
+               5:             Label
+    48(pcf_data):     11(ptr) Variable Function
+           78(i):     77(ptr) Variable Function
+   82(tesscoord):     16(ptr) Variable Function
+       89(param):     11(ptr) Variable Function
+       91(param):     16(ptr) Variable Function
+              54:     53(ptr) AccessChain 52(pcf_data_flTessFactor) 27
+              55:    6(float) Load 54
+              56:     30(ptr) AccessChain 48(pcf_data) 27 27
+                              Store 56 55
+              57:     53(ptr) AccessChain 52(pcf_data_flTessFactor) 37
+              58:    6(float) Load 57
+              59:     30(ptr) AccessChain 48(pcf_data) 27 37
+                              Store 59 58
+              61:     53(ptr) AccessChain 52(pcf_data_flTessFactor) 60
+              62:    6(float) Load 61
+              63:     30(ptr) AccessChain 48(pcf_data) 27 60
+                              Store 63 62
+              68:     53(ptr) AccessChain 67(pcf_data_flInsideTessFactor) 27
+              69:    6(float) Load 68
+              70:     30(ptr) AccessChain 48(pcf_data) 37
+                              Store 70 69
+              74:     53(ptr) AccessChain 73(pcf_data) 27
+              75:    6(float) Load 74
+              76:     30(ptr) AccessChain 48(pcf_data) 60
+                              Store 76 75
+              81:          15 Load 80(i)
+                              Store 78(i) 81
+              85:   13(fvec3) Load 84(tesscoord)
+                              Store 82(tesscoord) 85
+              88:          15 Load 78(i)
+              90:10(pcf_in_t) Load 48(pcf_data)
+                              Store 89(param) 90
+              92:   13(fvec3) Load 82(tesscoord)
+                              Store 91(param) 92
+              93: 17(gs_in_t) FunctionCall 22(@main(struct-pcf_in_t-f1[3]-f1-f11;struct-ds_in_t-vf4-vf31[3];vf3;) 89(param) 88 91(param)
+                              Store 87(@entryPointOutput) 93
+                              Return
+                              FunctionEnd
+22(@main(struct-pcf_in_t-f1[3]-f1-f11;struct-ds_in_t-vf4-vf31[3];vf3;): 17(gs_in_t) Function None 18
+    19(pcf_data):     11(ptr) FunctionParameter
+           20(i):          15 FunctionParameter
+   21(tesscoord):     16(ptr) FunctionParameter
+              23:             Label
+           25(o):     24(ptr) Variable Function
+              28:   12(fvec4) CompositeExtract 20(i) 0 0
+              31:     30(ptr) AccessChain 21(tesscoord) 29
+              32:    6(float) Load 31
+              33:   12(fvec4) CompositeConstruct 32 32 32 32
+              34:   12(fvec4) FAdd 28 33
+              36:     35(ptr) AccessChain 25(o) 27
+                              Store 36 34
+              38:   13(fvec3) CompositeExtract 20(i) 0 1
+              40:     30(ptr) AccessChain 21(tesscoord) 39
+              41:    6(float) Load 40
+              42:   13(fvec3) CompositeConstruct 41 41 41
+              43:   13(fvec3) FAdd 38 42
+              44:     16(ptr) AccessChain 25(o) 37
+                              Store 44 43
+              45: 17(gs_in_t) Load 25(o)
+                              ReturnValue 45
+                              FunctionEnd

--- a/Test/hlsl.domain.2.tese
+++ b/Test/hlsl.domain.2.tese
@@ -1,0 +1,35 @@
+// This will test having the PCF input to the domain shader not be given at the end of
+// the argument list.  We must move it to the end of the linkage in this case.
+
+struct ds_in_t 
+{ 
+    float4 pos  : POSITION; 
+    float3 norm : TEXCOORD0; 
+}; 
+
+struct pcf_in_t 
+{ 
+    float flTessFactor [3]   : SV_TessFactor; 
+    float flInsideTessFactor : SV_InsideTessFactor; 
+    float foo : PCF_FOO;
+}; 
+
+struct gs_in_t 
+{ 
+    float4 pos  : POSITION; 
+    float3 norm : TEXCOORD0; 
+}; 
+
+[domain ( "tri" )] 
+gs_in_t main (pcf_in_t pcf_data, const OutputPatch <ds_in_t, 3> i, float3 tesscoord : SV_DomainLocation) 
+{ 
+    gs_in_t o; 
+
+    o.pos  = i[0].pos + tesscoord.x;
+    o.norm = i[0].norm + tesscoord.y;
+
+    tesscoord.z;
+    
+    return o; 
+}
+

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -124,6 +124,7 @@ INSTANTIATE_TEST_CASE_P(
         {"hlsl.getdimensions.dx10.vert", "main"},
         {"hlsl.getsampleposition.dx10.frag", "main"},
         {"hlsl.domain.1.tese", "main"},
+        {"hlsl.domain.2.tese", "main"},
         {"hlsl.hull.1.tesc", "main"},
         {"hlsl.hull.2.tesc", "main"},
         {"hlsl.hull.void.tesc", "main"},


### PR DESCRIPTION
In the hull shader, the PCF output does not participate in an argument list, so has no defined ordering.  It is always put at the end of the linkage.  That means the DS input reading PCF data must also be at the end of the DS linkage as well, no matter where it may appear in the argument list.  This change makes sure that happens.

The detection is by looking for arguments that contain tessellation factor builtins, even as a struct member.  The whole struct is taken as the PCF output if any members are so qualified.
