### PR TITLE
Only try swizzles on vectors, numbers, and booleans.

### DIFF
--- a/Test/baseResults/invalidSwizzle.vert.out
+++ b/Test/baseResults/invalidSwizzle.vert.out
@@ -1,17 +1,20 @@
 invalidSwizzle.vert
-ERROR: 0:6: 'xx' : does not apply to this type:  global void
-ERROR: 0:7: 'xy' : does not apply to this type:  global void
-ERROR: 2 compilation errors.  No code generated.
+ERROR: 0:7: 'rr' : does not apply to this type:  uniform sampler2D
+ERROR: 0:7: '=' :  cannot convert from ' uniform sampler2D' to ' temp 2-component vector of float'
+ERROR: 0:8: 'xx' : does not apply to this type:  global void
+ERROR: 0:9: 'xy' : does not apply to this type:  global void
+ERROR: 4 compilation errors.  No code generated.
 
 
 Shader version: 420
 ERROR: node is still EOpNull!
-0:5  Function Definition: main( ( global void)
-0:5    Function Parameters: 
-0:6    Sequence
-0:6      Function Call: f( ( global void)
-0:7      Function Call: f( ( global void)
+0:6  Function Definition: main( ( global void)
+0:6    Function Parameters: 
+0:?     Sequence
+0:8      Function Call: f( ( global void)
+0:9      Function Call: f( ( global void)
 0:?   Linker Objects
+0:?     's' ( uniform sampler2D)
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 
@@ -23,12 +26,13 @@ ERROR: Linking vertex stage: No function definition (body) found:
 
 Shader version: 420
 ERROR: node is still EOpNull!
-0:5  Function Definition: main( ( global void)
-0:5    Function Parameters: 
-0:6    Sequence
-0:6      Function Call: f( ( global void)
-0:7      Function Call: f( ( global void)
+0:6  Function Definition: main( ( global void)
+0:6    Function Parameters: 
+0:?     Sequence
+0:8      Function Call: f( ( global void)
+0:9      Function Call: f( ( global void)
 0:?   Linker Objects
+0:?     's' ( uniform sampler2D)
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 

--- a/Test/invalidSwizzle.vert
+++ b/Test/invalidSwizzle.vert
@@ -1,8 +1,10 @@
 #version 420
 
 void f();
+uniform sampler2D s;
 
 void main() {
+    vec2 v = s.rr; // Swizzles do not apply to samplers
     f().xx; // Scalar swizzle does not apply to void
     f().xy; // Vector swizzle does not apply either
 }

--- a/glslang/Include/intermediate.h
+++ b/glslang/Include/intermediate.h
@@ -875,6 +875,8 @@ public:
     virtual bool isVector() const { return type.isVector(); }
     virtual bool isScalar() const { return type.isScalar(); }
     virtual bool isStruct() const { return type.isStruct(); }
+    virtual bool isFloatingDomain() const { return type.isFloatingDomain(); }
+    virtual bool isIntegerDomain() const { return type.isIntegerDomain(); }
     TString getCompleteString() const { return type.getCompleteString(); }
 
 protected:

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -665,7 +665,8 @@ TIntermTyped* TParseContext::handleDotDereference(const TSourceLoc& loc, TInterm
     // leaving swizzles and struct/block dereferences.
 
     TIntermTyped* result = base;
-    if (base->getBasicType() != EbtVoid && (base->isVector() || base->isScalar())) {
+    if ((base->isVector() || base->isScalar()) &&
+        (base->isFloatingDomain() || base->isIntegerDomain() || base->getBasicType() == EbtBool)) {
         if (base->isScalar()) {
             const char* dotFeature = "scalar swizzle";
             requireProfile(loc, ~EEsProfile, dotFeature);
@@ -4460,8 +4461,8 @@ void TParseContext::layoutObjectCheck(const TSourceLoc& loc, const TSymbol& symb
         switch (qualifier.storage) {
         case EvqVaryingIn:
         case EvqVaryingOut:
-            if (type.getBasicType() != EbtBlock || 
-                (!(*type.getStruct())[0].type->getQualifier().hasLocation() && 
+            if (type.getBasicType() != EbtBlock ||
+                (!(*type.getStruct())[0].type->getQualifier().hasLocation() &&
                   (*type.getStruct())[0].type->getQualifier().builtIn == EbvNone))
                 error(loc, "SPIR-V requires location for user input/output", "location", "");
             break;


### PR DESCRIPTION
This should solve all similar issues, for example if it's possible to get glslang to try to swizzle an `EbtBlock`.

Let me know if you figure the conditions for this should be in the `TType`/`TIntermediate` class instead of inline.

Resolves #1117.