### PR TITLE
Added attribute location getter.

### DIFF
--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1919,6 +1919,7 @@ int TProgram::getUniformArraySize(int index) const           { return reflection
 int TProgram::getNumLiveAttributes() const                   { return reflection->getNumAttributes(); }
 const char* TProgram::getAttributeName(int index) const      { return reflection->getAttribute(index).name.c_str(); }
 int TProgram::getAttributeType(int index) const              { return reflection->getAttribute(index).glDefineType; }
+int TProgram::getAttributeLocation(int index) const          { return reflection->getAttribute(index).getLocation(); }
 const TType* TProgram::getAttributeTType(int index) const    { return reflection->getAttribute(index).getType(); }
 const TType* TProgram::getUniformTType(int index) const      { return reflection->getUniform(index).getType(); }
 const TType* TProgram::getUniformBlockTType(int index) const { return reflection->getUniformBlock(index).getType(); }

--- a/glslang/MachineIndependent/reflection.h
+++ b/glslang/MachineIndependent/reflection.h
@@ -66,10 +66,16 @@ public:
             return -1;
         return type->getQualifier().layoutBinding;
     }
+    int getLocation() const
+    {
+        if (type == nullptr || !type->getQualifier().hasLocation())
+            return -1;
+        return type->getQualifier().layoutLocation;
+    }
     void dump() const
     {
-        printf("%s: offset %d, type %x, size %d, index %d, binding %d",
-               name.c_str(), offset, glDefineType, size, index, getBinding() );
+        printf("%s: offset %d, type %x, size %d, index %d, binding %d, location %d",
+               name.c_str(), offset, glDefineType, size, index, getBinding(), getLocation() );
 
         if (counterIndex != -1)
             printf(", counter %d", counterIndex);

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -681,6 +681,7 @@ public:
     unsigned getLocalSize(int dim) const;                  // return dim'th local size
     const char *getAttributeName(int index) const;         // can be used for glGetActiveAttrib()
     int getAttributeType(int index) const;                 // can be used for glGetActiveAttrib()
+	int getAttributeLocation(int index) const;             // returns the attributes location
     const TType* getUniformTType(int index) const;         // returns a TType*
     const TType* getUniformBlockTType(int index) const;    // returns a TType*
     const TType* getAttributeTType(int index) const;       // returns a TType*


### PR DESCRIPTION
This resolves issue https://github.com/KhronosGroup/glslang/issues/1324, gives access to layoutLocation from a shader attribute qualifier for reflections.