### PR TITLE
PP: lexing: use "C" locale for strtod() and atof().

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -41,6 +41,7 @@
 
 #include "../OSDependent/osinclude.h"
 #include <algorithm>
+#include <clocale>
 
 #include "preprocessor/PpContext.h"
 
@@ -188,7 +189,20 @@ bool TParseContext::parseShaderStrings(TPpContext& ppContext, TInputScanner& inp
 {
     currentScanner = &input;
     ppContext.setInput(input, versionWillBeError);
+
+    // Push the locale to "C", for numeric standard processing,
+    // where lexical analysis depends on library functions for
+    // "C" style locale.
+    TString startLocale(setlocale(LC_NUMERIC, nullptr));
+    if (startLocale != "C")
+        setlocale(LC_NUMERIC, "C");
+
+    // parse
     yyparse(this);
+
+    // pop the locale
+    if (startLocale != "C")
+        setlocale(LC_NUMERIC, startLocale.c_str());
 
     finish();
 

--- a/glslang/MachineIndependent/preprocessor/PpScanner.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpScanner.cpp
@@ -231,6 +231,7 @@ int TPpContext::lFloatConst(int len, int ch, TPpToken* ppToken)
     ppToken->name[len] = '\0';
 
     // Get the numerical value
+    // Depends on setlocale(LC_NUMERIC, "C") for correct behavior.
     ppToken->dval = strtod(ppToken->name, nullptr);
 
     // Return the right token type

--- a/glslang/MachineIndependent/preprocessor/PpTokens.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpTokens.cpp
@@ -216,6 +216,7 @@ int TPpContext::TokenStream::getToken(TParseContextBase& parseContext, TPpToken 
         case PpAtomConstFloat:
         case PpAtomConstDouble:
         case PpAtomConstFloat16:
+            // Depends on setlocale(LC_NUMERIC, "C") for correct behavior.
             ppToken->dval = atof(ppToken->name);
             break;
         case PpAtomConstInt:


### PR DESCRIPTION
Fixes #234. Fixes #1228.