### PR TITLE
Update spirv-tools known_good

### DIFF
--- a/known_good.json
+++ b/known_good.json
@@ -5,7 +5,7 @@
       "site" : "github",
       "subrepo" : "KhronosGroup/SPIRV-Tools",
       "subdir" : "External/spirv-tools",
-      "commit" : "4e4a254bc85ea41af93a048f1713ef27e04c01ab"
+      "commit" : "46a9ec9d2312bc8f2a87810614d06c721ea3121c"
     },
     {
       "name" : "spirv-tools/external/spirv-headers",


### PR DESCRIPTION
Contains the following improvements:

Fixes 1341: Atomics (and other instructions with side-effects) removed.
Add folding for redundant add/sub/mul/div/mix operations
Add constant folding rules for floating-point comparison
Add folding of redundant OpSelect insns
Add folding of OpCompositeExtract and OpConstantComposite