### PR TITLE
Set ENABLE_OPT default to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(ENABLE_NV_EXTENSIONS "Enables support of Nvidia-specific extensions" ON)
 
 option(ENABLE_HLSL "Enables HLSL input support" ON)
 
-option(ENABLE_OPT "Enables spirv-opt capability if present" ON)
+option(ENABLE_OPT "Enables spirv-opt capability if present" OFF)
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND WIN32)
     set(CMAKE_INSTALL_PREFIX "install" CACHE STRING "..." FORCE)


### PR DESCRIPTION
Reason: decision to use ENABLE_OPT should be explicitely
taken by glslang client (such as shaderc).