### PR TITLE
SPV: Do not generate ImageMSArray capability for sampled images

### DIFF
--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -466,7 +466,7 @@ Id Builder::makeImageType(Id sampledType, Dim dim, bool depth, bool arrayed, boo
     }
 
     if (ms) {
-        if (arrayed)
+        if (arrayed && ! (sampled == 1))
             addCapability(CapabilityImageMSArray);
         if (! sampled)
             addCapability(CapabilityStorageImageMultisample);

--- a/Test/baseResults/hlsl.getdimensions.dx10.frag.out
+++ b/Test/baseResults/hlsl.getdimensions.dx10.frag.out
@@ -2322,7 +2322,6 @@ gl_FragCoord origin is upper left
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
-                              Capability ImageMSArray
                               Capability ImageQuery
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/hlsl.getsampleposition.dx10.frag.out
+++ b/Test/baseResults/hlsl.getsampleposition.dx10.frag.out
@@ -582,7 +582,6 @@ gl_FragCoord origin is upper left
 // Id's are bound by 221
 
                               Capability Shader
-                              Capability ImageMSArray
                               Capability ImageQuery
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/hlsl.load.2dms.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.2dms.dx10.frag.out
@@ -361,7 +361,6 @@ gl_FragCoord origin is upper left
 
                               Capability Shader
                               Capability ImageGatherExtended
-                              Capability ImageMSArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main" 120 124

--- a/Test/baseResults/spv.separate.frag.out
+++ b/Test/baseResults/spv.separate.frag.out
@@ -8,7 +8,6 @@ spv.separate.frag
                               Capability Sampled1D
                               Capability SampledCubeArray
                               Capability SampledBuffer
-                              Capability ImageMSArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
                               EntryPoint Fragment 4  "main" 11 34


### PR DESCRIPTION
According to the specification description for the capability:

"ImageMSArray: An MS operand in OpTypeImage indicates multisampled,
 used without a sampler."

So the capability must not be included when the only images
used by the shader are sampled. The description of the Sampled
member of OpTypeImage is:

"Sampled indicates whether or not this image will be accessed
 in combination with a sampler, and must be one of the
 following values:
 0 indicates this is only known at run time, not at compile time
 1 indicates will be used with sampler
 2 indicates will be used without a sampler (a storage image)"

So we do not want to generate this capability when the image
Sampled value is 1.

There are a few tests that seemed to expect the capability to be
generated when only sampled images are used. The patch updates these
tests accordingly.