### PR TITLE
Fix for lumped/unity/batch builds

### DIFF
--- a/SPIRV/GlslangToSpv.h
+++ b/SPIRV/GlslangToSpv.h
@@ -32,6 +32,8 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#pragma once
+
 #if _MSC_VER >= 1900
     #pragma warning(disable : 4464) // relative include path contains '..'
 #endif

--- a/SPIRV/doc.h
+++ b/SPIRV/doc.h
@@ -36,6 +36,8 @@
 // Parameterize the SPIR-V enumerants.
 //
 
+#pragma once
+
 #include "spirv.hpp"
 
 #include <vector>

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -35,7 +35,9 @@
 //
 
 // this only applies to the standalone wrapper, not the front end in general
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 
 #include "ResourceLimits.h"
 #include "Worklist.h"

--- a/glslang/MachineIndependent/LiveTraverser.h
+++ b/glslang/MachineIndependent/LiveTraverser.h
@@ -33,6 +33,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
+#pragma once
+
 #include "../Include/Common.h"
 #include "reflection.h"
 #include "localintermediate.h"

--- a/glslang/MachineIndependent/RemoveTree.h
+++ b/glslang/MachineIndependent/RemoveTree.h
@@ -32,6 +32,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
+#pragma once
+
 namespace glslang {
 
 void RemoveAllTreeNodes(TIntermNode*);

--- a/glslang/MachineIndependent/ScanContext.h
+++ b/glslang/MachineIndependent/ScanContext.h
@@ -38,6 +38,8 @@
 // sits between the preprocessor scanner and parser.
 //
 
+#pragma once
+
 #include "ParseHelper.h"
 
 namespace glslang {

--- a/glslang/MachineIndependent/gl_types.h
+++ b/glslang/MachineIndependent/gl_types.h
@@ -21,6 +21,8 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
+#pragma once
+
 #define GL_FLOAT                          0x1406
 #define GL_FLOAT_VEC2                     0x8B50
 #define GL_FLOAT_VEC3                     0x8B51

--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
+++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
@@ -76,7 +76,9 @@ TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY OR OTHERWISE, EVEN IF
 NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \****************************************************************************/
 
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 
 #include <sstream>
 #include <cstdlib>

--- a/glslang/MachineIndependent/preprocessor/PpAtom.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpAtom.cpp
@@ -76,7 +76,9 @@ TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY OR OTHERWISE, EVEN IF
 NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \****************************************************************************/
 
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 
 #include <cassert>
 #include <cstdlib>

--- a/glslang/MachineIndependent/preprocessor/PpScanner.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpScanner.cpp
@@ -76,7 +76,9 @@ TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY OR OTHERWISE, EVEN IF
 NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 \****************************************************************************/
 
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 
 #include <cstdlib>
 #include <cstring>

--- a/glslang/MachineIndependent/preprocessor/PpTokens.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpTokens.cpp
@@ -80,8 +80,10 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // For recording and playing back the stream of tokens in a macro definition.
 //
 
-#if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/)
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
+#if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/)
 #define snprintf sprintf_s
 #endif
 

--- a/glslang/MachineIndependent/propagateNoContraction.h
+++ b/glslang/MachineIndependent/propagateNoContraction.h
@@ -37,6 +37,8 @@
 // propagate 'noContraction' qualifier.
 //
 
+#pragma once
+
 #include "../Include/intermediate.h"
 
 namespace glslang {


### PR DESCRIPTION
When glslang is compiled with some other build system that uses lumped/unity/batch builds, it had some compile errors -- mostly due to missing include guards in some headers, and redefinitions of preprocessor macros.