### PR TITLE
Refactor the StandAlone.cpp and WorkList.h files in order to use more C++ feature and remove dependencies with OS specific code.

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -476,8 +476,6 @@ void SetMessageOptions(EShMessages& messages)
 //
 // Thread entry point, for non-linking asynchronous mode.
 //
-// Return 0 for failure, 1 for success.
-//
 void CompileShaders(glslang::TWorklist& worklist)
 {
     glslang::TWorkItem* workItem;
@@ -788,9 +786,8 @@ int C_DECL main(int argc, char* argv[])
 
         if (Options & EOptionMultiThreaded)
         {
-            std::array<std::thread, 32> threads;
-            const unsigned int numThreads = std::min<unsigned int>(threads.size(), std::thread::hardware_concurrency());
-            for (unsigned int t = 0; t < numThreads; ++t)
+            std::array<std::thread, 16> threads;
+            for (unsigned int t = 0; t < threads.size(); ++t)
             {
                 threads[t] = std::thread(CompileShaders, std::ref(workList));
                 if (threads[t].get_id() == std::thread::id())
@@ -800,7 +797,7 @@ int C_DECL main(int argc, char* argv[])
                 }
             }
 
-            std::for_each(threads.begin(), threads.begin() + numThreads, [](std::thread& t) { t.join(); });
+            std::for_each(threads.begin(), threads.end(), [](std::thread& t) { t.join(); });
         } else
             CompileShaders(workList);
 

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -51,6 +51,7 @@
 #include <cctype>
 #include <cmath>
 #include <array>
+#include <memory>
 #include <thread>
 
 #include "../glslang/OSDependent/osinclude.h"

--- a/StandAlone/Worklist.h
+++ b/StandAlone/Worklist.h
@@ -36,8 +36,9 @@
 #define WORKLIST_H_INCLUDED
 
 #include "../glslang/OSDependent/osinclude.h"
-#include <string>
 #include <list>
+#include <mutex>
+#include <string>
 
 namespace glslang {
 
@@ -58,23 +59,18 @@ namespace glslang {
 
         void add(TWorkItem* item)
         {
-            GetGlobalLock();
-
+            std::lock_guard<std::mutex> guard(mutex);
             worklist.push_back(item);
-
-            ReleaseGlobalLock();
         }
 
         bool remove(TWorkItem*& item)
         {
-            GetGlobalLock();
+            std::lock_guard<std::mutex> guard(mutex);
 
             if (worklist.empty())
                 return false;
             item = worklist.front();
             worklist.pop_front();
-
-            ReleaseGlobalLock();
 
             return true;
         }
@@ -90,6 +86,7 @@ namespace glslang {
         }
 
     protected:
+        std::mutex mutex;
         std::list<TWorkItem*> worklist;
     };
 

--- a/glslang/OSDependent/Unix/ossource.cpp
+++ b/glslang/OSDependent/Unix/ossource.cpp
@@ -184,20 +184,6 @@ void ReleaseGlobalLock()
   pthread_mutex_unlock(&gMutex);
 }
 
-// TODO: non-windows: if we need these on linux, flesh them out
-void* OS_CreateThread(TThreadEntrypoint /*entry*/)
-{
-    return 0;
-}
-
-void OS_WaitForAllThreads(void* /*threads*/, int /*numThreads*/)
-{
-}
-
-void OS_Sleep(int /*milliseconds*/)
-{
-}
-
 void OS_DumpMemoryCounters()
 {
 }

--- a/glslang/OSDependent/Windows/ossource.cpp
+++ b/glslang/OSDependent/Windows/ossource.cpp
@@ -131,21 +131,6 @@ unsigned int __stdcall EnterGenericThread (void* entry)
     return ((TThreadEntrypoint)entry)(0);
 }
 
-void* OS_CreateThread(TThreadEntrypoint entry)
-{
-    return (void*)_beginthreadex(0, 0, EnterGenericThread, (void*)entry, 0, 0);
-}
-
-void OS_WaitForAllThreads(void* threads, int numThreads)
-{
-    WaitForMultipleObjects(numThreads, (HANDLE*)threads, true, INFINITE);
-}
-
-void OS_Sleep(int milliseconds)
-{
-    Sleep(milliseconds);
-}
-
 //#define DUMP_COUNTERS
 
 void OS_DumpMemoryCounters()

--- a/glslang/OSDependent/osinclude.h
+++ b/glslang/OSDependent/osinclude.h
@@ -53,11 +53,8 @@ void GetGlobalLock();
 void ReleaseGlobalLock();
 
 typedef unsigned int (*TThreadEntrypoint)(void*);
-void* OS_CreateThread(TThreadEntrypoint);
-void OS_WaitForAllThreads(void* threads, int numThreads);
 
 void OS_CleanupThreadData(void);
-void OS_Sleep(int milliseconds);
 
 void OS_DumpMemoryCounters();
 


### PR DESCRIPTION
Specific changes:

- Making WorkList class to have its own mutex instead of the OS specific
global one. The new mutex is the one from std library.

- Using the C++11 std library to handle threads in StandAlone
application
and enabling concurrent processing on non-windows platforms.

- converting the global variable Worklist into local variable workList.