### PR TITLE
Preprocessor: Evaluate INT_MIN / -1 to 0.

### DIFF
--- a/Test/baseResults/cppIntMinOverNegativeOne.frag.out
+++ b/Test/baseResults/cppIntMinOverNegativeOne.frag.out
@@ -1,0 +1,14 @@
+cppIntMinOverNegativeOne.frag
+Shader version: 100
+0:? Sequence
+0:?   Linker Objects
+
+
+Linked fragment stage:
+
+ERROR: Linking fragment stage: Missing entry point: Each stage requires one entry point
+
+Shader version: 100
+0:? Sequence
+0:?   Linker Objects
+

--- a/Test/cppIntMinOverNegativeOne.frag
+++ b/Test/cppIntMinOverNegativeOne.frag
@@ -1,0 +1,3 @@
+#if (-2147483648 / -1) != 0
+#error INT_MIN / -1 should yield 0, something went wrong.
+#endif

--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
+++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
@@ -84,6 +84,7 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdlib>
 #include <cstring>
 #include <cctype>
+#include <climits>
 
 #include "PpContext.h"
 #include "PpTokens.h"
@@ -350,7 +351,7 @@ namespace {
     int op_add(int a, int b) { return a + b; }
     int op_sub(int a, int b) { return a - b; }
     int op_mul(int a, int b) { return a * b; }
-    int op_div(int a, int b) { return a / b; }
+    int op_div(int a, int b) { return a == INT_MIN && b == -1 ? 0 : a / b; }
     int op_mod(int a, int b) { return a % b; }
     int op_pos(int a) { return a; }
     int op_neg(int a) { return -a; }

--- a/gtests/AST.FromFile.cpp
+++ b/gtests/AST.FromFile.cpp
@@ -78,6 +78,7 @@ INSTANTIATE_TEST_CASE_P(
         "matrixError.vert",
         "cppSimple.vert",
         "cppIndent.vert",
+        "cppIntMinOverNegativeOne.frag",
         "cppNest.vert",
         "cppBad.vert",
         "cppBad2.vert",


### PR DESCRIPTION
This is undefined behaviour which raises SIGFPE on x86.
Most C++ preprocessors evaluate this silently to 0.

Resolves #1112 