### PR TITLE
Fix Android build errors

### DIFF
--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -204,8 +204,8 @@ public:
 struct TResolverUniformAdaptor
 {
     TResolverUniformAdaptor(EShLanguage s, TIoMapResolver& r, TInfoSink& i, bool& e, TIntermediate& interm)
-      : resolver(r)
-      , stage(s)
+      : stage(s)
+      , resolver(r)
       , infoSink(i)
       , error(e)
       , intermediate(interm)
@@ -260,8 +260,8 @@ private:
 struct TResolverInOutAdaptor
 {
     TResolverInOutAdaptor(EShLanguage s, TIoMapResolver& r, TInfoSink& i, bool& e, TIntermediate& interm)
-      : resolver(r)
-      , stage(s)
+      : stage(s)
+      , resolver(r)
       , infoSink(i)
       , error(e)
       , intermediate(interm)

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -61,14 +61,14 @@ HlslParseContext::HlslParseContext(TSymbolTable& symbolTable, TIntermediate& int
     loopNestingLevel(0), annotationNestingLevel(0), structNestingLevel(0), controlFlowNestingLevel(0),
     postEntryPointReturn(false),
     limits(resources.limits),
+    inputPatch(nullptr),
     builtInIoIndex(nullptr),
     builtInIoBase(nullptr),
     nextInLocation(0), nextOutLocation(0),
     sourceEntryPointName(sourceEntryPointName),
     entryPointFunction(nullptr),
     entryPointFunctionBody(nullptr),
-    gsStreamOutput(nullptr),
-    inputPatch(nullptr)
+    gsStreamOutput(nullptr)
 {
     globalUniformDefaults.clear();
     globalUniformDefaults.layoutMatrix = ElmRowMajor;


### PR DESCRIPTION

... due to out of order initializers. 

glslang/MachineIndependent/iomapper.cpp:207:9: error: field 'resolver' will be initialized after field 'stage' [-Werror,-Wreorder]
      : resolver(r)
        ^
glslang/MachineIndependent/iomapper.cpp:263:9: error: field 'resolver' will be initialized after field 'stage' [-Werror,-Wreorder]
      : resolver(r)
        ^
hlsl/hlslParseHelper.cpp:70:5: error: field 'gsStreamOutput' will be initialized after field 'inputPatch' [-Werror,-Wreorder]
    gsStreamOutput(nullptr),
    ^