### PR TITLE
EShLangFragment falls through to EShLangCompute, only #ifndef AMD_EXTENSIONS.

### DIFF
--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -6355,8 +6355,8 @@ void TBuiltIns::identifyBuiltIns(int version, EProfile profile, const SpvVersion
 #ifdef AMD_EXTENSIONS
         if (profile != EEsProfile)
             symbolTable.relateToOperator("interpolateAtVertexAMD", EOpInterpolateAtVertex);
-        break;
 #endif
+        break;
 
     case EShLangCompute:
         symbolTable.relateToOperator("memoryBarrierShared",     EOpMemoryBarrierShared);


### PR DESCRIPTION
EShLangFragment falls through to EShLangCompute, only #ifndef AMD_EXTENSIONS.
This is probably a bug.