### PR TITLE
Travis: auto deploy build artifacts to GitHub Releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,11 @@ sudo: false
 dist: trusty
 
 env:
-  - GLSLANG_BUILD_TYPE=Release
-  - GLSLANG_BUILD_TYPE=Debug
+  global:
+    - secure: aGFrgzyKp+84hKrGkxVWg8cHV61uqrKEHT38gfSQK6+WS4GfLOyH83p7WnsEBb7AMhzU7LMNFdvOFr6+NaMpVnqRvc40CEG1Q+lNg9Pq9mhIZLowvDrfqTL9kQ+8Nbw5Q6/dg6CTvY7fvRfpfCEmKIUZBRkoKUuHeuM1uy3IupFcdNuL5bSYn3Beo+apSJginh9DI4BLDXFUgBzTRSLLyCX5g3cpaeGGOCr8quJlYx75W6HRck5g9SZuLtUoH9GFEV3l+ZEWB8noErW+J56L03bwNwFuuAh321evw++oQk5KFa8rlDvar3SJ3b1RHB8u/eq5DBYMyaK/fS8+Q7QbGr8diF/wDe68bKO7U9IhpNfExXmczCpExjHomW5TQv4rYdGhygPMfW97aIsPRYyNKcl4fkmb7NDrM8w0Jscdq2g5c2Kz0ItyZoBri/NXLwFQQjaVCs7Pf97TjuMA7mK0GJmDTRzi6SrDYlWMt5BQL3y0CCojyfLIRcTh0CQjQI29s97bLfQrYAxt9GNNFR+HTXRLLrkaAlJkPGEPwUywlSfEThnvHLesNxYqemolAYpQT4ithoL4GehGIHmaxsW295aKVhuRf8K9eBODNqrfblvM42UHhjntT+92ZnQ/Gkq80GqaMxnxi4PO5FyPIxt0r981b54YBkWi8YA4P7w5pNI=
+  matrix:
+    - GLSLANG_BUILD_TYPE=Release
+    - GLSLANG_BUILD_TYPE=Debug
 
 compiler:
   - clang
@@ -75,3 +78,46 @@ script:
       ctest --output-on-failure &&
       cd ../Test && ./runtests;
     fi
+
+after_success:
+  # For debug build, the generated dll has a postfix "d" in its name.
+  - if [[ "${GLSLANG_BUILD_TYPE}" == "Debug" ]]; then
+      export SUFFIX="d";
+    else
+      export SUFFIX="";
+    fi
+  # Create tarball for deployment
+  - if [[ ${CC} == clang* && "${BUILD_NDK}" != "ON" ]]; then
+      cd ../build/install;
+      export TARBALL=glslang-master-${TRAVIS_OS_NAME}-${GLSLANG_BUILD_TYPE}.zip;
+      zip ${TARBALL}
+        bin/glslangValidator
+        include/glslang/*
+        include/SPIRV/*
+        lib/libglslang${SUFFIX}.a
+        lib/libHLSL${SUFFIX}.a
+        lib/libOGLCompiler${SUFFIX}.a
+        lib/libOSDependent${SUFFIX}.a
+        lib/libSPIRV${SUFFIX}.a
+        lib/libSPVRemapper${SUFFIX}.a
+        lib/libSPIRV-Tools${SUFFIX}.a
+        lib/libSPIRV-Tools-opt${SUFFIX}.a;
+    fi
+
+before_deploy:
+  # Tag the current top of the tree as "master-tot".
+  # Travis CI replies on the tag name to properly push to GitHub Releases.
+  - git config --global user.name "Travis CI"
+  - git config --global user.email "builds@travis-ci.org"
+  - git tag -f master-tot
+  - git push -q -f https://${glslangtoken}@github.com/KhronosGroup/glslang --tags
+
+deploy:
+  provider: releases
+  api_key: ${glslangtoken}
+  on:
+    branch: master
+    condition: ${CC} == clang* && ${BUILD_NDK} != ON
+  file: ${TARBALL}
+  skip_cleanup: true
+  overwrite: true


### PR DESCRIPTION
Pushing a commit to the master branch will trigger a build on
Travis. If the build is successful, the artifacts will be
collected and pushed to GitHub Releases, under the "master-tot"
release.