### PR TITLE
HLSL: fix array[1] of vec4 constant declaration.

### DIFF
--- a/Test/baseResults/hlsl.array.frag.out
+++ b/Test/baseResults/hlsl.array.frag.out
@@ -2,72 +2,134 @@ hlsl.array.frag
 Shader version: 500
 gl_FragCoord origin is upper left
 0:? Sequence
-0:8  Function Definition: @PixelShaderFunction(i1;vf4[3]; ( temp 4-component vector of float)
-0:8    Function Parameters: 
-0:8      'i' ( in int)
-0:8      'input' ( in 3-element array of 4-component vector of float)
+0:15  Function Definition: @PixelShaderFunction(i1;vf4[3]; ( temp 4-component vector of float)
+0:15    Function Parameters: 
+0:15      'i' ( in int)
+0:15      'input' ( in 3-element array of 4-component vector of float)
 0:?     Sequence
-0:10      Branch: Return with expression
-0:10        add ( temp 4-component vector of float)
-0:10          add ( temp 4-component vector of float)
-0:10            add ( temp 4-component vector of float)
-0:10              add ( temp 4-component vector of float)
-0:10                add ( temp 4-component vector of float)
-0:10                  add ( temp 4-component vector of float)
-0:10                    direct index ( temp 4-component vector of float)
-0:10                      a: direct index for structure ( uniform 4-element array of 4-component vector of float)
-0:10                        'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s})
-0:10                        Constant:
-0:10                          0 (const uint)
-0:10                      Constant:
-0:10                        1 (const int)
-0:10                    indirect index ( temp 4-component vector of float)
-0:10                      a: direct index for structure ( uniform 4-element array of 4-component vector of float)
-0:10                        'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s})
-0:10                        Constant:
-0:10                          0 (const uint)
-0:10                      'i' ( in int)
-0:10                  direct index ( temp 4-component vector of float)
-0:10                    'input' ( in 3-element array of 4-component vector of float)
-0:10                    Constant:
-0:10                      2 (const int)
-0:10                indirect index ( temp 4-component vector of float)
-0:10                  'input' ( in 3-element array of 4-component vector of float)
-0:10                  'i' ( in int)
-0:10              direct index ( temp 4-component vector of float)
-0:10                'b' ( temp 10-element array of 4-component vector of float)
-0:10                Constant:
-0:10                  5 (const int)
-0:10            indirect index ( temp 4-component vector of float)
-0:10              'b' ( temp 10-element array of 4-component vector of float)
-0:10              'i' ( in int)
-0:10          indirect index ( temp 4-component vector of float)
-0:10            m: direct index for structure ( temp 7-element array of 4-component vector of float)
-0:10              indirect index ( temp structure{ temp 7-element array of 4-component vector of float m})
-0:10                s: direct index for structure ( uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m})
-0:10                  'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s})
-0:10                  Constant:
-0:10                    1 (const uint)
-0:10                'i' ( in int)
-0:10              Constant:
-0:10                0 (const int)
-0:10            'i' ( in int)
-0:8  Function Definition: PixelShaderFunction( ( temp void)
-0:8    Function Parameters: 
+0:17      Sequence
+0:17        move second child to first child ( temp 4-component vector of float)
+0:17          'tmp' ( temp 4-component vector of float)
+0:17          add ( temp 4-component vector of float)
+0:17            add ( temp 4-component vector of float)
+0:17              add ( temp 4-component vector of float)
+0:17                add ( temp 4-component vector of float)
+0:17                  Constant:
+0:17                    1.000000
+0:17                    2.000000
+0:17                    3.000000
+0:17                    4.000000
+0:17                  direct index ( temp 4-component vector of float)
+0:17                    a1: direct index for structure ( uniform 1-element array of 4-component vector of float)
+0:17                      'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s,  uniform 1-element array of 4-component vector of float a1,  uniform 2-element array of 4-component vector of float a2})
+0:17                      Constant:
+0:17                        2 (const uint)
+0:17                    Constant:
+0:17                      0 (const int)
+0:17                Constant:
+0:17                  1.000000
+0:17                  2.000000
+0:17                  3.000000
+0:17                  4.000000
+0:17              indirect index ( temp 4-component vector of float)
+0:17                a2: direct index for structure ( uniform 2-element array of 4-component vector of float)
+0:17                  'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s,  uniform 1-element array of 4-component vector of float a1,  uniform 2-element array of 4-component vector of float a2})
+0:17                  Constant:
+0:17                    3 (const uint)
+0:17                'i' ( in int)
+0:17            indirect index ( temp 4-component vector of float)
+0:17              Constant:
+0:17                1.000000
+0:17                2.000000
+0:17                3.000000
+0:17                4.000000
+0:17                1.000000
+0:17                2.000000
+0:17                3.000000
+0:17                4.000000
+0:17              'i' ( in int)
+0:18      Branch: Return with expression
+0:18        add ( temp 4-component vector of float)
+0:18          add ( temp 4-component vector of float)
+0:18            add ( temp 4-component vector of float)
+0:18              add ( temp 4-component vector of float)
+0:18                add ( temp 4-component vector of float)
+0:18                  add ( temp 4-component vector of float)
+0:18                    add ( temp 4-component vector of float)
+0:18                      direct index ( temp 4-component vector of float)
+0:18                        a: direct index for structure ( uniform 4-element array of 4-component vector of float)
+0:18                          'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s,  uniform 1-element array of 4-component vector of float a1,  uniform 2-element array of 4-component vector of float a2})
+0:18                          Constant:
+0:18                            0 (const uint)
+0:18                        Constant:
+0:18                          1 (const int)
+0:18                      indirect index ( temp 4-component vector of float)
+0:18                        a: direct index for structure ( uniform 4-element array of 4-component vector of float)
+0:18                          'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s,  uniform 1-element array of 4-component vector of float a1,  uniform 2-element array of 4-component vector of float a2})
+0:18                          Constant:
+0:18                            0 (const uint)
+0:18                        'i' ( in int)
+0:18                    direct index ( temp 4-component vector of float)
+0:18                      'input' ( in 3-element array of 4-component vector of float)
+0:18                      Constant:
+0:18                        2 (const int)
+0:18                  indirect index ( temp 4-component vector of float)
+0:18                    'input' ( in 3-element array of 4-component vector of float)
+0:18                    'i' ( in int)
+0:18                direct index ( temp 4-component vector of float)
+0:18                  'b' ( temp 10-element array of 4-component vector of float)
+0:18                  Constant:
+0:18                    5 (const int)
+0:18              indirect index ( temp 4-component vector of float)
+0:18                'b' ( temp 10-element array of 4-component vector of float)
+0:18                'i' ( in int)
+0:18            indirect index ( temp 4-component vector of float)
+0:18              m: direct index for structure ( temp 7-element array of 4-component vector of float)
+0:18                indirect index ( temp structure{ temp 7-element array of 4-component vector of float m})
+0:18                  s: direct index for structure ( uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m})
+0:18                    'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s,  uniform 1-element array of 4-component vector of float a1,  uniform 2-element array of 4-component vector of float a2})
+0:18                    Constant:
+0:18                      1 (const uint)
+0:18                  'i' ( in int)
+0:18                Constant:
+0:18                  0 (const int)
+0:18              'i' ( in int)
+0:18          'tmp' ( temp 4-component vector of float)
+0:15  Function Definition: PixelShaderFunction( ( temp void)
+0:15    Function Parameters: 
 0:?     Sequence
-0:8      move second child to first child ( temp int)
+0:15      move second child to first child ( temp int)
 0:?         'i' ( temp int)
 0:?         'i' (layout( location=0) flat in int)
-0:8      move second child to first child ( temp 3-element array of 4-component vector of float)
+0:15      move second child to first child ( temp 3-element array of 4-component vector of float)
 0:?         'input' ( temp 3-element array of 4-component vector of float)
 0:?         'input' (layout( location=1) in 3-element array of 4-component vector of float)
-0:8      move second child to first child ( temp 4-component vector of float)
+0:15      move second child to first child ( temp 4-component vector of float)
 0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
-0:8        Function Call: @PixelShaderFunction(i1;vf4[3]; ( temp 4-component vector of float)
+0:15        Function Call: @PixelShaderFunction(i1;vf4[3]; ( temp 4-component vector of float)
 0:?           'i' ( temp int)
 0:?           'input' ( temp 3-element array of 4-component vector of float)
 0:?   Linker Objects
-0:?     'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s})
+0:?     'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s,  uniform 1-element array of 4-component vector of float a1,  uniform 2-element array of 4-component vector of float a2})
+0:?     'C' ( const 4-component vector of float)
+0:?       1.000000
+0:?       2.000000
+0:?       3.000000
+0:?       4.000000
+0:?     'c1' ( const 1-element array of 4-component vector of float)
+0:?       1.000000
+0:?       2.000000
+0:?       3.000000
+0:?       4.000000
+0:?     'c2' ( const 2-element array of 4-component vector of float)
+0:?       1.000000
+0:?       2.000000
+0:?       3.000000
+0:?       4.000000
+0:?       1.000000
+0:?       2.000000
+0:?       3.000000
+0:?       4.000000
 0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
 0:?     'i' (layout( location=0) flat in int)
 0:?     'input' (layout( location=1) in 3-element array of 4-component vector of float)
@@ -79,116 +141,186 @@ Linked fragment stage:
 Shader version: 500
 gl_FragCoord origin is upper left
 0:? Sequence
-0:8  Function Definition: @PixelShaderFunction(i1;vf4[3]; ( temp 4-component vector of float)
-0:8    Function Parameters: 
-0:8      'i' ( in int)
-0:8      'input' ( in 3-element array of 4-component vector of float)
+0:15  Function Definition: @PixelShaderFunction(i1;vf4[3]; ( temp 4-component vector of float)
+0:15    Function Parameters: 
+0:15      'i' ( in int)
+0:15      'input' ( in 3-element array of 4-component vector of float)
 0:?     Sequence
-0:10      Branch: Return with expression
-0:10        add ( temp 4-component vector of float)
-0:10          add ( temp 4-component vector of float)
-0:10            add ( temp 4-component vector of float)
-0:10              add ( temp 4-component vector of float)
-0:10                add ( temp 4-component vector of float)
-0:10                  add ( temp 4-component vector of float)
-0:10                    direct index ( temp 4-component vector of float)
-0:10                      a: direct index for structure ( uniform 4-element array of 4-component vector of float)
-0:10                        'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s})
-0:10                        Constant:
-0:10                          0 (const uint)
-0:10                      Constant:
-0:10                        1 (const int)
-0:10                    indirect index ( temp 4-component vector of float)
-0:10                      a: direct index for structure ( uniform 4-element array of 4-component vector of float)
-0:10                        'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s})
-0:10                        Constant:
-0:10                          0 (const uint)
-0:10                      'i' ( in int)
-0:10                  direct index ( temp 4-component vector of float)
-0:10                    'input' ( in 3-element array of 4-component vector of float)
-0:10                    Constant:
-0:10                      2 (const int)
-0:10                indirect index ( temp 4-component vector of float)
-0:10                  'input' ( in 3-element array of 4-component vector of float)
-0:10                  'i' ( in int)
-0:10              direct index ( temp 4-component vector of float)
-0:10                'b' ( temp 10-element array of 4-component vector of float)
-0:10                Constant:
-0:10                  5 (const int)
-0:10            indirect index ( temp 4-component vector of float)
-0:10              'b' ( temp 10-element array of 4-component vector of float)
-0:10              'i' ( in int)
-0:10          indirect index ( temp 4-component vector of float)
-0:10            m: direct index for structure ( temp 7-element array of 4-component vector of float)
-0:10              indirect index ( temp structure{ temp 7-element array of 4-component vector of float m})
-0:10                s: direct index for structure ( uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m})
-0:10                  'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s})
-0:10                  Constant:
-0:10                    1 (const uint)
-0:10                'i' ( in int)
-0:10              Constant:
-0:10                0 (const int)
-0:10            'i' ( in int)
-0:8  Function Definition: PixelShaderFunction( ( temp void)
-0:8    Function Parameters: 
+0:17      Sequence
+0:17        move second child to first child ( temp 4-component vector of float)
+0:17          'tmp' ( temp 4-component vector of float)
+0:17          add ( temp 4-component vector of float)
+0:17            add ( temp 4-component vector of float)
+0:17              add ( temp 4-component vector of float)
+0:17                add ( temp 4-component vector of float)
+0:17                  Constant:
+0:17                    1.000000
+0:17                    2.000000
+0:17                    3.000000
+0:17                    4.000000
+0:17                  direct index ( temp 4-component vector of float)
+0:17                    a1: direct index for structure ( uniform 1-element array of 4-component vector of float)
+0:17                      'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s,  uniform 1-element array of 4-component vector of float a1,  uniform 2-element array of 4-component vector of float a2})
+0:17                      Constant:
+0:17                        2 (const uint)
+0:17                    Constant:
+0:17                      0 (const int)
+0:17                Constant:
+0:17                  1.000000
+0:17                  2.000000
+0:17                  3.000000
+0:17                  4.000000
+0:17              indirect index ( temp 4-component vector of float)
+0:17                a2: direct index for structure ( uniform 2-element array of 4-component vector of float)
+0:17                  'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s,  uniform 1-element array of 4-component vector of float a1,  uniform 2-element array of 4-component vector of float a2})
+0:17                  Constant:
+0:17                    3 (const uint)
+0:17                'i' ( in int)
+0:17            indirect index ( temp 4-component vector of float)
+0:17              Constant:
+0:17                1.000000
+0:17                2.000000
+0:17                3.000000
+0:17                4.000000
+0:17                1.000000
+0:17                2.000000
+0:17                3.000000
+0:17                4.000000
+0:17              'i' ( in int)
+0:18      Branch: Return with expression
+0:18        add ( temp 4-component vector of float)
+0:18          add ( temp 4-component vector of float)
+0:18            add ( temp 4-component vector of float)
+0:18              add ( temp 4-component vector of float)
+0:18                add ( temp 4-component vector of float)
+0:18                  add ( temp 4-component vector of float)
+0:18                    add ( temp 4-component vector of float)
+0:18                      direct index ( temp 4-component vector of float)
+0:18                        a: direct index for structure ( uniform 4-element array of 4-component vector of float)
+0:18                          'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s,  uniform 1-element array of 4-component vector of float a1,  uniform 2-element array of 4-component vector of float a2})
+0:18                          Constant:
+0:18                            0 (const uint)
+0:18                        Constant:
+0:18                          1 (const int)
+0:18                      indirect index ( temp 4-component vector of float)
+0:18                        a: direct index for structure ( uniform 4-element array of 4-component vector of float)
+0:18                          'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s,  uniform 1-element array of 4-component vector of float a1,  uniform 2-element array of 4-component vector of float a2})
+0:18                          Constant:
+0:18                            0 (const uint)
+0:18                        'i' ( in int)
+0:18                    direct index ( temp 4-component vector of float)
+0:18                      'input' ( in 3-element array of 4-component vector of float)
+0:18                      Constant:
+0:18                        2 (const int)
+0:18                  indirect index ( temp 4-component vector of float)
+0:18                    'input' ( in 3-element array of 4-component vector of float)
+0:18                    'i' ( in int)
+0:18                direct index ( temp 4-component vector of float)
+0:18                  'b' ( temp 10-element array of 4-component vector of float)
+0:18                  Constant:
+0:18                    5 (const int)
+0:18              indirect index ( temp 4-component vector of float)
+0:18                'b' ( temp 10-element array of 4-component vector of float)
+0:18                'i' ( in int)
+0:18            indirect index ( temp 4-component vector of float)
+0:18              m: direct index for structure ( temp 7-element array of 4-component vector of float)
+0:18                indirect index ( temp structure{ temp 7-element array of 4-component vector of float m})
+0:18                  s: direct index for structure ( uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m})
+0:18                    'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s,  uniform 1-element array of 4-component vector of float a1,  uniform 2-element array of 4-component vector of float a2})
+0:18                    Constant:
+0:18                      1 (const uint)
+0:18                  'i' ( in int)
+0:18                Constant:
+0:18                  0 (const int)
+0:18              'i' ( in int)
+0:18          'tmp' ( temp 4-component vector of float)
+0:15  Function Definition: PixelShaderFunction( ( temp void)
+0:15    Function Parameters: 
 0:?     Sequence
-0:8      move second child to first child ( temp int)
+0:15      move second child to first child ( temp int)
 0:?         'i' ( temp int)
 0:?         'i' (layout( location=0) flat in int)
-0:8      move second child to first child ( temp 3-element array of 4-component vector of float)
+0:15      move second child to first child ( temp 3-element array of 4-component vector of float)
 0:?         'input' ( temp 3-element array of 4-component vector of float)
 0:?         'input' (layout( location=1) in 3-element array of 4-component vector of float)
-0:8      move second child to first child ( temp 4-component vector of float)
+0:15      move second child to first child ( temp 4-component vector of float)
 0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
-0:8        Function Call: @PixelShaderFunction(i1;vf4[3]; ( temp 4-component vector of float)
+0:15        Function Call: @PixelShaderFunction(i1;vf4[3]; ( temp 4-component vector of float)
 0:?           'i' ( temp int)
 0:?           'input' ( temp 3-element array of 4-component vector of float)
 0:?   Linker Objects
-0:?     'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s})
+0:?     'anon@0' (layout( row_major std140) uniform block{ uniform 4-element array of 4-component vector of float a,  uniform 11-element array of structure{ temp 7-element array of 4-component vector of float m} s,  uniform 1-element array of 4-component vector of float a1,  uniform 2-element array of 4-component vector of float a2})
+0:?     'C' ( const 4-component vector of float)
+0:?       1.000000
+0:?       2.000000
+0:?       3.000000
+0:?       4.000000
+0:?     'c1' ( const 1-element array of 4-component vector of float)
+0:?       1.000000
+0:?       2.000000
+0:?       3.000000
+0:?       4.000000
+0:?     'c2' ( const 2-element array of 4-component vector of float)
+0:?       1.000000
+0:?       2.000000
+0:?       3.000000
+0:?       4.000000
+0:?       1.000000
+0:?       2.000000
+0:?       3.000000
+0:?       4.000000
 0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
 0:?     'i' (layout( location=0) flat in int)
 0:?     'input' (layout( location=1) in 3-element array of 4-component vector of float)
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 81
+// Id's are bound by 110
 
                               Capability Shader
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "PixelShaderFunction" 68 72 75
+                              EntryPoint Fragment 4  "PixelShaderFunction" 96 100 103
                               ExecutionMode 4 OriginUpperLeft
                               Source HLSL 500
                               Name 4  "PixelShaderFunction"
                               Name 17  "@PixelShaderFunction(i1;vf4[3];"
                               Name 15  "i"
                               Name 16  "input"
-                              Name 23  ""
-                              MemberName 23 0  "m"
-                              Name 26  "$Global"
-                              MemberName 26($Global) 0  "a"
-                              MemberName 26($Global) 1  "s"
-                              Name 28  ""
-                              Name 50  "b"
-                              Name 66  "i"
-                              Name 68  "i"
-                              Name 70  "input"
-                              Name 72  "input"
-                              Name 75  "@entryPointOutput"
-                              Name 76  "param"
-                              Name 78  "param"
-                              Decorate 20 ArrayStride 16
-                              Decorate 22 ArrayStride 16
-                              MemberDecorate 23 0 Offset 0
-                              Decorate 25 ArrayStride 112
-                              MemberDecorate 26($Global) 0 Offset 0
-                              MemberDecorate 26($Global) 1 Offset 64
-                              Decorate 26($Global) Block
-                              Decorate 28 DescriptorSet 0
-                              Decorate 68(i) Flat
-                              Decorate 68(i) Location 0
-                              Decorate 72(input) Location 1
-                              Decorate 75(@entryPointOutput) Location 0
+                              Name 20  "tmp"
+                              Name 30  ""
+                              MemberName 30 0  "m"
+                              Name 37  "$Global"
+                              MemberName 37($Global) 0  "a"
+                              MemberName 37($Global) 1  "s"
+                              MemberName 37($Global) 2  "a1"
+                              MemberName 37($Global) 3  "a2"
+                              Name 39  ""
+                              Name 55  "indexable"
+                              Name 76  "b"
+                              Name 94  "i"
+                              Name 96  "i"
+                              Name 98  "input"
+                              Name 100  "input"
+                              Name 103  "@entryPointOutput"
+                              Name 104  "param"
+                              Name 106  "param"
+                              Decorate 27 ArrayStride 16
+                              Decorate 29 ArrayStride 16
+                              MemberDecorate 30 0 Offset 0
+                              Decorate 32 ArrayStride 112
+                              Decorate 34 ArrayStride 16
+                              Decorate 36 ArrayStride 16
+                              MemberDecorate 37($Global) 0 Offset 0
+                              MemberDecorate 37($Global) 1 Offset 64
+                              MemberDecorate 37($Global) 2 Offset 1296
+                              MemberDecorate 37($Global) 3 Offset 1312
+                              Decorate 37($Global) Block
+                              Decorate 39 DescriptorSet 0
+                              Decorate 96(i) Flat
+                              Decorate 96(i) Location 0
+                              Decorate 100(input) Location 1
+                              Decorate 103(@entryPointOutput) Location 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeInt 32 1
@@ -200,78 +332,109 @@ gl_FragCoord origin is upper left
               12:             TypeArray 9(fvec4) 11
               13:             TypePointer Function 12
               14:             TypeFunction 9(fvec4) 7(ptr) 13(ptr)
-              19:     10(int) Constant 4
-              20:             TypeArray 9(fvec4) 19
-              21:     10(int) Constant 7
-              22:             TypeArray 9(fvec4) 21
-              23:             TypeStruct 22
-              24:     10(int) Constant 11
-              25:             TypeArray 23(struct) 24
-     26($Global):             TypeStruct 20 25
-              27:             TypePointer Uniform 26($Global)
-              28:     27(ptr) Variable Uniform
-              29:      6(int) Constant 0
-              30:      6(int) Constant 1
-              31:             TypePointer Uniform 9(fvec4)
-              38:      6(int) Constant 2
-              39:             TypePointer Function 9(fvec4)
-              47:     10(int) Constant 10
-              48:             TypeArray 9(fvec4) 47
-              49:             TypePointer Function 48
-              51:      6(int) Constant 5
-              67:             TypePointer Input 6(int)
-           68(i):     67(ptr) Variable Input
-              71:             TypePointer Input 12
-       72(input):     71(ptr) Variable Input
-              74:             TypePointer Output 9(fvec4)
-75(@entryPointOutput):     74(ptr) Variable Output
+              19:             TypePointer Function 9(fvec4)
+              21:    8(float) Constant 1065353216
+              22:    8(float) Constant 1073741824
+              23:    8(float) Constant 1077936128
+              24:    8(float) Constant 1082130432
+              25:    9(fvec4) ConstantComposite 21 22 23 24
+              26:     10(int) Constant 4
+              27:             TypeArray 9(fvec4) 26
+              28:     10(int) Constant 7
+              29:             TypeArray 9(fvec4) 28
+              30:             TypeStruct 29
+              31:     10(int) Constant 11
+              32:             TypeArray 30(struct) 31
+              33:     10(int) Constant 1
+              34:             TypeArray 9(fvec4) 33
+              35:     10(int) Constant 2
+              36:             TypeArray 9(fvec4) 35
+     37($Global):             TypeStruct 27 32 34 36
+              38:             TypePointer Uniform 37($Global)
+              39:     38(ptr) Variable Uniform
+              40:      6(int) Constant 2
+              41:      6(int) Constant 0
+              42:             TypePointer Uniform 9(fvec4)
+              47:      6(int) Constant 3
+              52:          36 ConstantComposite 25 25
+              54:             TypePointer Function 36
+              59:      6(int) Constant 1
+              73:     10(int) Constant 10
+              74:             TypeArray 9(fvec4) 73
+              75:             TypePointer Function 74
+              77:      6(int) Constant 5
+              95:             TypePointer Input 6(int)
+           96(i):     95(ptr) Variable Input
+              99:             TypePointer Input 12
+      100(input):     99(ptr) Variable Input
+             102:             TypePointer Output 9(fvec4)
+103(@entryPointOutput):    102(ptr) Variable Output
+             109:          34 ConstantComposite 25
 4(PixelShaderFunction):           2 Function None 3
                5:             Label
-           66(i):      7(ptr) Variable Function
-       70(input):     13(ptr) Variable Function
-       76(param):      7(ptr) Variable Function
-       78(param):     13(ptr) Variable Function
-              69:      6(int) Load 68(i)
-                              Store 66(i) 69
-              73:          12 Load 72(input)
-                              Store 70(input) 73
-              77:      6(int) Load 66(i)
-                              Store 76(param) 77
-              79:          12 Load 70(input)
-                              Store 78(param) 79
-              80:    9(fvec4) FunctionCall 17(@PixelShaderFunction(i1;vf4[3];) 76(param) 78(param)
-                              Store 75(@entryPointOutput) 80
+           94(i):      7(ptr) Variable Function
+       98(input):     13(ptr) Variable Function
+      104(param):      7(ptr) Variable Function
+      106(param):     13(ptr) Variable Function
+              97:      6(int) Load 96(i)
+                              Store 94(i) 97
+             101:          12 Load 100(input)
+                              Store 98(input) 101
+             105:      6(int) Load 94(i)
+                              Store 104(param) 105
+             107:          12 Load 98(input)
+                              Store 106(param) 107
+             108:    9(fvec4) FunctionCall 17(@PixelShaderFunction(i1;vf4[3];) 104(param) 106(param)
+                              Store 103(@entryPointOutput) 108
                               Return
                               FunctionEnd
 17(@PixelShaderFunction(i1;vf4[3];):    9(fvec4) Function None 14
            15(i):      7(ptr) FunctionParameter
        16(input):     13(ptr) FunctionParameter
               18:             Label
-           50(b):     49(ptr) Variable Function
-              32:     31(ptr) AccessChain 28 29 30
-              33:    9(fvec4) Load 32
-              34:      6(int) Load 15(i)
-              35:     31(ptr) AccessChain 28 29 34
-              36:    9(fvec4) Load 35
-              37:    9(fvec4) FAdd 33 36
-              40:     39(ptr) AccessChain 16(input) 38
-              41:    9(fvec4) Load 40
-              42:    9(fvec4) FAdd 37 41
-              43:      6(int) Load 15(i)
-              44:     39(ptr) AccessChain 16(input) 43
-              45:    9(fvec4) Load 44
-              46:    9(fvec4) FAdd 42 45
-              52:     39(ptr) AccessChain 50(b) 51
-              53:    9(fvec4) Load 52
-              54:    9(fvec4) FAdd 46 53
-              55:      6(int) Load 15(i)
-              56:     39(ptr) AccessChain 50(b) 55
+         20(tmp):     19(ptr) Variable Function
+   55(indexable):     54(ptr) Variable Function
+           76(b):     75(ptr) Variable Function
+              43:     42(ptr) AccessChain 39 40 41
+              44:    9(fvec4) Load 43
+              45:    9(fvec4) FAdd 25 44
+              46:    9(fvec4) FAdd 45 25
+              48:      6(int) Load 15(i)
+              49:     42(ptr) AccessChain 39 47 48
+              50:    9(fvec4) Load 49
+              51:    9(fvec4) FAdd 46 50
+              53:      6(int) Load 15(i)
+                              Store 55(indexable) 52
+              56:     19(ptr) AccessChain 55(indexable) 53
               57:    9(fvec4) Load 56
-              58:    9(fvec4) FAdd 54 57
-              59:      6(int) Load 15(i)
-              60:      6(int) Load 15(i)
-              61:     31(ptr) AccessChain 28 30 59 29 60
-              62:    9(fvec4) Load 61
-              63:    9(fvec4) FAdd 58 62
-                              ReturnValue 63
+              58:    9(fvec4) FAdd 51 57
+                              Store 20(tmp) 58
+              60:     42(ptr) AccessChain 39 41 59
+              61:    9(fvec4) Load 60
+              62:      6(int) Load 15(i)
+              63:     42(ptr) AccessChain 39 41 62
+              64:    9(fvec4) Load 63
+              65:    9(fvec4) FAdd 61 64
+              66:     19(ptr) AccessChain 16(input) 40
+              67:    9(fvec4) Load 66
+              68:    9(fvec4) FAdd 65 67
+              69:      6(int) Load 15(i)
+              70:     19(ptr) AccessChain 16(input) 69
+              71:    9(fvec4) Load 70
+              72:    9(fvec4) FAdd 68 71
+              78:     19(ptr) AccessChain 76(b) 77
+              79:    9(fvec4) Load 78
+              80:    9(fvec4) FAdd 72 79
+              81:      6(int) Load 15(i)
+              82:     19(ptr) AccessChain 76(b) 81
+              83:    9(fvec4) Load 82
+              84:    9(fvec4) FAdd 80 83
+              85:      6(int) Load 15(i)
+              86:      6(int) Load 15(i)
+              87:     42(ptr) AccessChain 39 59 85 41 86
+              88:    9(fvec4) Load 87
+              89:    9(fvec4) FAdd 84 88
+              90:    9(fvec4) Load 20(tmp)
+              91:    9(fvec4) FAdd 89 90
+                              ReturnValue 91
                               FunctionEnd

--- a/Test/baseResults/hlsl.constantbuffer.frag.out
+++ b/Test/baseResults/hlsl.constantbuffer.frag.out
@@ -45,7 +45,7 @@ gl_FragCoord origin is upper left
 0:24                direct index (layout( row_major std140) temp 4-element array of block{layout( row_major std140) uniform bool x, layout( row_major std140) uniform float y})
 0:24                  'cb3' (layout( row_major std140) uniform 2-element array of 4-element array of block{layout( row_major std140) uniform bool x, layout( row_major std140) uniform float y})
 0:24                  Constant:
-0:24                    2 (const int)
+0:24                    1 (const int)
 0:24                Constant:
 0:24                  3 (const int)
 0:24              Constant:
@@ -113,7 +113,7 @@ gl_FragCoord origin is upper left
 0:24                direct index (layout( row_major std140) temp 4-element array of block{layout( row_major std140) uniform bool x, layout( row_major std140) uniform float y})
 0:24                  'cb3' (layout( row_major std140) uniform 2-element array of 4-element array of block{layout( row_major std140) uniform bool x, layout( row_major std140) uniform float y})
 0:24                  Constant:
-0:24                    2 (const int)
+0:24                    1 (const int)
 0:24                Constant:
 0:24                  3 (const int)
 0:24              Constant:
@@ -231,7 +231,7 @@ gl_FragCoord origin is upper left
               54:    7(fvec4)   FAdd 45 53
                                 ReturnValue 54
               56:               Label
-              58:     41(ptr)   AccessChain 18(cb3) 21 57 20
+              58:     41(ptr)   AccessChain 18(cb3) 20 57 20
               59:    6(float)   Load 58
               60:    7(fvec4)   CompositeConstruct 59 59 59 59
                                 ReturnValue 60

--- a/Test/hlsl.array.frag
+++ b/Test/hlsl.array.frag
@@ -4,8 +4,17 @@ struct {
     float4 m[7];
 } s[11];
 
+
+const float4 C = float4(1,2,3,4);
+float4 a1[1] = { float4(1,2,3,4) };
+float4 a2[2] = { C, float4(1,2,3,4), };
+const float4 c1[1] = { float4(1,2,3,4) };
+const float4 c2[2] = { C, float4(1,2,3,4), };
+
 float4 PixelShaderFunction(int i, float4 input[3]) : COLOR0
 {
     float4 b[10];
-    return a[1] + a[i] + input[2] + input[i] + b[5] + b[i] + s[i].m[i];
+    float4 tmp = C + a1[0] + c1[0] + a2[i] + c2[i];
+    return a[1] + a[i] + input[2] + input[i] + b[5] + b[i] + s[i].m[i] + tmp;
 }
+

--- a/Test/hlsl.constantbuffer.frag
+++ b/Test/hlsl.constantbuffer.frag
@@ -21,6 +21,6 @@ float4 main() : SV_Target0
     if (cb3[1][2].x)
         return cb1.x + cb2[1].y + c1;
     else
-        return cb3[2][3].y;
+        return cb3[1][3].y;
 }
 

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -911,8 +911,20 @@ TIntermTyped* HlslParseContext::handleBracketDereference(const TSourceLoc& loc, 
     return result;
 }
 
-void HlslParseContext::checkIndex(const TSourceLoc& /*loc*/, const TType& /*type*/, int& /*index*/)
+void HlslParseContext::checkIndex(const TSourceLoc& loc, const TType& type, int& index)
 {
+    bool out = false;
+    if (type.isArray()) {
+        if (type.isExplicitlySizedArray() && index >= type.getOuterArraySize())
+            out = true;
+    } else if (type.isVector()) {
+        if (index >= type.getVectorSize())
+            out = true;
+    }
+
+    if (out)
+        error(loc, " index out of bounds ", "[]", "");
+
     // HLSL todo: any rules for index fixups?
 }
 

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -7750,7 +7750,7 @@ TIntermTyped* HlslParseContext::addConstructor(const TSourceLoc& loc, TIntermTyp
     bool singleArg;
     TIntermAggregate* aggrNode = node->getAsAggregate();
     if (aggrNode != nullptr) {
-        if (aggrNode->getOp() != EOpNull || aggrNode->getSequence().size() == 1)
+        if (aggrNode->getOp() != EOpNull)
             singleArg = true;
         else
             singleArg = false;


### PR DESCRIPTION
+ const arrays with only one element where interpreted as an immediate. 
for example, 
`float4 a1[1] = { float4(1,2,3,4) };  `
a1[0] was the x component of the float4, instead of the float4 itself.

+ And a some bound checking tests, instead of accessing uninitialized memory in case of a typo..
