### PR TITLE
SPV: 1st pass implementation of SPV_EXT_shader_viewport_index_layer.

### DIFF
--- a/SPIRV/GLSL.ext.KHR.h
+++ b/SPIRV/GLSL.ext.KHR.h
@@ -43,5 +43,6 @@ static const char* const E_SPV_KHR_16bit_storage                = "SPV_KHR_16bit
 static const char* const E_SPV_KHR_storage_buffer_storage_class = "SPV_KHR_storage_buffer_storage_class";
 static const char* const E_SPV_KHR_post_depth_coverage          = "SPV_KHR_post_depth_coverage";
 static const char* const E_SPV_EXT_shader_stencil_export        = "SPV_EXT_shader_stencil_export";
+static const char* const E_SPV_EXT_shader_viewport_index_layer  = "SPV_EXT_shader_viewport_index_layer";
 
 #endif  // #ifndef GLSLextKHR_H

--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -455,15 +455,13 @@ spv::BuiltIn TGlslangToSpvTraverser::TranslateBuiltInDecoration(glslang::TBuiltI
     case glslang::EbvViewportIndex:
         if (!memberDeclaration) {
             builder.addCapability(spv::CapabilityMultiViewport);
-#ifdef NV_EXTENSIONS
             if (glslangIntermediate->getStage() == EShLangVertex ||
                 glslangIntermediate->getStage() == EShLangTessControl ||
                 glslangIntermediate->getStage() == EShLangTessEvaluation) {
 
-                builder.addExtension(spv::E_SPV_NV_viewport_array2);
-                builder.addCapability(spv::CapabilityShaderViewportIndexLayerNV);
+                builder.addExtension(spv::E_SPV_EXT_shader_viewport_index_layer);
+                builder.addCapability(spv::CapabilityShaderViewportIndexLayerEXT);
             }
-#endif
         }
         return spv::BuiltInViewportIndex;
 
@@ -482,15 +480,13 @@ spv::BuiltIn TGlslangToSpvTraverser::TranslateBuiltInDecoration(glslang::TBuiltI
     case glslang::EbvLayer:
         if (!memberDeclaration) {
             builder.addCapability(spv::CapabilityGeometry);
-#ifdef NV_EXTENSIONS
             if (glslangIntermediate->getStage() == EShLangVertex ||
                 glslangIntermediate->getStage() == EShLangTessControl ||
                 glslangIntermediate->getStage() == EShLangTessEvaluation) {
 
-                builder.addExtension(spv::E_SPV_NV_viewport_array2);
-                builder.addCapability(spv::CapabilityShaderViewportIndexLayerNV);
+                builder.addExtension(spv::E_SPV_EXT_shader_viewport_index_layer);
+                builder.addCapability(spv::CapabilityShaderViewportIndexLayerEXT);
             }
-#endif
         }
 
         return spv::BuiltInLayer;
@@ -5475,14 +5471,12 @@ spv::Id TGlslangToSpvTraverser::getSymbolId(const glslang::TIntermSymbol* symbol
     }
     else if (builtIn == spv::BuiltInLayer) {
         // SPV_NV_viewport_array2 extension
-        if (symbol->getQualifier().layoutViewportRelative)
-        {
+        if (symbol->getQualifier().layoutViewportRelative) {
             addDecoration(id, (spv::Decoration)spv::DecorationViewportRelativeNV);
             builder.addCapability(spv::CapabilityShaderViewportMaskNV);
             builder.addExtension(spv::E_SPV_NV_viewport_array2);
         }
-        if(symbol->getQualifier().layoutSecondaryViewportRelativeOffset != -2048)
-        {
+        if (symbol->getQualifier().layoutSecondaryViewportRelativeOffset != -2048) {
             addDecoration(id, (spv::Decoration)spv::DecorationSecondaryViewportRelativeNV, symbol->getQualifier().layoutSecondaryViewportRelativeOffset);
             builder.addCapability(spv::CapabilityShaderStereoViewNV);
             builder.addExtension(spv::E_SPV_NV_stereo_view_rendering);

--- a/Test/baseResults/spv.stereoViewRendering.vert.out
+++ b/Test/baseResults/spv.stereoViewRendering.vert.out
@@ -8,6 +8,7 @@ spv.stereoViewRendering.vert
                               Capability ShaderViewportIndexLayerNV
                               Capability ShaderViewportMaskNV
                               Capability ShaderStereoViewNV
+                              Extension  "SPV_EXT_shader_viewport_index_layer"
                               Extension  "SPV_NV_stereo_view_rendering"
                               Extension  "SPV_NV_viewport_array2"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.viewportArray2.tesc.out
+++ b/Test/baseResults/spv.viewportArray2.tesc.out
@@ -7,6 +7,7 @@ spv.viewportArray2.tesc
                               Capability MultiViewport
                               Capability ShaderViewportIndexLayerNV
                               Capability ShaderViewportMaskNV
+                              Extension  "SPV_EXT_shader_viewport_index_layer"
                               Extension  "SPV_NV_viewport_array2"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.viewportArray2.vert.out
+++ b/Test/baseResults/spv.viewportArray2.vert.out
@@ -8,6 +8,7 @@ spv.viewportArray2.vert
                               Capability MultiViewport
                               Capability ShaderViewportIndexLayerNV
                               Capability ShaderViewportMaskNV
+                              Extension  "SPV_EXT_shader_viewport_index_layer"
                               Extension  "SPV_NV_viewport_array2"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450


### PR DESCRIPTION
I'm unclear on when to require which extension, given there is a choice, and the more general choice (EXT) is available after the specific choice (NV).

Feel free to update, etc.
