### PR TITLE
HLSL: compilation warning fix: no functional change

### DIFF
--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -1165,7 +1165,7 @@ bool HlslParseContext::shouldFlatten(const TType& type) const
     const TStorageQualifier qualifier = type.getQualifier().storage;
 
     return (qualifier == EvqUniform && type.isArray() && intermediate.getFlattenUniformArrays()) ||
-           type.isStruct() && type.containsOpaque();
+           (type.isStruct() && type.containsOpaque());
 }
 
 // Top level variable flattening: construct data


### PR DESCRIPTION
One liner to eliminate a compile warning.