### PR TITLE
Reverse order of setShiftBindingForSet parameters

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -268,7 +268,7 @@ void Error(const char* message)
 //
 // Process an optional binding base of one the forms:
 //   --argname [stage] base            // base for stage (if given) or all stages (if not)
-//   --argname [stage] [set base]...   // set/base pairs: set the base for given binding set.
+//   --argname [stage] [base set]...   // set/base pairs: set the base for given binding set.
 
 // Where stage is one of the forms accepted by FindLanguage, and base is an integer
 //
@@ -293,8 +293,8 @@ void ProcessBindingBase(int& argc, char**& argv, glslang::TResourceType res)
     if ((argc - arg) > 2 && isdigit(argv[arg+0][0]) && isdigit(argv[arg+1][0])) {
         // Parse a per-set binding base
         while ((argc - arg) > 2 && isdigit(argv[arg+0][0]) && isdigit(argv[arg+1][0])) {
-            const int setNum = atoi(argv[arg++]);
             const int baseNum = atoi(argv[arg++]);
+            const int setNum = atoi(argv[arg++]);
             perSetBase[setNum] = baseNum;
         }
     } else {
@@ -821,7 +821,7 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
             // TODO: use a range based for loop here, when available in all environments.
             for (auto i = baseBindingForSet[res][compUnit.stage].begin();
                  i != baseBindingForSet[res][compUnit.stage].end(); ++i)
-                shader->setShiftBindingForSet(res, i->first, i->second);
+                shader->setShiftBindingForSet(res, i->second, i->first);
         }
 
         shader->setFlattenUniformArrays((Options & EOptionFlattenUniformArrays) != 0);
@@ -1302,24 +1302,24 @@ void usage()
            "              Set descriptor set for all resources\n"
            "  --rsb [stage] type set binding       synonym for --resource-set-binding\n"
            "  --shift-image-binding [stage] num    base binding number for images (uav)\n"
-           "  --shift-image-binding [stage] [set num]... per-descriptor-set shift values\n"
+           "  --shift-image-binding [stage] [num set]... per-descriptor-set shift values\n"
            "  --sib [stage] num                    synonym for --shift-image-binding\n"
            "  --shift-sampler-binding [stage] num  base binding number for samplers\n"
-           "  --shift-sampler-binding [stage] [set num]... per-descriptor-set shift values\n"
+           "  --shift-sampler-binding [stage] [num set]... per-descriptor-set shift values\n"
            "  --ssb [stage] num                    synonym for --shift-sampler-binding\n"
            "  --shift-ssbo-binding [stage] num     base binding number for SSBOs\n"
-           "  --shift-ssbo-binding [stage] [set num]... per-descriptor-set shift values\n"
+           "  --shift-ssbo-binding [stage] [num set]... per-descriptor-set shift values\n"
            "  --sbb [stage] num                    synonym for --shift-ssbo-binding\n"
            "  --shift-texture-binding [stage] num  base binding number for textures\n"
-           "  --shift-texture-binding [stage] [set num]... per-descriptor-set shift values\n"
+           "  --shift-texture-binding [stage] [num set]... per-descriptor-set shift values\n"
            "  --stb [stage] num                    synonym for --shift-texture-binding\n"
            "  --shift-uav-binding [stage] num      base binding number for UAVs\n"
-           "  --shift-uav-binding [stage] [set num]... per-descriptor-set shift values\n"
+           "  --shift-uav-binding [stage] [num set]... per-descriptor-set shift values\n"
            "  --suavb [stage] num                  synonym for --shift-uav-binding\n"
            "  --shift-UBO-binding [stage] num      base binding number for UBOs\n"
-           "  --shift-UBO-binding [stage] [set num]... per-descriptor-set shift values\n"
+           "  --shift-UBO-binding [stage] [num set]... per-descriptor-set shift values\n"
            "  --shift-cbuffer-binding [stage] num  synonym for --shift-UBO-binding\n"
-           "  --shift-cbuffer-binding [stage] [set num]... per-descriptor-set shift values\n"
+           "  --shift-cbuffer-binding [stage] [num set]... per-descriptor-set shift values\n"
            "  --sub [stage] num                    synonym for --shift-UBO-binding\n"
            "  --source-entrypoint <name>           the given shader source function is\n"
            "                                       renamed to be the <name> given in -e\n"

--- a/Test/runtests
+++ b/Test/runtests
@@ -108,7 +108,7 @@ diff -b $BASEDIR/hlsl.explicitDescriptorSet-2.frag.out $TARGETDIR/hlsl.explicitD
 # Testing per-descriptor-set IO map shift
 #
 echo 'Testing per-descriptor-set IO map shift'
-$EXE -e main --hlsl-iomap --ssb 1 10 2 15 --stb 20 --stb 2 25 --suavb 30 --suavb 2 40 --sub 6 50 -i -q -D -V hlsl.shift.per-set.frag > $TARGETDIR/hlsl.shift.per-set.frag.out || HASERROR=1
+$EXE -e main --hlsl-iomap --ssb 10 1 15 2 --stb 20 --stb 25 2 --suavb 30 --suavb 40 2 --sub 50 6 -i -q -D -V hlsl.shift.per-set.frag > $TARGETDIR/hlsl.shift.per-set.frag.out || HASERROR=1
 diff -b $BASEDIR/hlsl.shift.per-set.frag.out $TARGETDIR/hlsl.shift.per-set.frag.out || HASERROR=1
 
 #

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1667,8 +1667,8 @@ void TShader::setShiftBinding(TResourceType res, unsigned int base) {
 }
 
 // Set binding base for given resource type for a given binding set.
-void TShader::setShiftBindingForSet(TResourceType res, unsigned int set, unsigned int base) {
-    intermediate->setShiftBindingForSet(res, set, base); 
+void TShader::setShiftBindingForSet(TResourceType res, unsigned int base, unsigned int set) {
+    intermediate->setShiftBindingForSet(res, base, set);
 }
 
 // Set binding base for sampler types

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -271,7 +271,7 @@ public:
 
     unsigned int getShiftBinding(TResourceType res) const { return shiftBinding[res]; }
 
-    void setShiftBindingForSet(TResourceType res, unsigned int set, unsigned int shift)
+    void setShiftBindingForSet(TResourceType res, unsigned int shift, unsigned int set)
     {
         if (shift == 0) // ignore if there's no shift: it's a no-op.
             return;
@@ -281,8 +281,8 @@ public:
         const char* name = getResourceName(res);
         if (name != nullptr) {
             processes.addProcess(name);
-            processes.addArgument(set);
             processes.addArgument(shift);
+            processes.addArgument(set);
         }
     }
 

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -368,7 +368,7 @@ public:
     void setShiftUavBinding(unsigned int base);      // DEPRECATED: use setShiftBinding
     void setShiftCbufferBinding(unsigned int base);  // synonym for setShiftUboBinding
     void setShiftSsboBinding(unsigned int base);     // DEPRECATED: use setShiftBinding
-    void setShiftBindingForSet(TResourceType res, unsigned int set, unsigned int base);
+    void setShiftBindingForSet(TResourceType res, unsigned int base, unsigned int set);
     void setResourceSetBinding(const std::vector<std::string>& base);
     void setAutoMapBindings(bool map);
     void setAutoMapLocations(bool map);


### PR DESCRIPTION
**WIP until coordination with all involved parties.**

Per feedback on PR #1111, this reverses the order of the parameters for the setShiftBindingForSet API.

It is now:

    void TShader::setShiftBindingForSet(TResourceType res, unsigned int base, unsigned int set);

No test result diffs (but the test source invocation reverses the order).
