### PR TITLE
Fix warning about conversion from size_t to int

### DIFF
--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -5107,7 +5107,7 @@ void HlslParseContext::expandArguments(const TSourceLoc& loc, const TFunction& f
                 aggregate->getSequence().insert(it, args.begin(), args.end());
             }
         }
-        functionParamNumberOffset += (args.size() - 1);
+        functionParamNumberOffset += (int)(args.size() - 1);
     };
 
     // Process each argument's conversion


### PR DESCRIPTION
Not necessarily to be merged as is unless someone can confirm it's safe. I ran into this on MSVC2015 with warnings-as-errors, but I can't tell if it's safe to silence the warning like this - because indirectly it's pointing to code doing something that might underflow.

I can't tell from the surrounding code if `args` could ever be empty - in which case doing `args.size() - 1` as unsigned size_t would underflow I think. `setArgList` only gets called further down below, and from an uninformed position I can't tell if it's theoretically possible to end up with an empty struct getting to there.