### PR TITLE
Update SPIRV-Tools known-good

### DIFF
--- a/Test/baseLegalResults/hlsl.partialFlattenLocal.vert.out
+++ b/Test/baseLegalResults/hlsl.partialFlattenLocal.vert.out
@@ -52,11 +52,9 @@ WARNING: AST will form illegal SPIR-V; need to transform to legalize
                               Store 137 38
                               Branch 100
              100:             Label
-             164:     21(int) Phi 25 5 119 102
-                              LoopMerge 101 102 None
-                              Branch 103
-             103:             Label
+             164:     21(int) Phi 25 5 119 106
              105:    54(bool) SLessThan 164 31
+                              LoopMerge 101 106 None
                               BranchConditional 105 106 101
              106:               Label
              138:     39(ptr)   AccessChain 133 164
@@ -69,8 +67,6 @@ WARNING: AST will form illegal SPIR-V; need to transform to legalize
              116:   14(fvec3)   Load 140
              117:   14(fvec3)   VectorShuffle 116 114 3 4 2
                                 Store 140 117
-                                Branch 102
-             102:               Label
              119:     21(int)   IAdd 164 31
                                 Branch 100
              101:             Label

--- a/known_good.json
+++ b/known_good.json
@@ -5,14 +5,14 @@
       "site" : "github",
       "subrepo" : "KhronosGroup/SPIRV-Tools",
       "subdir" : "External/spirv-tools",
-      "commit" : "eb0c73dad6102fc0d4f03c62fe910348bae43a11"
+      "commit" : "9e19fc0f31ceaf1f6bc907dbf17dcfded85f2ce8"
     },
     {
       "name" : "spirv-tools/external/spirv-headers",
       "site" : "github",
       "subrepo" : "KhronosGroup/SPIRV-Headers",
       "subdir" : "External/spirv-tools/external/spirv-headers",
-      "commit" : "061097878467b8e040fbf153a837d844ef9f9f96"
+      "commit" : "ce309203d7eceaf908bea8862c27f3e0749f7d00"
     }
   ]
 }


### PR DESCRIPTION
Update SPIRV-Tools.  Relevant functional changes:
 - Optimizer enhancements:
   - ADCE now removes OpSwitch
   - Block merging occurs in more cases
 - Optimizer fixes:
   - Constant propagation (CCP): support matrix constants
   - KhronosGroup/SPIRV-Tools#1199: Optimizer: Fix CCP: don't propagate spec constants.
   - KhronosGroup/SPIRV-Tools#1203: Optimizer: Fix common uniform elim bug introduced by refactoring.
   - KhronosGroup/SPIRV-Tools#1210: Optimizer: Aggressive dead code elimination: Fix 'break' identification.
   - KhronosGroup/SPIRV-Tools#1212: Optimizer: Aggressive dead code elimination: Was skipping too many instructions.
   - KhronosGroup/SPIRV-Tools#1214: Optimizer: Aggressive dead code elimination: Fix infinite loop.
   - KhronosGroup/SPIRV-Tools#1228: Optimizer: Fix CCP: Handling of varying Phi nodes; was resulting in infinite loop.
   - KhronosGroup/SPIRV-Tools#1245: Optimizer: Dead branch elimination: Avoid a null pointer dereference.
   - KhronosGroup/SPIRV-Tools#1250: Optimizer: Dead branch elimination: Avoid spuriously reporting a change.

Update SPIRV-Headers, with "unified1" directory.

Updated one Glslang legalization test base result due to better block merging.