### PR TITLE
Replace en-dash with simple ASCII hyphen

### DIFF
--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -598,7 +598,7 @@ protected:
 /********************************************************************************
 The following IO resolver maps types in HLSL register space, as follows:
 
-t – for shader resource views (SRV)
+t - for shader resource views (SRV)
    TEXTURE1D
    TEXTURE1DARRAY
    TEXTURE2D
@@ -613,7 +613,7 @@ t – for shader resource views (SRV)
    BUFFER
    TBUFFER
     
-s – for samplers
+s - for samplers
    SAMPLER
    SAMPLER1D
    SAMPLER2D
@@ -622,7 +622,7 @@ s – for samplers
    SAMPLERSTATE
    SAMPLERCOMPARISONSTATE
 
-u – for unordered access views (UAV)
+u - for unordered access views (UAV)
    RWBYTEADDRESSBUFFER
    RWSTRUCTUREDBUFFER
    APPENDSTRUCTUREDBUFFER
@@ -634,7 +634,7 @@ u – for unordered access views (UAV)
    RWTEXTURE2DARRAY
    RWTEXTURE3D
 
-b – for constant buffer views (CBV)
+b - for constant buffer views (CBV)
    CBUFFER
    CONSTANTBUFFER
  ********************************************************************************/


### PR DESCRIPTION
Currently there's a few en-dashes in a comment in `iomapper.cpp`, I think because of copy-paste from [this MSDN page](https://msdn.microsoft.com/en-us/library/windows/desktop/dn899207%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396). Without a UTF-8 BOM if the system codepage doesn't include the character this can lead to compile warnings - see baldurk/renderdoc#915. I think this change is preferable to adding a BOM and potential headaches from that.

If this change isn't desired then feel free to reject the PR, but I think it's a good idea.