### PR TITLE
Fix dref explicit LOD form of sample with cube texture arrays

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -3345,7 +3345,7 @@ spv::Id TGlslangToSpvTraverser::createImageTextureFunctionCall(glslang::TIntermO
 
     // lod
     if (cracked.lod) {
-        params.lod = arguments[2];
+        params.lod = arguments[2 + extraArgs];
         ++extraArgs;
     } else if (glslangIntermediate->getStage() != EShLangFragment) {
         // we need to invent the default lod for an explicit lod instruction for a non-fragment stage
@@ -3354,7 +3354,7 @@ spv::Id TGlslangToSpvTraverser::createImageTextureFunctionCall(glslang::TIntermO
 
     // multisample
     if (sampler.ms) {
-        params.sample = arguments[2]; // For MS, "sample" should be specified
+        params.sample = arguments[2 + extraArgs]; // For MS, "sample" should be specified
         ++extraArgs;
     }
 

--- a/Test/baseResults/hlsl.samplecmplevelzero.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmplevelzero.array.dx10.frag.out
@@ -713,7 +713,7 @@ gl_FragCoord origin is upper left
              127:    6(float) CompositeExtract 124 2
              128:    6(float) CompositeExtract 124 3
              129:    7(fvec4) CompositeConstruct 125 126 127 128
-             130:    6(float) ImageSampleDrefExplicitLod 122 129 29 Lod 29
+             130:    6(float) ImageSampleDrefExplicitLod 122 129 29 Lod 34
                               Store 114(r60) 130
              135:         132 Load 134(g_tTexcdi4a)
              136:          18 Load 20(g_sSamp)
@@ -723,7 +723,7 @@ gl_FragCoord origin is upper left
              142:    6(float) CompositeExtract 124 2
              143:    6(float) CompositeExtract 124 3
              144:    7(fvec4) CompositeConstruct 140 141 142 143
-             145:    6(float) ImageSampleDrefExplicitLod 139 144 29 Lod 29
+             145:    6(float) ImageSampleDrefExplicitLod 139 144 29 Lod 34
                               Store 131(r62) 145
              150:         147 Load 149(g_tTexcdu4a)
              151:          18 Load 20(g_sSamp)
@@ -733,7 +733,7 @@ gl_FragCoord origin is upper left
              157:    6(float) CompositeExtract 124 2
              158:    6(float) CompositeExtract 124 3
              159:    7(fvec4) CompositeConstruct 155 156 157 158
-             160:    6(float) ImageSampleDrefExplicitLod 154 159 29 Lod 29
+             160:    6(float) ImageSampleDrefExplicitLod 154 159 29 Lod 34
                               Store 146(r64) 160
              167:    166(ptr) AccessChain 162(psout) 163
                               Store 167 165


### PR DESCRIPTION
The dref parameter was being used as the LOD.  Now the dref is the dref, and the LOD is the LOD.  Would only have impacted texture cube array form, which uses all 4 components of the vec4 coord.

Fixes #998.