### PR TITLE
Improve --auto-map-locations for uniforms

### DIFF
--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -431,7 +431,8 @@ struct TDefaultIoResolverBase : public glslang::TIoMapResolver
 
         // no locations added if already present, a built-in variable, a block, or an opaque
         if (type.getQualifier().hasLocation() || type.isBuiltIn() ||
-            type.getBasicType() == EbtBlock || type.containsOpaque())
+            type.getBasicType() == EbtBlock ||
+            (type.containsOpaque() && intermediate.getSpv().openGl == 0))
             return -1;
 
         // no locations on blocks of built-in variables

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -443,7 +443,11 @@ struct TDefaultIoResolverBase : public glslang::TIoMapResolver
                 return -1;
         }
 
-        return nextUniformLocation++;
+        int location = nextUniformLocation;
+
+        nextUniformLocation += TIntermediate::computeTypeUniformLocationSize(type);
+
+        return location;
     }
     bool validateInOut(EShLanguage /*stage*/, const char* /*name*/, const TType& /*type*/, bool /*is_live*/) override
     {

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -590,6 +590,7 @@ public:
     int addUsedOffsets(int binding, int offset, int numOffsets);
     bool addUsedConstantId(int id);
     static int computeTypeLocationSize(const TType&, EShLanguage);
+    static int computeTypeUniformLocationSize(const TType&);
 
     bool setXfbBufferStride(int buffer, unsigned stride)
     {


### PR DESCRIPTION
These patches make --auto-map-locations take into account the size of uniforms (structs and arrays occupy more than one location) and also assign locations to opaque types.