### PR TITLE
Address part B of #982: $Global will use std140 instead of HLSL offsets.

### DIFF
--- a/Test/baseResults/hlsl.amend.frag.out
+++ b/Test/baseResults/hlsl.amend.frag.out
@@ -184,9 +184,9 @@ gl_FragCoord origin is upper left
                               Name 22  ""
                               MemberDecorate 20($Global) 0 Offset 0
                               MemberDecorate 20($Global) 1 Offset 16
-                              MemberDecorate 20($Global) 2 Offset 20
-                              MemberDecorate 20($Global) 3 Offset 32
-                              MemberDecorate 20($Global) 4 Offset 36
+                              MemberDecorate 20($Global) 2 Offset 32
+                              MemberDecorate 20($Global) 3 Offset 44
+                              MemberDecorate 20($Global) 4 Offset 48
                               Decorate 20($Global) Block
                               Decorate 22 DescriptorSet 0
                2:             TypeVoid

--- a/Test/baseResults/hlsl.gatherRGBA.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.gatherRGBA.array.dx10.frag.out
@@ -813,7 +813,7 @@ gl_FragCoord origin is upper left
                               Decorate 20(g_sSamp) DescriptorSet 0
                               Decorate 20(g_sSamp) Binding 0
                               MemberDecorate 26($Global) 0 Offset 0
-                              MemberDecorate 26($Global) 1 Offset 4
+                              MemberDecorate 26($Global) 1 Offset 8
                               MemberDecorate 26($Global) 2 Offset 16
                               MemberDecorate 26($Global) 3 Offset 32
                               Decorate 26($Global) Block

--- a/Test/baseResults/hlsl.gatherRGBA.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.gatherRGBA.basic.dx10.frag.out
@@ -824,7 +824,7 @@ gl_FragCoord origin is upper left
                               Decorate 20(g_sSamp) DescriptorSet 0
                               Decorate 20(g_sSamp) Binding 0
                               MemberDecorate 26($Global) 0 Offset 0
-                              MemberDecorate 26($Global) 1 Offset 4
+                              MemberDecorate 26($Global) 1 Offset 8
                               MemberDecorate 26($Global) 2 Offset 16
                               MemberDecorate 26($Global) 3 Offset 32
                               Decorate 26($Global) Block

--- a/Test/baseResults/hlsl.gatherRGBA.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.gatherRGBA.offset.dx10.frag.out
@@ -1333,11 +1333,11 @@ gl_FragCoord origin is upper left
                               Decorate 20(g_sSamp) DescriptorSet 0
                               Decorate 20(g_sSamp) Binding 0
                               MemberDecorate 30($Global) 0 Offset 0
-                              MemberDecorate 30($Global) 1 Offset 4
+                              MemberDecorate 30($Global) 1 Offset 8
                               MemberDecorate 30($Global) 2 Offset 16
                               MemberDecorate 30($Global) 3 Offset 32
                               MemberDecorate 30($Global) 4 Offset 48
-                              MemberDecorate 30($Global) 5 Offset 52
+                              MemberDecorate 30($Global) 5 Offset 56
                               MemberDecorate 30($Global) 6 Offset 64
                               MemberDecorate 30($Global) 7 Offset 80
                               Decorate 30($Global) Block

--- a/Test/baseResults/hlsl.gatherRGBA.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.gatherRGBA.offsetarray.dx10.frag.out
@@ -1322,11 +1322,11 @@ gl_FragCoord origin is upper left
                               Decorate 20(g_sSamp) DescriptorSet 0
                               Decorate 20(g_sSamp) Binding 0
                               MemberDecorate 30($Global) 0 Offset 0
-                              MemberDecorate 30($Global) 1 Offset 4
+                              MemberDecorate 30($Global) 1 Offset 8
                               MemberDecorate 30($Global) 2 Offset 16
                               MemberDecorate 30($Global) 3 Offset 32
                               MemberDecorate 30($Global) 4 Offset 48
-                              MemberDecorate 30($Global) 5 Offset 52
+                              MemberDecorate 30($Global) 5 Offset 56
                               MemberDecorate 30($Global) 6 Offset 64
                               MemberDecorate 30($Global) 7 Offset 80
                               Decorate 30($Global) Block

--- a/Test/baseResults/hlsl.gathercmpRGBA.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.gathercmpRGBA.offset.dx10.frag.out
@@ -506,7 +506,7 @@ gl_FragCoord origin is upper left
                               Decorate 20(g_sSampCmp) DescriptorSet 0
                               Decorate 20(g_sSampCmp) Binding 0
                               MemberDecorate 27($Global) 0 Offset 0
-                              MemberDecorate 27($Global) 1 Offset 4
+                              MemberDecorate 27($Global) 1 Offset 8
                               MemberDecorate 27($Global) 2 Offset 16
                               MemberDecorate 27($Global) 3 Offset 32
                               Decorate 27($Global) Block

--- a/Test/baseResults/hlsl.getdimensions.rw.dx10.frag.out
+++ b/Test/baseResults/hlsl.getdimensions.rw.dx10.frag.out
@@ -812,11 +812,11 @@ gl_FragCoord origin is upper left
                               Decorate 225(g_sSamp) DescriptorSet 0
                               Decorate 225(g_sSamp) Binding 0
                               MemberDecorate 229($Global) 0 Offset 0
-                              MemberDecorate 229($Global) 1 Offset 4
+                              MemberDecorate 229($Global) 1 Offset 8
                               MemberDecorate 229($Global) 2 Offset 16
                               MemberDecorate 229($Global) 3 Offset 32
                               MemberDecorate 229($Global) 4 Offset 48
-                              MemberDecorate 229($Global) 5 Offset 52
+                              MemberDecorate 229($Global) 5 Offset 56
                               MemberDecorate 229($Global) 6 Offset 64
                               MemberDecorate 229($Global) 7 Offset 80
                               Decorate 229($Global) Block

--- a/Test/baseResults/hlsl.implicitBool.frag.out
+++ b/Test/baseResults/hlsl.implicitBool.frag.out
@@ -358,8 +358,8 @@ gl_FragCoord origin is upper left
                               Name 138  "@entryPointOutput"
                               MemberDecorate 16($Global) 0 Offset 0
                               MemberDecorate 16($Global) 1 Offset 4
-                              MemberDecorate 16($Global) 2 Offset 8
-                              MemberDecorate 16($Global) 3 Offset 12
+                              MemberDecorate 16($Global) 2 Offset 16
+                              MemberDecorate 16($Global) 3 Offset 32
                               Decorate 16($Global) Block
                               Decorate 18 DescriptorSet 0
                               Decorate 138(@entryPointOutput) Location 0

--- a/Test/baseResults/hlsl.isfinite.frag.out
+++ b/Test/baseResults/hlsl.isfinite.frag.out
@@ -196,7 +196,7 @@ gl_FragCoord origin is upper left
                               Name 65  "@finitetmp"
                               Name 83  "@entryPointOutput"
                               MemberDecorate 35($Global) 0 Offset 0
-                              MemberDecorate 35($Global) 1 Offset 4
+                              MemberDecorate 35($Global) 1 Offset 8
                               MemberDecorate 35($Global) 2 Offset 16
                               Decorate 35($Global) Block
                               Decorate 37 DescriptorSet 0

--- a/Test/baseResults/hlsl.load.2dms.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.2dms.dx10.frag.out
@@ -395,11 +395,11 @@ gl_FragCoord origin is upper left
                               Name 129  "g_sSamp"
                               Decorate 14(g_tTex2dmsf4) DescriptorSet 0
                               MemberDecorate 20($Global) 0 Offset 0
-                              MemberDecorate 20($Global) 1 Offset 4
+                              MemberDecorate 20($Global) 1 Offset 8
                               MemberDecorate 20($Global) 2 Offset 16
                               MemberDecorate 20($Global) 3 Offset 32
                               MemberDecorate 20($Global) 4 Offset 48
-                              MemberDecorate 20($Global) 5 Offset 52
+                              MemberDecorate 20($Global) 5 Offset 56
                               MemberDecorate 20($Global) 6 Offset 64
                               MemberDecorate 20($Global) 7 Offset 80
                               Decorate 20($Global) Block

--- a/Test/baseResults/hlsl.load.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.array.dx10.frag.out
@@ -440,11 +440,11 @@ gl_FragCoord origin is upper left
                               Name 158  "g_tTexcdu4a"
                               Decorate 14(g_tTex1df4a) DescriptorSet 0
                               MemberDecorate 20($Global) 0 Offset 0
-                              MemberDecorate 20($Global) 1 Offset 4
+                              MemberDecorate 20($Global) 1 Offset 8
                               MemberDecorate 20($Global) 2 Offset 16
                               MemberDecorate 20($Global) 3 Offset 32
                               MemberDecorate 20($Global) 4 Offset 48
-                              MemberDecorate 20($Global) 5 Offset 52
+                              MemberDecorate 20($Global) 5 Offset 56
                               MemberDecorate 20($Global) 6 Offset 64
                               MemberDecorate 20($Global) 7 Offset 80
                               Decorate 20($Global) Block

--- a/Test/baseResults/hlsl.load.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.basic.dx10.frag.out
@@ -543,11 +543,11 @@ gl_FragCoord origin is upper left
                               Decorate 14(g_tTex1df4) DescriptorSet 0
                               Decorate 14(g_tTex1df4) Binding 0
                               MemberDecorate 20($Global) 0 Offset 0
-                              MemberDecorate 20($Global) 1 Offset 4
+                              MemberDecorate 20($Global) 1 Offset 8
                               MemberDecorate 20($Global) 2 Offset 16
                               MemberDecorate 20($Global) 3 Offset 32
                               MemberDecorate 20($Global) 4 Offset 48
-                              MemberDecorate 20($Global) 5 Offset 52
+                              MemberDecorate 20($Global) 5 Offset 56
                               MemberDecorate 20($Global) 6 Offset 64
                               MemberDecorate 20($Global) 7 Offset 80
                               Decorate 20($Global) Block

--- a/Test/baseResults/hlsl.load.basic.dx10.vert.out
+++ b/Test/baseResults/hlsl.load.basic.dx10.vert.out
@@ -505,11 +505,11 @@ Shader version: 500
                               Decorate 14(g_tTex1df4) DescriptorSet 0
                               Decorate 14(g_tTex1df4) Binding 0
                               MemberDecorate 20($Global) 0 Offset 0
-                              MemberDecorate 20($Global) 1 Offset 4
+                              MemberDecorate 20($Global) 1 Offset 8
                               MemberDecorate 20($Global) 2 Offset 16
                               MemberDecorate 20($Global) 3 Offset 32
                               MemberDecorate 20($Global) 4 Offset 48
-                              MemberDecorate 20($Global) 5 Offset 52
+                              MemberDecorate 20($Global) 5 Offset 56
                               MemberDecorate 20($Global) 6 Offset 64
                               MemberDecorate 20($Global) 7 Offset 80
                               Decorate 20($Global) Block

--- a/Test/baseResults/hlsl.load.buffer.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.buffer.dx10.frag.out
@@ -202,11 +202,11 @@ gl_FragCoord origin is upper left
                               Name 71  "g_tTexbf4_test"
                               Decorate 16(g_tTexbf4) DescriptorSet 0
                               MemberDecorate 22($Global) 0 Offset 0
-                              MemberDecorate 22($Global) 1 Offset 4
+                              MemberDecorate 22($Global) 1 Offset 8
                               MemberDecorate 22($Global) 2 Offset 16
                               MemberDecorate 22($Global) 3 Offset 32
                               MemberDecorate 22($Global) 4 Offset 48
-                              MemberDecorate 22($Global) 5 Offset 52
+                              MemberDecorate 22($Global) 5 Offset 56
                               MemberDecorate 22($Global) 6 Offset 64
                               MemberDecorate 22($Global) 7 Offset 80
                               Decorate 22($Global) Block

--- a/Test/baseResults/hlsl.load.buffer.float.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.buffer.float.dx10.frag.out
@@ -208,11 +208,11 @@ gl_FragCoord origin is upper left
                               Name 74  "g_tTexbfs_test"
                               Decorate 16(g_tTexbfs) DescriptorSet 0
                               MemberDecorate 22($Global) 0 Offset 0
-                              MemberDecorate 22($Global) 1 Offset 4
+                              MemberDecorate 22($Global) 1 Offset 8
                               MemberDecorate 22($Global) 2 Offset 16
                               MemberDecorate 22($Global) 3 Offset 32
                               MemberDecorate 22($Global) 4 Offset 48
-                              MemberDecorate 22($Global) 5 Offset 52
+                              MemberDecorate 22($Global) 5 Offset 56
                               MemberDecorate 22($Global) 6 Offset 64
                               MemberDecorate 22($Global) 7 Offset 80
                               Decorate 22($Global) Block

--- a/Test/baseResults/hlsl.load.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.offset.dx10.frag.out
@@ -616,11 +616,11 @@ gl_FragCoord origin is upper left
                               Decorate 14(g_tTex1df4) DescriptorSet 0
                               Decorate 14(g_tTex1df4) Binding 0
                               MemberDecorate 20($Global) 0 Offset 0
-                              MemberDecorate 20($Global) 1 Offset 4
+                              MemberDecorate 20($Global) 1 Offset 8
                               MemberDecorate 20($Global) 2 Offset 16
                               MemberDecorate 20($Global) 3 Offset 32
                               MemberDecorate 20($Global) 4 Offset 48
-                              MemberDecorate 20($Global) 5 Offset 52
+                              MemberDecorate 20($Global) 5 Offset 56
                               MemberDecorate 20($Global) 6 Offset 64
                               MemberDecorate 20($Global) 7 Offset 80
                               Decorate 20($Global) Block

--- a/Test/baseResults/hlsl.load.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.offsetarray.dx10.frag.out
@@ -489,11 +489,11 @@ gl_FragCoord origin is upper left
                               Name 173  "g_tTexcdu4a"
                               Decorate 14(g_tTex1df4a) DescriptorSet 0
                               MemberDecorate 20($Global) 0 Offset 0
-                              MemberDecorate 20($Global) 1 Offset 4
+                              MemberDecorate 20($Global) 1 Offset 8
                               MemberDecorate 20($Global) 2 Offset 16
                               MemberDecorate 20($Global) 3 Offset 32
                               MemberDecorate 20($Global) 4 Offset 48
-                              MemberDecorate 20($Global) 5 Offset 52
+                              MemberDecorate 20($Global) 5 Offset 56
                               MemberDecorate 20($Global) 6 Offset 64
                               MemberDecorate 20($Global) 7 Offset 80
                               Decorate 20($Global) Block

--- a/Test/baseResults/hlsl.load.rwbuffer.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.rwbuffer.dx10.frag.out
@@ -141,11 +141,11 @@ gl_FragCoord origin is upper left
                               Name 54  "Color"
                               Decorate 14(g_tBuffF) DescriptorSet 0
                               MemberDecorate 20($Global) 0 Offset 0
-                              MemberDecorate 20($Global) 1 Offset 4
+                              MemberDecorate 20($Global) 1 Offset 8
                               MemberDecorate 20($Global) 2 Offset 16
                               MemberDecorate 20($Global) 3 Offset 32
                               MemberDecorate 20($Global) 4 Offset 48
-                              MemberDecorate 20($Global) 5 Offset 52
+                              MemberDecorate 20($Global) 5 Offset 56
                               MemberDecorate 20($Global) 6 Offset 64
                               MemberDecorate 20($Global) 7 Offset 80
                               Decorate 20($Global) Block

--- a/Test/baseResults/hlsl.load.rwtexture.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.rwtexture.array.dx10.frag.out
@@ -253,11 +253,11 @@ gl_FragCoord origin is upper left
                               Name 118  "g_tTex3du4"
                               Decorate 14(g_tTex1df4a) DescriptorSet 0
                               MemberDecorate 20($Global) 0 Offset 0
-                              MemberDecorate 20($Global) 1 Offset 4
+                              MemberDecorate 20($Global) 1 Offset 8
                               MemberDecorate 20($Global) 2 Offset 16
                               MemberDecorate 20($Global) 3 Offset 32
                               MemberDecorate 20($Global) 4 Offset 48
-                              MemberDecorate 20($Global) 5 Offset 52
+                              MemberDecorate 20($Global) 5 Offset 56
                               MemberDecorate 20($Global) 6 Offset 64
                               MemberDecorate 20($Global) 7 Offset 80
                               Decorate 20($Global) Block

--- a/Test/baseResults/hlsl.load.rwtexture.dx10.frag.out
+++ b/Test/baseResults/hlsl.load.rwtexture.dx10.frag.out
@@ -290,11 +290,11 @@ gl_FragCoord origin is upper left
                               Decorate 14(g_tTex1df4) DescriptorSet 0
                               Decorate 14(g_tTex1df4) Binding 0
                               MemberDecorate 20($Global) 0 Offset 0
-                              MemberDecorate 20($Global) 1 Offset 4
+                              MemberDecorate 20($Global) 1 Offset 8
                               MemberDecorate 20($Global) 2 Offset 16
                               MemberDecorate 20($Global) 3 Offset 32
                               MemberDecorate 20($Global) 4 Offset 48
-                              MemberDecorate 20($Global) 5 Offset 52
+                              MemberDecorate 20($Global) 5 Offset 56
                               MemberDecorate 20($Global) 6 Offset 64
                               MemberDecorate 20($Global) 7 Offset 80
                               Decorate 20($Global) Block

--- a/Test/baseResults/hlsl.rw.atomics.frag.out
+++ b/Test/baseResults/hlsl.rw.atomics.frag.out
@@ -3998,7 +3998,7 @@ gl_FragCoord origin is upper left
                               Name 1146  "g_tBuffF"
                               Decorate 15(g_tTex1di1) DescriptorSet 0
                               MemberDecorate 21($Global) 0 Offset 0
-                              MemberDecorate 21($Global) 1 Offset 4
+                              MemberDecorate 21($Global) 1 Offset 8
                               MemberDecorate 21($Global) 2 Offset 16
                               MemberDecorate 21($Global) 3 Offset 28
                               MemberDecorate 21($Global) 4 Offset 32

--- a/Test/baseResults/hlsl.rw.bracket.frag.out
+++ b/Test/baseResults/hlsl.rw.bracket.frag.out
@@ -1881,11 +1881,11 @@ gl_FragCoord origin is upper left
                               Name 603  "g_tTex2di4a"
                               Name 606  "g_tTex2du4a"
                               MemberDecorate 63($Global) 0 Offset 0
-                              MemberDecorate 63($Global) 1 Offset 4
+                              MemberDecorate 63($Global) 1 Offset 8
                               MemberDecorate 63($Global) 2 Offset 16
                               MemberDecorate 63($Global) 3 Offset 32
                               MemberDecorate 63($Global) 4 Offset 48
-                              MemberDecorate 63($Global) 5 Offset 52
+                              MemberDecorate 63($Global) 5 Offset 56
                               MemberDecorate 63($Global) 6 Offset 64
                               MemberDecorate 63($Global) 7 Offset 80
                               MemberDecorate 63($Global) 8 Offset 96

--- a/Test/baseResults/hlsl.rw.scalar.bracket.frag.out
+++ b/Test/baseResults/hlsl.rw.scalar.bracket.frag.out
@@ -1827,11 +1827,11 @@ gl_FragCoord origin is upper left
                               Name 567  "g_tTex2di1a"
                               Name 570  "g_tTex2du1a"
                               MemberDecorate 59($Global) 0 Offset 0
-                              MemberDecorate 59($Global) 1 Offset 4
+                              MemberDecorate 59($Global) 1 Offset 8
                               MemberDecorate 59($Global) 2 Offset 16
                               MemberDecorate 59($Global) 3 Offset 32
                               MemberDecorate 59($Global) 4 Offset 48
-                              MemberDecorate 59($Global) 5 Offset 52
+                              MemberDecorate 59($Global) 5 Offset 56
                               MemberDecorate 59($Global) 6 Offset 64
                               MemberDecorate 59($Global) 7 Offset 80
                               MemberDecorate 59($Global) 8 Offset 96

--- a/Test/baseResults/hlsl.rw.vec2.bracket.frag.out
+++ b/Test/baseResults/hlsl.rw.vec2.bracket.frag.out
@@ -1846,11 +1846,11 @@ gl_FragCoord origin is upper left
                               Name 601  "g_tTex2di2a"
                               Name 604  "g_tTex2du2a"
                               MemberDecorate 64($Global) 0 Offset 0
-                              MemberDecorate 64($Global) 1 Offset 4
+                              MemberDecorate 64($Global) 1 Offset 8
                               MemberDecorate 64($Global) 2 Offset 16
                               MemberDecorate 64($Global) 3 Offset 32
                               MemberDecorate 64($Global) 4 Offset 48
-                              MemberDecorate 64($Global) 5 Offset 52
+                              MemberDecorate 64($Global) 5 Offset 56
                               MemberDecorate 64($Global) 6 Offset 64
                               MemberDecorate 64($Global) 7 Offset 80
                               MemberDecorate 64($Global) 8 Offset 96

--- a/Test/baseResults/hlsl.tx.bracket.frag.out
+++ b/Test/baseResults/hlsl.tx.bracket.frag.out
@@ -484,11 +484,11 @@ gl_FragCoord origin is upper left
                               Name 184  "g_tTex2di4a"
                               Name 187  "g_tTex2du4a"
                               MemberDecorate 45($Global) 0 Offset 0
-                              MemberDecorate 45($Global) 1 Offset 4
+                              MemberDecorate 45($Global) 1 Offset 8
                               MemberDecorate 45($Global) 2 Offset 16
                               MemberDecorate 45($Global) 3 Offset 32
                               MemberDecorate 45($Global) 4 Offset 48
-                              MemberDecorate 45($Global) 5 Offset 52
+                              MemberDecorate 45($Global) 5 Offset 56
                               MemberDecorate 45($Global) 6 Offset 64
                               MemberDecorate 45($Global) 7 Offset 80
                               Decorate 45($Global) Block


### PR DESCRIPTION
From comment about this:
Adjust alignment for HLSL rules
TODO: make this consistent in early phases of code: adjusting this late means inconsistencies with earlier code, which for reflection is an issue.
Until reflection is brought in sync with these adjustments, don't apply HLSL offsets to $Global,
which is the most likely to rely on reflection, and least likely to rely
implicit layouts.