### PR TITLE
Skip outermost array when assigning locations to auto-array interfaces

### DIFF
--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -478,7 +478,16 @@ struct TDefaultIoResolverBase : public glslang::TIoMapResolver
         // Placeholder. This does not do proper cross-stage lining up, nor
         // work with mixed location/no-location declarations.
         int location = nextLocation;
-        nextLocation += TIntermediate::computeTypeLocationSize(type, stage);
+        int typeLocationSize;
+        // Don’t take into account the outer-most array if the stage’s
+        // interface is automatically an array.
+        if (type.getQualifier().isArrayedIo(stage)) {
+                TType elementType(type, 0);
+                typeLocationSize = TIntermediate::computeTypeLocationSize(elementType, stage);
+        } else {
+                typeLocationSize = TIntermediate::computeTypeLocationSize(type, stage);
+        }
+        nextLocation += typeLocationSize;
 
         return location;
     }


### PR DESCRIPTION
Without this patch for example when it is generating locations for geometry shader inputs it will count the size of the input including the implicit outer array.