### PR TITLE
HLSL: Implement support for RT/Viewport output from VS

### DIFF
--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -9115,7 +9115,7 @@ bool HlslParseContext::isOutputBuiltIn(const TQualifier& qualifier) const
         return language == EShLangFragment;
     case EbvLayer:
     case EbvViewportIndex:
-        return language == EShLangGeometry;
+        return language == EShLangGeometry || language == EShLangVertex;
     case EbvPrimitiveId:
         return language == EShLangGeometry;
     case EbvTessLevelInner:


### PR DESCRIPTION
In DX10/DX11 you can only output RT/Viewport indices from GS; however,
DX11.4/DX12 add support for outputting these from VS as well.

This is supported by Vulkan if the relevant extension is available, and
by MSL and by MSL (which you can cross-compile to via SPIRV-Cross).