### PR TITLE
Make glslang validator support files ending in .glsl

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -1202,7 +1202,6 @@ int C_DECL main(int argc, char* argv[])
 EShLanguage FindLanguage(const std::string& name, bool parseStageName)
 {
     std::string stage_name;
-
     if (shaderStageName) {
         stage_name = shaderStageName;
     } else if (parseStageName) {
@@ -1225,6 +1224,8 @@ EShLanguage FindLanguage(const std::string& name, bool parseStageName)
             usage();
             return EShLangVertex;
         }
+    } else {
+      stage_name = name;
     }
     if (stage_name == "vert")
         return EShLangVertex;

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -1214,9 +1214,9 @@ EShLanguage FindLanguage(const std::string& name, bool parseStageName)
         size_t second_ext_start =
             has_first_ext ? name.find_last_of(".", first_ext_start - 1) : std::string::npos;
         bool has_second_ext = second_ext_start != std::string::npos;
+        std::string first_ext = name.substr(first_ext_start + 1, std::string::npos);
         bool uses_unified_ext = has_first_ext && (first_ext == "glsl" ||
                                                   first_ext == "hlsl");
-        std::string first_ext = name.substr(first_ext_start + 1, std::string::npos);
         if (has_first_ext && !uses_unified_ext) {
           stage_name = first_ext;
         } else if (uses_unified_ext && has_second_ext) {


### PR DESCRIPTION
This patch makes  the validator accept *.stage_name.[g/h]lsl pattern
for file names.

This patch preserves previous behavior (i.e. *.vert/*.frag/etc. in file
names still work).