### PR TITLE
track declared builtin type

### DIFF
--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -400,6 +400,7 @@ public:
         invariant = false;
         noContraction = false;
         makeTemporary();
+        declaredBuiltIn = EbvNone;
     }
 
     // drop qualifiers that don't belong in a temporary variable
@@ -457,6 +458,7 @@ public:
     const char*         semanticName;
     TStorageQualifier   storage   : 6;
     TBuiltInVariable    builtIn   : 8;
+    TBuiltInVariable    declaredBuiltIn : 8;
     TPrecisionQualifier precision : 3;
     bool invariant    : 1; // require canonical treatment for cross-shader invariance
     bool noContraction: 1; // prevent contraction and reassociation, e.g., for 'precise' keyword, and expressions it affects

--- a/glslang/MachineIndependent/SymbolTable.h
+++ b/glslang/MachineIndependent/SymbolTable.h
@@ -198,7 +198,6 @@ struct TParameter {
     TString *name;
     TType* type;
     TIntermTyped* defaultValue;
-    TBuiltInVariable declaredBuiltIn;
     void copyParam(const TParameter& param)
     {
         if (param.name)
@@ -207,8 +206,8 @@ struct TParameter {
             name = 0;
         type = param.type->clone();
         defaultValue = param.defaultValue;
-        declaredBuiltIn = param.declaredBuiltIn;
     }
+    TBuiltInVariable getDeclaredBuiltIn() const { return type->getQualifier().declaredBuiltIn; }
 };
 
 //
@@ -241,7 +240,6 @@ public:
     virtual void addParameter(TParameter& p)
     {
         assert(writable);
-        p.declaredBuiltIn = p.type->getQualifier().builtIn;
         parameters.push_back(p);
         p.type->appendMangledName(mangledName);
 

--- a/hlsl/hlslParseHelper.h
+++ b/hlsl/hlslParseHelper.h
@@ -289,7 +289,7 @@ protected:
     bool isReference(const TType& type) const { return isStructBufferType(type); }
 
     // Return true if this a buffer type that has an associated counter buffer.
-    bool hasStructBuffCounter(const TString& name) const;
+    bool hasStructBuffCounter(const TType&) const;
 
     // Finalization step: remove unused buffer blocks from linkage (we don't know until the
     // shader is entirely compiled)
@@ -383,7 +383,6 @@ protected:
     // Structuredbuffer shared types.  Typically there are only a few.
     TVector<TType*> structBufferTypes;
     
-    TMap<TString, TBuiltInVariable> structBufferBuiltIn;
     TMap<TString, bool> structBufferCounter;
 
     // The builtin interstage IO map considers e.g, EvqPosition on input and output separately, so that we


### PR DESCRIPTION
Marking as WIP since it might deserve discussion or at least explicit consideration, as it touches the TType member data.

During type sanitization, the TQualifier's TBuiltInVariable type is lost.  However, sometimes it's needed downstream.  There were already two methods in use to track it through to places it was needed: one in the TParameter, and another in a map in the HlslParseContext used for structured buffers.

The latter was going to be insufficient when SB types with counters are passed to user functions, and it's proving awkward to track the data to where it's needed. This PR holds a proposal: track the original declared builtin type in the TType, so it's trivially available anywhere needed.

This lets the other two mechanisms be removed (as they are in this PR).  There's also a side benefit of not losing certain types of information before the reflection interface.

This PR contains only that proposal, so it changes no test results.  If it's acceptable, I'll build on it for the last piece of SB counter functionality.
