### PR TITLE
Don't try to swizzle void.

### DIFF
--- a/Test/baseResults/invalidSwizzle.vert.out
+++ b/Test/baseResults/invalidSwizzle.vert.out
@@ -1,0 +1,34 @@
+invalidSwizzle.vert
+ERROR: 0:6: 'xx' : does not apply to this type:  global void
+ERROR: 0:7: 'xy' : does not apply to this type:  global void
+ERROR: 2 compilation errors.  No code generated.
+
+
+Shader version: 420
+ERROR: node is still EOpNull!
+0:5  Function Definition: main( ( global void)
+0:5    Function Parameters: 
+0:6    Sequence
+0:6      Function Call: f( ( global void)
+0:7      Function Call: f( ( global void)
+0:?   Linker Objects
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+
+Linked vertex stage:
+
+ERROR: Linking vertex stage: No function definition (body) found: 
+    f(
+
+Shader version: 420
+ERROR: node is still EOpNull!
+0:5  Function Definition: main( ( global void)
+0:5    Function Parameters: 
+0:6    Sequence
+0:6      Function Call: f( ( global void)
+0:7      Function Call: f( ( global void)
+0:?   Linker Objects
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+

--- a/Test/invalidSwizzle.vert
+++ b/Test/invalidSwizzle.vert
@@ -1,0 +1,8 @@
+#version 420
+
+void f();
+
+void main() {
+    f().xx; // Scalar swizzle does not apply to void
+    f().xy; // Vector swizzle does not apply either
+}

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -663,7 +663,7 @@ TIntermTyped* TParseContext::handleDotDereference(const TSourceLoc& loc, TInterm
     // leaving swizzles and struct/block dereferences.
 
     TIntermTyped* result = base;
-    if (base->isVector() || base->isScalar()) {
+    if (base->getBasicType() != EbtVoid && (base->isVector() || base->isScalar())) {
         if (base->isScalar()) {
             const char* dotFeature = "scalar swizzle";
             requireProfile(loc, ~EEsProfile, dotFeature);

--- a/gtests/AST.FromFile.cpp
+++ b/gtests/AST.FromFile.cpp
@@ -188,6 +188,7 @@ INSTANTIATE_TEST_CASE_P(
         "structDeref.frag",
         "structure.frag",
         "swizzle.frag",
+        "invalidSwizzle.vert",
         "syntaxError.frag",
         "test.frag",
         "texture.frag",


### PR DESCRIPTION
This seems like an adequate fix, it also makes the result make more sense for vector swizzles which were previously considered "out of range" on void, instead of just not applicable.

Resolves #1108 