### PR TITLE
Memory fixes, round 1

### DIFF
--- a/OGLCompilersDLL/InitializeDll.cpp
+++ b/OGLCompilersDLL/InitializeDll.cpp
@@ -45,6 +45,10 @@ namespace glslang {
 
 OS_TLSIndex ThreadInitializeIndex = OS_INVALID_TLS_INDEX;
 
+// Per-process initialization.
+// Needs to be called at least once before parsing, etc. is done.
+// Will also do thread initialization for the calling thread; other
+// threads will need to do that explicitly.
 bool InitProcess()
 {
     glslang::GetGlobalLock();
@@ -85,7 +89,9 @@ bool InitProcess()
     return true;
 }
 
-
+// Per-thread scoped initialization.
+// Must be called at least once by each new thread sharing the
+// symbol tables, etc., needed to parse.
 bool InitThread()
 {
     //
@@ -109,7 +115,9 @@ bool InitThread()
     return true;
 }
 
-
+// Thread-scoped tear down. Needs to be done by all but the last
+// thread, which calls DetachProcess() instead.
+// NB. TODO: Not currently being executed by each thread.
 bool DetachThread()
 {
     bool success = true;
@@ -126,13 +134,13 @@ bool DetachThread()
             success = false;
         }
 
-        FreeGlobalPools();
-
+        FreeMemoryPools();
     }
 
     return success;
 }
 
+// Process-scoped tear down. Needs to be done by final thread in process.
 bool DetachProcess()
 {
     bool success = true;

--- a/OGLCompilersDLL/InitializeDll.cpp
+++ b/OGLCompilersDLL/InitializeDll.cpp
@@ -148,8 +148,6 @@ bool DetachProcess()
     if (ThreadInitializeIndex == OS_INVALID_TLS_INDEX)
         return true;
 
-    ShFinalize();
-
     success = DetachThread();
 
     FreePoolIndex();

--- a/OGLCompilersDLL/InitializeDll.h
+++ b/OGLCompilersDLL/InitializeDll.h
@@ -40,7 +40,7 @@ namespace glslang {
 
 bool InitProcess();
 bool InitThread();
-bool DetachThread();
+bool DetachThread(); // TODO: use this or remove it; ideally make it unneeded
 bool DetachProcess();
 
 } // end namespace glslang

--- a/OGLCompilersDLL/InitializeDll.h
+++ b/OGLCompilersDLL/InitializeDll.h
@@ -40,6 +40,8 @@ namespace glslang {
 
 bool InitProcess();
 bool InitThread();
+bool DetachThread();  // not called from standalone, perhaps other tools rely on parts of it
+bool DetachProcess(); // not called from standalone, perhaps other tools rely on parts of it
 
 } // end namespace glslang
 

--- a/OGLCompilersDLL/InitializeDll.h
+++ b/OGLCompilersDLL/InitializeDll.h
@@ -40,8 +40,6 @@ namespace glslang {
 
 bool InitProcess();
 bool InitThread();
-bool DetachThread(); // TODO: use this or remove it; ideally make it unneeded
-bool DetachProcess();
 
 } // end namespace glslang
 

--- a/glslang/Include/InitializeGlobals.h
+++ b/glslang/Include/InitializeGlobals.h
@@ -37,11 +37,7 @@
 
 namespace glslang {
 
-void InitializeMemoryPools();
-void FreeMemoryPools();
-
 bool InitializePoolIndex();
-void FreePoolIndex();
 
 } // end namespace glslang
 

--- a/glslang/Include/InitializeGlobals.h
+++ b/glslang/Include/InitializeGlobals.h
@@ -38,7 +38,8 @@
 namespace glslang {
 
 void InitializeMemoryPools();
-void FreeGlobalPools();
+void FreeMemoryPools();
+
 bool InitializePoolIndex();
 void FreePoolIndex();
 

--- a/glslang/Include/PoolAlloc.h
+++ b/glslang/Include/PoolAlloc.h
@@ -250,15 +250,8 @@ private:
 // different times.  But a simple use is to have a global pop
 // with everyone using the same global allocator.
 //
-typedef TPoolAllocator* PoolAllocatorPointer;
 extern TPoolAllocator& GetThreadPoolAllocator();
-
-struct TThreadMemoryPools
-{
-    TPoolAllocator* threadPoolAllocator;
-};
-
-void SetThreadPoolAllocator(TPoolAllocator& poolAllocator);
+void SetThreadPoolAllocator(TPoolAllocator* poolAllocator);
 
 //
 // This STL compatible allocator is intended to be used as the allocator

--- a/glslang/Include/ShHandle.h
+++ b/glslang/Include/ShHandle.h
@@ -56,11 +56,14 @@ class TUniformMap;
 //
 class TShHandleBase {
 public:
-    TShHandleBase() { }
-    virtual ~TShHandleBase() { }
+    TShHandleBase() { pool = new glslang::TPoolAllocator; }
+    virtual ~TShHandleBase() { delete pool; }
     virtual TCompiler* getAsCompiler() { return 0; }
     virtual TLinker* getAsLinker() { return 0; }
     virtual TUniformMap* getAsUniformMap() { return 0; }
+    virtual glslang::TPoolAllocator* getPool() const { return pool; }
+private:
+    glslang::TPoolAllocator* pool;
 };
 
 //

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -722,9 +722,6 @@ bool ProcessDeferred(
     const std::string sourceEntryPointName = "",
     const TEnvironment* environment = nullptr)  // optional way of fully setting all versions, overriding the above
 {
-    if (! InitThread())
-        return false;
-
     // This must be undone (.pop()) by the caller, after it finishes consuming the created tree.
     GetThreadPoolAllocator().push();
 
@@ -1299,7 +1296,7 @@ int __fastcall ShFinalize()
     glslang::HlslScanContext::deleteKeywordMap();
 #endif
 
-    return DetachProcess() ? 1 : 0;
+    return 1;
 }
 
 //
@@ -1331,6 +1328,8 @@ int ShCompile(
     TCompiler* compiler = base->getAsCompiler();
     if (compiler == 0)
         return 0;
+
+    SetThreadPoolAllocator(compiler->getPool());
 
     compiler->infoSink.info.erase();
     compiler->infoSink.debug.erase();
@@ -1389,6 +1388,8 @@ int ShLinkExt(
     TShHandleBase* base = reinterpret_cast<TShHandleBase*>(linkHandle);
     TLinker* linker = static_cast<TLinker*>(base->getAsLinker());
 
+    SetThreadPoolAllocator(linker->getPool());
+
     if (linker == 0)
         return 0;
 
@@ -1423,9 +1424,6 @@ void ShSetEncryptionMethod(ShHandle handle)
 //
 const char* ShGetInfoLog(const ShHandle handle)
 {
-    if (!InitThread())
-        return 0;
-
     if (handle == 0)
         return 0;
 
@@ -1449,9 +1447,6 @@ const char* ShGetInfoLog(const ShHandle handle)
 //
 const void* ShGetExecutable(const ShHandle handle)
 {
-    if (!InitThread())
-        return 0;
-
     if (handle == 0)
         return 0;
 
@@ -1474,9 +1469,6 @@ const void* ShGetExecutable(const ShHandle handle)
 //
 int ShSetVirtualAttributeBindings(const ShHandle handle, const ShBindingTable* table)
 {
-    if (!InitThread())
-        return 0;
-
     if (handle == 0)
         return 0;
 
@@ -1496,9 +1488,6 @@ int ShSetVirtualAttributeBindings(const ShHandle handle, const ShBindingTable* t
 //
 int ShSetFixedAttributeBindings(const ShHandle handle, const ShBindingTable* table)
 {
-    if (!InitThread())
-        return 0;
-
     if (handle == 0)
         return 0;
 
@@ -1517,9 +1506,6 @@ int ShSetFixedAttributeBindings(const ShHandle handle, const ShBindingTable* tab
 //
 int ShExcludeAttributes(const ShHandle handle, int *attributes, int count)
 {
-    if (!InitThread())
-        return 0;
-
     if (handle == 0)
         return 0;
 
@@ -1541,9 +1527,6 @@ int ShExcludeAttributes(const ShHandle handle, int *attributes, int count)
 //
 int ShGetUniformLocation(const ShHandle handle, const char* name)
 {
-    if (!InitThread())
-        return 0;
-
     if (handle == 0)
         return -1;
 
@@ -1707,8 +1690,8 @@ bool TShader::parse(const TBuiltInResource* builtInResources, int defaultVersion
 {
     if (! InitThread())
         return false;
-
     SetThreadPoolAllocator(pool);
+
     if (! preamble)
         preamble = "";
 
@@ -1730,8 +1713,8 @@ bool TShader::preprocess(const TBuiltInResource* builtInResources,
 {
     if (! InitThread())
         return false;
-
     SetThreadPoolAllocator(pool);
+
     if (! preamble)
         preamble = "";
 

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1286,7 +1286,6 @@ int __fastcall ShFinalize()
     }
 
     if (PerProcessGPA != nullptr) {
-        PerProcessGPA->popAll();
         delete PerProcessGPA;
         PerProcessGPA = nullptr;
     }

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1299,7 +1299,7 @@ int __fastcall ShFinalize()
     glslang::HlslScanContext::deleteKeywordMap();
 #endif
 
-    return 1;
+    return DetachProcess() ? 1 : 0;
 }
 
 //

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1602,8 +1602,9 @@ public:
 };
 
 TShader::TShader(EShLanguage s)
-    : pool(0), stage(s), lengths(nullptr), stringNames(nullptr), preamble("")
+    : stage(s), lengths(nullptr), stringNames(nullptr), preamble("")
 {
+    pool = new TPoolAllocator;
     infoSink = new TInfoSink;
     compiler = new TDeferredCompiler(stage, *infoSink);
     intermediate = new TIntermediate(s);
@@ -1707,7 +1708,6 @@ bool TShader::parse(const TBuiltInResource* builtInResources, int defaultVersion
     if (! InitThread())
         return false;
 
-    pool = new TPoolAllocator();
     SetThreadPoolAllocator(pool);
     if (! preamble)
         preamble = "";
@@ -1731,7 +1731,6 @@ bool TShader::preprocess(const TBuiltInResource* builtInResources,
     if (! InitThread())
         return false;
 
-    pool = new TPoolAllocator();
     SetThreadPoolAllocator(pool);
     if (! preamble)
         preamble = "";
@@ -1752,8 +1751,9 @@ const char* TShader::getInfoDebugLog()
     return infoSink->debug.c_str();
 }
 
-TProgram::TProgram() : pool(0), reflection(0), ioMapper(nullptr), linked(false)
+TProgram::TProgram() : reflection(0), ioMapper(nullptr), linked(false)
 {
+    pool = new TPoolAllocator;
     infoSink = new TInfoSink;
     for (int s = 0; s < EShLangCount; ++s) {
         intermediate[s] = 0;
@@ -1788,7 +1788,6 @@ bool TProgram::link(EShMessages messages)
 
     bool error = false;
 
-    pool = new TPoolAllocator();
     SetThreadPoolAllocator(pool);
 
     for (int s = 0; s < EShLangCount; ++s) {

--- a/glslang/OSDependent/Unix/ossource.cpp
+++ b/glslang/OSDependent/Unix/ossource.cpp
@@ -43,6 +43,9 @@
 #include <assert.h>
 #include <errno.h>
 #include <stdint.h>
+#include <cstdio>
+#include <sys/time.h>
+#include <sys/resource.h>
 
 namespace glslang {
 
@@ -184,8 +187,18 @@ void ReleaseGlobalLock()
   pthread_mutex_unlock(&gMutex);
 }
 
+// #define DUMP_COUNTERS
+
 void OS_DumpMemoryCounters()
 {
+#ifdef DUMP_COUNTERS
+    struct rusage usage;
+
+    if (getrusage(RUSAGE_SELF, &usage) == 0)
+        printf("Working set size: %ld\n", usage.ru_maxrss * 1024);
+#else
+    printf("Recompile with DUMP_COUNTERS defined to see counters.\n");
+#endif
 }
 
 } // end namespace glslang

--- a/glslang/OSDependent/Unix/ossource.cpp
+++ b/glslang/OSDependent/Unix/ossource.cpp
@@ -56,7 +56,6 @@ namespace glslang {
 //
 static void DetachThreadLinux(void *)
 {
-    DetachThread();
 }
 
 //

--- a/glslang/OSDependent/Unix/ossource.cpp
+++ b/glslang/OSDependent/Unix/ossource.cpp
@@ -56,6 +56,7 @@ namespace glslang {
 //
 static void DetachThreadLinux(void *)
 {
+    DetachThread();
 }
 
 //

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -68,15 +68,14 @@
 #endif
 
 //
-// Driver must call this first, once, before doing any other
-// compiler/linker operations.
+// Call before doing any other compiler/linker operations.
 //
 // (Call once per process, not once per thread.)
 //
 SH_IMPORT_EXPORT int ShInitialize();
 
 //
-// Driver should call this at process shutdown.
+// Call this at process shutdown to clean up memory.
 //
 SH_IMPORT_EXPORT int __fastcall ShFinalize();
 
@@ -290,7 +289,7 @@ SH_IMPORT_EXPORT int ShGetUniformLocation(const ShHandle uniformMap, const char*
 // Deferred-Lowering C++ Interface
 // -----------------------------------
 //
-// Below is a new alternate C++ interface that might potentially replace the above
+// Below is a new alternate C++ interface, which deprecates the above
 // opaque handle-based interface.
 //
 // The below is further designed to handle multiple compilation units per stage, where


### PR DESCRIPTION
First commit: Non-functional; clean-up rationalization.

Second commit:  

> Move to a normal model of ownership of memory pools, for new/delete.

> Addresses step 4 of #976, overlaps #916.

> For each pool, now, it is newed, remembered, and freed by the same entity, rather than having a mix (thread finalize freeing current pool) that could  lead to double freeing of the same pool. It is quite rational and simple now.

> This will enable reinstalling process and thread tear down.

Third commit: On it's way, will actually add tear down logic that's been skipped so far

Main issue: Nothing triggering per-thread tear down of additional threads.