### PR TITLE
Nonfunctional: minor: use std::array for per-set shifts, fix warning.

### DIFF
--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -677,8 +677,7 @@ protected:
     std::array<unsigned int, EResCount> shiftBinding;
 
     // Per-descriptor-set shift values
-    typedef std::map<int, int> TDescriptorSetShift;
-    TDescriptorSetShift shiftBindingForSet[EResCount];
+    std::array<std::map<int, int>, EResCount>  shiftBindingForSet;
 
     std::vector<std::string> resourceSetBinding;
     bool autoMapBindings;

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -1157,8 +1157,8 @@ bool HlslParseContext::shouldFlatten(const TType& type, TStorageQualifier qualif
     case EvqVaryingOut:
         return type.isStruct() || type.isArray();
     case EvqUniform:
-        return type.isArray() && intermediate.getFlattenUniformArrays() && topLevel ||
-               type.isStruct() && type.containsOpaque();
+        return (type.isArray() && intermediate.getFlattenUniformArrays() && topLevel) ||
+               (type.isStruct() && type.containsOpaque());
     default:
         return type.isStruct() && type.containsOpaque();
     };


### PR DESCRIPTION
Two unrelated, minor tweaks:

(1) Use std::array for shiftBindingForSet, rather than a C array.  Now matches shiftBinding.

(2) Add parens in shouldFlatten() to make compiler warning happy.