### PR TITLE
HLSL: nonfunctional: add helper access methods to TAttributeMap

### DIFF
--- a/hlsl/hlslAttributes.cpp
+++ b/hlsl/hlslAttributes.cpp
@@ -36,6 +36,7 @@
 #include "hlslAttributes.h"
 #include <cstdlib>
 #include <cctype>
+#include <algorithm>
 
 namespace glslang {
     // Map the given string to an attribute enum from TAttributeType,
@@ -129,6 +130,53 @@ namespace glslang {
     bool TAttributeMap::contains(TAttributeType attr) const
     {
         return attributes.find(attr) != attributes.end();
+    }
+
+    // extract integers out of attribute arguments stored in attribute aggregate
+    bool TAttributeMap::getInt(TAttributeType attr, int& value, int argNum) const 
+    {
+        const TConstUnion* intConst = getConstUnion(attr, EbtInt, argNum);
+
+        if (intConst == nullptr)
+            return false;
+
+        value = intConst->getIConst();
+        return true;
+    };
+
+    // extract strings out of attribute arguments stored in attribute aggregate.
+    // convert to lower case if converToLower is true (for case-insensitive compare convenience)
+    bool TAttributeMap::getString(TAttributeType attr, TString& value, int argNum, bool convertToLower) const 
+    {
+        const TConstUnion* stringConst = getConstUnion(attr, EbtString, argNum);
+
+        if (stringConst == nullptr)
+            return false;
+
+        value = *stringConst->getSConst();
+
+        // Convenience.
+        if (convertToLower)
+            std::transform(value.begin(), value.end(), value.begin(), ::tolower);
+
+        return true;
+    };
+
+    // Helper to get attribute const union.  Returns nullptr on failure.
+    const TConstUnion* TAttributeMap::getConstUnion(TAttributeType attr, TBasicType basicType, int argNum) const
+    {
+        const TIntermAggregate* attrAgg = (*this)[attr];
+        if (attrAgg == nullptr)
+            return nullptr;
+
+        if (argNum >= int(attrAgg->getSequence().size()))
+            return nullptr;
+
+        const TConstUnion* constVal = &attrAgg->getSequence()[argNum]->getAsConstantUnion()->getConstArray()[0];
+        if (constVal == nullptr || constVal->getType() != basicType)
+            return nullptr;
+        
+        return constVal;
     }
 
 } // end namespace glslang

--- a/hlsl/hlslAttributes.h
+++ b/hlsl/hlslAttributes.h
@@ -93,7 +93,16 @@ namespace glslang {
         // True if entry exists in map (even if value is nullptr)
         bool contains(TAttributeType) const;
 
+        // Obtain attribute as integer
+        bool getInt(TAttributeType attr, int& value, int argNum = 0) const;
+
+        // Obtain attribute as string, with optional to-lower transform
+        bool getString(TAttributeType attr, TString& value, int argNum = 0, bool convertToLower = true) const;
+
     protected:
+        // Helper to get attribute const union
+        const TConstUnion* getConstUnion(TAttributeType attr, TBasicType, int argNum) const;
+
         // Find an attribute enum given its name.
         static TAttributeType attributeFromName(const TString& nameSpace, const TString& name);
 


### PR DESCRIPTION
There was some code replication around getting string and integer values out of an attribute map.  This adds new methods to the TAttributeMap class to encapsulate some accessor details.