### PR TITLE
HLSL: fix return type for isfinite

### DIFF
--- a/Test/baseResults/hlsl.isfinite.frag.out
+++ b/Test/baseResults/hlsl.isfinite.frag.out
@@ -2,37 +2,85 @@ hlsl.isfinite.frag
 Shader version: 500
 gl_FragCoord origin is upper left
 0:? Sequence
-0:5  Function Definition: @main( ( temp 4-component vector of float)
-0:5    Function Parameters: 
+0:7  Function Definition: test1(f1; ( temp bool)
+0:7    Function Parameters: 
+0:7      'v' ( in float)
 0:?     Sequence
-0:6      Sequence
-0:6        move second child to first child ( temp float)
-0:6          '@finitetmp' ( temp float)
-0:6          f: direct index for structure ( uniform float)
-0:6            'anon@0' (layout( row_major std140) uniform block{ uniform float f})
-0:6            Constant:
-0:6              0 (const uint)
-0:6        logical-and ( temp bool)
-0:6          Negate conditional ( temp bool)
-0:6            isnan ( temp bool)
-0:6              '@finitetmp' ( temp float)
-0:6          Negate conditional ( temp bool)
-0:6            isinf ( temp bool)
-0:6              '@finitetmp' ( temp float)
 0:8      Branch: Return with expression
-0:8        Constant:
-0:8          0.000000
-0:8          0.000000
-0:8          0.000000
-0:8          0.000000
-0:5  Function Definition: main( ( temp void)
-0:5    Function Parameters: 
+0:8        logical-and ( temp bool)
+0:8          Negate conditional ( temp bool)
+0:8            isnan ( temp bool)
+0:8              'v' ( in float)
+0:8          Sequence
+0:8            move second child to first child ( temp float)
+0:8              '@finitetmp' ( temp float)
+0:8              'v' ( in float)
+0:8            logical-and ( temp bool)
+0:8              Negate conditional ( temp bool)
+0:8                isnan ( temp bool)
+0:8                  '@finitetmp' ( temp float)
+0:8              Negate conditional ( temp bool)
+0:8                isinf ( temp bool)
+0:8                  '@finitetmp' ( temp float)
+0:12  Function Definition: @main( ( temp 4-component vector of float)
+0:12    Function Parameters: 
 0:?     Sequence
-0:5      move second child to first child ( temp 4-component vector of float)
+0:13      Sequence
+0:13        move second child to first child ( temp float)
+0:13          '@finitetmp' ( temp float)
+0:13          f: direct index for structure ( uniform float)
+0:13            'anon@0' (layout( row_major std140) uniform block{ uniform float f,  uniform 2-component vector of float f2,  uniform 3-component vector of float f3})
+0:13            Constant:
+0:13              0 (const uint)
+0:13        logical-and ( temp bool)
+0:13          Negate conditional ( temp bool)
+0:13            isnan ( temp bool)
+0:13              '@finitetmp' ( temp float)
+0:13          Negate conditional ( temp bool)
+0:13            isinf ( temp bool)
+0:13              '@finitetmp' ( temp float)
+0:14      Sequence
+0:14        move second child to first child ( temp 2-component vector of float)
+0:14          '@finitetmp' ( temp 2-component vector of float)
+0:14          f2: direct index for structure ( uniform 2-component vector of float)
+0:14            'anon@0' (layout( row_major std140) uniform block{ uniform float f,  uniform 2-component vector of float f2,  uniform 3-component vector of float f3})
+0:14            Constant:
+0:14              1 (const uint)
+0:14        logical-and ( temp 2-component vector of bool)
+0:14          Negate conditional ( temp 2-component vector of bool)
+0:14            isnan ( temp 2-component vector of bool)
+0:14              '@finitetmp' ( temp 2-component vector of float)
+0:14          Negate conditional ( temp 2-component vector of bool)
+0:14            isinf ( temp 2-component vector of bool)
+0:14              '@finitetmp' ( temp 2-component vector of float)
+0:15      Sequence
+0:15        move second child to first child ( temp 3-component vector of float)
+0:15          '@finitetmp' ( temp 3-component vector of float)
+0:15          f3: direct index for structure ( uniform 3-component vector of float)
+0:15            'anon@0' (layout( row_major std140) uniform block{ uniform float f,  uniform 2-component vector of float f2,  uniform 3-component vector of float f3})
+0:15            Constant:
+0:15              2 (const uint)
+0:15        logical-and ( temp 3-component vector of bool)
+0:15          Negate conditional ( temp 3-component vector of bool)
+0:15            isnan ( temp 3-component vector of bool)
+0:15              '@finitetmp' ( temp 3-component vector of float)
+0:15          Negate conditional ( temp 3-component vector of bool)
+0:15            isinf ( temp 3-component vector of bool)
+0:15              '@finitetmp' ( temp 3-component vector of float)
+0:17      Branch: Return with expression
+0:17        Constant:
+0:17          0.000000
+0:17          0.000000
+0:17          0.000000
+0:17          0.000000
+0:12  Function Definition: main( ( temp void)
+0:12    Function Parameters: 
+0:?     Sequence
+0:12      move second child to first child ( temp 4-component vector of float)
 0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
-0:5        Function Call: @main( ( temp 4-component vector of float)
+0:12        Function Call: @main( ( temp 4-component vector of float)
 0:?   Linker Objects
-0:?     'anon@0' (layout( row_major std140) uniform block{ uniform float f})
+0:?     'anon@0' (layout( row_major std140) uniform block{ uniform float f,  uniform 2-component vector of float f2,  uniform 3-component vector of float f3})
 0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
 
 
@@ -42,100 +90,229 @@ Linked fragment stage:
 Shader version: 500
 gl_FragCoord origin is upper left
 0:? Sequence
-0:5  Function Definition: @main( ( temp 4-component vector of float)
-0:5    Function Parameters: 
+0:7  Function Definition: test1(f1; ( temp bool)
+0:7    Function Parameters: 
+0:7      'v' ( in float)
 0:?     Sequence
-0:6      Sequence
-0:6        move second child to first child ( temp float)
-0:6          '@finitetmp' ( temp float)
-0:6          f: direct index for structure ( uniform float)
-0:6            'anon@0' (layout( row_major std140) uniform block{ uniform float f})
-0:6            Constant:
-0:6              0 (const uint)
-0:6        logical-and ( temp bool)
-0:6          Negate conditional ( temp bool)
-0:6            isnan ( temp bool)
-0:6              '@finitetmp' ( temp float)
-0:6          Negate conditional ( temp bool)
-0:6            isinf ( temp bool)
-0:6              '@finitetmp' ( temp float)
 0:8      Branch: Return with expression
-0:8        Constant:
-0:8          0.000000
-0:8          0.000000
-0:8          0.000000
-0:8          0.000000
-0:5  Function Definition: main( ( temp void)
-0:5    Function Parameters: 
+0:8        logical-and ( temp bool)
+0:8          Negate conditional ( temp bool)
+0:8            isnan ( temp bool)
+0:8              'v' ( in float)
+0:8          Sequence
+0:8            move second child to first child ( temp float)
+0:8              '@finitetmp' ( temp float)
+0:8              'v' ( in float)
+0:8            logical-and ( temp bool)
+0:8              Negate conditional ( temp bool)
+0:8                isnan ( temp bool)
+0:8                  '@finitetmp' ( temp float)
+0:8              Negate conditional ( temp bool)
+0:8                isinf ( temp bool)
+0:8                  '@finitetmp' ( temp float)
+0:12  Function Definition: @main( ( temp 4-component vector of float)
+0:12    Function Parameters: 
 0:?     Sequence
-0:5      move second child to first child ( temp 4-component vector of float)
+0:13      Sequence
+0:13        move second child to first child ( temp float)
+0:13          '@finitetmp' ( temp float)
+0:13          f: direct index for structure ( uniform float)
+0:13            'anon@0' (layout( row_major std140) uniform block{ uniform float f,  uniform 2-component vector of float f2,  uniform 3-component vector of float f3})
+0:13            Constant:
+0:13              0 (const uint)
+0:13        logical-and ( temp bool)
+0:13          Negate conditional ( temp bool)
+0:13            isnan ( temp bool)
+0:13              '@finitetmp' ( temp float)
+0:13          Negate conditional ( temp bool)
+0:13            isinf ( temp bool)
+0:13              '@finitetmp' ( temp float)
+0:14      Sequence
+0:14        move second child to first child ( temp 2-component vector of float)
+0:14          '@finitetmp' ( temp 2-component vector of float)
+0:14          f2: direct index for structure ( uniform 2-component vector of float)
+0:14            'anon@0' (layout( row_major std140) uniform block{ uniform float f,  uniform 2-component vector of float f2,  uniform 3-component vector of float f3})
+0:14            Constant:
+0:14              1 (const uint)
+0:14        logical-and ( temp 2-component vector of bool)
+0:14          Negate conditional ( temp 2-component vector of bool)
+0:14            isnan ( temp 2-component vector of bool)
+0:14              '@finitetmp' ( temp 2-component vector of float)
+0:14          Negate conditional ( temp 2-component vector of bool)
+0:14            isinf ( temp 2-component vector of bool)
+0:14              '@finitetmp' ( temp 2-component vector of float)
+0:15      Sequence
+0:15        move second child to first child ( temp 3-component vector of float)
+0:15          '@finitetmp' ( temp 3-component vector of float)
+0:15          f3: direct index for structure ( uniform 3-component vector of float)
+0:15            'anon@0' (layout( row_major std140) uniform block{ uniform float f,  uniform 2-component vector of float f2,  uniform 3-component vector of float f3})
+0:15            Constant:
+0:15              2 (const uint)
+0:15        logical-and ( temp 3-component vector of bool)
+0:15          Negate conditional ( temp 3-component vector of bool)
+0:15            isnan ( temp 3-component vector of bool)
+0:15              '@finitetmp' ( temp 3-component vector of float)
+0:15          Negate conditional ( temp 3-component vector of bool)
+0:15            isinf ( temp 3-component vector of bool)
+0:15              '@finitetmp' ( temp 3-component vector of float)
+0:17      Branch: Return with expression
+0:17        Constant:
+0:17          0.000000
+0:17          0.000000
+0:17          0.000000
+0:17          0.000000
+0:12  Function Definition: main( ( temp void)
+0:12    Function Parameters: 
+0:?     Sequence
+0:12      move second child to first child ( temp 4-component vector of float)
 0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
-0:5        Function Call: @main( ( temp 4-component vector of float)
+0:12        Function Call: @main( ( temp 4-component vector of float)
 0:?   Linker Objects
-0:?     'anon@0' (layout( row_major std140) uniform block{ uniform float f})
+0:?     'anon@0' (layout( row_major std140) uniform block{ uniform float f,  uniform 2-component vector of float f2,  uniform 3-component vector of float f3})
 0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 38
+// Id's are bound by 95
 
                               Capability Shader
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 36
+                              EntryPoint Fragment 4  "main" 93
                               ExecutionMode 4 OriginUpperLeft
                               Source HLSL 500
                               Name 4  "main"
-                              Name 9  "@main("
-                              Name 12  "@finitetmp"
-                              Name 13  "$Global"
-                              MemberName 13($Global) 0  "f"
-                              Name 15  ""
-                              Name 36  "@entryPointOutput"
-                              MemberDecorate 13($Global) 0 Offset 0
-                              Decorate 13($Global) Block
-                              Decorate 15 DescriptorSet 0
-                              Decorate 36(@entryPointOutput) Location 0
+                              Name 11  "test1(f1;"
+                              Name 10  "v"
+                              Name 15  "@main("
+                              Name 22  "@finitetmp"
+                              Name 36  "@finitetmp"
+                              Name 39  "$Global"
+                              MemberName 39($Global) 0  "f"
+                              MemberName 39($Global) 1  "f2"
+                              MemberName 39($Global) 2  "f3"
+                              Name 41  ""
+                              Name 57  "@finitetmp"
+                              Name 73  "@finitetmp"
+                              Name 93  "@entryPointOutput"
+                              MemberDecorate 39($Global) 0 Offset 0
+                              MemberDecorate 39($Global) 1 Offset 8
+                              MemberDecorate 39($Global) 2 Offset 16
+                              Decorate 39($Global) Block
+                              Decorate 41 DescriptorSet 0
+                              Decorate 93(@entryPointOutput) Location 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
-               7:             TypeVector 6(float) 4
-               8:             TypeFunction 7(fvec4)
-              11:             TypePointer Function 6(float)
-     13($Global):             TypeStruct 6(float)
-              14:             TypePointer Uniform 13($Global)
-              15:     14(ptr) Variable Uniform
-              16:             TypeInt 32 1
-              17:     16(int) Constant 0
-              18:             TypePointer Uniform 6(float)
-              21:             TypeBool
-              31:    6(float) Constant 0
-              32:    7(fvec4) ConstantComposite 31 31 31 31
-              35:             TypePointer Output 7(fvec4)
-36(@entryPointOutput):     35(ptr) Variable Output
+               7:             TypePointer Function 6(float)
+               8:             TypeBool
+               9:             TypeFunction 8(bool) 7(ptr)
+              13:             TypeVector 6(float) 4
+              14:             TypeFunction 13(fvec4)
+              37:             TypeVector 6(float) 2
+              38:             TypeVector 6(float) 3
+     39($Global):             TypeStruct 6(float) 37(fvec2) 38(fvec3)
+              40:             TypePointer Uniform 39($Global)
+              41:     40(ptr) Variable Uniform
+              42:             TypeInt 32 1
+              43:     42(int) Constant 0
+              44:             TypePointer Uniform 6(float)
+              56:             TypePointer Function 37(fvec2)
+              58:     42(int) Constant 1
+              59:             TypePointer Uniform 37(fvec2)
+              63:             TypeVector 8(bool) 2
+              72:             TypePointer Function 38(fvec3)
+              74:     42(int) Constant 2
+              75:             TypePointer Uniform 38(fvec3)
+              79:             TypeVector 8(bool) 3
+              88:    6(float) Constant 0
+              89:   13(fvec4) ConstantComposite 88 88 88 88
+              92:             TypePointer Output 13(fvec4)
+93(@entryPointOutput):     92(ptr) Variable Output
          4(main):           2 Function None 3
                5:             Label
-              37:    7(fvec4) FunctionCall 9(@main()
-                              Store 36(@entryPointOutput) 37
+              94:   13(fvec4) FunctionCall 15(@main()
+                              Store 93(@entryPointOutput) 94
                               Return
                               FunctionEnd
-       9(@main():    7(fvec4) Function None 8
-              10:             Label
-  12(@finitetmp):     11(ptr) Variable Function
-              19:     18(ptr) AccessChain 15 17
-              20:    6(float) Load 19
-                              Store 12(@finitetmp) 20
-              22:    6(float) Load 12(@finitetmp)
-              23:    21(bool) IsNan 22
-              24:    21(bool) LogicalNot 23
-                              SelectionMerge 26 None
-                              BranchConditional 24 25 26
-              25:               Label
-              27:    6(float)   Load 12(@finitetmp)
-              28:    21(bool)   IsInf 27
-              29:    21(bool)   LogicalNot 28
-                                Branch 26
-              26:             Label
-              30:    21(bool) Phi 24 10 29 25
-                              ReturnValue 32
+   11(test1(f1;):     8(bool) Function None 9
+           10(v):      7(ptr) FunctionParameter
+              12:             Label
+  22(@finitetmp):      7(ptr) Variable Function
+              17:    6(float) Load 10(v)
+              18:     8(bool) IsNan 17
+              19:     8(bool) LogicalNot 18
+                              SelectionMerge 21 None
+                              BranchConditional 19 20 21
+              20:               Label
+              23:    6(float)   Load 10(v)
+                                Store 22(@finitetmp) 23
+              24:    6(float)   Load 22(@finitetmp)
+              25:     8(bool)   IsNan 24
+              26:     8(bool)   LogicalNot 25
+                                SelectionMerge 28 None
+                                BranchConditional 26 27 28
+              27:                 Label
+              29:    6(float)     Load 22(@finitetmp)
+              30:     8(bool)     IsInf 29
+              31:     8(bool)     LogicalNot 30
+                                  Branch 28
+              28:               Label
+              32:     8(bool)   Phi 26 20 31 27
+                                Branch 21
+              21:             Label
+              33:     8(bool) Phi 19 12 32 28
+                              ReturnValue 33
+                              FunctionEnd
+      15(@main():   13(fvec4) Function None 14
+              16:             Label
+  36(@finitetmp):      7(ptr) Variable Function
+  57(@finitetmp):     56(ptr) Variable Function
+  73(@finitetmp):     72(ptr) Variable Function
+              45:     44(ptr) AccessChain 41 43
+              46:    6(float) Load 45
+                              Store 36(@finitetmp) 46
+              47:    6(float) Load 36(@finitetmp)
+              48:     8(bool) IsNan 47
+              49:     8(bool) LogicalNot 48
+                              SelectionMerge 51 None
+                              BranchConditional 49 50 51
+              50:               Label
+              52:    6(float)   Load 36(@finitetmp)
+              53:     8(bool)   IsInf 52
+              54:     8(bool)   LogicalNot 53
+                                Branch 51
+              51:             Label
+              55:     8(bool) Phi 49 16 54 50
+              60:     59(ptr) AccessChain 41 58
+              61:   37(fvec2) Load 60
+                              Store 57(@finitetmp) 61
+              62:   37(fvec2) Load 57(@finitetmp)
+              64:   63(bvec2) IsNan 62
+              65:   63(bvec2) LogicalNot 64
+                              SelectionMerge 67 None
+                              BranchConditional 65 66 67
+              66:               Label
+              68:   37(fvec2)   Load 57(@finitetmp)
+              69:   63(bvec2)   IsInf 68
+              70:   63(bvec2)   LogicalNot 69
+                                Branch 67
+              67:             Label
+              71:     8(bool) Phi 65 51 70 66
+              76:     75(ptr) AccessChain 41 74
+              77:   38(fvec3) Load 76
+                              Store 73(@finitetmp) 77
+              78:   38(fvec3) Load 73(@finitetmp)
+              80:   79(bvec3) IsNan 78
+              81:   79(bvec3) LogicalNot 80
+                              SelectionMerge 83 None
+                              BranchConditional 81 82 83
+              82:               Label
+              84:   38(fvec3)   Load 73(@finitetmp)
+              85:   79(bvec3)   IsInf 84
+              86:   79(bvec3)   LogicalNot 85
+                                Branch 83
+              83:             Label
+              87:     8(bool) Phi 81 67 86 82
+                              ReturnValue 89
                               FunctionEnd

--- a/Test/hlsl.isfinite.frag
+++ b/Test/hlsl.isfinite.frag
@@ -1,9 +1,18 @@
 
-uniform float f;
+uniform float  f;
+uniform float2 f2;
+uniform float3 f3;
+
+bool test1(float v)
+{
+    return !isnan(v) && isfinite(v);
+}
 
 float4 main() : SV_Target0
 {
     isfinite(f);
+    isfinite(f2);
+    isfinite(f3);
 
     return 0;
 }

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -3907,25 +3907,27 @@ void HlslParseContext::decomposeIntrinsic(const TSourceLoc& loc, TIntermTyped*& 
 
             TIntermAggregate* compoundStatement = intermediate.makeAggregate(tmpArgAssign, loc);
 
+            const TType boolType(EbtBool, EvqTemporary, arg0->getVectorSize(), arg0->getMatrixCols(), arg0->getMatrixRows());
+
             TIntermTyped* isnan = handleUnaryMath(loc, "isnan", EOpIsNan, intermediate.addSymbol(*tempArg, loc));
-            isnan->setType(TType(EbtBool));
+            isnan->setType(boolType);
 
             TIntermTyped* notnan = handleUnaryMath(loc, "!", EOpLogicalNot, isnan);
-            notnan->setType(TType(EbtBool));
+            notnan->setType(boolType);
 
             TIntermTyped* isinf = handleUnaryMath(loc, "isinf", EOpIsInf, intermediate.addSymbol(*tempArg, loc));
-            isinf->setType(TType(EbtBool));
+            isinf->setType(boolType);
 
             TIntermTyped* notinf = handleUnaryMath(loc, "!", EOpLogicalNot, isinf);
-            notinf->setType(TType(EbtBool));
+            notinf->setType(boolType);
             
             TIntermTyped* andNode = handleBinaryMath(loc, "and", EOpLogicalAnd, notnan, notinf);
-            andNode->setType(TType(EbtBool));
+            andNode->setType(boolType);
 
             compoundStatement = intermediate.growAggregate(compoundStatement, andNode);
             compoundStatement->setOperator(EOpSequence);
             compoundStatement->setLoc(loc);
-            compoundStatement->setType(TType(EbtVoid));
+            compoundStatement->setType(boolType);
 
             node = compoundStatement;
 


### PR DESCRIPTION
The prior decomposition of isfinite was not setting the return type on the sequence node.  (Sequence was used because there's an internal temporary to avoid the complex rvalue problem).