### PR TITLE
Allowed for LIB_TYPE to be set to switch between static and shared libs for glslang, SPIRV, and HLSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,14 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # Adhere to GNU filesystem layout conventions
 include(GNUInstallDirs)
 
+option(BUILD_SHARED_LIBS "Build Shared Libraries" OFF)
+
+set(LIB_TYPE STATIC)
+
+if(BUILD_SHARED_LIBS)
+    set(LIB_TYPE SHARED)
+endif()
+
 option(SKIP_GLSLANG_INSTALL "Skip installation" ${SKIP_GLSLANG_INSTALL})
 if(NOT ${SKIP_GLSLANG_INSTALL})
   set(ENABLE_GLSLANG_INSTALL ON)

--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -40,13 +40,18 @@ if(ENABLE_NV_EXTENSIONS)
          GLSL.ext.NV.h)
 endif(ENABLE_NV_EXTENSIONS)
 
-add_library(SPIRV STATIC ${SOURCES} ${HEADERS})
+add_library(SPIRV ${LIB_TYPE} ${SOURCES} ${HEADERS})
 set_property(TARGET SPIRV PROPERTY FOLDER glslang)
 set_property(TARGET SPIRV PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-add_library(SPVRemapper STATIC ${SPVREMAP_SOURCES} ${SPVREMAP_HEADERS})
+add_library(SPVRemapper ${LIB_TYPE} ${SPVREMAP_SOURCES} ${SPVREMAP_HEADERS})
 set_property(TARGET SPVRemapper PROPERTY FOLDER glslang)
 set_property(TARGET SPVRemapper PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+    set_target_properties(SPIRV PROPERTIES PREFIX "")
+    set_target_properties(SPVRemapper PROPERTIES PREFIX "")
+endif()
 
 if(ENABLE_OPT)
     target_include_directories(SPIRV

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -80,10 +80,15 @@ set(HEADERS
 #                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 # set(BISON_GLSLParser_OUTPUT_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/MachineIndependent/glslang_tab.cpp)
 
-add_library(glslang STATIC ${BISON_GLSLParser_OUTPUT_SOURCE} ${SOURCES} ${HEADERS})
+add_library(glslang ${LIB_TYPE} ${BISON_GLSLParser_OUTPUT_SOURCE} ${SOURCES} ${HEADERS})
 set_property(TARGET glslang PROPERTY FOLDER glslang)
 set_property(TARGET glslang PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(glslang OGLCompiler OSDependent)
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+    set_target_properties(glslang PROPERTIES PREFIX "")
+endif()
+
 if(ENABLE_HLSL)
     target_link_libraries(glslang HLSL)
 endif()

--- a/hlsl/CMakeLists.txt
+++ b/hlsl/CMakeLists.txt
@@ -17,9 +17,13 @@ set(HEADERS
     hlslGrammar.h
     hlslParseables.h)
 
-add_library(HLSL STATIC ${SOURCES} ${HEADERS})
+add_library(HLSL ${LIB_TYPE} ${SOURCES} ${HEADERS})
 set_property(TARGET HLSL PROPERTY FOLDER hlsl)
 set_property(TARGET HLSL PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+    set_target_properties(HLSL PROPERTIES PREFIX "")
+endif()
 
 if(WIN32)
     source_group("Source" FILES ${SOURCES} ${HEADERS})


### PR DESCRIPTION
This adds the ability to switch the projects glslang, SPIRV, and HLSL from static to shared libraries by setting ${BUILD_SHARED_LIBS} to ON. ${BUILD_SHARED_LIBS} is set to OFF by default.
(Fixed pull request)