### PR TITLE
Allow --hlsl-enable-16bit-types to be used without AMD_EXTENSIONS

### DIFF
--- a/hlsl/hlslGrammar.cpp
+++ b/hlsl/hlslGrammar.cpp
@@ -1377,9 +1377,7 @@ bool HlslGrammar::acceptType(TType& type)
 }
 bool HlslGrammar::acceptType(TType& type, TIntermNode*& nodeList)
 {
-    // Basic types for min* types, broken out here in case of future
-    // changes, e.g, to use native halfs.
-#ifdef AMD_EXTENSIONS
+    // Basic types for min* types, use native halfs if the option allows them.
     bool enable16BitTypes = parseContext.hlslEnable16BitTypes();
 
     const TBasicType min16float_bt = enable16BitTypes ? EbtFloat16 : EbtFloat;
@@ -1388,14 +1386,6 @@ bool HlslGrammar::acceptType(TType& type, TIntermNode*& nodeList)
     const TBasicType min16int_bt   = enable16BitTypes ? EbtInt16   : EbtInt;
     const TBasicType min12int_bt   = enable16BitTypes ? EbtInt16   : EbtInt;
     const TBasicType min16uint_bt  = enable16BitTypes ? EbtUint16  : EbtUint;
-#else
-    static const TBasicType min16float_bt = EbtFloat;
-    static const TBasicType min10float_bt = EbtFloat;
-    static const TBasicType half_bt       = EbtFloat;
-    static const TBasicType min16int_bt   = EbtInt;
-    static const TBasicType min12int_bt   = EbtInt;
-    static const TBasicType min16uint_bt  = EbtUint;
-#endif
 
     // Some types might have turned into identifiers. Take the hit for checking
     // when this has happened.


### PR DESCRIPTION
Since GL_KHX_shader_explicit_arithmetic_types_float16/GL_KHX_shader_explicit_arithmetic_types defines float16, min types could be mapped to float16/(u)int16 without AMD_EXTENSIONS.