### PR TITLE
HLSL: (minor) fix type on clip/cull index result

### DIFF
--- a/Test/baseResults/hlsl.clipdistance-1.frag.out
+++ b/Test/baseResults/hlsl.clipdistance-1.frag.out
@@ -23,14 +23,14 @@ gl_FragCoord origin is upper left
 0:?       Sequence
 0:4        move second child to first child ( temp float)
 0:?           'clip' ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( in float ClipDistance)
 0:?             'clip' ( in 1-element array of float ClipDistance)
 0:4            Constant:
 0:4              0 (const int)
 0:?       Sequence
 0:4        move second child to first child ( temp float)
 0:?           'cull' ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( in float CullDistance)
 0:?             'cull' ( in 1-element array of float CullDistance)
 0:4            Constant:
 0:4              0 (const int)
@@ -74,14 +74,14 @@ gl_FragCoord origin is upper left
 0:?       Sequence
 0:4        move second child to first child ( temp float)
 0:?           'clip' ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( in float ClipDistance)
 0:?             'clip' ( in 1-element array of float ClipDistance)
 0:4            Constant:
 0:4              0 (const int)
 0:?       Sequence
 0:4        move second child to first child ( temp float)
 0:?           'cull' ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( in float CullDistance)
 0:?             'cull' ( in 1-element array of float CullDistance)
 0:4            Constant:
 0:4              0 (const int)

--- a/Test/baseResults/hlsl.clipdistance-1.vert.out
+++ b/Test/baseResults/hlsl.clipdistance-1.vert.out
@@ -34,14 +34,14 @@ Shader version: 500
 0:?         'pos' ( temp 4-component vector of float)
 0:?       Sequence
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float ClipDistance)
 0:?             'clip' ( out 1-element array of float ClipDistance)
 0:4            Constant:
 0:4              0 (const int)
 0:?           'clip' ( temp float)
 0:?       Sequence
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float CullDistance)
 0:?             'cull' ( out 1-element array of float CullDistance)
 0:4            Constant:
 0:4              0 (const int)
@@ -90,14 +90,14 @@ Shader version: 500
 0:?         'pos' ( temp 4-component vector of float)
 0:?       Sequence
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float ClipDistance)
 0:?             'clip' ( out 1-element array of float ClipDistance)
 0:4            Constant:
 0:4              0 (const int)
 0:?           'clip' ( temp float)
 0:?       Sequence
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float CullDistance)
 0:?             'cull' ( out 1-element array of float CullDistance)
 0:4            Constant:
 0:4              0 (const int)

--- a/Test/baseResults/hlsl.clipdistance-2.frag.out
+++ b/Test/baseResults/hlsl.clipdistance-2.frag.out
@@ -41,7 +41,7 @@ gl_FragCoord origin is upper left
 0:4                0 (const int)
 0:4            Constant:
 0:4              0 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float ClipDistance)
 0:?             'clip' ( in 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              0 (const int)
@@ -53,7 +53,7 @@ gl_FragCoord origin is upper left
 0:4                0 (const int)
 0:4            Constant:
 0:4              1 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float ClipDistance)
 0:?             'clip' ( in 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              1 (const int)
@@ -65,7 +65,7 @@ gl_FragCoord origin is upper left
 0:4                1 (const int)
 0:4            Constant:
 0:4              0 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float ClipDistance)
 0:?             'clip' ( in 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              2 (const int)
@@ -77,7 +77,7 @@ gl_FragCoord origin is upper left
 0:4                1 (const int)
 0:4            Constant:
 0:4              1 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float ClipDistance)
 0:?             'clip' ( in 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              3 (const int)
@@ -90,7 +90,7 @@ gl_FragCoord origin is upper left
 0:4                0 (const int)
 0:4            Constant:
 0:4              0 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float CullDistance)
 0:?             'cull' ( in 4-element array of float CullDistance)
 0:4            Constant:
 0:4              0 (const int)
@@ -102,7 +102,7 @@ gl_FragCoord origin is upper left
 0:4                0 (const int)
 0:4            Constant:
 0:4              1 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float CullDistance)
 0:?             'cull' ( in 4-element array of float CullDistance)
 0:4            Constant:
 0:4              1 (const int)
@@ -114,7 +114,7 @@ gl_FragCoord origin is upper left
 0:4                1 (const int)
 0:4            Constant:
 0:4              0 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float CullDistance)
 0:?             'cull' ( in 4-element array of float CullDistance)
 0:4            Constant:
 0:4              2 (const int)
@@ -126,7 +126,7 @@ gl_FragCoord origin is upper left
 0:4                1 (const int)
 0:4            Constant:
 0:4              1 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float CullDistance)
 0:?             'cull' ( in 4-element array of float CullDistance)
 0:4            Constant:
 0:4              3 (const int)
@@ -188,7 +188,7 @@ gl_FragCoord origin is upper left
 0:4                0 (const int)
 0:4            Constant:
 0:4              0 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float ClipDistance)
 0:?             'clip' ( in 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              0 (const int)
@@ -200,7 +200,7 @@ gl_FragCoord origin is upper left
 0:4                0 (const int)
 0:4            Constant:
 0:4              1 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float ClipDistance)
 0:?             'clip' ( in 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              1 (const int)
@@ -212,7 +212,7 @@ gl_FragCoord origin is upper left
 0:4                1 (const int)
 0:4            Constant:
 0:4              0 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float ClipDistance)
 0:?             'clip' ( in 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              2 (const int)
@@ -224,7 +224,7 @@ gl_FragCoord origin is upper left
 0:4                1 (const int)
 0:4            Constant:
 0:4              1 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float ClipDistance)
 0:?             'clip' ( in 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              3 (const int)
@@ -237,7 +237,7 @@ gl_FragCoord origin is upper left
 0:4                0 (const int)
 0:4            Constant:
 0:4              0 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float CullDistance)
 0:?             'cull' ( in 4-element array of float CullDistance)
 0:4            Constant:
 0:4              0 (const int)
@@ -249,7 +249,7 @@ gl_FragCoord origin is upper left
 0:4                0 (const int)
 0:4            Constant:
 0:4              1 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float CullDistance)
 0:?             'cull' ( in 4-element array of float CullDistance)
 0:4            Constant:
 0:4              1 (const int)
@@ -261,7 +261,7 @@ gl_FragCoord origin is upper left
 0:4                1 (const int)
 0:4            Constant:
 0:4              0 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float CullDistance)
 0:?             'cull' ( in 4-element array of float CullDistance)
 0:4            Constant:
 0:4              2 (const int)
@@ -273,7 +273,7 @@ gl_FragCoord origin is upper left
 0:4                1 (const int)
 0:4            Constant:
 0:4              1 (const int)
-0:4          direct index ( temp float)
+0:4          direct index ( in float CullDistance)
 0:?             'cull' ( in 4-element array of float CullDistance)
 0:4            Constant:
 0:4              3 (const int)

--- a/Test/baseResults/hlsl.clipdistance-2.vert.out
+++ b/Test/baseResults/hlsl.clipdistance-2.vert.out
@@ -106,7 +106,7 @@ Shader version: 500
 0:?         'pos' ( temp 4-component vector of float)
 0:?       Sequence
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float ClipDistance)
 0:?             'clip' ( out 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              0 (const int)
@@ -118,7 +118,7 @@ Shader version: 500
 0:4            Constant:
 0:4              0 (const int)
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float ClipDistance)
 0:?             'clip' ( out 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              1 (const int)
@@ -130,7 +130,7 @@ Shader version: 500
 0:4            Constant:
 0:4              1 (const int)
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float ClipDistance)
 0:?             'clip' ( out 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              2 (const int)
@@ -142,7 +142,7 @@ Shader version: 500
 0:4            Constant:
 0:4              0 (const int)
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float ClipDistance)
 0:?             'clip' ( out 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              3 (const int)
@@ -155,7 +155,7 @@ Shader version: 500
 0:4              1 (const int)
 0:?       Sequence
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float CullDistance)
 0:?             'cull' ( out 4-element array of float CullDistance)
 0:4            Constant:
 0:4              0 (const int)
@@ -167,7 +167,7 @@ Shader version: 500
 0:4            Constant:
 0:4              0 (const int)
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float CullDistance)
 0:?             'cull' ( out 4-element array of float CullDistance)
 0:4            Constant:
 0:4              1 (const int)
@@ -179,7 +179,7 @@ Shader version: 500
 0:4            Constant:
 0:4              1 (const int)
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float CullDistance)
 0:?             'cull' ( out 4-element array of float CullDistance)
 0:4            Constant:
 0:4              2 (const int)
@@ -191,7 +191,7 @@ Shader version: 500
 0:4            Constant:
 0:4              0 (const int)
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float CullDistance)
 0:?             'cull' ( out 4-element array of float CullDistance)
 0:4            Constant:
 0:4              3 (const int)
@@ -318,7 +318,7 @@ Shader version: 500
 0:?         'pos' ( temp 4-component vector of float)
 0:?       Sequence
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float ClipDistance)
 0:?             'clip' ( out 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              0 (const int)
@@ -330,7 +330,7 @@ Shader version: 500
 0:4            Constant:
 0:4              0 (const int)
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float ClipDistance)
 0:?             'clip' ( out 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              1 (const int)
@@ -342,7 +342,7 @@ Shader version: 500
 0:4            Constant:
 0:4              1 (const int)
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float ClipDistance)
 0:?             'clip' ( out 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              2 (const int)
@@ -354,7 +354,7 @@ Shader version: 500
 0:4            Constant:
 0:4              0 (const int)
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float ClipDistance)
 0:?             'clip' ( out 4-element array of float ClipDistance)
 0:4            Constant:
 0:4              3 (const int)
@@ -367,7 +367,7 @@ Shader version: 500
 0:4              1 (const int)
 0:?       Sequence
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float CullDistance)
 0:?             'cull' ( out 4-element array of float CullDistance)
 0:4            Constant:
 0:4              0 (const int)
@@ -379,7 +379,7 @@ Shader version: 500
 0:4            Constant:
 0:4              0 (const int)
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float CullDistance)
 0:?             'cull' ( out 4-element array of float CullDistance)
 0:4            Constant:
 0:4              1 (const int)
@@ -391,7 +391,7 @@ Shader version: 500
 0:4            Constant:
 0:4              1 (const int)
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float CullDistance)
 0:?             'cull' ( out 4-element array of float CullDistance)
 0:4            Constant:
 0:4              2 (const int)
@@ -403,7 +403,7 @@ Shader version: 500
 0:4            Constant:
 0:4              0 (const int)
 0:4        move second child to first child ( temp float)
-0:4          direct index ( temp float)
+0:4          direct index ( out float CullDistance)
 0:?             'cull' ( out 4-element array of float CullDistance)
 0:4            Constant:
 0:4              3 (const int)

--- a/Test/baseResults/hlsl.clipdistance-4.frag.out
+++ b/Test/baseResults/hlsl.clipdistance-4.frag.out
@@ -35,7 +35,7 @@ gl_FragCoord origin is upper left
 0:7                  1 (const int)
 0:7              Constant:
 0:7                0 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                0 (const int)
@@ -47,7 +47,7 @@ gl_FragCoord origin is upper left
 0:7                  1 (const int)
 0:7              Constant:
 0:7                1 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                1 (const int)
@@ -59,7 +59,7 @@ gl_FragCoord origin is upper left
 0:7                  1 (const int)
 0:7              Constant:
 0:7                2 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                2 (const int)
@@ -71,7 +71,7 @@ gl_FragCoord origin is upper left
 0:7                  1 (const int)
 0:7              Constant:
 0:7                3 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                3 (const int)
@@ -124,7 +124,7 @@ gl_FragCoord origin is upper left
 0:7                  1 (const int)
 0:7              Constant:
 0:7                0 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                0 (const int)
@@ -136,7 +136,7 @@ gl_FragCoord origin is upper left
 0:7                  1 (const int)
 0:7              Constant:
 0:7                1 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                1 (const int)
@@ -148,7 +148,7 @@ gl_FragCoord origin is upper left
 0:7                  1 (const int)
 0:7              Constant:
 0:7                2 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                2 (const int)
@@ -160,7 +160,7 @@ gl_FragCoord origin is upper left
 0:7                  1 (const int)
 0:7              Constant:
 0:7                3 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                3 (const int)

--- a/Test/baseResults/hlsl.clipdistance-4.vert.out
+++ b/Test/baseResults/hlsl.clipdistance-4.vert.out
@@ -80,7 +80,7 @@ Shader version: 500
 0:11              0 (const int)
 0:?         Sequence
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                0 (const int)
@@ -92,7 +92,7 @@ Shader version: 500
 0:11              Constant:
 0:11                0 (const int)
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                1 (const int)
@@ -104,7 +104,7 @@ Shader version: 500
 0:11              Constant:
 0:11                1 (const int)
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                2 (const int)
@@ -116,7 +116,7 @@ Shader version: 500
 0:11              Constant:
 0:11                2 (const int)
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                3 (const int)
@@ -217,7 +217,7 @@ Shader version: 500
 0:11              0 (const int)
 0:?         Sequence
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                0 (const int)
@@ -229,7 +229,7 @@ Shader version: 500
 0:11              Constant:
 0:11                0 (const int)
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                1 (const int)
@@ -241,7 +241,7 @@ Shader version: 500
 0:11              Constant:
 0:11                1 (const int)
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                2 (const int)
@@ -253,7 +253,7 @@ Shader version: 500
 0:11              Constant:
 0:11                2 (const int)
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                3 (const int)

--- a/Test/baseResults/hlsl.clipdistance-5.frag.out
+++ b/Test/baseResults/hlsl.clipdistance-5.frag.out
@@ -55,7 +55,7 @@ gl_FragCoord origin is upper left
 0:7                  0 (const int)
 0:7              Constant:
 0:7                0 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                0 (const int)
@@ -70,7 +70,7 @@ gl_FragCoord origin is upper left
 0:7                  0 (const int)
 0:7              Constant:
 0:7                1 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                1 (const int)
@@ -85,7 +85,7 @@ gl_FragCoord origin is upper left
 0:7                  1 (const int)
 0:7              Constant:
 0:7                0 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                2 (const int)
@@ -100,7 +100,7 @@ gl_FragCoord origin is upper left
 0:7                  1 (const int)
 0:7              Constant:
 0:7                1 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                3 (const int)
@@ -173,7 +173,7 @@ gl_FragCoord origin is upper left
 0:7                  0 (const int)
 0:7              Constant:
 0:7                0 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                0 (const int)
@@ -188,7 +188,7 @@ gl_FragCoord origin is upper left
 0:7                  0 (const int)
 0:7              Constant:
 0:7                1 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                1 (const int)
@@ -203,7 +203,7 @@ gl_FragCoord origin is upper left
 0:7                  1 (const int)
 0:7              Constant:
 0:7                0 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                2 (const int)
@@ -218,7 +218,7 @@ gl_FragCoord origin is upper left
 0:7                  1 (const int)
 0:7              Constant:
 0:7                1 (const int)
-0:7            direct index ( temp float)
+0:7            direct index ( in float ClipDistance)
 0:?               'v.ClipRect' ( in 4-element array of float ClipDistance)
 0:7              Constant:
 0:7                3 (const int)

--- a/Test/baseResults/hlsl.clipdistance-5.vert.out
+++ b/Test/baseResults/hlsl.clipdistance-5.vert.out
@@ -92,7 +92,7 @@ Shader version: 500
 0:11              0 (const int)
 0:?         Sequence
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                0 (const int)
@@ -107,7 +107,7 @@ Shader version: 500
 0:11              Constant:
 0:11                0 (const int)
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                1 (const int)
@@ -122,7 +122,7 @@ Shader version: 500
 0:11              Constant:
 0:11                1 (const int)
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                2 (const int)
@@ -137,7 +137,7 @@ Shader version: 500
 0:11              Constant:
 0:11                0 (const int)
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                3 (const int)
@@ -253,7 +253,7 @@ Shader version: 500
 0:11              0 (const int)
 0:?         Sequence
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                0 (const int)
@@ -268,7 +268,7 @@ Shader version: 500
 0:11              Constant:
 0:11                0 (const int)
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                1 (const int)
@@ -283,7 +283,7 @@ Shader version: 500
 0:11              Constant:
 0:11                1 (const int)
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                2 (const int)
@@ -298,7 +298,7 @@ Shader version: 500
 0:11              Constant:
 0:11                0 (const int)
 0:11          move second child to first child ( temp float)
-0:11            direct index ( temp float)
+0:11            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.ClipRect' ( out 4-element array of float ClipDistance)
 0:11              Constant:
 0:11                3 (const int)

--- a/Test/baseResults/hlsl.clipdistance-6.frag.out
+++ b/Test/baseResults/hlsl.clipdistance-6.frag.out
@@ -40,7 +40,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                0 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                0 (const int)
@@ -52,7 +52,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                1 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                1 (const int)
@@ -64,7 +64,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                2 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                2 (const int)
@@ -76,7 +76,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                3 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                3 (const int)
@@ -89,7 +89,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                0 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                4 (const int)
@@ -101,7 +101,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                1 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                5 (const int)
@@ -113,7 +113,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                2 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                6 (const int)
@@ -125,7 +125,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                3 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                7 (const int)
@@ -183,7 +183,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                0 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                0 (const int)
@@ -195,7 +195,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                1 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                1 (const int)
@@ -207,7 +207,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                2 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                2 (const int)
@@ -219,7 +219,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                3 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                3 (const int)
@@ -232,7 +232,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                0 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                4 (const int)
@@ -244,7 +244,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                1 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                5 (const int)
@@ -256,7 +256,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                2 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                6 (const int)
@@ -268,7 +268,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                3 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                7 (const int)

--- a/Test/baseResults/hlsl.clipdistance-6.vert.out
+++ b/Test/baseResults/hlsl.clipdistance-6.vert.out
@@ -111,7 +111,7 @@ Shader version: 500
 0:8              0 (const int)
 0:?         Sequence
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                0 (const int)
@@ -123,7 +123,7 @@ Shader version: 500
 0:8              Constant:
 0:8                0 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                1 (const int)
@@ -135,7 +135,7 @@ Shader version: 500
 0:8              Constant:
 0:8                1 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                2 (const int)
@@ -147,7 +147,7 @@ Shader version: 500
 0:8              Constant:
 0:8                2 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                3 (const int)
@@ -160,7 +160,7 @@ Shader version: 500
 0:8                3 (const int)
 0:?         Sequence
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                4 (const int)
@@ -172,7 +172,7 @@ Shader version: 500
 0:8              Constant:
 0:8                0 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                5 (const int)
@@ -184,7 +184,7 @@ Shader version: 500
 0:8              Constant:
 0:8                1 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                6 (const int)
@@ -196,7 +196,7 @@ Shader version: 500
 0:8              Constant:
 0:8                2 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                7 (const int)
@@ -327,7 +327,7 @@ Shader version: 500
 0:8              0 (const int)
 0:?         Sequence
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                0 (const int)
@@ -339,7 +339,7 @@ Shader version: 500
 0:8              Constant:
 0:8                0 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                1 (const int)
@@ -351,7 +351,7 @@ Shader version: 500
 0:8              Constant:
 0:8                1 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                2 (const int)
@@ -363,7 +363,7 @@ Shader version: 500
 0:8              Constant:
 0:8                2 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                3 (const int)
@@ -376,7 +376,7 @@ Shader version: 500
 0:8                3 (const int)
 0:?         Sequence
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                4 (const int)
@@ -388,7 +388,7 @@ Shader version: 500
 0:8              Constant:
 0:8                0 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                5 (const int)
@@ -400,7 +400,7 @@ Shader version: 500
 0:8              Constant:
 0:8                1 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                6 (const int)
@@ -412,7 +412,7 @@ Shader version: 500
 0:8              Constant:
 0:8                2 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                7 (const int)

--- a/Test/baseResults/hlsl.clipdistance-7.frag.out
+++ b/Test/baseResults/hlsl.clipdistance-7.frag.out
@@ -46,7 +46,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                0 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                0 (const int)
@@ -58,7 +58,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                1 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                1 (const int)
@@ -70,7 +70,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                2 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                2 (const int)
@@ -83,7 +83,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                0 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                4 (const int)
@@ -95,7 +95,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                1 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                5 (const int)
@@ -107,7 +107,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                2 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                6 (const int)
@@ -119,7 +119,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                3 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                7 (const int)
@@ -183,7 +183,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                0 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                0 (const int)
@@ -195,7 +195,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                1 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                1 (const int)
@@ -207,7 +207,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                2 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                2 (const int)
@@ -220,7 +220,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                0 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                4 (const int)
@@ -232,7 +232,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                1 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                5 (const int)
@@ -244,7 +244,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                2 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                6 (const int)
@@ -256,7 +256,7 @@ gl_FragCoord origin is upper left
 0:8                  2 (const int)
 0:8              Constant:
 0:8                3 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                7 (const int)

--- a/Test/baseResults/hlsl.clipdistance-7.vert.out
+++ b/Test/baseResults/hlsl.clipdistance-7.vert.out
@@ -101,7 +101,7 @@ Shader version: 500
 0:8              0 (const int)
 0:?         Sequence
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                0 (const int)
@@ -113,7 +113,7 @@ Shader version: 500
 0:8              Constant:
 0:8                0 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                1 (const int)
@@ -125,7 +125,7 @@ Shader version: 500
 0:8              Constant:
 0:8                1 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                2 (const int)
@@ -138,7 +138,7 @@ Shader version: 500
 0:8                2 (const int)
 0:?         Sequence
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                4 (const int)
@@ -150,7 +150,7 @@ Shader version: 500
 0:8              Constant:
 0:8                0 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                5 (const int)
@@ -162,7 +162,7 @@ Shader version: 500
 0:8              Constant:
 0:8                1 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                6 (const int)
@@ -174,7 +174,7 @@ Shader version: 500
 0:8              Constant:
 0:8                2 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                7 (const int)
@@ -295,7 +295,7 @@ Shader version: 500
 0:8              0 (const int)
 0:?         Sequence
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                0 (const int)
@@ -307,7 +307,7 @@ Shader version: 500
 0:8              Constant:
 0:8                0 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                1 (const int)
@@ -319,7 +319,7 @@ Shader version: 500
 0:8              Constant:
 0:8                1 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                2 (const int)
@@ -332,7 +332,7 @@ Shader version: 500
 0:8                2 (const int)
 0:?         Sequence
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                4 (const int)
@@ -344,7 +344,7 @@ Shader version: 500
 0:8              Constant:
 0:8                0 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                5 (const int)
@@ -356,7 +356,7 @@ Shader version: 500
 0:8              Constant:
 0:8                1 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                6 (const int)
@@ -368,7 +368,7 @@ Shader version: 500
 0:8              Constant:
 0:8                2 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 8-element array of float ClipDistance)
 0:8              Constant:
 0:8                7 (const int)

--- a/Test/baseResults/hlsl.clipdistance-8.frag.out
+++ b/Test/baseResults/hlsl.clipdistance-8.frag.out
@@ -43,7 +43,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                0 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                0 (const int)
@@ -55,7 +55,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                1 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                1 (const int)
@@ -67,7 +67,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                2 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                2 (const int)
@@ -77,7 +77,7 @@ gl_FragCoord origin is upper left
 0:?               'v' ( temp structure{ temp 4-component vector of float Position,  temp 3-component vector of float clip0,  temp float clip1})
 0:8              Constant:
 0:8                2 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                3 (const int)
@@ -138,7 +138,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                0 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                0 (const int)
@@ -150,7 +150,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                1 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                1 (const int)
@@ -162,7 +162,7 @@ gl_FragCoord origin is upper left
 0:8                  1 (const int)
 0:8              Constant:
 0:8                2 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                2 (const int)
@@ -172,7 +172,7 @@ gl_FragCoord origin is upper left
 0:?               'v' ( temp structure{ temp 4-component vector of float Position,  temp 3-component vector of float clip0,  temp float clip1})
 0:8              Constant:
 0:8                2 (const int)
-0:8            direct index ( temp float)
+0:8            direct index ( in float ClipDistance)
 0:?               'v.clip1' ( in 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                3 (const int)

--- a/Test/baseResults/hlsl.clipdistance-8.vert.out
+++ b/Test/baseResults/hlsl.clipdistance-8.vert.out
@@ -68,7 +68,7 @@ Shader version: 500
 0:8              0 (const int)
 0:?         Sequence
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                0 (const int)
@@ -80,7 +80,7 @@ Shader version: 500
 0:8              Constant:
 0:8                0 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                1 (const int)
@@ -92,7 +92,7 @@ Shader version: 500
 0:8              Constant:
 0:8                1 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                2 (const int)
@@ -105,7 +105,7 @@ Shader version: 500
 0:8                2 (const int)
 0:?         Sequence
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                3 (const int)
@@ -190,7 +190,7 @@ Shader version: 500
 0:8              0 (const int)
 0:?         Sequence
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                0 (const int)
@@ -202,7 +202,7 @@ Shader version: 500
 0:8              Constant:
 0:8                0 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                1 (const int)
@@ -214,7 +214,7 @@ Shader version: 500
 0:8              Constant:
 0:8                1 (const int)
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                2 (const int)
@@ -227,7 +227,7 @@ Shader version: 500
 0:8                2 (const int)
 0:?         Sequence
 0:8          move second child to first child ( temp float)
-0:8            direct index ( temp float)
+0:8            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 4-element array of float ClipDistance)
 0:8              Constant:
 0:8                3 (const int)

--- a/Test/baseResults/hlsl.clipdistance-9.frag.out
+++ b/Test/baseResults/hlsl.clipdistance-9.frag.out
@@ -29,7 +29,7 @@ gl_FragCoord origin is upper left
 0:?             'clip0' ( temp 3-component vector of float)
 0:6            Constant:
 0:6              0 (const int)
-0:6          direct index ( temp float)
+0:6          direct index ( in float ClipDistance)
 0:?             'clip0' ( in 4-element array of float ClipDistance)
 0:6            Constant:
 0:6              0 (const int)
@@ -38,7 +38,7 @@ gl_FragCoord origin is upper left
 0:?             'clip0' ( temp 3-component vector of float)
 0:6            Constant:
 0:6              1 (const int)
-0:6          direct index ( temp float)
+0:6          direct index ( in float ClipDistance)
 0:?             'clip0' ( in 4-element array of float ClipDistance)
 0:6            Constant:
 0:6              1 (const int)
@@ -47,14 +47,14 @@ gl_FragCoord origin is upper left
 0:?             'clip0' ( temp 3-component vector of float)
 0:6            Constant:
 0:6              2 (const int)
-0:6          direct index ( temp float)
+0:6          direct index ( in float ClipDistance)
 0:?             'clip0' ( in 4-element array of float ClipDistance)
 0:6            Constant:
 0:6              2 (const int)
 0:?       Sequence
 0:6        move second child to first child ( temp float)
 0:?           'clip1' ( temp float)
-0:6          direct index ( temp float)
+0:6          direct index ( in float ClipDistance)
 0:?             'clip0' ( in 4-element array of float ClipDistance)
 0:6            Constant:
 0:6              3 (const int)
@@ -103,7 +103,7 @@ gl_FragCoord origin is upper left
 0:?             'clip0' ( temp 3-component vector of float)
 0:6            Constant:
 0:6              0 (const int)
-0:6          direct index ( temp float)
+0:6          direct index ( in float ClipDistance)
 0:?             'clip0' ( in 4-element array of float ClipDistance)
 0:6            Constant:
 0:6              0 (const int)
@@ -112,7 +112,7 @@ gl_FragCoord origin is upper left
 0:?             'clip0' ( temp 3-component vector of float)
 0:6            Constant:
 0:6              1 (const int)
-0:6          direct index ( temp float)
+0:6          direct index ( in float ClipDistance)
 0:?             'clip0' ( in 4-element array of float ClipDistance)
 0:6            Constant:
 0:6              1 (const int)
@@ -121,14 +121,14 @@ gl_FragCoord origin is upper left
 0:?             'clip0' ( temp 3-component vector of float)
 0:6            Constant:
 0:6              2 (const int)
-0:6          direct index ( temp float)
+0:6          direct index ( in float ClipDistance)
 0:?             'clip0' ( in 4-element array of float ClipDistance)
 0:6            Constant:
 0:6              2 (const int)
 0:?       Sequence
 0:6        move second child to first child ( temp float)
 0:?           'clip1' ( temp float)
-0:6          direct index ( temp float)
+0:6          direct index ( in float ClipDistance)
 0:?             'clip0' ( in 4-element array of float ClipDistance)
 0:6            Constant:
 0:6              3 (const int)

--- a/Test/baseResults/hlsl.clipdistance-9.vert.out
+++ b/Test/baseResults/hlsl.clipdistance-9.vert.out
@@ -57,7 +57,7 @@ Shader version: 500
 0:7              0 (const int)
 0:?       Sequence
 0:7        move second child to first child ( temp float)
-0:7          direct index ( temp float)
+0:7          direct index ( out float ClipDistance)
 0:?             'clip0' ( out 4-element array of float ClipDistance)
 0:7            Constant:
 0:7              0 (const int)
@@ -66,7 +66,7 @@ Shader version: 500
 0:7            Constant:
 0:7              0 (const int)
 0:7        move second child to first child ( temp float)
-0:7          direct index ( temp float)
+0:7          direct index ( out float ClipDistance)
 0:?             'clip0' ( out 4-element array of float ClipDistance)
 0:7            Constant:
 0:7              1 (const int)
@@ -75,7 +75,7 @@ Shader version: 500
 0:7            Constant:
 0:7              1 (const int)
 0:7        move second child to first child ( temp float)
-0:7          direct index ( temp float)
+0:7          direct index ( out float ClipDistance)
 0:?             'clip0' ( out 4-element array of float ClipDistance)
 0:7            Constant:
 0:7              2 (const int)
@@ -85,7 +85,7 @@ Shader version: 500
 0:7              2 (const int)
 0:?       Sequence
 0:7        move second child to first child ( temp float)
-0:7          direct index ( temp float)
+0:7          direct index ( out float ClipDistance)
 0:?             'clip0' ( out 4-element array of float ClipDistance)
 0:7            Constant:
 0:7              3 (const int)
@@ -156,7 +156,7 @@ Shader version: 500
 0:7              0 (const int)
 0:?       Sequence
 0:7        move second child to first child ( temp float)
-0:7          direct index ( temp float)
+0:7          direct index ( out float ClipDistance)
 0:?             'clip0' ( out 4-element array of float ClipDistance)
 0:7            Constant:
 0:7              0 (const int)
@@ -165,7 +165,7 @@ Shader version: 500
 0:7            Constant:
 0:7              0 (const int)
 0:7        move second child to first child ( temp float)
-0:7          direct index ( temp float)
+0:7          direct index ( out float ClipDistance)
 0:?             'clip0' ( out 4-element array of float ClipDistance)
 0:7            Constant:
 0:7              1 (const int)
@@ -174,7 +174,7 @@ Shader version: 500
 0:7            Constant:
 0:7              1 (const int)
 0:7        move second child to first child ( temp float)
-0:7          direct index ( temp float)
+0:7          direct index ( out float ClipDistance)
 0:?             'clip0' ( out 4-element array of float ClipDistance)
 0:7            Constant:
 0:7              2 (const int)
@@ -184,7 +184,7 @@ Shader version: 500
 0:7              2 (const int)
 0:?       Sequence
 0:7        move second child to first child ( temp float)
-0:7          direct index ( temp float)
+0:7          direct index ( out float ClipDistance)
 0:?             'clip0' ( out 4-element array of float ClipDistance)
 0:7            Constant:
 0:7              3 (const int)

--- a/Test/baseResults/hlsl.semantic.vert.out
+++ b/Test/baseResults/hlsl.semantic.vert.out
@@ -48,7 +48,7 @@ Shader version: 500
 0:?             'ins' ( temp structure{ temp float clip0,  temp float clip1,  temp float cull0,  temp float cull1,  temp int ii})
 0:?         Sequence
 0:10          move second child to first child ( temp float)
-0:10            direct index ( temp float)
+0:10            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 2-element array of float ClipDistance)
 0:10              Constant:
 0:10                0 (const int)
@@ -58,7 +58,7 @@ Shader version: 500
 0:10                0 (const int)
 0:?         Sequence
 0:10          move second child to first child ( temp float)
-0:10            direct index ( temp float)
+0:10            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 2-element array of float ClipDistance)
 0:10              Constant:
 0:10                1 (const int)
@@ -68,7 +68,7 @@ Shader version: 500
 0:10                1 (const int)
 0:?         Sequence
 0:10          move second child to first child ( temp float)
-0:10            direct index ( temp float)
+0:10            direct index ( out float CullDistance)
 0:?               '@entryPointOutput.cull1' ( out 2-element array of float CullDistance)
 0:10              Constant:
 0:10                0 (const int)
@@ -78,7 +78,7 @@ Shader version: 500
 0:10                2 (const int)
 0:?         Sequence
 0:10          move second child to first child ( temp float)
-0:10            direct index ( temp float)
+0:10            direct index ( out float CullDistance)
 0:?               '@entryPointOutput.cull1' ( out 2-element array of float CullDistance)
 0:10              Constant:
 0:10                1 (const int)
@@ -155,7 +155,7 @@ Shader version: 500
 0:?             'ins' ( temp structure{ temp float clip0,  temp float clip1,  temp float cull0,  temp float cull1,  temp int ii})
 0:?         Sequence
 0:10          move second child to first child ( temp float)
-0:10            direct index ( temp float)
+0:10            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 2-element array of float ClipDistance)
 0:10              Constant:
 0:10                0 (const int)
@@ -165,7 +165,7 @@ Shader version: 500
 0:10                0 (const int)
 0:?         Sequence
 0:10          move second child to first child ( temp float)
-0:10            direct index ( temp float)
+0:10            direct index ( out float ClipDistance)
 0:?               '@entryPointOutput.clip1' ( out 2-element array of float ClipDistance)
 0:10              Constant:
 0:10                1 (const int)
@@ -175,7 +175,7 @@ Shader version: 500
 0:10                1 (const int)
 0:?         Sequence
 0:10          move second child to first child ( temp float)
-0:10            direct index ( temp float)
+0:10            direct index ( out float CullDistance)
 0:?               '@entryPointOutput.cull1' ( out 2-element array of float CullDistance)
 0:10              Constant:
 0:10                0 (const int)
@@ -185,7 +185,7 @@ Shader version: 500
 0:10                2 (const int)
 0:?         Sequence
 0:10          move second child to first child ( temp float)
-0:10            direct index ( temp float)
+0:10            direct index ( out float CullDistance)
 0:?               '@entryPointOutput.cull1' ( out 2-element array of float CullDistance)
 0:10              Constant:
 0:10                1 (const int)

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -2412,9 +2412,15 @@ TIntermAggregate* HlslParseContext::assignClipCullDistance(const TSourceLoc& loc
     // Loop through every component of every element of the internal, and copy to or from the matching external.
     for (int internalArrayPos = 0; internalArrayPos < internalNodeArraySize; ++internalArrayPos) {
         for (int internalComponent = 0; internalComponent < internalNodeVectorSize; ++internalComponent) {
+            TIntermTyped* clipCullMember = clipCullSym;
+
             // array member to read from / write to:
-            TIntermTyped* clipCullMember = intermediate.addIndex(EOpIndexDirect, clipCullSym,
-                                                            intermediate.addConstantUnion(clipCullArrayPos++, loc), loc);
+            {
+                const TType derefType(clipCullMember->getType(), 0);
+                clipCullMember = intermediate.addIndex(EOpIndexDirect, clipCullMember,
+                                                       intermediate.addConstantUnion(clipCullArrayPos++, loc), loc);
+                clipCullMember->setType(derefType);
+            }
 
             TIntermTyped* internalMember = internalNode;
 


### PR DESCRIPTION
While adding geometry stage support for clip/cull, it transpired that the existing clip/cull support was not setting the type of the result of indexing into the clup/cull variable.  That's a defect independent of the geometry 
support, so to get a lot of unrelated diffs out of the geometry PR, this problem is addressed separately.  It'll matter more when another indirection is added to the result of this indirection.  In advance of that, it's just qualifier changes.

This doesn't appear to change the generated SPIR-V, but that's probably down to something else being forgiving.
