### PR TITLE
HLSL: minor: add warning for mat() matrix size truncation

### DIFF
--- a/Test/baseResults/hlsl.cbuffer-identifier.vert.out
+++ b/Test/baseResults/hlsl.cbuffer-identifier.vert.out
@@ -1,4 +1,6 @@
 hlsl.cbuffer-identifier.vert
+WARNING: 0:29: '' : mul() matrix size mismatch 
+
 Shader version: 500
 0:? Sequence
 0:22  Function Definition: @main(struct-VS_INPUT-vf4-vf31; ( temp structure{ temp 4-component vector of float Pos,  temp 3-component vector of float Norm})

--- a/Test/baseResults/hlsl.mul-truncate.frag.out
+++ b/Test/baseResults/hlsl.mul-truncate.frag.out
@@ -1,4 +1,13 @@
 hlsl.mul-truncate.frag
+WARNING: 0:24: '' : mul() matrix size mismatch 
+WARNING: 0:25: '' : mul() matrix size mismatch 
+WARNING: 0:28: '' : mul() matrix size mismatch 
+WARNING: 0:29: '' : mul() matrix size mismatch 
+WARNING: 0:32: '' : mul() matrix size mismatch 
+WARNING: 0:33: '' : mul() matrix size mismatch 
+WARNING: 0:34: '' : mul() matrix size mismatch 
+WARNING: 0:35: '' : mul() matrix size mismatch 
+
 Shader version: 500
 gl_FragCoord origin is upper left
 0:? Sequence

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -3238,7 +3238,7 @@ void HlslParseContext::decomposeStructBufferMethods(const TSourceLoc& loc, TInte
 
             // Index into the array to find the item being loaded.
             // Byte address buffers index in bytes (only multiples of 4 permitted... not so much a byte address
-            // buffer then, but that's what it calls itself.
+            // buffer then, but that's what it calls itself).
 
             int size = 0;
 
@@ -5242,6 +5242,10 @@ void HlslParseContext::addGenMulArgumentConversion(const TSourceLoc& loc, TFunct
         // It's something with scalars: we'll just leave it alone.  Function selection will handle it
         // downstream.
     }
+
+    // Warn if we altered one of the arguments
+    if (arg0 != argAggregate->getSequence()[0] || arg1 != argAggregate->getSequence()[1])
+        warn(loc, "mul() matrix size mismatch", "", "");
 
     // Put arguments back.  (They might be unchanged, in which case this is harmless).
     argAggregate->getSequence()[0] = arg0;


### PR DESCRIPTION
Minor change to add a compilation warning on implicit matrix size truncations.
