### PR TITLE
HLSL: allow name mangling based on texture template type

### DIFF
--- a/Test/baseResults/hlsl.tx.overload.frag.out
+++ b/Test/baseResults/hlsl.tx.overload.frag.out
@@ -1,0 +1,228 @@
+hlsl.tx.overload.frag
+Shader version: 500
+gl_FragCoord origin is upper left
+0:? Sequence
+0:8  Function Definition: Func(t211; ( temp float)
+0:8    Function Parameters: 
+0:8      'DummyTex' ( in texture2D)
+0:?     Sequence
+0:8      Branch: Return with expression
+0:8        Constant:
+0:8          1.000000
+0:9  Function Definition: Func(t21; ( temp 4-component vector of float)
+0:9    Function Parameters: 
+0:9      'DummyTex' ( in texture2D)
+0:?     Sequence
+0:9      Branch: Return with expression
+0:?         Constant:
+0:?           0.000000
+0:?           0.000000
+0:?           0.000000
+0:?           0.000000
+0:11  Function Definition: Func(I211; ( temp float)
+0:11    Function Parameters: 
+0:11      'DummyTex' (layout( r32f) in image2D)
+0:?     Sequence
+0:11      Branch: Return with expression
+0:11        Constant:
+0:11          1.000000
+0:12  Function Definition: Func(I21; ( temp 4-component vector of float)
+0:12    Function Parameters: 
+0:12      'DummyTex' (layout( rgba32f) in image2D)
+0:?     Sequence
+0:12      Branch: Return with expression
+0:?         Constant:
+0:?           0.000000
+0:?           0.000000
+0:?           0.000000
+0:?           0.000000
+0:15  Function Definition: @main( ( temp 4-component vector of float)
+0:15    Function Parameters: 
+0:?     Sequence
+0:16      Branch: Return with expression
+0:16        add ( temp 4-component vector of float)
+0:16          add ( temp 4-component vector of float)
+0:16            add ( temp 4-component vector of float)
+0:16              Function Call: Func(t211; ( temp float)
+0:16                'tf1' ( uniform texture2D)
+0:16              Function Call: Func(t21; ( temp 4-component vector of float)
+0:16                'tf4' ( uniform texture2D)
+0:16            Function Call: Func(I211; ( temp float)
+0:16              'twf1' (layout( r32f) uniform image2D)
+0:16          Function Call: Func(I21; ( temp 4-component vector of float)
+0:16            'twf4' (layout( rgba32f) uniform image2D)
+0:15  Function Definition: main( ( temp void)
+0:15    Function Parameters: 
+0:?     Sequence
+0:15      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:15        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     'tf1' ( uniform texture2D)
+0:?     'tf4' ( uniform texture2D)
+0:?     'twf1' (layout( r32f) uniform image2D)
+0:?     'twf4' (layout( rgba32f) uniform image2D)
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+
+Linked fragment stage:
+
+
+Shader version: 500
+gl_FragCoord origin is upper left
+0:? Sequence
+0:8  Function Definition: Func(t211; ( temp float)
+0:8    Function Parameters: 
+0:8      'DummyTex' ( in texture2D)
+0:?     Sequence
+0:8      Branch: Return with expression
+0:8        Constant:
+0:8          1.000000
+0:9  Function Definition: Func(t21; ( temp 4-component vector of float)
+0:9    Function Parameters: 
+0:9      'DummyTex' ( in texture2D)
+0:?     Sequence
+0:9      Branch: Return with expression
+0:?         Constant:
+0:?           0.000000
+0:?           0.000000
+0:?           0.000000
+0:?           0.000000
+0:11  Function Definition: Func(I211; ( temp float)
+0:11    Function Parameters: 
+0:11      'DummyTex' (layout( r32f) in image2D)
+0:?     Sequence
+0:11      Branch: Return with expression
+0:11        Constant:
+0:11          1.000000
+0:12  Function Definition: Func(I21; ( temp 4-component vector of float)
+0:12    Function Parameters: 
+0:12      'DummyTex' (layout( rgba32f) in image2D)
+0:?     Sequence
+0:12      Branch: Return with expression
+0:?         Constant:
+0:?           0.000000
+0:?           0.000000
+0:?           0.000000
+0:?           0.000000
+0:15  Function Definition: @main( ( temp 4-component vector of float)
+0:15    Function Parameters: 
+0:?     Sequence
+0:16      Branch: Return with expression
+0:16        add ( temp 4-component vector of float)
+0:16          add ( temp 4-component vector of float)
+0:16            add ( temp 4-component vector of float)
+0:16              Function Call: Func(t211; ( temp float)
+0:16                'tf1' ( uniform texture2D)
+0:16              Function Call: Func(t21; ( temp 4-component vector of float)
+0:16                'tf4' ( uniform texture2D)
+0:16            Function Call: Func(I211; ( temp float)
+0:16              'twf1' (layout( r32f) uniform image2D)
+0:16          Function Call: Func(I21; ( temp 4-component vector of float)
+0:16            'twf4' (layout( rgba32f) uniform image2D)
+0:15  Function Definition: main( ( temp void)
+0:15    Function Parameters: 
+0:?     Sequence
+0:15      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:15        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     'tf1' ( uniform texture2D)
+0:?     'tf4' ( uniform texture2D)
+0:?     'twf1' (layout( r32f) uniform image2D)
+0:?     'twf4' (layout( rgba32f) uniform image2D)
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+// Module Version 10000
+// Generated by (magic number): 80001
+// Id's are bound by 62
+
+                              Capability Shader
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Fragment 4  "main" 60
+                              ExecutionMode 4 OriginUpperLeft
+                              Source HLSL 500
+                              Name 4  "main"
+                              Name 11  "Func(t211;"
+                              Name 10  "DummyTex"
+                              Name 16  "Func(t21;"
+                              Name 15  "DummyTex"
+                              Name 22  "Func(I211;"
+                              Name 21  "DummyTex"
+                              Name 28  "Func(I21;"
+                              Name 27  "DummyTex"
+                              Name 31  "@main("
+                              Name 44  "tf1"
+                              Name 46  "tf4"
+                              Name 50  "twf1"
+                              Name 54  "twf4"
+                              Name 60  "@entryPointOutput"
+                              Decorate 44(tf1) DescriptorSet 0
+                              Decorate 46(tf4) DescriptorSet 0
+                              Decorate 50(twf1) DescriptorSet 0
+                              Decorate 54(twf4) DescriptorSet 0
+                              Decorate 60(@entryPointOutput) Location 0
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeFloat 32
+               7:             TypeImage 6(float) 2D sampled format:Unknown
+               8:             TypePointer UniformConstant 7
+               9:             TypeFunction 6(float) 8(ptr)
+              13:             TypeVector 6(float) 4
+              14:             TypeFunction 13(fvec4) 8(ptr)
+              18:             TypeImage 6(float) 2D nonsampled format:R32f
+              19:             TypePointer UniformConstant 18
+              20:             TypeFunction 6(float) 19(ptr)
+              24:             TypeImage 6(float) 2D nonsampled format:Rgba32f
+              25:             TypePointer UniformConstant 24
+              26:             TypeFunction 13(fvec4) 25(ptr)
+              30:             TypeFunction 13(fvec4)
+              33:    6(float) Constant 1065353216
+              36:    6(float) Constant 0
+              37:   13(fvec4) ConstantComposite 36 36 36 36
+         44(tf1):      8(ptr) Variable UniformConstant
+         46(tf4):      8(ptr) Variable UniformConstant
+        50(twf1):     19(ptr) Variable UniformConstant
+        54(twf4):     25(ptr) Variable UniformConstant
+              59:             TypePointer Output 13(fvec4)
+60(@entryPointOutput):     59(ptr) Variable Output
+         4(main):           2 Function None 3
+               5:             Label
+              61:   13(fvec4) FunctionCall 31(@main()
+                              Store 60(@entryPointOutput) 61
+                              Return
+                              FunctionEnd
+  11(Func(t211;):    6(float) Function None 9
+    10(DummyTex):      8(ptr) FunctionParameter
+              12:             Label
+                              ReturnValue 33
+                              FunctionEnd
+   16(Func(t21;):   13(fvec4) Function None 14
+    15(DummyTex):      8(ptr) FunctionParameter
+              17:             Label
+                              ReturnValue 37
+                              FunctionEnd
+  22(Func(I211;):    6(float) Function None 20
+    21(DummyTex):     19(ptr) FunctionParameter
+              23:             Label
+                              ReturnValue 33
+                              FunctionEnd
+   28(Func(I21;):   13(fvec4) Function None 26
+    27(DummyTex):     25(ptr) FunctionParameter
+              29:             Label
+                              ReturnValue 37
+                              FunctionEnd
+      31(@main():   13(fvec4) Function None 30
+              32:             Label
+              45:    6(float) FunctionCall 11(Func(t211;) 44(tf1)
+              47:   13(fvec4) FunctionCall 16(Func(t21;) 46(tf4)
+              48:   13(fvec4) CompositeConstruct 45 45 45 45
+              49:   13(fvec4) FAdd 48 47
+              51:    6(float) FunctionCall 22(Func(I211;) 50(twf1)
+              52:   13(fvec4) CompositeConstruct 51 51 51 51
+              53:   13(fvec4) FAdd 49 52
+              55:   13(fvec4) FunctionCall 28(Func(I21;) 54(twf4)
+              56:   13(fvec4) FAdd 53 55
+                              ReturnValue 56
+                              FunctionEnd

--- a/Test/hlsl.tx.overload.frag
+++ b/Test/hlsl.tx.overload.frag
@@ -1,0 +1,17 @@
+
+Texture2D<float>  tf1;
+Texture2D<float4> tf4;
+
+RWTexture2D<float>  twf1;
+RWTexture2D<float4> twf4;
+
+float Func(Texture2D<float> DummyTex) { return 1.0f; }
+float4 Func(Texture2D<float4> DummyTex) { return float4(0,0,0,0); }
+
+float Func(RWTexture2D<float> DummyTex) { return 1.0f; }
+float4 Func(RWTexture2D<float4> DummyTex) { return float4(0,0,0,0); }
+
+float4 main() : SV_TARGET
+{
+    return Func(tf1) + Func(tf4) + Func(twf1) + Func(twf4);
+}

--- a/glslang/MachineIndependent/SymbolTable.cpp
+++ b/glslang/MachineIndependent/SymbolTable.cpp
@@ -99,6 +99,14 @@ void TType::buildMangledName(TString& mangledName) const
         case EsdSubpass:  mangledName += "P";  break;
         default: break; // some compilers want this
         }
+
+        switch (sampler.vectorSize) {
+        case 1: mangledName += "1"; break;
+        case 2: mangledName += "2"; break;
+        case 3: mangledName += "3"; break;
+        case 4: break; // default to prior name mangle behavior
+        }
+
         if (sampler.ms)
             mangledName += "M";
         break;

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -287,6 +287,7 @@ INSTANTIATE_TEST_CASE_P(
         {"hlsl.swizzle.frag", "PixelShaderFunction"},
         {"hlsl.templatetypes.frag", "PixelShaderFunction"},
         {"hlsl.tx.bracket.frag", "main"},
+        {"hlsl.tx.overload.frag", "main"},
         {"hlsl.type.half.frag", "main"},
         {"hlsl.type.identifier.frag", "main"},
         {"hlsl.typeGraphCopy.vert", "main"},


### PR DESCRIPTION
Name mangling did not account for the vector size in the template type of a texture. E.g, Texture2D&lt;float**3**&gt;.  This adds that.  The mangle is as it ever was for the vec4 case, which leaves all GLSL behavior and most HLSL mangling behavior uneffected.  For vec1-3 the size is added to the mangle.  (Review request: as an alternate choice, it could also be added to the mangle in all cases, though probably with a large number of test changes).

Current limitation: textures cannot presently be templatized on structured types, so this works only for textures templatized on vectors of basic types.

Fixes #895.