### PR TITLE
Set cmake-policy CMP0048 to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 # increase to 3.1 once all major distributions
 # include a version of CMake >= 3.1
 cmake_minimum_required(VERSION 2.8.12)
+if (POLICY CMP0048)
+  cmake_policy(SET CMP0048 NEW)
+endif()
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Adhere to GNU filesystem layout conventions


### PR DESCRIPTION
When including this Project as subdirectory, cmake pushes a warning about the [CMP0048 Policy](https://cmake.org/cmake/help/latest/policy/CMP0048.html). This would be fixed when adding
```cmake
if (POLICY CMP0048)
  cmake_policy(SET CMP0048 NEW)
endif()
```
after `cmake_minimum_required(VERSION 2.8.12)`.

Same as KhronosGroup/SPIRV-Tools/issues/864
