### PR TITLE
CMake file changes for SPIR-V legalization for HLSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ option(ENABLE_NV_EXTENSIONS "Enables support of Nvidia-specific extensions" ON)
 
 option(ENABLE_HLSL "Enables HLSL input support" ON)
 
+option(ENABLE_OPT "Enables spirv-opt capability if present" ON)
+
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND WIN32)
     set(CMAKE_INSTALL_PREFIX "install" CACHE STRING "..." FORCE)
 endif()
@@ -82,6 +84,17 @@ endfunction(glslang_set_link_args)
 
 # We depend on these for later projects, so they should come first.
 add_subdirectory(External)
+
+if(NOT TARGET SPIRV-Tools-opt)
+    set(ENABLE_OPT OFF)
+endif()
+
+if(ENABLE_OPT)
+    message(STATUS "optimizer enabled")
+    add_definitions(-DENABLE_OPT)
+elseif(ENABLE_HLSL)
+    message(STATUS "spirv-tools not linked - illegal SPIRV may be generated for HLSL")
+endif()
 
 add_subdirectory(glslang)
 add_subdirectory(OGLCompilersDLL)

--- a/External/CMakeLists.txt
+++ b/External/CMakeLists.txt
@@ -33,3 +33,10 @@ if(BUILD_TESTING)
             "Google Mock was not found - tests based on that will not build")
     endif()
 endif()
+
+if(ENABLE_OPT AND NOT TARGET SPIRV-Tools-opt)
+    if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/spirv-tools)
+        add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/spirv-tools spirv-tools)
+    endif()
+endif()
+

--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -42,11 +42,20 @@ endif(ENABLE_NV_EXTENSIONS)
 add_library(SPIRV STATIC ${SOURCES} ${HEADERS})
 set_property(TARGET SPIRV PROPERTY FOLDER glslang)
 set_property(TARGET SPIRV PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(SPIRV glslang)
 
 add_library(SPVRemapper STATIC ${SPVREMAP_SOURCES} ${SPVREMAP_HEADERS})
 set_property(TARGET SPVRemapper PROPERTY FOLDER glslang)
 set_property(TARGET SPVRemapper PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+if(ENABLE_OPT)
+    target_include_directories(SPIRV
+        PRIVATE ${spirv-tools_SOURCE_DIR}/include
+        PRIVATE ${spirv-tools_SOURCE_DIR}/source
+    )
+    target_link_libraries(SPIRV glslang SPIRV-Tools-opt SPVRemapper)
+else()
+    target_link_libraries(SPIRV glslang)
+endif(ENABLE_OPT)
 
 if(WIN32)
     source_group("Source" FILES ${SOURCES} ${HEADERS})


### PR DESCRIPTION
Also added known-good mechanism to fetch latest validated spirv-tools.
Also added -Od and -Os to disable optimizer and optimize for size.

Fetching spirv-tools is optional for both glsl and hlsl. Legalization
of hlsl is done by default if spirv-opt is present at cmake time.
Optimization for glsl is currently done through explicit option.

Also includes code from JohnK to disable current workarounds dealing
with writes of opaque types.