### PR TITLE
Improve build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,22 @@ branch.
 
 ### Dependencies
 
+* A C++11 compiler
 * [CMake][cmake]: for generating compilation targets.
+* make: _Linux_, ninja is an alternative, if configured.
 * [Python 2.7][python]: for executing SPIRV-Tools scripts. (Optional if not using SPIRV-Tools.)
 * [bison][bison]: _optional_, but needed when changing the grammar (glslang.y).
 * [googletest][googletest]: _optional_, but should use if making any changes to glslang.
 
 ### Build steps
 
+The following steps assume a Bash shell. On Windows, that could be the Git Bash
+shell or some other shell of your choosing.
+
 #### 1) Check-Out this project 
 
 ```bash
 cd <parent of where you want glslang to be>
-# If using SSH
-git clone git@github.com:KhronosGroup/glslang.git
-# Or if using HTTPS
 git clone https://github.com/KhronosGroup/glslang.git
 ```
 
@@ -89,28 +91,27 @@ spirv-tools with this:
 ./update_glslang_sources.py
 ```
 
-For running the CMake GUI or Visual Studio with python dependencies, you will,
-in addition to python within the cygwin environment, need a Windows [python][python]
-installation, including selecting the `PATH` update.
-
 #### 3) Configure
 
-Assume the source directory is `$SOURCE_DIR` and
-the build directory is `$BUILD_DIR`:
-
-For building on Linux (assuming using the Ninja generator):
+Assume the source directory is `$SOURCE_DIR` and the build directory is
+`$BUILD_DIR`. First ensure the build directory exists, then navigate to it:
 
 ```bash
+mkdir -p $BUILD_DIR
 cd $BUILD_DIR
+```
 
-cmake -GNinja -DCMAKE_BUILD_TYPE={Debug|Release|RelWithDebInfo} \
-      -DCMAKE_INSTALL_PREFIX=`pwd`/install $SOURCE_DIR
+For building on Linux:
+
+```bash
+cmake -DCMAKE_BUILD_TYPE={Debug|Release|RelWithDebInfo} \
+      -DCMAKE_INSTALL_PREFIX="$(pwd)/install" $SOURCE_DIR
 ```
 
 For building on Windows:
 
 ```bash
-cmake $SOURCE_DIR -DCMAKE_INSTALL_PREFIX=`pwd`/install
+cmake $SOURCE_DIR -DCMAKE_INSTALL_PREFIX="$(pwd)/install"
 # The CMAKE_INSTALL_PREFIX part is for testing (explained later).
 ```
 
@@ -120,7 +121,7 @@ The CMake GUI also works for Windows (version 3.4.1 tested).
 
 ```bash
 # for Linux:
-ninja install
+make -j4 install
 
 # for Windows:
 cmake --build . --config {Release|Debug|MinSizeRel|RelWithDebInfo} \


### PR DESCRIPTION
Fixed Windows build instructions:
- ./update_glslang_sources.py is not a valid command on Windows.
  Just call python explicitly.
- -DCMAKE_INSTALL_PREFIX=\`pwd\`/install creates a directory named \`pwd\`.
  Replaced with %CD%.

Simplified:
- Remove SSH clone instructions. Instructions on how to clone are for
  those unfamiliar with GitHub, so fewer options are better and SSH
  requires additional configuration to make work.
- Replace ninja with make, because more people are familiar with it and
  we probably don't need to explain how to install it. Fixes #956.
- The section mentioning cygwin is unclear and doesn't seem necessary
  to build.

Expanded:
- Mention minimum language version in the Dependencies section.
  Though perhaps we should elaborate on exactly which compilers are
  supported? Issue #42 discusses what compilers to support, but that
  information doesn't seem to be communicated anywhere.