### PR TITLE
HLSL: allow keyword-identifiers as cbuffer/struct names.

### DIFF
--- a/Test/baseResults/hlsl.cbuffer-identifier.vert.out
+++ b/Test/baseResults/hlsl.cbuffer-identifier.vert.out
@@ -1,0 +1,415 @@
+hlsl.cbuffer-identifier.vert
+Shader version: 500
+0:? Sequence
+0:22  Function Definition: @main(struct-VS_INPUT-vf4-vf31; ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22    Function Parameters: 
+0:22      'input' ( in structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:?     Sequence
+0:23      Sequence
+0:23        move second child to first child ( temp int)
+0:23          'ConstantBuffer' ( temp int)
+0:23          Constant:
+0:23            42 (const int)
+0:25      Sequence
+0:25        move second child to first child ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:25          'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:25          Constant:
+0:25            0.000000
+0:25            0.000000
+0:25            0.000000
+0:25            0.000000
+0:25            0.000000
+0:25            0.000000
+0:25            0.000000
+0:26      move second child to first child ( temp 4-component vector of float)
+0:26        Pos: direct index for structure ( temp 4-component vector of float)
+0:26          'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:26          Constant:
+0:26            0 (const int)
+0:26        matrix-times-vector ( temp 4-component vector of float)
+0:26          World: direct index for structure (layout( row_major std140) uniform 4X4 matrix of float)
+0:26            'anon@0' (layout( binding=0 row_major std140) uniform block{layout( row_major std140) uniform 4X4 matrix of float World, layout( row_major std140) uniform 4X4 matrix of float View, layout( row_major std140) uniform 4X4 matrix of float Projection})
+0:26            Constant:
+0:26              0 (const uint)
+0:26          Pos: direct index for structure ( temp 4-component vector of float)
+0:26            'input' ( in structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:26            Constant:
+0:26              0 (const int)
+0:27      move second child to first child ( temp 4-component vector of float)
+0:27        Pos: direct index for structure ( temp 4-component vector of float)
+0:27          'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:27          Constant:
+0:27            0 (const int)
+0:27        matrix-times-vector ( temp 4-component vector of float)
+0:27          View: direct index for structure (layout( row_major std140) uniform 4X4 matrix of float)
+0:27            'anon@0' (layout( binding=0 row_major std140) uniform block{layout( row_major std140) uniform 4X4 matrix of float World, layout( row_major std140) uniform 4X4 matrix of float View, layout( row_major std140) uniform 4X4 matrix of float Projection})
+0:27            Constant:
+0:27              1 (const uint)
+0:27          Pos: direct index for structure ( temp 4-component vector of float)
+0:27            'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:27            Constant:
+0:27              0 (const int)
+0:28      move second child to first child ( temp 4-component vector of float)
+0:28        Pos: direct index for structure ( temp 4-component vector of float)
+0:28          'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:28          Constant:
+0:28            0 (const int)
+0:28        matrix-times-vector ( temp 4-component vector of float)
+0:28          Projection: direct index for structure (layout( row_major std140) uniform 4X4 matrix of float)
+0:28            'anon@0' (layout( binding=0 row_major std140) uniform block{layout( row_major std140) uniform 4X4 matrix of float World, layout( row_major std140) uniform 4X4 matrix of float View, layout( row_major std140) uniform 4X4 matrix of float Projection})
+0:28            Constant:
+0:28              2 (const uint)
+0:28          Pos: direct index for structure ( temp 4-component vector of float)
+0:28            'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:28            Constant:
+0:28              0 (const int)
+0:29      move second child to first child ( temp 3-component vector of float)
+0:29        Norm: direct index for structure ( temp 3-component vector of float)
+0:29          'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:29          Constant:
+0:29            1 (const int)
+0:29        Construct vec3 ( temp 3-component vector of float)
+0:29          matrix-times-vector ( temp 4-component vector of float)
+0:29            Construct mat3x4 ( uniform 3X4 matrix of float)
+0:29              World: direct index for structure (layout( row_major std140) uniform 4X4 matrix of float)
+0:29                'anon@0' (layout( binding=0 row_major std140) uniform block{layout( row_major std140) uniform 4X4 matrix of float World, layout( row_major std140) uniform 4X4 matrix of float View, layout( row_major std140) uniform 4X4 matrix of float Projection})
+0:29                Constant:
+0:29                  0 (const uint)
+0:29            Norm: direct index for structure ( temp 3-component vector of float)
+0:29              'input' ( in structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:29              Constant:
+0:29                1 (const int)
+0:31      Branch: Return with expression
+0:31        'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22  Function Definition: main( ( temp void)
+0:22    Function Parameters: 
+0:?     Sequence
+0:22      Sequence
+0:22        move second child to first child ( temp 4-component vector of float)
+0:22          Pos: direct index for structure ( temp 4-component vector of float)
+0:?             'input' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22            Constant:
+0:22              0 (const int)
+0:?           'input.Pos' (layout( location=0) in 4-component vector of float)
+0:22        move second child to first child ( temp 3-component vector of float)
+0:22          Norm: direct index for structure ( temp 3-component vector of float)
+0:?             'input' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22            Constant:
+0:22              1 (const int)
+0:?           'input.Norm' (layout( location=1) in 3-component vector of float)
+0:22      Sequence
+0:22        move second child to first child ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22          'flattenTemp' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22          Function Call: @main(struct-VS_INPUT-vf4-vf31; ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:?             'input' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22        move second child to first child ( temp 4-component vector of float)
+0:?           '@entryPointOutput.Pos' ( out 4-component vector of float Position)
+0:22          Pos: direct index for structure ( temp 4-component vector of float)
+0:22            'flattenTemp' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22            Constant:
+0:22              0 (const int)
+0:22        move second child to first child ( temp 3-component vector of float)
+0:?           '@entryPointOutput.Norm' (layout( location=0) out 3-component vector of float)
+0:22          Norm: direct index for structure ( temp 3-component vector of float)
+0:22            'flattenTemp' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22            Constant:
+0:22              1 (const int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( binding=0 row_major std140) uniform block{layout( row_major std140) uniform 4X4 matrix of float World, layout( row_major std140) uniform 4X4 matrix of float View, layout( row_major std140) uniform 4X4 matrix of float Projection})
+0:?     '@entryPointOutput.Pos' ( out 4-component vector of float Position)
+0:?     '@entryPointOutput.Norm' (layout( location=0) out 3-component vector of float)
+0:?     'input.Pos' (layout( location=0) in 4-component vector of float)
+0:?     'input.Norm' (layout( location=1) in 3-component vector of float)
+
+
+Linked vertex stage:
+
+
+Shader version: 500
+0:? Sequence
+0:22  Function Definition: @main(struct-VS_INPUT-vf4-vf31; ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22    Function Parameters: 
+0:22      'input' ( in structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:?     Sequence
+0:23      Sequence
+0:23        move second child to first child ( temp int)
+0:23          'ConstantBuffer' ( temp int)
+0:23          Constant:
+0:23            42 (const int)
+0:25      Sequence
+0:25        move second child to first child ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:25          'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:25          Constant:
+0:25            0.000000
+0:25            0.000000
+0:25            0.000000
+0:25            0.000000
+0:25            0.000000
+0:25            0.000000
+0:25            0.000000
+0:26      move second child to first child ( temp 4-component vector of float)
+0:26        Pos: direct index for structure ( temp 4-component vector of float)
+0:26          'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:26          Constant:
+0:26            0 (const int)
+0:26        matrix-times-vector ( temp 4-component vector of float)
+0:26          World: direct index for structure (layout( row_major std140) uniform 4X4 matrix of float)
+0:26            'anon@0' (layout( binding=0 row_major std140) uniform block{layout( row_major std140) uniform 4X4 matrix of float World, layout( row_major std140) uniform 4X4 matrix of float View, layout( row_major std140) uniform 4X4 matrix of float Projection})
+0:26            Constant:
+0:26              0 (const uint)
+0:26          Pos: direct index for structure ( temp 4-component vector of float)
+0:26            'input' ( in structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:26            Constant:
+0:26              0 (const int)
+0:27      move second child to first child ( temp 4-component vector of float)
+0:27        Pos: direct index for structure ( temp 4-component vector of float)
+0:27          'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:27          Constant:
+0:27            0 (const int)
+0:27        matrix-times-vector ( temp 4-component vector of float)
+0:27          View: direct index for structure (layout( row_major std140) uniform 4X4 matrix of float)
+0:27            'anon@0' (layout( binding=0 row_major std140) uniform block{layout( row_major std140) uniform 4X4 matrix of float World, layout( row_major std140) uniform 4X4 matrix of float View, layout( row_major std140) uniform 4X4 matrix of float Projection})
+0:27            Constant:
+0:27              1 (const uint)
+0:27          Pos: direct index for structure ( temp 4-component vector of float)
+0:27            'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:27            Constant:
+0:27              0 (const int)
+0:28      move second child to first child ( temp 4-component vector of float)
+0:28        Pos: direct index for structure ( temp 4-component vector of float)
+0:28          'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:28          Constant:
+0:28            0 (const int)
+0:28        matrix-times-vector ( temp 4-component vector of float)
+0:28          Projection: direct index for structure (layout( row_major std140) uniform 4X4 matrix of float)
+0:28            'anon@0' (layout( binding=0 row_major std140) uniform block{layout( row_major std140) uniform 4X4 matrix of float World, layout( row_major std140) uniform 4X4 matrix of float View, layout( row_major std140) uniform 4X4 matrix of float Projection})
+0:28            Constant:
+0:28              2 (const uint)
+0:28          Pos: direct index for structure ( temp 4-component vector of float)
+0:28            'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:28            Constant:
+0:28              0 (const int)
+0:29      move second child to first child ( temp 3-component vector of float)
+0:29        Norm: direct index for structure ( temp 3-component vector of float)
+0:29          'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:29          Constant:
+0:29            1 (const int)
+0:29        Construct vec3 ( temp 3-component vector of float)
+0:29          matrix-times-vector ( temp 4-component vector of float)
+0:29            Construct mat3x4 ( uniform 3X4 matrix of float)
+0:29              World: direct index for structure (layout( row_major std140) uniform 4X4 matrix of float)
+0:29                'anon@0' (layout( binding=0 row_major std140) uniform block{layout( row_major std140) uniform 4X4 matrix of float World, layout( row_major std140) uniform 4X4 matrix of float View, layout( row_major std140) uniform 4X4 matrix of float Projection})
+0:29                Constant:
+0:29                  0 (const uint)
+0:29            Norm: direct index for structure ( temp 3-component vector of float)
+0:29              'input' ( in structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:29              Constant:
+0:29                1 (const int)
+0:31      Branch: Return with expression
+0:31        'output' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22  Function Definition: main( ( temp void)
+0:22    Function Parameters: 
+0:?     Sequence
+0:22      Sequence
+0:22        move second child to first child ( temp 4-component vector of float)
+0:22          Pos: direct index for structure ( temp 4-component vector of float)
+0:?             'input' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22            Constant:
+0:22              0 (const int)
+0:?           'input.Pos' (layout( location=0) in 4-component vector of float)
+0:22        move second child to first child ( temp 3-component vector of float)
+0:22          Norm: direct index for structure ( temp 3-component vector of float)
+0:?             'input' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22            Constant:
+0:22              1 (const int)
+0:?           'input.Norm' (layout( location=1) in 3-component vector of float)
+0:22      Sequence
+0:22        move second child to first child ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22          'flattenTemp' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22          Function Call: @main(struct-VS_INPUT-vf4-vf31; ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:?             'input' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22        move second child to first child ( temp 4-component vector of float)
+0:?           '@entryPointOutput.Pos' ( out 4-component vector of float Position)
+0:22          Pos: direct index for structure ( temp 4-component vector of float)
+0:22            'flattenTemp' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22            Constant:
+0:22              0 (const int)
+0:22        move second child to first child ( temp 3-component vector of float)
+0:?           '@entryPointOutput.Norm' (layout( location=0) out 3-component vector of float)
+0:22          Norm: direct index for structure ( temp 3-component vector of float)
+0:22            'flattenTemp' ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})
+0:22            Constant:
+0:22              1 (const int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( binding=0 row_major std140) uniform block{layout( row_major std140) uniform 4X4 matrix of float World, layout( row_major std140) uniform 4X4 matrix of float View, layout( row_major std140) uniform 4X4 matrix of float Projection})
+0:?     '@entryPointOutput.Pos' ( out 4-component vector of float Position)
+0:?     '@entryPointOutput.Norm' (layout( location=0) out 3-component vector of float)
+0:?     'input.Pos' (layout( location=0) in 4-component vector of float)
+0:?     'input.Norm' (layout( location=1) in 3-component vector of float)
+
+// Module Version 10000
+// Generated by (magic number): 80002
+// Id's are bound by 106
+
+                              Capability Shader
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Vertex 4  "main" 87 91 99 103
+                              Source HLSL 500
+                              Name 4  "main"
+                              Name 9  "VS_INPUT"
+                              MemberName 9(VS_INPUT) 0  "Pos"
+                              MemberName 9(VS_INPUT) 1  "Norm"
+                              Name 11  "PS_INPUT"
+                              MemberName 11(PS_INPUT) 0  "Pos"
+                              MemberName 11(PS_INPUT) 1  "Norm"
+                              Name 14  "@main(struct-VS_INPUT-vf4-vf31;"
+                              Name 13  "input"
+                              Name 18  "ConstantBuffer"
+                              Name 21  "output"
+                              Name 28  "C"
+                              MemberName 28(C) 0  "World"
+                              MemberName 28(C) 1  "View"
+                              MemberName 28(C) 2  "Projection"
+                              Name 30  ""
+                              Name 85  "input"
+                              Name 87  "input.Pos"
+                              Name 91  "input.Norm"
+                              Name 94  "flattenTemp"
+                              Name 95  "param"
+                              Name 99  "@entryPointOutput.Pos"
+                              Name 103  "@entryPointOutput.Norm"
+                              MemberDecorate 28(C) 0 RowMajor
+                              MemberDecorate 28(C) 0 Offset 0
+                              MemberDecorate 28(C) 0 MatrixStride 16
+                              MemberDecorate 28(C) 1 RowMajor
+                              MemberDecorate 28(C) 1 Offset 64
+                              MemberDecorate 28(C) 1 MatrixStride 16
+                              MemberDecorate 28(C) 2 RowMajor
+                              MemberDecorate 28(C) 2 Offset 128
+                              MemberDecorate 28(C) 2 MatrixStride 16
+                              Decorate 28(C) Block
+                              Decorate 30 DescriptorSet 0
+                              Decorate 30 Binding 0
+                              Decorate 87(input.Pos) Location 0
+                              Decorate 91(input.Norm) Location 1
+                              Decorate 99(@entryPointOutput.Pos) BuiltIn Position
+                              Decorate 103(@entryPointOutput.Norm) Location 0
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeFloat 32
+               7:             TypeVector 6(float) 4
+               8:             TypeVector 6(float) 3
+     9(VS_INPUT):             TypeStruct 7(fvec4) 8(fvec3)
+              10:             TypePointer Function 9(VS_INPUT)
+    11(PS_INPUT):             TypeStruct 7(fvec4) 8(fvec3)
+              12:             TypeFunction 11(PS_INPUT) 10(ptr)
+              16:             TypeInt 32 1
+              17:             TypePointer Function 16(int)
+              19:     16(int) Constant 42
+              20:             TypePointer Function 11(PS_INPUT)
+              22:    6(float) Constant 0
+              23:    7(fvec4) ConstantComposite 22 22 22 22
+              24:    8(fvec3) ConstantComposite 22 22 22
+              25:11(PS_INPUT) ConstantComposite 23 24
+              26:     16(int) Constant 0
+              27:             TypeMatrix 7(fvec4) 4
+           28(C):             TypeStruct 27 27 27
+              29:             TypePointer Uniform 28(C)
+              30:     29(ptr) Variable Uniform
+              31:             TypePointer Uniform 27
+              34:             TypePointer Function 7(fvec4)
+              39:     16(int) Constant 1
+              46:     16(int) Constant 2
+              55:             TypeMatrix 7(fvec4) 3
+              56:    6(float) Constant 1065353216
+              73:             TypePointer Function 8(fvec3)
+              86:             TypePointer Input 7(fvec4)
+   87(input.Pos):     86(ptr) Variable Input
+              90:             TypePointer Input 8(fvec3)
+  91(input.Norm):     90(ptr) Variable Input
+              98:             TypePointer Output 7(fvec4)
+99(@entryPointOutput.Pos):     98(ptr) Variable Output
+             102:             TypePointer Output 8(fvec3)
+103(@entryPointOutput.Norm):    102(ptr) Variable Output
+         4(main):           2 Function None 3
+               5:             Label
+       85(input):     10(ptr) Variable Function
+ 94(flattenTemp):     20(ptr) Variable Function
+       95(param):     10(ptr) Variable Function
+              88:    7(fvec4) Load 87(input.Pos)
+              89:     34(ptr) AccessChain 85(input) 26
+                              Store 89 88
+              92:    8(fvec3) Load 91(input.Norm)
+              93:     73(ptr) AccessChain 85(input) 39
+                              Store 93 92
+              96: 9(VS_INPUT) Load 85(input)
+                              Store 95(param) 96
+              97:11(PS_INPUT) FunctionCall 14(@main(struct-VS_INPUT-vf4-vf31;) 95(param)
+                              Store 94(flattenTemp) 97
+             100:     34(ptr) AccessChain 94(flattenTemp) 26
+             101:    7(fvec4) Load 100
+                              Store 99(@entryPointOutput.Pos) 101
+             104:     73(ptr) AccessChain 94(flattenTemp) 39
+             105:    8(fvec3) Load 104
+                              Store 103(@entryPointOutput.Norm) 105
+                              Return
+                              FunctionEnd
+14(@main(struct-VS_INPUT-vf4-vf31;):11(PS_INPUT) Function None 12
+       13(input):     10(ptr) FunctionParameter
+              15:             Label
+18(ConstantBuffer):     17(ptr) Variable Function
+      21(output):     20(ptr) Variable Function
+                              Store 18(ConstantBuffer) 19
+                              Store 21(output) 25
+              32:     31(ptr) AccessChain 30 26
+              33:          27 Load 32
+              35:     34(ptr) AccessChain 13(input) 26
+              36:    7(fvec4) Load 35
+              37:    7(fvec4) MatrixTimesVector 33 36
+              38:     34(ptr) AccessChain 21(output) 26
+                              Store 38 37
+              40:     31(ptr) AccessChain 30 39
+              41:          27 Load 40
+              42:     34(ptr) AccessChain 21(output) 26
+              43:    7(fvec4) Load 42
+              44:    7(fvec4) MatrixTimesVector 41 43
+              45:     34(ptr) AccessChain 21(output) 26
+                              Store 45 44
+              47:     31(ptr) AccessChain 30 46
+              48:          27 Load 47
+              49:     34(ptr) AccessChain 21(output) 26
+              50:    7(fvec4) Load 49
+              51:    7(fvec4) MatrixTimesVector 48 50
+              52:     34(ptr) AccessChain 21(output) 26
+                              Store 52 51
+              53:     31(ptr) AccessChain 30 26
+              54:          27 Load 53
+              57:    6(float) CompositeExtract 54 0 0
+              58:    6(float) CompositeExtract 54 0 1
+              59:    6(float) CompositeExtract 54 0 2
+              60:    6(float) CompositeExtract 54 0 3
+              61:    6(float) CompositeExtract 54 1 0
+              62:    6(float) CompositeExtract 54 1 1
+              63:    6(float) CompositeExtract 54 1 2
+              64:    6(float) CompositeExtract 54 1 3
+              65:    6(float) CompositeExtract 54 2 0
+              66:    6(float) CompositeExtract 54 2 1
+              67:    6(float) CompositeExtract 54 2 2
+              68:    6(float) CompositeExtract 54 2 3
+              69:    7(fvec4) CompositeConstruct 57 58 59 60
+              70:    7(fvec4) CompositeConstruct 61 62 63 64
+              71:    7(fvec4) CompositeConstruct 65 66 67 68
+              72:          55 CompositeConstruct 69 70 71
+              74:     73(ptr) AccessChain 13(input) 39
+              75:    8(fvec3) Load 74
+              76:    7(fvec4) MatrixTimesVector 72 75
+              77:    6(float) CompositeExtract 76 0
+              78:    6(float) CompositeExtract 76 1
+              79:    6(float) CompositeExtract 76 2
+              80:    8(fvec3) CompositeConstruct 77 78 79
+              81:     73(ptr) AccessChain 21(output) 39
+                              Store 81 80
+              82:11(PS_INPUT) Load 21(output)
+                              ReturnValue 82
+                              FunctionEnd

--- a/Test/hlsl.cbuffer-identifier.vert
+++ b/Test/hlsl.cbuffer-identifier.vert
@@ -1,0 +1,32 @@
+
+cbuffer ConstantBuffer : register( b0 )
+{
+    matrix World;
+    matrix View;
+    matrix Projection;
+};
+
+struct VS_INPUT
+{
+    float4 Pos : POSITION;
+    float3 Norm : NORMAL;
+};
+
+struct PS_INPUT
+{
+    float4 Pos : SV_POSITION;
+    float3 Norm : TEXCOORD0;
+};
+
+PS_INPUT main( VS_INPUT input )
+{
+    int ConstantBuffer = 42;  // test ConstantBuffer as an identifier
+
+    PS_INPUT output = (PS_INPUT)0;
+    output.Pos = mul( input.Pos, World );
+    output.Pos = mul( output.Pos, View );
+    output.Pos = mul( output.Pos, Projection );
+    output.Norm = mul( input.Norm, World );  // Work when output.Norm = mul( input.Norm, (float3x3)World );
+
+    return output;
+}

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -108,6 +108,7 @@ INSTANTIATE_TEST_CASE_P(
         {"hlsl.calculatelod.dx10.frag", "main"},
         {"hlsl.calculatelodunclamped.dx10.frag", "main"},
         {"hlsl.cast.frag", "PixelShaderFunction"},
+        {"hlsl.cbuffer-identifier.vert", "main"},
         {"hlsl.charLit.vert", "main"},
         {"hlsl.clip.frag", "main"},
         {"hlsl.clipdistance-1.frag", "main"},

--- a/hlsl/hlslGrammar.cpp
+++ b/hlsl/hlslGrammar.cpp
@@ -2029,10 +2029,18 @@ bool HlslGrammar::acceptStruct(TType& type, TIntermNode*& nodeList)
 
     // Now known to be one of CBUFFER, TBUFFER, CLASS, or STRUCT
 
-    // IDENTIFIER
+
+    // IDENTIFIER.  It might also be a keyword which can double as an identifier.
+    // For example:  'cbuffer ConstantBuffer' or 'struct ConstantBuffer' is legal.
+    // 'cbuffer int' is also legal, and 'struct int' appears rejected only because
+    // it attempts to redefine the 'int' type.
+    const char* idString = getTypeString(peek());
     TString structName = "";
-    if (peekTokenClass(EHTokIdentifier)) {
-        structName = *token.string;
+    if (peekTokenClass(EHTokIdentifier) || idString != nullptr) {
+        if (idString != nullptr)
+            structName = *idString;
+        else
+            structName = *token.string;
         advanceToken();
     }
 
@@ -4056,6 +4064,7 @@ const char* HlslGrammar::getTypeString(EHlslTokenClass tokenClass) const
     case EHTokMin10float: return "min10float";
     case EHTokMin16int:   return "min16int";
     case EHTokMin12int:   return "min12int";
+    case EHTokConstantBuffer: return "ConstantBuffer";
     default:
         return nullptr;
     }


### PR DESCRIPTION
Issue #791 was partially fixed by PR #1161 (the mat mul implicit truncations were its main point), but it still wouldn't compile due to the use of ConstantBuffer as an identifier.  Apparently those fall into the same class as "float float", where float is both a type and an identifier.

This allows struct definitions with such keyword-identifiers, and adds ConstantBuffer to the set.  'cbuffer int' is legal in HLSL, and 'struct int' appears to only be rejected due to the redefinition of the 'int' type.

Fixes #791
