### PR TITLE
SPV: Memory qualifiers should decorate top-level block members

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -2531,7 +2531,9 @@ void TGlslangToSpvTraverser::decorateStructType(const glslang::TType& type,
             }
             addMemberDecoration(spvType, member, TranslateInvariantDecoration(memberQualifier));
 
-            if (qualifier.storage == glslang::EvqBuffer) {
+            if (type.getBasicType() == glslang::EbtBlock &&
+                qualifier.storage == glslang::EvqBuffer) {
+                // Add memory decorations only to top-level members of shader storage block
                 std::vector<spv::Decoration> memory;
                 TranslateMemoryDecoration(memberQualifier, memory);
                 for (unsigned int i = 0; i < memory.size(); ++i)

--- a/Test/baseResults/hlsl.structbuffer.coherent.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.coherent.frag.out
@@ -208,9 +208,7 @@ gl_FragCoord origin is upper left
                               MemberDecorate 15(sbuf2) 0 Offset 0
                               Decorate 15(sbuf2) BufferBlock
                               Decorate 17(sbuf2) DescriptorSet 0
-                              MemberDecorate 28(sb_t) 0 Coherent
                               MemberDecorate 28(sb_t) 0 Offset 0
-                              MemberDecorate 28(sb_t) 1 Coherent
                               MemberDecorate 28(sb_t) 1 Offset 12
                               Decorate 29 ArrayStride 16
                               MemberDecorate 30(sbuf) 0 Coherent

--- a/Test/baseResults/hlsl.structbuffer.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.frag.out
@@ -221,11 +221,8 @@ gl_FragCoord origin is upper left
                               Name 89  "pos"
                               Name 92  "@entryPointOutput"
                               Name 93  "param"
-                              MemberDecorate 19(sb_t) 0 NonWritable
                               MemberDecorate 19(sb_t) 0 Offset 0
-                              MemberDecorate 19(sb_t) 1 NonWritable
                               MemberDecorate 19(sb_t) 1 Offset 12
-                              MemberDecorate 19(sb_t) 2 NonWritable
                               MemberDecorate 19(sb_t) 2 Offset 16
                               Decorate 20 ArrayStride 32
                               MemberDecorate 21(sbuf) 0 NonWritable

--- a/Test/baseResults/spv.memoryQualifier.frag.out
+++ b/Test/baseResults/spv.memoryQualifier.frag.out
@@ -44,9 +44,7 @@ spv.memoryQualifier.frag
                               Decorate 44(iCube) DescriptorSet 0
                               Decorate 44(iCube) Binding 3
                               Decorate 44(iCube) NonReadable
-                              MemberDecorate 49(Data) 0 Coherent
                               MemberDecorate 49(Data) 0 Offset 0
-                              MemberDecorate 49(Data) 1 Coherent
                               MemberDecorate 49(Data) 1 Offset 8
                               MemberDecorate 50(Buffer) 0 Coherent
                               MemberDecorate 50(Buffer) 0 Volatile

--- a/Test/baseResults/spv.ssbo.autoassign.frag.out
+++ b/Test/baseResults/spv.ssbo.autoassign.frag.out
@@ -30,9 +30,7 @@ spv.ssbo.autoassign.frag
                               Name 92  "pos"
                               Name 95  "@entryPointOutput"
                               Name 96  "param"
-                              MemberDecorate 14(BufType) 0 NonWritable
                               MemberDecorate 14(BufType) 0 Offset 0
-                              MemberDecorate 14(BufType) 1 NonWritable
                               MemberDecorate 14(BufType) 1 Offset 16
                               Decorate 15 ArrayStride 32
                               MemberDecorate 16(SB0) 0 NonWritable


### PR DESCRIPTION
We encounter this problem when the shader is written like this:

```
struct S
{
    vec4 f;
};

layout(binding = 0) buffer Buf1
{
    readonly S s1;
};

layout(binding = 1) buffer Buf2
{
    writeonly S s2;
};
```

In SPIR-V, memory qualifiers are propagated to structure members. So `S.f` have both "readonly" and "writeonly" decorations. This is erroneous. 