### PR TITLE
Update spirv-tools known-good

### DIFF
--- a/known_good.json
+++ b/known_good.json
@@ -5,7 +5,7 @@
       "site" : "github",
       "subrepo" : "KhronosGroup/SPIRV-Tools",
       "subdir" : "External/spirv-tools",
-      "commit" : "83228137e16c0d7fe33eaceddf6f67115d45338f"
+      "commit" : "188cd3780d76256d6bfcbdb216b6368e9b070628"
     },
     {
       "name" : "spirv-tools/external/spirv-headers",


### PR DESCRIPTION
This fixes spirv-tools issue 989 where if-break can be incorrectly
deleted from a loop.