### PR TITLE
HLSL: force textures to shadow modes from combined samplers

### DIFF
--- a/Test/baseResults/hlsl.gathercmpRGBA.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.gathercmpRGBA.offset.dx10.frag.out
@@ -10,7 +10,7 @@ gl_FragCoord origin is upper left
 0:45          'txval001' ( temp 4-component vector of float)
 0:45          textureGatherOffset ( temp 4-component vector of float)
 0:45            Construct combined texture-sampler ( temp sampler2DShadow)
-0:45              'g_tTex2df4' ( uniform texture2D)
+0:45              'g_tTex2df4' ( uniform texture2DShadow)
 0:45              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:45            c2: direct index for structure ( uniform 2-component vector of float)
 0:45              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -26,7 +26,7 @@ gl_FragCoord origin is upper left
 0:46          'txval011' ( temp 4-component vector of int)
 0:46          textureGatherOffset ( temp 4-component vector of int)
 0:46            Construct combined texture-sampler ( temp isampler2DShadow)
-0:46              'g_tTex2di4' ( uniform itexture2D)
+0:46              'g_tTex2di4' ( uniform itexture2DShadow)
 0:46              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:46            c2: direct index for structure ( uniform 2-component vector of float)
 0:46              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -42,7 +42,7 @@ gl_FragCoord origin is upper left
 0:47          'txval021' ( temp 4-component vector of uint)
 0:47          textureGatherOffset ( temp 4-component vector of uint)
 0:47            Construct combined texture-sampler ( temp usampler2DShadow)
-0:47              'g_tTex2du4' ( uniform utexture2D)
+0:47              'g_tTex2du4' ( uniform utexture2DShadow)
 0:47              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:47            c2: direct index for structure ( uniform 2-component vector of float)
 0:47              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -58,7 +58,7 @@ gl_FragCoord origin is upper left
 0:49          'txval004' ( temp 4-component vector of float)
 0:49          textureGatherOffsets ( temp 4-component vector of float)
 0:49            Construct combined texture-sampler ( temp sampler2DShadow)
-0:49              'g_tTex2df4' ( uniform texture2D)
+0:49              'g_tTex2df4' ( uniform texture2DShadow)
 0:49              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:49            c2: direct index for structure ( uniform 2-component vector of float)
 0:49              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -80,7 +80,7 @@ gl_FragCoord origin is upper left
 0:50          'txval014' ( temp 4-component vector of int)
 0:50          textureGatherOffsets ( temp 4-component vector of int)
 0:50            Construct combined texture-sampler ( temp isampler2DShadow)
-0:50              'g_tTex2di4' ( uniform itexture2D)
+0:50              'g_tTex2di4' ( uniform itexture2DShadow)
 0:50              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:50            c2: direct index for structure ( uniform 2-component vector of float)
 0:50              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -102,7 +102,7 @@ gl_FragCoord origin is upper left
 0:51          'txval024' ( temp 4-component vector of uint)
 0:51          textureGatherOffsets ( temp 4-component vector of uint)
 0:51            Construct combined texture-sampler ( temp usampler2DShadow)
-0:51              'g_tTex2du4' ( uniform utexture2D)
+0:51              'g_tTex2du4' ( uniform utexture2DShadow)
 0:51              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:51            c2: direct index for structure ( uniform 2-component vector of float)
 0:51              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -124,7 +124,7 @@ gl_FragCoord origin is upper left
 0:53          'txval401' ( temp 4-component vector of float)
 0:53          textureGatherOffset ( temp 4-component vector of float)
 0:53            Construct combined texture-sampler ( temp sampler2DShadow)
-0:53              'g_tTex2df4' ( uniform texture2D)
+0:53              'g_tTex2df4' ( uniform texture2DShadow)
 0:53              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:53            c2: direct index for structure ( uniform 2-component vector of float)
 0:53              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -140,7 +140,7 @@ gl_FragCoord origin is upper left
 0:54          'txval411' ( temp 4-component vector of int)
 0:54          textureGatherOffset ( temp 4-component vector of int)
 0:54            Construct combined texture-sampler ( temp isampler2DShadow)
-0:54              'g_tTex2di4' ( uniform itexture2D)
+0:54              'g_tTex2di4' ( uniform itexture2DShadow)
 0:54              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:54            c2: direct index for structure ( uniform 2-component vector of float)
 0:54              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -156,7 +156,7 @@ gl_FragCoord origin is upper left
 0:55          'txval421' ( temp 4-component vector of uint)
 0:55          textureGatherOffset ( temp 4-component vector of uint)
 0:55            Construct combined texture-sampler ( temp usampler2DShadow)
-0:55              'g_tTex2du4' ( uniform utexture2D)
+0:55              'g_tTex2du4' ( uniform utexture2DShadow)
 0:55              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:55            c2: direct index for structure ( uniform 2-component vector of float)
 0:55              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -211,9 +211,9 @@ gl_FragCoord origin is upper left
 0:?     'g_tTex1df4' (layout( binding=0) uniform texture1D)
 0:?     'g_tTex1di4' ( uniform itexture1D)
 0:?     'g_tTex1du4' ( uniform utexture1D)
-0:?     'g_tTex2df4' ( uniform texture2D)
-0:?     'g_tTex2di4' ( uniform itexture2D)
-0:?     'g_tTex2du4' ( uniform utexture2D)
+0:?     'g_tTex2df4' ( uniform texture2DShadow)
+0:?     'g_tTex2di4' ( uniform itexture2DShadow)
+0:?     'g_tTex2du4' ( uniform utexture2DShadow)
 0:?     'g_tTex3df4' ( uniform texture3D)
 0:?     'g_tTex3di4' ( uniform itexture3D)
 0:?     'g_tTex3du4' ( uniform utexture3D)
@@ -239,7 +239,7 @@ gl_FragCoord origin is upper left
 0:45          'txval001' ( temp 4-component vector of float)
 0:45          textureGatherOffset ( temp 4-component vector of float)
 0:45            Construct combined texture-sampler ( temp sampler2DShadow)
-0:45              'g_tTex2df4' ( uniform texture2D)
+0:45              'g_tTex2df4' ( uniform texture2DShadow)
 0:45              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:45            c2: direct index for structure ( uniform 2-component vector of float)
 0:45              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -255,7 +255,7 @@ gl_FragCoord origin is upper left
 0:46          'txval011' ( temp 4-component vector of int)
 0:46          textureGatherOffset ( temp 4-component vector of int)
 0:46            Construct combined texture-sampler ( temp isampler2DShadow)
-0:46              'g_tTex2di4' ( uniform itexture2D)
+0:46              'g_tTex2di4' ( uniform itexture2DShadow)
 0:46              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:46            c2: direct index for structure ( uniform 2-component vector of float)
 0:46              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -271,7 +271,7 @@ gl_FragCoord origin is upper left
 0:47          'txval021' ( temp 4-component vector of uint)
 0:47          textureGatherOffset ( temp 4-component vector of uint)
 0:47            Construct combined texture-sampler ( temp usampler2DShadow)
-0:47              'g_tTex2du4' ( uniform utexture2D)
+0:47              'g_tTex2du4' ( uniform utexture2DShadow)
 0:47              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:47            c2: direct index for structure ( uniform 2-component vector of float)
 0:47              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -287,7 +287,7 @@ gl_FragCoord origin is upper left
 0:49          'txval004' ( temp 4-component vector of float)
 0:49          textureGatherOffsets ( temp 4-component vector of float)
 0:49            Construct combined texture-sampler ( temp sampler2DShadow)
-0:49              'g_tTex2df4' ( uniform texture2D)
+0:49              'g_tTex2df4' ( uniform texture2DShadow)
 0:49              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:49            c2: direct index for structure ( uniform 2-component vector of float)
 0:49              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -309,7 +309,7 @@ gl_FragCoord origin is upper left
 0:50          'txval014' ( temp 4-component vector of int)
 0:50          textureGatherOffsets ( temp 4-component vector of int)
 0:50            Construct combined texture-sampler ( temp isampler2DShadow)
-0:50              'g_tTex2di4' ( uniform itexture2D)
+0:50              'g_tTex2di4' ( uniform itexture2DShadow)
 0:50              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:50            c2: direct index for structure ( uniform 2-component vector of float)
 0:50              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -331,7 +331,7 @@ gl_FragCoord origin is upper left
 0:51          'txval024' ( temp 4-component vector of uint)
 0:51          textureGatherOffsets ( temp 4-component vector of uint)
 0:51            Construct combined texture-sampler ( temp usampler2DShadow)
-0:51              'g_tTex2du4' ( uniform utexture2D)
+0:51              'g_tTex2du4' ( uniform utexture2DShadow)
 0:51              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:51            c2: direct index for structure ( uniform 2-component vector of float)
 0:51              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -353,7 +353,7 @@ gl_FragCoord origin is upper left
 0:53          'txval401' ( temp 4-component vector of float)
 0:53          textureGatherOffset ( temp 4-component vector of float)
 0:53            Construct combined texture-sampler ( temp sampler2DShadow)
-0:53              'g_tTex2df4' ( uniform texture2D)
+0:53              'g_tTex2df4' ( uniform texture2DShadow)
 0:53              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:53            c2: direct index for structure ( uniform 2-component vector of float)
 0:53              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -369,7 +369,7 @@ gl_FragCoord origin is upper left
 0:54          'txval411' ( temp 4-component vector of int)
 0:54          textureGatherOffset ( temp 4-component vector of int)
 0:54            Construct combined texture-sampler ( temp isampler2DShadow)
-0:54              'g_tTex2di4' ( uniform itexture2D)
+0:54              'g_tTex2di4' ( uniform itexture2DShadow)
 0:54              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:54            c2: direct index for structure ( uniform 2-component vector of float)
 0:54              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -385,7 +385,7 @@ gl_FragCoord origin is upper left
 0:55          'txval421' ( temp 4-component vector of uint)
 0:55          textureGatherOffset ( temp 4-component vector of uint)
 0:55            Construct combined texture-sampler ( temp usampler2DShadow)
-0:55              'g_tTex2du4' ( uniform utexture2D)
+0:55              'g_tTex2du4' ( uniform utexture2DShadow)
 0:55              'g_sSampCmp' (layout( binding=0) uniform sampler)
 0:55            c2: direct index for structure ( uniform 2-component vector of float)
 0:55              'anon@0' (layout( row_major std140) uniform block{ uniform float c1,  uniform 2-component vector of float c2,  uniform 3-component vector of float c3,  uniform 4-component vector of float c4})
@@ -440,9 +440,9 @@ gl_FragCoord origin is upper left
 0:?     'g_tTex1df4' (layout( binding=0) uniform texture1D)
 0:?     'g_tTex1di4' ( uniform itexture1D)
 0:?     'g_tTex1du4' ( uniform utexture1D)
-0:?     'g_tTex2df4' ( uniform texture2D)
-0:?     'g_tTex2di4' ( uniform itexture2D)
-0:?     'g_tTex2du4' ( uniform utexture2D)
+0:?     'g_tTex2df4' ( uniform texture2DShadow)
+0:?     'g_tTex2di4' ( uniform itexture2DShadow)
+0:?     'g_tTex2du4' ( uniform utexture2DShadow)
 0:?     'g_tTex3df4' ( uniform texture3D)
 0:?     'g_tTex3di4' ( uniform itexture3D)
 0:?     'g_tTex3du4' ( uniform utexture3D)
@@ -455,13 +455,13 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 167
+// Id's are bound by 164
 
                               Capability Shader
                               Capability Sampled1D
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 132 136
+                              EntryPoint Fragment 4  "main" 129 133
                               ExecutionMode 4 OriginUpperLeft
                               Source HLSL 500
                               Name 4  "main"
@@ -472,61 +472,61 @@ gl_FragCoord origin is upper left
                               Name 13  "txval001"
                               Name 16  "g_tTex2df4"
                               Name 20  "g_sSampCmp"
-                              Name 27  "$Global"
-                              MemberName 27($Global) 0  "c1"
-                              MemberName 27($Global) 1  "c2"
-                              MemberName 27($Global) 2  "c3"
-                              MemberName 27($Global) 3  "c4"
-                              Name 29  ""
-                              Name 42  "txval011"
-                              Name 45  "g_tTex2di4"
-                              Name 59  "txval021"
-                              Name 62  "g_tTex2du4"
-                              Name 72  "txval004"
-                              Name 82  "txval014"
-                              Name 90  "txval024"
-                              Name 98  "txval401"
-                              Name 105  "txval411"
-                              Name 112  "txval421"
-                              Name 120  "psout"
-                              Name 129  "flattenTemp"
-                              Name 132  "@entryPointOutput.Color"
-                              Name 136  "@entryPointOutput.Depth"
-                              Name 141  "g_tTex1df4a"
-                              Name 142  "g_tTex1df4"
-                              Name 145  "g_tTex1di4"
-                              Name 148  "g_tTex1du4"
-                              Name 151  "g_tTex3df4"
-                              Name 154  "g_tTex3di4"
-                              Name 157  "g_tTex3du4"
-                              Name 160  "g_tTexcdf4"
-                              Name 163  "g_tTexcdi4"
-                              Name 166  "g_tTexcdu4"
+                              Name 26  "$Global"
+                              MemberName 26($Global) 0  "c1"
+                              MemberName 26($Global) 1  "c2"
+                              MemberName 26($Global) 2  "c3"
+                              MemberName 26($Global) 3  "c4"
+                              Name 28  ""
+                              Name 41  "txval011"
+                              Name 44  "g_tTex2di4"
+                              Name 57  "txval021"
+                              Name 60  "g_tTex2du4"
+                              Name 69  "txval004"
+                              Name 79  "txval014"
+                              Name 87  "txval024"
+                              Name 95  "txval401"
+                              Name 102  "txval411"
+                              Name 109  "txval421"
+                              Name 117  "psout"
+                              Name 126  "flattenTemp"
+                              Name 129  "@entryPointOutput.Color"
+                              Name 133  "@entryPointOutput.Depth"
+                              Name 138  "g_tTex1df4a"
+                              Name 139  "g_tTex1df4"
+                              Name 142  "g_tTex1di4"
+                              Name 145  "g_tTex1du4"
+                              Name 148  "g_tTex3df4"
+                              Name 151  "g_tTex3di4"
+                              Name 154  "g_tTex3du4"
+                              Name 157  "g_tTexcdf4"
+                              Name 160  "g_tTexcdi4"
+                              Name 163  "g_tTexcdu4"
                               Decorate 16(g_tTex2df4) DescriptorSet 0
                               Decorate 20(g_sSampCmp) DescriptorSet 0
                               Decorate 20(g_sSampCmp) Binding 0
-                              MemberDecorate 27($Global) 0 Offset 0
-                              MemberDecorate 27($Global) 1 Offset 8
-                              MemberDecorate 27($Global) 2 Offset 16
-                              MemberDecorate 27($Global) 3 Offset 32
-                              Decorate 27($Global) Block
-                              Decorate 29 DescriptorSet 0
-                              Decorate 45(g_tTex2di4) DescriptorSet 0
-                              Decorate 62(g_tTex2du4) DescriptorSet 0
-                              Decorate 132(@entryPointOutput.Color) Location 0
-                              Decorate 136(@entryPointOutput.Depth) BuiltIn FragDepth
-                              Decorate 141(g_tTex1df4a) DescriptorSet 0
-                              Decorate 141(g_tTex1df4a) Binding 1
-                              Decorate 142(g_tTex1df4) DescriptorSet 0
-                              Decorate 142(g_tTex1df4) Binding 0
-                              Decorate 145(g_tTex1di4) DescriptorSet 0
-                              Decorate 148(g_tTex1du4) DescriptorSet 0
-                              Decorate 151(g_tTex3df4) DescriptorSet 0
-                              Decorate 154(g_tTex3di4) DescriptorSet 0
-                              Decorate 157(g_tTex3du4) DescriptorSet 0
-                              Decorate 160(g_tTexcdf4) DescriptorSet 0
-                              Decorate 163(g_tTexcdi4) DescriptorSet 0
-                              Decorate 166(g_tTexcdu4) DescriptorSet 0
+                              MemberDecorate 26($Global) 0 Offset 0
+                              MemberDecorate 26($Global) 1 Offset 8
+                              MemberDecorate 26($Global) 2 Offset 16
+                              MemberDecorate 26($Global) 3 Offset 32
+                              Decorate 26($Global) Block
+                              Decorate 28 DescriptorSet 0
+                              Decorate 44(g_tTex2di4) DescriptorSet 0
+                              Decorate 60(g_tTex2du4) DescriptorSet 0
+                              Decorate 129(@entryPointOutput.Color) Location 0
+                              Decorate 133(@entryPointOutput.Depth) BuiltIn FragDepth
+                              Decorate 138(g_tTex1df4a) DescriptorSet 0
+                              Decorate 138(g_tTex1df4a) Binding 1
+                              Decorate 139(g_tTex1df4) DescriptorSet 0
+                              Decorate 139(g_tTex1df4) Binding 0
+                              Decorate 142(g_tTex1di4) DescriptorSet 0
+                              Decorate 145(g_tTex1du4) DescriptorSet 0
+                              Decorate 148(g_tTex3df4) DescriptorSet 0
+                              Decorate 151(g_tTex3di4) DescriptorSet 0
+                              Decorate 154(g_tTex3du4) DescriptorSet 0
+                              Decorate 157(g_tTexcdf4) DescriptorSet 0
+                              Decorate 160(g_tTexcdi4) DescriptorSet 0
+                              Decorate 163(g_tTexcdu4) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -534,177 +534,174 @@ gl_FragCoord origin is upper left
     8(PS_OUTPUT):             TypeStruct 7(fvec4) 6(float)
                9:             TypeFunction 8(PS_OUTPUT)
               12:             TypePointer Function 7(fvec4)
-              14:             TypeImage 6(float) 2D sampled format:Unknown
+              14:             TypeImage 6(float) 2D depth sampled format:Unknown
               15:             TypePointer UniformConstant 14
   16(g_tTex2df4):     15(ptr) Variable UniformConstant
               18:             TypeSampler
               19:             TypePointer UniformConstant 18
   20(g_sSampCmp):     19(ptr) Variable UniformConstant
-              22:             TypeImage 6(float) 2D depth sampled format:Unknown
-              23:             TypeSampledImage 22
-              25:             TypeVector 6(float) 2
-              26:             TypeVector 6(float) 3
-     27($Global):             TypeStruct 6(float) 25(fvec2) 26(fvec3) 7(fvec4)
-              28:             TypePointer Uniform 27($Global)
-              29:     28(ptr) Variable Uniform
-              30:             TypeInt 32 1
-              31:     30(int) Constant 1
-              32:             TypePointer Uniform 25(fvec2)
-              35:    6(float) Constant 1061158912
-              36:             TypeVector 30(int) 2
-              37:     30(int) Constant 0
-              38:   36(ivec2) ConstantComposite 31 37
-              40:             TypeVector 30(int) 4
-              41:             TypePointer Function 40(ivec4)
-              43:             TypeImage 30(int) 2D sampled format:Unknown
-              44:             TypePointer UniformConstant 43
-  45(g_tTex2di4):     44(ptr) Variable UniformConstant
-              48:             TypeImage 30(int) 2D depth sampled format:Unknown
-              49:             TypeSampledImage 48
-              53:     30(int) Constant 4294967295
-              54:   36(ivec2) ConstantComposite 31 53
-              56:             TypeInt 32 0
-              57:             TypeVector 56(int) 4
-              58:             TypePointer Function 57(ivec4)
-              60:             TypeImage 56(int) 2D sampled format:Unknown
-              61:             TypePointer UniformConstant 60
-  62(g_tTex2du4):     61(ptr) Variable UniformConstant
-              65:             TypeImage 56(int) 2D depth sampled format:Unknown
-              66:             TypeSampledImage 65
-              70:   36(ivec2) ConstantComposite 31 31
-              78:     56(int) Constant 4
-              79:             TypeArray 36(ivec2) 78
-              80:          79 ConstantComposite 38 38 38 38
-              88:          79 ConstantComposite 54 54 54 54
-              96:          79 ConstantComposite 70 70 70 70
-             119:             TypePointer Function 8(PS_OUTPUT)
-             121:    6(float) Constant 1065353216
-             122:    7(fvec4) ConstantComposite 121 121 121 121
-             124:             TypePointer Function 6(float)
-             131:             TypePointer Output 7(fvec4)
-132(@entryPointOutput.Color):    131(ptr) Variable Output
-             135:             TypePointer Output 6(float)
-136(@entryPointOutput.Depth):    135(ptr) Variable Output
-             139:             TypeImage 6(float) 1D sampled format:Unknown
-             140:             TypePointer UniformConstant 139
-141(g_tTex1df4a):    140(ptr) Variable UniformConstant
- 142(g_tTex1df4):    140(ptr) Variable UniformConstant
-             143:             TypeImage 30(int) 1D sampled format:Unknown
+              22:             TypeSampledImage 14
+              24:             TypeVector 6(float) 2
+              25:             TypeVector 6(float) 3
+     26($Global):             TypeStruct 6(float) 24(fvec2) 25(fvec3) 7(fvec4)
+              27:             TypePointer Uniform 26($Global)
+              28:     27(ptr) Variable Uniform
+              29:             TypeInt 32 1
+              30:     29(int) Constant 1
+              31:             TypePointer Uniform 24(fvec2)
+              34:    6(float) Constant 1061158912
+              35:             TypeVector 29(int) 2
+              36:     29(int) Constant 0
+              37:   35(ivec2) ConstantComposite 30 36
+              39:             TypeVector 29(int) 4
+              40:             TypePointer Function 39(ivec4)
+              42:             TypeImage 29(int) 2D depth sampled format:Unknown
+              43:             TypePointer UniformConstant 42
+  44(g_tTex2di4):     43(ptr) Variable UniformConstant
+              47:             TypeSampledImage 42
+              51:     29(int) Constant 4294967295
+              52:   35(ivec2) ConstantComposite 30 51
+              54:             TypeInt 32 0
+              55:             TypeVector 54(int) 4
+              56:             TypePointer Function 55(ivec4)
+              58:             TypeImage 54(int) 2D depth sampled format:Unknown
+              59:             TypePointer UniformConstant 58
+  60(g_tTex2du4):     59(ptr) Variable UniformConstant
+              63:             TypeSampledImage 58
+              67:   35(ivec2) ConstantComposite 30 30
+              75:     54(int) Constant 4
+              76:             TypeArray 35(ivec2) 75
+              77:          76 ConstantComposite 37 37 37 37
+              85:          76 ConstantComposite 52 52 52 52
+              93:          76 ConstantComposite 67 67 67 67
+             116:             TypePointer Function 8(PS_OUTPUT)
+             118:    6(float) Constant 1065353216
+             119:    7(fvec4) ConstantComposite 118 118 118 118
+             121:             TypePointer Function 6(float)
+             128:             TypePointer Output 7(fvec4)
+129(@entryPointOutput.Color):    128(ptr) Variable Output
+             132:             TypePointer Output 6(float)
+133(@entryPointOutput.Depth):    132(ptr) Variable Output
+             136:             TypeImage 6(float) 1D sampled format:Unknown
+             137:             TypePointer UniformConstant 136
+138(g_tTex1df4a):    137(ptr) Variable UniformConstant
+ 139(g_tTex1df4):    137(ptr) Variable UniformConstant
+             140:             TypeImage 29(int) 1D sampled format:Unknown
+             141:             TypePointer UniformConstant 140
+ 142(g_tTex1di4):    141(ptr) Variable UniformConstant
+             143:             TypeImage 54(int) 1D sampled format:Unknown
              144:             TypePointer UniformConstant 143
- 145(g_tTex1di4):    144(ptr) Variable UniformConstant
-             146:             TypeImage 56(int) 1D sampled format:Unknown
+ 145(g_tTex1du4):    144(ptr) Variable UniformConstant
+             146:             TypeImage 6(float) 3D sampled format:Unknown
              147:             TypePointer UniformConstant 146
- 148(g_tTex1du4):    147(ptr) Variable UniformConstant
-             149:             TypeImage 6(float) 3D sampled format:Unknown
+ 148(g_tTex3df4):    147(ptr) Variable UniformConstant
+             149:             TypeImage 29(int) 3D sampled format:Unknown
              150:             TypePointer UniformConstant 149
- 151(g_tTex3df4):    150(ptr) Variable UniformConstant
-             152:             TypeImage 30(int) 3D sampled format:Unknown
+ 151(g_tTex3di4):    150(ptr) Variable UniformConstant
+             152:             TypeImage 54(int) 3D sampled format:Unknown
              153:             TypePointer UniformConstant 152
- 154(g_tTex3di4):    153(ptr) Variable UniformConstant
-             155:             TypeImage 56(int) 3D sampled format:Unknown
+ 154(g_tTex3du4):    153(ptr) Variable UniformConstant
+             155:             TypeImage 6(float) Cube sampled format:Unknown
              156:             TypePointer UniformConstant 155
- 157(g_tTex3du4):    156(ptr) Variable UniformConstant
-             158:             TypeImage 6(float) Cube sampled format:Unknown
+ 157(g_tTexcdf4):    156(ptr) Variable UniformConstant
+             158:             TypeImage 29(int) Cube sampled format:Unknown
              159:             TypePointer UniformConstant 158
- 160(g_tTexcdf4):    159(ptr) Variable UniformConstant
-             161:             TypeImage 30(int) Cube sampled format:Unknown
+ 160(g_tTexcdi4):    159(ptr) Variable UniformConstant
+             161:             TypeImage 54(int) Cube sampled format:Unknown
              162:             TypePointer UniformConstant 161
- 163(g_tTexcdi4):    162(ptr) Variable UniformConstant
-             164:             TypeImage 56(int) Cube sampled format:Unknown
-             165:             TypePointer UniformConstant 164
- 166(g_tTexcdu4):    165(ptr) Variable UniformConstant
+ 163(g_tTexcdu4):    162(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
-129(flattenTemp):    119(ptr) Variable Function
-             130:8(PS_OUTPUT) FunctionCall 10(@main()
-                              Store 129(flattenTemp) 130
-             133:     12(ptr) AccessChain 129(flattenTemp) 37
-             134:    7(fvec4) Load 133
-                              Store 132(@entryPointOutput.Color) 134
-             137:    124(ptr) AccessChain 129(flattenTemp) 31
-             138:    6(float) Load 137
-                              Store 136(@entryPointOutput.Depth) 138
+126(flattenTemp):    116(ptr) Variable Function
+             127:8(PS_OUTPUT) FunctionCall 10(@main()
+                              Store 126(flattenTemp) 127
+             130:     12(ptr) AccessChain 126(flattenTemp) 36
+             131:    7(fvec4) Load 130
+                              Store 129(@entryPointOutput.Color) 131
+             134:    121(ptr) AccessChain 126(flattenTemp) 30
+             135:    6(float) Load 134
+                              Store 133(@entryPointOutput.Depth) 135
                               Return
                               FunctionEnd
       10(@main():8(PS_OUTPUT) Function None 9
               11:             Label
     13(txval001):     12(ptr) Variable Function
-    42(txval011):     41(ptr) Variable Function
-    59(txval021):     58(ptr) Variable Function
-    72(txval004):     12(ptr) Variable Function
-    82(txval014):     41(ptr) Variable Function
-    90(txval024):     58(ptr) Variable Function
-    98(txval401):     12(ptr) Variable Function
-   105(txval411):     41(ptr) Variable Function
-   112(txval421):     58(ptr) Variable Function
-      120(psout):    119(ptr) Variable Function
+    41(txval011):     40(ptr) Variable Function
+    57(txval021):     56(ptr) Variable Function
+    69(txval004):     12(ptr) Variable Function
+    79(txval014):     40(ptr) Variable Function
+    87(txval024):     56(ptr) Variable Function
+    95(txval401):     12(ptr) Variable Function
+   102(txval411):     40(ptr) Variable Function
+   109(txval421):     56(ptr) Variable Function
+      117(psout):    116(ptr) Variable Function
               17:          14 Load 16(g_tTex2df4)
               21:          18 Load 20(g_sSampCmp)
-              24:          23 SampledImage 17 21
-              33:     32(ptr) AccessChain 29 31
-              34:   25(fvec2) Load 33
-              39:    7(fvec4) ImageDrefGather 24 34 35 ConstOffset 38
-                              Store 13(txval001) 39
-              46:          43 Load 45(g_tTex2di4)
-              47:          18 Load 20(g_sSampCmp)
-              50:          49 SampledImage 46 47
-              51:     32(ptr) AccessChain 29 31
-              52:   25(fvec2) Load 51
-              55:   40(ivec4) ImageDrefGather 50 52 35 ConstOffset 54
-                              Store 42(txval011) 55
-              63:          60 Load 62(g_tTex2du4)
-              64:          18 Load 20(g_sSampCmp)
-              67:          66 SampledImage 63 64
-              68:     32(ptr) AccessChain 29 31
-              69:   25(fvec2) Load 68
-              71:   57(ivec4) ImageDrefGather 67 69 35 ConstOffset 70
-                              Store 59(txval021) 71
-              73:          14 Load 16(g_tTex2df4)
-              74:          18 Load 20(g_sSampCmp)
-              75:          23 SampledImage 73 74
-              76:     32(ptr) AccessChain 29 31
-              77:   25(fvec2) Load 76
-              81:    7(fvec4) ImageDrefGather 75 77 35 ConstOffsets 80
-                              Store 72(txval004) 81
-              83:          43 Load 45(g_tTex2di4)
-              84:          18 Load 20(g_sSampCmp)
-              85:          49 SampledImage 83 84
-              86:     32(ptr) AccessChain 29 31
-              87:   25(fvec2) Load 86
-              89:   40(ivec4) ImageDrefGather 85 87 35 ConstOffsets 88
-                              Store 82(txval014) 89
-              91:          60 Load 62(g_tTex2du4)
-              92:          18 Load 20(g_sSampCmp)
-              93:          66 SampledImage 91 92
-              94:     32(ptr) AccessChain 29 31
-              95:   25(fvec2) Load 94
-              97:   57(ivec4) ImageDrefGather 93 95 35 ConstOffsets 96
-                              Store 90(txval024) 97
-              99:          14 Load 16(g_tTex2df4)
-             100:          18 Load 20(g_sSampCmp)
-             101:          23 SampledImage 99 100
-             102:     32(ptr) AccessChain 29 31
-             103:   25(fvec2) Load 102
-             104:    7(fvec4) ImageDrefGather 101 103 35 ConstOffset 38
-                              Store 98(txval401) 104
-             106:          43 Load 45(g_tTex2di4)
-             107:          18 Load 20(g_sSampCmp)
-             108:          49 SampledImage 106 107
-             109:     32(ptr) AccessChain 29 31
-             110:   25(fvec2) Load 109
-             111:   40(ivec4) ImageDrefGather 108 110 35 ConstOffset 54
-                              Store 105(txval411) 111
-             113:          60 Load 62(g_tTex2du4)
-             114:          18 Load 20(g_sSampCmp)
-             115:          66 SampledImage 113 114
-             116:     32(ptr) AccessChain 29 31
-             117:   25(fvec2) Load 116
-             118:   57(ivec4) ImageDrefGather 115 117 35 ConstOffset 70
-                              Store 112(txval421) 118
-             123:     12(ptr) AccessChain 120(psout) 37
-                              Store 123 122
-             125:    124(ptr) AccessChain 120(psout) 31
-                              Store 125 121
-             126:8(PS_OUTPUT) Load 120(psout)
-                              ReturnValue 126
+              23:          22 SampledImage 17 21
+              32:     31(ptr) AccessChain 28 30
+              33:   24(fvec2) Load 32
+              38:    7(fvec4) ImageDrefGather 23 33 34 ConstOffset 37
+                              Store 13(txval001) 38
+              45:          42 Load 44(g_tTex2di4)
+              46:          18 Load 20(g_sSampCmp)
+              48:          47 SampledImage 45 46
+              49:     31(ptr) AccessChain 28 30
+              50:   24(fvec2) Load 49
+              53:   39(ivec4) ImageDrefGather 48 50 34 ConstOffset 52
+                              Store 41(txval011) 53
+              61:          58 Load 60(g_tTex2du4)
+              62:          18 Load 20(g_sSampCmp)
+              64:          63 SampledImage 61 62
+              65:     31(ptr) AccessChain 28 30
+              66:   24(fvec2) Load 65
+              68:   55(ivec4) ImageDrefGather 64 66 34 ConstOffset 67
+                              Store 57(txval021) 68
+              70:          14 Load 16(g_tTex2df4)
+              71:          18 Load 20(g_sSampCmp)
+              72:          22 SampledImage 70 71
+              73:     31(ptr) AccessChain 28 30
+              74:   24(fvec2) Load 73
+              78:    7(fvec4) ImageDrefGather 72 74 34 ConstOffsets 77
+                              Store 69(txval004) 78
+              80:          42 Load 44(g_tTex2di4)
+              81:          18 Load 20(g_sSampCmp)
+              82:          47 SampledImage 80 81
+              83:     31(ptr) AccessChain 28 30
+              84:   24(fvec2) Load 83
+              86:   39(ivec4) ImageDrefGather 82 84 34 ConstOffsets 85
+                              Store 79(txval014) 86
+              88:          58 Load 60(g_tTex2du4)
+              89:          18 Load 20(g_sSampCmp)
+              90:          63 SampledImage 88 89
+              91:     31(ptr) AccessChain 28 30
+              92:   24(fvec2) Load 91
+              94:   55(ivec4) ImageDrefGather 90 92 34 ConstOffsets 93
+                              Store 87(txval024) 94
+              96:          14 Load 16(g_tTex2df4)
+              97:          18 Load 20(g_sSampCmp)
+              98:          22 SampledImage 96 97
+              99:     31(ptr) AccessChain 28 30
+             100:   24(fvec2) Load 99
+             101:    7(fvec4) ImageDrefGather 98 100 34 ConstOffset 37
+                              Store 95(txval401) 101
+             103:          42 Load 44(g_tTex2di4)
+             104:          18 Load 20(g_sSampCmp)
+             105:          47 SampledImage 103 104
+             106:     31(ptr) AccessChain 28 30
+             107:   24(fvec2) Load 106
+             108:   39(ivec4) ImageDrefGather 105 107 34 ConstOffset 52
+                              Store 102(txval411) 108
+             110:          58 Load 60(g_tTex2du4)
+             111:          18 Load 20(g_sSampCmp)
+             112:          63 SampledImage 110 111
+             113:     31(ptr) AccessChain 28 30
+             114:   24(fvec2) Load 113
+             115:   55(ivec4) ImageDrefGather 112 114 34 ConstOffset 67
+                              Store 109(txval421) 115
+             120:     12(ptr) AccessChain 117(psout) 36
+                              Store 120 119
+             122:    121(ptr) AccessChain 117(psout) 30
+                              Store 122 118
+             123:8(PS_OUTPUT) Load 117(psout)
+                              ReturnValue 123
                               FunctionEnd

--- a/Test/baseResults/hlsl.samplecmp.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmp.array.dx10.frag.out
@@ -10,7 +10,7 @@ gl_FragCoord origin is upper left
 0:42          'r10' ( temp float)
 0:42          texture ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DArrayShadow)
-0:42              'g_tTex1df4a' ( uniform texture1DArray)
+0:42              'g_tTex1df4a' ( uniform texture1DArrayShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -23,7 +23,7 @@ gl_FragCoord origin is upper left
 0:43          'r12' ( temp float)
 0:43          texture ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DArrayShadow)
-0:43              'g_tTex1di4a' ( uniform itexture1DArray)
+0:43              'g_tTex1di4a' ( uniform itexture1DArrayShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -36,7 +36,7 @@ gl_FragCoord origin is upper left
 0:44          'r14' ( temp float)
 0:44          texture ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DArrayShadow)
-0:44              'g_tTex1du4a' ( uniform utexture1DArray)
+0:44              'g_tTex1du4a' ( uniform utexture1DArrayShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -49,7 +49,7 @@ gl_FragCoord origin is upper left
 0:47          'r30' ( temp float)
 0:47          texture ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DArrayShadow)
-0:47              'g_tTex2df4a' ( uniform texture2DArray)
+0:47              'g_tTex2df4a' ( uniform texture2DArrayShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -63,7 +63,7 @@ gl_FragCoord origin is upper left
 0:48          'r32' ( temp float)
 0:48          texture ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DArrayShadow)
-0:48              'g_tTex2di4a' ( uniform itexture2DArray)
+0:48              'g_tTex2di4a' ( uniform itexture2DArrayShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -77,7 +77,7 @@ gl_FragCoord origin is upper left
 0:49          'r34' ( temp float)
 0:49          texture ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DArrayShadow)
-0:49              'g_tTex2du4a' ( uniform utexture2DArray)
+0:49              'g_tTex2du4a' ( uniform utexture2DArrayShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -91,7 +91,7 @@ gl_FragCoord origin is upper left
 0:52          'r60' ( temp float)
 0:52          texture ( temp float)
 0:52            Construct combined texture-sampler ( temp samplerCubeArrayShadow)
-0:52              'g_tTexcdf4a' ( uniform textureCubeArray)
+0:52              'g_tTexcdf4a' ( uniform textureCubeArrayShadow)
 0:52              'g_sSamp' (layout( binding=0) uniform sampler)
 0:52            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -106,7 +106,7 @@ gl_FragCoord origin is upper left
 0:53          'r62' ( temp float)
 0:53          texture ( temp float)
 0:53            Construct combined texture-sampler ( temp isamplerCubeArrayShadow)
-0:53              'g_tTexcdi4a' ( uniform itextureCubeArray)
+0:53              'g_tTexcdi4a' ( uniform itextureCubeArrayShadow)
 0:53              'g_sSamp' (layout( binding=0) uniform sampler)
 0:53            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -121,7 +121,7 @@ gl_FragCoord origin is upper left
 0:54          'r64' ( temp float)
 0:54          texture ( temp float)
 0:54            Construct combined texture-sampler ( temp usamplerCubeArrayShadow)
-0:54              'g_tTexcdu4a' ( uniform utextureCubeArray)
+0:54              'g_tTexcdu4a' ( uniform utextureCubeArrayShadow)
 0:54              'g_sSamp' (layout( binding=0) uniform sampler)
 0:54            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -183,15 +183,15 @@ gl_FragCoord origin is upper left
 0:?     'g_tTexcdf4' ( uniform textureCube)
 0:?     'g_tTexcdi4' ( uniform itextureCube)
 0:?     'g_tTexcdu4' ( uniform utextureCube)
-0:?     'g_tTex1df4a' ( uniform texture1DArray)
-0:?     'g_tTex1di4a' ( uniform itexture1DArray)
-0:?     'g_tTex1du4a' ( uniform utexture1DArray)
-0:?     'g_tTex2df4a' ( uniform texture2DArray)
-0:?     'g_tTex2di4a' ( uniform itexture2DArray)
-0:?     'g_tTex2du4a' ( uniform utexture2DArray)
-0:?     'g_tTexcdf4a' ( uniform textureCubeArray)
-0:?     'g_tTexcdi4a' ( uniform itextureCubeArray)
-0:?     'g_tTexcdu4a' ( uniform utextureCubeArray)
+0:?     'g_tTex1df4a' ( uniform texture1DArrayShadow)
+0:?     'g_tTex1di4a' ( uniform itexture1DArrayShadow)
+0:?     'g_tTex1du4a' ( uniform utexture1DArrayShadow)
+0:?     'g_tTex2df4a' ( uniform texture2DArrayShadow)
+0:?     'g_tTex2di4a' ( uniform itexture2DArrayShadow)
+0:?     'g_tTex2du4a' ( uniform utexture2DArrayShadow)
+0:?     'g_tTexcdf4a' ( uniform textureCubeArrayShadow)
+0:?     'g_tTexcdi4a' ( uniform itextureCubeArrayShadow)
+0:?     'g_tTexcdu4a' ( uniform utextureCubeArrayShadow)
 0:?     '@entryPointOutput.Depth' ( out float FragDepth)
 0:?     '@entryPointOutput.Color' (layout( location=0) out 4-component vector of float)
 
@@ -210,7 +210,7 @@ gl_FragCoord origin is upper left
 0:42          'r10' ( temp float)
 0:42          texture ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DArrayShadow)
-0:42              'g_tTex1df4a' ( uniform texture1DArray)
+0:42              'g_tTex1df4a' ( uniform texture1DArrayShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -223,7 +223,7 @@ gl_FragCoord origin is upper left
 0:43          'r12' ( temp float)
 0:43          texture ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DArrayShadow)
-0:43              'g_tTex1di4a' ( uniform itexture1DArray)
+0:43              'g_tTex1di4a' ( uniform itexture1DArrayShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -236,7 +236,7 @@ gl_FragCoord origin is upper left
 0:44          'r14' ( temp float)
 0:44          texture ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DArrayShadow)
-0:44              'g_tTex1du4a' ( uniform utexture1DArray)
+0:44              'g_tTex1du4a' ( uniform utexture1DArrayShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -249,7 +249,7 @@ gl_FragCoord origin is upper left
 0:47          'r30' ( temp float)
 0:47          texture ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DArrayShadow)
-0:47              'g_tTex2df4a' ( uniform texture2DArray)
+0:47              'g_tTex2df4a' ( uniform texture2DArrayShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -263,7 +263,7 @@ gl_FragCoord origin is upper left
 0:48          'r32' ( temp float)
 0:48          texture ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DArrayShadow)
-0:48              'g_tTex2di4a' ( uniform itexture2DArray)
+0:48              'g_tTex2di4a' ( uniform itexture2DArrayShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -277,7 +277,7 @@ gl_FragCoord origin is upper left
 0:49          'r34' ( temp float)
 0:49          texture ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DArrayShadow)
-0:49              'g_tTex2du4a' ( uniform utexture2DArray)
+0:49              'g_tTex2du4a' ( uniform utexture2DArrayShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -291,7 +291,7 @@ gl_FragCoord origin is upper left
 0:52          'r60' ( temp float)
 0:52          texture ( temp float)
 0:52            Construct combined texture-sampler ( temp samplerCubeArrayShadow)
-0:52              'g_tTexcdf4a' ( uniform textureCubeArray)
+0:52              'g_tTexcdf4a' ( uniform textureCubeArrayShadow)
 0:52              'g_sSamp' (layout( binding=0) uniform sampler)
 0:52            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -306,7 +306,7 @@ gl_FragCoord origin is upper left
 0:53          'r62' ( temp float)
 0:53          texture ( temp float)
 0:53            Construct combined texture-sampler ( temp isamplerCubeArrayShadow)
-0:53              'g_tTexcdi4a' ( uniform itextureCubeArray)
+0:53              'g_tTexcdi4a' ( uniform itextureCubeArrayShadow)
 0:53              'g_sSamp' (layout( binding=0) uniform sampler)
 0:53            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -321,7 +321,7 @@ gl_FragCoord origin is upper left
 0:54          'r64' ( temp float)
 0:54          texture ( temp float)
 0:54            Construct combined texture-sampler ( temp usamplerCubeArrayShadow)
-0:54              'g_tTexcdu4a' ( uniform utextureCubeArray)
+0:54              'g_tTexcdu4a' ( uniform utextureCubeArrayShadow)
 0:54              'g_sSamp' (layout( binding=0) uniform sampler)
 0:54            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -383,28 +383,28 @@ gl_FragCoord origin is upper left
 0:?     'g_tTexcdf4' ( uniform textureCube)
 0:?     'g_tTexcdi4' ( uniform itextureCube)
 0:?     'g_tTexcdu4' ( uniform utextureCube)
-0:?     'g_tTex1df4a' ( uniform texture1DArray)
-0:?     'g_tTex1di4a' ( uniform itexture1DArray)
-0:?     'g_tTex1du4a' ( uniform utexture1DArray)
-0:?     'g_tTex2df4a' ( uniform texture2DArray)
-0:?     'g_tTex2di4a' ( uniform itexture2DArray)
-0:?     'g_tTex2du4a' ( uniform utexture2DArray)
-0:?     'g_tTexcdf4a' ( uniform textureCubeArray)
-0:?     'g_tTexcdi4a' ( uniform itextureCubeArray)
-0:?     'g_tTexcdu4a' ( uniform utextureCubeArray)
+0:?     'g_tTex1df4a' ( uniform texture1DArrayShadow)
+0:?     'g_tTex1di4a' ( uniform itexture1DArrayShadow)
+0:?     'g_tTex1du4a' ( uniform utexture1DArrayShadow)
+0:?     'g_tTex2df4a' ( uniform texture2DArrayShadow)
+0:?     'g_tTex2di4a' ( uniform itexture2DArrayShadow)
+0:?     'g_tTex2du4a' ( uniform utexture2DArrayShadow)
+0:?     'g_tTexcdf4a' ( uniform textureCubeArrayShadow)
+0:?     'g_tTexcdi4a' ( uniform itextureCubeArrayShadow)
+0:?     'g_tTexcdu4a' ( uniform utextureCubeArrayShadow)
 0:?     '@entryPointOutput.Depth' ( out float FragDepth)
 0:?     '@entryPointOutput.Color' (layout( location=0) out 4-component vector of float)
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 218
+// Id's are bound by 209
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 175 179
+                              EntryPoint Fragment 4  "main" 166 170
                               ExecutionMode 4 OriginUpperLeft
                               Source HLSL 500
                               Name 4  "main"
@@ -415,64 +415,64 @@ gl_FragCoord origin is upper left
                               Name 13  "r10"
                               Name 16  "g_tTex1df4a"
                               Name 20  "g_sSamp"
-                              Name 36  "r12"
-                              Name 40  "g_tTex1di4a"
-                              Name 51  "r14"
-                              Name 55  "g_tTex1du4a"
-                              Name 66  "r30"
-                              Name 69  "g_tTex2df4a"
-                              Name 83  "r32"
-                              Name 86  "g_tTex2di4a"
-                              Name 98  "r34"
-                              Name 101  "g_tTex2du4a"
-                              Name 113  "r60"
-                              Name 116  "g_tTexcdf4a"
-                              Name 130  "r62"
-                              Name 133  "g_tTexcdi4a"
-                              Name 145  "r64"
-                              Name 148  "g_tTexcdu4a"
-                              Name 161  "psout"
-                              Name 172  "flattenTemp"
-                              Name 175  "@entryPointOutput.Color"
-                              Name 179  "@entryPointOutput.Depth"
-                              Name 184  "g_tTex1df4"
-                              Name 187  "g_tTex1di4"
-                              Name 190  "g_tTex1du4"
-                              Name 193  "g_tTex2df4"
-                              Name 196  "g_tTex2di4"
-                              Name 199  "g_tTex2du4"
-                              Name 202  "g_tTex3df4"
-                              Name 205  "g_tTex3di4"
-                              Name 208  "g_tTex3du4"
-                              Name 211  "g_tTexcdf4"
-                              Name 214  "g_tTexcdi4"
-                              Name 217  "g_tTexcdu4"
+                              Name 35  "r12"
+                              Name 39  "g_tTex1di4a"
+                              Name 49  "r14"
+                              Name 53  "g_tTex1du4a"
+                              Name 63  "r30"
+                              Name 66  "g_tTex2df4a"
+                              Name 79  "r32"
+                              Name 82  "g_tTex2di4a"
+                              Name 93  "r34"
+                              Name 96  "g_tTex2du4a"
+                              Name 107  "r60"
+                              Name 110  "g_tTexcdf4a"
+                              Name 123  "r62"
+                              Name 126  "g_tTexcdi4a"
+                              Name 137  "r64"
+                              Name 140  "g_tTexcdu4a"
+                              Name 152  "psout"
+                              Name 163  "flattenTemp"
+                              Name 166  "@entryPointOutput.Color"
+                              Name 170  "@entryPointOutput.Depth"
+                              Name 175  "g_tTex1df4"
+                              Name 178  "g_tTex1di4"
+                              Name 181  "g_tTex1du4"
+                              Name 184  "g_tTex2df4"
+                              Name 187  "g_tTex2di4"
+                              Name 190  "g_tTex2du4"
+                              Name 193  "g_tTex3df4"
+                              Name 196  "g_tTex3di4"
+                              Name 199  "g_tTex3du4"
+                              Name 202  "g_tTexcdf4"
+                              Name 205  "g_tTexcdi4"
+                              Name 208  "g_tTexcdu4"
                               Decorate 16(g_tTex1df4a) DescriptorSet 0
                               Decorate 20(g_sSamp) DescriptorSet 0
                               Decorate 20(g_sSamp) Binding 0
-                              Decorate 40(g_tTex1di4a) DescriptorSet 0
-                              Decorate 55(g_tTex1du4a) DescriptorSet 0
-                              Decorate 69(g_tTex2df4a) DescriptorSet 0
-                              Decorate 86(g_tTex2di4a) DescriptorSet 0
-                              Decorate 101(g_tTex2du4a) DescriptorSet 0
-                              Decorate 116(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 133(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 148(g_tTexcdu4a) DescriptorSet 0
-                              Decorate 175(@entryPointOutput.Color) Location 0
-                              Decorate 179(@entryPointOutput.Depth) BuiltIn FragDepth
-                              Decorate 184(g_tTex1df4) DescriptorSet 0
-                              Decorate 184(g_tTex1df4) Binding 0
-                              Decorate 187(g_tTex1di4) DescriptorSet 0
-                              Decorate 190(g_tTex1du4) DescriptorSet 0
-                              Decorate 193(g_tTex2df4) DescriptorSet 0
-                              Decorate 196(g_tTex2di4) DescriptorSet 0
-                              Decorate 199(g_tTex2du4) DescriptorSet 0
-                              Decorate 202(g_tTex3df4) DescriptorSet 0
-                              Decorate 205(g_tTex3di4) DescriptorSet 0
-                              Decorate 208(g_tTex3du4) DescriptorSet 0
-                              Decorate 211(g_tTexcdf4) DescriptorSet 0
-                              Decorate 214(g_tTexcdi4) DescriptorSet 0
-                              Decorate 217(g_tTexcdu4) DescriptorSet 0
+                              Decorate 39(g_tTex1di4a) DescriptorSet 0
+                              Decorate 53(g_tTex1du4a) DescriptorSet 0
+                              Decorate 66(g_tTex2df4a) DescriptorSet 0
+                              Decorate 82(g_tTex2di4a) DescriptorSet 0
+                              Decorate 96(g_tTex2du4a) DescriptorSet 0
+                              Decorate 110(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 126(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 140(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 166(@entryPointOutput.Color) Location 0
+                              Decorate 170(@entryPointOutput.Depth) BuiltIn FragDepth
+                              Decorate 175(g_tTex1df4) DescriptorSet 0
+                              Decorate 175(g_tTex1df4) Binding 0
+                              Decorate 178(g_tTex1di4) DescriptorSet 0
+                              Decorate 181(g_tTex1du4) DescriptorSet 0
+                              Decorate 184(g_tTex2df4) DescriptorSet 0
+                              Decorate 187(g_tTex2di4) DescriptorSet 0
+                              Decorate 190(g_tTex2du4) DescriptorSet 0
+                              Decorate 193(g_tTex3df4) DescriptorSet 0
+                              Decorate 196(g_tTex3di4) DescriptorSet 0
+                              Decorate 199(g_tTex3du4) DescriptorSet 0
+                              Decorate 202(g_tTexcdf4) DescriptorSet 0
+                              Decorate 205(g_tTexcdi4) DescriptorSet 0
+                              Decorate 208(g_tTexcdu4) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -480,228 +480,219 @@ gl_FragCoord origin is upper left
     8(PS_OUTPUT):             TypeStruct 7(fvec4) 6(float)
                9:             TypeFunction 8(PS_OUTPUT)
               12:             TypePointer Function 6(float)
-              14:             TypeImage 6(float) 1D array sampled format:Unknown
+              14:             TypeImage 6(float) 1D depth array sampled format:Unknown
               15:             TypePointer UniformConstant 14
  16(g_tTex1df4a):     15(ptr) Variable UniformConstant
               18:             TypeSampler
               19:             TypePointer UniformConstant 18
      20(g_sSamp):     19(ptr) Variable UniformConstant
-              22:             TypeImage 6(float) 1D depth array sampled format:Unknown
-              23:             TypeSampledImage 22
-              25:             TypeVector 6(float) 2
-              26:    6(float) Constant 1036831949
-              27:    6(float) Constant 1045220557
-              28:   25(fvec2) ConstantComposite 26 27
-              29:    6(float) Constant 1061158912
-              30:             TypeVector 6(float) 3
-              37:             TypeInt 32 1
-              38:             TypeImage 37(int) 1D array sampled format:Unknown
-              39:             TypePointer UniformConstant 38
- 40(g_tTex1di4a):     39(ptr) Variable UniformConstant
-              43:             TypeImage 37(int) 1D depth array sampled format:Unknown
-              44:             TypeSampledImage 43
-              52:             TypeInt 32 0
-              53:             TypeImage 52(int) 1D array sampled format:Unknown
-              54:             TypePointer UniformConstant 53
- 55(g_tTex1du4a):     54(ptr) Variable UniformConstant
-              58:             TypeImage 52(int) 1D depth array sampled format:Unknown
-              59:             TypeSampledImage 58
-              67:             TypeImage 6(float) 2D array sampled format:Unknown
-              68:             TypePointer UniformConstant 67
- 69(g_tTex2df4a):     68(ptr) Variable UniformConstant
-              72:             TypeImage 6(float) 2D depth array sampled format:Unknown
-              73:             TypeSampledImage 72
-              75:    6(float) Constant 1050253722
-              76:   30(fvec3) ConstantComposite 26 27 75
-              84:             TypeImage 37(int) 2D array sampled format:Unknown
-              85:             TypePointer UniformConstant 84
- 86(g_tTex2di4a):     85(ptr) Variable UniformConstant
-              89:             TypeImage 37(int) 2D depth array sampled format:Unknown
-              90:             TypeSampledImage 89
-              99:             TypeImage 52(int) 2D array sampled format:Unknown
-             100:             TypePointer UniformConstant 99
-101(g_tTex2du4a):    100(ptr) Variable UniformConstant
-             104:             TypeImage 52(int) 2D depth array sampled format:Unknown
-             105:             TypeSampledImage 104
-             114:             TypeImage 6(float) Cube array sampled format:Unknown
-             115:             TypePointer UniformConstant 114
-116(g_tTexcdf4a):    115(ptr) Variable UniformConstant
-             119:             TypeImage 6(float) Cube depth array sampled format:Unknown
-             120:             TypeSampledImage 119
-             122:    6(float) Constant 1053609165
-             123:    7(fvec4) ConstantComposite 26 27 75 122
-             131:             TypeImage 37(int) Cube array sampled format:Unknown
-             132:             TypePointer UniformConstant 131
-133(g_tTexcdi4a):    132(ptr) Variable UniformConstant
-             136:             TypeImage 37(int) Cube depth array sampled format:Unknown
-             137:             TypeSampledImage 136
-             146:             TypeImage 52(int) Cube array sampled format:Unknown
-             147:             TypePointer UniformConstant 146
-148(g_tTexcdu4a):    147(ptr) Variable UniformConstant
-             151:             TypeImage 52(int) Cube depth array sampled format:Unknown
-             152:             TypeSampledImage 151
-             160:             TypePointer Function 8(PS_OUTPUT)
-             162:     37(int) Constant 0
-             163:    6(float) Constant 1065353216
-             164:    7(fvec4) ConstantComposite 163 163 163 163
-             165:             TypePointer Function 7(fvec4)
-             167:     37(int) Constant 1
-             174:             TypePointer Output 7(fvec4)
-175(@entryPointOutput.Color):    174(ptr) Variable Output
-             178:             TypePointer Output 6(float)
-179(@entryPointOutput.Depth):    178(ptr) Variable Output
-             182:             TypeImage 6(float) 1D sampled format:Unknown
+              22:             TypeSampledImage 14
+              24:             TypeVector 6(float) 2
+              25:    6(float) Constant 1036831949
+              26:    6(float) Constant 1045220557
+              27:   24(fvec2) ConstantComposite 25 26
+              28:    6(float) Constant 1061158912
+              29:             TypeVector 6(float) 3
+              36:             TypeInt 32 1
+              37:             TypeImage 36(int) 1D depth array sampled format:Unknown
+              38:             TypePointer UniformConstant 37
+ 39(g_tTex1di4a):     38(ptr) Variable UniformConstant
+              42:             TypeSampledImage 37
+              50:             TypeInt 32 0
+              51:             TypeImage 50(int) 1D depth array sampled format:Unknown
+              52:             TypePointer UniformConstant 51
+ 53(g_tTex1du4a):     52(ptr) Variable UniformConstant
+              56:             TypeSampledImage 51
+              64:             TypeImage 6(float) 2D depth array sampled format:Unknown
+              65:             TypePointer UniformConstant 64
+ 66(g_tTex2df4a):     65(ptr) Variable UniformConstant
+              69:             TypeSampledImage 64
+              71:    6(float) Constant 1050253722
+              72:   29(fvec3) ConstantComposite 25 26 71
+              80:             TypeImage 36(int) 2D depth array sampled format:Unknown
+              81:             TypePointer UniformConstant 80
+ 82(g_tTex2di4a):     81(ptr) Variable UniformConstant
+              85:             TypeSampledImage 80
+              94:             TypeImage 50(int) 2D depth array sampled format:Unknown
+              95:             TypePointer UniformConstant 94
+ 96(g_tTex2du4a):     95(ptr) Variable UniformConstant
+              99:             TypeSampledImage 94
+             108:             TypeImage 6(float) Cube depth array sampled format:Unknown
+             109:             TypePointer UniformConstant 108
+110(g_tTexcdf4a):    109(ptr) Variable UniformConstant
+             113:             TypeSampledImage 108
+             115:    6(float) Constant 1053609165
+             116:    7(fvec4) ConstantComposite 25 26 71 115
+             124:             TypeImage 36(int) Cube depth array sampled format:Unknown
+             125:             TypePointer UniformConstant 124
+126(g_tTexcdi4a):    125(ptr) Variable UniformConstant
+             129:             TypeSampledImage 124
+             138:             TypeImage 50(int) Cube depth array sampled format:Unknown
+             139:             TypePointer UniformConstant 138
+140(g_tTexcdu4a):    139(ptr) Variable UniformConstant
+             143:             TypeSampledImage 138
+             151:             TypePointer Function 8(PS_OUTPUT)
+             153:     36(int) Constant 0
+             154:    6(float) Constant 1065353216
+             155:    7(fvec4) ConstantComposite 154 154 154 154
+             156:             TypePointer Function 7(fvec4)
+             158:     36(int) Constant 1
+             165:             TypePointer Output 7(fvec4)
+166(@entryPointOutput.Color):    165(ptr) Variable Output
+             169:             TypePointer Output 6(float)
+170(@entryPointOutput.Depth):    169(ptr) Variable Output
+             173:             TypeImage 6(float) 1D sampled format:Unknown
+             174:             TypePointer UniformConstant 173
+ 175(g_tTex1df4):    174(ptr) Variable UniformConstant
+             176:             TypeImage 36(int) 1D sampled format:Unknown
+             177:             TypePointer UniformConstant 176
+ 178(g_tTex1di4):    177(ptr) Variable UniformConstant
+             179:             TypeImage 50(int) 1D sampled format:Unknown
+             180:             TypePointer UniformConstant 179
+ 181(g_tTex1du4):    180(ptr) Variable UniformConstant
+             182:             TypeImage 6(float) 2D sampled format:Unknown
              183:             TypePointer UniformConstant 182
- 184(g_tTex1df4):    183(ptr) Variable UniformConstant
-             185:             TypeImage 37(int) 1D sampled format:Unknown
+ 184(g_tTex2df4):    183(ptr) Variable UniformConstant
+             185:             TypeImage 36(int) 2D sampled format:Unknown
              186:             TypePointer UniformConstant 185
- 187(g_tTex1di4):    186(ptr) Variable UniformConstant
-             188:             TypeImage 52(int) 1D sampled format:Unknown
+ 187(g_tTex2di4):    186(ptr) Variable UniformConstant
+             188:             TypeImage 50(int) 2D sampled format:Unknown
              189:             TypePointer UniformConstant 188
- 190(g_tTex1du4):    189(ptr) Variable UniformConstant
-             191:             TypeImage 6(float) 2D sampled format:Unknown
+ 190(g_tTex2du4):    189(ptr) Variable UniformConstant
+             191:             TypeImage 6(float) 3D sampled format:Unknown
              192:             TypePointer UniformConstant 191
- 193(g_tTex2df4):    192(ptr) Variable UniformConstant
-             194:             TypeImage 37(int) 2D sampled format:Unknown
+ 193(g_tTex3df4):    192(ptr) Variable UniformConstant
+             194:             TypeImage 36(int) 3D sampled format:Unknown
              195:             TypePointer UniformConstant 194
- 196(g_tTex2di4):    195(ptr) Variable UniformConstant
-             197:             TypeImage 52(int) 2D sampled format:Unknown
+ 196(g_tTex3di4):    195(ptr) Variable UniformConstant
+             197:             TypeImage 50(int) 3D sampled format:Unknown
              198:             TypePointer UniformConstant 197
- 199(g_tTex2du4):    198(ptr) Variable UniformConstant
-             200:             TypeImage 6(float) 3D sampled format:Unknown
+ 199(g_tTex3du4):    198(ptr) Variable UniformConstant
+             200:             TypeImage 6(float) Cube sampled format:Unknown
              201:             TypePointer UniformConstant 200
- 202(g_tTex3df4):    201(ptr) Variable UniformConstant
-             203:             TypeImage 37(int) 3D sampled format:Unknown
+ 202(g_tTexcdf4):    201(ptr) Variable UniformConstant
+             203:             TypeImage 36(int) Cube sampled format:Unknown
              204:             TypePointer UniformConstant 203
- 205(g_tTex3di4):    204(ptr) Variable UniformConstant
-             206:             TypeImage 52(int) 3D sampled format:Unknown
+ 205(g_tTexcdi4):    204(ptr) Variable UniformConstant
+             206:             TypeImage 50(int) Cube sampled format:Unknown
              207:             TypePointer UniformConstant 206
- 208(g_tTex3du4):    207(ptr) Variable UniformConstant
-             209:             TypeImage 6(float) Cube sampled format:Unknown
-             210:             TypePointer UniformConstant 209
- 211(g_tTexcdf4):    210(ptr) Variable UniformConstant
-             212:             TypeImage 37(int) Cube sampled format:Unknown
-             213:             TypePointer UniformConstant 212
- 214(g_tTexcdi4):    213(ptr) Variable UniformConstant
-             215:             TypeImage 52(int) Cube sampled format:Unknown
-             216:             TypePointer UniformConstant 215
- 217(g_tTexcdu4):    216(ptr) Variable UniformConstant
+ 208(g_tTexcdu4):    207(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
-172(flattenTemp):    160(ptr) Variable Function
-             173:8(PS_OUTPUT) FunctionCall 10(@main()
-                              Store 172(flattenTemp) 173
-             176:    165(ptr) AccessChain 172(flattenTemp) 162
-             177:    7(fvec4) Load 176
-                              Store 175(@entryPointOutput.Color) 177
-             180:     12(ptr) AccessChain 172(flattenTemp) 167
-             181:    6(float) Load 180
-                              Store 179(@entryPointOutput.Depth) 181
+163(flattenTemp):    151(ptr) Variable Function
+             164:8(PS_OUTPUT) FunctionCall 10(@main()
+                              Store 163(flattenTemp) 164
+             167:    156(ptr) AccessChain 163(flattenTemp) 153
+             168:    7(fvec4) Load 167
+                              Store 166(@entryPointOutput.Color) 168
+             171:     12(ptr) AccessChain 163(flattenTemp) 158
+             172:    6(float) Load 171
+                              Store 170(@entryPointOutput.Depth) 172
                               Return
                               FunctionEnd
       10(@main():8(PS_OUTPUT) Function None 9
               11:             Label
          13(r10):     12(ptr) Variable Function
-         36(r12):     12(ptr) Variable Function
-         51(r14):     12(ptr) Variable Function
-         66(r30):     12(ptr) Variable Function
-         83(r32):     12(ptr) Variable Function
-         98(r34):     12(ptr) Variable Function
-        113(r60):     12(ptr) Variable Function
-        130(r62):     12(ptr) Variable Function
-        145(r64):     12(ptr) Variable Function
-      161(psout):    160(ptr) Variable Function
+         35(r12):     12(ptr) Variable Function
+         49(r14):     12(ptr) Variable Function
+         63(r30):     12(ptr) Variable Function
+         79(r32):     12(ptr) Variable Function
+         93(r34):     12(ptr) Variable Function
+        107(r60):     12(ptr) Variable Function
+        123(r62):     12(ptr) Variable Function
+        137(r64):     12(ptr) Variable Function
+      152(psout):    151(ptr) Variable Function
               17:          14 Load 16(g_tTex1df4a)
               21:          18 Load 20(g_sSamp)
-              24:          23 SampledImage 17 21
-              31:    6(float) CompositeExtract 28 0
-              32:    6(float) CompositeExtract 28 1
-              33:   30(fvec3) CompositeConstruct 31 32 29
-              34:    6(float) CompositeExtract 33 2
-              35:    6(float) ImageSampleDrefImplicitLod 24 33 34
-                              Store 13(r10) 35
-              41:          38 Load 40(g_tTex1di4a)
-              42:          18 Load 20(g_sSamp)
-              45:          44 SampledImage 41 42
-              46:    6(float) CompositeExtract 28 0
-              47:    6(float) CompositeExtract 28 1
-              48:   30(fvec3) CompositeConstruct 46 47 29
-              49:    6(float) CompositeExtract 48 2
-              50:    6(float) ImageSampleDrefImplicitLod 45 48 49
-                              Store 36(r12) 50
-              56:          53 Load 55(g_tTex1du4a)
-              57:          18 Load 20(g_sSamp)
-              60:          59 SampledImage 56 57
-              61:    6(float) CompositeExtract 28 0
-              62:    6(float) CompositeExtract 28 1
-              63:   30(fvec3) CompositeConstruct 61 62 29
-              64:    6(float) CompositeExtract 63 2
-              65:    6(float) ImageSampleDrefImplicitLod 60 63 64
-                              Store 51(r14) 65
-              70:          67 Load 69(g_tTex2df4a)
-              71:          18 Load 20(g_sSamp)
-              74:          73 SampledImage 70 71
-              77:    6(float) CompositeExtract 76 0
-              78:    6(float) CompositeExtract 76 1
-              79:    6(float) CompositeExtract 76 2
-              80:    7(fvec4) CompositeConstruct 77 78 79 29
-              81:    6(float) CompositeExtract 80 3
-              82:    6(float) ImageSampleDrefImplicitLod 74 80 81
-                              Store 66(r30) 82
-              87:          84 Load 86(g_tTex2di4a)
-              88:          18 Load 20(g_sSamp)
-              91:          90 SampledImage 87 88
-              92:    6(float) CompositeExtract 76 0
-              93:    6(float) CompositeExtract 76 1
-              94:    6(float) CompositeExtract 76 2
-              95:    7(fvec4) CompositeConstruct 92 93 94 29
-              96:    6(float) CompositeExtract 95 3
-              97:    6(float) ImageSampleDrefImplicitLod 91 95 96
-                              Store 83(r32) 97
-             102:          99 Load 101(g_tTex2du4a)
-             103:          18 Load 20(g_sSamp)
-             106:         105 SampledImage 102 103
-             107:    6(float) CompositeExtract 76 0
-             108:    6(float) CompositeExtract 76 1
-             109:    6(float) CompositeExtract 76 2
-             110:    7(fvec4) CompositeConstruct 107 108 109 29
-             111:    6(float) CompositeExtract 110 3
-             112:    6(float) ImageSampleDrefImplicitLod 106 110 111
-                              Store 98(r34) 112
-             117:         114 Load 116(g_tTexcdf4a)
-             118:          18 Load 20(g_sSamp)
-             121:         120 SampledImage 117 118
-             124:    6(float) CompositeExtract 123 0
-             125:    6(float) CompositeExtract 123 1
-             126:    6(float) CompositeExtract 123 2
-             127:    6(float) CompositeExtract 123 3
-             128:    7(fvec4) CompositeConstruct 124 125 126 127
-             129:    6(float) ImageSampleDrefImplicitLod 121 128 29
-                              Store 113(r60) 129
-             134:         131 Load 133(g_tTexcdi4a)
-             135:          18 Load 20(g_sSamp)
-             138:         137 SampledImage 134 135
-             139:    6(float) CompositeExtract 123 0
-             140:    6(float) CompositeExtract 123 1
-             141:    6(float) CompositeExtract 123 2
-             142:    6(float) CompositeExtract 123 3
-             143:    7(fvec4) CompositeConstruct 139 140 141 142
-             144:    6(float) ImageSampleDrefImplicitLod 138 143 29
-                              Store 130(r62) 144
-             149:         146 Load 148(g_tTexcdu4a)
-             150:          18 Load 20(g_sSamp)
-             153:         152 SampledImage 149 150
-             154:    6(float) CompositeExtract 123 0
-             155:    6(float) CompositeExtract 123 1
-             156:    6(float) CompositeExtract 123 2
-             157:    6(float) CompositeExtract 123 3
-             158:    7(fvec4) CompositeConstruct 154 155 156 157
-             159:    6(float) ImageSampleDrefImplicitLod 153 158 29
-                              Store 145(r64) 159
-             166:    165(ptr) AccessChain 161(psout) 162
-                              Store 166 164
-             168:     12(ptr) AccessChain 161(psout) 167
-                              Store 168 163
-             169:8(PS_OUTPUT) Load 161(psout)
-                              ReturnValue 169
+              23:          22 SampledImage 17 21
+              30:    6(float) CompositeExtract 27 0
+              31:    6(float) CompositeExtract 27 1
+              32:   29(fvec3) CompositeConstruct 30 31 28
+              33:    6(float) CompositeExtract 32 2
+              34:    6(float) ImageSampleDrefImplicitLod 23 32 33
+                              Store 13(r10) 34
+              40:          37 Load 39(g_tTex1di4a)
+              41:          18 Load 20(g_sSamp)
+              43:          42 SampledImage 40 41
+              44:    6(float) CompositeExtract 27 0
+              45:    6(float) CompositeExtract 27 1
+              46:   29(fvec3) CompositeConstruct 44 45 28
+              47:    6(float) CompositeExtract 46 2
+              48:    6(float) ImageSampleDrefImplicitLod 43 46 47
+                              Store 35(r12) 48
+              54:          51 Load 53(g_tTex1du4a)
+              55:          18 Load 20(g_sSamp)
+              57:          56 SampledImage 54 55
+              58:    6(float) CompositeExtract 27 0
+              59:    6(float) CompositeExtract 27 1
+              60:   29(fvec3) CompositeConstruct 58 59 28
+              61:    6(float) CompositeExtract 60 2
+              62:    6(float) ImageSampleDrefImplicitLod 57 60 61
+                              Store 49(r14) 62
+              67:          64 Load 66(g_tTex2df4a)
+              68:          18 Load 20(g_sSamp)
+              70:          69 SampledImage 67 68
+              73:    6(float) CompositeExtract 72 0
+              74:    6(float) CompositeExtract 72 1
+              75:    6(float) CompositeExtract 72 2
+              76:    7(fvec4) CompositeConstruct 73 74 75 28
+              77:    6(float) CompositeExtract 76 3
+              78:    6(float) ImageSampleDrefImplicitLod 70 76 77
+                              Store 63(r30) 78
+              83:          80 Load 82(g_tTex2di4a)
+              84:          18 Load 20(g_sSamp)
+              86:          85 SampledImage 83 84
+              87:    6(float) CompositeExtract 72 0
+              88:    6(float) CompositeExtract 72 1
+              89:    6(float) CompositeExtract 72 2
+              90:    7(fvec4) CompositeConstruct 87 88 89 28
+              91:    6(float) CompositeExtract 90 3
+              92:    6(float) ImageSampleDrefImplicitLod 86 90 91
+                              Store 79(r32) 92
+              97:          94 Load 96(g_tTex2du4a)
+              98:          18 Load 20(g_sSamp)
+             100:          99 SampledImage 97 98
+             101:    6(float) CompositeExtract 72 0
+             102:    6(float) CompositeExtract 72 1
+             103:    6(float) CompositeExtract 72 2
+             104:    7(fvec4) CompositeConstruct 101 102 103 28
+             105:    6(float) CompositeExtract 104 3
+             106:    6(float) ImageSampleDrefImplicitLod 100 104 105
+                              Store 93(r34) 106
+             111:         108 Load 110(g_tTexcdf4a)
+             112:          18 Load 20(g_sSamp)
+             114:         113 SampledImage 111 112
+             117:    6(float) CompositeExtract 116 0
+             118:    6(float) CompositeExtract 116 1
+             119:    6(float) CompositeExtract 116 2
+             120:    6(float) CompositeExtract 116 3
+             121:    7(fvec4) CompositeConstruct 117 118 119 120
+             122:    6(float) ImageSampleDrefImplicitLod 114 121 28
+                              Store 107(r60) 122
+             127:         124 Load 126(g_tTexcdi4a)
+             128:          18 Load 20(g_sSamp)
+             130:         129 SampledImage 127 128
+             131:    6(float) CompositeExtract 116 0
+             132:    6(float) CompositeExtract 116 1
+             133:    6(float) CompositeExtract 116 2
+             134:    6(float) CompositeExtract 116 3
+             135:    7(fvec4) CompositeConstruct 131 132 133 134
+             136:    6(float) ImageSampleDrefImplicitLod 130 135 28
+                              Store 123(r62) 136
+             141:         138 Load 140(g_tTexcdu4a)
+             142:          18 Load 20(g_sSamp)
+             144:         143 SampledImage 141 142
+             145:    6(float) CompositeExtract 116 0
+             146:    6(float) CompositeExtract 116 1
+             147:    6(float) CompositeExtract 116 2
+             148:    6(float) CompositeExtract 116 3
+             149:    7(fvec4) CompositeConstruct 145 146 147 148
+             150:    6(float) ImageSampleDrefImplicitLod 144 149 28
+                              Store 137(r64) 150
+             157:    156(ptr) AccessChain 152(psout) 153
+                              Store 157 155
+             159:     12(ptr) AccessChain 152(psout) 158
+                              Store 159 154
+             160:8(PS_OUTPUT) Load 152(psout)
+                              ReturnValue 160
                               FunctionEnd

--- a/Test/baseResults/hlsl.samplecmp.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmp.basic.dx10.frag.out
@@ -10,7 +10,7 @@ gl_FragCoord origin is upper left
 0:42          'r00' ( temp float)
 0:42          texture ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DShadow)
-0:42              'g_tTex1df4' (layout( binding=0) uniform texture1D)
+0:42              'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec2 ( temp 2-component vector of float)
 0:42              Constant:
@@ -22,7 +22,7 @@ gl_FragCoord origin is upper left
 0:43          'r02' ( temp float)
 0:43          texture ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DShadow)
-0:43              'g_tTex1di4' ( uniform itexture1D)
+0:43              'g_tTex1di4' ( uniform itexture1DShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec2 ( temp 2-component vector of float)
 0:43              Constant:
@@ -34,7 +34,7 @@ gl_FragCoord origin is upper left
 0:44          'r04' ( temp float)
 0:44          texture ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DShadow)
-0:44              'g_tTex1du4' ( uniform utexture1D)
+0:44              'g_tTex1du4' ( uniform utexture1DShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec2 ( temp 2-component vector of float)
 0:44              Constant:
@@ -46,7 +46,7 @@ gl_FragCoord origin is upper left
 0:47          'r20' ( temp float)
 0:47          texture ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DShadow)
-0:47              'g_tTex2df4' ( uniform texture2D)
+0:47              'g_tTex2df4' ( uniform texture2DShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -59,7 +59,7 @@ gl_FragCoord origin is upper left
 0:48          'r22' ( temp float)
 0:48          texture ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DShadow)
-0:48              'g_tTex2di4' ( uniform itexture2D)
+0:48              'g_tTex2di4' ( uniform itexture2DShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -72,7 +72,7 @@ gl_FragCoord origin is upper left
 0:49          'r24' ( temp float)
 0:49          texture ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DShadow)
-0:49              'g_tTex2du4' ( uniform utexture2D)
+0:49              'g_tTex2du4' ( uniform utexture2DShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -85,7 +85,7 @@ gl_FragCoord origin is upper left
 0:53          'r50' ( temp float)
 0:53          texture ( temp float)
 0:53            Construct combined texture-sampler ( temp samplerCubeShadow)
-0:53              'g_tTexcdf4' ( uniform textureCube)
+0:53              'g_tTexcdf4' ( uniform textureCubeShadow)
 0:53              'g_sSamp' (layout( binding=0) uniform sampler)
 0:53            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -99,7 +99,7 @@ gl_FragCoord origin is upper left
 0:54          'r52' ( temp float)
 0:54          texture ( temp float)
 0:54            Construct combined texture-sampler ( temp isamplerCubeShadow)
-0:54              'g_tTexcdi4' ( uniform itextureCube)
+0:54              'g_tTexcdi4' ( uniform itextureCubeShadow)
 0:54              'g_sSamp' (layout( binding=0) uniform sampler)
 0:54            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -113,7 +113,7 @@ gl_FragCoord origin is upper left
 0:55          'r54' ( temp float)
 0:55          texture ( temp float)
 0:55            Construct combined texture-sampler ( temp usamplerCubeShadow)
-0:55              'g_tTexcdu4' ( uniform utextureCube)
+0:55              'g_tTexcdu4' ( uniform utextureCubeShadow)
 0:55              'g_sSamp' (layout( binding=0) uniform sampler)
 0:55            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -162,18 +162,18 @@ gl_FragCoord origin is upper left
 0:38              1 (const int)
 0:?   Linker Objects
 0:?     'g_sSamp' (layout( binding=0) uniform sampler)
-0:?     'g_tTex1df4' (layout( binding=0) uniform texture1D)
-0:?     'g_tTex1di4' ( uniform itexture1D)
-0:?     'g_tTex1du4' ( uniform utexture1D)
-0:?     'g_tTex2df4' ( uniform texture2D)
-0:?     'g_tTex2di4' ( uniform itexture2D)
-0:?     'g_tTex2du4' ( uniform utexture2D)
+0:?     'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
+0:?     'g_tTex1di4' ( uniform itexture1DShadow)
+0:?     'g_tTex1du4' ( uniform utexture1DShadow)
+0:?     'g_tTex2df4' ( uniform texture2DShadow)
+0:?     'g_tTex2di4' ( uniform itexture2DShadow)
+0:?     'g_tTex2du4' ( uniform utexture2DShadow)
 0:?     'g_tTex3df4' ( uniform texture3D)
 0:?     'g_tTex3di4' ( uniform itexture3D)
 0:?     'g_tTex3du4' ( uniform utexture3D)
-0:?     'g_tTexcdf4' ( uniform textureCube)
-0:?     'g_tTexcdi4' ( uniform itextureCube)
-0:?     'g_tTexcdu4' ( uniform utextureCube)
+0:?     'g_tTexcdf4' ( uniform textureCubeShadow)
+0:?     'g_tTexcdi4' ( uniform itextureCubeShadow)
+0:?     'g_tTexcdu4' ( uniform utextureCubeShadow)
 0:?     'g_tTex1df4a' ( uniform texture1DArray)
 0:?     'g_tTex1di4a' ( uniform itexture1DArray)
 0:?     'g_tTex1du4a' ( uniform utexture1DArray)
@@ -201,7 +201,7 @@ gl_FragCoord origin is upper left
 0:42          'r00' ( temp float)
 0:42          texture ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DShadow)
-0:42              'g_tTex1df4' (layout( binding=0) uniform texture1D)
+0:42              'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec2 ( temp 2-component vector of float)
 0:42              Constant:
@@ -213,7 +213,7 @@ gl_FragCoord origin is upper left
 0:43          'r02' ( temp float)
 0:43          texture ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DShadow)
-0:43              'g_tTex1di4' ( uniform itexture1D)
+0:43              'g_tTex1di4' ( uniform itexture1DShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec2 ( temp 2-component vector of float)
 0:43              Constant:
@@ -225,7 +225,7 @@ gl_FragCoord origin is upper left
 0:44          'r04' ( temp float)
 0:44          texture ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DShadow)
-0:44              'g_tTex1du4' ( uniform utexture1D)
+0:44              'g_tTex1du4' ( uniform utexture1DShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec2 ( temp 2-component vector of float)
 0:44              Constant:
@@ -237,7 +237,7 @@ gl_FragCoord origin is upper left
 0:47          'r20' ( temp float)
 0:47          texture ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DShadow)
-0:47              'g_tTex2df4' ( uniform texture2D)
+0:47              'g_tTex2df4' ( uniform texture2DShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -250,7 +250,7 @@ gl_FragCoord origin is upper left
 0:48          'r22' ( temp float)
 0:48          texture ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DShadow)
-0:48              'g_tTex2di4' ( uniform itexture2D)
+0:48              'g_tTex2di4' ( uniform itexture2DShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -263,7 +263,7 @@ gl_FragCoord origin is upper left
 0:49          'r24' ( temp float)
 0:49          texture ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DShadow)
-0:49              'g_tTex2du4' ( uniform utexture2D)
+0:49              'g_tTex2du4' ( uniform utexture2DShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -276,7 +276,7 @@ gl_FragCoord origin is upper left
 0:53          'r50' ( temp float)
 0:53          texture ( temp float)
 0:53            Construct combined texture-sampler ( temp samplerCubeShadow)
-0:53              'g_tTexcdf4' ( uniform textureCube)
+0:53              'g_tTexcdf4' ( uniform textureCubeShadow)
 0:53              'g_sSamp' (layout( binding=0) uniform sampler)
 0:53            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -290,7 +290,7 @@ gl_FragCoord origin is upper left
 0:54          'r52' ( temp float)
 0:54          texture ( temp float)
 0:54            Construct combined texture-sampler ( temp isamplerCubeShadow)
-0:54              'g_tTexcdi4' ( uniform itextureCube)
+0:54              'g_tTexcdi4' ( uniform itextureCubeShadow)
 0:54              'g_sSamp' (layout( binding=0) uniform sampler)
 0:54            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -304,7 +304,7 @@ gl_FragCoord origin is upper left
 0:55          'r54' ( temp float)
 0:55          texture ( temp float)
 0:55            Construct combined texture-sampler ( temp usamplerCubeShadow)
-0:55              'g_tTexcdu4' ( uniform utextureCube)
+0:55              'g_tTexcdu4' ( uniform utextureCubeShadow)
 0:55              'g_sSamp' (layout( binding=0) uniform sampler)
 0:55            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -353,18 +353,18 @@ gl_FragCoord origin is upper left
 0:38              1 (const int)
 0:?   Linker Objects
 0:?     'g_sSamp' (layout( binding=0) uniform sampler)
-0:?     'g_tTex1df4' (layout( binding=0) uniform texture1D)
-0:?     'g_tTex1di4' ( uniform itexture1D)
-0:?     'g_tTex1du4' ( uniform utexture1D)
-0:?     'g_tTex2df4' ( uniform texture2D)
-0:?     'g_tTex2di4' ( uniform itexture2D)
-0:?     'g_tTex2du4' ( uniform utexture2D)
+0:?     'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
+0:?     'g_tTex1di4' ( uniform itexture1DShadow)
+0:?     'g_tTex1du4' ( uniform utexture1DShadow)
+0:?     'g_tTex2df4' ( uniform texture2DShadow)
+0:?     'g_tTex2di4' ( uniform itexture2DShadow)
+0:?     'g_tTex2du4' ( uniform utexture2DShadow)
 0:?     'g_tTex3df4' ( uniform texture3D)
 0:?     'g_tTex3di4' ( uniform itexture3D)
 0:?     'g_tTex3du4' ( uniform utexture3D)
-0:?     'g_tTexcdf4' ( uniform textureCube)
-0:?     'g_tTexcdi4' ( uniform itextureCube)
-0:?     'g_tTexcdu4' ( uniform utextureCube)
+0:?     'g_tTexcdf4' ( uniform textureCubeShadow)
+0:?     'g_tTexcdi4' ( uniform itextureCubeShadow)
+0:?     'g_tTexcdu4' ( uniform utextureCubeShadow)
 0:?     'g_tTex1df4a' ( uniform texture1DArray)
 0:?     'g_tTex1di4a' ( uniform itexture1DArray)
 0:?     'g_tTex1du4a' ( uniform utexture1DArray)
@@ -379,14 +379,14 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 207
+// Id's are bound by 198
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 164 168
+                              EntryPoint Fragment 4  "main" 155 159
                               ExecutionMode 4 OriginUpperLeft
                               Source HLSL 500
                               Name 4  "main"
@@ -397,64 +397,64 @@ gl_FragCoord origin is upper left
                               Name 13  "r00"
                               Name 16  "g_tTex1df4"
                               Name 20  "g_sSamp"
-                              Name 31  "r02"
-                              Name 35  "g_tTex1di4"
-                              Name 44  "r04"
-                              Name 48  "g_tTex1du4"
-                              Name 57  "r20"
-                              Name 60  "g_tTex2df4"
-                              Name 74  "r22"
-                              Name 77  "g_tTex2di4"
-                              Name 88  "r24"
-                              Name 91  "g_tTex2du4"
-                              Name 102  "r50"
-                              Name 105  "g_tTexcdf4"
-                              Name 119  "r52"
-                              Name 122  "g_tTexcdi4"
-                              Name 134  "r54"
-                              Name 137  "g_tTexcdu4"
-                              Name 150  "psout"
-                              Name 161  "flattenTemp"
-                              Name 164  "@entryPointOutput.Color"
-                              Name 168  "@entryPointOutput.Depth"
-                              Name 173  "g_tTex3df4"
-                              Name 176  "g_tTex3di4"
-                              Name 179  "g_tTex3du4"
-                              Name 182  "g_tTex1df4a"
-                              Name 185  "g_tTex1di4a"
-                              Name 188  "g_tTex1du4a"
-                              Name 191  "g_tTex2df4a"
-                              Name 194  "g_tTex2di4a"
-                              Name 197  "g_tTex2du4a"
-                              Name 200  "g_tTexcdf4a"
-                              Name 203  "g_tTexcdi4a"
-                              Name 206  "g_tTexcdu4a"
+                              Name 30  "r02"
+                              Name 34  "g_tTex1di4"
+                              Name 42  "r04"
+                              Name 46  "g_tTex1du4"
+                              Name 54  "r20"
+                              Name 57  "g_tTex2df4"
+                              Name 70  "r22"
+                              Name 73  "g_tTex2di4"
+                              Name 83  "r24"
+                              Name 86  "g_tTex2du4"
+                              Name 96  "r50"
+                              Name 99  "g_tTexcdf4"
+                              Name 112  "r52"
+                              Name 115  "g_tTexcdi4"
+                              Name 126  "r54"
+                              Name 129  "g_tTexcdu4"
+                              Name 141  "psout"
+                              Name 152  "flattenTemp"
+                              Name 155  "@entryPointOutput.Color"
+                              Name 159  "@entryPointOutput.Depth"
+                              Name 164  "g_tTex3df4"
+                              Name 167  "g_tTex3di4"
+                              Name 170  "g_tTex3du4"
+                              Name 173  "g_tTex1df4a"
+                              Name 176  "g_tTex1di4a"
+                              Name 179  "g_tTex1du4a"
+                              Name 182  "g_tTex2df4a"
+                              Name 185  "g_tTex2di4a"
+                              Name 188  "g_tTex2du4a"
+                              Name 191  "g_tTexcdf4a"
+                              Name 194  "g_tTexcdi4a"
+                              Name 197  "g_tTexcdu4a"
                               Decorate 16(g_tTex1df4) DescriptorSet 0
                               Decorate 16(g_tTex1df4) Binding 0
                               Decorate 20(g_sSamp) DescriptorSet 0
                               Decorate 20(g_sSamp) Binding 0
-                              Decorate 35(g_tTex1di4) DescriptorSet 0
-                              Decorate 48(g_tTex1du4) DescriptorSet 0
-                              Decorate 60(g_tTex2df4) DescriptorSet 0
-                              Decorate 77(g_tTex2di4) DescriptorSet 0
-                              Decorate 91(g_tTex2du4) DescriptorSet 0
-                              Decorate 105(g_tTexcdf4) DescriptorSet 0
-                              Decorate 122(g_tTexcdi4) DescriptorSet 0
-                              Decorate 137(g_tTexcdu4) DescriptorSet 0
-                              Decorate 164(@entryPointOutput.Color) Location 0
-                              Decorate 168(@entryPointOutput.Depth) BuiltIn FragDepth
-                              Decorate 173(g_tTex3df4) DescriptorSet 0
-                              Decorate 176(g_tTex3di4) DescriptorSet 0
-                              Decorate 179(g_tTex3du4) DescriptorSet 0
-                              Decorate 182(g_tTex1df4a) DescriptorSet 0
-                              Decorate 185(g_tTex1di4a) DescriptorSet 0
-                              Decorate 188(g_tTex1du4a) DescriptorSet 0
-                              Decorate 191(g_tTex2df4a) DescriptorSet 0
-                              Decorate 194(g_tTex2di4a) DescriptorSet 0
-                              Decorate 197(g_tTex2du4a) DescriptorSet 0
-                              Decorate 200(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 203(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 206(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 34(g_tTex1di4) DescriptorSet 0
+                              Decorate 46(g_tTex1du4) DescriptorSet 0
+                              Decorate 57(g_tTex2df4) DescriptorSet 0
+                              Decorate 73(g_tTex2di4) DescriptorSet 0
+                              Decorate 86(g_tTex2du4) DescriptorSet 0
+                              Decorate 99(g_tTexcdf4) DescriptorSet 0
+                              Decorate 115(g_tTexcdi4) DescriptorSet 0
+                              Decorate 129(g_tTexcdu4) DescriptorSet 0
+                              Decorate 155(@entryPointOutput.Color) Location 0
+                              Decorate 159(@entryPointOutput.Depth) BuiltIn FragDepth
+                              Decorate 164(g_tTex3df4) DescriptorSet 0
+                              Decorate 167(g_tTex3di4) DescriptorSet 0
+                              Decorate 170(g_tTex3du4) DescriptorSet 0
+                              Decorate 173(g_tTex1df4a) DescriptorSet 0
+                              Decorate 176(g_tTex1di4a) DescriptorSet 0
+                              Decorate 179(g_tTex1du4a) DescriptorSet 0
+                              Decorate 182(g_tTex2df4a) DescriptorSet 0
+                              Decorate 185(g_tTex2di4a) DescriptorSet 0
+                              Decorate 188(g_tTex2du4a) DescriptorSet 0
+                              Decorate 191(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 194(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 197(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -462,217 +462,208 @@ gl_FragCoord origin is upper left
     8(PS_OUTPUT):             TypeStruct 7(fvec4) 6(float)
                9:             TypeFunction 8(PS_OUTPUT)
               12:             TypePointer Function 6(float)
-              14:             TypeImage 6(float) 1D sampled format:Unknown
+              14:             TypeImage 6(float) 1D depth sampled format:Unknown
               15:             TypePointer UniformConstant 14
   16(g_tTex1df4):     15(ptr) Variable UniformConstant
               18:             TypeSampler
               19:             TypePointer UniformConstant 18
      20(g_sSamp):     19(ptr) Variable UniformConstant
-              22:             TypeImage 6(float) 1D depth sampled format:Unknown
-              23:             TypeSampledImage 22
-              25:    6(float) Constant 1036831949
-              26:    6(float) Constant 1061158912
-              27:             TypeVector 6(float) 2
-              32:             TypeInt 32 1
-              33:             TypeImage 32(int) 1D sampled format:Unknown
-              34:             TypePointer UniformConstant 33
-  35(g_tTex1di4):     34(ptr) Variable UniformConstant
-              38:             TypeImage 32(int) 1D depth sampled format:Unknown
-              39:             TypeSampledImage 38
-              45:             TypeInt 32 0
-              46:             TypeImage 45(int) 1D sampled format:Unknown
-              47:             TypePointer UniformConstant 46
-  48(g_tTex1du4):     47(ptr) Variable UniformConstant
-              51:             TypeImage 45(int) 1D depth sampled format:Unknown
-              52:             TypeSampledImage 51
-              58:             TypeImage 6(float) 2D sampled format:Unknown
-              59:             TypePointer UniformConstant 58
-  60(g_tTex2df4):     59(ptr) Variable UniformConstant
-              63:             TypeImage 6(float) 2D depth sampled format:Unknown
-              64:             TypeSampledImage 63
-              66:    6(float) Constant 1045220557
-              67:   27(fvec2) ConstantComposite 25 66
-              68:             TypeVector 6(float) 3
-              75:             TypeImage 32(int) 2D sampled format:Unknown
-              76:             TypePointer UniformConstant 75
-  77(g_tTex2di4):     76(ptr) Variable UniformConstant
-              80:             TypeImage 32(int) 2D depth sampled format:Unknown
-              81:             TypeSampledImage 80
-              89:             TypeImage 45(int) 2D sampled format:Unknown
-              90:             TypePointer UniformConstant 89
-  91(g_tTex2du4):     90(ptr) Variable UniformConstant
-              94:             TypeImage 45(int) 2D depth sampled format:Unknown
-              95:             TypeSampledImage 94
-             103:             TypeImage 6(float) Cube sampled format:Unknown
-             104:             TypePointer UniformConstant 103
- 105(g_tTexcdf4):    104(ptr) Variable UniformConstant
-             108:             TypeImage 6(float) Cube depth sampled format:Unknown
-             109:             TypeSampledImage 108
-             111:    6(float) Constant 1050253722
-             112:   68(fvec3) ConstantComposite 25 66 111
-             120:             TypeImage 32(int) Cube sampled format:Unknown
-             121:             TypePointer UniformConstant 120
- 122(g_tTexcdi4):    121(ptr) Variable UniformConstant
-             125:             TypeImage 32(int) Cube depth sampled format:Unknown
-             126:             TypeSampledImage 125
-             135:             TypeImage 45(int) Cube sampled format:Unknown
-             136:             TypePointer UniformConstant 135
- 137(g_tTexcdu4):    136(ptr) Variable UniformConstant
-             140:             TypeImage 45(int) Cube depth sampled format:Unknown
-             141:             TypeSampledImage 140
-             149:             TypePointer Function 8(PS_OUTPUT)
-             151:     32(int) Constant 0
-             152:    6(float) Constant 1065353216
-             153:    7(fvec4) ConstantComposite 152 152 152 152
-             154:             TypePointer Function 7(fvec4)
-             156:     32(int) Constant 1
-             163:             TypePointer Output 7(fvec4)
-164(@entryPointOutput.Color):    163(ptr) Variable Output
-             167:             TypePointer Output 6(float)
-168(@entryPointOutput.Depth):    167(ptr) Variable Output
-             171:             TypeImage 6(float) 3D sampled format:Unknown
+              22:             TypeSampledImage 14
+              24:    6(float) Constant 1036831949
+              25:    6(float) Constant 1061158912
+              26:             TypeVector 6(float) 2
+              31:             TypeInt 32 1
+              32:             TypeImage 31(int) 1D depth sampled format:Unknown
+              33:             TypePointer UniformConstant 32
+  34(g_tTex1di4):     33(ptr) Variable UniformConstant
+              37:             TypeSampledImage 32
+              43:             TypeInt 32 0
+              44:             TypeImage 43(int) 1D depth sampled format:Unknown
+              45:             TypePointer UniformConstant 44
+  46(g_tTex1du4):     45(ptr) Variable UniformConstant
+              49:             TypeSampledImage 44
+              55:             TypeImage 6(float) 2D depth sampled format:Unknown
+              56:             TypePointer UniformConstant 55
+  57(g_tTex2df4):     56(ptr) Variable UniformConstant
+              60:             TypeSampledImage 55
+              62:    6(float) Constant 1045220557
+              63:   26(fvec2) ConstantComposite 24 62
+              64:             TypeVector 6(float) 3
+              71:             TypeImage 31(int) 2D depth sampled format:Unknown
+              72:             TypePointer UniformConstant 71
+  73(g_tTex2di4):     72(ptr) Variable UniformConstant
+              76:             TypeSampledImage 71
+              84:             TypeImage 43(int) 2D depth sampled format:Unknown
+              85:             TypePointer UniformConstant 84
+  86(g_tTex2du4):     85(ptr) Variable UniformConstant
+              89:             TypeSampledImage 84
+              97:             TypeImage 6(float) Cube depth sampled format:Unknown
+              98:             TypePointer UniformConstant 97
+  99(g_tTexcdf4):     98(ptr) Variable UniformConstant
+             102:             TypeSampledImage 97
+             104:    6(float) Constant 1050253722
+             105:   64(fvec3) ConstantComposite 24 62 104
+             113:             TypeImage 31(int) Cube depth sampled format:Unknown
+             114:             TypePointer UniformConstant 113
+ 115(g_tTexcdi4):    114(ptr) Variable UniformConstant
+             118:             TypeSampledImage 113
+             127:             TypeImage 43(int) Cube depth sampled format:Unknown
+             128:             TypePointer UniformConstant 127
+ 129(g_tTexcdu4):    128(ptr) Variable UniformConstant
+             132:             TypeSampledImage 127
+             140:             TypePointer Function 8(PS_OUTPUT)
+             142:     31(int) Constant 0
+             143:    6(float) Constant 1065353216
+             144:    7(fvec4) ConstantComposite 143 143 143 143
+             145:             TypePointer Function 7(fvec4)
+             147:     31(int) Constant 1
+             154:             TypePointer Output 7(fvec4)
+155(@entryPointOutput.Color):    154(ptr) Variable Output
+             158:             TypePointer Output 6(float)
+159(@entryPointOutput.Depth):    158(ptr) Variable Output
+             162:             TypeImage 6(float) 3D sampled format:Unknown
+             163:             TypePointer UniformConstant 162
+ 164(g_tTex3df4):    163(ptr) Variable UniformConstant
+             165:             TypeImage 31(int) 3D sampled format:Unknown
+             166:             TypePointer UniformConstant 165
+ 167(g_tTex3di4):    166(ptr) Variable UniformConstant
+             168:             TypeImage 43(int) 3D sampled format:Unknown
+             169:             TypePointer UniformConstant 168
+ 170(g_tTex3du4):    169(ptr) Variable UniformConstant
+             171:             TypeImage 6(float) 1D array sampled format:Unknown
              172:             TypePointer UniformConstant 171
- 173(g_tTex3df4):    172(ptr) Variable UniformConstant
-             174:             TypeImage 32(int) 3D sampled format:Unknown
+173(g_tTex1df4a):    172(ptr) Variable UniformConstant
+             174:             TypeImage 31(int) 1D array sampled format:Unknown
              175:             TypePointer UniformConstant 174
- 176(g_tTex3di4):    175(ptr) Variable UniformConstant
-             177:             TypeImage 45(int) 3D sampled format:Unknown
+176(g_tTex1di4a):    175(ptr) Variable UniformConstant
+             177:             TypeImage 43(int) 1D array sampled format:Unknown
              178:             TypePointer UniformConstant 177
- 179(g_tTex3du4):    178(ptr) Variable UniformConstant
-             180:             TypeImage 6(float) 1D array sampled format:Unknown
+179(g_tTex1du4a):    178(ptr) Variable UniformConstant
+             180:             TypeImage 6(float) 2D array sampled format:Unknown
              181:             TypePointer UniformConstant 180
-182(g_tTex1df4a):    181(ptr) Variable UniformConstant
-             183:             TypeImage 32(int) 1D array sampled format:Unknown
+182(g_tTex2df4a):    181(ptr) Variable UniformConstant
+             183:             TypeImage 31(int) 2D array sampled format:Unknown
              184:             TypePointer UniformConstant 183
-185(g_tTex1di4a):    184(ptr) Variable UniformConstant
-             186:             TypeImage 45(int) 1D array sampled format:Unknown
+185(g_tTex2di4a):    184(ptr) Variable UniformConstant
+             186:             TypeImage 43(int) 2D array sampled format:Unknown
              187:             TypePointer UniformConstant 186
-188(g_tTex1du4a):    187(ptr) Variable UniformConstant
-             189:             TypeImage 6(float) 2D array sampled format:Unknown
+188(g_tTex2du4a):    187(ptr) Variable UniformConstant
+             189:             TypeImage 6(float) Cube array sampled format:Unknown
              190:             TypePointer UniformConstant 189
-191(g_tTex2df4a):    190(ptr) Variable UniformConstant
-             192:             TypeImage 32(int) 2D array sampled format:Unknown
+191(g_tTexcdf4a):    190(ptr) Variable UniformConstant
+             192:             TypeImage 31(int) Cube array sampled format:Unknown
              193:             TypePointer UniformConstant 192
-194(g_tTex2di4a):    193(ptr) Variable UniformConstant
-             195:             TypeImage 45(int) 2D array sampled format:Unknown
+194(g_tTexcdi4a):    193(ptr) Variable UniformConstant
+             195:             TypeImage 43(int) Cube array sampled format:Unknown
              196:             TypePointer UniformConstant 195
-197(g_tTex2du4a):    196(ptr) Variable UniformConstant
-             198:             TypeImage 6(float) Cube array sampled format:Unknown
-             199:             TypePointer UniformConstant 198
-200(g_tTexcdf4a):    199(ptr) Variable UniformConstant
-             201:             TypeImage 32(int) Cube array sampled format:Unknown
-             202:             TypePointer UniformConstant 201
-203(g_tTexcdi4a):    202(ptr) Variable UniformConstant
-             204:             TypeImage 45(int) Cube array sampled format:Unknown
-             205:             TypePointer UniformConstant 204
-206(g_tTexcdu4a):    205(ptr) Variable UniformConstant
+197(g_tTexcdu4a):    196(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
-161(flattenTemp):    149(ptr) Variable Function
-             162:8(PS_OUTPUT) FunctionCall 10(@main()
-                              Store 161(flattenTemp) 162
-             165:    154(ptr) AccessChain 161(flattenTemp) 151
-             166:    7(fvec4) Load 165
-                              Store 164(@entryPointOutput.Color) 166
-             169:     12(ptr) AccessChain 161(flattenTemp) 156
-             170:    6(float) Load 169
-                              Store 168(@entryPointOutput.Depth) 170
+152(flattenTemp):    140(ptr) Variable Function
+             153:8(PS_OUTPUT) FunctionCall 10(@main()
+                              Store 152(flattenTemp) 153
+             156:    145(ptr) AccessChain 152(flattenTemp) 142
+             157:    7(fvec4) Load 156
+                              Store 155(@entryPointOutput.Color) 157
+             160:     12(ptr) AccessChain 152(flattenTemp) 147
+             161:    6(float) Load 160
+                              Store 159(@entryPointOutput.Depth) 161
                               Return
                               FunctionEnd
       10(@main():8(PS_OUTPUT) Function None 9
               11:             Label
          13(r00):     12(ptr) Variable Function
-         31(r02):     12(ptr) Variable Function
-         44(r04):     12(ptr) Variable Function
-         57(r20):     12(ptr) Variable Function
-         74(r22):     12(ptr) Variable Function
-         88(r24):     12(ptr) Variable Function
-        102(r50):     12(ptr) Variable Function
-        119(r52):     12(ptr) Variable Function
-        134(r54):     12(ptr) Variable Function
-      150(psout):    149(ptr) Variable Function
+         30(r02):     12(ptr) Variable Function
+         42(r04):     12(ptr) Variable Function
+         54(r20):     12(ptr) Variable Function
+         70(r22):     12(ptr) Variable Function
+         83(r24):     12(ptr) Variable Function
+         96(r50):     12(ptr) Variable Function
+        112(r52):     12(ptr) Variable Function
+        126(r54):     12(ptr) Variable Function
+      141(psout):    140(ptr) Variable Function
               17:          14 Load 16(g_tTex1df4)
               21:          18 Load 20(g_sSamp)
-              24:          23 SampledImage 17 21
-              28:   27(fvec2) CompositeConstruct 25 26
-              29:    6(float) CompositeExtract 28 1
-              30:    6(float) ImageSampleDrefImplicitLod 24 28 29
-                              Store 13(r00) 30
-              36:          33 Load 35(g_tTex1di4)
-              37:          18 Load 20(g_sSamp)
-              40:          39 SampledImage 36 37
-              41:   27(fvec2) CompositeConstruct 25 26
-              42:    6(float) CompositeExtract 41 1
-              43:    6(float) ImageSampleDrefImplicitLod 40 41 42
-                              Store 31(r02) 43
-              49:          46 Load 48(g_tTex1du4)
-              50:          18 Load 20(g_sSamp)
-              53:          52 SampledImage 49 50
-              54:   27(fvec2) CompositeConstruct 25 26
-              55:    6(float) CompositeExtract 54 1
-              56:    6(float) ImageSampleDrefImplicitLod 53 54 55
-                              Store 44(r04) 56
-              61:          58 Load 60(g_tTex2df4)
-              62:          18 Load 20(g_sSamp)
-              65:          64 SampledImage 61 62
-              69:    6(float) CompositeExtract 67 0
-              70:    6(float) CompositeExtract 67 1
-              71:   68(fvec3) CompositeConstruct 69 70 26
-              72:    6(float) CompositeExtract 71 2
-              73:    6(float) ImageSampleDrefImplicitLod 65 71 72
-                              Store 57(r20) 73
-              78:          75 Load 77(g_tTex2di4)
-              79:          18 Load 20(g_sSamp)
-              82:          81 SampledImage 78 79
-              83:    6(float) CompositeExtract 67 0
-              84:    6(float) CompositeExtract 67 1
-              85:   68(fvec3) CompositeConstruct 83 84 26
-              86:    6(float) CompositeExtract 85 2
-              87:    6(float) ImageSampleDrefImplicitLod 82 85 86
-                              Store 74(r22) 87
-              92:          89 Load 91(g_tTex2du4)
-              93:          18 Load 20(g_sSamp)
-              96:          95 SampledImage 92 93
-              97:    6(float) CompositeExtract 67 0
-              98:    6(float) CompositeExtract 67 1
-              99:   68(fvec3) CompositeConstruct 97 98 26
-             100:    6(float) CompositeExtract 99 2
-             101:    6(float) ImageSampleDrefImplicitLod 96 99 100
-                              Store 88(r24) 101
-             106:         103 Load 105(g_tTexcdf4)
-             107:          18 Load 20(g_sSamp)
-             110:         109 SampledImage 106 107
-             113:    6(float) CompositeExtract 112 0
-             114:    6(float) CompositeExtract 112 1
-             115:    6(float) CompositeExtract 112 2
-             116:    7(fvec4) CompositeConstruct 113 114 115 26
-             117:    6(float) CompositeExtract 116 3
-             118:    6(float) ImageSampleDrefImplicitLod 110 116 117
-                              Store 102(r50) 118
-             123:         120 Load 122(g_tTexcdi4)
-             124:          18 Load 20(g_sSamp)
-             127:         126 SampledImage 123 124
-             128:    6(float) CompositeExtract 112 0
-             129:    6(float) CompositeExtract 112 1
-             130:    6(float) CompositeExtract 112 2
-             131:    7(fvec4) CompositeConstruct 128 129 130 26
-             132:    6(float) CompositeExtract 131 3
-             133:    6(float) ImageSampleDrefImplicitLod 127 131 132
-                              Store 119(r52) 133
-             138:         135 Load 137(g_tTexcdu4)
-             139:          18 Load 20(g_sSamp)
-             142:         141 SampledImage 138 139
-             143:    6(float) CompositeExtract 112 0
-             144:    6(float) CompositeExtract 112 1
-             145:    6(float) CompositeExtract 112 2
-             146:    7(fvec4) CompositeConstruct 143 144 145 26
-             147:    6(float) CompositeExtract 146 3
-             148:    6(float) ImageSampleDrefImplicitLod 142 146 147
-                              Store 134(r54) 148
-             155:    154(ptr) AccessChain 150(psout) 151
-                              Store 155 153
-             157:     12(ptr) AccessChain 150(psout) 156
-                              Store 157 152
-             158:8(PS_OUTPUT) Load 150(psout)
-                              ReturnValue 158
+              23:          22 SampledImage 17 21
+              27:   26(fvec2) CompositeConstruct 24 25
+              28:    6(float) CompositeExtract 27 1
+              29:    6(float) ImageSampleDrefImplicitLod 23 27 28
+                              Store 13(r00) 29
+              35:          32 Load 34(g_tTex1di4)
+              36:          18 Load 20(g_sSamp)
+              38:          37 SampledImage 35 36
+              39:   26(fvec2) CompositeConstruct 24 25
+              40:    6(float) CompositeExtract 39 1
+              41:    6(float) ImageSampleDrefImplicitLod 38 39 40
+                              Store 30(r02) 41
+              47:          44 Load 46(g_tTex1du4)
+              48:          18 Load 20(g_sSamp)
+              50:          49 SampledImage 47 48
+              51:   26(fvec2) CompositeConstruct 24 25
+              52:    6(float) CompositeExtract 51 1
+              53:    6(float) ImageSampleDrefImplicitLod 50 51 52
+                              Store 42(r04) 53
+              58:          55 Load 57(g_tTex2df4)
+              59:          18 Load 20(g_sSamp)
+              61:          60 SampledImage 58 59
+              65:    6(float) CompositeExtract 63 0
+              66:    6(float) CompositeExtract 63 1
+              67:   64(fvec3) CompositeConstruct 65 66 25
+              68:    6(float) CompositeExtract 67 2
+              69:    6(float) ImageSampleDrefImplicitLod 61 67 68
+                              Store 54(r20) 69
+              74:          71 Load 73(g_tTex2di4)
+              75:          18 Load 20(g_sSamp)
+              77:          76 SampledImage 74 75
+              78:    6(float) CompositeExtract 63 0
+              79:    6(float) CompositeExtract 63 1
+              80:   64(fvec3) CompositeConstruct 78 79 25
+              81:    6(float) CompositeExtract 80 2
+              82:    6(float) ImageSampleDrefImplicitLod 77 80 81
+                              Store 70(r22) 82
+              87:          84 Load 86(g_tTex2du4)
+              88:          18 Load 20(g_sSamp)
+              90:          89 SampledImage 87 88
+              91:    6(float) CompositeExtract 63 0
+              92:    6(float) CompositeExtract 63 1
+              93:   64(fvec3) CompositeConstruct 91 92 25
+              94:    6(float) CompositeExtract 93 2
+              95:    6(float) ImageSampleDrefImplicitLod 90 93 94
+                              Store 83(r24) 95
+             100:          97 Load 99(g_tTexcdf4)
+             101:          18 Load 20(g_sSamp)
+             103:         102 SampledImage 100 101
+             106:    6(float) CompositeExtract 105 0
+             107:    6(float) CompositeExtract 105 1
+             108:    6(float) CompositeExtract 105 2
+             109:    7(fvec4) CompositeConstruct 106 107 108 25
+             110:    6(float) CompositeExtract 109 3
+             111:    6(float) ImageSampleDrefImplicitLod 103 109 110
+                              Store 96(r50) 111
+             116:         113 Load 115(g_tTexcdi4)
+             117:          18 Load 20(g_sSamp)
+             119:         118 SampledImage 116 117
+             120:    6(float) CompositeExtract 105 0
+             121:    6(float) CompositeExtract 105 1
+             122:    6(float) CompositeExtract 105 2
+             123:    7(fvec4) CompositeConstruct 120 121 122 25
+             124:    6(float) CompositeExtract 123 3
+             125:    6(float) ImageSampleDrefImplicitLod 119 123 124
+                              Store 112(r52) 125
+             130:         127 Load 129(g_tTexcdu4)
+             131:          18 Load 20(g_sSamp)
+             133:         132 SampledImage 130 131
+             134:    6(float) CompositeExtract 105 0
+             135:    6(float) CompositeExtract 105 1
+             136:    6(float) CompositeExtract 105 2
+             137:    7(fvec4) CompositeConstruct 134 135 136 25
+             138:    6(float) CompositeExtract 137 3
+             139:    6(float) ImageSampleDrefImplicitLod 133 137 138
+                              Store 126(r54) 139
+             146:    145(ptr) AccessChain 141(psout) 142
+                              Store 146 144
+             148:     12(ptr) AccessChain 141(psout) 147
+                              Store 148 143
+             149:8(PS_OUTPUT) Load 141(psout)
+                              ReturnValue 149
                               FunctionEnd

--- a/Test/baseResults/hlsl.samplecmp.negative.frag.out
+++ b/Test/baseResults/hlsl.samplecmp.negative.frag.out
@@ -1,47 +1,48 @@
 hlsl.samplecmp.negative.frag
-ERROR: 0:9: '' : expected: SamplerComparisonState 
+ERROR: 0:10: '' : expected: SamplerComparisonState 
 ERROR: 1 compilation errors.  No code generated.
 
 
 Shader version: 500
 gl_FragCoord origin is upper left
 ERROR: node is still EOpNull!
-0:7  Function Definition: @main( ( temp 4-component vector of float)
-0:7    Function Parameters: 
+0:8  Function Definition: @main( ( temp 4-component vector of float)
+0:8    Function Parameters: 
 0:?     Sequence
-0:8      texture ( temp float)
-0:8        Construct combined texture-sampler ( temp sampler2DShadow)
-0:8          'g_shadowTex' ( uniform texture2D)
-0:8          'g_shadowSamplerComp' ( uniform sampler)
-0:8        Construct vec3 ( temp 3-component vector of float)
+0:9      texture ( temp float)
+0:9        Construct combined texture-sampler ( temp sampler2DShadow)
+0:9          'g_shadowTex' ( uniform texture2DShadow)
+0:9          'g_shadowSamplerComp' ( uniform sampler)
+0:9        Construct vec3 ( temp 3-component vector of float)
 0:?           Constant:
 0:?             0.000000
 0:?             0.000000
-0:8          Constant:
-0:8            0.000000
-0:9      ERROR: Bad aggregation op
+0:9          Constant:
+0:9            0.000000
+0:10      ERROR: Bad aggregation op
  ( temp float)
-0:9        'g_shadowTex' ( uniform texture2D)
-0:9        'g_shadowSampler' ( uniform sampler)
+0:10        'g_nonShadowTex' ( uniform texture2D)
+0:10        'g_shadowSampler' ( uniform sampler)
 0:?         Constant:
 0:?           0.000000
 0:?           0.000000
-0:9        Constant:
-0:9          0.000000
-0:11      Branch: Return with expression
-0:11        Constant:
-0:11          0.000000
-0:11          0.000000
-0:11          0.000000
-0:11          0.000000
-0:7  Function Definition: main( ( temp void)
-0:7    Function Parameters: 
+0:10        Constant:
+0:10          0.000000
+0:12      Branch: Return with expression
+0:12        Constant:
+0:12          0.000000
+0:12          0.000000
+0:12          0.000000
+0:12          0.000000
+0:8  Function Definition: main( ( temp void)
+0:8    Function Parameters: 
 0:?     Sequence
-0:7      move second child to first child ( temp 4-component vector of float)
+0:8      move second child to first child ( temp 4-component vector of float)
 0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
-0:7        Function Call: @main( ( temp 4-component vector of float)
+0:8        Function Call: @main( ( temp 4-component vector of float)
 0:?   Linker Objects
-0:?     'g_shadowTex' ( uniform texture2D)
+0:?     'g_nonShadowTex' ( uniform texture2D)
+0:?     'g_shadowTex' ( uniform texture2DShadow)
 0:?     'g_shadowSampler' ( uniform sampler)
 0:?     'g_shadowSamplerComp' ( uniform sampler)
 0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
@@ -53,42 +54,43 @@ Linked fragment stage:
 Shader version: 500
 gl_FragCoord origin is upper left
 ERROR: node is still EOpNull!
-0:7  Function Definition: @main( ( temp 4-component vector of float)
-0:7    Function Parameters: 
+0:8  Function Definition: @main( ( temp 4-component vector of float)
+0:8    Function Parameters: 
 0:?     Sequence
-0:8      texture ( temp float)
-0:8        Construct combined texture-sampler ( temp sampler2DShadow)
-0:8          'g_shadowTex' ( uniform texture2D)
-0:8          'g_shadowSamplerComp' ( uniform sampler)
-0:8        Construct vec3 ( temp 3-component vector of float)
+0:9      texture ( temp float)
+0:9        Construct combined texture-sampler ( temp sampler2DShadow)
+0:9          'g_shadowTex' ( uniform texture2DShadow)
+0:9          'g_shadowSamplerComp' ( uniform sampler)
+0:9        Construct vec3 ( temp 3-component vector of float)
 0:?           Constant:
 0:?             0.000000
 0:?             0.000000
-0:8          Constant:
-0:8            0.000000
-0:9      ERROR: Bad aggregation op
+0:9          Constant:
+0:9            0.000000
+0:10      ERROR: Bad aggregation op
  ( temp float)
-0:9        'g_shadowTex' ( uniform texture2D)
-0:9        'g_shadowSampler' ( uniform sampler)
+0:10        'g_nonShadowTex' ( uniform texture2D)
+0:10        'g_shadowSampler' ( uniform sampler)
 0:?         Constant:
 0:?           0.000000
 0:?           0.000000
-0:9        Constant:
-0:9          0.000000
-0:11      Branch: Return with expression
-0:11        Constant:
-0:11          0.000000
-0:11          0.000000
-0:11          0.000000
-0:11          0.000000
-0:7  Function Definition: main( ( temp void)
-0:7    Function Parameters: 
+0:10        Constant:
+0:10          0.000000
+0:12      Branch: Return with expression
+0:12        Constant:
+0:12          0.000000
+0:12          0.000000
+0:12          0.000000
+0:12          0.000000
+0:8  Function Definition: main( ( temp void)
+0:8    Function Parameters: 
 0:?     Sequence
-0:7      move second child to first child ( temp 4-component vector of float)
+0:8      move second child to first child ( temp 4-component vector of float)
 0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
-0:7        Function Call: @main( ( temp 4-component vector of float)
+0:8        Function Call: @main( ( temp 4-component vector of float)
 0:?   Linker Objects
-0:?     'g_shadowTex' ( uniform texture2D)
+0:?     'g_nonShadowTex' ( uniform texture2D)
+0:?     'g_shadowTex' ( uniform texture2DShadow)
 0:?     'g_shadowSampler' ( uniform sampler)
 0:?     'g_shadowSamplerComp' ( uniform sampler)
 0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)

--- a/Test/baseResults/hlsl.samplecmp.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmp.offset.dx10.frag.out
@@ -10,7 +10,7 @@ gl_FragCoord origin is upper left
 0:42          'r01' ( temp float)
 0:42          textureOffset ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DShadow)
-0:42              'g_tTex1df4' (layout( binding=0) uniform texture1D)
+0:42              'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec2 ( temp 2-component vector of float)
 0:42              Constant:
@@ -24,7 +24,7 @@ gl_FragCoord origin is upper left
 0:43          'r03' ( temp float)
 0:43          textureOffset ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DShadow)
-0:43              'g_tTex1di4' ( uniform itexture1D)
+0:43              'g_tTex1di4' ( uniform itexture1DShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec2 ( temp 2-component vector of float)
 0:43              Constant:
@@ -38,7 +38,7 @@ gl_FragCoord origin is upper left
 0:44          'r05' ( temp float)
 0:44          textureOffset ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DShadow)
-0:44              'g_tTex1du4' ( uniform utexture1D)
+0:44              'g_tTex1du4' ( uniform utexture1DShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec2 ( temp 2-component vector of float)
 0:44              Constant:
@@ -52,7 +52,7 @@ gl_FragCoord origin is upper left
 0:47          'r21' ( temp float)
 0:47          textureOffset ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DShadow)
-0:47              'g_tTex2df4' ( uniform texture2D)
+0:47              'g_tTex2df4' ( uniform texture2DShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -68,7 +68,7 @@ gl_FragCoord origin is upper left
 0:48          'r23' ( temp float)
 0:48          textureOffset ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DShadow)
-0:48              'g_tTex2di4' ( uniform itexture2D)
+0:48              'g_tTex2di4' ( uniform itexture2DShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -84,7 +84,7 @@ gl_FragCoord origin is upper left
 0:49          'r25' ( temp float)
 0:49          textureOffset ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DShadow)
-0:49              'g_tTex2du4' ( uniform utexture2D)
+0:49              'g_tTex2du4' ( uniform utexture2DShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -135,12 +135,12 @@ gl_FragCoord origin is upper left
 0:38              1 (const int)
 0:?   Linker Objects
 0:?     'g_sSamp' (layout( binding=0) uniform sampler)
-0:?     'g_tTex1df4' (layout( binding=0) uniform texture1D)
-0:?     'g_tTex1di4' ( uniform itexture1D)
-0:?     'g_tTex1du4' ( uniform utexture1D)
-0:?     'g_tTex2df4' ( uniform texture2D)
-0:?     'g_tTex2di4' ( uniform itexture2D)
-0:?     'g_tTex2du4' ( uniform utexture2D)
+0:?     'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
+0:?     'g_tTex1di4' ( uniform itexture1DShadow)
+0:?     'g_tTex1du4' ( uniform utexture1DShadow)
+0:?     'g_tTex2df4' ( uniform texture2DShadow)
+0:?     'g_tTex2di4' ( uniform itexture2DShadow)
+0:?     'g_tTex2du4' ( uniform utexture2DShadow)
 0:?     'g_tTex3df4' ( uniform texture3D)
 0:?     'g_tTex3di4' ( uniform itexture3D)
 0:?     'g_tTex3du4' ( uniform utexture3D)
@@ -174,7 +174,7 @@ gl_FragCoord origin is upper left
 0:42          'r01' ( temp float)
 0:42          textureOffset ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DShadow)
-0:42              'g_tTex1df4' (layout( binding=0) uniform texture1D)
+0:42              'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec2 ( temp 2-component vector of float)
 0:42              Constant:
@@ -188,7 +188,7 @@ gl_FragCoord origin is upper left
 0:43          'r03' ( temp float)
 0:43          textureOffset ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DShadow)
-0:43              'g_tTex1di4' ( uniform itexture1D)
+0:43              'g_tTex1di4' ( uniform itexture1DShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec2 ( temp 2-component vector of float)
 0:43              Constant:
@@ -202,7 +202,7 @@ gl_FragCoord origin is upper left
 0:44          'r05' ( temp float)
 0:44          textureOffset ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DShadow)
-0:44              'g_tTex1du4' ( uniform utexture1D)
+0:44              'g_tTex1du4' ( uniform utexture1DShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec2 ( temp 2-component vector of float)
 0:44              Constant:
@@ -216,7 +216,7 @@ gl_FragCoord origin is upper left
 0:47          'r21' ( temp float)
 0:47          textureOffset ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DShadow)
-0:47              'g_tTex2df4' ( uniform texture2D)
+0:47              'g_tTex2df4' ( uniform texture2DShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -232,7 +232,7 @@ gl_FragCoord origin is upper left
 0:48          'r23' ( temp float)
 0:48          textureOffset ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DShadow)
-0:48              'g_tTex2di4' ( uniform itexture2D)
+0:48              'g_tTex2di4' ( uniform itexture2DShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -248,7 +248,7 @@ gl_FragCoord origin is upper left
 0:49          'r25' ( temp float)
 0:49          textureOffset ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DShadow)
-0:49              'g_tTex2du4' ( uniform utexture2D)
+0:49              'g_tTex2du4' ( uniform utexture2DShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -299,12 +299,12 @@ gl_FragCoord origin is upper left
 0:38              1 (const int)
 0:?   Linker Objects
 0:?     'g_sSamp' (layout( binding=0) uniform sampler)
-0:?     'g_tTex1df4' (layout( binding=0) uniform texture1D)
-0:?     'g_tTex1di4' ( uniform itexture1D)
-0:?     'g_tTex1du4' ( uniform utexture1D)
-0:?     'g_tTex2df4' ( uniform texture2D)
-0:?     'g_tTex2di4' ( uniform itexture2D)
-0:?     'g_tTex2du4' ( uniform utexture2D)
+0:?     'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
+0:?     'g_tTex1di4' ( uniform itexture1DShadow)
+0:?     'g_tTex1du4' ( uniform utexture1DShadow)
+0:?     'g_tTex2df4' ( uniform texture2DShadow)
+0:?     'g_tTex2di4' ( uniform itexture2DShadow)
+0:?     'g_tTex2du4' ( uniform utexture2DShadow)
 0:?     'g_tTex3df4' ( uniform texture3D)
 0:?     'g_tTex3di4' ( uniform itexture3D)
 0:?     'g_tTex3du4' ( uniform utexture3D)
@@ -325,14 +325,14 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 173
+// Id's are bound by 167
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 121 125
+                              EntryPoint Fragment 4  "main" 115 119
                               ExecutionMode 4 OriginUpperLeft
                               Source HLSL 500
                               Name 4  "main"
@@ -343,61 +343,61 @@ gl_FragCoord origin is upper left
                               Name 13  "r01"
                               Name 16  "g_tTex1df4"
                               Name 20  "g_sSamp"
-                              Name 33  "r03"
-                              Name 36  "g_tTex1di4"
-                              Name 45  "r05"
-                              Name 49  "g_tTex1du4"
-                              Name 58  "r21"
-                              Name 61  "g_tTex2df4"
-                              Name 78  "r23"
-                              Name 81  "g_tTex2di4"
-                              Name 92  "r25"
-                              Name 95  "g_tTex2du4"
-                              Name 107  "psout"
-                              Name 118  "flattenTemp"
-                              Name 121  "@entryPointOutput.Color"
-                              Name 125  "@entryPointOutput.Depth"
-                              Name 130  "g_tTex3df4"
-                              Name 133  "g_tTex3di4"
-                              Name 136  "g_tTex3du4"
-                              Name 139  "g_tTexcdf4"
-                              Name 142  "g_tTexcdi4"
-                              Name 145  "g_tTexcdu4"
-                              Name 148  "g_tTex1df4a"
-                              Name 151  "g_tTex1di4a"
-                              Name 154  "g_tTex1du4a"
-                              Name 157  "g_tTex2df4a"
-                              Name 160  "g_tTex2di4a"
-                              Name 163  "g_tTex2du4a"
-                              Name 166  "g_tTexcdf4a"
-                              Name 169  "g_tTexcdi4a"
-                              Name 172  "g_tTexcdu4a"
+                              Name 32  "r03"
+                              Name 35  "g_tTex1di4"
+                              Name 43  "r05"
+                              Name 47  "g_tTex1du4"
+                              Name 55  "r21"
+                              Name 58  "g_tTex2df4"
+                              Name 74  "r23"
+                              Name 77  "g_tTex2di4"
+                              Name 87  "r25"
+                              Name 90  "g_tTex2du4"
+                              Name 101  "psout"
+                              Name 112  "flattenTemp"
+                              Name 115  "@entryPointOutput.Color"
+                              Name 119  "@entryPointOutput.Depth"
+                              Name 124  "g_tTex3df4"
+                              Name 127  "g_tTex3di4"
+                              Name 130  "g_tTex3du4"
+                              Name 133  "g_tTexcdf4"
+                              Name 136  "g_tTexcdi4"
+                              Name 139  "g_tTexcdu4"
+                              Name 142  "g_tTex1df4a"
+                              Name 145  "g_tTex1di4a"
+                              Name 148  "g_tTex1du4a"
+                              Name 151  "g_tTex2df4a"
+                              Name 154  "g_tTex2di4a"
+                              Name 157  "g_tTex2du4a"
+                              Name 160  "g_tTexcdf4a"
+                              Name 163  "g_tTexcdi4a"
+                              Name 166  "g_tTexcdu4a"
                               Decorate 16(g_tTex1df4) DescriptorSet 0
                               Decorate 16(g_tTex1df4) Binding 0
                               Decorate 20(g_sSamp) DescriptorSet 0
                               Decorate 20(g_sSamp) Binding 0
-                              Decorate 36(g_tTex1di4) DescriptorSet 0
-                              Decorate 49(g_tTex1du4) DescriptorSet 0
-                              Decorate 61(g_tTex2df4) DescriptorSet 0
-                              Decorate 81(g_tTex2di4) DescriptorSet 0
-                              Decorate 95(g_tTex2du4) DescriptorSet 0
-                              Decorate 121(@entryPointOutput.Color) Location 0
-                              Decorate 125(@entryPointOutput.Depth) BuiltIn FragDepth
-                              Decorate 130(g_tTex3df4) DescriptorSet 0
-                              Decorate 133(g_tTex3di4) DescriptorSet 0
-                              Decorate 136(g_tTex3du4) DescriptorSet 0
-                              Decorate 139(g_tTexcdf4) DescriptorSet 0
-                              Decorate 142(g_tTexcdi4) DescriptorSet 0
-                              Decorate 145(g_tTexcdu4) DescriptorSet 0
-                              Decorate 148(g_tTex1df4a) DescriptorSet 0
-                              Decorate 151(g_tTex1di4a) DescriptorSet 0
-                              Decorate 154(g_tTex1du4a) DescriptorSet 0
-                              Decorate 157(g_tTex2df4a) DescriptorSet 0
-                              Decorate 160(g_tTex2di4a) DescriptorSet 0
-                              Decorate 163(g_tTex2du4a) DescriptorSet 0
-                              Decorate 166(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 169(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 172(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 35(g_tTex1di4) DescriptorSet 0
+                              Decorate 47(g_tTex1du4) DescriptorSet 0
+                              Decorate 58(g_tTex2df4) DescriptorSet 0
+                              Decorate 77(g_tTex2di4) DescriptorSet 0
+                              Decorate 90(g_tTex2du4) DescriptorSet 0
+                              Decorate 115(@entryPointOutput.Color) Location 0
+                              Decorate 119(@entryPointOutput.Depth) BuiltIn FragDepth
+                              Decorate 124(g_tTex3df4) DescriptorSet 0
+                              Decorate 127(g_tTex3di4) DescriptorSet 0
+                              Decorate 130(g_tTex3du4) DescriptorSet 0
+                              Decorate 133(g_tTexcdf4) DescriptorSet 0
+                              Decorate 136(g_tTexcdi4) DescriptorSet 0
+                              Decorate 139(g_tTexcdu4) DescriptorSet 0
+                              Decorate 142(g_tTex1df4a) DescriptorSet 0
+                              Decorate 145(g_tTex1di4a) DescriptorSet 0
+                              Decorate 148(g_tTex1du4a) DescriptorSet 0
+                              Decorate 151(g_tTex2df4a) DescriptorSet 0
+                              Decorate 154(g_tTex2di4a) DescriptorSet 0
+                              Decorate 157(g_tTex2du4a) DescriptorSet 0
+                              Decorate 160(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 163(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 166(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -405,180 +405,174 @@ gl_FragCoord origin is upper left
     8(PS_OUTPUT):             TypeStruct 7(fvec4) 6(float)
                9:             TypeFunction 8(PS_OUTPUT)
               12:             TypePointer Function 6(float)
-              14:             TypeImage 6(float) 1D sampled format:Unknown
+              14:             TypeImage 6(float) 1D depth sampled format:Unknown
               15:             TypePointer UniformConstant 14
   16(g_tTex1df4):     15(ptr) Variable UniformConstant
               18:             TypeSampler
               19:             TypePointer UniformConstant 18
      20(g_sSamp):     19(ptr) Variable UniformConstant
-              22:             TypeImage 6(float) 1D depth sampled format:Unknown
-              23:             TypeSampledImage 22
-              25:    6(float) Constant 1036831949
-              26:    6(float) Constant 1061158912
-              27:             TypeVector 6(float) 2
-              29:             TypeInt 32 1
-              30:     29(int) Constant 2
-              34:             TypeImage 29(int) 1D sampled format:Unknown
-              35:             TypePointer UniformConstant 34
-  36(g_tTex1di4):     35(ptr) Variable UniformConstant
-              39:             TypeImage 29(int) 1D depth sampled format:Unknown
-              40:             TypeSampledImage 39
-              46:             TypeInt 32 0
-              47:             TypeImage 46(int) 1D sampled format:Unknown
-              48:             TypePointer UniformConstant 47
-  49(g_tTex1du4):     48(ptr) Variable UniformConstant
-              52:             TypeImage 46(int) 1D depth sampled format:Unknown
-              53:             TypeSampledImage 52
-              59:             TypeImage 6(float) 2D sampled format:Unknown
-              60:             TypePointer UniformConstant 59
-  61(g_tTex2df4):     60(ptr) Variable UniformConstant
-              64:             TypeImage 6(float) 2D depth sampled format:Unknown
-              65:             TypeSampledImage 64
-              67:    6(float) Constant 1045220557
-              68:   27(fvec2) ConstantComposite 25 67
-              69:             TypeVector 6(float) 3
-              73:             TypeVector 29(int) 2
-              74:     29(int) Constant 3
-              75:   73(ivec2) ConstantComposite 30 74
-              79:             TypeImage 29(int) 2D sampled format:Unknown
-              80:             TypePointer UniformConstant 79
-  81(g_tTex2di4):     80(ptr) Variable UniformConstant
-              84:             TypeImage 29(int) 2D depth sampled format:Unknown
-              85:             TypeSampledImage 84
-              93:             TypeImage 46(int) 2D sampled format:Unknown
-              94:             TypePointer UniformConstant 93
-  95(g_tTex2du4):     94(ptr) Variable UniformConstant
-              98:             TypeImage 46(int) 2D depth sampled format:Unknown
-              99:             TypeSampledImage 98
-             106:             TypePointer Function 8(PS_OUTPUT)
-             108:     29(int) Constant 0
-             109:    6(float) Constant 1065353216
-             110:    7(fvec4) ConstantComposite 109 109 109 109
-             111:             TypePointer Function 7(fvec4)
-             113:     29(int) Constant 1
-             120:             TypePointer Output 7(fvec4)
-121(@entryPointOutput.Color):    120(ptr) Variable Output
-             124:             TypePointer Output 6(float)
-125(@entryPointOutput.Depth):    124(ptr) Variable Output
-             128:             TypeImage 6(float) 3D sampled format:Unknown
+              22:             TypeSampledImage 14
+              24:    6(float) Constant 1036831949
+              25:    6(float) Constant 1061158912
+              26:             TypeVector 6(float) 2
+              28:             TypeInt 32 1
+              29:     28(int) Constant 2
+              33:             TypeImage 28(int) 1D depth sampled format:Unknown
+              34:             TypePointer UniformConstant 33
+  35(g_tTex1di4):     34(ptr) Variable UniformConstant
+              38:             TypeSampledImage 33
+              44:             TypeInt 32 0
+              45:             TypeImage 44(int) 1D depth sampled format:Unknown
+              46:             TypePointer UniformConstant 45
+  47(g_tTex1du4):     46(ptr) Variable UniformConstant
+              50:             TypeSampledImage 45
+              56:             TypeImage 6(float) 2D depth sampled format:Unknown
+              57:             TypePointer UniformConstant 56
+  58(g_tTex2df4):     57(ptr) Variable UniformConstant
+              61:             TypeSampledImage 56
+              63:    6(float) Constant 1045220557
+              64:   26(fvec2) ConstantComposite 24 63
+              65:             TypeVector 6(float) 3
+              69:             TypeVector 28(int) 2
+              70:     28(int) Constant 3
+              71:   69(ivec2) ConstantComposite 29 70
+              75:             TypeImage 28(int) 2D depth sampled format:Unknown
+              76:             TypePointer UniformConstant 75
+  77(g_tTex2di4):     76(ptr) Variable UniformConstant
+              80:             TypeSampledImage 75
+              88:             TypeImage 44(int) 2D depth sampled format:Unknown
+              89:             TypePointer UniformConstant 88
+  90(g_tTex2du4):     89(ptr) Variable UniformConstant
+              93:             TypeSampledImage 88
+             100:             TypePointer Function 8(PS_OUTPUT)
+             102:     28(int) Constant 0
+             103:    6(float) Constant 1065353216
+             104:    7(fvec4) ConstantComposite 103 103 103 103
+             105:             TypePointer Function 7(fvec4)
+             107:     28(int) Constant 1
+             114:             TypePointer Output 7(fvec4)
+115(@entryPointOutput.Color):    114(ptr) Variable Output
+             118:             TypePointer Output 6(float)
+119(@entryPointOutput.Depth):    118(ptr) Variable Output
+             122:             TypeImage 6(float) 3D sampled format:Unknown
+             123:             TypePointer UniformConstant 122
+ 124(g_tTex3df4):    123(ptr) Variable UniformConstant
+             125:             TypeImage 28(int) 3D sampled format:Unknown
+             126:             TypePointer UniformConstant 125
+ 127(g_tTex3di4):    126(ptr) Variable UniformConstant
+             128:             TypeImage 44(int) 3D sampled format:Unknown
              129:             TypePointer UniformConstant 128
- 130(g_tTex3df4):    129(ptr) Variable UniformConstant
-             131:             TypeImage 29(int) 3D sampled format:Unknown
+ 130(g_tTex3du4):    129(ptr) Variable UniformConstant
+             131:             TypeImage 6(float) Cube sampled format:Unknown
              132:             TypePointer UniformConstant 131
- 133(g_tTex3di4):    132(ptr) Variable UniformConstant
-             134:             TypeImage 46(int) 3D sampled format:Unknown
+ 133(g_tTexcdf4):    132(ptr) Variable UniformConstant
+             134:             TypeImage 28(int) Cube sampled format:Unknown
              135:             TypePointer UniformConstant 134
- 136(g_tTex3du4):    135(ptr) Variable UniformConstant
-             137:             TypeImage 6(float) Cube sampled format:Unknown
+ 136(g_tTexcdi4):    135(ptr) Variable UniformConstant
+             137:             TypeImage 44(int) Cube sampled format:Unknown
              138:             TypePointer UniformConstant 137
- 139(g_tTexcdf4):    138(ptr) Variable UniformConstant
-             140:             TypeImage 29(int) Cube sampled format:Unknown
+ 139(g_tTexcdu4):    138(ptr) Variable UniformConstant
+             140:             TypeImage 6(float) 1D array sampled format:Unknown
              141:             TypePointer UniformConstant 140
- 142(g_tTexcdi4):    141(ptr) Variable UniformConstant
-             143:             TypeImage 46(int) Cube sampled format:Unknown
+142(g_tTex1df4a):    141(ptr) Variable UniformConstant
+             143:             TypeImage 28(int) 1D array sampled format:Unknown
              144:             TypePointer UniformConstant 143
- 145(g_tTexcdu4):    144(ptr) Variable UniformConstant
-             146:             TypeImage 6(float) 1D array sampled format:Unknown
+145(g_tTex1di4a):    144(ptr) Variable UniformConstant
+             146:             TypeImage 44(int) 1D array sampled format:Unknown
              147:             TypePointer UniformConstant 146
-148(g_tTex1df4a):    147(ptr) Variable UniformConstant
-             149:             TypeImage 29(int) 1D array sampled format:Unknown
+148(g_tTex1du4a):    147(ptr) Variable UniformConstant
+             149:             TypeImage 6(float) 2D array sampled format:Unknown
              150:             TypePointer UniformConstant 149
-151(g_tTex1di4a):    150(ptr) Variable UniformConstant
-             152:             TypeImage 46(int) 1D array sampled format:Unknown
+151(g_tTex2df4a):    150(ptr) Variable UniformConstant
+             152:             TypeImage 28(int) 2D array sampled format:Unknown
              153:             TypePointer UniformConstant 152
-154(g_tTex1du4a):    153(ptr) Variable UniformConstant
-             155:             TypeImage 6(float) 2D array sampled format:Unknown
+154(g_tTex2di4a):    153(ptr) Variable UniformConstant
+             155:             TypeImage 44(int) 2D array sampled format:Unknown
              156:             TypePointer UniformConstant 155
-157(g_tTex2df4a):    156(ptr) Variable UniformConstant
-             158:             TypeImage 29(int) 2D array sampled format:Unknown
+157(g_tTex2du4a):    156(ptr) Variable UniformConstant
+             158:             TypeImage 6(float) Cube array sampled format:Unknown
              159:             TypePointer UniformConstant 158
-160(g_tTex2di4a):    159(ptr) Variable UniformConstant
-             161:             TypeImage 46(int) 2D array sampled format:Unknown
+160(g_tTexcdf4a):    159(ptr) Variable UniformConstant
+             161:             TypeImage 28(int) Cube array sampled format:Unknown
              162:             TypePointer UniformConstant 161
-163(g_tTex2du4a):    162(ptr) Variable UniformConstant
-             164:             TypeImage 6(float) Cube array sampled format:Unknown
+163(g_tTexcdi4a):    162(ptr) Variable UniformConstant
+             164:             TypeImage 44(int) Cube array sampled format:Unknown
              165:             TypePointer UniformConstant 164
-166(g_tTexcdf4a):    165(ptr) Variable UniformConstant
-             167:             TypeImage 29(int) Cube array sampled format:Unknown
-             168:             TypePointer UniformConstant 167
-169(g_tTexcdi4a):    168(ptr) Variable UniformConstant
-             170:             TypeImage 46(int) Cube array sampled format:Unknown
-             171:             TypePointer UniformConstant 170
-172(g_tTexcdu4a):    171(ptr) Variable UniformConstant
+166(g_tTexcdu4a):    165(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
-118(flattenTemp):    106(ptr) Variable Function
-             119:8(PS_OUTPUT) FunctionCall 10(@main()
-                              Store 118(flattenTemp) 119
-             122:    111(ptr) AccessChain 118(flattenTemp) 108
-             123:    7(fvec4) Load 122
-                              Store 121(@entryPointOutput.Color) 123
-             126:     12(ptr) AccessChain 118(flattenTemp) 113
-             127:    6(float) Load 126
-                              Store 125(@entryPointOutput.Depth) 127
+112(flattenTemp):    100(ptr) Variable Function
+             113:8(PS_OUTPUT) FunctionCall 10(@main()
+                              Store 112(flattenTemp) 113
+             116:    105(ptr) AccessChain 112(flattenTemp) 102
+             117:    7(fvec4) Load 116
+                              Store 115(@entryPointOutput.Color) 117
+             120:     12(ptr) AccessChain 112(flattenTemp) 107
+             121:    6(float) Load 120
+                              Store 119(@entryPointOutput.Depth) 121
                               Return
                               FunctionEnd
       10(@main():8(PS_OUTPUT) Function None 9
               11:             Label
          13(r01):     12(ptr) Variable Function
-         33(r03):     12(ptr) Variable Function
-         45(r05):     12(ptr) Variable Function
-         58(r21):     12(ptr) Variable Function
-         78(r23):     12(ptr) Variable Function
-         92(r25):     12(ptr) Variable Function
-      107(psout):    106(ptr) Variable Function
+         32(r03):     12(ptr) Variable Function
+         43(r05):     12(ptr) Variable Function
+         55(r21):     12(ptr) Variable Function
+         74(r23):     12(ptr) Variable Function
+         87(r25):     12(ptr) Variable Function
+      101(psout):    100(ptr) Variable Function
               17:          14 Load 16(g_tTex1df4)
               21:          18 Load 20(g_sSamp)
-              24:          23 SampledImage 17 21
-              28:   27(fvec2) CompositeConstruct 25 26
-              31:    6(float) CompositeExtract 28 1
-              32:    6(float) ImageSampleDrefImplicitLod 24 28 31 ConstOffset 30
-                              Store 13(r01) 32
-              37:          34 Load 36(g_tTex1di4)
-              38:          18 Load 20(g_sSamp)
-              41:          40 SampledImage 37 38
-              42:   27(fvec2) CompositeConstruct 25 26
-              43:    6(float) CompositeExtract 42 1
-              44:    6(float) ImageSampleDrefImplicitLod 41 42 43 ConstOffset 30
-                              Store 33(r03) 44
-              50:          47 Load 49(g_tTex1du4)
-              51:          18 Load 20(g_sSamp)
-              54:          53 SampledImage 50 51
-              55:   27(fvec2) CompositeConstruct 25 26
-              56:    6(float) CompositeExtract 55 1
-              57:    6(float) ImageSampleDrefImplicitLod 54 55 56 ConstOffset 30
-                              Store 45(r05) 57
-              62:          59 Load 61(g_tTex2df4)
-              63:          18 Load 20(g_sSamp)
-              66:          65 SampledImage 62 63
-              70:    6(float) CompositeExtract 68 0
-              71:    6(float) CompositeExtract 68 1
-              72:   69(fvec3) CompositeConstruct 70 71 26
-              76:    6(float) CompositeExtract 72 2
-              77:    6(float) ImageSampleDrefImplicitLod 66 72 76 ConstOffset 75
-                              Store 58(r21) 77
-              82:          79 Load 81(g_tTex2di4)
-              83:          18 Load 20(g_sSamp)
-              86:          85 SampledImage 82 83
-              87:    6(float) CompositeExtract 68 0
-              88:    6(float) CompositeExtract 68 1
-              89:   69(fvec3) CompositeConstruct 87 88 26
-              90:    6(float) CompositeExtract 89 2
-              91:    6(float) ImageSampleDrefImplicitLod 86 89 90 ConstOffset 75
-                              Store 78(r23) 91
-              96:          93 Load 95(g_tTex2du4)
-              97:          18 Load 20(g_sSamp)
-             100:          99 SampledImage 96 97
-             101:    6(float) CompositeExtract 68 0
-             102:    6(float) CompositeExtract 68 1
-             103:   69(fvec3) CompositeConstruct 101 102 26
-             104:    6(float) CompositeExtract 103 2
-             105:    6(float) ImageSampleDrefImplicitLod 100 103 104 ConstOffset 75
-                              Store 92(r25) 105
-             112:    111(ptr) AccessChain 107(psout) 108
-                              Store 112 110
-             114:     12(ptr) AccessChain 107(psout) 113
-                              Store 114 109
-             115:8(PS_OUTPUT) Load 107(psout)
-                              ReturnValue 115
+              23:          22 SampledImage 17 21
+              27:   26(fvec2) CompositeConstruct 24 25
+              30:    6(float) CompositeExtract 27 1
+              31:    6(float) ImageSampleDrefImplicitLod 23 27 30 ConstOffset 29
+                              Store 13(r01) 31
+              36:          33 Load 35(g_tTex1di4)
+              37:          18 Load 20(g_sSamp)
+              39:          38 SampledImage 36 37
+              40:   26(fvec2) CompositeConstruct 24 25
+              41:    6(float) CompositeExtract 40 1
+              42:    6(float) ImageSampleDrefImplicitLod 39 40 41 ConstOffset 29
+                              Store 32(r03) 42
+              48:          45 Load 47(g_tTex1du4)
+              49:          18 Load 20(g_sSamp)
+              51:          50 SampledImage 48 49
+              52:   26(fvec2) CompositeConstruct 24 25
+              53:    6(float) CompositeExtract 52 1
+              54:    6(float) ImageSampleDrefImplicitLod 51 52 53 ConstOffset 29
+                              Store 43(r05) 54
+              59:          56 Load 58(g_tTex2df4)
+              60:          18 Load 20(g_sSamp)
+              62:          61 SampledImage 59 60
+              66:    6(float) CompositeExtract 64 0
+              67:    6(float) CompositeExtract 64 1
+              68:   65(fvec3) CompositeConstruct 66 67 25
+              72:    6(float) CompositeExtract 68 2
+              73:    6(float) ImageSampleDrefImplicitLod 62 68 72 ConstOffset 71
+                              Store 55(r21) 73
+              78:          75 Load 77(g_tTex2di4)
+              79:          18 Load 20(g_sSamp)
+              81:          80 SampledImage 78 79
+              82:    6(float) CompositeExtract 64 0
+              83:    6(float) CompositeExtract 64 1
+              84:   65(fvec3) CompositeConstruct 82 83 25
+              85:    6(float) CompositeExtract 84 2
+              86:    6(float) ImageSampleDrefImplicitLod 81 84 85 ConstOffset 71
+                              Store 74(r23) 86
+              91:          88 Load 90(g_tTex2du4)
+              92:          18 Load 20(g_sSamp)
+              94:          93 SampledImage 91 92
+              95:    6(float) CompositeExtract 64 0
+              96:    6(float) CompositeExtract 64 1
+              97:   65(fvec3) CompositeConstruct 95 96 25
+              98:    6(float) CompositeExtract 97 2
+              99:    6(float) ImageSampleDrefImplicitLod 94 97 98 ConstOffset 71
+                              Store 87(r25) 99
+             106:    105(ptr) AccessChain 101(psout) 102
+                              Store 106 104
+             108:     12(ptr) AccessChain 101(psout) 107
+                              Store 108 103
+             109:8(PS_OUTPUT) Load 101(psout)
+                              ReturnValue 109
                               FunctionEnd

--- a/Test/baseResults/hlsl.samplecmp.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmp.offsetarray.dx10.frag.out
@@ -10,7 +10,7 @@ gl_FragCoord origin is upper left
 0:42          'r11' ( temp float)
 0:42          textureOffset ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DArrayShadow)
-0:42              'g_tTex1df4a' ( uniform texture1DArray)
+0:42              'g_tTex1df4a' ( uniform texture1DArrayShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -25,7 +25,7 @@ gl_FragCoord origin is upper left
 0:43          'r13' ( temp float)
 0:43          textureOffset ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DArrayShadow)
-0:43              'g_tTex1di4a' ( uniform itexture1DArray)
+0:43              'g_tTex1di4a' ( uniform itexture1DArrayShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -40,7 +40,7 @@ gl_FragCoord origin is upper left
 0:44          'r15' ( temp float)
 0:44          textureOffset ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DArrayShadow)
-0:44              'g_tTex1du4a' ( uniform utexture1DArray)
+0:44              'g_tTex1du4a' ( uniform utexture1DArrayShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -55,7 +55,7 @@ gl_FragCoord origin is upper left
 0:47          'r31' ( temp float)
 0:47          textureOffset ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DArrayShadow)
-0:47              'g_tTex2df4a' ( uniform texture2DArray)
+0:47              'g_tTex2df4a' ( uniform texture2DArrayShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -72,7 +72,7 @@ gl_FragCoord origin is upper left
 0:48          'r33' ( temp float)
 0:48          textureOffset ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DArrayShadow)
-0:48              'g_tTex2di4a' ( uniform itexture2DArray)
+0:48              'g_tTex2di4a' ( uniform itexture2DArrayShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -89,7 +89,7 @@ gl_FragCoord origin is upper left
 0:49          'r35' ( temp float)
 0:49          textureOffset ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DArrayShadow)
-0:49              'g_tTex2du4a' ( uniform utexture2DArray)
+0:49              'g_tTex2du4a' ( uniform utexture2DArrayShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -153,12 +153,12 @@ gl_FragCoord origin is upper left
 0:?     'g_tTexcdf4' ( uniform textureCube)
 0:?     'g_tTexcdi4' ( uniform itextureCube)
 0:?     'g_tTexcdu4' ( uniform utextureCube)
-0:?     'g_tTex1df4a' ( uniform texture1DArray)
-0:?     'g_tTex1di4a' ( uniform itexture1DArray)
-0:?     'g_tTex1du4a' ( uniform utexture1DArray)
-0:?     'g_tTex2df4a' ( uniform texture2DArray)
-0:?     'g_tTex2di4a' ( uniform itexture2DArray)
-0:?     'g_tTex2du4a' ( uniform utexture2DArray)
+0:?     'g_tTex1df4a' ( uniform texture1DArrayShadow)
+0:?     'g_tTex1di4a' ( uniform itexture1DArrayShadow)
+0:?     'g_tTex1du4a' ( uniform utexture1DArrayShadow)
+0:?     'g_tTex2df4a' ( uniform texture2DArrayShadow)
+0:?     'g_tTex2di4a' ( uniform itexture2DArrayShadow)
+0:?     'g_tTex2du4a' ( uniform utexture2DArrayShadow)
 0:?     'g_tTexcdf4a' ( uniform textureCubeArray)
 0:?     'g_tTexcdi4a' ( uniform itextureCubeArray)
 0:?     'g_tTexcdu4a' ( uniform utextureCubeArray)
@@ -180,7 +180,7 @@ gl_FragCoord origin is upper left
 0:42          'r11' ( temp float)
 0:42          textureOffset ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DArrayShadow)
-0:42              'g_tTex1df4a' ( uniform texture1DArray)
+0:42              'g_tTex1df4a' ( uniform texture1DArrayShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -195,7 +195,7 @@ gl_FragCoord origin is upper left
 0:43          'r13' ( temp float)
 0:43          textureOffset ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DArrayShadow)
-0:43              'g_tTex1di4a' ( uniform itexture1DArray)
+0:43              'g_tTex1di4a' ( uniform itexture1DArrayShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -210,7 +210,7 @@ gl_FragCoord origin is upper left
 0:44          'r15' ( temp float)
 0:44          textureOffset ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DArrayShadow)
-0:44              'g_tTex1du4a' ( uniform utexture1DArray)
+0:44              'g_tTex1du4a' ( uniform utexture1DArrayShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -225,7 +225,7 @@ gl_FragCoord origin is upper left
 0:47          'r31' ( temp float)
 0:47          textureOffset ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DArrayShadow)
-0:47              'g_tTex2df4a' ( uniform texture2DArray)
+0:47              'g_tTex2df4a' ( uniform texture2DArrayShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -242,7 +242,7 @@ gl_FragCoord origin is upper left
 0:48          'r33' ( temp float)
 0:48          textureOffset ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DArrayShadow)
-0:48              'g_tTex2di4a' ( uniform itexture2DArray)
+0:48              'g_tTex2di4a' ( uniform itexture2DArrayShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -259,7 +259,7 @@ gl_FragCoord origin is upper left
 0:49          'r35' ( temp float)
 0:49          textureOffset ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DArrayShadow)
-0:49              'g_tTex2du4a' ( uniform utexture2DArray)
+0:49              'g_tTex2du4a' ( uniform utexture2DArrayShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -323,12 +323,12 @@ gl_FragCoord origin is upper left
 0:?     'g_tTexcdf4' ( uniform textureCube)
 0:?     'g_tTexcdi4' ( uniform itextureCube)
 0:?     'g_tTexcdu4' ( uniform utextureCube)
-0:?     'g_tTex1df4a' ( uniform texture1DArray)
-0:?     'g_tTex1di4a' ( uniform itexture1DArray)
-0:?     'g_tTex1du4a' ( uniform utexture1DArray)
-0:?     'g_tTex2df4a' ( uniform texture2DArray)
-0:?     'g_tTex2di4a' ( uniform itexture2DArray)
-0:?     'g_tTex2du4a' ( uniform utexture2DArray)
+0:?     'g_tTex1df4a' ( uniform texture1DArrayShadow)
+0:?     'g_tTex1di4a' ( uniform itexture1DArrayShadow)
+0:?     'g_tTex1du4a' ( uniform utexture1DArrayShadow)
+0:?     'g_tTex2df4a' ( uniform texture2DArrayShadow)
+0:?     'g_tTex2di4a' ( uniform itexture2DArrayShadow)
+0:?     'g_tTex2du4a' ( uniform utexture2DArrayShadow)
 0:?     'g_tTexcdf4a' ( uniform textureCubeArray)
 0:?     'g_tTexcdi4a' ( uniform itextureCubeArray)
 0:?     'g_tTexcdu4a' ( uniform utextureCubeArray)
@@ -337,14 +337,14 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 184
+// Id's are bound by 178
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 132 136
+                              EntryPoint Fragment 4  "main" 126 130
                               ExecutionMode 4 OriginUpperLeft
                               Source HLSL 500
                               Name 4  "main"
@@ -355,61 +355,61 @@ gl_FragCoord origin is upper left
                               Name 13  "r11"
                               Name 16  "g_tTex1df4a"
                               Name 20  "g_sSamp"
-                              Name 38  "r13"
-                              Name 41  "g_tTex1di4a"
-                              Name 52  "r15"
-                              Name 56  "g_tTex1du4a"
-                              Name 67  "r31"
-                              Name 70  "g_tTex2df4a"
-                              Name 87  "r33"
-                              Name 90  "g_tTex2di4a"
-                              Name 102  "r35"
-                              Name 105  "g_tTex2du4a"
-                              Name 118  "psout"
-                              Name 129  "flattenTemp"
-                              Name 132  "@entryPointOutput.Color"
-                              Name 136  "@entryPointOutput.Depth"
-                              Name 141  "g_tTex1df4"
-                              Name 144  "g_tTex1di4"
-                              Name 147  "g_tTex1du4"
-                              Name 150  "g_tTex2df4"
-                              Name 153  "g_tTex2di4"
-                              Name 156  "g_tTex2du4"
-                              Name 159  "g_tTex3df4"
-                              Name 162  "g_tTex3di4"
-                              Name 165  "g_tTex3du4"
-                              Name 168  "g_tTexcdf4"
-                              Name 171  "g_tTexcdi4"
-                              Name 174  "g_tTexcdu4"
-                              Name 177  "g_tTexcdf4a"
-                              Name 180  "g_tTexcdi4a"
-                              Name 183  "g_tTexcdu4a"
+                              Name 37  "r13"
+                              Name 40  "g_tTex1di4a"
+                              Name 50  "r15"
+                              Name 54  "g_tTex1du4a"
+                              Name 64  "r31"
+                              Name 67  "g_tTex2df4a"
+                              Name 83  "r33"
+                              Name 86  "g_tTex2di4a"
+                              Name 97  "r35"
+                              Name 100  "g_tTex2du4a"
+                              Name 112  "psout"
+                              Name 123  "flattenTemp"
+                              Name 126  "@entryPointOutput.Color"
+                              Name 130  "@entryPointOutput.Depth"
+                              Name 135  "g_tTex1df4"
+                              Name 138  "g_tTex1di4"
+                              Name 141  "g_tTex1du4"
+                              Name 144  "g_tTex2df4"
+                              Name 147  "g_tTex2di4"
+                              Name 150  "g_tTex2du4"
+                              Name 153  "g_tTex3df4"
+                              Name 156  "g_tTex3di4"
+                              Name 159  "g_tTex3du4"
+                              Name 162  "g_tTexcdf4"
+                              Name 165  "g_tTexcdi4"
+                              Name 168  "g_tTexcdu4"
+                              Name 171  "g_tTexcdf4a"
+                              Name 174  "g_tTexcdi4a"
+                              Name 177  "g_tTexcdu4a"
                               Decorate 16(g_tTex1df4a) DescriptorSet 0
                               Decorate 20(g_sSamp) DescriptorSet 0
                               Decorate 20(g_sSamp) Binding 0
-                              Decorate 41(g_tTex1di4a) DescriptorSet 0
-                              Decorate 56(g_tTex1du4a) DescriptorSet 0
-                              Decorate 70(g_tTex2df4a) DescriptorSet 0
-                              Decorate 90(g_tTex2di4a) DescriptorSet 0
-                              Decorate 105(g_tTex2du4a) DescriptorSet 0
-                              Decorate 132(@entryPointOutput.Color) Location 0
-                              Decorate 136(@entryPointOutput.Depth) BuiltIn FragDepth
-                              Decorate 141(g_tTex1df4) DescriptorSet 0
-                              Decorate 141(g_tTex1df4) Binding 0
-                              Decorate 144(g_tTex1di4) DescriptorSet 0
-                              Decorate 147(g_tTex1du4) DescriptorSet 0
-                              Decorate 150(g_tTex2df4) DescriptorSet 0
-                              Decorate 153(g_tTex2di4) DescriptorSet 0
-                              Decorate 156(g_tTex2du4) DescriptorSet 0
-                              Decorate 159(g_tTex3df4) DescriptorSet 0
-                              Decorate 162(g_tTex3di4) DescriptorSet 0
-                              Decorate 165(g_tTex3du4) DescriptorSet 0
-                              Decorate 168(g_tTexcdf4) DescriptorSet 0
-                              Decorate 171(g_tTexcdi4) DescriptorSet 0
-                              Decorate 174(g_tTexcdu4) DescriptorSet 0
-                              Decorate 177(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 180(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 183(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 40(g_tTex1di4a) DescriptorSet 0
+                              Decorate 54(g_tTex1du4a) DescriptorSet 0
+                              Decorate 67(g_tTex2df4a) DescriptorSet 0
+                              Decorate 86(g_tTex2di4a) DescriptorSet 0
+                              Decorate 100(g_tTex2du4a) DescriptorSet 0
+                              Decorate 126(@entryPointOutput.Color) Location 0
+                              Decorate 130(@entryPointOutput.Depth) BuiltIn FragDepth
+                              Decorate 135(g_tTex1df4) DescriptorSet 0
+                              Decorate 135(g_tTex1df4) Binding 0
+                              Decorate 138(g_tTex1di4) DescriptorSet 0
+                              Decorate 141(g_tTex1du4) DescriptorSet 0
+                              Decorate 144(g_tTex2df4) DescriptorSet 0
+                              Decorate 147(g_tTex2di4) DescriptorSet 0
+                              Decorate 150(g_tTex2du4) DescriptorSet 0
+                              Decorate 153(g_tTex3df4) DescriptorSet 0
+                              Decorate 156(g_tTex3di4) DescriptorSet 0
+                              Decorate 159(g_tTex3du4) DescriptorSet 0
+                              Decorate 162(g_tTexcdf4) DescriptorSet 0
+                              Decorate 165(g_tTexcdi4) DescriptorSet 0
+                              Decorate 168(g_tTexcdu4) DescriptorSet 0
+                              Decorate 171(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 174(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 177(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -417,191 +417,185 @@ gl_FragCoord origin is upper left
     8(PS_OUTPUT):             TypeStruct 7(fvec4) 6(float)
                9:             TypeFunction 8(PS_OUTPUT)
               12:             TypePointer Function 6(float)
-              14:             TypeImage 6(float) 1D array sampled format:Unknown
+              14:             TypeImage 6(float) 1D depth array sampled format:Unknown
               15:             TypePointer UniformConstant 14
  16(g_tTex1df4a):     15(ptr) Variable UniformConstant
               18:             TypeSampler
               19:             TypePointer UniformConstant 18
      20(g_sSamp):     19(ptr) Variable UniformConstant
-              22:             TypeImage 6(float) 1D depth array sampled format:Unknown
-              23:             TypeSampledImage 22
-              25:             TypeVector 6(float) 2
-              26:    6(float) Constant 1036831949
-              27:    6(float) Constant 1045220557
-              28:   25(fvec2) ConstantComposite 26 27
-              29:    6(float) Constant 1061158912
-              30:             TypeVector 6(float) 3
-              34:             TypeInt 32 1
-              35:     34(int) Constant 2
-              39:             TypeImage 34(int) 1D array sampled format:Unknown
-              40:             TypePointer UniformConstant 39
- 41(g_tTex1di4a):     40(ptr) Variable UniformConstant
-              44:             TypeImage 34(int) 1D depth array sampled format:Unknown
-              45:             TypeSampledImage 44
-              53:             TypeInt 32 0
-              54:             TypeImage 53(int) 1D array sampled format:Unknown
-              55:             TypePointer UniformConstant 54
- 56(g_tTex1du4a):     55(ptr) Variable UniformConstant
-              59:             TypeImage 53(int) 1D depth array sampled format:Unknown
-              60:             TypeSampledImage 59
-              68:             TypeImage 6(float) 2D array sampled format:Unknown
-              69:             TypePointer UniformConstant 68
- 70(g_tTex2df4a):     69(ptr) Variable UniformConstant
-              73:             TypeImage 6(float) 2D depth array sampled format:Unknown
-              74:             TypeSampledImage 73
-              76:    6(float) Constant 1050253722
-              77:   30(fvec3) ConstantComposite 26 27 76
-              82:             TypeVector 34(int) 2
-              83:     34(int) Constant 3
-              84:   82(ivec2) ConstantComposite 35 83
-              88:             TypeImage 34(int) 2D array sampled format:Unknown
-              89:             TypePointer UniformConstant 88
- 90(g_tTex2di4a):     89(ptr) Variable UniformConstant
-              93:             TypeImage 34(int) 2D depth array sampled format:Unknown
-              94:             TypeSampledImage 93
-             103:             TypeImage 53(int) 2D array sampled format:Unknown
-             104:             TypePointer UniformConstant 103
-105(g_tTex2du4a):    104(ptr) Variable UniformConstant
-             108:             TypeImage 53(int) 2D depth array sampled format:Unknown
-             109:             TypeSampledImage 108
-             117:             TypePointer Function 8(PS_OUTPUT)
-             119:     34(int) Constant 0
-             120:    6(float) Constant 1065353216
-             121:    7(fvec4) ConstantComposite 120 120 120 120
-             122:             TypePointer Function 7(fvec4)
-             124:     34(int) Constant 1
-             131:             TypePointer Output 7(fvec4)
-132(@entryPointOutput.Color):    131(ptr) Variable Output
-             135:             TypePointer Output 6(float)
-136(@entryPointOutput.Depth):    135(ptr) Variable Output
-             139:             TypeImage 6(float) 1D sampled format:Unknown
+              22:             TypeSampledImage 14
+              24:             TypeVector 6(float) 2
+              25:    6(float) Constant 1036831949
+              26:    6(float) Constant 1045220557
+              27:   24(fvec2) ConstantComposite 25 26
+              28:    6(float) Constant 1061158912
+              29:             TypeVector 6(float) 3
+              33:             TypeInt 32 1
+              34:     33(int) Constant 2
+              38:             TypeImage 33(int) 1D depth array sampled format:Unknown
+              39:             TypePointer UniformConstant 38
+ 40(g_tTex1di4a):     39(ptr) Variable UniformConstant
+              43:             TypeSampledImage 38
+              51:             TypeInt 32 0
+              52:             TypeImage 51(int) 1D depth array sampled format:Unknown
+              53:             TypePointer UniformConstant 52
+ 54(g_tTex1du4a):     53(ptr) Variable UniformConstant
+              57:             TypeSampledImage 52
+              65:             TypeImage 6(float) 2D depth array sampled format:Unknown
+              66:             TypePointer UniformConstant 65
+ 67(g_tTex2df4a):     66(ptr) Variable UniformConstant
+              70:             TypeSampledImage 65
+              72:    6(float) Constant 1050253722
+              73:   29(fvec3) ConstantComposite 25 26 72
+              78:             TypeVector 33(int) 2
+              79:     33(int) Constant 3
+              80:   78(ivec2) ConstantComposite 34 79
+              84:             TypeImage 33(int) 2D depth array sampled format:Unknown
+              85:             TypePointer UniformConstant 84
+ 86(g_tTex2di4a):     85(ptr) Variable UniformConstant
+              89:             TypeSampledImage 84
+              98:             TypeImage 51(int) 2D depth array sampled format:Unknown
+              99:             TypePointer UniformConstant 98
+100(g_tTex2du4a):     99(ptr) Variable UniformConstant
+             103:             TypeSampledImage 98
+             111:             TypePointer Function 8(PS_OUTPUT)
+             113:     33(int) Constant 0
+             114:    6(float) Constant 1065353216
+             115:    7(fvec4) ConstantComposite 114 114 114 114
+             116:             TypePointer Function 7(fvec4)
+             118:     33(int) Constant 1
+             125:             TypePointer Output 7(fvec4)
+126(@entryPointOutput.Color):    125(ptr) Variable Output
+             129:             TypePointer Output 6(float)
+130(@entryPointOutput.Depth):    129(ptr) Variable Output
+             133:             TypeImage 6(float) 1D sampled format:Unknown
+             134:             TypePointer UniformConstant 133
+ 135(g_tTex1df4):    134(ptr) Variable UniformConstant
+             136:             TypeImage 33(int) 1D sampled format:Unknown
+             137:             TypePointer UniformConstant 136
+ 138(g_tTex1di4):    137(ptr) Variable UniformConstant
+             139:             TypeImage 51(int) 1D sampled format:Unknown
              140:             TypePointer UniformConstant 139
- 141(g_tTex1df4):    140(ptr) Variable UniformConstant
-             142:             TypeImage 34(int) 1D sampled format:Unknown
+ 141(g_tTex1du4):    140(ptr) Variable UniformConstant
+             142:             TypeImage 6(float) 2D sampled format:Unknown
              143:             TypePointer UniformConstant 142
- 144(g_tTex1di4):    143(ptr) Variable UniformConstant
-             145:             TypeImage 53(int) 1D sampled format:Unknown
+ 144(g_tTex2df4):    143(ptr) Variable UniformConstant
+             145:             TypeImage 33(int) 2D sampled format:Unknown
              146:             TypePointer UniformConstant 145
- 147(g_tTex1du4):    146(ptr) Variable UniformConstant
-             148:             TypeImage 6(float) 2D sampled format:Unknown
+ 147(g_tTex2di4):    146(ptr) Variable UniformConstant
+             148:             TypeImage 51(int) 2D sampled format:Unknown
              149:             TypePointer UniformConstant 148
- 150(g_tTex2df4):    149(ptr) Variable UniformConstant
-             151:             TypeImage 34(int) 2D sampled format:Unknown
+ 150(g_tTex2du4):    149(ptr) Variable UniformConstant
+             151:             TypeImage 6(float) 3D sampled format:Unknown
              152:             TypePointer UniformConstant 151
- 153(g_tTex2di4):    152(ptr) Variable UniformConstant
-             154:             TypeImage 53(int) 2D sampled format:Unknown
+ 153(g_tTex3df4):    152(ptr) Variable UniformConstant
+             154:             TypeImage 33(int) 3D sampled format:Unknown
              155:             TypePointer UniformConstant 154
- 156(g_tTex2du4):    155(ptr) Variable UniformConstant
-             157:             TypeImage 6(float) 3D sampled format:Unknown
+ 156(g_tTex3di4):    155(ptr) Variable UniformConstant
+             157:             TypeImage 51(int) 3D sampled format:Unknown
              158:             TypePointer UniformConstant 157
- 159(g_tTex3df4):    158(ptr) Variable UniformConstant
-             160:             TypeImage 34(int) 3D sampled format:Unknown
+ 159(g_tTex3du4):    158(ptr) Variable UniformConstant
+             160:             TypeImage 6(float) Cube sampled format:Unknown
              161:             TypePointer UniformConstant 160
- 162(g_tTex3di4):    161(ptr) Variable UniformConstant
-             163:             TypeImage 53(int) 3D sampled format:Unknown
+ 162(g_tTexcdf4):    161(ptr) Variable UniformConstant
+             163:             TypeImage 33(int) Cube sampled format:Unknown
              164:             TypePointer UniformConstant 163
- 165(g_tTex3du4):    164(ptr) Variable UniformConstant
-             166:             TypeImage 6(float) Cube sampled format:Unknown
+ 165(g_tTexcdi4):    164(ptr) Variable UniformConstant
+             166:             TypeImage 51(int) Cube sampled format:Unknown
              167:             TypePointer UniformConstant 166
- 168(g_tTexcdf4):    167(ptr) Variable UniformConstant
-             169:             TypeImage 34(int) Cube sampled format:Unknown
+ 168(g_tTexcdu4):    167(ptr) Variable UniformConstant
+             169:             TypeImage 6(float) Cube array sampled format:Unknown
              170:             TypePointer UniformConstant 169
- 171(g_tTexcdi4):    170(ptr) Variable UniformConstant
-             172:             TypeImage 53(int) Cube sampled format:Unknown
+171(g_tTexcdf4a):    170(ptr) Variable UniformConstant
+             172:             TypeImage 33(int) Cube array sampled format:Unknown
              173:             TypePointer UniformConstant 172
- 174(g_tTexcdu4):    173(ptr) Variable UniformConstant
-             175:             TypeImage 6(float) Cube array sampled format:Unknown
+174(g_tTexcdi4a):    173(ptr) Variable UniformConstant
+             175:             TypeImage 51(int) Cube array sampled format:Unknown
              176:             TypePointer UniformConstant 175
-177(g_tTexcdf4a):    176(ptr) Variable UniformConstant
-             178:             TypeImage 34(int) Cube array sampled format:Unknown
-             179:             TypePointer UniformConstant 178
-180(g_tTexcdi4a):    179(ptr) Variable UniformConstant
-             181:             TypeImage 53(int) Cube array sampled format:Unknown
-             182:             TypePointer UniformConstant 181
-183(g_tTexcdu4a):    182(ptr) Variable UniformConstant
+177(g_tTexcdu4a):    176(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
-129(flattenTemp):    117(ptr) Variable Function
-             130:8(PS_OUTPUT) FunctionCall 10(@main()
-                              Store 129(flattenTemp) 130
-             133:    122(ptr) AccessChain 129(flattenTemp) 119
-             134:    7(fvec4) Load 133
-                              Store 132(@entryPointOutput.Color) 134
-             137:     12(ptr) AccessChain 129(flattenTemp) 124
-             138:    6(float) Load 137
-                              Store 136(@entryPointOutput.Depth) 138
+123(flattenTemp):    111(ptr) Variable Function
+             124:8(PS_OUTPUT) FunctionCall 10(@main()
+                              Store 123(flattenTemp) 124
+             127:    116(ptr) AccessChain 123(flattenTemp) 113
+             128:    7(fvec4) Load 127
+                              Store 126(@entryPointOutput.Color) 128
+             131:     12(ptr) AccessChain 123(flattenTemp) 118
+             132:    6(float) Load 131
+                              Store 130(@entryPointOutput.Depth) 132
                               Return
                               FunctionEnd
       10(@main():8(PS_OUTPUT) Function None 9
               11:             Label
          13(r11):     12(ptr) Variable Function
-         38(r13):     12(ptr) Variable Function
-         52(r15):     12(ptr) Variable Function
-         67(r31):     12(ptr) Variable Function
-         87(r33):     12(ptr) Variable Function
-        102(r35):     12(ptr) Variable Function
-      118(psout):    117(ptr) Variable Function
+         37(r13):     12(ptr) Variable Function
+         50(r15):     12(ptr) Variable Function
+         64(r31):     12(ptr) Variable Function
+         83(r33):     12(ptr) Variable Function
+         97(r35):     12(ptr) Variable Function
+      112(psout):    111(ptr) Variable Function
               17:          14 Load 16(g_tTex1df4a)
               21:          18 Load 20(g_sSamp)
-              24:          23 SampledImage 17 21
-              31:    6(float) CompositeExtract 28 0
-              32:    6(float) CompositeExtract 28 1
-              33:   30(fvec3) CompositeConstruct 31 32 29
-              36:    6(float) CompositeExtract 33 2
-              37:    6(float) ImageSampleDrefImplicitLod 24 33 36 ConstOffset 35
-                              Store 13(r11) 37
-              42:          39 Load 41(g_tTex1di4a)
-              43:          18 Load 20(g_sSamp)
-              46:          45 SampledImage 42 43
-              47:    6(float) CompositeExtract 28 0
-              48:    6(float) CompositeExtract 28 1
-              49:   30(fvec3) CompositeConstruct 47 48 29
-              50:    6(float) CompositeExtract 49 2
-              51:    6(float) ImageSampleDrefImplicitLod 46 49 50 ConstOffset 35
-                              Store 38(r13) 51
-              57:          54 Load 56(g_tTex1du4a)
-              58:          18 Load 20(g_sSamp)
-              61:          60 SampledImage 57 58
-              62:    6(float) CompositeExtract 28 0
-              63:    6(float) CompositeExtract 28 1
-              64:   30(fvec3) CompositeConstruct 62 63 29
-              65:    6(float) CompositeExtract 64 2
-              66:    6(float) ImageSampleDrefImplicitLod 61 64 65 ConstOffset 35
-                              Store 52(r15) 66
-              71:          68 Load 70(g_tTex2df4a)
-              72:          18 Load 20(g_sSamp)
-              75:          74 SampledImage 71 72
-              78:    6(float) CompositeExtract 77 0
-              79:    6(float) CompositeExtract 77 1
-              80:    6(float) CompositeExtract 77 2
-              81:    7(fvec4) CompositeConstruct 78 79 80 29
-              85:    6(float) CompositeExtract 81 3
-              86:    6(float) ImageSampleDrefImplicitLod 75 81 85 ConstOffset 84
-                              Store 67(r31) 86
-              91:          88 Load 90(g_tTex2di4a)
-              92:          18 Load 20(g_sSamp)
-              95:          94 SampledImage 91 92
-              96:    6(float) CompositeExtract 77 0
-              97:    6(float) CompositeExtract 77 1
-              98:    6(float) CompositeExtract 77 2
-              99:    7(fvec4) CompositeConstruct 96 97 98 29
-             100:    6(float) CompositeExtract 99 3
-             101:    6(float) ImageSampleDrefImplicitLod 95 99 100 ConstOffset 84
-                              Store 87(r33) 101
-             106:         103 Load 105(g_tTex2du4a)
-             107:          18 Load 20(g_sSamp)
-             110:         109 SampledImage 106 107
-             111:    6(float) CompositeExtract 77 0
-             112:    6(float) CompositeExtract 77 1
-             113:    6(float) CompositeExtract 77 2
-             114:    7(fvec4) CompositeConstruct 111 112 113 29
-             115:    6(float) CompositeExtract 114 3
-             116:    6(float) ImageSampleDrefImplicitLod 110 114 115 ConstOffset 84
-                              Store 102(r35) 116
-             123:    122(ptr) AccessChain 118(psout) 119
-                              Store 123 121
-             125:     12(ptr) AccessChain 118(psout) 124
-                              Store 125 120
-             126:8(PS_OUTPUT) Load 118(psout)
-                              ReturnValue 126
+              23:          22 SampledImage 17 21
+              30:    6(float) CompositeExtract 27 0
+              31:    6(float) CompositeExtract 27 1
+              32:   29(fvec3) CompositeConstruct 30 31 28
+              35:    6(float) CompositeExtract 32 2
+              36:    6(float) ImageSampleDrefImplicitLod 23 32 35 ConstOffset 34
+                              Store 13(r11) 36
+              41:          38 Load 40(g_tTex1di4a)
+              42:          18 Load 20(g_sSamp)
+              44:          43 SampledImage 41 42
+              45:    6(float) CompositeExtract 27 0
+              46:    6(float) CompositeExtract 27 1
+              47:   29(fvec3) CompositeConstruct 45 46 28
+              48:    6(float) CompositeExtract 47 2
+              49:    6(float) ImageSampleDrefImplicitLod 44 47 48 ConstOffset 34
+                              Store 37(r13) 49
+              55:          52 Load 54(g_tTex1du4a)
+              56:          18 Load 20(g_sSamp)
+              58:          57 SampledImage 55 56
+              59:    6(float) CompositeExtract 27 0
+              60:    6(float) CompositeExtract 27 1
+              61:   29(fvec3) CompositeConstruct 59 60 28
+              62:    6(float) CompositeExtract 61 2
+              63:    6(float) ImageSampleDrefImplicitLod 58 61 62 ConstOffset 34
+                              Store 50(r15) 63
+              68:          65 Load 67(g_tTex2df4a)
+              69:          18 Load 20(g_sSamp)
+              71:          70 SampledImage 68 69
+              74:    6(float) CompositeExtract 73 0
+              75:    6(float) CompositeExtract 73 1
+              76:    6(float) CompositeExtract 73 2
+              77:    7(fvec4) CompositeConstruct 74 75 76 28
+              81:    6(float) CompositeExtract 77 3
+              82:    6(float) ImageSampleDrefImplicitLod 71 77 81 ConstOffset 80
+                              Store 64(r31) 82
+              87:          84 Load 86(g_tTex2di4a)
+              88:          18 Load 20(g_sSamp)
+              90:          89 SampledImage 87 88
+              91:    6(float) CompositeExtract 73 0
+              92:    6(float) CompositeExtract 73 1
+              93:    6(float) CompositeExtract 73 2
+              94:    7(fvec4) CompositeConstruct 91 92 93 28
+              95:    6(float) CompositeExtract 94 3
+              96:    6(float) ImageSampleDrefImplicitLod 90 94 95 ConstOffset 80
+                              Store 83(r33) 96
+             101:          98 Load 100(g_tTex2du4a)
+             102:          18 Load 20(g_sSamp)
+             104:         103 SampledImage 101 102
+             105:    6(float) CompositeExtract 73 0
+             106:    6(float) CompositeExtract 73 1
+             107:    6(float) CompositeExtract 73 2
+             108:    7(fvec4) CompositeConstruct 105 106 107 28
+             109:    6(float) CompositeExtract 108 3
+             110:    6(float) ImageSampleDrefImplicitLod 104 108 109 ConstOffset 80
+                              Store 97(r35) 110
+             117:    116(ptr) AccessChain 112(psout) 113
+                              Store 117 115
+             119:     12(ptr) AccessChain 112(psout) 118
+                              Store 119 114
+             120:8(PS_OUTPUT) Load 112(psout)
+                              ReturnValue 120
                               FunctionEnd

--- a/Test/baseResults/hlsl.samplecmplevelzero.array.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmplevelzero.array.dx10.frag.out
@@ -10,7 +10,7 @@ gl_FragCoord origin is upper left
 0:42          'r10' ( temp float)
 0:42          textureLod ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DArrayShadow)
-0:42              'g_tTex1df4a' ( uniform texture1DArray)
+0:42              'g_tTex1df4a' ( uniform texture1DArrayShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -25,7 +25,7 @@ gl_FragCoord origin is upper left
 0:43          'r12' ( temp float)
 0:43          textureLod ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DArrayShadow)
-0:43              'g_tTex1di4a' ( uniform itexture1DArray)
+0:43              'g_tTex1di4a' ( uniform itexture1DArrayShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -40,7 +40,7 @@ gl_FragCoord origin is upper left
 0:44          'r14' ( temp float)
 0:44          textureLod ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DArrayShadow)
-0:44              'g_tTex1du4a' ( uniform utexture1DArray)
+0:44              'g_tTex1du4a' ( uniform utexture1DArrayShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -55,7 +55,7 @@ gl_FragCoord origin is upper left
 0:47          'r30' ( temp float)
 0:47          textureLod ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DArrayShadow)
-0:47              'g_tTex2df4a' ( uniform texture2DArray)
+0:47              'g_tTex2df4a' ( uniform texture2DArrayShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -71,7 +71,7 @@ gl_FragCoord origin is upper left
 0:48          'r32' ( temp float)
 0:48          textureLod ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DArrayShadow)
-0:48              'g_tTex2di4a' ( uniform itexture2DArray)
+0:48              'g_tTex2di4a' ( uniform itexture2DArrayShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -87,7 +87,7 @@ gl_FragCoord origin is upper left
 0:49          'r34' ( temp float)
 0:49          textureLod ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DArrayShadow)
-0:49              'g_tTex2du4a' ( uniform utexture2DArray)
+0:49              'g_tTex2du4a' ( uniform utexture2DArrayShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -103,7 +103,7 @@ gl_FragCoord origin is upper left
 0:52          'r60' ( temp float)
 0:52          textureLod ( temp float)
 0:52            Construct combined texture-sampler ( temp samplerCubeArrayShadow)
-0:52              'g_tTexcdf4a' ( uniform textureCubeArray)
+0:52              'g_tTexcdf4a' ( uniform textureCubeArrayShadow)
 0:52              'g_sSamp' (layout( binding=0) uniform sampler)
 0:52            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -120,7 +120,7 @@ gl_FragCoord origin is upper left
 0:53          'r62' ( temp float)
 0:53          textureLod ( temp float)
 0:53            Construct combined texture-sampler ( temp isamplerCubeArrayShadow)
-0:53              'g_tTexcdi4a' ( uniform itextureCubeArray)
+0:53              'g_tTexcdi4a' ( uniform itextureCubeArrayShadow)
 0:53              'g_sSamp' (layout( binding=0) uniform sampler)
 0:53            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -137,7 +137,7 @@ gl_FragCoord origin is upper left
 0:54          'r64' ( temp float)
 0:54          textureLod ( temp float)
 0:54            Construct combined texture-sampler ( temp usamplerCubeArrayShadow)
-0:54              'g_tTexcdu4a' ( uniform utextureCubeArray)
+0:54              'g_tTexcdu4a' ( uniform utextureCubeArrayShadow)
 0:54              'g_sSamp' (layout( binding=0) uniform sampler)
 0:54            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -201,15 +201,15 @@ gl_FragCoord origin is upper left
 0:?     'g_tTexcdf4' ( uniform textureCube)
 0:?     'g_tTexcdi4' ( uniform itextureCube)
 0:?     'g_tTexcdu4' ( uniform utextureCube)
-0:?     'g_tTex1df4a' ( uniform texture1DArray)
-0:?     'g_tTex1di4a' ( uniform itexture1DArray)
-0:?     'g_tTex1du4a' ( uniform utexture1DArray)
-0:?     'g_tTex2df4a' ( uniform texture2DArray)
-0:?     'g_tTex2di4a' ( uniform itexture2DArray)
-0:?     'g_tTex2du4a' ( uniform utexture2DArray)
-0:?     'g_tTexcdf4a' ( uniform textureCubeArray)
-0:?     'g_tTexcdi4a' ( uniform itextureCubeArray)
-0:?     'g_tTexcdu4a' ( uniform utextureCubeArray)
+0:?     'g_tTex1df4a' ( uniform texture1DArrayShadow)
+0:?     'g_tTex1di4a' ( uniform itexture1DArrayShadow)
+0:?     'g_tTex1du4a' ( uniform utexture1DArrayShadow)
+0:?     'g_tTex2df4a' ( uniform texture2DArrayShadow)
+0:?     'g_tTex2di4a' ( uniform itexture2DArrayShadow)
+0:?     'g_tTex2du4a' ( uniform utexture2DArrayShadow)
+0:?     'g_tTexcdf4a' ( uniform textureCubeArrayShadow)
+0:?     'g_tTexcdi4a' ( uniform itextureCubeArrayShadow)
+0:?     'g_tTexcdu4a' ( uniform utextureCubeArrayShadow)
 0:?     '@entryPointOutput.Depth' ( out float FragDepth)
 0:?     '@entryPointOutput.Color' (layout( location=0) out 4-component vector of float)
 
@@ -228,7 +228,7 @@ gl_FragCoord origin is upper left
 0:42          'r10' ( temp float)
 0:42          textureLod ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DArrayShadow)
-0:42              'g_tTex1df4a' ( uniform texture1DArray)
+0:42              'g_tTex1df4a' ( uniform texture1DArrayShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -243,7 +243,7 @@ gl_FragCoord origin is upper left
 0:43          'r12' ( temp float)
 0:43          textureLod ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DArrayShadow)
-0:43              'g_tTex1di4a' ( uniform itexture1DArray)
+0:43              'g_tTex1di4a' ( uniform itexture1DArrayShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -258,7 +258,7 @@ gl_FragCoord origin is upper left
 0:44          'r14' ( temp float)
 0:44          textureLod ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DArrayShadow)
-0:44              'g_tTex1du4a' ( uniform utexture1DArray)
+0:44              'g_tTex1du4a' ( uniform utexture1DArrayShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -273,7 +273,7 @@ gl_FragCoord origin is upper left
 0:47          'r30' ( temp float)
 0:47          textureLod ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DArrayShadow)
-0:47              'g_tTex2df4a' ( uniform texture2DArray)
+0:47              'g_tTex2df4a' ( uniform texture2DArrayShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -289,7 +289,7 @@ gl_FragCoord origin is upper left
 0:48          'r32' ( temp float)
 0:48          textureLod ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DArrayShadow)
-0:48              'g_tTex2di4a' ( uniform itexture2DArray)
+0:48              'g_tTex2di4a' ( uniform itexture2DArrayShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -305,7 +305,7 @@ gl_FragCoord origin is upper left
 0:49          'r34' ( temp float)
 0:49          textureLod ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DArrayShadow)
-0:49              'g_tTex2du4a' ( uniform utexture2DArray)
+0:49              'g_tTex2du4a' ( uniform utexture2DArrayShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -321,7 +321,7 @@ gl_FragCoord origin is upper left
 0:52          'r60' ( temp float)
 0:52          textureLod ( temp float)
 0:52            Construct combined texture-sampler ( temp samplerCubeArrayShadow)
-0:52              'g_tTexcdf4a' ( uniform textureCubeArray)
+0:52              'g_tTexcdf4a' ( uniform textureCubeArrayShadow)
 0:52              'g_sSamp' (layout( binding=0) uniform sampler)
 0:52            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -338,7 +338,7 @@ gl_FragCoord origin is upper left
 0:53          'r62' ( temp float)
 0:53          textureLod ( temp float)
 0:53            Construct combined texture-sampler ( temp isamplerCubeArrayShadow)
-0:53              'g_tTexcdi4a' ( uniform itextureCubeArray)
+0:53              'g_tTexcdi4a' ( uniform itextureCubeArrayShadow)
 0:53              'g_sSamp' (layout( binding=0) uniform sampler)
 0:53            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -355,7 +355,7 @@ gl_FragCoord origin is upper left
 0:54          'r64' ( temp float)
 0:54          textureLod ( temp float)
 0:54            Construct combined texture-sampler ( temp usamplerCubeArrayShadow)
-0:54              'g_tTexcdu4a' ( uniform utextureCubeArray)
+0:54              'g_tTexcdu4a' ( uniform utextureCubeArrayShadow)
 0:54              'g_sSamp' (layout( binding=0) uniform sampler)
 0:54            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -419,28 +419,28 @@ gl_FragCoord origin is upper left
 0:?     'g_tTexcdf4' ( uniform textureCube)
 0:?     'g_tTexcdi4' ( uniform itextureCube)
 0:?     'g_tTexcdu4' ( uniform utextureCube)
-0:?     'g_tTex1df4a' ( uniform texture1DArray)
-0:?     'g_tTex1di4a' ( uniform itexture1DArray)
-0:?     'g_tTex1du4a' ( uniform utexture1DArray)
-0:?     'g_tTex2df4a' ( uniform texture2DArray)
-0:?     'g_tTex2di4a' ( uniform itexture2DArray)
-0:?     'g_tTex2du4a' ( uniform utexture2DArray)
-0:?     'g_tTexcdf4a' ( uniform textureCubeArray)
-0:?     'g_tTexcdi4a' ( uniform itextureCubeArray)
-0:?     'g_tTexcdu4a' ( uniform utextureCubeArray)
+0:?     'g_tTex1df4a' ( uniform texture1DArrayShadow)
+0:?     'g_tTex1di4a' ( uniform itexture1DArrayShadow)
+0:?     'g_tTex1du4a' ( uniform utexture1DArrayShadow)
+0:?     'g_tTex2df4a' ( uniform texture2DArrayShadow)
+0:?     'g_tTex2di4a' ( uniform itexture2DArrayShadow)
+0:?     'g_tTex2du4a' ( uniform utexture2DArrayShadow)
+0:?     'g_tTexcdf4a' ( uniform textureCubeArrayShadow)
+0:?     'g_tTexcdi4a' ( uniform itextureCubeArrayShadow)
+0:?     'g_tTexcdu4a' ( uniform utextureCubeArrayShadow)
 0:?     '@entryPointOutput.Depth' ( out float FragDepth)
 0:?     '@entryPointOutput.Color' (layout( location=0) out 4-component vector of float)
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 219
+// Id's are bound by 210
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 176 180
+                              EntryPoint Fragment 4  "main" 167 171
                               ExecutionMode 4 OriginUpperLeft
                               Source HLSL 500
                               Name 4  "main"
@@ -451,64 +451,64 @@ gl_FragCoord origin is upper left
                               Name 13  "r10"
                               Name 16  "g_tTex1df4a"
                               Name 20  "g_sSamp"
-                              Name 37  "r12"
-                              Name 41  "g_tTex1di4a"
-                              Name 52  "r14"
-                              Name 56  "g_tTex1du4a"
-                              Name 67  "r30"
-                              Name 70  "g_tTex2df4a"
-                              Name 84  "r32"
-                              Name 87  "g_tTex2di4a"
-                              Name 99  "r34"
-                              Name 102  "g_tTex2du4a"
-                              Name 114  "r60"
-                              Name 117  "g_tTexcdf4a"
-                              Name 131  "r62"
-                              Name 134  "g_tTexcdi4a"
-                              Name 146  "r64"
-                              Name 149  "g_tTexcdu4a"
-                              Name 162  "psout"
-                              Name 173  "flattenTemp"
-                              Name 176  "@entryPointOutput.Color"
-                              Name 180  "@entryPointOutput.Depth"
-                              Name 185  "g_tTex1df4"
-                              Name 188  "g_tTex1di4"
-                              Name 191  "g_tTex1du4"
-                              Name 194  "g_tTex2df4"
-                              Name 197  "g_tTex2di4"
-                              Name 200  "g_tTex2du4"
-                              Name 203  "g_tTex3df4"
-                              Name 206  "g_tTex3di4"
-                              Name 209  "g_tTex3du4"
-                              Name 212  "g_tTexcdf4"
-                              Name 215  "g_tTexcdi4"
-                              Name 218  "g_tTexcdu4"
+                              Name 36  "r12"
+                              Name 40  "g_tTex1di4a"
+                              Name 50  "r14"
+                              Name 54  "g_tTex1du4a"
+                              Name 64  "r30"
+                              Name 67  "g_tTex2df4a"
+                              Name 80  "r32"
+                              Name 83  "g_tTex2di4a"
+                              Name 94  "r34"
+                              Name 97  "g_tTex2du4a"
+                              Name 108  "r60"
+                              Name 111  "g_tTexcdf4a"
+                              Name 124  "r62"
+                              Name 127  "g_tTexcdi4a"
+                              Name 138  "r64"
+                              Name 141  "g_tTexcdu4a"
+                              Name 153  "psout"
+                              Name 164  "flattenTemp"
+                              Name 167  "@entryPointOutput.Color"
+                              Name 171  "@entryPointOutput.Depth"
+                              Name 176  "g_tTex1df4"
+                              Name 179  "g_tTex1di4"
+                              Name 182  "g_tTex1du4"
+                              Name 185  "g_tTex2df4"
+                              Name 188  "g_tTex2di4"
+                              Name 191  "g_tTex2du4"
+                              Name 194  "g_tTex3df4"
+                              Name 197  "g_tTex3di4"
+                              Name 200  "g_tTex3du4"
+                              Name 203  "g_tTexcdf4"
+                              Name 206  "g_tTexcdi4"
+                              Name 209  "g_tTexcdu4"
                               Decorate 16(g_tTex1df4a) DescriptorSet 0
                               Decorate 20(g_sSamp) DescriptorSet 0
                               Decorate 20(g_sSamp) Binding 0
-                              Decorate 41(g_tTex1di4a) DescriptorSet 0
-                              Decorate 56(g_tTex1du4a) DescriptorSet 0
-                              Decorate 70(g_tTex2df4a) DescriptorSet 0
-                              Decorate 87(g_tTex2di4a) DescriptorSet 0
-                              Decorate 102(g_tTex2du4a) DescriptorSet 0
-                              Decorate 117(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 134(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 149(g_tTexcdu4a) DescriptorSet 0
-                              Decorate 176(@entryPointOutput.Color) Location 0
-                              Decorate 180(@entryPointOutput.Depth) BuiltIn FragDepth
-                              Decorate 185(g_tTex1df4) DescriptorSet 0
-                              Decorate 185(g_tTex1df4) Binding 0
-                              Decorate 188(g_tTex1di4) DescriptorSet 0
-                              Decorate 191(g_tTex1du4) DescriptorSet 0
-                              Decorate 194(g_tTex2df4) DescriptorSet 0
-                              Decorate 197(g_tTex2di4) DescriptorSet 0
-                              Decorate 200(g_tTex2du4) DescriptorSet 0
-                              Decorate 203(g_tTex3df4) DescriptorSet 0
-                              Decorate 206(g_tTex3di4) DescriptorSet 0
-                              Decorate 209(g_tTex3du4) DescriptorSet 0
-                              Decorate 212(g_tTexcdf4) DescriptorSet 0
-                              Decorate 215(g_tTexcdi4) DescriptorSet 0
-                              Decorate 218(g_tTexcdu4) DescriptorSet 0
+                              Decorate 40(g_tTex1di4a) DescriptorSet 0
+                              Decorate 54(g_tTex1du4a) DescriptorSet 0
+                              Decorate 67(g_tTex2df4a) DescriptorSet 0
+                              Decorate 83(g_tTex2di4a) DescriptorSet 0
+                              Decorate 97(g_tTex2du4a) DescriptorSet 0
+                              Decorate 111(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 127(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 141(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 167(@entryPointOutput.Color) Location 0
+                              Decorate 171(@entryPointOutput.Depth) BuiltIn FragDepth
+                              Decorate 176(g_tTex1df4) DescriptorSet 0
+                              Decorate 176(g_tTex1df4) Binding 0
+                              Decorate 179(g_tTex1di4) DescriptorSet 0
+                              Decorate 182(g_tTex1du4) DescriptorSet 0
+                              Decorate 185(g_tTex2df4) DescriptorSet 0
+                              Decorate 188(g_tTex2di4) DescriptorSet 0
+                              Decorate 191(g_tTex2du4) DescriptorSet 0
+                              Decorate 194(g_tTex3df4) DescriptorSet 0
+                              Decorate 197(g_tTex3di4) DescriptorSet 0
+                              Decorate 200(g_tTex3du4) DescriptorSet 0
+                              Decorate 203(g_tTexcdf4) DescriptorSet 0
+                              Decorate 206(g_tTexcdi4) DescriptorSet 0
+                              Decorate 209(g_tTexcdu4) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -516,229 +516,220 @@ gl_FragCoord origin is upper left
     8(PS_OUTPUT):             TypeStruct 7(fvec4) 6(float)
                9:             TypeFunction 8(PS_OUTPUT)
               12:             TypePointer Function 6(float)
-              14:             TypeImage 6(float) 1D array sampled format:Unknown
+              14:             TypeImage 6(float) 1D depth array sampled format:Unknown
               15:             TypePointer UniformConstant 14
  16(g_tTex1df4a):     15(ptr) Variable UniformConstant
               18:             TypeSampler
               19:             TypePointer UniformConstant 18
      20(g_sSamp):     19(ptr) Variable UniformConstant
-              22:             TypeImage 6(float) 1D depth array sampled format:Unknown
-              23:             TypeSampledImage 22
-              25:             TypeVector 6(float) 2
-              26:    6(float) Constant 1036831949
-              27:    6(float) Constant 1045220557
-              28:   25(fvec2) ConstantComposite 26 27
-              29:    6(float) Constant 1061158912
-              30:             TypeVector 6(float) 3
-              34:    6(float) Constant 0
-              38:             TypeInt 32 1
-              39:             TypeImage 38(int) 1D array sampled format:Unknown
-              40:             TypePointer UniformConstant 39
- 41(g_tTex1di4a):     40(ptr) Variable UniformConstant
-              44:             TypeImage 38(int) 1D depth array sampled format:Unknown
-              45:             TypeSampledImage 44
-              53:             TypeInt 32 0
-              54:             TypeImage 53(int) 1D array sampled format:Unknown
-              55:             TypePointer UniformConstant 54
- 56(g_tTex1du4a):     55(ptr) Variable UniformConstant
-              59:             TypeImage 53(int) 1D depth array sampled format:Unknown
-              60:             TypeSampledImage 59
-              68:             TypeImage 6(float) 2D array sampled format:Unknown
-              69:             TypePointer UniformConstant 68
- 70(g_tTex2df4a):     69(ptr) Variable UniformConstant
-              73:             TypeImage 6(float) 2D depth array sampled format:Unknown
-              74:             TypeSampledImage 73
-              76:    6(float) Constant 1050253722
-              77:   30(fvec3) ConstantComposite 26 27 76
-              85:             TypeImage 38(int) 2D array sampled format:Unknown
-              86:             TypePointer UniformConstant 85
- 87(g_tTex2di4a):     86(ptr) Variable UniformConstant
-              90:             TypeImage 38(int) 2D depth array sampled format:Unknown
-              91:             TypeSampledImage 90
-             100:             TypeImage 53(int) 2D array sampled format:Unknown
-             101:             TypePointer UniformConstant 100
-102(g_tTex2du4a):    101(ptr) Variable UniformConstant
-             105:             TypeImage 53(int) 2D depth array sampled format:Unknown
-             106:             TypeSampledImage 105
-             115:             TypeImage 6(float) Cube array sampled format:Unknown
-             116:             TypePointer UniformConstant 115
-117(g_tTexcdf4a):    116(ptr) Variable UniformConstant
-             120:             TypeImage 6(float) Cube depth array sampled format:Unknown
-             121:             TypeSampledImage 120
-             123:    6(float) Constant 1053609165
-             124:    7(fvec4) ConstantComposite 26 27 76 123
-             132:             TypeImage 38(int) Cube array sampled format:Unknown
-             133:             TypePointer UniformConstant 132
-134(g_tTexcdi4a):    133(ptr) Variable UniformConstant
-             137:             TypeImage 38(int) Cube depth array sampled format:Unknown
-             138:             TypeSampledImage 137
-             147:             TypeImage 53(int) Cube array sampled format:Unknown
-             148:             TypePointer UniformConstant 147
-149(g_tTexcdu4a):    148(ptr) Variable UniformConstant
-             152:             TypeImage 53(int) Cube depth array sampled format:Unknown
-             153:             TypeSampledImage 152
-             161:             TypePointer Function 8(PS_OUTPUT)
-             163:     38(int) Constant 0
-             164:    6(float) Constant 1065353216
-             165:    7(fvec4) ConstantComposite 164 164 164 164
-             166:             TypePointer Function 7(fvec4)
-             168:     38(int) Constant 1
-             175:             TypePointer Output 7(fvec4)
-176(@entryPointOutput.Color):    175(ptr) Variable Output
-             179:             TypePointer Output 6(float)
-180(@entryPointOutput.Depth):    179(ptr) Variable Output
-             183:             TypeImage 6(float) 1D sampled format:Unknown
+              22:             TypeSampledImage 14
+              24:             TypeVector 6(float) 2
+              25:    6(float) Constant 1036831949
+              26:    6(float) Constant 1045220557
+              27:   24(fvec2) ConstantComposite 25 26
+              28:    6(float) Constant 1061158912
+              29:             TypeVector 6(float) 3
+              33:    6(float) Constant 0
+              37:             TypeInt 32 1
+              38:             TypeImage 37(int) 1D depth array sampled format:Unknown
+              39:             TypePointer UniformConstant 38
+ 40(g_tTex1di4a):     39(ptr) Variable UniformConstant
+              43:             TypeSampledImage 38
+              51:             TypeInt 32 0
+              52:             TypeImage 51(int) 1D depth array sampled format:Unknown
+              53:             TypePointer UniformConstant 52
+ 54(g_tTex1du4a):     53(ptr) Variable UniformConstant
+              57:             TypeSampledImage 52
+              65:             TypeImage 6(float) 2D depth array sampled format:Unknown
+              66:             TypePointer UniformConstant 65
+ 67(g_tTex2df4a):     66(ptr) Variable UniformConstant
+              70:             TypeSampledImage 65
+              72:    6(float) Constant 1050253722
+              73:   29(fvec3) ConstantComposite 25 26 72
+              81:             TypeImage 37(int) 2D depth array sampled format:Unknown
+              82:             TypePointer UniformConstant 81
+ 83(g_tTex2di4a):     82(ptr) Variable UniformConstant
+              86:             TypeSampledImage 81
+              95:             TypeImage 51(int) 2D depth array sampled format:Unknown
+              96:             TypePointer UniformConstant 95
+ 97(g_tTex2du4a):     96(ptr) Variable UniformConstant
+             100:             TypeSampledImage 95
+             109:             TypeImage 6(float) Cube depth array sampled format:Unknown
+             110:             TypePointer UniformConstant 109
+111(g_tTexcdf4a):    110(ptr) Variable UniformConstant
+             114:             TypeSampledImage 109
+             116:    6(float) Constant 1053609165
+             117:    7(fvec4) ConstantComposite 25 26 72 116
+             125:             TypeImage 37(int) Cube depth array sampled format:Unknown
+             126:             TypePointer UniformConstant 125
+127(g_tTexcdi4a):    126(ptr) Variable UniformConstant
+             130:             TypeSampledImage 125
+             139:             TypeImage 51(int) Cube depth array sampled format:Unknown
+             140:             TypePointer UniformConstant 139
+141(g_tTexcdu4a):    140(ptr) Variable UniformConstant
+             144:             TypeSampledImage 139
+             152:             TypePointer Function 8(PS_OUTPUT)
+             154:     37(int) Constant 0
+             155:    6(float) Constant 1065353216
+             156:    7(fvec4) ConstantComposite 155 155 155 155
+             157:             TypePointer Function 7(fvec4)
+             159:     37(int) Constant 1
+             166:             TypePointer Output 7(fvec4)
+167(@entryPointOutput.Color):    166(ptr) Variable Output
+             170:             TypePointer Output 6(float)
+171(@entryPointOutput.Depth):    170(ptr) Variable Output
+             174:             TypeImage 6(float) 1D sampled format:Unknown
+             175:             TypePointer UniformConstant 174
+ 176(g_tTex1df4):    175(ptr) Variable UniformConstant
+             177:             TypeImage 37(int) 1D sampled format:Unknown
+             178:             TypePointer UniformConstant 177
+ 179(g_tTex1di4):    178(ptr) Variable UniformConstant
+             180:             TypeImage 51(int) 1D sampled format:Unknown
+             181:             TypePointer UniformConstant 180
+ 182(g_tTex1du4):    181(ptr) Variable UniformConstant
+             183:             TypeImage 6(float) 2D sampled format:Unknown
              184:             TypePointer UniformConstant 183
- 185(g_tTex1df4):    184(ptr) Variable UniformConstant
-             186:             TypeImage 38(int) 1D sampled format:Unknown
+ 185(g_tTex2df4):    184(ptr) Variable UniformConstant
+             186:             TypeImage 37(int) 2D sampled format:Unknown
              187:             TypePointer UniformConstant 186
- 188(g_tTex1di4):    187(ptr) Variable UniformConstant
-             189:             TypeImage 53(int) 1D sampled format:Unknown
+ 188(g_tTex2di4):    187(ptr) Variable UniformConstant
+             189:             TypeImage 51(int) 2D sampled format:Unknown
              190:             TypePointer UniformConstant 189
- 191(g_tTex1du4):    190(ptr) Variable UniformConstant
-             192:             TypeImage 6(float) 2D sampled format:Unknown
+ 191(g_tTex2du4):    190(ptr) Variable UniformConstant
+             192:             TypeImage 6(float) 3D sampled format:Unknown
              193:             TypePointer UniformConstant 192
- 194(g_tTex2df4):    193(ptr) Variable UniformConstant
-             195:             TypeImage 38(int) 2D sampled format:Unknown
+ 194(g_tTex3df4):    193(ptr) Variable UniformConstant
+             195:             TypeImage 37(int) 3D sampled format:Unknown
              196:             TypePointer UniformConstant 195
- 197(g_tTex2di4):    196(ptr) Variable UniformConstant
-             198:             TypeImage 53(int) 2D sampled format:Unknown
+ 197(g_tTex3di4):    196(ptr) Variable UniformConstant
+             198:             TypeImage 51(int) 3D sampled format:Unknown
              199:             TypePointer UniformConstant 198
- 200(g_tTex2du4):    199(ptr) Variable UniformConstant
-             201:             TypeImage 6(float) 3D sampled format:Unknown
+ 200(g_tTex3du4):    199(ptr) Variable UniformConstant
+             201:             TypeImage 6(float) Cube sampled format:Unknown
              202:             TypePointer UniformConstant 201
- 203(g_tTex3df4):    202(ptr) Variable UniformConstant
-             204:             TypeImage 38(int) 3D sampled format:Unknown
+ 203(g_tTexcdf4):    202(ptr) Variable UniformConstant
+             204:             TypeImage 37(int) Cube sampled format:Unknown
              205:             TypePointer UniformConstant 204
- 206(g_tTex3di4):    205(ptr) Variable UniformConstant
-             207:             TypeImage 53(int) 3D sampled format:Unknown
+ 206(g_tTexcdi4):    205(ptr) Variable UniformConstant
+             207:             TypeImage 51(int) Cube sampled format:Unknown
              208:             TypePointer UniformConstant 207
- 209(g_tTex3du4):    208(ptr) Variable UniformConstant
-             210:             TypeImage 6(float) Cube sampled format:Unknown
-             211:             TypePointer UniformConstant 210
- 212(g_tTexcdf4):    211(ptr) Variable UniformConstant
-             213:             TypeImage 38(int) Cube sampled format:Unknown
-             214:             TypePointer UniformConstant 213
- 215(g_tTexcdi4):    214(ptr) Variable UniformConstant
-             216:             TypeImage 53(int) Cube sampled format:Unknown
-             217:             TypePointer UniformConstant 216
- 218(g_tTexcdu4):    217(ptr) Variable UniformConstant
+ 209(g_tTexcdu4):    208(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
-173(flattenTemp):    161(ptr) Variable Function
-             174:8(PS_OUTPUT) FunctionCall 10(@main()
-                              Store 173(flattenTemp) 174
-             177:    166(ptr) AccessChain 173(flattenTemp) 163
-             178:    7(fvec4) Load 177
-                              Store 176(@entryPointOutput.Color) 178
-             181:     12(ptr) AccessChain 173(flattenTemp) 168
-             182:    6(float) Load 181
-                              Store 180(@entryPointOutput.Depth) 182
+164(flattenTemp):    152(ptr) Variable Function
+             165:8(PS_OUTPUT) FunctionCall 10(@main()
+                              Store 164(flattenTemp) 165
+             168:    157(ptr) AccessChain 164(flattenTemp) 154
+             169:    7(fvec4) Load 168
+                              Store 167(@entryPointOutput.Color) 169
+             172:     12(ptr) AccessChain 164(flattenTemp) 159
+             173:    6(float) Load 172
+                              Store 171(@entryPointOutput.Depth) 173
                               Return
                               FunctionEnd
       10(@main():8(PS_OUTPUT) Function None 9
               11:             Label
          13(r10):     12(ptr) Variable Function
-         37(r12):     12(ptr) Variable Function
-         52(r14):     12(ptr) Variable Function
-         67(r30):     12(ptr) Variable Function
-         84(r32):     12(ptr) Variable Function
-         99(r34):     12(ptr) Variable Function
-        114(r60):     12(ptr) Variable Function
-        131(r62):     12(ptr) Variable Function
-        146(r64):     12(ptr) Variable Function
-      162(psout):    161(ptr) Variable Function
+         36(r12):     12(ptr) Variable Function
+         50(r14):     12(ptr) Variable Function
+         64(r30):     12(ptr) Variable Function
+         80(r32):     12(ptr) Variable Function
+         94(r34):     12(ptr) Variable Function
+        108(r60):     12(ptr) Variable Function
+        124(r62):     12(ptr) Variable Function
+        138(r64):     12(ptr) Variable Function
+      153(psout):    152(ptr) Variable Function
               17:          14 Load 16(g_tTex1df4a)
               21:          18 Load 20(g_sSamp)
-              24:          23 SampledImage 17 21
-              31:    6(float) CompositeExtract 28 0
-              32:    6(float) CompositeExtract 28 1
-              33:   30(fvec3) CompositeConstruct 31 32 29
-              35:    6(float) CompositeExtract 33 2
-              36:    6(float) ImageSampleDrefExplicitLod 24 33 35 Lod 34
-                              Store 13(r10) 36
-              42:          39 Load 41(g_tTex1di4a)
-              43:          18 Load 20(g_sSamp)
-              46:          45 SampledImage 42 43
-              47:    6(float) CompositeExtract 28 0
-              48:    6(float) CompositeExtract 28 1
-              49:   30(fvec3) CompositeConstruct 47 48 29
-              50:    6(float) CompositeExtract 49 2
-              51:    6(float) ImageSampleDrefExplicitLod 46 49 50 Lod 34
-                              Store 37(r12) 51
-              57:          54 Load 56(g_tTex1du4a)
-              58:          18 Load 20(g_sSamp)
-              61:          60 SampledImage 57 58
-              62:    6(float) CompositeExtract 28 0
-              63:    6(float) CompositeExtract 28 1
-              64:   30(fvec3) CompositeConstruct 62 63 29
-              65:    6(float) CompositeExtract 64 2
-              66:    6(float) ImageSampleDrefExplicitLod 61 64 65 Lod 34
-                              Store 52(r14) 66
-              71:          68 Load 70(g_tTex2df4a)
-              72:          18 Load 20(g_sSamp)
-              75:          74 SampledImage 71 72
-              78:    6(float) CompositeExtract 77 0
-              79:    6(float) CompositeExtract 77 1
-              80:    6(float) CompositeExtract 77 2
-              81:    7(fvec4) CompositeConstruct 78 79 80 29
-              82:    6(float) CompositeExtract 81 3
-              83:    6(float) ImageSampleDrefExplicitLod 75 81 82 Lod 34
-                              Store 67(r30) 83
-              88:          85 Load 87(g_tTex2di4a)
-              89:          18 Load 20(g_sSamp)
-              92:          91 SampledImage 88 89
-              93:    6(float) CompositeExtract 77 0
-              94:    6(float) CompositeExtract 77 1
-              95:    6(float) CompositeExtract 77 2
-              96:    7(fvec4) CompositeConstruct 93 94 95 29
-              97:    6(float) CompositeExtract 96 3
-              98:    6(float) ImageSampleDrefExplicitLod 92 96 97 Lod 34
-                              Store 84(r32) 98
-             103:         100 Load 102(g_tTex2du4a)
-             104:          18 Load 20(g_sSamp)
-             107:         106 SampledImage 103 104
-             108:    6(float) CompositeExtract 77 0
-             109:    6(float) CompositeExtract 77 1
-             110:    6(float) CompositeExtract 77 2
-             111:    7(fvec4) CompositeConstruct 108 109 110 29
-             112:    6(float) CompositeExtract 111 3
-             113:    6(float) ImageSampleDrefExplicitLod 107 111 112 Lod 34
-                              Store 99(r34) 113
-             118:         115 Load 117(g_tTexcdf4a)
-             119:          18 Load 20(g_sSamp)
-             122:         121 SampledImage 118 119
-             125:    6(float) CompositeExtract 124 0
-             126:    6(float) CompositeExtract 124 1
-             127:    6(float) CompositeExtract 124 2
-             128:    6(float) CompositeExtract 124 3
-             129:    7(fvec4) CompositeConstruct 125 126 127 128
-             130:    6(float) ImageSampleDrefExplicitLod 122 129 29 Lod 34
-                              Store 114(r60) 130
-             135:         132 Load 134(g_tTexcdi4a)
-             136:          18 Load 20(g_sSamp)
-             139:         138 SampledImage 135 136
-             140:    6(float) CompositeExtract 124 0
-             141:    6(float) CompositeExtract 124 1
-             142:    6(float) CompositeExtract 124 2
-             143:    6(float) CompositeExtract 124 3
-             144:    7(fvec4) CompositeConstruct 140 141 142 143
-             145:    6(float) ImageSampleDrefExplicitLod 139 144 29 Lod 34
-                              Store 131(r62) 145
-             150:         147 Load 149(g_tTexcdu4a)
-             151:          18 Load 20(g_sSamp)
-             154:         153 SampledImage 150 151
-             155:    6(float) CompositeExtract 124 0
-             156:    6(float) CompositeExtract 124 1
-             157:    6(float) CompositeExtract 124 2
-             158:    6(float) CompositeExtract 124 3
-             159:    7(fvec4) CompositeConstruct 155 156 157 158
-             160:    6(float) ImageSampleDrefExplicitLod 154 159 29 Lod 34
-                              Store 146(r64) 160
-             167:    166(ptr) AccessChain 162(psout) 163
-                              Store 167 165
-             169:     12(ptr) AccessChain 162(psout) 168
-                              Store 169 164
-             170:8(PS_OUTPUT) Load 162(psout)
-                              ReturnValue 170
+              23:          22 SampledImage 17 21
+              30:    6(float) CompositeExtract 27 0
+              31:    6(float) CompositeExtract 27 1
+              32:   29(fvec3) CompositeConstruct 30 31 28
+              34:    6(float) CompositeExtract 32 2
+              35:    6(float) ImageSampleDrefExplicitLod 23 32 34 Lod 33
+                              Store 13(r10) 35
+              41:          38 Load 40(g_tTex1di4a)
+              42:          18 Load 20(g_sSamp)
+              44:          43 SampledImage 41 42
+              45:    6(float) CompositeExtract 27 0
+              46:    6(float) CompositeExtract 27 1
+              47:   29(fvec3) CompositeConstruct 45 46 28
+              48:    6(float) CompositeExtract 47 2
+              49:    6(float) ImageSampleDrefExplicitLod 44 47 48 Lod 33
+                              Store 36(r12) 49
+              55:          52 Load 54(g_tTex1du4a)
+              56:          18 Load 20(g_sSamp)
+              58:          57 SampledImage 55 56
+              59:    6(float) CompositeExtract 27 0
+              60:    6(float) CompositeExtract 27 1
+              61:   29(fvec3) CompositeConstruct 59 60 28
+              62:    6(float) CompositeExtract 61 2
+              63:    6(float) ImageSampleDrefExplicitLod 58 61 62 Lod 33
+                              Store 50(r14) 63
+              68:          65 Load 67(g_tTex2df4a)
+              69:          18 Load 20(g_sSamp)
+              71:          70 SampledImage 68 69
+              74:    6(float) CompositeExtract 73 0
+              75:    6(float) CompositeExtract 73 1
+              76:    6(float) CompositeExtract 73 2
+              77:    7(fvec4) CompositeConstruct 74 75 76 28
+              78:    6(float) CompositeExtract 77 3
+              79:    6(float) ImageSampleDrefExplicitLod 71 77 78 Lod 33
+                              Store 64(r30) 79
+              84:          81 Load 83(g_tTex2di4a)
+              85:          18 Load 20(g_sSamp)
+              87:          86 SampledImage 84 85
+              88:    6(float) CompositeExtract 73 0
+              89:    6(float) CompositeExtract 73 1
+              90:    6(float) CompositeExtract 73 2
+              91:    7(fvec4) CompositeConstruct 88 89 90 28
+              92:    6(float) CompositeExtract 91 3
+              93:    6(float) ImageSampleDrefExplicitLod 87 91 92 Lod 33
+                              Store 80(r32) 93
+              98:          95 Load 97(g_tTex2du4a)
+              99:          18 Load 20(g_sSamp)
+             101:         100 SampledImage 98 99
+             102:    6(float) CompositeExtract 73 0
+             103:    6(float) CompositeExtract 73 1
+             104:    6(float) CompositeExtract 73 2
+             105:    7(fvec4) CompositeConstruct 102 103 104 28
+             106:    6(float) CompositeExtract 105 3
+             107:    6(float) ImageSampleDrefExplicitLod 101 105 106 Lod 33
+                              Store 94(r34) 107
+             112:         109 Load 111(g_tTexcdf4a)
+             113:          18 Load 20(g_sSamp)
+             115:         114 SampledImage 112 113
+             118:    6(float) CompositeExtract 117 0
+             119:    6(float) CompositeExtract 117 1
+             120:    6(float) CompositeExtract 117 2
+             121:    6(float) CompositeExtract 117 3
+             122:    7(fvec4) CompositeConstruct 118 119 120 121
+             123:    6(float) ImageSampleDrefExplicitLod 115 122 28 Lod 33
+                              Store 108(r60) 123
+             128:         125 Load 127(g_tTexcdi4a)
+             129:          18 Load 20(g_sSamp)
+             131:         130 SampledImage 128 129
+             132:    6(float) CompositeExtract 117 0
+             133:    6(float) CompositeExtract 117 1
+             134:    6(float) CompositeExtract 117 2
+             135:    6(float) CompositeExtract 117 3
+             136:    7(fvec4) CompositeConstruct 132 133 134 135
+             137:    6(float) ImageSampleDrefExplicitLod 131 136 28 Lod 33
+                              Store 124(r62) 137
+             142:         139 Load 141(g_tTexcdu4a)
+             143:          18 Load 20(g_sSamp)
+             145:         144 SampledImage 142 143
+             146:    6(float) CompositeExtract 117 0
+             147:    6(float) CompositeExtract 117 1
+             148:    6(float) CompositeExtract 117 2
+             149:    6(float) CompositeExtract 117 3
+             150:    7(fvec4) CompositeConstruct 146 147 148 149
+             151:    6(float) ImageSampleDrefExplicitLod 145 150 28 Lod 33
+                              Store 138(r64) 151
+             158:    157(ptr) AccessChain 153(psout) 154
+                              Store 158 156
+             160:     12(ptr) AccessChain 153(psout) 159
+                              Store 160 155
+             161:8(PS_OUTPUT) Load 153(psout)
+                              ReturnValue 161
                               FunctionEnd

--- a/Test/baseResults/hlsl.samplecmplevelzero.basic.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmplevelzero.basic.dx10.frag.out
@@ -10,7 +10,7 @@ gl_FragCoord origin is upper left
 0:42          'r00' ( temp float)
 0:42          textureLod ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DShadow)
-0:42              'g_tTex1df4' (layout( binding=0) uniform texture1D)
+0:42              'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec2 ( temp 2-component vector of float)
 0:42              Constant:
@@ -24,7 +24,7 @@ gl_FragCoord origin is upper left
 0:43          'r02' ( temp float)
 0:43          textureLod ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DShadow)
-0:43              'g_tTex1di4' ( uniform itexture1D)
+0:43              'g_tTex1di4' ( uniform itexture1DShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec2 ( temp 2-component vector of float)
 0:43              Constant:
@@ -38,7 +38,7 @@ gl_FragCoord origin is upper left
 0:44          'r04' ( temp float)
 0:44          textureLod ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DShadow)
-0:44              'g_tTex1du4' ( uniform utexture1D)
+0:44              'g_tTex1du4' ( uniform utexture1DShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec2 ( temp 2-component vector of float)
 0:44              Constant:
@@ -52,7 +52,7 @@ gl_FragCoord origin is upper left
 0:47          'r20' ( temp float)
 0:47          textureLod ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DShadow)
-0:47              'g_tTex2df4' ( uniform texture2D)
+0:47              'g_tTex2df4' ( uniform texture2DShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -67,7 +67,7 @@ gl_FragCoord origin is upper left
 0:48          'r22' ( temp float)
 0:48          textureLod ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DShadow)
-0:48              'g_tTex2di4' ( uniform itexture2D)
+0:48              'g_tTex2di4' ( uniform itexture2DShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -82,7 +82,7 @@ gl_FragCoord origin is upper left
 0:49          'r24' ( temp float)
 0:49          textureLod ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DShadow)
-0:49              'g_tTex2du4' ( uniform utexture2D)
+0:49              'g_tTex2du4' ( uniform utexture2DShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -97,7 +97,7 @@ gl_FragCoord origin is upper left
 0:53          'r50' ( temp float)
 0:53          textureLod ( temp float)
 0:53            Construct combined texture-sampler ( temp samplerCubeShadow)
-0:53              'g_tTexcdf4' ( uniform textureCube)
+0:53              'g_tTexcdf4' ( uniform textureCubeShadow)
 0:53              'g_sSamp' (layout( binding=0) uniform sampler)
 0:53            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -113,7 +113,7 @@ gl_FragCoord origin is upper left
 0:54          'r52' ( temp float)
 0:54          textureLod ( temp float)
 0:54            Construct combined texture-sampler ( temp isamplerCubeShadow)
-0:54              'g_tTexcdi4' ( uniform itextureCube)
+0:54              'g_tTexcdi4' ( uniform itextureCubeShadow)
 0:54              'g_sSamp' (layout( binding=0) uniform sampler)
 0:54            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -129,7 +129,7 @@ gl_FragCoord origin is upper left
 0:55          'r54' ( temp float)
 0:55          textureLod ( temp float)
 0:55            Construct combined texture-sampler ( temp usamplerCubeShadow)
-0:55              'g_tTexcdu4' ( uniform utextureCube)
+0:55              'g_tTexcdu4' ( uniform utextureCubeShadow)
 0:55              'g_sSamp' (layout( binding=0) uniform sampler)
 0:55            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -180,18 +180,18 @@ gl_FragCoord origin is upper left
 0:38              1 (const int)
 0:?   Linker Objects
 0:?     'g_sSamp' (layout( binding=0) uniform sampler)
-0:?     'g_tTex1df4' (layout( binding=0) uniform texture1D)
-0:?     'g_tTex1di4' ( uniform itexture1D)
-0:?     'g_tTex1du4' ( uniform utexture1D)
-0:?     'g_tTex2df4' ( uniform texture2D)
-0:?     'g_tTex2di4' ( uniform itexture2D)
-0:?     'g_tTex2du4' ( uniform utexture2D)
+0:?     'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
+0:?     'g_tTex1di4' ( uniform itexture1DShadow)
+0:?     'g_tTex1du4' ( uniform utexture1DShadow)
+0:?     'g_tTex2df4' ( uniform texture2DShadow)
+0:?     'g_tTex2di4' ( uniform itexture2DShadow)
+0:?     'g_tTex2du4' ( uniform utexture2DShadow)
 0:?     'g_tTex3df4' ( uniform texture3D)
 0:?     'g_tTex3di4' ( uniform itexture3D)
 0:?     'g_tTex3du4' ( uniform utexture3D)
-0:?     'g_tTexcdf4' ( uniform textureCube)
-0:?     'g_tTexcdi4' ( uniform itextureCube)
-0:?     'g_tTexcdu4' ( uniform utextureCube)
+0:?     'g_tTexcdf4' ( uniform textureCubeShadow)
+0:?     'g_tTexcdi4' ( uniform itextureCubeShadow)
+0:?     'g_tTexcdu4' ( uniform utextureCubeShadow)
 0:?     'g_tTex1df4a' ( uniform texture1DArray)
 0:?     'g_tTex1di4a' ( uniform itexture1DArray)
 0:?     'g_tTex1du4a' ( uniform utexture1DArray)
@@ -219,7 +219,7 @@ gl_FragCoord origin is upper left
 0:42          'r00' ( temp float)
 0:42          textureLod ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DShadow)
-0:42              'g_tTex1df4' (layout( binding=0) uniform texture1D)
+0:42              'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec2 ( temp 2-component vector of float)
 0:42              Constant:
@@ -233,7 +233,7 @@ gl_FragCoord origin is upper left
 0:43          'r02' ( temp float)
 0:43          textureLod ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DShadow)
-0:43              'g_tTex1di4' ( uniform itexture1D)
+0:43              'g_tTex1di4' ( uniform itexture1DShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec2 ( temp 2-component vector of float)
 0:43              Constant:
@@ -247,7 +247,7 @@ gl_FragCoord origin is upper left
 0:44          'r04' ( temp float)
 0:44          textureLod ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DShadow)
-0:44              'g_tTex1du4' ( uniform utexture1D)
+0:44              'g_tTex1du4' ( uniform utexture1DShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec2 ( temp 2-component vector of float)
 0:44              Constant:
@@ -261,7 +261,7 @@ gl_FragCoord origin is upper left
 0:47          'r20' ( temp float)
 0:47          textureLod ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DShadow)
-0:47              'g_tTex2df4' ( uniform texture2D)
+0:47              'g_tTex2df4' ( uniform texture2DShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -276,7 +276,7 @@ gl_FragCoord origin is upper left
 0:48          'r22' ( temp float)
 0:48          textureLod ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DShadow)
-0:48              'g_tTex2di4' ( uniform itexture2D)
+0:48              'g_tTex2di4' ( uniform itexture2DShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -291,7 +291,7 @@ gl_FragCoord origin is upper left
 0:49          'r24' ( temp float)
 0:49          textureLod ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DShadow)
-0:49              'g_tTex2du4' ( uniform utexture2D)
+0:49              'g_tTex2du4' ( uniform utexture2DShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -306,7 +306,7 @@ gl_FragCoord origin is upper left
 0:53          'r50' ( temp float)
 0:53          textureLod ( temp float)
 0:53            Construct combined texture-sampler ( temp samplerCubeShadow)
-0:53              'g_tTexcdf4' ( uniform textureCube)
+0:53              'g_tTexcdf4' ( uniform textureCubeShadow)
 0:53              'g_sSamp' (layout( binding=0) uniform sampler)
 0:53            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -322,7 +322,7 @@ gl_FragCoord origin is upper left
 0:54          'r52' ( temp float)
 0:54          textureLod ( temp float)
 0:54            Construct combined texture-sampler ( temp isamplerCubeShadow)
-0:54              'g_tTexcdi4' ( uniform itextureCube)
+0:54              'g_tTexcdi4' ( uniform itextureCubeShadow)
 0:54              'g_sSamp' (layout( binding=0) uniform sampler)
 0:54            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -338,7 +338,7 @@ gl_FragCoord origin is upper left
 0:55          'r54' ( temp float)
 0:55          textureLod ( temp float)
 0:55            Construct combined texture-sampler ( temp usamplerCubeShadow)
-0:55              'g_tTexcdu4' ( uniform utextureCube)
+0:55              'g_tTexcdu4' ( uniform utextureCubeShadow)
 0:55              'g_sSamp' (layout( binding=0) uniform sampler)
 0:55            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -389,18 +389,18 @@ gl_FragCoord origin is upper left
 0:38              1 (const int)
 0:?   Linker Objects
 0:?     'g_sSamp' (layout( binding=0) uniform sampler)
-0:?     'g_tTex1df4' (layout( binding=0) uniform texture1D)
-0:?     'g_tTex1di4' ( uniform itexture1D)
-0:?     'g_tTex1du4' ( uniform utexture1D)
-0:?     'g_tTex2df4' ( uniform texture2D)
-0:?     'g_tTex2di4' ( uniform itexture2D)
-0:?     'g_tTex2du4' ( uniform utexture2D)
+0:?     'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
+0:?     'g_tTex1di4' ( uniform itexture1DShadow)
+0:?     'g_tTex1du4' ( uniform utexture1DShadow)
+0:?     'g_tTex2df4' ( uniform texture2DShadow)
+0:?     'g_tTex2di4' ( uniform itexture2DShadow)
+0:?     'g_tTex2du4' ( uniform utexture2DShadow)
 0:?     'g_tTex3df4' ( uniform texture3D)
 0:?     'g_tTex3di4' ( uniform itexture3D)
 0:?     'g_tTex3du4' ( uniform utexture3D)
-0:?     'g_tTexcdf4' ( uniform textureCube)
-0:?     'g_tTexcdi4' ( uniform itextureCube)
-0:?     'g_tTexcdu4' ( uniform utextureCube)
+0:?     'g_tTexcdf4' ( uniform textureCubeShadow)
+0:?     'g_tTexcdi4' ( uniform itextureCubeShadow)
+0:?     'g_tTexcdu4' ( uniform utextureCubeShadow)
 0:?     'g_tTex1df4a' ( uniform texture1DArray)
 0:?     'g_tTex1di4a' ( uniform itexture1DArray)
 0:?     'g_tTex1du4a' ( uniform utexture1DArray)
@@ -415,14 +415,14 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 208
+// Id's are bound by 199
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 165 169
+                              EntryPoint Fragment 4  "main" 156 160
                               ExecutionMode 4 OriginUpperLeft
                               Source HLSL 500
                               Name 4  "main"
@@ -433,64 +433,64 @@ gl_FragCoord origin is upper left
                               Name 13  "r00"
                               Name 16  "g_tTex1df4"
                               Name 20  "g_sSamp"
-                              Name 32  "r02"
-                              Name 36  "g_tTex1di4"
-                              Name 45  "r04"
-                              Name 49  "g_tTex1du4"
-                              Name 58  "r20"
-                              Name 61  "g_tTex2df4"
-                              Name 75  "r22"
-                              Name 78  "g_tTex2di4"
-                              Name 89  "r24"
-                              Name 92  "g_tTex2du4"
-                              Name 103  "r50"
-                              Name 106  "g_tTexcdf4"
-                              Name 120  "r52"
-                              Name 123  "g_tTexcdi4"
-                              Name 135  "r54"
-                              Name 138  "g_tTexcdu4"
-                              Name 151  "psout"
-                              Name 162  "flattenTemp"
-                              Name 165  "@entryPointOutput.Color"
-                              Name 169  "@entryPointOutput.Depth"
-                              Name 174  "g_tTex3df4"
-                              Name 177  "g_tTex3di4"
-                              Name 180  "g_tTex3du4"
-                              Name 183  "g_tTex1df4a"
-                              Name 186  "g_tTex1di4a"
-                              Name 189  "g_tTex1du4a"
-                              Name 192  "g_tTex2df4a"
-                              Name 195  "g_tTex2di4a"
-                              Name 198  "g_tTex2du4a"
-                              Name 201  "g_tTexcdf4a"
-                              Name 204  "g_tTexcdi4a"
-                              Name 207  "g_tTexcdu4a"
+                              Name 31  "r02"
+                              Name 35  "g_tTex1di4"
+                              Name 43  "r04"
+                              Name 47  "g_tTex1du4"
+                              Name 55  "r20"
+                              Name 58  "g_tTex2df4"
+                              Name 71  "r22"
+                              Name 74  "g_tTex2di4"
+                              Name 84  "r24"
+                              Name 87  "g_tTex2du4"
+                              Name 97  "r50"
+                              Name 100  "g_tTexcdf4"
+                              Name 113  "r52"
+                              Name 116  "g_tTexcdi4"
+                              Name 127  "r54"
+                              Name 130  "g_tTexcdu4"
+                              Name 142  "psout"
+                              Name 153  "flattenTemp"
+                              Name 156  "@entryPointOutput.Color"
+                              Name 160  "@entryPointOutput.Depth"
+                              Name 165  "g_tTex3df4"
+                              Name 168  "g_tTex3di4"
+                              Name 171  "g_tTex3du4"
+                              Name 174  "g_tTex1df4a"
+                              Name 177  "g_tTex1di4a"
+                              Name 180  "g_tTex1du4a"
+                              Name 183  "g_tTex2df4a"
+                              Name 186  "g_tTex2di4a"
+                              Name 189  "g_tTex2du4a"
+                              Name 192  "g_tTexcdf4a"
+                              Name 195  "g_tTexcdi4a"
+                              Name 198  "g_tTexcdu4a"
                               Decorate 16(g_tTex1df4) DescriptorSet 0
                               Decorate 16(g_tTex1df4) Binding 0
                               Decorate 20(g_sSamp) DescriptorSet 0
                               Decorate 20(g_sSamp) Binding 0
-                              Decorate 36(g_tTex1di4) DescriptorSet 0
-                              Decorate 49(g_tTex1du4) DescriptorSet 0
-                              Decorate 61(g_tTex2df4) DescriptorSet 0
-                              Decorate 78(g_tTex2di4) DescriptorSet 0
-                              Decorate 92(g_tTex2du4) DescriptorSet 0
-                              Decorate 106(g_tTexcdf4) DescriptorSet 0
-                              Decorate 123(g_tTexcdi4) DescriptorSet 0
-                              Decorate 138(g_tTexcdu4) DescriptorSet 0
-                              Decorate 165(@entryPointOutput.Color) Location 0
-                              Decorate 169(@entryPointOutput.Depth) BuiltIn FragDepth
-                              Decorate 174(g_tTex3df4) DescriptorSet 0
-                              Decorate 177(g_tTex3di4) DescriptorSet 0
-                              Decorate 180(g_tTex3du4) DescriptorSet 0
-                              Decorate 183(g_tTex1df4a) DescriptorSet 0
-                              Decorate 186(g_tTex1di4a) DescriptorSet 0
-                              Decorate 189(g_tTex1du4a) DescriptorSet 0
-                              Decorate 192(g_tTex2df4a) DescriptorSet 0
-                              Decorate 195(g_tTex2di4a) DescriptorSet 0
-                              Decorate 198(g_tTex2du4a) DescriptorSet 0
-                              Decorate 201(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 204(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 207(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 35(g_tTex1di4) DescriptorSet 0
+                              Decorate 47(g_tTex1du4) DescriptorSet 0
+                              Decorate 58(g_tTex2df4) DescriptorSet 0
+                              Decorate 74(g_tTex2di4) DescriptorSet 0
+                              Decorate 87(g_tTex2du4) DescriptorSet 0
+                              Decorate 100(g_tTexcdf4) DescriptorSet 0
+                              Decorate 116(g_tTexcdi4) DescriptorSet 0
+                              Decorate 130(g_tTexcdu4) DescriptorSet 0
+                              Decorate 156(@entryPointOutput.Color) Location 0
+                              Decorate 160(@entryPointOutput.Depth) BuiltIn FragDepth
+                              Decorate 165(g_tTex3df4) DescriptorSet 0
+                              Decorate 168(g_tTex3di4) DescriptorSet 0
+                              Decorate 171(g_tTex3du4) DescriptorSet 0
+                              Decorate 174(g_tTex1df4a) DescriptorSet 0
+                              Decorate 177(g_tTex1di4a) DescriptorSet 0
+                              Decorate 180(g_tTex1du4a) DescriptorSet 0
+                              Decorate 183(g_tTex2df4a) DescriptorSet 0
+                              Decorate 186(g_tTex2di4a) DescriptorSet 0
+                              Decorate 189(g_tTex2du4a) DescriptorSet 0
+                              Decorate 192(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 195(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 198(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -498,218 +498,209 @@ gl_FragCoord origin is upper left
     8(PS_OUTPUT):             TypeStruct 7(fvec4) 6(float)
                9:             TypeFunction 8(PS_OUTPUT)
               12:             TypePointer Function 6(float)
-              14:             TypeImage 6(float) 1D sampled format:Unknown
+              14:             TypeImage 6(float) 1D depth sampled format:Unknown
               15:             TypePointer UniformConstant 14
   16(g_tTex1df4):     15(ptr) Variable UniformConstant
               18:             TypeSampler
               19:             TypePointer UniformConstant 18
      20(g_sSamp):     19(ptr) Variable UniformConstant
-              22:             TypeImage 6(float) 1D depth sampled format:Unknown
-              23:             TypeSampledImage 22
-              25:    6(float) Constant 1036831949
-              26:    6(float) Constant 1061158912
-              27:             TypeVector 6(float) 2
-              29:    6(float) Constant 0
-              33:             TypeInt 32 1
-              34:             TypeImage 33(int) 1D sampled format:Unknown
-              35:             TypePointer UniformConstant 34
-  36(g_tTex1di4):     35(ptr) Variable UniformConstant
-              39:             TypeImage 33(int) 1D depth sampled format:Unknown
-              40:             TypeSampledImage 39
-              46:             TypeInt 32 0
-              47:             TypeImage 46(int) 1D sampled format:Unknown
-              48:             TypePointer UniformConstant 47
-  49(g_tTex1du4):     48(ptr) Variable UniformConstant
-              52:             TypeImage 46(int) 1D depth sampled format:Unknown
-              53:             TypeSampledImage 52
-              59:             TypeImage 6(float) 2D sampled format:Unknown
-              60:             TypePointer UniformConstant 59
-  61(g_tTex2df4):     60(ptr) Variable UniformConstant
-              64:             TypeImage 6(float) 2D depth sampled format:Unknown
-              65:             TypeSampledImage 64
-              67:    6(float) Constant 1045220557
-              68:   27(fvec2) ConstantComposite 25 67
-              69:             TypeVector 6(float) 3
-              76:             TypeImage 33(int) 2D sampled format:Unknown
-              77:             TypePointer UniformConstant 76
-  78(g_tTex2di4):     77(ptr) Variable UniformConstant
-              81:             TypeImage 33(int) 2D depth sampled format:Unknown
-              82:             TypeSampledImage 81
-              90:             TypeImage 46(int) 2D sampled format:Unknown
-              91:             TypePointer UniformConstant 90
-  92(g_tTex2du4):     91(ptr) Variable UniformConstant
-              95:             TypeImage 46(int) 2D depth sampled format:Unknown
-              96:             TypeSampledImage 95
-             104:             TypeImage 6(float) Cube sampled format:Unknown
-             105:             TypePointer UniformConstant 104
- 106(g_tTexcdf4):    105(ptr) Variable UniformConstant
-             109:             TypeImage 6(float) Cube depth sampled format:Unknown
-             110:             TypeSampledImage 109
-             112:    6(float) Constant 1050253722
-             113:   69(fvec3) ConstantComposite 25 67 112
-             121:             TypeImage 33(int) Cube sampled format:Unknown
-             122:             TypePointer UniformConstant 121
- 123(g_tTexcdi4):    122(ptr) Variable UniformConstant
-             126:             TypeImage 33(int) Cube depth sampled format:Unknown
-             127:             TypeSampledImage 126
-             136:             TypeImage 46(int) Cube sampled format:Unknown
-             137:             TypePointer UniformConstant 136
- 138(g_tTexcdu4):    137(ptr) Variable UniformConstant
-             141:             TypeImage 46(int) Cube depth sampled format:Unknown
-             142:             TypeSampledImage 141
-             150:             TypePointer Function 8(PS_OUTPUT)
-             152:     33(int) Constant 0
-             153:    6(float) Constant 1065353216
-             154:    7(fvec4) ConstantComposite 153 153 153 153
-             155:             TypePointer Function 7(fvec4)
-             157:     33(int) Constant 1
-             164:             TypePointer Output 7(fvec4)
-165(@entryPointOutput.Color):    164(ptr) Variable Output
-             168:             TypePointer Output 6(float)
-169(@entryPointOutput.Depth):    168(ptr) Variable Output
-             172:             TypeImage 6(float) 3D sampled format:Unknown
+              22:             TypeSampledImage 14
+              24:    6(float) Constant 1036831949
+              25:    6(float) Constant 1061158912
+              26:             TypeVector 6(float) 2
+              28:    6(float) Constant 0
+              32:             TypeInt 32 1
+              33:             TypeImage 32(int) 1D depth sampled format:Unknown
+              34:             TypePointer UniformConstant 33
+  35(g_tTex1di4):     34(ptr) Variable UniformConstant
+              38:             TypeSampledImage 33
+              44:             TypeInt 32 0
+              45:             TypeImage 44(int) 1D depth sampled format:Unknown
+              46:             TypePointer UniformConstant 45
+  47(g_tTex1du4):     46(ptr) Variable UniformConstant
+              50:             TypeSampledImage 45
+              56:             TypeImage 6(float) 2D depth sampled format:Unknown
+              57:             TypePointer UniformConstant 56
+  58(g_tTex2df4):     57(ptr) Variable UniformConstant
+              61:             TypeSampledImage 56
+              63:    6(float) Constant 1045220557
+              64:   26(fvec2) ConstantComposite 24 63
+              65:             TypeVector 6(float) 3
+              72:             TypeImage 32(int) 2D depth sampled format:Unknown
+              73:             TypePointer UniformConstant 72
+  74(g_tTex2di4):     73(ptr) Variable UniformConstant
+              77:             TypeSampledImage 72
+              85:             TypeImage 44(int) 2D depth sampled format:Unknown
+              86:             TypePointer UniformConstant 85
+  87(g_tTex2du4):     86(ptr) Variable UniformConstant
+              90:             TypeSampledImage 85
+              98:             TypeImage 6(float) Cube depth sampled format:Unknown
+              99:             TypePointer UniformConstant 98
+ 100(g_tTexcdf4):     99(ptr) Variable UniformConstant
+             103:             TypeSampledImage 98
+             105:    6(float) Constant 1050253722
+             106:   65(fvec3) ConstantComposite 24 63 105
+             114:             TypeImage 32(int) Cube depth sampled format:Unknown
+             115:             TypePointer UniformConstant 114
+ 116(g_tTexcdi4):    115(ptr) Variable UniformConstant
+             119:             TypeSampledImage 114
+             128:             TypeImage 44(int) Cube depth sampled format:Unknown
+             129:             TypePointer UniformConstant 128
+ 130(g_tTexcdu4):    129(ptr) Variable UniformConstant
+             133:             TypeSampledImage 128
+             141:             TypePointer Function 8(PS_OUTPUT)
+             143:     32(int) Constant 0
+             144:    6(float) Constant 1065353216
+             145:    7(fvec4) ConstantComposite 144 144 144 144
+             146:             TypePointer Function 7(fvec4)
+             148:     32(int) Constant 1
+             155:             TypePointer Output 7(fvec4)
+156(@entryPointOutput.Color):    155(ptr) Variable Output
+             159:             TypePointer Output 6(float)
+160(@entryPointOutput.Depth):    159(ptr) Variable Output
+             163:             TypeImage 6(float) 3D sampled format:Unknown
+             164:             TypePointer UniformConstant 163
+ 165(g_tTex3df4):    164(ptr) Variable UniformConstant
+             166:             TypeImage 32(int) 3D sampled format:Unknown
+             167:             TypePointer UniformConstant 166
+ 168(g_tTex3di4):    167(ptr) Variable UniformConstant
+             169:             TypeImage 44(int) 3D sampled format:Unknown
+             170:             TypePointer UniformConstant 169
+ 171(g_tTex3du4):    170(ptr) Variable UniformConstant
+             172:             TypeImage 6(float) 1D array sampled format:Unknown
              173:             TypePointer UniformConstant 172
- 174(g_tTex3df4):    173(ptr) Variable UniformConstant
-             175:             TypeImage 33(int) 3D sampled format:Unknown
+174(g_tTex1df4a):    173(ptr) Variable UniformConstant
+             175:             TypeImage 32(int) 1D array sampled format:Unknown
              176:             TypePointer UniformConstant 175
- 177(g_tTex3di4):    176(ptr) Variable UniformConstant
-             178:             TypeImage 46(int) 3D sampled format:Unknown
+177(g_tTex1di4a):    176(ptr) Variable UniformConstant
+             178:             TypeImage 44(int) 1D array sampled format:Unknown
              179:             TypePointer UniformConstant 178
- 180(g_tTex3du4):    179(ptr) Variable UniformConstant
-             181:             TypeImage 6(float) 1D array sampled format:Unknown
+180(g_tTex1du4a):    179(ptr) Variable UniformConstant
+             181:             TypeImage 6(float) 2D array sampled format:Unknown
              182:             TypePointer UniformConstant 181
-183(g_tTex1df4a):    182(ptr) Variable UniformConstant
-             184:             TypeImage 33(int) 1D array sampled format:Unknown
+183(g_tTex2df4a):    182(ptr) Variable UniformConstant
+             184:             TypeImage 32(int) 2D array sampled format:Unknown
              185:             TypePointer UniformConstant 184
-186(g_tTex1di4a):    185(ptr) Variable UniformConstant
-             187:             TypeImage 46(int) 1D array sampled format:Unknown
+186(g_tTex2di4a):    185(ptr) Variable UniformConstant
+             187:             TypeImage 44(int) 2D array sampled format:Unknown
              188:             TypePointer UniformConstant 187
-189(g_tTex1du4a):    188(ptr) Variable UniformConstant
-             190:             TypeImage 6(float) 2D array sampled format:Unknown
+189(g_tTex2du4a):    188(ptr) Variable UniformConstant
+             190:             TypeImage 6(float) Cube array sampled format:Unknown
              191:             TypePointer UniformConstant 190
-192(g_tTex2df4a):    191(ptr) Variable UniformConstant
-             193:             TypeImage 33(int) 2D array sampled format:Unknown
+192(g_tTexcdf4a):    191(ptr) Variable UniformConstant
+             193:             TypeImage 32(int) Cube array sampled format:Unknown
              194:             TypePointer UniformConstant 193
-195(g_tTex2di4a):    194(ptr) Variable UniformConstant
-             196:             TypeImage 46(int) 2D array sampled format:Unknown
+195(g_tTexcdi4a):    194(ptr) Variable UniformConstant
+             196:             TypeImage 44(int) Cube array sampled format:Unknown
              197:             TypePointer UniformConstant 196
-198(g_tTex2du4a):    197(ptr) Variable UniformConstant
-             199:             TypeImage 6(float) Cube array sampled format:Unknown
-             200:             TypePointer UniformConstant 199
-201(g_tTexcdf4a):    200(ptr) Variable UniformConstant
-             202:             TypeImage 33(int) Cube array sampled format:Unknown
-             203:             TypePointer UniformConstant 202
-204(g_tTexcdi4a):    203(ptr) Variable UniformConstant
-             205:             TypeImage 46(int) Cube array sampled format:Unknown
-             206:             TypePointer UniformConstant 205
-207(g_tTexcdu4a):    206(ptr) Variable UniformConstant
+198(g_tTexcdu4a):    197(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
-162(flattenTemp):    150(ptr) Variable Function
-             163:8(PS_OUTPUT) FunctionCall 10(@main()
-                              Store 162(flattenTemp) 163
-             166:    155(ptr) AccessChain 162(flattenTemp) 152
-             167:    7(fvec4) Load 166
-                              Store 165(@entryPointOutput.Color) 167
-             170:     12(ptr) AccessChain 162(flattenTemp) 157
-             171:    6(float) Load 170
-                              Store 169(@entryPointOutput.Depth) 171
+153(flattenTemp):    141(ptr) Variable Function
+             154:8(PS_OUTPUT) FunctionCall 10(@main()
+                              Store 153(flattenTemp) 154
+             157:    146(ptr) AccessChain 153(flattenTemp) 143
+             158:    7(fvec4) Load 157
+                              Store 156(@entryPointOutput.Color) 158
+             161:     12(ptr) AccessChain 153(flattenTemp) 148
+             162:    6(float) Load 161
+                              Store 160(@entryPointOutput.Depth) 162
                               Return
                               FunctionEnd
       10(@main():8(PS_OUTPUT) Function None 9
               11:             Label
          13(r00):     12(ptr) Variable Function
-         32(r02):     12(ptr) Variable Function
-         45(r04):     12(ptr) Variable Function
-         58(r20):     12(ptr) Variable Function
-         75(r22):     12(ptr) Variable Function
-         89(r24):     12(ptr) Variable Function
-        103(r50):     12(ptr) Variable Function
-        120(r52):     12(ptr) Variable Function
-        135(r54):     12(ptr) Variable Function
-      151(psout):    150(ptr) Variable Function
+         31(r02):     12(ptr) Variable Function
+         43(r04):     12(ptr) Variable Function
+         55(r20):     12(ptr) Variable Function
+         71(r22):     12(ptr) Variable Function
+         84(r24):     12(ptr) Variable Function
+         97(r50):     12(ptr) Variable Function
+        113(r52):     12(ptr) Variable Function
+        127(r54):     12(ptr) Variable Function
+      142(psout):    141(ptr) Variable Function
               17:          14 Load 16(g_tTex1df4)
               21:          18 Load 20(g_sSamp)
-              24:          23 SampledImage 17 21
-              28:   27(fvec2) CompositeConstruct 25 26
-              30:    6(float) CompositeExtract 28 1
-              31:    6(float) ImageSampleDrefExplicitLod 24 28 30 Lod 29
-                              Store 13(r00) 31
-              37:          34 Load 36(g_tTex1di4)
-              38:          18 Load 20(g_sSamp)
-              41:          40 SampledImage 37 38
-              42:   27(fvec2) CompositeConstruct 25 26
-              43:    6(float) CompositeExtract 42 1
-              44:    6(float) ImageSampleDrefExplicitLod 41 42 43 Lod 29
-                              Store 32(r02) 44
-              50:          47 Load 49(g_tTex1du4)
-              51:          18 Load 20(g_sSamp)
-              54:          53 SampledImage 50 51
-              55:   27(fvec2) CompositeConstruct 25 26
-              56:    6(float) CompositeExtract 55 1
-              57:    6(float) ImageSampleDrefExplicitLod 54 55 56 Lod 29
-                              Store 45(r04) 57
-              62:          59 Load 61(g_tTex2df4)
-              63:          18 Load 20(g_sSamp)
-              66:          65 SampledImage 62 63
-              70:    6(float) CompositeExtract 68 0
-              71:    6(float) CompositeExtract 68 1
-              72:   69(fvec3) CompositeConstruct 70 71 26
-              73:    6(float) CompositeExtract 72 2
-              74:    6(float) ImageSampleDrefExplicitLod 66 72 73 Lod 29
-                              Store 58(r20) 74
-              79:          76 Load 78(g_tTex2di4)
-              80:          18 Load 20(g_sSamp)
-              83:          82 SampledImage 79 80
-              84:    6(float) CompositeExtract 68 0
-              85:    6(float) CompositeExtract 68 1
-              86:   69(fvec3) CompositeConstruct 84 85 26
-              87:    6(float) CompositeExtract 86 2
-              88:    6(float) ImageSampleDrefExplicitLod 83 86 87 Lod 29
-                              Store 75(r22) 88
-              93:          90 Load 92(g_tTex2du4)
-              94:          18 Load 20(g_sSamp)
-              97:          96 SampledImage 93 94
-              98:    6(float) CompositeExtract 68 0
-              99:    6(float) CompositeExtract 68 1
-             100:   69(fvec3) CompositeConstruct 98 99 26
-             101:    6(float) CompositeExtract 100 2
-             102:    6(float) ImageSampleDrefExplicitLod 97 100 101 Lod 29
-                              Store 89(r24) 102
-             107:         104 Load 106(g_tTexcdf4)
-             108:          18 Load 20(g_sSamp)
-             111:         110 SampledImage 107 108
-             114:    6(float) CompositeExtract 113 0
-             115:    6(float) CompositeExtract 113 1
-             116:    6(float) CompositeExtract 113 2
-             117:    7(fvec4) CompositeConstruct 114 115 116 26
-             118:    6(float) CompositeExtract 117 3
-             119:    6(float) ImageSampleDrefExplicitLod 111 117 118 Lod 29
-                              Store 103(r50) 119
-             124:         121 Load 123(g_tTexcdi4)
-             125:          18 Load 20(g_sSamp)
-             128:         127 SampledImage 124 125
-             129:    6(float) CompositeExtract 113 0
-             130:    6(float) CompositeExtract 113 1
-             131:    6(float) CompositeExtract 113 2
-             132:    7(fvec4) CompositeConstruct 129 130 131 26
-             133:    6(float) CompositeExtract 132 3
-             134:    6(float) ImageSampleDrefExplicitLod 128 132 133 Lod 29
-                              Store 120(r52) 134
-             139:         136 Load 138(g_tTexcdu4)
-             140:          18 Load 20(g_sSamp)
-             143:         142 SampledImage 139 140
-             144:    6(float) CompositeExtract 113 0
-             145:    6(float) CompositeExtract 113 1
-             146:    6(float) CompositeExtract 113 2
-             147:    7(fvec4) CompositeConstruct 144 145 146 26
-             148:    6(float) CompositeExtract 147 3
-             149:    6(float) ImageSampleDrefExplicitLod 143 147 148 Lod 29
-                              Store 135(r54) 149
-             156:    155(ptr) AccessChain 151(psout) 152
-                              Store 156 154
-             158:     12(ptr) AccessChain 151(psout) 157
-                              Store 158 153
-             159:8(PS_OUTPUT) Load 151(psout)
-                              ReturnValue 159
+              23:          22 SampledImage 17 21
+              27:   26(fvec2) CompositeConstruct 24 25
+              29:    6(float) CompositeExtract 27 1
+              30:    6(float) ImageSampleDrefExplicitLod 23 27 29 Lod 28
+                              Store 13(r00) 30
+              36:          33 Load 35(g_tTex1di4)
+              37:          18 Load 20(g_sSamp)
+              39:          38 SampledImage 36 37
+              40:   26(fvec2) CompositeConstruct 24 25
+              41:    6(float) CompositeExtract 40 1
+              42:    6(float) ImageSampleDrefExplicitLod 39 40 41 Lod 28
+                              Store 31(r02) 42
+              48:          45 Load 47(g_tTex1du4)
+              49:          18 Load 20(g_sSamp)
+              51:          50 SampledImage 48 49
+              52:   26(fvec2) CompositeConstruct 24 25
+              53:    6(float) CompositeExtract 52 1
+              54:    6(float) ImageSampleDrefExplicitLod 51 52 53 Lod 28
+                              Store 43(r04) 54
+              59:          56 Load 58(g_tTex2df4)
+              60:          18 Load 20(g_sSamp)
+              62:          61 SampledImage 59 60
+              66:    6(float) CompositeExtract 64 0
+              67:    6(float) CompositeExtract 64 1
+              68:   65(fvec3) CompositeConstruct 66 67 25
+              69:    6(float) CompositeExtract 68 2
+              70:    6(float) ImageSampleDrefExplicitLod 62 68 69 Lod 28
+                              Store 55(r20) 70
+              75:          72 Load 74(g_tTex2di4)
+              76:          18 Load 20(g_sSamp)
+              78:          77 SampledImage 75 76
+              79:    6(float) CompositeExtract 64 0
+              80:    6(float) CompositeExtract 64 1
+              81:   65(fvec3) CompositeConstruct 79 80 25
+              82:    6(float) CompositeExtract 81 2
+              83:    6(float) ImageSampleDrefExplicitLod 78 81 82 Lod 28
+                              Store 71(r22) 83
+              88:          85 Load 87(g_tTex2du4)
+              89:          18 Load 20(g_sSamp)
+              91:          90 SampledImage 88 89
+              92:    6(float) CompositeExtract 64 0
+              93:    6(float) CompositeExtract 64 1
+              94:   65(fvec3) CompositeConstruct 92 93 25
+              95:    6(float) CompositeExtract 94 2
+              96:    6(float) ImageSampleDrefExplicitLod 91 94 95 Lod 28
+                              Store 84(r24) 96
+             101:          98 Load 100(g_tTexcdf4)
+             102:          18 Load 20(g_sSamp)
+             104:         103 SampledImage 101 102
+             107:    6(float) CompositeExtract 106 0
+             108:    6(float) CompositeExtract 106 1
+             109:    6(float) CompositeExtract 106 2
+             110:    7(fvec4) CompositeConstruct 107 108 109 25
+             111:    6(float) CompositeExtract 110 3
+             112:    6(float) ImageSampleDrefExplicitLod 104 110 111 Lod 28
+                              Store 97(r50) 112
+             117:         114 Load 116(g_tTexcdi4)
+             118:          18 Load 20(g_sSamp)
+             120:         119 SampledImage 117 118
+             121:    6(float) CompositeExtract 106 0
+             122:    6(float) CompositeExtract 106 1
+             123:    6(float) CompositeExtract 106 2
+             124:    7(fvec4) CompositeConstruct 121 122 123 25
+             125:    6(float) CompositeExtract 124 3
+             126:    6(float) ImageSampleDrefExplicitLod 120 124 125 Lod 28
+                              Store 113(r52) 126
+             131:         128 Load 130(g_tTexcdu4)
+             132:          18 Load 20(g_sSamp)
+             134:         133 SampledImage 131 132
+             135:    6(float) CompositeExtract 106 0
+             136:    6(float) CompositeExtract 106 1
+             137:    6(float) CompositeExtract 106 2
+             138:    7(fvec4) CompositeConstruct 135 136 137 25
+             139:    6(float) CompositeExtract 138 3
+             140:    6(float) ImageSampleDrefExplicitLod 134 138 139 Lod 28
+                              Store 127(r54) 140
+             147:    146(ptr) AccessChain 142(psout) 143
+                              Store 147 145
+             149:     12(ptr) AccessChain 142(psout) 148
+                              Store 149 144
+             150:8(PS_OUTPUT) Load 142(psout)
+                              ReturnValue 150
                               FunctionEnd

--- a/Test/baseResults/hlsl.samplecmplevelzero.offset.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmplevelzero.offset.dx10.frag.out
@@ -10,7 +10,7 @@ gl_FragCoord origin is upper left
 0:42          'r01' ( temp float)
 0:42          textureLodOffset ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DShadow)
-0:42              'g_tTex1df4' (layout( binding=0) uniform texture1D)
+0:42              'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec2 ( temp 2-component vector of float)
 0:42              Constant:
@@ -26,7 +26,7 @@ gl_FragCoord origin is upper left
 0:43          'r03' ( temp float)
 0:43          textureLodOffset ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DShadow)
-0:43              'g_tTex1di4' ( uniform itexture1D)
+0:43              'g_tTex1di4' ( uniform itexture1DShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec2 ( temp 2-component vector of float)
 0:43              Constant:
@@ -42,7 +42,7 @@ gl_FragCoord origin is upper left
 0:44          'r05' ( temp float)
 0:44          textureLodOffset ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DShadow)
-0:44              'g_tTex1du4' ( uniform utexture1D)
+0:44              'g_tTex1du4' ( uniform utexture1DShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec2 ( temp 2-component vector of float)
 0:44              Constant:
@@ -58,7 +58,7 @@ gl_FragCoord origin is upper left
 0:47          'r21' ( temp float)
 0:47          textureLodOffset ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DShadow)
-0:47              'g_tTex2df4' ( uniform texture2D)
+0:47              'g_tTex2df4' ( uniform texture2DShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -76,7 +76,7 @@ gl_FragCoord origin is upper left
 0:48          'r23' ( temp float)
 0:48          textureLodOffset ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DShadow)
-0:48              'g_tTex2di4' ( uniform itexture2D)
+0:48              'g_tTex2di4' ( uniform itexture2DShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -94,7 +94,7 @@ gl_FragCoord origin is upper left
 0:49          'r25' ( temp float)
 0:49          textureLodOffset ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DShadow)
-0:49              'g_tTex2du4' ( uniform utexture2D)
+0:49              'g_tTex2du4' ( uniform utexture2DShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -147,12 +147,12 @@ gl_FragCoord origin is upper left
 0:38              1 (const int)
 0:?   Linker Objects
 0:?     'g_sSamp' (layout( binding=0) uniform sampler)
-0:?     'g_tTex1df4' (layout( binding=0) uniform texture1D)
-0:?     'g_tTex1di4' ( uniform itexture1D)
-0:?     'g_tTex1du4' ( uniform utexture1D)
-0:?     'g_tTex2df4' ( uniform texture2D)
-0:?     'g_tTex2di4' ( uniform itexture2D)
-0:?     'g_tTex2du4' ( uniform utexture2D)
+0:?     'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
+0:?     'g_tTex1di4' ( uniform itexture1DShadow)
+0:?     'g_tTex1du4' ( uniform utexture1DShadow)
+0:?     'g_tTex2df4' ( uniform texture2DShadow)
+0:?     'g_tTex2di4' ( uniform itexture2DShadow)
+0:?     'g_tTex2du4' ( uniform utexture2DShadow)
 0:?     'g_tTex3df4' ( uniform texture3D)
 0:?     'g_tTex3di4' ( uniform itexture3D)
 0:?     'g_tTex3du4' ( uniform utexture3D)
@@ -186,7 +186,7 @@ gl_FragCoord origin is upper left
 0:42          'r01' ( temp float)
 0:42          textureLodOffset ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DShadow)
-0:42              'g_tTex1df4' (layout( binding=0) uniform texture1D)
+0:42              'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec2 ( temp 2-component vector of float)
 0:42              Constant:
@@ -202,7 +202,7 @@ gl_FragCoord origin is upper left
 0:43          'r03' ( temp float)
 0:43          textureLodOffset ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DShadow)
-0:43              'g_tTex1di4' ( uniform itexture1D)
+0:43              'g_tTex1di4' ( uniform itexture1DShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec2 ( temp 2-component vector of float)
 0:43              Constant:
@@ -218,7 +218,7 @@ gl_FragCoord origin is upper left
 0:44          'r05' ( temp float)
 0:44          textureLodOffset ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DShadow)
-0:44              'g_tTex1du4' ( uniform utexture1D)
+0:44              'g_tTex1du4' ( uniform utexture1DShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec2 ( temp 2-component vector of float)
 0:44              Constant:
@@ -234,7 +234,7 @@ gl_FragCoord origin is upper left
 0:47          'r21' ( temp float)
 0:47          textureLodOffset ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DShadow)
-0:47              'g_tTex2df4' ( uniform texture2D)
+0:47              'g_tTex2df4' ( uniform texture2DShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -252,7 +252,7 @@ gl_FragCoord origin is upper left
 0:48          'r23' ( temp float)
 0:48          textureLodOffset ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DShadow)
-0:48              'g_tTex2di4' ( uniform itexture2D)
+0:48              'g_tTex2di4' ( uniform itexture2DShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -270,7 +270,7 @@ gl_FragCoord origin is upper left
 0:49          'r25' ( temp float)
 0:49          textureLodOffset ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DShadow)
-0:49              'g_tTex2du4' ( uniform utexture2D)
+0:49              'g_tTex2du4' ( uniform utexture2DShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -323,12 +323,12 @@ gl_FragCoord origin is upper left
 0:38              1 (const int)
 0:?   Linker Objects
 0:?     'g_sSamp' (layout( binding=0) uniform sampler)
-0:?     'g_tTex1df4' (layout( binding=0) uniform texture1D)
-0:?     'g_tTex1di4' ( uniform itexture1D)
-0:?     'g_tTex1du4' ( uniform utexture1D)
-0:?     'g_tTex2df4' ( uniform texture2D)
-0:?     'g_tTex2di4' ( uniform itexture2D)
-0:?     'g_tTex2du4' ( uniform utexture2D)
+0:?     'g_tTex1df4' (layout( binding=0) uniform texture1DShadow)
+0:?     'g_tTex1di4' ( uniform itexture1DShadow)
+0:?     'g_tTex1du4' ( uniform utexture1DShadow)
+0:?     'g_tTex2df4' ( uniform texture2DShadow)
+0:?     'g_tTex2di4' ( uniform itexture2DShadow)
+0:?     'g_tTex2du4' ( uniform utexture2DShadow)
 0:?     'g_tTex3df4' ( uniform texture3D)
 0:?     'g_tTex3di4' ( uniform itexture3D)
 0:?     'g_tTex3du4' ( uniform utexture3D)
@@ -349,14 +349,14 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 174
+// Id's are bound by 168
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 122 126
+                              EntryPoint Fragment 4  "main" 116 120
                               ExecutionMode 4 OriginUpperLeft
                               Source HLSL 500
                               Name 4  "main"
@@ -367,61 +367,61 @@ gl_FragCoord origin is upper left
                               Name 13  "r01"
                               Name 16  "g_tTex1df4"
                               Name 20  "g_sSamp"
-                              Name 34  "r03"
-                              Name 37  "g_tTex1di4"
-                              Name 46  "r05"
-                              Name 50  "g_tTex1du4"
-                              Name 59  "r21"
-                              Name 62  "g_tTex2df4"
-                              Name 79  "r23"
-                              Name 82  "g_tTex2di4"
-                              Name 93  "r25"
-                              Name 96  "g_tTex2du4"
-                              Name 108  "psout"
-                              Name 119  "flattenTemp"
-                              Name 122  "@entryPointOutput.Color"
-                              Name 126  "@entryPointOutput.Depth"
-                              Name 131  "g_tTex3df4"
-                              Name 134  "g_tTex3di4"
-                              Name 137  "g_tTex3du4"
-                              Name 140  "g_tTexcdf4"
-                              Name 143  "g_tTexcdi4"
-                              Name 146  "g_tTexcdu4"
-                              Name 149  "g_tTex1df4a"
-                              Name 152  "g_tTex1di4a"
-                              Name 155  "g_tTex1du4a"
-                              Name 158  "g_tTex2df4a"
-                              Name 161  "g_tTex2di4a"
-                              Name 164  "g_tTex2du4a"
-                              Name 167  "g_tTexcdf4a"
-                              Name 170  "g_tTexcdi4a"
-                              Name 173  "g_tTexcdu4a"
+                              Name 33  "r03"
+                              Name 36  "g_tTex1di4"
+                              Name 44  "r05"
+                              Name 48  "g_tTex1du4"
+                              Name 56  "r21"
+                              Name 59  "g_tTex2df4"
+                              Name 75  "r23"
+                              Name 78  "g_tTex2di4"
+                              Name 88  "r25"
+                              Name 91  "g_tTex2du4"
+                              Name 102  "psout"
+                              Name 113  "flattenTemp"
+                              Name 116  "@entryPointOutput.Color"
+                              Name 120  "@entryPointOutput.Depth"
+                              Name 125  "g_tTex3df4"
+                              Name 128  "g_tTex3di4"
+                              Name 131  "g_tTex3du4"
+                              Name 134  "g_tTexcdf4"
+                              Name 137  "g_tTexcdi4"
+                              Name 140  "g_tTexcdu4"
+                              Name 143  "g_tTex1df4a"
+                              Name 146  "g_tTex1di4a"
+                              Name 149  "g_tTex1du4a"
+                              Name 152  "g_tTex2df4a"
+                              Name 155  "g_tTex2di4a"
+                              Name 158  "g_tTex2du4a"
+                              Name 161  "g_tTexcdf4a"
+                              Name 164  "g_tTexcdi4a"
+                              Name 167  "g_tTexcdu4a"
                               Decorate 16(g_tTex1df4) DescriptorSet 0
                               Decorate 16(g_tTex1df4) Binding 0
                               Decorate 20(g_sSamp) DescriptorSet 0
                               Decorate 20(g_sSamp) Binding 0
-                              Decorate 37(g_tTex1di4) DescriptorSet 0
-                              Decorate 50(g_tTex1du4) DescriptorSet 0
-                              Decorate 62(g_tTex2df4) DescriptorSet 0
-                              Decorate 82(g_tTex2di4) DescriptorSet 0
-                              Decorate 96(g_tTex2du4) DescriptorSet 0
-                              Decorate 122(@entryPointOutput.Color) Location 0
-                              Decorate 126(@entryPointOutput.Depth) BuiltIn FragDepth
-                              Decorate 131(g_tTex3df4) DescriptorSet 0
-                              Decorate 134(g_tTex3di4) DescriptorSet 0
-                              Decorate 137(g_tTex3du4) DescriptorSet 0
-                              Decorate 140(g_tTexcdf4) DescriptorSet 0
-                              Decorate 143(g_tTexcdi4) DescriptorSet 0
-                              Decorate 146(g_tTexcdu4) DescriptorSet 0
-                              Decorate 149(g_tTex1df4a) DescriptorSet 0
-                              Decorate 152(g_tTex1di4a) DescriptorSet 0
-                              Decorate 155(g_tTex1du4a) DescriptorSet 0
-                              Decorate 158(g_tTex2df4a) DescriptorSet 0
-                              Decorate 161(g_tTex2di4a) DescriptorSet 0
-                              Decorate 164(g_tTex2du4a) DescriptorSet 0
-                              Decorate 167(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 170(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 173(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 36(g_tTex1di4) DescriptorSet 0
+                              Decorate 48(g_tTex1du4) DescriptorSet 0
+                              Decorate 59(g_tTex2df4) DescriptorSet 0
+                              Decorate 78(g_tTex2di4) DescriptorSet 0
+                              Decorate 91(g_tTex2du4) DescriptorSet 0
+                              Decorate 116(@entryPointOutput.Color) Location 0
+                              Decorate 120(@entryPointOutput.Depth) BuiltIn FragDepth
+                              Decorate 125(g_tTex3df4) DescriptorSet 0
+                              Decorate 128(g_tTex3di4) DescriptorSet 0
+                              Decorate 131(g_tTex3du4) DescriptorSet 0
+                              Decorate 134(g_tTexcdf4) DescriptorSet 0
+                              Decorate 137(g_tTexcdi4) DescriptorSet 0
+                              Decorate 140(g_tTexcdu4) DescriptorSet 0
+                              Decorate 143(g_tTex1df4a) DescriptorSet 0
+                              Decorate 146(g_tTex1di4a) DescriptorSet 0
+                              Decorate 149(g_tTex1du4a) DescriptorSet 0
+                              Decorate 152(g_tTex2df4a) DescriptorSet 0
+                              Decorate 155(g_tTex2di4a) DescriptorSet 0
+                              Decorate 158(g_tTex2du4a) DescriptorSet 0
+                              Decorate 161(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 164(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 167(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -429,181 +429,175 @@ gl_FragCoord origin is upper left
     8(PS_OUTPUT):             TypeStruct 7(fvec4) 6(float)
                9:             TypeFunction 8(PS_OUTPUT)
               12:             TypePointer Function 6(float)
-              14:             TypeImage 6(float) 1D sampled format:Unknown
+              14:             TypeImage 6(float) 1D depth sampled format:Unknown
               15:             TypePointer UniformConstant 14
   16(g_tTex1df4):     15(ptr) Variable UniformConstant
               18:             TypeSampler
               19:             TypePointer UniformConstant 18
      20(g_sSamp):     19(ptr) Variable UniformConstant
-              22:             TypeImage 6(float) 1D depth sampled format:Unknown
-              23:             TypeSampledImage 22
-              25:    6(float) Constant 1036831949
-              26:    6(float) Constant 1061158912
-              27:             TypeVector 6(float) 2
-              29:    6(float) Constant 0
-              30:             TypeInt 32 1
-              31:     30(int) Constant 2
-              35:             TypeImage 30(int) 1D sampled format:Unknown
-              36:             TypePointer UniformConstant 35
-  37(g_tTex1di4):     36(ptr) Variable UniformConstant
-              40:             TypeImage 30(int) 1D depth sampled format:Unknown
-              41:             TypeSampledImage 40
-              47:             TypeInt 32 0
-              48:             TypeImage 47(int) 1D sampled format:Unknown
-              49:             TypePointer UniformConstant 48
-  50(g_tTex1du4):     49(ptr) Variable UniformConstant
-              53:             TypeImage 47(int) 1D depth sampled format:Unknown
-              54:             TypeSampledImage 53
-              60:             TypeImage 6(float) 2D sampled format:Unknown
-              61:             TypePointer UniformConstant 60
-  62(g_tTex2df4):     61(ptr) Variable UniformConstant
-              65:             TypeImage 6(float) 2D depth sampled format:Unknown
-              66:             TypeSampledImage 65
-              68:    6(float) Constant 1045220557
-              69:   27(fvec2) ConstantComposite 25 68
-              70:             TypeVector 6(float) 3
-              74:             TypeVector 30(int) 2
-              75:     30(int) Constant 3
-              76:   74(ivec2) ConstantComposite 31 75
-              80:             TypeImage 30(int) 2D sampled format:Unknown
-              81:             TypePointer UniformConstant 80
-  82(g_tTex2di4):     81(ptr) Variable UniformConstant
-              85:             TypeImage 30(int) 2D depth sampled format:Unknown
-              86:             TypeSampledImage 85
-              94:             TypeImage 47(int) 2D sampled format:Unknown
-              95:             TypePointer UniformConstant 94
-  96(g_tTex2du4):     95(ptr) Variable UniformConstant
-              99:             TypeImage 47(int) 2D depth sampled format:Unknown
-             100:             TypeSampledImage 99
-             107:             TypePointer Function 8(PS_OUTPUT)
-             109:     30(int) Constant 0
-             110:    6(float) Constant 1065353216
-             111:    7(fvec4) ConstantComposite 110 110 110 110
-             112:             TypePointer Function 7(fvec4)
-             114:     30(int) Constant 1
-             121:             TypePointer Output 7(fvec4)
-122(@entryPointOutput.Color):    121(ptr) Variable Output
-             125:             TypePointer Output 6(float)
-126(@entryPointOutput.Depth):    125(ptr) Variable Output
-             129:             TypeImage 6(float) 3D sampled format:Unknown
+              22:             TypeSampledImage 14
+              24:    6(float) Constant 1036831949
+              25:    6(float) Constant 1061158912
+              26:             TypeVector 6(float) 2
+              28:    6(float) Constant 0
+              29:             TypeInt 32 1
+              30:     29(int) Constant 2
+              34:             TypeImage 29(int) 1D depth sampled format:Unknown
+              35:             TypePointer UniformConstant 34
+  36(g_tTex1di4):     35(ptr) Variable UniformConstant
+              39:             TypeSampledImage 34
+              45:             TypeInt 32 0
+              46:             TypeImage 45(int) 1D depth sampled format:Unknown
+              47:             TypePointer UniformConstant 46
+  48(g_tTex1du4):     47(ptr) Variable UniformConstant
+              51:             TypeSampledImage 46
+              57:             TypeImage 6(float) 2D depth sampled format:Unknown
+              58:             TypePointer UniformConstant 57
+  59(g_tTex2df4):     58(ptr) Variable UniformConstant
+              62:             TypeSampledImage 57
+              64:    6(float) Constant 1045220557
+              65:   26(fvec2) ConstantComposite 24 64
+              66:             TypeVector 6(float) 3
+              70:             TypeVector 29(int) 2
+              71:     29(int) Constant 3
+              72:   70(ivec2) ConstantComposite 30 71
+              76:             TypeImage 29(int) 2D depth sampled format:Unknown
+              77:             TypePointer UniformConstant 76
+  78(g_tTex2di4):     77(ptr) Variable UniformConstant
+              81:             TypeSampledImage 76
+              89:             TypeImage 45(int) 2D depth sampled format:Unknown
+              90:             TypePointer UniformConstant 89
+  91(g_tTex2du4):     90(ptr) Variable UniformConstant
+              94:             TypeSampledImage 89
+             101:             TypePointer Function 8(PS_OUTPUT)
+             103:     29(int) Constant 0
+             104:    6(float) Constant 1065353216
+             105:    7(fvec4) ConstantComposite 104 104 104 104
+             106:             TypePointer Function 7(fvec4)
+             108:     29(int) Constant 1
+             115:             TypePointer Output 7(fvec4)
+116(@entryPointOutput.Color):    115(ptr) Variable Output
+             119:             TypePointer Output 6(float)
+120(@entryPointOutput.Depth):    119(ptr) Variable Output
+             123:             TypeImage 6(float) 3D sampled format:Unknown
+             124:             TypePointer UniformConstant 123
+ 125(g_tTex3df4):    124(ptr) Variable UniformConstant
+             126:             TypeImage 29(int) 3D sampled format:Unknown
+             127:             TypePointer UniformConstant 126
+ 128(g_tTex3di4):    127(ptr) Variable UniformConstant
+             129:             TypeImage 45(int) 3D sampled format:Unknown
              130:             TypePointer UniformConstant 129
- 131(g_tTex3df4):    130(ptr) Variable UniformConstant
-             132:             TypeImage 30(int) 3D sampled format:Unknown
+ 131(g_tTex3du4):    130(ptr) Variable UniformConstant
+             132:             TypeImage 6(float) Cube sampled format:Unknown
              133:             TypePointer UniformConstant 132
- 134(g_tTex3di4):    133(ptr) Variable UniformConstant
-             135:             TypeImage 47(int) 3D sampled format:Unknown
+ 134(g_tTexcdf4):    133(ptr) Variable UniformConstant
+             135:             TypeImage 29(int) Cube sampled format:Unknown
              136:             TypePointer UniformConstant 135
- 137(g_tTex3du4):    136(ptr) Variable UniformConstant
-             138:             TypeImage 6(float) Cube sampled format:Unknown
+ 137(g_tTexcdi4):    136(ptr) Variable UniformConstant
+             138:             TypeImage 45(int) Cube sampled format:Unknown
              139:             TypePointer UniformConstant 138
- 140(g_tTexcdf4):    139(ptr) Variable UniformConstant
-             141:             TypeImage 30(int) Cube sampled format:Unknown
+ 140(g_tTexcdu4):    139(ptr) Variable UniformConstant
+             141:             TypeImage 6(float) 1D array sampled format:Unknown
              142:             TypePointer UniformConstant 141
- 143(g_tTexcdi4):    142(ptr) Variable UniformConstant
-             144:             TypeImage 47(int) Cube sampled format:Unknown
+143(g_tTex1df4a):    142(ptr) Variable UniformConstant
+             144:             TypeImage 29(int) 1D array sampled format:Unknown
              145:             TypePointer UniformConstant 144
- 146(g_tTexcdu4):    145(ptr) Variable UniformConstant
-             147:             TypeImage 6(float) 1D array sampled format:Unknown
+146(g_tTex1di4a):    145(ptr) Variable UniformConstant
+             147:             TypeImage 45(int) 1D array sampled format:Unknown
              148:             TypePointer UniformConstant 147
-149(g_tTex1df4a):    148(ptr) Variable UniformConstant
-             150:             TypeImage 30(int) 1D array sampled format:Unknown
+149(g_tTex1du4a):    148(ptr) Variable UniformConstant
+             150:             TypeImage 6(float) 2D array sampled format:Unknown
              151:             TypePointer UniformConstant 150
-152(g_tTex1di4a):    151(ptr) Variable UniformConstant
-             153:             TypeImage 47(int) 1D array sampled format:Unknown
+152(g_tTex2df4a):    151(ptr) Variable UniformConstant
+             153:             TypeImage 29(int) 2D array sampled format:Unknown
              154:             TypePointer UniformConstant 153
-155(g_tTex1du4a):    154(ptr) Variable UniformConstant
-             156:             TypeImage 6(float) 2D array sampled format:Unknown
+155(g_tTex2di4a):    154(ptr) Variable UniformConstant
+             156:             TypeImage 45(int) 2D array sampled format:Unknown
              157:             TypePointer UniformConstant 156
-158(g_tTex2df4a):    157(ptr) Variable UniformConstant
-             159:             TypeImage 30(int) 2D array sampled format:Unknown
+158(g_tTex2du4a):    157(ptr) Variable UniformConstant
+             159:             TypeImage 6(float) Cube array sampled format:Unknown
              160:             TypePointer UniformConstant 159
-161(g_tTex2di4a):    160(ptr) Variable UniformConstant
-             162:             TypeImage 47(int) 2D array sampled format:Unknown
+161(g_tTexcdf4a):    160(ptr) Variable UniformConstant
+             162:             TypeImage 29(int) Cube array sampled format:Unknown
              163:             TypePointer UniformConstant 162
-164(g_tTex2du4a):    163(ptr) Variable UniformConstant
-             165:             TypeImage 6(float) Cube array sampled format:Unknown
+164(g_tTexcdi4a):    163(ptr) Variable UniformConstant
+             165:             TypeImage 45(int) Cube array sampled format:Unknown
              166:             TypePointer UniformConstant 165
-167(g_tTexcdf4a):    166(ptr) Variable UniformConstant
-             168:             TypeImage 30(int) Cube array sampled format:Unknown
-             169:             TypePointer UniformConstant 168
-170(g_tTexcdi4a):    169(ptr) Variable UniformConstant
-             171:             TypeImage 47(int) Cube array sampled format:Unknown
-             172:             TypePointer UniformConstant 171
-173(g_tTexcdu4a):    172(ptr) Variable UniformConstant
+167(g_tTexcdu4a):    166(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
-119(flattenTemp):    107(ptr) Variable Function
-             120:8(PS_OUTPUT) FunctionCall 10(@main()
-                              Store 119(flattenTemp) 120
-             123:    112(ptr) AccessChain 119(flattenTemp) 109
-             124:    7(fvec4) Load 123
-                              Store 122(@entryPointOutput.Color) 124
-             127:     12(ptr) AccessChain 119(flattenTemp) 114
-             128:    6(float) Load 127
-                              Store 126(@entryPointOutput.Depth) 128
+113(flattenTemp):    101(ptr) Variable Function
+             114:8(PS_OUTPUT) FunctionCall 10(@main()
+                              Store 113(flattenTemp) 114
+             117:    106(ptr) AccessChain 113(flattenTemp) 103
+             118:    7(fvec4) Load 117
+                              Store 116(@entryPointOutput.Color) 118
+             121:     12(ptr) AccessChain 113(flattenTemp) 108
+             122:    6(float) Load 121
+                              Store 120(@entryPointOutput.Depth) 122
                               Return
                               FunctionEnd
       10(@main():8(PS_OUTPUT) Function None 9
               11:             Label
          13(r01):     12(ptr) Variable Function
-         34(r03):     12(ptr) Variable Function
-         46(r05):     12(ptr) Variable Function
-         59(r21):     12(ptr) Variable Function
-         79(r23):     12(ptr) Variable Function
-         93(r25):     12(ptr) Variable Function
-      108(psout):    107(ptr) Variable Function
+         33(r03):     12(ptr) Variable Function
+         44(r05):     12(ptr) Variable Function
+         56(r21):     12(ptr) Variable Function
+         75(r23):     12(ptr) Variable Function
+         88(r25):     12(ptr) Variable Function
+      102(psout):    101(ptr) Variable Function
               17:          14 Load 16(g_tTex1df4)
               21:          18 Load 20(g_sSamp)
-              24:          23 SampledImage 17 21
-              28:   27(fvec2) CompositeConstruct 25 26
-              32:    6(float) CompositeExtract 28 1
-              33:    6(float) ImageSampleDrefExplicitLod 24 28 32 Lod ConstOffset 29 31
-                              Store 13(r01) 33
-              38:          35 Load 37(g_tTex1di4)
-              39:          18 Load 20(g_sSamp)
-              42:          41 SampledImage 38 39
-              43:   27(fvec2) CompositeConstruct 25 26
-              44:    6(float) CompositeExtract 43 1
-              45:    6(float) ImageSampleDrefExplicitLod 42 43 44 Lod ConstOffset 29 31
-                              Store 34(r03) 45
-              51:          48 Load 50(g_tTex1du4)
-              52:          18 Load 20(g_sSamp)
-              55:          54 SampledImage 51 52
-              56:   27(fvec2) CompositeConstruct 25 26
-              57:    6(float) CompositeExtract 56 1
-              58:    6(float) ImageSampleDrefExplicitLod 55 56 57 Lod ConstOffset 29 31
-                              Store 46(r05) 58
-              63:          60 Load 62(g_tTex2df4)
-              64:          18 Load 20(g_sSamp)
-              67:          66 SampledImage 63 64
-              71:    6(float) CompositeExtract 69 0
-              72:    6(float) CompositeExtract 69 1
-              73:   70(fvec3) CompositeConstruct 71 72 26
-              77:    6(float) CompositeExtract 73 2
-              78:    6(float) ImageSampleDrefExplicitLod 67 73 77 Lod ConstOffset 29 76
-                              Store 59(r21) 78
-              83:          80 Load 82(g_tTex2di4)
-              84:          18 Load 20(g_sSamp)
-              87:          86 SampledImage 83 84
-              88:    6(float) CompositeExtract 69 0
-              89:    6(float) CompositeExtract 69 1
-              90:   70(fvec3) CompositeConstruct 88 89 26
-              91:    6(float) CompositeExtract 90 2
-              92:    6(float) ImageSampleDrefExplicitLod 87 90 91 Lod ConstOffset 29 76
-                              Store 79(r23) 92
-              97:          94 Load 96(g_tTex2du4)
-              98:          18 Load 20(g_sSamp)
-             101:         100 SampledImage 97 98
-             102:    6(float) CompositeExtract 69 0
-             103:    6(float) CompositeExtract 69 1
-             104:   70(fvec3) CompositeConstruct 102 103 26
-             105:    6(float) CompositeExtract 104 2
-             106:    6(float) ImageSampleDrefExplicitLod 101 104 105 Lod ConstOffset 29 76
-                              Store 93(r25) 106
-             113:    112(ptr) AccessChain 108(psout) 109
-                              Store 113 111
-             115:     12(ptr) AccessChain 108(psout) 114
-                              Store 115 110
-             116:8(PS_OUTPUT) Load 108(psout)
-                              ReturnValue 116
+              23:          22 SampledImage 17 21
+              27:   26(fvec2) CompositeConstruct 24 25
+              31:    6(float) CompositeExtract 27 1
+              32:    6(float) ImageSampleDrefExplicitLod 23 27 31 Lod ConstOffset 28 30
+                              Store 13(r01) 32
+              37:          34 Load 36(g_tTex1di4)
+              38:          18 Load 20(g_sSamp)
+              40:          39 SampledImage 37 38
+              41:   26(fvec2) CompositeConstruct 24 25
+              42:    6(float) CompositeExtract 41 1
+              43:    6(float) ImageSampleDrefExplicitLod 40 41 42 Lod ConstOffset 28 30
+                              Store 33(r03) 43
+              49:          46 Load 48(g_tTex1du4)
+              50:          18 Load 20(g_sSamp)
+              52:          51 SampledImage 49 50
+              53:   26(fvec2) CompositeConstruct 24 25
+              54:    6(float) CompositeExtract 53 1
+              55:    6(float) ImageSampleDrefExplicitLod 52 53 54 Lod ConstOffset 28 30
+                              Store 44(r05) 55
+              60:          57 Load 59(g_tTex2df4)
+              61:          18 Load 20(g_sSamp)
+              63:          62 SampledImage 60 61
+              67:    6(float) CompositeExtract 65 0
+              68:    6(float) CompositeExtract 65 1
+              69:   66(fvec3) CompositeConstruct 67 68 25
+              73:    6(float) CompositeExtract 69 2
+              74:    6(float) ImageSampleDrefExplicitLod 63 69 73 Lod ConstOffset 28 72
+                              Store 56(r21) 74
+              79:          76 Load 78(g_tTex2di4)
+              80:          18 Load 20(g_sSamp)
+              82:          81 SampledImage 79 80
+              83:    6(float) CompositeExtract 65 0
+              84:    6(float) CompositeExtract 65 1
+              85:   66(fvec3) CompositeConstruct 83 84 25
+              86:    6(float) CompositeExtract 85 2
+              87:    6(float) ImageSampleDrefExplicitLod 82 85 86 Lod ConstOffset 28 72
+                              Store 75(r23) 87
+              92:          89 Load 91(g_tTex2du4)
+              93:          18 Load 20(g_sSamp)
+              95:          94 SampledImage 92 93
+              96:    6(float) CompositeExtract 65 0
+              97:    6(float) CompositeExtract 65 1
+              98:   66(fvec3) CompositeConstruct 96 97 25
+              99:    6(float) CompositeExtract 98 2
+             100:    6(float) ImageSampleDrefExplicitLod 95 98 99 Lod ConstOffset 28 72
+                              Store 88(r25) 100
+             107:    106(ptr) AccessChain 102(psout) 103
+                              Store 107 105
+             109:     12(ptr) AccessChain 102(psout) 108
+                              Store 109 104
+             110:8(PS_OUTPUT) Load 102(psout)
+                              ReturnValue 110
                               FunctionEnd

--- a/Test/baseResults/hlsl.samplecmplevelzero.offsetarray.dx10.frag.out
+++ b/Test/baseResults/hlsl.samplecmplevelzero.offsetarray.dx10.frag.out
@@ -10,7 +10,7 @@ gl_FragCoord origin is upper left
 0:42          'r11' ( temp float)
 0:42          textureLodOffset ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DArrayShadow)
-0:42              'g_tTex1df4a' ( uniform texture1DArray)
+0:42              'g_tTex1df4a' ( uniform texture1DArrayShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -27,7 +27,7 @@ gl_FragCoord origin is upper left
 0:43          'r13' ( temp float)
 0:43          textureLodOffset ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DArrayShadow)
-0:43              'g_tTex1di4a' ( uniform itexture1DArray)
+0:43              'g_tTex1di4a' ( uniform itexture1DArrayShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -44,7 +44,7 @@ gl_FragCoord origin is upper left
 0:44          'r15' ( temp float)
 0:44          textureLodOffset ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DArrayShadow)
-0:44              'g_tTex1du4a' ( uniform utexture1DArray)
+0:44              'g_tTex1du4a' ( uniform utexture1DArrayShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -61,7 +61,7 @@ gl_FragCoord origin is upper left
 0:47          'r31' ( temp float)
 0:47          textureLodOffset ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DArrayShadow)
-0:47              'g_tTex2df4a' ( uniform texture2DArray)
+0:47              'g_tTex2df4a' ( uniform texture2DArrayShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -80,7 +80,7 @@ gl_FragCoord origin is upper left
 0:48          'r33' ( temp float)
 0:48          textureLodOffset ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DArrayShadow)
-0:48              'g_tTex2di4a' ( uniform itexture2DArray)
+0:48              'g_tTex2di4a' ( uniform itexture2DArrayShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -99,7 +99,7 @@ gl_FragCoord origin is upper left
 0:49          'r35' ( temp float)
 0:49          textureLodOffset ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DArrayShadow)
-0:49              'g_tTex2du4a' ( uniform utexture2DArray)
+0:49              'g_tTex2du4a' ( uniform utexture2DArrayShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -165,12 +165,12 @@ gl_FragCoord origin is upper left
 0:?     'g_tTexcdf4' ( uniform textureCube)
 0:?     'g_tTexcdi4' ( uniform itextureCube)
 0:?     'g_tTexcdu4' ( uniform utextureCube)
-0:?     'g_tTex1df4a' ( uniform texture1DArray)
-0:?     'g_tTex1di4a' ( uniform itexture1DArray)
-0:?     'g_tTex1du4a' ( uniform utexture1DArray)
-0:?     'g_tTex2df4a' ( uniform texture2DArray)
-0:?     'g_tTex2di4a' ( uniform itexture2DArray)
-0:?     'g_tTex2du4a' ( uniform utexture2DArray)
+0:?     'g_tTex1df4a' ( uniform texture1DArrayShadow)
+0:?     'g_tTex1di4a' ( uniform itexture1DArrayShadow)
+0:?     'g_tTex1du4a' ( uniform utexture1DArrayShadow)
+0:?     'g_tTex2df4a' ( uniform texture2DArrayShadow)
+0:?     'g_tTex2di4a' ( uniform itexture2DArrayShadow)
+0:?     'g_tTex2du4a' ( uniform utexture2DArrayShadow)
 0:?     'g_tTexcdf4a' ( uniform textureCubeArray)
 0:?     'g_tTexcdi4a' ( uniform itextureCubeArray)
 0:?     'g_tTexcdu4a' ( uniform utextureCubeArray)
@@ -192,7 +192,7 @@ gl_FragCoord origin is upper left
 0:42          'r11' ( temp float)
 0:42          textureLodOffset ( temp float)
 0:42            Construct combined texture-sampler ( temp sampler1DArrayShadow)
-0:42              'g_tTex1df4a' ( uniform texture1DArray)
+0:42              'g_tTex1df4a' ( uniform texture1DArrayShadow)
 0:42              'g_sSamp' (layout( binding=0) uniform sampler)
 0:42            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -209,7 +209,7 @@ gl_FragCoord origin is upper left
 0:43          'r13' ( temp float)
 0:43          textureLodOffset ( temp float)
 0:43            Construct combined texture-sampler ( temp isampler1DArrayShadow)
-0:43              'g_tTex1di4a' ( uniform itexture1DArray)
+0:43              'g_tTex1di4a' ( uniform itexture1DArrayShadow)
 0:43              'g_sSamp' (layout( binding=0) uniform sampler)
 0:43            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -226,7 +226,7 @@ gl_FragCoord origin is upper left
 0:44          'r15' ( temp float)
 0:44          textureLodOffset ( temp float)
 0:44            Construct combined texture-sampler ( temp usampler1DArrayShadow)
-0:44              'g_tTex1du4a' ( uniform utexture1DArray)
+0:44              'g_tTex1du4a' ( uniform utexture1DArrayShadow)
 0:44              'g_sSamp' (layout( binding=0) uniform sampler)
 0:44            Construct vec3 ( temp 3-component vector of float)
 0:?               Constant:
@@ -243,7 +243,7 @@ gl_FragCoord origin is upper left
 0:47          'r31' ( temp float)
 0:47          textureLodOffset ( temp float)
 0:47            Construct combined texture-sampler ( temp sampler2DArrayShadow)
-0:47              'g_tTex2df4a' ( uniform texture2DArray)
+0:47              'g_tTex2df4a' ( uniform texture2DArrayShadow)
 0:47              'g_sSamp' (layout( binding=0) uniform sampler)
 0:47            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -262,7 +262,7 @@ gl_FragCoord origin is upper left
 0:48          'r33' ( temp float)
 0:48          textureLodOffset ( temp float)
 0:48            Construct combined texture-sampler ( temp isampler2DArrayShadow)
-0:48              'g_tTex2di4a' ( uniform itexture2DArray)
+0:48              'g_tTex2di4a' ( uniform itexture2DArrayShadow)
 0:48              'g_sSamp' (layout( binding=0) uniform sampler)
 0:48            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -281,7 +281,7 @@ gl_FragCoord origin is upper left
 0:49          'r35' ( temp float)
 0:49          textureLodOffset ( temp float)
 0:49            Construct combined texture-sampler ( temp usampler2DArrayShadow)
-0:49              'g_tTex2du4a' ( uniform utexture2DArray)
+0:49              'g_tTex2du4a' ( uniform utexture2DArrayShadow)
 0:49              'g_sSamp' (layout( binding=0) uniform sampler)
 0:49            Construct vec4 ( temp 4-component vector of float)
 0:?               Constant:
@@ -347,12 +347,12 @@ gl_FragCoord origin is upper left
 0:?     'g_tTexcdf4' ( uniform textureCube)
 0:?     'g_tTexcdi4' ( uniform itextureCube)
 0:?     'g_tTexcdu4' ( uniform utextureCube)
-0:?     'g_tTex1df4a' ( uniform texture1DArray)
-0:?     'g_tTex1di4a' ( uniform itexture1DArray)
-0:?     'g_tTex1du4a' ( uniform utexture1DArray)
-0:?     'g_tTex2df4a' ( uniform texture2DArray)
-0:?     'g_tTex2di4a' ( uniform itexture2DArray)
-0:?     'g_tTex2du4a' ( uniform utexture2DArray)
+0:?     'g_tTex1df4a' ( uniform texture1DArrayShadow)
+0:?     'g_tTex1di4a' ( uniform itexture1DArrayShadow)
+0:?     'g_tTex1du4a' ( uniform utexture1DArrayShadow)
+0:?     'g_tTex2df4a' ( uniform texture2DArrayShadow)
+0:?     'g_tTex2di4a' ( uniform itexture2DArrayShadow)
+0:?     'g_tTex2du4a' ( uniform utexture2DArrayShadow)
 0:?     'g_tTexcdf4a' ( uniform textureCubeArray)
 0:?     'g_tTexcdi4a' ( uniform itextureCubeArray)
 0:?     'g_tTexcdu4a' ( uniform utextureCubeArray)
@@ -361,14 +361,14 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 80001
-// Id's are bound by 185
+// Id's are bound by 179
 
                               Capability Shader
                               Capability Sampled1D
                               Capability SampledCubeArray
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 133 137
+                              EntryPoint Fragment 4  "main" 127 131
                               ExecutionMode 4 OriginUpperLeft
                               Source HLSL 500
                               Name 4  "main"
@@ -379,61 +379,61 @@ gl_FragCoord origin is upper left
                               Name 13  "r11"
                               Name 16  "g_tTex1df4a"
                               Name 20  "g_sSamp"
-                              Name 39  "r13"
-                              Name 42  "g_tTex1di4a"
-                              Name 53  "r15"
-                              Name 57  "g_tTex1du4a"
-                              Name 68  "r31"
-                              Name 71  "g_tTex2df4a"
-                              Name 88  "r33"
-                              Name 91  "g_tTex2di4a"
-                              Name 103  "r35"
-                              Name 106  "g_tTex2du4a"
-                              Name 119  "psout"
-                              Name 130  "flattenTemp"
-                              Name 133  "@entryPointOutput.Color"
-                              Name 137  "@entryPointOutput.Depth"
-                              Name 142  "g_tTex1df4"
-                              Name 145  "g_tTex1di4"
-                              Name 148  "g_tTex1du4"
-                              Name 151  "g_tTex2df4"
-                              Name 154  "g_tTex2di4"
-                              Name 157  "g_tTex2du4"
-                              Name 160  "g_tTex3df4"
-                              Name 163  "g_tTex3di4"
-                              Name 166  "g_tTex3du4"
-                              Name 169  "g_tTexcdf4"
-                              Name 172  "g_tTexcdi4"
-                              Name 175  "g_tTexcdu4"
-                              Name 178  "g_tTexcdf4a"
-                              Name 181  "g_tTexcdi4a"
-                              Name 184  "g_tTexcdu4a"
+                              Name 38  "r13"
+                              Name 41  "g_tTex1di4a"
+                              Name 51  "r15"
+                              Name 55  "g_tTex1du4a"
+                              Name 65  "r31"
+                              Name 68  "g_tTex2df4a"
+                              Name 84  "r33"
+                              Name 87  "g_tTex2di4a"
+                              Name 98  "r35"
+                              Name 101  "g_tTex2du4a"
+                              Name 113  "psout"
+                              Name 124  "flattenTemp"
+                              Name 127  "@entryPointOutput.Color"
+                              Name 131  "@entryPointOutput.Depth"
+                              Name 136  "g_tTex1df4"
+                              Name 139  "g_tTex1di4"
+                              Name 142  "g_tTex1du4"
+                              Name 145  "g_tTex2df4"
+                              Name 148  "g_tTex2di4"
+                              Name 151  "g_tTex2du4"
+                              Name 154  "g_tTex3df4"
+                              Name 157  "g_tTex3di4"
+                              Name 160  "g_tTex3du4"
+                              Name 163  "g_tTexcdf4"
+                              Name 166  "g_tTexcdi4"
+                              Name 169  "g_tTexcdu4"
+                              Name 172  "g_tTexcdf4a"
+                              Name 175  "g_tTexcdi4a"
+                              Name 178  "g_tTexcdu4a"
                               Decorate 16(g_tTex1df4a) DescriptorSet 0
                               Decorate 20(g_sSamp) DescriptorSet 0
                               Decorate 20(g_sSamp) Binding 0
-                              Decorate 42(g_tTex1di4a) DescriptorSet 0
-                              Decorate 57(g_tTex1du4a) DescriptorSet 0
-                              Decorate 71(g_tTex2df4a) DescriptorSet 0
-                              Decorate 91(g_tTex2di4a) DescriptorSet 0
-                              Decorate 106(g_tTex2du4a) DescriptorSet 0
-                              Decorate 133(@entryPointOutput.Color) Location 0
-                              Decorate 137(@entryPointOutput.Depth) BuiltIn FragDepth
-                              Decorate 142(g_tTex1df4) DescriptorSet 0
-                              Decorate 142(g_tTex1df4) Binding 0
-                              Decorate 145(g_tTex1di4) DescriptorSet 0
-                              Decorate 148(g_tTex1du4) DescriptorSet 0
-                              Decorate 151(g_tTex2df4) DescriptorSet 0
-                              Decorate 154(g_tTex2di4) DescriptorSet 0
-                              Decorate 157(g_tTex2du4) DescriptorSet 0
-                              Decorate 160(g_tTex3df4) DescriptorSet 0
-                              Decorate 163(g_tTex3di4) DescriptorSet 0
-                              Decorate 166(g_tTex3du4) DescriptorSet 0
-                              Decorate 169(g_tTexcdf4) DescriptorSet 0
-                              Decorate 172(g_tTexcdi4) DescriptorSet 0
-                              Decorate 175(g_tTexcdu4) DescriptorSet 0
-                              Decorate 178(g_tTexcdf4a) DescriptorSet 0
-                              Decorate 181(g_tTexcdi4a) DescriptorSet 0
-                              Decorate 184(g_tTexcdu4a) DescriptorSet 0
+                              Decorate 41(g_tTex1di4a) DescriptorSet 0
+                              Decorate 55(g_tTex1du4a) DescriptorSet 0
+                              Decorate 68(g_tTex2df4a) DescriptorSet 0
+                              Decorate 87(g_tTex2di4a) DescriptorSet 0
+                              Decorate 101(g_tTex2du4a) DescriptorSet 0
+                              Decorate 127(@entryPointOutput.Color) Location 0
+                              Decorate 131(@entryPointOutput.Depth) BuiltIn FragDepth
+                              Decorate 136(g_tTex1df4) DescriptorSet 0
+                              Decorate 136(g_tTex1df4) Binding 0
+                              Decorate 139(g_tTex1di4) DescriptorSet 0
+                              Decorate 142(g_tTex1du4) DescriptorSet 0
+                              Decorate 145(g_tTex2df4) DescriptorSet 0
+                              Decorate 148(g_tTex2di4) DescriptorSet 0
+                              Decorate 151(g_tTex2du4) DescriptorSet 0
+                              Decorate 154(g_tTex3df4) DescriptorSet 0
+                              Decorate 157(g_tTex3di4) DescriptorSet 0
+                              Decorate 160(g_tTex3du4) DescriptorSet 0
+                              Decorate 163(g_tTexcdf4) DescriptorSet 0
+                              Decorate 166(g_tTexcdi4) DescriptorSet 0
+                              Decorate 169(g_tTexcdu4) DescriptorSet 0
+                              Decorate 172(g_tTexcdf4a) DescriptorSet 0
+                              Decorate 175(g_tTexcdi4a) DescriptorSet 0
+                              Decorate 178(g_tTexcdu4a) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32
@@ -441,192 +441,186 @@ gl_FragCoord origin is upper left
     8(PS_OUTPUT):             TypeStruct 7(fvec4) 6(float)
                9:             TypeFunction 8(PS_OUTPUT)
               12:             TypePointer Function 6(float)
-              14:             TypeImage 6(float) 1D array sampled format:Unknown
+              14:             TypeImage 6(float) 1D depth array sampled format:Unknown
               15:             TypePointer UniformConstant 14
  16(g_tTex1df4a):     15(ptr) Variable UniformConstant
               18:             TypeSampler
               19:             TypePointer UniformConstant 18
      20(g_sSamp):     19(ptr) Variable UniformConstant
-              22:             TypeImage 6(float) 1D depth array sampled format:Unknown
-              23:             TypeSampledImage 22
-              25:             TypeVector 6(float) 2
-              26:    6(float) Constant 1036831949
-              27:    6(float) Constant 1045220557
-              28:   25(fvec2) ConstantComposite 26 27
-              29:    6(float) Constant 1061158912
-              30:             TypeVector 6(float) 3
-              34:    6(float) Constant 0
-              35:             TypeInt 32 1
-              36:     35(int) Constant 2
-              40:             TypeImage 35(int) 1D array sampled format:Unknown
-              41:             TypePointer UniformConstant 40
- 42(g_tTex1di4a):     41(ptr) Variable UniformConstant
-              45:             TypeImage 35(int) 1D depth array sampled format:Unknown
-              46:             TypeSampledImage 45
-              54:             TypeInt 32 0
-              55:             TypeImage 54(int) 1D array sampled format:Unknown
-              56:             TypePointer UniformConstant 55
- 57(g_tTex1du4a):     56(ptr) Variable UniformConstant
-              60:             TypeImage 54(int) 1D depth array sampled format:Unknown
-              61:             TypeSampledImage 60
-              69:             TypeImage 6(float) 2D array sampled format:Unknown
-              70:             TypePointer UniformConstant 69
- 71(g_tTex2df4a):     70(ptr) Variable UniformConstant
-              74:             TypeImage 6(float) 2D depth array sampled format:Unknown
-              75:             TypeSampledImage 74
-              77:    6(float) Constant 1050253722
-              78:   30(fvec3) ConstantComposite 26 27 77
-              83:             TypeVector 35(int) 2
-              84:     35(int) Constant 3
-              85:   83(ivec2) ConstantComposite 36 84
-              89:             TypeImage 35(int) 2D array sampled format:Unknown
-              90:             TypePointer UniformConstant 89
- 91(g_tTex2di4a):     90(ptr) Variable UniformConstant
-              94:             TypeImage 35(int) 2D depth array sampled format:Unknown
-              95:             TypeSampledImage 94
-             104:             TypeImage 54(int) 2D array sampled format:Unknown
-             105:             TypePointer UniformConstant 104
-106(g_tTex2du4a):    105(ptr) Variable UniformConstant
-             109:             TypeImage 54(int) 2D depth array sampled format:Unknown
-             110:             TypeSampledImage 109
-             118:             TypePointer Function 8(PS_OUTPUT)
-             120:     35(int) Constant 0
-             121:    6(float) Constant 1065353216
-             122:    7(fvec4) ConstantComposite 121 121 121 121
-             123:             TypePointer Function 7(fvec4)
-             125:     35(int) Constant 1
-             132:             TypePointer Output 7(fvec4)
-133(@entryPointOutput.Color):    132(ptr) Variable Output
-             136:             TypePointer Output 6(float)
-137(@entryPointOutput.Depth):    136(ptr) Variable Output
-             140:             TypeImage 6(float) 1D sampled format:Unknown
+              22:             TypeSampledImage 14
+              24:             TypeVector 6(float) 2
+              25:    6(float) Constant 1036831949
+              26:    6(float) Constant 1045220557
+              27:   24(fvec2) ConstantComposite 25 26
+              28:    6(float) Constant 1061158912
+              29:             TypeVector 6(float) 3
+              33:    6(float) Constant 0
+              34:             TypeInt 32 1
+              35:     34(int) Constant 2
+              39:             TypeImage 34(int) 1D depth array sampled format:Unknown
+              40:             TypePointer UniformConstant 39
+ 41(g_tTex1di4a):     40(ptr) Variable UniformConstant
+              44:             TypeSampledImage 39
+              52:             TypeInt 32 0
+              53:             TypeImage 52(int) 1D depth array sampled format:Unknown
+              54:             TypePointer UniformConstant 53
+ 55(g_tTex1du4a):     54(ptr) Variable UniformConstant
+              58:             TypeSampledImage 53
+              66:             TypeImage 6(float) 2D depth array sampled format:Unknown
+              67:             TypePointer UniformConstant 66
+ 68(g_tTex2df4a):     67(ptr) Variable UniformConstant
+              71:             TypeSampledImage 66
+              73:    6(float) Constant 1050253722
+              74:   29(fvec3) ConstantComposite 25 26 73
+              79:             TypeVector 34(int) 2
+              80:     34(int) Constant 3
+              81:   79(ivec2) ConstantComposite 35 80
+              85:             TypeImage 34(int) 2D depth array sampled format:Unknown
+              86:             TypePointer UniformConstant 85
+ 87(g_tTex2di4a):     86(ptr) Variable UniformConstant
+              90:             TypeSampledImage 85
+              99:             TypeImage 52(int) 2D depth array sampled format:Unknown
+             100:             TypePointer UniformConstant 99
+101(g_tTex2du4a):    100(ptr) Variable UniformConstant
+             104:             TypeSampledImage 99
+             112:             TypePointer Function 8(PS_OUTPUT)
+             114:     34(int) Constant 0
+             115:    6(float) Constant 1065353216
+             116:    7(fvec4) ConstantComposite 115 115 115 115
+             117:             TypePointer Function 7(fvec4)
+             119:     34(int) Constant 1
+             126:             TypePointer Output 7(fvec4)
+127(@entryPointOutput.Color):    126(ptr) Variable Output
+             130:             TypePointer Output 6(float)
+131(@entryPointOutput.Depth):    130(ptr) Variable Output
+             134:             TypeImage 6(float) 1D sampled format:Unknown
+             135:             TypePointer UniformConstant 134
+ 136(g_tTex1df4):    135(ptr) Variable UniformConstant
+             137:             TypeImage 34(int) 1D sampled format:Unknown
+             138:             TypePointer UniformConstant 137
+ 139(g_tTex1di4):    138(ptr) Variable UniformConstant
+             140:             TypeImage 52(int) 1D sampled format:Unknown
              141:             TypePointer UniformConstant 140
- 142(g_tTex1df4):    141(ptr) Variable UniformConstant
-             143:             TypeImage 35(int) 1D sampled format:Unknown
+ 142(g_tTex1du4):    141(ptr) Variable UniformConstant
+             143:             TypeImage 6(float) 2D sampled format:Unknown
              144:             TypePointer UniformConstant 143
- 145(g_tTex1di4):    144(ptr) Variable UniformConstant
-             146:             TypeImage 54(int) 1D sampled format:Unknown
+ 145(g_tTex2df4):    144(ptr) Variable UniformConstant
+             146:             TypeImage 34(int) 2D sampled format:Unknown
              147:             TypePointer UniformConstant 146
- 148(g_tTex1du4):    147(ptr) Variable UniformConstant
-             149:             TypeImage 6(float) 2D sampled format:Unknown
+ 148(g_tTex2di4):    147(ptr) Variable UniformConstant
+             149:             TypeImage 52(int) 2D sampled format:Unknown
              150:             TypePointer UniformConstant 149
- 151(g_tTex2df4):    150(ptr) Variable UniformConstant
-             152:             TypeImage 35(int) 2D sampled format:Unknown
+ 151(g_tTex2du4):    150(ptr) Variable UniformConstant
+             152:             TypeImage 6(float) 3D sampled format:Unknown
              153:             TypePointer UniformConstant 152
- 154(g_tTex2di4):    153(ptr) Variable UniformConstant
-             155:             TypeImage 54(int) 2D sampled format:Unknown
+ 154(g_tTex3df4):    153(ptr) Variable UniformConstant
+             155:             TypeImage 34(int) 3D sampled format:Unknown
              156:             TypePointer UniformConstant 155
- 157(g_tTex2du4):    156(ptr) Variable UniformConstant
-             158:             TypeImage 6(float) 3D sampled format:Unknown
+ 157(g_tTex3di4):    156(ptr) Variable UniformConstant
+             158:             TypeImage 52(int) 3D sampled format:Unknown
              159:             TypePointer UniformConstant 158
- 160(g_tTex3df4):    159(ptr) Variable UniformConstant
-             161:             TypeImage 35(int) 3D sampled format:Unknown
+ 160(g_tTex3du4):    159(ptr) Variable UniformConstant
+             161:             TypeImage 6(float) Cube sampled format:Unknown
              162:             TypePointer UniformConstant 161
- 163(g_tTex3di4):    162(ptr) Variable UniformConstant
-             164:             TypeImage 54(int) 3D sampled format:Unknown
+ 163(g_tTexcdf4):    162(ptr) Variable UniformConstant
+             164:             TypeImage 34(int) Cube sampled format:Unknown
              165:             TypePointer UniformConstant 164
- 166(g_tTex3du4):    165(ptr) Variable UniformConstant
-             167:             TypeImage 6(float) Cube sampled format:Unknown
+ 166(g_tTexcdi4):    165(ptr) Variable UniformConstant
+             167:             TypeImage 52(int) Cube sampled format:Unknown
              168:             TypePointer UniformConstant 167
- 169(g_tTexcdf4):    168(ptr) Variable UniformConstant
-             170:             TypeImage 35(int) Cube sampled format:Unknown
+ 169(g_tTexcdu4):    168(ptr) Variable UniformConstant
+             170:             TypeImage 6(float) Cube array sampled format:Unknown
              171:             TypePointer UniformConstant 170
- 172(g_tTexcdi4):    171(ptr) Variable UniformConstant
-             173:             TypeImage 54(int) Cube sampled format:Unknown
+172(g_tTexcdf4a):    171(ptr) Variable UniformConstant
+             173:             TypeImage 34(int) Cube array sampled format:Unknown
              174:             TypePointer UniformConstant 173
- 175(g_tTexcdu4):    174(ptr) Variable UniformConstant
-             176:             TypeImage 6(float) Cube array sampled format:Unknown
+175(g_tTexcdi4a):    174(ptr) Variable UniformConstant
+             176:             TypeImage 52(int) Cube array sampled format:Unknown
              177:             TypePointer UniformConstant 176
-178(g_tTexcdf4a):    177(ptr) Variable UniformConstant
-             179:             TypeImage 35(int) Cube array sampled format:Unknown
-             180:             TypePointer UniformConstant 179
-181(g_tTexcdi4a):    180(ptr) Variable UniformConstant
-             182:             TypeImage 54(int) Cube array sampled format:Unknown
-             183:             TypePointer UniformConstant 182
-184(g_tTexcdu4a):    183(ptr) Variable UniformConstant
+178(g_tTexcdu4a):    177(ptr) Variable UniformConstant
          4(main):           2 Function None 3
                5:             Label
-130(flattenTemp):    118(ptr) Variable Function
-             131:8(PS_OUTPUT) FunctionCall 10(@main()
-                              Store 130(flattenTemp) 131
-             134:    123(ptr) AccessChain 130(flattenTemp) 120
-             135:    7(fvec4) Load 134
-                              Store 133(@entryPointOutput.Color) 135
-             138:     12(ptr) AccessChain 130(flattenTemp) 125
-             139:    6(float) Load 138
-                              Store 137(@entryPointOutput.Depth) 139
+124(flattenTemp):    112(ptr) Variable Function
+             125:8(PS_OUTPUT) FunctionCall 10(@main()
+                              Store 124(flattenTemp) 125
+             128:    117(ptr) AccessChain 124(flattenTemp) 114
+             129:    7(fvec4) Load 128
+                              Store 127(@entryPointOutput.Color) 129
+             132:     12(ptr) AccessChain 124(flattenTemp) 119
+             133:    6(float) Load 132
+                              Store 131(@entryPointOutput.Depth) 133
                               Return
                               FunctionEnd
       10(@main():8(PS_OUTPUT) Function None 9
               11:             Label
          13(r11):     12(ptr) Variable Function
-         39(r13):     12(ptr) Variable Function
-         53(r15):     12(ptr) Variable Function
-         68(r31):     12(ptr) Variable Function
-         88(r33):     12(ptr) Variable Function
-        103(r35):     12(ptr) Variable Function
-      119(psout):    118(ptr) Variable Function
+         38(r13):     12(ptr) Variable Function
+         51(r15):     12(ptr) Variable Function
+         65(r31):     12(ptr) Variable Function
+         84(r33):     12(ptr) Variable Function
+         98(r35):     12(ptr) Variable Function
+      113(psout):    112(ptr) Variable Function
               17:          14 Load 16(g_tTex1df4a)
               21:          18 Load 20(g_sSamp)
-              24:          23 SampledImage 17 21
-              31:    6(float) CompositeExtract 28 0
-              32:    6(float) CompositeExtract 28 1
-              33:   30(fvec3) CompositeConstruct 31 32 29
-              37:    6(float) CompositeExtract 33 2
-              38:    6(float) ImageSampleDrefExplicitLod 24 33 37 Lod ConstOffset 34 36
-                              Store 13(r11) 38
-              43:          40 Load 42(g_tTex1di4a)
-              44:          18 Load 20(g_sSamp)
-              47:          46 SampledImage 43 44
-              48:    6(float) CompositeExtract 28 0
-              49:    6(float) CompositeExtract 28 1
-              50:   30(fvec3) CompositeConstruct 48 49 29
-              51:    6(float) CompositeExtract 50 2
-              52:    6(float) ImageSampleDrefExplicitLod 47 50 51 Lod ConstOffset 34 36
-                              Store 39(r13) 52
-              58:          55 Load 57(g_tTex1du4a)
-              59:          18 Load 20(g_sSamp)
-              62:          61 SampledImage 58 59
-              63:    6(float) CompositeExtract 28 0
-              64:    6(float) CompositeExtract 28 1
-              65:   30(fvec3) CompositeConstruct 63 64 29
-              66:    6(float) CompositeExtract 65 2
-              67:    6(float) ImageSampleDrefExplicitLod 62 65 66 Lod ConstOffset 34 36
-                              Store 53(r15) 67
-              72:          69 Load 71(g_tTex2df4a)
-              73:          18 Load 20(g_sSamp)
-              76:          75 SampledImage 72 73
-              79:    6(float) CompositeExtract 78 0
-              80:    6(float) CompositeExtract 78 1
-              81:    6(float) CompositeExtract 78 2
-              82:    7(fvec4) CompositeConstruct 79 80 81 29
-              86:    6(float) CompositeExtract 82 3
-              87:    6(float) ImageSampleDrefExplicitLod 76 82 86 Lod ConstOffset 34 85
-                              Store 68(r31) 87
-              92:          89 Load 91(g_tTex2di4a)
-              93:          18 Load 20(g_sSamp)
-              96:          95 SampledImage 92 93
-              97:    6(float) CompositeExtract 78 0
-              98:    6(float) CompositeExtract 78 1
-              99:    6(float) CompositeExtract 78 2
-             100:    7(fvec4) CompositeConstruct 97 98 99 29
-             101:    6(float) CompositeExtract 100 3
-             102:    6(float) ImageSampleDrefExplicitLod 96 100 101 Lod ConstOffset 34 85
-                              Store 88(r33) 102
-             107:         104 Load 106(g_tTex2du4a)
-             108:          18 Load 20(g_sSamp)
-             111:         110 SampledImage 107 108
-             112:    6(float) CompositeExtract 78 0
-             113:    6(float) CompositeExtract 78 1
-             114:    6(float) CompositeExtract 78 2
-             115:    7(fvec4) CompositeConstruct 112 113 114 29
-             116:    6(float) CompositeExtract 115 3
-             117:    6(float) ImageSampleDrefExplicitLod 111 115 116 Lod ConstOffset 34 85
-                              Store 103(r35) 117
-             124:    123(ptr) AccessChain 119(psout) 120
-                              Store 124 122
-             126:     12(ptr) AccessChain 119(psout) 125
-                              Store 126 121
-             127:8(PS_OUTPUT) Load 119(psout)
-                              ReturnValue 127
+              23:          22 SampledImage 17 21
+              30:    6(float) CompositeExtract 27 0
+              31:    6(float) CompositeExtract 27 1
+              32:   29(fvec3) CompositeConstruct 30 31 28
+              36:    6(float) CompositeExtract 32 2
+              37:    6(float) ImageSampleDrefExplicitLod 23 32 36 Lod ConstOffset 33 35
+                              Store 13(r11) 37
+              42:          39 Load 41(g_tTex1di4a)
+              43:          18 Load 20(g_sSamp)
+              45:          44 SampledImage 42 43
+              46:    6(float) CompositeExtract 27 0
+              47:    6(float) CompositeExtract 27 1
+              48:   29(fvec3) CompositeConstruct 46 47 28
+              49:    6(float) CompositeExtract 48 2
+              50:    6(float) ImageSampleDrefExplicitLod 45 48 49 Lod ConstOffset 33 35
+                              Store 38(r13) 50
+              56:          53 Load 55(g_tTex1du4a)
+              57:          18 Load 20(g_sSamp)
+              59:          58 SampledImage 56 57
+              60:    6(float) CompositeExtract 27 0
+              61:    6(float) CompositeExtract 27 1
+              62:   29(fvec3) CompositeConstruct 60 61 28
+              63:    6(float) CompositeExtract 62 2
+              64:    6(float) ImageSampleDrefExplicitLod 59 62 63 Lod ConstOffset 33 35
+                              Store 51(r15) 64
+              69:          66 Load 68(g_tTex2df4a)
+              70:          18 Load 20(g_sSamp)
+              72:          71 SampledImage 69 70
+              75:    6(float) CompositeExtract 74 0
+              76:    6(float) CompositeExtract 74 1
+              77:    6(float) CompositeExtract 74 2
+              78:    7(fvec4) CompositeConstruct 75 76 77 28
+              82:    6(float) CompositeExtract 78 3
+              83:    6(float) ImageSampleDrefExplicitLod 72 78 82 Lod ConstOffset 33 81
+                              Store 65(r31) 83
+              88:          85 Load 87(g_tTex2di4a)
+              89:          18 Load 20(g_sSamp)
+              91:          90 SampledImage 88 89
+              92:    6(float) CompositeExtract 74 0
+              93:    6(float) CompositeExtract 74 1
+              94:    6(float) CompositeExtract 74 2
+              95:    7(fvec4) CompositeConstruct 92 93 94 28
+              96:    6(float) CompositeExtract 95 3
+              97:    6(float) ImageSampleDrefExplicitLod 91 95 96 Lod ConstOffset 33 81
+                              Store 84(r33) 97
+             102:          99 Load 101(g_tTex2du4a)
+             103:          18 Load 20(g_sSamp)
+             105:         104 SampledImage 102 103
+             106:    6(float) CompositeExtract 74 0
+             107:    6(float) CompositeExtract 74 1
+             108:    6(float) CompositeExtract 74 2
+             109:    7(fvec4) CompositeConstruct 106 107 108 28
+             110:    6(float) CompositeExtract 109 3
+             111:    6(float) ImageSampleDrefExplicitLod 105 109 110 Lod ConstOffset 33 81
+                              Store 98(r35) 111
+             118:    117(ptr) AccessChain 113(psout) 114
+                              Store 118 116
+             120:     12(ptr) AccessChain 113(psout) 119
+                              Store 120 115
+             121:8(PS_OUTPUT) Load 113(psout)
+                              ReturnValue 121
                               FunctionEnd

--- a/Test/hlsl.samplecmp.negative.frag
+++ b/Test/hlsl.samplecmp.negative.frag
@@ -1,4 +1,5 @@
 
+Texture2D g_nonShadowTex;
 Texture2D g_shadowTex;
 SamplerState g_shadowSampler;
 SamplerComparisonState g_shadowSamplerComp;
@@ -6,7 +7,7 @@ SamplerComparisonState g_shadowSamplerComp;
 float4 main() : SV_Target0
 {
     g_shadowTex.SampleCmp(g_shadowSamplerComp, float2(0,0), 0); // OK
-    g_shadowTex.SampleCmp(g_shadowSampler, float2(0,0), 0);     // ERROR (should be comparison sampler)
+    g_nonShadowTex.SampleCmp(g_shadowSampler, float2(0,0), 0);     // ERROR (should be comparison sampler)
 
     return 0;
 }

--- a/hlsl/hlslParseHelper.h
+++ b/hlsl/hlslParseHelper.h
@@ -262,6 +262,7 @@ protected:
     bool wasSplit(int id) const { return splitNonIoVars.find(id) != splitNonIoVars.end(); }
     TVariable* getSplitNonIoVar(int id) const;
     void addPatchConstantInvocation();
+    void fixTextureShadowModes();
     TIntermTyped* makeIntegerIndex(TIntermTyped*);
 
     void fixBuiltInIoType(TType&);
@@ -455,6 +456,11 @@ protected:
     };
 
     TVector<tMipsOperatorData> mipsOperatorMipArg;
+
+    // This can be removed if and when the texture shadow workarounnd in
+    // HlslParseContext::handleSamplerTextureCombine is removed.  It maps
+    // texture symbol IDs to the shadow modes of samplers they were combined with.
+    TMap<int, bool> textureShadowMode;
 };
 
 // This is the prefix we use for built-in methods to avoid namespace collisions with


### PR DESCRIPTION
Texture shadow mode must match the state of the sampler they are combined with.  This change does that, both for the AST and the symbol table.  Note that the texture cannot easily be *created* the right way, because this may not be known at that time.  Instead, the texture is subsequently patched.

This cannot work if a single texture is used with both a shadow and non-shadow sampler, so that case is detected and generates an error. This is permitted by the HLSL language, however.  See #1073 discussion.

Fixed one test source that was using a texture with both shadow and non-shadow samplers.

Addresses #1073.  (Is not a complete fix, given mismatch between what HLSL allows and what SPIR-V currently requires).