### PR TITLE
Appveyor: auto deploy build artifacts to GitHub Releases

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ version: "{build}"
 os: Visual Studio 2013
 
 platform:
-  - Any CPU
+  - x64
 
 configuration:
   - Debug
@@ -39,3 +39,45 @@ build_script:
 test_script:
   - ctest -C %CONFIGURATION% --output-on-failure
   - cd ../Test && bash runtests
+  - cd ../build
+
+after_test:
+  # For debug build, the generated dll has a postfix "d" in its name.
+  - ps: >-
+      If ($env:configuration -Match "Debug") {
+        $env:SUFFIX="d"
+      } Else {
+        $env:SUFFIX=""
+      }
+  - cd install
+  # Zip all glslang artifacts for uploading and deploying
+  - 7z a glslang-master-windows-"%PLATFORM%"-"%CONFIGURATION%".zip
+    bin\glslangValidator.exe
+    include\glslang\*
+    include\SPIRV\*
+    lib\glslang%SUFFIX%.lib
+    lib\HLSL%SUFFIX%.lib
+    lib\OGLCompiler%SUFFIX%.lib
+    lib\OSDependent%SUFFIX%.lib
+    lib\SPIRV%SUFFIX%.lib
+    lib\SPVRemapper%SUFFIX%.lib
+    lib\SPIRV-Tools%SUFFIX%.lib
+    lib\SPIRV-Tools-opt%SUFFIX%.lib
+
+artifacts:
+  - path: build\install\*.zip
+    name: artifacts-zip
+
+deploy:
+  - provider: GitHub
+    auth_token:
+      secure: YglcSYdl0TylEa59H4K6lylBEDr586NAt2EMgZquSo+iuPrwgZQuJLPCoihSm9y6
+    release: master-tot
+    description: "Continuous build of the latest master branch by Appveyor and Travis CI"
+    artifact: artifacts-zip
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+      branch: master
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013


### PR DESCRIPTION
Pushing a commit to the master branch will trigger a build on
Appveyor. If the build is successful, the artifacts will be
collected and pushed to GitHub Releases, under the "master-tot"
release.