### PR TITLE
include/Common.h: reorder includes to avoid redefinition on some platforms

### DIFF
--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -37,21 +37,8 @@
 #ifndef _COMMON_INCLUDED_
 #define _COMMON_INCLUDED_
 
-#if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/) || defined MINGW_HAS_SECURE_API
-    #include <basetsd.h>
-    #define snprintf sprintf_s
-    #define safe_vsprintf(buf,max,format,args) vsnprintf_s((buf), (max), (max), (format), (args))
-#elif defined (solaris)
-    #define safe_vsprintf(buf,max,format,args) vsnprintf((buf), (max), (format), (args))
-    #include <sys/int_types.h>
-    #define UINT_PTR uintptr_t
-#else
-    #define safe_vsprintf(buf,max,format,args) vsnprintf((buf), (max), (format), (args))
-    #include <stdint.h>
-    #define UINT_PTR uintptr_t
-#endif
 
-#if defined(__ANDROID__) || (defined(_MSC_VER) && _MSC_VER < 1700)
+#if defined(__ANDROID__) || _MSC_VER < 1700
 #include <sstream>
 namespace std {
 template<typename T>
@@ -61,6 +48,22 @@ std::string to_string(const T& val) {
   return os.str();
 }
 }
+#endif
+
+#if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/) || defined MINGW_HAS_SECURE_API
+    #include <basetsd.h>
+    #ifndef snprintf
+    #define snprintf sprintf_s
+    #endif
+    #define safe_vsprintf(buf,max,format,args) vsnprintf_s((buf), (max), (max), (format), (args))
+#elif defined (solaris)
+    #define safe_vsprintf(buf,max,format,args) vsnprintf((buf), (max), (format), (args))
+    #include <sys/int_types.h>
+    #define UINT_PTR uintptr_t
+#else
+    #define safe_vsprintf(buf,max,format,args) vsnprintf((buf), (max), (format), (args))
+    #include <stdint.h>
+    #define UINT_PTR uintptr_t
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER < 1800


### PR DESCRIPTION
On some systems sstream defines snprintf, this leads to the a redefinition of sprintf_s if snprintf is defined before checking if it exists in sstream.