### PR TITLE
Add bit width of types to disassembleInstruction

### DIFF
--- a/SPIRV/disassemble.cpp
+++ b/SPIRV/disassemble.cpp
@@ -353,10 +353,21 @@ void SpirvStream::disassembleInstruction(Id resultId, Id /*typeId*/, Op opCode, 
         if (resultId != 0 && idDescriptor[resultId].size() == 0) {
             switch (opCode) {
             case OpTypeInt:
-                idDescriptor[resultId] = "int";
+                switch (stream[word]) {
+                case 8:  idDescriptor[resultId] = "int8_t"; break;
+                case 16: idDescriptor[resultId] = "int16_t"; break;
+                default: assert(0); // fallthrough
+                case 32: idDescriptor[resultId] = "int"; break;
+                case 64: idDescriptor[resultId] = "int64_t"; break;
+                }
                 break;
             case OpTypeFloat:
-                idDescriptor[resultId] = "float";
+                switch (stream[word]) {
+                case 16: idDescriptor[resultId] = "float16_t"; break;
+                default: assert(0); // fallthrough
+                case 32: idDescriptor[resultId] = "float"; break;
+                case 64: idDescriptor[resultId] = "float64_t"; break;
+                }
                 break;
             case OpTypeBool:
                 idDescriptor[resultId] = "bool";
@@ -368,8 +379,18 @@ void SpirvStream::disassembleInstruction(Id resultId, Id /*typeId*/, Op opCode, 
                 idDescriptor[resultId] = "ptr";
                 break;
             case OpTypeVector:
-                if (idDescriptor[stream[word]].size() > 0)
+                if (idDescriptor[stream[word]].size() > 0) {
                     idDescriptor[resultId].append(idDescriptor[stream[word]].begin(), idDescriptor[stream[word]].begin() + 1);
+                    if (strstr(idDescriptor[stream[word]].c_str(), "8")) {
+                        idDescriptor[resultId].append("8");
+                    }
+                    if (strstr(idDescriptor[stream[word]].c_str(), "16")) {
+                        idDescriptor[resultId].append("16");
+                    }
+                    if (strstr(idDescriptor[stream[word]].c_str(), "64")) {
+                        idDescriptor[resultId].append("64");
+                    }
+                }
                 idDescriptor[resultId].append("vec");
                 switch (stream[word + 1]) {
                 case 2:   idDescriptor[resultId].append("2");   break;

--- a/Test/baseResults/hlsl.intrinsics.double.frag.out
+++ b/Test/baseResults/hlsl.intrinsics.double.frag.out
@@ -231,28 +231,28 @@ gl_FragCoord origin is upper left
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 64
-               7:             TypePointer Function 6(float)
-               8:             TypeVector 6(float) 2
-               9:             TypePointer Function 8(fvec2)
-              10:             TypeVector 6(float) 3
-              11:             TypePointer Function 10(fvec3)
-              12:             TypeVector 6(float) 4
-              13:             TypePointer Function 12(fvec4)
+               7:             TypePointer Function 6(float64_t)
+               8:             TypeVector 6(float64_t) 2
+               9:             TypePointer Function 8(f64vec2)
+              10:             TypeVector 6(float64_t) 3
+              11:             TypePointer Function 10(f64vec3)
+              12:             TypeVector 6(float64_t) 4
+              13:             TypePointer Function 12(f64vec4)
               14:             TypeInt 32 0
               15:             TypePointer Function 14(int)
               16:             TypeFloat 32
               17:             TypeFunction 16(float) 7(ptr) 7(ptr) 7(ptr) 9(ptr) 11(ptr) 13(ptr) 15(ptr) 15(ptr)
               36:             TypeVector 14(int) 2
               39:   16(float) Constant 0
-              43:             TypePointer Input 6(float)
+              43:             TypePointer Input 6(float64_t)
       44(inDV1a):     43(ptr) Variable Input
       47(inDV1b):     43(ptr) Variable Input
       50(inDV1c):     43(ptr) Variable Input
-              53:             TypePointer Input 8(fvec2)
+              53:             TypePointer Input 8(f64vec2)
        54(inDV2):     53(ptr) Variable Input
-              57:             TypePointer Input 10(fvec3)
+              57:             TypePointer Input 10(f64vec3)
        58(inDV3):     57(ptr) Variable Input
-              61:             TypePointer Input 12(fvec4)
+              61:             TypePointer Input 12(f64vec4)
        62(inDV4):     61(ptr) Variable Input
               65:             TypePointer Input 14(int)
        66(inU1a):     65(ptr) Variable Input
@@ -277,33 +277,33 @@ gl_FragCoord origin is upper left
        83(param):     13(ptr) Variable Function
        85(param):     15(ptr) Variable Function
        87(param):     15(ptr) Variable Function
-              45:    6(float) Load 44(inDV1a)
+              45:6(float64_t) Load 44(inDV1a)
                               Store 42(inDV1a) 45
-              48:    6(float) Load 47(inDV1b)
+              48:6(float64_t) Load 47(inDV1b)
                               Store 46(inDV1b) 48
-              51:    6(float) Load 50(inDV1c)
+              51:6(float64_t) Load 50(inDV1c)
                               Store 49(inDV1c) 51
-              55:    8(fvec2) Load 54(inDV2)
+              55:  8(f64vec2) Load 54(inDV2)
                               Store 52(inDV2) 55
-              59:   10(fvec3) Load 58(inDV3)
+              59: 10(f64vec3) Load 58(inDV3)
                               Store 56(inDV3) 59
-              63:   12(fvec4) Load 62(inDV4)
+              63: 12(f64vec4) Load 62(inDV4)
                               Store 60(inDV4) 63
               67:     14(int) Load 66(inU1a)
                               Store 64(inU1a) 67
               70:     14(int) Load 69(inU1b)
                               Store 68(inU1b) 70
-              74:    6(float) Load 42(inDV1a)
+              74:6(float64_t) Load 42(inDV1a)
                               Store 73(param) 74
-              76:    6(float) Load 46(inDV1b)
+              76:6(float64_t) Load 46(inDV1b)
                               Store 75(param) 76
-              78:    6(float) Load 49(inDV1c)
+              78:6(float64_t) Load 49(inDV1c)
                               Store 77(param) 78
-              80:    8(fvec2) Load 52(inDV2)
+              80:  8(f64vec2) Load 52(inDV2)
                               Store 79(param) 80
-              82:   10(fvec3) Load 56(inDV3)
+              82: 10(f64vec3) Load 56(inDV3)
                               Store 81(param) 82
-              84:   12(fvec4) Load 60(inDV4)
+              84: 12(f64vec4) Load 60(inDV4)
                               Store 83(param) 84
               86:     14(int) Load 64(inU1a)
                               Store 85(param) 86
@@ -325,15 +325,15 @@ gl_FragCoord origin is upper left
               27:             Label
          28(r00):      7(ptr) Variable Function
          33(r01):      7(ptr) Variable Function
-              29:    6(float) Load 18(inDV1a)
-              30:    6(float) Load 19(inDV1b)
-              31:    6(float) Load 20(inDV1c)
-              32:    6(float) ExtInst 1(GLSL.std.450) 50(Fma) 29 30 31
+              29:6(float64_t) Load 18(inDV1a)
+              30:6(float64_t) Load 19(inDV1b)
+              31:6(float64_t) Load 20(inDV1c)
+              32:6(float64_t) ExtInst 1(GLSL.std.450) 50(Fma) 29 30 31
                               Store 28(r00) 32
               34:     14(int) Load 24(inU1a)
               35:     14(int) Load 25(inU1b)
               37:   36(ivec2) CompositeConstruct 34 35
-              38:    6(float) Bitcast 37
+              38:6(float64_t) Bitcast 37
                               Store 33(r01) 38
                               ReturnValue 39
                               FunctionEnd

--- a/Test/baseResults/hlsl.matType.frag.out
+++ b/Test/baseResults/hlsl.matType.frag.out
@@ -82,8 +82,8 @@ gl_FragCoord origin is upper left
               19:             TypeVector 6(float) 2
               20:             TypeMatrix 19(fvec2) 1
               21:             TypeFloat 64
-              22:             TypeVector 21(float) 3
-              23:             TypeMatrix 22(fvec3) 2
+              22:             TypeVector 21(float64_t) 3
+              23:             TypeMatrix 22(f64vec3) 2
               24:             TypeInt 32 1
               25:             TypeVector 24(int) 4
               26:             TypeMatrix 25(ivec4) 4

--- a/Test/baseResults/hlsl.overload.frag.out
+++ b/Test/baseResults/hlsl.overload.frag.out
@@ -937,7 +937,7 @@ gl_FragCoord origin is upper left
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 64
-               7:             TypePointer Function 6(float)
+               7:             TypePointer Function 6(float64_t)
                8:             TypeBool
                9:             TypePointer Function 8(bool)
               10:             TypeFunction 2 7(ptr) 9(ptr)
@@ -967,8 +967,8 @@ gl_FragCoord origin is upper left
              113:             TypeVector 22(int) 3
              114:             TypePointer Function 113(ivec3)
              115:             TypeFunction 2 114(ptr)
-             125:             TypeVector 6(float) 3
-             126:             TypePointer Function 125(fvec3)
+             125:             TypeVector 6(float64_t) 3
+             126:             TypePointer Function 125(f64vec3)
              127:             TypeFunction 2 126(ptr)
              134:             TypeVector 15(int) 2
              135:             TypePointer Function 134(ivec2)
@@ -976,14 +976,14 @@ gl_FragCoord origin is upper left
              149:             TypeVector 29(float) 4
              150:             TypePointer Function 149(fvec4)
              151:             TypeFunction 149(fvec4) 150(ptr)
-             334:    6(float) Constant 0 0
+             334:6(float64_t) Constant 0 0
              339:     15(int) Constant 0
              348:   29(float) Constant 0
              353:     15(int) Constant 1
              373:     22(int) Constant 0
              374:     22(int) Constant 1
              394:   29(float) Constant 1065353216
-             414:    6(float) Constant 0 1072693248
+             414:6(float64_t) Constant 0 1072693248
              484:             TypeVector 22(int) 2
              494:             TypeVector 22(int) 4
              503:             TypeVector 8(bool) 3
@@ -1283,117 +1283,117 @@ gl_FragCoord origin is upper left
       497(param):     23(ptr) Variable Function
       500(param):      9(ptr) Variable Function
       506(param):      9(ptr) Variable Function
-             158:    6(float) Load 155(d)
+             158:6(float64_t) Load 155(d)
                               Store 157(param) 158
              160:     8(bool) Load 156(b)
                               Store 159(param) 160
              161:           2 FunctionCall 13(foo1(d1;b1;) 157(param) 159(param)
-             163:    6(float) Load 155(d)
+             163:6(float64_t) Load 155(d)
                               Store 162(param) 163
-             165:    6(float) Load 155(d)
+             165:6(float64_t) Load 155(d)
                               Store 164(param) 165
              166:           2 FunctionCall 39(foo1(d1;d1;) 162(param) 164(param)
-             169:    6(float) Load 155(d)
+             169:6(float64_t) Load 155(d)
                               Store 168(param) 169
              171:     15(int) Load 167(u)
                               Store 170(param) 171
              172:           2 FunctionCall 20(foo1(d1;u1;) 168(param) 170(param)
-             175:    6(float) Load 155(d)
+             175:6(float64_t) Load 155(d)
                               Store 174(param) 175
              177:     22(int) Load 173(i)
                               Store 176(param) 177
              178:           2 FunctionCall 27(foo1(d1;i1;) 174(param) 176(param)
-             181:    6(float) Load 155(d)
+             181:6(float64_t) Load 155(d)
                               Store 180(param) 181
              183:   29(float) Load 179(f)
                               Store 182(param) 183
              184:           2 FunctionCall 34(foo1(d1;f1;) 180(param) 182(param)
              185:   29(float) Load 179(f)
-             186:    6(float) FConvert 185
+             186:6(float64_t) FConvert 185
                               Store 187(param) 186
              189:     8(bool) Load 156(b)
                               Store 188(param) 189
              190:           2 FunctionCall 13(foo1(d1;b1;) 187(param) 188(param)
              191:   29(float) Load 179(f)
-             192:    6(float) FConvert 191
+             192:6(float64_t) FConvert 191
                               Store 193(param) 192
-             195:    6(float) Load 155(d)
+             195:6(float64_t) Load 155(d)
                               Store 194(param) 195
              196:           2 FunctionCall 39(foo1(d1;d1;) 193(param) 194(param)
              197:   29(float) Load 179(f)
-             198:    6(float) FConvert 197
+             198:6(float64_t) FConvert 197
                               Store 199(param) 198
              201:     15(int) Load 167(u)
                               Store 200(param) 201
              202:           2 FunctionCall 20(foo1(d1;u1;) 199(param) 200(param)
              203:   29(float) Load 179(f)
-             204:    6(float) FConvert 203
+             204:6(float64_t) FConvert 203
                               Store 205(param) 204
              207:     22(int) Load 173(i)
                               Store 206(param) 207
              208:           2 FunctionCall 27(foo1(d1;i1;) 205(param) 206(param)
              209:   29(float) Load 179(f)
-             210:    6(float) FConvert 209
+             210:6(float64_t) FConvert 209
                               Store 211(param) 210
              213:   29(float) Load 179(f)
                               Store 212(param) 213
              214:           2 FunctionCall 34(foo1(d1;f1;) 211(param) 212(param)
              215:     15(int) Load 167(u)
-             216:    6(float) ConvertUToF 215
+             216:6(float64_t) ConvertUToF 215
                               Store 217(param) 216
              219:     8(bool) Load 156(b)
                               Store 218(param) 219
              220:           2 FunctionCall 13(foo1(d1;b1;) 217(param) 218(param)
              221:     15(int) Load 167(u)
-             222:    6(float) ConvertUToF 221
+             222:6(float64_t) ConvertUToF 221
                               Store 223(param) 222
-             225:    6(float) Load 155(d)
+             225:6(float64_t) Load 155(d)
                               Store 224(param) 225
              226:           2 FunctionCall 39(foo1(d1;d1;) 223(param) 224(param)
              227:     15(int) Load 167(u)
-             228:    6(float) ConvertUToF 227
+             228:6(float64_t) ConvertUToF 227
                               Store 229(param) 228
              231:     15(int) Load 167(u)
                               Store 230(param) 231
              232:           2 FunctionCall 20(foo1(d1;u1;) 229(param) 230(param)
              233:     15(int) Load 167(u)
-             234:    6(float) ConvertUToF 233
+             234:6(float64_t) ConvertUToF 233
                               Store 235(param) 234
              237:     22(int) Load 173(i)
                               Store 236(param) 237
              238:           2 FunctionCall 27(foo1(d1;i1;) 235(param) 236(param)
              239:     15(int) Load 167(u)
-             240:    6(float) ConvertUToF 239
+             240:6(float64_t) ConvertUToF 239
                               Store 241(param) 240
              243:   29(float) Load 179(f)
                               Store 242(param) 243
              244:           2 FunctionCall 34(foo1(d1;f1;) 241(param) 242(param)
              245:     22(int) Load 173(i)
-             246:    6(float) ConvertSToF 245
+             246:6(float64_t) ConvertSToF 245
                               Store 247(param) 246
              249:     8(bool) Load 156(b)
                               Store 248(param) 249
              250:           2 FunctionCall 13(foo1(d1;b1;) 247(param) 248(param)
              251:     22(int) Load 173(i)
-             252:    6(float) ConvertSToF 251
+             252:6(float64_t) ConvertSToF 251
                               Store 253(param) 252
-             255:    6(float) Load 155(d)
+             255:6(float64_t) Load 155(d)
                               Store 254(param) 255
              256:           2 FunctionCall 39(foo1(d1;d1;) 253(param) 254(param)
              257:     22(int) Load 173(i)
-             258:    6(float) ConvertSToF 257
+             258:6(float64_t) ConvertSToF 257
                               Store 259(param) 258
              261:     15(int) Load 167(u)
                               Store 260(param) 261
              262:           2 FunctionCall 20(foo1(d1;u1;) 259(param) 260(param)
              263:     22(int) Load 173(i)
-             264:    6(float) ConvertSToF 263
+             264:6(float64_t) ConvertSToF 263
                               Store 265(param) 264
              267:     22(int) Load 173(i)
                               Store 266(param) 267
              268:           2 FunctionCall 27(foo1(d1;i1;) 265(param) 266(param)
              269:     22(int) Load 173(i)
-             270:    6(float) ConvertSToF 269
+             270:6(float64_t) ConvertSToF 269
                               Store 271(param) 270
              273:   29(float) Load 179(f)
                               Store 272(param) 273
@@ -1407,7 +1407,7 @@ gl_FragCoord origin is upper left
              281:     15(int) Load 167(u)
              282:     22(int) Bitcast 281
                               Store 283(param) 282
-             285:    6(float) Load 155(d)
+             285:6(float64_t) Load 155(d)
                               Store 284(param) 285
              286:           2 FunctionCall 64(foo2(i1;d1;) 283(param) 284(param)
              287:     15(int) Load 167(u)
@@ -1435,7 +1435,7 @@ gl_FragCoord origin is upper left
              309:           2 FunctionCall 44(foo2(i1;b1;) 305(param) 307(param)
              311:     22(int) Load 173(i)
                               Store 310(param) 311
-             313:    6(float) Load 155(d)
+             313:6(float64_t) Load 155(d)
                               Store 312(param) 313
              314:           2 FunctionCall 64(foo2(i1;d1;) 310(param) 312(param)
              316:     22(int) Load 173(i)
@@ -1456,7 +1456,7 @@ gl_FragCoord origin is upper left
              331:     8(bool) Load 156(b)
                               Store 330(param) 331
              332:           2 FunctionCall 68(foo3(b1;) 330(param)
-             333:    6(float) Load 155(d)
+             333:6(float64_t) Load 155(d)
              335:     8(bool) FOrdNotEqual 333 334
                               Store 336(param) 335
              337:           2 FunctionCall 68(foo3(b1;) 336(param)
@@ -1476,7 +1476,7 @@ gl_FragCoord origin is upper left
              354:     15(int) Select 352 353 339
                               Store 355(param) 354
              356:           2 FunctionCall 72(foo4(u1;) 355(param)
-             357:    6(float) Load 155(d)
+             357:6(float64_t) Load 155(d)
              358:     15(int) ConvertFToU 357
                               Store 359(param) 358
              360:           2 FunctionCall 72(foo4(u1;) 359(param)
@@ -1495,7 +1495,7 @@ gl_FragCoord origin is upper left
              375:     22(int) Select 372 374 373
                               Store 376(param) 375
              377:           2 FunctionCall 76(foo5(i1;) 376(param)
-             378:    6(float) Load 155(d)
+             378:6(float64_t) Load 155(d)
              379:     22(int) ConvertFToS 378
                               Store 380(param) 379
              381:           2 FunctionCall 76(foo5(i1;) 380(param)
@@ -1514,7 +1514,7 @@ gl_FragCoord origin is upper left
              395:   29(float) Select 393 394 348
                               Store 396(param) 395
              397:           2 FunctionCall 80(foo6(f1;) 396(param)
-             398:    6(float) Load 155(d)
+             398:6(float64_t) Load 155(d)
              399:   29(float) FConvert 398
                               Store 400(param) 399
              401:           2 FunctionCall 80(foo6(f1;) 400(param)
@@ -1530,22 +1530,22 @@ gl_FragCoord origin is upper left
                               Store 410(param) 411
              412:           2 FunctionCall 80(foo6(f1;) 410(param)
              413:     8(bool) Load 156(b)
-             415:    6(float) Select 413 414 334
+             415:6(float64_t) Select 413 414 334
                               Store 416(param) 415
              417:           2 FunctionCall 84(foo7(d1;) 416(param)
-             419:    6(float) Load 155(d)
+             419:6(float64_t) Load 155(d)
                               Store 418(param) 419
              420:           2 FunctionCall 84(foo7(d1;) 418(param)
              421:     15(int) Load 167(u)
-             422:    6(float) ConvertUToF 421
+             422:6(float64_t) ConvertUToF 421
                               Store 423(param) 422
              424:           2 FunctionCall 84(foo7(d1;) 423(param)
              425:     22(int) Load 173(i)
-             426:    6(float) ConvertSToF 425
+             426:6(float64_t) ConvertSToF 425
                               Store 427(param) 426
              428:           2 FunctionCall 84(foo7(d1;) 427(param)
              429:   29(float) Load 179(f)
-             430:    6(float) FConvert 429
+             430:6(float64_t) FConvert 429
                               Store 431(param) 430
              432:           2 FunctionCall 84(foo7(d1;) 431(param)
              433:     8(bool) Load 156(b)
@@ -1568,7 +1568,7 @@ gl_FragCoord origin is upper left
              450:     15(int) ConvertFToU 449
                               Store 451(param) 450
              452:           2 FunctionCall 96(foo9(u1;) 451(param)
-             453:    6(float) Load 155(d)
+             453:6(float64_t) Load 155(d)
              454:     15(int) ConvertFToU 453
                               Store 455(param) 454
              456:           2 FunctionCall 96(foo9(u1;) 455(param)
@@ -1580,7 +1580,7 @@ gl_FragCoord origin is upper left
              462:     22(int) ConvertFToS 461
                               Store 463(param) 462
              464:           2 FunctionCall 102(foo10(i1;) 463(param)
-             465:    6(float) Load 155(d)
+             465:6(float64_t) Load 155(d)
              466:     22(int) ConvertFToS 465
                               Store 467(param) 466
              468:           2 FunctionCall 102(foo10(i1;) 467(param)
@@ -1589,12 +1589,12 @@ gl_FragCoord origin is upper left
                               Store 471(param) 470
              472:           2 FunctionCall 120(foo11(u1;) 471(param)
              473:   29(float) Load 179(f)
-             474:    6(float) FConvert 473
+             474:6(float64_t) FConvert 473
                               Store 475(param) 474
              476:           2 FunctionCall 111(foo11(d1;) 475(param)
              477:   29(float) Load 179(f)
              478:  104(fvec3) CompositeConstruct 477 477 477
-             479:  125(fvec3) FConvert 478
+             479:125(f64vec3) FConvert 478
                               Store 480(param) 479
              481:           2 FunctionCall 129(foo12(vd3;) 480(param)
              482:     22(int) Load 173(i)

--- a/Test/baseResults/hlsl.promotions.frag.out
+++ b/Test/baseResults/hlsl.promotions.frag.out
@@ -1715,18 +1715,18 @@ gl_FragCoord origin is upper left
               29:             TypePointer Function 28(bvec3)
               30:             TypeFunction 2 29(ptr)
               34:             TypeFloat 64
-              35:             TypeVector 34(float) 3
-              36:             TypePointer Function 35(fvec3)
+              35:             TypeVector 34(float64_t) 3
+              36:             TypePointer Function 35(f64vec3)
               37:             TypeFunction 2 36(ptr)
               41:             TypeFunction 7(fvec3) 8(ptr)
               54:             TypeFunction 14(ivec3) 15(ptr)
               67:             TypeFunction 21(ivec3) 22(ptr)
               80:             TypeFunction 28(bvec3) 29(ptr)
-              93:             TypeFunction 35(fvec3) 36(ptr)
+              93:             TypeFunction 35(f64vec3) 36(ptr)
              106:             TypeVector 6(float) 4
   107(PS_OUTPUT):             TypeStruct 106(fvec4)
              108:             TypeFunction 107(PS_OUTPUT)
-    111($Global):             TypeStruct 14(ivec3) 21(ivec3) 7(fvec3) 21(ivec3) 35(fvec3) 13(int) 20(int) 6(float) 20(int) 34(float)
+    111($Global):             TypeStruct 14(ivec3) 21(ivec3) 7(fvec3) 21(ivec3) 35(f64vec3) 13(int) 20(int) 6(float) 20(int) 34(float64_t)
              112:             TypePointer Uniform 111($Global)
              113:    112(ptr) Variable Uniform
              114:     13(int) Constant 0
@@ -1741,24 +1741,24 @@ gl_FragCoord origin is upper left
              142:    7(fvec3) ConstantComposite 140 140 140
              143:    7(fvec3) ConstantComposite 141 141 141
              151:     13(int) Constant 4
-             152:             TypePointer Uniform 35(fvec3)
+             152:             TypePointer Uniform 35(f64vec3)
              172:   14(ivec3) ConstantComposite 114 114 114
              173:   14(ivec3) ConstantComposite 134 134 134
              181:     13(int) Constant 2
              182:             TypePointer Uniform 7(fvec3)
              218:     20(int) Constant 1
              219:   21(ivec3) ConstantComposite 218 218 218
-             261:   34(float) Constant 0 0
-             262:   35(fvec3) ConstantComposite 261 261 261
-             288:   34(float) Constant 0 1072693248
-             289:   35(fvec3) ConstantComposite 288 288 288
+             261:34(float64_t) Constant 0 0
+             262: 35(f64vec3) ConstantComposite 261 261 261
+             288:34(float64_t) Constant 0 1072693248
+             289: 35(f64vec3) ConstantComposite 288 288 288
              473:     13(int) Constant 5
              474:             TypePointer Uniform 13(int)
              480:     13(int) Constant 6
              481:             TypePointer Uniform 20(int)
              488:     13(int) Constant 8
              494:     13(int) Constant 9
-             495:             TypePointer Uniform 34(float)
+             495:             TypePointer Uniform 34(float64_t)
              514:     13(int) Constant 7
              515:             TypePointer Uniform 6(float)
              574:             TypePointer Function 13(int)
@@ -1841,11 +1841,11 @@ gl_FragCoord origin is upper left
            51(p):      8(ptr) FunctionParameter
               53:             Label
              153:    152(ptr) AccessChain 113 151
-             154:   35(fvec3) Load 153
+             154: 35(f64vec3) Load 153
              155:    7(fvec3) FConvert 154
                               Store 51(p) 155
              156:    152(ptr) AccessChain 113 151
-             157:   35(fvec3) Load 156
+             157: 35(f64vec3) Load 156
              158:    7(fvec3) FConvert 157
                               ReturnValue 158
                               FunctionEnd
@@ -1891,11 +1891,11 @@ gl_FragCoord origin is upper left
            64(p):     15(ptr) FunctionParameter
               66:             Label
              191:    152(ptr) AccessChain 113 151
-             192:   35(fvec3) Load 191
+             192: 35(f64vec3) Load 191
              193:   14(ivec3) ConvertFToS 192
                               Store 64(p) 193
              194:    152(ptr) AccessChain 113 151
-             195:   35(fvec3) Load 194
+             195: 35(f64vec3) Load 194
              196:   14(ivec3) ConvertFToS 195
                               ReturnValue 196
                               FunctionEnd
@@ -1941,11 +1941,11 @@ gl_FragCoord origin is upper left
            77(p):     22(ptr) FunctionParameter
               79:             Label
              227:    152(ptr) AccessChain 113 151
-             228:   35(fvec3) Load 227
+             228: 35(f64vec3) Load 227
              229:   21(ivec3) ConvertFToU 228
                               Store 77(p) 229
              230:    152(ptr) AccessChain 113 151
-             231:   35(fvec3) Load 230
+             231: 35(f64vec3) Load 230
              232:   21(ivec3) ConvertFToU 231
                               ReturnValue 232
                               FunctionEnd
@@ -1989,62 +1989,62 @@ gl_FragCoord origin is upper left
            90(p):     29(ptr) FunctionParameter
               92:             Label
              259:    152(ptr) AccessChain 113 151
-             260:   35(fvec3) Load 259
+             260: 35(f64vec3) Load 259
              263:   28(bvec3) FOrdNotEqual 260 262
                               Store 90(p) 263
              264:    152(ptr) AccessChain 113 151
-             265:   35(fvec3) Load 264
+             265: 35(f64vec3) Load 264
              266:   28(bvec3) FOrdNotEqual 265 262
                               ReturnValue 266
                               FunctionEnd
-95(Fn_R_D3I(vd3;):   35(fvec3) Function None 93
+95(Fn_R_D3I(vd3;): 35(f64vec3) Function None 93
            94(p):     36(ptr) FunctionParameter
               96:             Label
              269:    115(ptr) AccessChain 113 114
              270:   14(ivec3) Load 269
-             271:   35(fvec3) ConvertSToF 270
+             271: 35(f64vec3) ConvertSToF 270
                               Store 94(p) 271
              272:    115(ptr) AccessChain 113 114
              273:   14(ivec3) Load 272
-             274:   35(fvec3) ConvertSToF 273
+             274: 35(f64vec3) ConvertSToF 273
                               ReturnValue 274
                               FunctionEnd
-98(Fn_R_D3U(vd3;):   35(fvec3) Function None 93
+98(Fn_R_D3U(vd3;): 35(f64vec3) Function None 93
            97(p):     36(ptr) FunctionParameter
               99:             Label
              277:    125(ptr) AccessChain 113 124
              278:   21(ivec3) Load 277
-             279:   35(fvec3) ConvertUToF 278
+             279: 35(f64vec3) ConvertUToF 278
                               Store 97(p) 279
              280:    125(ptr) AccessChain 113 124
              281:   21(ivec3) Load 280
-             282:   35(fvec3) ConvertUToF 281
+             282: 35(f64vec3) ConvertUToF 281
                               ReturnValue 282
                               FunctionEnd
-101(Fn_R_D3B(vd3;):   35(fvec3) Function None 93
+101(Fn_R_D3B(vd3;): 35(f64vec3) Function None 93
           100(p):     36(ptr) FunctionParameter
              102:             Label
              285:    125(ptr) AccessChain 113 134
              286:   21(ivec3) Load 285
              287:   28(bvec3) INotEqual 286 138
-             290:   35(fvec3) Select 287 289 262
+             290: 35(f64vec3) Select 287 289 262
                               Store 100(p) 290
              291:    125(ptr) AccessChain 113 134
              292:   21(ivec3) Load 291
              293:   28(bvec3) INotEqual 292 138
-             294:   35(fvec3) Select 293 289 262
+             294: 35(f64vec3) Select 293 289 262
                               ReturnValue 294
                               FunctionEnd
-104(Fn_R_D3F(vd3;):   35(fvec3) Function None 93
+104(Fn_R_D3F(vd3;): 35(f64vec3) Function None 93
           103(p):     36(ptr) FunctionParameter
              105:             Label
              297:    182(ptr) AccessChain 113 181
              298:    7(fvec3) Load 297
-             299:   35(fvec3) FConvert 298
+             299: 35(f64vec3) FConvert 298
                               Store 103(p) 299
              300:    182(ptr) AccessChain 113 181
              301:    7(fvec3) Load 300
-             302:   35(fvec3) FConvert 301
+             302: 35(f64vec3) FConvert 301
                               ReturnValue 302
                               FunctionEnd
      109(@main():107(PS_OUTPUT) Function None 108
@@ -2087,7 +2087,7 @@ gl_FragCoord origin is upper left
              317:    7(fvec3) ConvertUToF 316
                               Store 314(r02) 317
              319:    152(ptr) AccessChain 113 151
-             320:   35(fvec3) Load 319
+             320: 35(f64vec3) Load 319
              321:    7(fvec3) FConvert 320
                               Store 318(r03) 321
              323:    125(ptr) AccessChain 113 134
@@ -2104,7 +2104,7 @@ gl_FragCoord origin is upper left
              334:   14(ivec3) ConvertFToS 333
                               Store 331(r12) 334
              336:    152(ptr) AccessChain 113 151
-             337:   35(fvec3) Load 336
+             337: 35(f64vec3) Load 336
              338:   14(ivec3) ConvertFToS 337
                               Store 335(r13) 338
              340:    125(ptr) AccessChain 113 134
@@ -2121,7 +2121,7 @@ gl_FragCoord origin is upper left
              351:   21(ivec3) ConvertFToU 350
                               Store 348(r22) 351
              353:    152(ptr) AccessChain 113 151
-             354:   35(fvec3) Load 353
+             354: 35(f64vec3) Load 353
              355:   21(ivec3) ConvertFToU 354
                               Store 352(r23) 355
              357:    115(ptr) AccessChain 113 114
@@ -2137,25 +2137,25 @@ gl_FragCoord origin is upper left
              367:   28(bvec3) FOrdNotEqual 366 142
                               Store 364(r32) 367
              369:    152(ptr) AccessChain 113 151
-             370:   35(fvec3) Load 369
+             370: 35(f64vec3) Load 369
              371:   28(bvec3) FOrdNotEqual 370 262
                               Store 368(r33) 371
              373:    115(ptr) AccessChain 113 114
              374:   14(ivec3) Load 373
-             375:   35(fvec3) ConvertSToF 374
+             375: 35(f64vec3) ConvertSToF 374
                               Store 372(r40) 375
              377:    125(ptr) AccessChain 113 124
              378:   21(ivec3) Load 377
-             379:   35(fvec3) ConvertUToF 378
+             379: 35(f64vec3) ConvertUToF 378
                               Store 376(r41) 379
              381:    182(ptr) AccessChain 113 181
              382:    7(fvec3) Load 381
-             383:   35(fvec3) FConvert 382
+             383: 35(f64vec3) FConvert 382
                               Store 380(r42) 383
              385:    125(ptr) AccessChain 113 134
              386:   21(ivec3) Load 385
              387:   28(bvec3) INotEqual 386 138
-             388:   35(fvec3) Select 387 289 262
+             388: 35(f64vec3) Select 387 289 262
                               Store 384(r43) 388
              389:    115(ptr) AccessChain 113 114
              390:   14(ivec3) Load 389
@@ -2177,7 +2177,7 @@ gl_FragCoord origin is upper left
              404:    7(fvec3) FMul 403 402
                               Store 314(r02) 404
              405:    152(ptr) AccessChain 113 151
-             406:   35(fvec3) Load 405
+             406: 35(f64vec3) Load 405
              407:    7(fvec3) FConvert 406
              408:    7(fvec3) Load 318(r03)
              409:    7(fvec3) FMul 408 407
@@ -2202,7 +2202,7 @@ gl_FragCoord origin is upper left
              425:   14(ivec3) IMul 424 423
                               Store 331(r12) 425
              426:    152(ptr) AccessChain 113 151
-             427:   35(fvec3) Load 426
+             427: 35(f64vec3) Load 426
              428:   14(ivec3) ConvertFToS 427
              429:   14(ivec3) Load 335(r13)
              430:   14(ivec3) IMul 429 428
@@ -2227,35 +2227,35 @@ gl_FragCoord origin is upper left
              446:   21(ivec3) IMul 445 444
                               Store 348(r22) 446
              447:    152(ptr) AccessChain 113 151
-             448:   35(fvec3) Load 447
+             448: 35(f64vec3) Load 447
              449:   21(ivec3) ConvertFToU 448
              450:   21(ivec3) Load 352(r23)
              451:   21(ivec3) IMul 450 449
                               Store 352(r23) 451
              452:    115(ptr) AccessChain 113 114
              453:   14(ivec3) Load 452
-             454:   35(fvec3) ConvertSToF 453
-             455:   35(fvec3) Load 372(r40)
-             456:   35(fvec3) FMul 455 454
+             454: 35(f64vec3) ConvertSToF 453
+             455: 35(f64vec3) Load 372(r40)
+             456: 35(f64vec3) FMul 455 454
                               Store 372(r40) 456
              457:    125(ptr) AccessChain 113 124
              458:   21(ivec3) Load 457
-             459:   35(fvec3) ConvertUToF 458
-             460:   35(fvec3) Load 376(r41)
-             461:   35(fvec3) FMul 460 459
+             459: 35(f64vec3) ConvertUToF 458
+             460: 35(f64vec3) Load 376(r41)
+             461: 35(f64vec3) FMul 460 459
                               Store 376(r41) 461
              462:    182(ptr) AccessChain 113 181
              463:    7(fvec3) Load 462
-             464:   35(fvec3) FConvert 463
-             465:   35(fvec3) Load 380(r42)
-             466:   35(fvec3) FMul 465 464
+             464: 35(f64vec3) FConvert 463
+             465: 35(f64vec3) Load 380(r42)
+             466: 35(f64vec3) FMul 465 464
                               Store 380(r42) 466
              467:    125(ptr) AccessChain 113 134
              468:   21(ivec3) Load 467
              469:   28(bvec3) INotEqual 468 138
-             470:   35(fvec3) Select 469 289 262
-             471:   35(fvec3) Load 384(r43)
-             472:   35(fvec3) FMul 471 470
+             470: 35(f64vec3) Select 469 289 262
+             471: 35(f64vec3) Load 384(r43)
+             472: 35(f64vec3) FMul 471 470
                               Store 384(r43) 472
              475:    474(ptr) AccessChain 113 473
              476:     13(int) Load 475
@@ -2277,7 +2277,7 @@ gl_FragCoord origin is upper left
              493:    7(fvec3) VectorTimesScalar 492 491
                               Store 314(r02) 493
              496:    495(ptr) AccessChain 113 494
-             497:   34(float) Load 496
+             497:34(float64_t) Load 496
              498:    6(float) FConvert 497
              499:    7(fvec3) Load 318(r03)
              500:    7(fvec3) VectorTimesScalar 499 498
@@ -2305,7 +2305,7 @@ gl_FragCoord origin is upper left
              521:   14(ivec3) IMul 519 520
                               Store 331(r12) 521
              522:    495(ptr) AccessChain 113 494
-             523:   34(float) Load 522
+             523:34(float64_t) Load 522
              524:     13(int) ConvertFToS 523
              525:   14(ivec3) Load 335(r13)
              526:   14(ivec3) CompositeConstruct 524 524 524
@@ -2334,7 +2334,7 @@ gl_FragCoord origin is upper left
              546:   21(ivec3) IMul 544 545
                               Store 348(r22) 546
              547:    495(ptr) AccessChain 113 494
-             548:   34(float) Load 547
+             548:34(float64_t) Load 547
              549:     20(int) ConvertFToU 548
              550:   21(ivec3) Load 352(r23)
              551:   21(ivec3) CompositeConstruct 549 549 549
@@ -2342,28 +2342,28 @@ gl_FragCoord origin is upper left
                               Store 352(r23) 552
              553:    474(ptr) AccessChain 113 473
              554:     13(int) Load 553
-             555:   34(float) ConvertSToF 554
-             556:   35(fvec3) Load 372(r40)
-             557:   35(fvec3) VectorTimesScalar 556 555
+             555:34(float64_t) ConvertSToF 554
+             556: 35(f64vec3) Load 372(r40)
+             557: 35(f64vec3) VectorTimesScalar 556 555
                               Store 372(r40) 557
              558:    481(ptr) AccessChain 113 488
              559:     20(int) Load 558
-             560:   34(float) ConvertUToF 559
-             561:   35(fvec3) Load 376(r41)
-             562:   35(fvec3) VectorTimesScalar 561 560
+             560:34(float64_t) ConvertUToF 559
+             561: 35(f64vec3) Load 376(r41)
+             562: 35(f64vec3) VectorTimesScalar 561 560
                               Store 376(r41) 562
              563:    515(ptr) AccessChain 113 514
              564:    6(float) Load 563
-             565:   34(float) FConvert 564
-             566:   35(fvec3) Load 380(r42)
-             567:   35(fvec3) VectorTimesScalar 566 565
+             565:34(float64_t) FConvert 564
+             566: 35(f64vec3) Load 380(r42)
+             567: 35(f64vec3) VectorTimesScalar 566 565
                               Store 380(r42) 567
              568:    481(ptr) AccessChain 113 480
              569:     20(int) Load 568
              570:    27(bool) INotEqual 569 137
-             571:   34(float) Select 570 288 261
-             572:   35(fvec3) Load 384(r43)
-             573:   35(fvec3) VectorTimesScalar 572 571
+             571:34(float64_t) Select 570 288 261
+             572: 35(f64vec3) Load 384(r43)
+             573: 35(f64vec3) VectorTimesScalar 572 571
                               Store 384(r43) 573
                               Store 575(c1) 124
                               Store 576(c2) 124

--- a/Test/baseResults/hlsl.templatetypes.frag.out
+++ b/Test/baseResults/hlsl.templatetypes.frag.out
@@ -571,8 +571,8 @@ gl_FragCoord origin is upper left
               28:     25(int) Constant 1
               29:             TypePointer Function 6(float)
               31:             TypeFloat 64
-              32:             TypePointer Function 31(float)
-              34:   31(float) Constant 0 1072693248
+              32:             TypePointer Function 31(float64_t)
+              34:31(float64_t) Constant 0 1072693248
               35:             TypeInt 32 0
               36:             TypePointer Function 35(int)
               38:     35(int) Constant 1
@@ -587,10 +587,10 @@ gl_FragCoord origin is upper left
               49:             TypeVector 6(float) 2
               50:             TypePointer Function 49(fvec2)
               52:   49(fvec2) ConstantComposite 13 14
-              53:             TypeVector 31(float) 2
-              54:             TypePointer Function 53(fvec2)
-              56:   31(float) Constant 0 1073741824
-              57:   53(fvec2) ConstantComposite 34 56
+              53:             TypeVector 31(float64_t) 2
+              54:             TypePointer Function 53(f64vec2)
+              56:31(float64_t) Constant 0 1073741824
+              57: 53(f64vec2) ConstantComposite 34 56
               58:             TypeVector 35(int) 2
               59:             TypePointer Function 58(ivec2)
               61:     35(int) Constant 2
@@ -605,10 +605,10 @@ gl_FragCoord origin is upper left
               72:             TypeVector 6(float) 3
               73:             TypePointer Function 72(fvec3)
               75:   72(fvec3) ConstantComposite 13 14 15
-              76:             TypeVector 31(float) 3
-              77:             TypePointer Function 76(fvec3)
-              79:   31(float) Constant 0 1074266112
-              80:   76(fvec3) ConstantComposite 34 56 79
+              76:             TypeVector 31(float64_t) 3
+              77:             TypePointer Function 76(f64vec3)
+              79:31(float64_t) Constant 0 1074266112
+              80: 76(f64vec3) ConstantComposite 34 56 79
               81:             TypeVector 35(int) 3
               82:             TypePointer Function 81(ivec3)
               84:     35(int) Constant 3
@@ -620,10 +620,10 @@ gl_FragCoord origin is upper left
               91:             TypePointer Function 90(ivec4)
               93:     25(int) Constant 4
               94:   90(ivec4) ConstantComposite 28 47 70 93
-              96:             TypeVector 31(float) 4
-              97:             TypePointer Function 96(fvec4)
-              99:   31(float) Constant 0 1074790400
-             100:   96(fvec4) ConstantComposite 34 56 79 99
+              96:             TypeVector 31(float64_t) 4
+              97:             TypePointer Function 96(f64vec4)
+              99:31(float64_t) Constant 0 1074790400
+             100: 96(f64vec4) ConstantComposite 34 56 79 99
              101:             TypeVector 35(int) 4
              102:             TypePointer Function 101(ivec4)
              104:     35(int) Constant 4

--- a/Test/baseResults/hlsl.wavebroadcast.comp.out
+++ b/Test/baseResults/hlsl.wavebroadcast.comp.out
@@ -2346,8 +2346,8 @@ local_size = (32, 16, 1)
               16:             TypeFloat 32
               17:             TypeVector 16(float) 4
               18:             TypeFloat 64
-              19:             TypeVector 18(float) 4
-       20(Types):             TypeStruct 13(ivec4) 15(ivec4) 17(fvec4) 19(fvec4)
+              19:             TypeVector 18(float64_t) 4
+       20(Types):             TypeStruct 13(ivec4) 15(ivec4) 17(fvec4) 19(f64vec4)
               21:             TypeRuntimeArray 20(Types)
         22(data):             TypeStruct 21
               23:             TypePointer Uniform 22(data)
@@ -2371,10 +2371,10 @@ local_size = (32, 16, 1)
              137:             TypeVector 16(float) 2
              149:             TypeVector 16(float) 3
              159:     14(int) Constant 3
-             162:             TypePointer Uniform 19(fvec4)
-             171:             TypePointer Uniform 18(float)
-             180:             TypeVector 18(float) 2
-             192:             TypeVector 18(float) 3
+             162:             TypePointer Uniform 19(f64vec4)
+             171:             TypePointer Uniform 18(float64_t)
+             180:             TypeVector 18(float64_t) 2
+             192:             TypeVector 18(float64_t) 3
              353:             TypePointer Input 7(ivec3)
         354(dti):    353(ptr) Variable Input
        4(CSMain):           2 Function None 3
@@ -2522,8 +2522,8 @@ local_size = (32, 16, 1)
              160:     27(ptr) AccessChain 10(dti) 26
              161:      6(int) Load 160
              163:    162(ptr) AccessChain 24(data) 25 161 159
-             164:   19(fvec4) Load 163
-             165:   19(fvec4) GroupNonUniformBroadcastFirst 36 164
+             164: 19(f64vec4) Load 163
+             165: 19(f64vec4) GroupNonUniformBroadcastFirst 36 164
              166:    162(ptr) AccessChain 24(data) 25 158 159
                               Store 166 165
              167:     27(ptr) AccessChain 10(dti) 26
@@ -2531,8 +2531,8 @@ local_size = (32, 16, 1)
              169:     27(ptr) AccessChain 10(dti) 26
              170:      6(int) Load 169
              172:    171(ptr) AccessChain 24(data) 25 170 159 26
-             173:   18(float) Load 172
-             174:   18(float) GroupNonUniformBroadcastFirst 36 173
+             173:18(float64_t) Load 172
+             174:18(float64_t) GroupNonUniformBroadcastFirst 36 173
              175:    171(ptr) AccessChain 24(data) 25 168 159 26
                               Store 175 174
              176:     27(ptr) AccessChain 10(dti) 26
@@ -2540,24 +2540,24 @@ local_size = (32, 16, 1)
              178:     27(ptr) AccessChain 10(dti) 26
              179:      6(int) Load 178
              181:    162(ptr) AccessChain 24(data) 25 179 159
-             182:   19(fvec4) Load 181
-             183:  180(fvec2) VectorShuffle 182 182 0 1
-             184:  180(fvec2) GroupNonUniformBroadcastFirst 36 183
+             182: 19(f64vec4) Load 181
+             183:180(f64vec2) VectorShuffle 182 182 0 1
+             184:180(f64vec2) GroupNonUniformBroadcastFirst 36 183
              185:    162(ptr) AccessChain 24(data) 25 177 159
-             186:   19(fvec4) Load 185
-             187:   19(fvec4) VectorShuffle 186 184 4 5 2 3
+             186: 19(f64vec4) Load 185
+             187: 19(f64vec4) VectorShuffle 186 184 4 5 2 3
                               Store 185 187
              188:     27(ptr) AccessChain 10(dti) 26
              189:      6(int) Load 188
              190:     27(ptr) AccessChain 10(dti) 26
              191:      6(int) Load 190
              193:    162(ptr) AccessChain 24(data) 25 191 159
-             194:   19(fvec4) Load 193
-             195:  192(fvec3) VectorShuffle 194 194 0 1 2
-             196:  192(fvec3) GroupNonUniformBroadcastFirst 36 195
+             194: 19(f64vec4) Load 193
+             195:192(f64vec3) VectorShuffle 194 194 0 1 2
+             196:192(f64vec3) GroupNonUniformBroadcastFirst 36 195
              197:    162(ptr) AccessChain 24(data) 25 189 159
-             198:   19(fvec4) Load 197
-             199:   19(fvec4) VectorShuffle 198 196 4 5 6 3
+             198: 19(f64vec4) Load 197
+             199: 19(f64vec4) VectorShuffle 198 196 4 5 6 3
                               Store 197 199
              200:     27(ptr) AccessChain 10(dti) 26
              201:      6(int) Load 200
@@ -2690,8 +2690,8 @@ local_size = (32, 16, 1)
              316:     27(ptr) AccessChain 10(dti) 26
              317:      6(int) Load 316
              318:    162(ptr) AccessChain 24(data) 25 317 159
-             319:   19(fvec4) Load 318
-             320:   19(fvec4) GroupNonUniformBroadcastFirst 36 319
+             319: 19(f64vec4) Load 318
+             320: 19(f64vec4) GroupNonUniformBroadcastFirst 36 319
              321:    162(ptr) AccessChain 24(data) 25 315 159
                               Store 321 320
              322:     27(ptr) AccessChain 10(dti) 26
@@ -2699,8 +2699,8 @@ local_size = (32, 16, 1)
              324:     27(ptr) AccessChain 10(dti) 26
              325:      6(int) Load 324
              326:    171(ptr) AccessChain 24(data) 25 325 159 26
-             327:   18(float) Load 326
-             328:   18(float) GroupNonUniformBroadcastFirst 36 327
+             327:18(float64_t) Load 326
+             328:18(float64_t) GroupNonUniformBroadcastFirst 36 327
              329:    171(ptr) AccessChain 24(data) 25 323 159 26
                               Store 329 328
              330:     27(ptr) AccessChain 10(dti) 26
@@ -2708,24 +2708,24 @@ local_size = (32, 16, 1)
              332:     27(ptr) AccessChain 10(dti) 26
              333:      6(int) Load 332
              334:    162(ptr) AccessChain 24(data) 25 333 159
-             335:   19(fvec4) Load 334
-             336:  180(fvec2) VectorShuffle 335 335 0 1
-             337:  180(fvec2) GroupNonUniformBroadcastFirst 36 336
+             335: 19(f64vec4) Load 334
+             336:180(f64vec2) VectorShuffle 335 335 0 1
+             337:180(f64vec2) GroupNonUniformBroadcastFirst 36 336
              338:    162(ptr) AccessChain 24(data) 25 331 159
-             339:   19(fvec4) Load 338
-             340:   19(fvec4) VectorShuffle 339 337 4 5 2 3
+             339: 19(f64vec4) Load 338
+             340: 19(f64vec4) VectorShuffle 339 337 4 5 2 3
                               Store 338 340
              341:     27(ptr) AccessChain 10(dti) 26
              342:      6(int) Load 341
              343:     27(ptr) AccessChain 10(dti) 26
              344:      6(int) Load 343
              345:    162(ptr) AccessChain 24(data) 25 344 159
-             346:   19(fvec4) Load 345
-             347:  192(fvec3) VectorShuffle 346 346 0 1 2
-             348:  192(fvec3) GroupNonUniformBroadcastFirst 36 347
+             346: 19(f64vec4) Load 345
+             347:192(f64vec3) VectorShuffle 346 346 0 1 2
+             348:192(f64vec3) GroupNonUniformBroadcastFirst 36 347
              349:    162(ptr) AccessChain 24(data) 25 342 159
-             350:   19(fvec4) Load 349
-             351:   19(fvec4) VectorShuffle 350 348 4 5 6 3
+             350: 19(f64vec4) Load 349
+             351: 19(f64vec4) VectorShuffle 350 348 4 5 6 3
                               Store 349 351
                               Return
                               FunctionEnd

--- a/Test/baseResults/hlsl.waveprefix.comp.out
+++ b/Test/baseResults/hlsl.waveprefix.comp.out
@@ -2370,8 +2370,8 @@ local_size = (32, 16, 1)
               16:             TypeFloat 32
               17:             TypeVector 16(float) 4
               18:             TypeFloat 64
-              19:             TypeVector 18(float) 4
-       20(Types):             TypeStruct 13(ivec4) 15(ivec4) 17(fvec4) 19(fvec4)
+              19:             TypeVector 18(float64_t) 4
+       20(Types):             TypeStruct 13(ivec4) 15(ivec4) 17(fvec4) 19(f64vec4)
               21:             TypeRuntimeArray 20(Types)
         22(data):             TypeStruct 21
               23:             TypePointer Uniform 22(data)
@@ -2394,10 +2394,10 @@ local_size = (32, 16, 1)
              136:             TypeVector 16(float) 2
              148:             TypeVector 16(float) 3
              158:     14(int) Constant 3
-             161:             TypePointer Uniform 19(fvec4)
-             170:             TypePointer Uniform 18(float)
-             179:             TypeVector 18(float) 2
-             191:             TypeVector 18(float) 3
+             161:             TypePointer Uniform 19(f64vec4)
+             170:             TypePointer Uniform 18(float64_t)
+             179:             TypeVector 18(float64_t) 2
+             191:             TypeVector 18(float64_t) 3
              357:             TypeBool
              363:             TypePointer Input 7(ivec3)
         364(dti):    363(ptr) Variable Input
@@ -2546,8 +2546,8 @@ local_size = (32, 16, 1)
              159:     27(ptr) AccessChain 10(dti) 26
              160:      6(int) Load 159
              162:    161(ptr) AccessChain 24(data) 25 160 158
-             163:   19(fvec4) Load 162
-             164:   19(fvec4) GroupNonUniformFAdd 35 InclusiveScan 163
+             163: 19(f64vec4) Load 162
+             164: 19(f64vec4) GroupNonUniformFAdd 35 InclusiveScan 163
              165:    161(ptr) AccessChain 24(data) 25 157 158
                               Store 165 164
              166:     27(ptr) AccessChain 10(dti) 26
@@ -2555,8 +2555,8 @@ local_size = (32, 16, 1)
              168:     27(ptr) AccessChain 10(dti) 26
              169:      6(int) Load 168
              171:    170(ptr) AccessChain 24(data) 25 169 158 26
-             172:   18(float) Load 171
-             173:   18(float) GroupNonUniformFAdd 35 InclusiveScan 172
+             172:18(float64_t) Load 171
+             173:18(float64_t) GroupNonUniformFAdd 35 InclusiveScan 172
              174:    170(ptr) AccessChain 24(data) 25 167 158 26
                               Store 174 173
              175:     27(ptr) AccessChain 10(dti) 26
@@ -2564,24 +2564,24 @@ local_size = (32, 16, 1)
              177:     27(ptr) AccessChain 10(dti) 26
              178:      6(int) Load 177
              180:    161(ptr) AccessChain 24(data) 25 178 158
-             181:   19(fvec4) Load 180
-             182:  179(fvec2) VectorShuffle 181 181 0 1
-             183:  179(fvec2) GroupNonUniformFAdd 35 InclusiveScan 182
+             181: 19(f64vec4) Load 180
+             182:179(f64vec2) VectorShuffle 181 181 0 1
+             183:179(f64vec2) GroupNonUniformFAdd 35 InclusiveScan 182
              184:    161(ptr) AccessChain 24(data) 25 176 158
-             185:   19(fvec4) Load 184
-             186:   19(fvec4) VectorShuffle 185 183 4 5 2 3
+             185: 19(f64vec4) Load 184
+             186: 19(f64vec4) VectorShuffle 185 183 4 5 2 3
                               Store 184 186
              187:     27(ptr) AccessChain 10(dti) 26
              188:      6(int) Load 187
              189:     27(ptr) AccessChain 10(dti) 26
              190:      6(int) Load 189
              192:    161(ptr) AccessChain 24(data) 25 190 158
-             193:   19(fvec4) Load 192
-             194:  191(fvec3) VectorShuffle 193 193 0 1 2
-             195:  191(fvec3) GroupNonUniformFAdd 35 InclusiveScan 194
+             193: 19(f64vec4) Load 192
+             194:191(f64vec3) VectorShuffle 193 193 0 1 2
+             195:191(f64vec3) GroupNonUniformFAdd 35 InclusiveScan 194
              196:    161(ptr) AccessChain 24(data) 25 188 158
-             197:   19(fvec4) Load 196
-             198:   19(fvec4) VectorShuffle 197 195 4 5 6 3
+             197: 19(f64vec4) Load 196
+             198: 19(f64vec4) VectorShuffle 197 195 4 5 6 3
                               Store 196 198
              199:     27(ptr) AccessChain 10(dti) 26
              200:      6(int) Load 199
@@ -2714,8 +2714,8 @@ local_size = (32, 16, 1)
              315:     27(ptr) AccessChain 10(dti) 26
              316:      6(int) Load 315
              317:    161(ptr) AccessChain 24(data) 25 316 158
-             318:   19(fvec4) Load 317
-             319:   19(fvec4) GroupNonUniformFMul 35 InclusiveScan 318
+             318: 19(f64vec4) Load 317
+             319: 19(f64vec4) GroupNonUniformFMul 35 InclusiveScan 318
              320:    161(ptr) AccessChain 24(data) 25 314 158
                               Store 320 319
              321:     27(ptr) AccessChain 10(dti) 26
@@ -2723,8 +2723,8 @@ local_size = (32, 16, 1)
              323:     27(ptr) AccessChain 10(dti) 26
              324:      6(int) Load 323
              325:    170(ptr) AccessChain 24(data) 25 324 158 26
-             326:   18(float) Load 325
-             327:   18(float) GroupNonUniformFMul 35 InclusiveScan 326
+             326:18(float64_t) Load 325
+             327:18(float64_t) GroupNonUniformFMul 35 InclusiveScan 326
              328:    170(ptr) AccessChain 24(data) 25 322 158 26
                               Store 328 327
              329:     27(ptr) AccessChain 10(dti) 26
@@ -2732,24 +2732,24 @@ local_size = (32, 16, 1)
              331:     27(ptr) AccessChain 10(dti) 26
              332:      6(int) Load 331
              333:    161(ptr) AccessChain 24(data) 25 332 158
-             334:   19(fvec4) Load 333
-             335:  179(fvec2) VectorShuffle 334 334 0 1
-             336:  179(fvec2) GroupNonUniformFMul 35 InclusiveScan 335
+             334: 19(f64vec4) Load 333
+             335:179(f64vec2) VectorShuffle 334 334 0 1
+             336:179(f64vec2) GroupNonUniformFMul 35 InclusiveScan 335
              337:    161(ptr) AccessChain 24(data) 25 330 158
-             338:   19(fvec4) Load 337
-             339:   19(fvec4) VectorShuffle 338 336 4 5 2 3
+             338: 19(f64vec4) Load 337
+             339: 19(f64vec4) VectorShuffle 338 336 4 5 2 3
                               Store 337 339
              340:     27(ptr) AccessChain 10(dti) 26
              341:      6(int) Load 340
              342:     27(ptr) AccessChain 10(dti) 26
              343:      6(int) Load 342
              344:    161(ptr) AccessChain 24(data) 25 343 158
-             345:   19(fvec4) Load 344
-             346:  191(fvec3) VectorShuffle 345 345 0 1 2
-             347:  191(fvec3) GroupNonUniformFMul 35 InclusiveScan 346
+             345: 19(f64vec4) Load 344
+             346:191(f64vec3) VectorShuffle 345 345 0 1 2
+             347:191(f64vec3) GroupNonUniformFMul 35 InclusiveScan 346
              348:    161(ptr) AccessChain 24(data) 25 341 158
-             349:   19(fvec4) Load 348
-             350:   19(fvec4) VectorShuffle 349 347 4 5 6 3
+             349: 19(f64vec4) Load 348
+             350: 19(f64vec4) VectorShuffle 349 347 4 5 6 3
                               Store 348 350
              351:     27(ptr) AccessChain 10(dti) 26
              352:      6(int) Load 351

--- a/Test/baseResults/hlsl.wavequad.comp.out
+++ b/Test/baseResults/hlsl.wavequad.comp.out
@@ -8073,8 +8073,8 @@ local_size = (32, 16, 1)
               16:             TypeFloat 32
               17:             TypeVector 16(float) 4
               18:             TypeFloat 64
-              19:             TypeVector 18(float) 4
-       20(Types):             TypeStruct 13(ivec4) 15(ivec4) 17(fvec4) 19(fvec4)
+              19:             TypeVector 18(float64_t) 4
+       20(Types):             TypeStruct 13(ivec4) 15(ivec4) 17(fvec4) 19(f64vec4)
               21:             TypeRuntimeArray 20(Types)
         22(data):             TypeStruct 21
               23:             TypePointer Uniform 22(data)
@@ -8097,10 +8097,10 @@ local_size = (32, 16, 1)
              136:             TypeVector 16(float) 2
              148:             TypeVector 16(float) 3
              158:     14(int) Constant 3
-             161:             TypePointer Uniform 19(fvec4)
-             170:             TypePointer Uniform 18(float)
-             179:             TypeVector 18(float) 2
-             191:             TypeVector 18(float) 3
+             161:             TypePointer Uniform 19(f64vec4)
+             170:             TypePointer Uniform 18(float64_t)
+             179:             TypeVector 18(float64_t) 2
+             191:             TypeVector 18(float64_t) 3
              205:      6(int) Constant 1
              358:      6(int) Constant 2
             1114:             TypePointer Input 7(ivec3)
@@ -8250,8 +8250,8 @@ local_size = (32, 16, 1)
              159:     27(ptr) AccessChain 10(dti) 26
              160:      6(int) Load 159
              162:    161(ptr) AccessChain 24(data) 25 160 158
-             163:   19(fvec4) Load 162
-             164:   19(fvec4) GroupNonUniformQuadBroadcast 35 163 26
+             163: 19(f64vec4) Load 162
+             164: 19(f64vec4) GroupNonUniformQuadBroadcast 35 163 26
              165:    161(ptr) AccessChain 24(data) 25 157 158
                               Store 165 164
              166:     27(ptr) AccessChain 10(dti) 26
@@ -8259,8 +8259,8 @@ local_size = (32, 16, 1)
              168:     27(ptr) AccessChain 10(dti) 26
              169:      6(int) Load 168
              171:    170(ptr) AccessChain 24(data) 25 169 158 26
-             172:   18(float) Load 171
-             173:   18(float) GroupNonUniformQuadBroadcast 35 172 26
+             172:18(float64_t) Load 171
+             173:18(float64_t) GroupNonUniformQuadBroadcast 35 172 26
              174:    170(ptr) AccessChain 24(data) 25 167 158 26
                               Store 174 173
              175:     27(ptr) AccessChain 10(dti) 26
@@ -8268,24 +8268,24 @@ local_size = (32, 16, 1)
              177:     27(ptr) AccessChain 10(dti) 26
              178:      6(int) Load 177
              180:    161(ptr) AccessChain 24(data) 25 178 158
-             181:   19(fvec4) Load 180
-             182:  179(fvec2) VectorShuffle 181 181 0 1
-             183:  179(fvec2) GroupNonUniformQuadBroadcast 35 182 26
+             181: 19(f64vec4) Load 180
+             182:179(f64vec2) VectorShuffle 181 181 0 1
+             183:179(f64vec2) GroupNonUniformQuadBroadcast 35 182 26
              184:    161(ptr) AccessChain 24(data) 25 176 158
-             185:   19(fvec4) Load 184
-             186:   19(fvec4) VectorShuffle 185 183 4 5 2 3
+             185: 19(f64vec4) Load 184
+             186: 19(f64vec4) VectorShuffle 185 183 4 5 2 3
                               Store 184 186
              187:     27(ptr) AccessChain 10(dti) 26
              188:      6(int) Load 187
              189:     27(ptr) AccessChain 10(dti) 26
              190:      6(int) Load 189
              192:    161(ptr) AccessChain 24(data) 25 190 158
-             193:   19(fvec4) Load 192
-             194:  191(fvec3) VectorShuffle 193 193 0 1 2
-             195:  191(fvec3) GroupNonUniformQuadBroadcast 35 194 26
+             193: 19(f64vec4) Load 192
+             194:191(f64vec3) VectorShuffle 193 193 0 1 2
+             195:191(f64vec3) GroupNonUniformQuadBroadcast 35 194 26
              196:    161(ptr) AccessChain 24(data) 25 188 158
-             197:   19(fvec4) Load 196
-             198:   19(fvec4) VectorShuffle 197 195 4 5 6 3
+             197: 19(f64vec4) Load 196
+             198: 19(f64vec4) VectorShuffle 197 195 4 5 6 3
                               Store 196 198
              199:     27(ptr) AccessChain 10(dti) 26
              200:      6(int) Load 199
@@ -8418,8 +8418,8 @@ local_size = (32, 16, 1)
              316:     27(ptr) AccessChain 10(dti) 26
              317:      6(int) Load 316
              318:    161(ptr) AccessChain 24(data) 25 317 158
-             319:   19(fvec4) Load 318
-             320:   19(fvec4) GroupNonUniformQuadBroadcast 35 319 205
+             319: 19(f64vec4) Load 318
+             320: 19(f64vec4) GroupNonUniformQuadBroadcast 35 319 205
              321:    161(ptr) AccessChain 24(data) 25 315 158
                               Store 321 320
              322:     27(ptr) AccessChain 10(dti) 26
@@ -8427,8 +8427,8 @@ local_size = (32, 16, 1)
              324:     27(ptr) AccessChain 10(dti) 26
              325:      6(int) Load 324
              326:    170(ptr) AccessChain 24(data) 25 325 158 26
-             327:   18(float) Load 326
-             328:   18(float) GroupNonUniformQuadBroadcast 35 327 205
+             327:18(float64_t) Load 326
+             328:18(float64_t) GroupNonUniformQuadBroadcast 35 327 205
              329:    170(ptr) AccessChain 24(data) 25 323 158 26
                               Store 329 328
              330:     27(ptr) AccessChain 10(dti) 26
@@ -8436,24 +8436,24 @@ local_size = (32, 16, 1)
              332:     27(ptr) AccessChain 10(dti) 26
              333:      6(int) Load 332
              334:    161(ptr) AccessChain 24(data) 25 333 158
-             335:   19(fvec4) Load 334
-             336:  179(fvec2) VectorShuffle 335 335 0 1
-             337:  179(fvec2) GroupNonUniformQuadBroadcast 35 336 205
+             335: 19(f64vec4) Load 334
+             336:179(f64vec2) VectorShuffle 335 335 0 1
+             337:179(f64vec2) GroupNonUniformQuadBroadcast 35 336 205
              338:    161(ptr) AccessChain 24(data) 25 331 158
-             339:   19(fvec4) Load 338
-             340:   19(fvec4) VectorShuffle 339 337 4 5 2 3
+             339: 19(f64vec4) Load 338
+             340: 19(f64vec4) VectorShuffle 339 337 4 5 2 3
                               Store 338 340
              341:     27(ptr) AccessChain 10(dti) 26
              342:      6(int) Load 341
              343:     27(ptr) AccessChain 10(dti) 26
              344:      6(int) Load 343
              345:    161(ptr) AccessChain 24(data) 25 344 158
-             346:   19(fvec4) Load 345
-             347:  191(fvec3) VectorShuffle 346 346 0 1 2
-             348:  191(fvec3) GroupNonUniformQuadBroadcast 35 347 205
+             346: 19(f64vec4) Load 345
+             347:191(f64vec3) VectorShuffle 346 346 0 1 2
+             348:191(f64vec3) GroupNonUniformQuadBroadcast 35 347 205
              349:    161(ptr) AccessChain 24(data) 25 342 158
-             350:   19(fvec4) Load 349
-             351:   19(fvec4) VectorShuffle 350 348 4 5 6 3
+             350: 19(f64vec4) Load 349
+             351: 19(f64vec4) VectorShuffle 350 348 4 5 6 3
                               Store 349 351
              352:     27(ptr) AccessChain 10(dti) 26
              353:      6(int) Load 352
@@ -8586,8 +8586,8 @@ local_size = (32, 16, 1)
              469:     27(ptr) AccessChain 10(dti) 26
              470:      6(int) Load 469
              471:    161(ptr) AccessChain 24(data) 25 470 158
-             472:   19(fvec4) Load 471
-             473:   19(fvec4) GroupNonUniformQuadBroadcast 35 472 358
+             472: 19(f64vec4) Load 471
+             473: 19(f64vec4) GroupNonUniformQuadBroadcast 35 472 358
              474:    161(ptr) AccessChain 24(data) 25 468 158
                               Store 474 473
              475:     27(ptr) AccessChain 10(dti) 26
@@ -8595,8 +8595,8 @@ local_size = (32, 16, 1)
              477:     27(ptr) AccessChain 10(dti) 26
              478:      6(int) Load 477
              479:    170(ptr) AccessChain 24(data) 25 478 158 26
-             480:   18(float) Load 479
-             481:   18(float) GroupNonUniformQuadBroadcast 35 480 358
+             480:18(float64_t) Load 479
+             481:18(float64_t) GroupNonUniformQuadBroadcast 35 480 358
              482:    170(ptr) AccessChain 24(data) 25 476 158 26
                               Store 482 481
              483:     27(ptr) AccessChain 10(dti) 26
@@ -8604,24 +8604,24 @@ local_size = (32, 16, 1)
              485:     27(ptr) AccessChain 10(dti) 26
              486:      6(int) Load 485
              487:    161(ptr) AccessChain 24(data) 25 486 158
-             488:   19(fvec4) Load 487
-             489:  179(fvec2) VectorShuffle 488 488 0 1
-             490:  179(fvec2) GroupNonUniformQuadBroadcast 35 489 358
+             488: 19(f64vec4) Load 487
+             489:179(f64vec2) VectorShuffle 488 488 0 1
+             490:179(f64vec2) GroupNonUniformQuadBroadcast 35 489 358
              491:    161(ptr) AccessChain 24(data) 25 484 158
-             492:   19(fvec4) Load 491
-             493:   19(fvec4) VectorShuffle 492 490 4 5 2 3
+             492: 19(f64vec4) Load 491
+             493: 19(f64vec4) VectorShuffle 492 490 4 5 2 3
                               Store 491 493
              494:     27(ptr) AccessChain 10(dti) 26
              495:      6(int) Load 494
              496:     27(ptr) AccessChain 10(dti) 26
              497:      6(int) Load 496
              498:    161(ptr) AccessChain 24(data) 25 497 158
-             499:   19(fvec4) Load 498
-             500:  191(fvec3) VectorShuffle 499 499 0 1 2
-             501:  191(fvec3) GroupNonUniformQuadBroadcast 35 500 358
+             499: 19(f64vec4) Load 498
+             500:191(f64vec3) VectorShuffle 499 499 0 1 2
+             501:191(f64vec3) GroupNonUniformQuadBroadcast 35 500 358
              502:    161(ptr) AccessChain 24(data) 25 495 158
-             503:   19(fvec4) Load 502
-             504:   19(fvec4) VectorShuffle 503 501 4 5 6 3
+             503: 19(f64vec4) Load 502
+             504: 19(f64vec4) VectorShuffle 503 501 4 5 6 3
                               Store 502 504
              505:     27(ptr) AccessChain 10(dti) 26
              506:      6(int) Load 505
@@ -8754,8 +8754,8 @@ local_size = (32, 16, 1)
              621:     27(ptr) AccessChain 10(dti) 26
              622:      6(int) Load 621
              623:    161(ptr) AccessChain 24(data) 25 622 158
-             624:   19(fvec4) Load 623
-             625:   19(fvec4) GroupNonUniformQuadBroadcast 35 624 35
+             624: 19(f64vec4) Load 623
+             625: 19(f64vec4) GroupNonUniformQuadBroadcast 35 624 35
              626:    161(ptr) AccessChain 24(data) 25 620 158
                               Store 626 625
              627:     27(ptr) AccessChain 10(dti) 26
@@ -8763,8 +8763,8 @@ local_size = (32, 16, 1)
              629:     27(ptr) AccessChain 10(dti) 26
              630:      6(int) Load 629
              631:    170(ptr) AccessChain 24(data) 25 630 158 26
-             632:   18(float) Load 631
-             633:   18(float) GroupNonUniformQuadBroadcast 35 632 35
+             632:18(float64_t) Load 631
+             633:18(float64_t) GroupNonUniformQuadBroadcast 35 632 35
              634:    170(ptr) AccessChain 24(data) 25 628 158 26
                               Store 634 633
              635:     27(ptr) AccessChain 10(dti) 26
@@ -8772,24 +8772,24 @@ local_size = (32, 16, 1)
              637:     27(ptr) AccessChain 10(dti) 26
              638:      6(int) Load 637
              639:    161(ptr) AccessChain 24(data) 25 638 158
-             640:   19(fvec4) Load 639
-             641:  179(fvec2) VectorShuffle 640 640 0 1
-             642:  179(fvec2) GroupNonUniformQuadBroadcast 35 641 35
+             640: 19(f64vec4) Load 639
+             641:179(f64vec2) VectorShuffle 640 640 0 1
+             642:179(f64vec2) GroupNonUniformQuadBroadcast 35 641 35
              643:    161(ptr) AccessChain 24(data) 25 636 158
-             644:   19(fvec4) Load 643
-             645:   19(fvec4) VectorShuffle 644 642 4 5 2 3
+             644: 19(f64vec4) Load 643
+             645: 19(f64vec4) VectorShuffle 644 642 4 5 2 3
                               Store 643 645
              646:     27(ptr) AccessChain 10(dti) 26
              647:      6(int) Load 646
              648:     27(ptr) AccessChain 10(dti) 26
              649:      6(int) Load 648
              650:    161(ptr) AccessChain 24(data) 25 649 158
-             651:   19(fvec4) Load 650
-             652:  191(fvec3) VectorShuffle 651 651 0 1 2
-             653:  191(fvec3) GroupNonUniformQuadBroadcast 35 652 35
+             651: 19(f64vec4) Load 650
+             652:191(f64vec3) VectorShuffle 651 651 0 1 2
+             653:191(f64vec3) GroupNonUniformQuadBroadcast 35 652 35
              654:    161(ptr) AccessChain 24(data) 25 647 158
-             655:   19(fvec4) Load 654
-             656:   19(fvec4) VectorShuffle 655 653 4 5 6 3
+             655: 19(f64vec4) Load 654
+             656: 19(f64vec4) VectorShuffle 655 653 4 5 6 3
                               Store 654 656
              657:     27(ptr) AccessChain 10(dti) 26
              658:      6(int) Load 657
@@ -8922,8 +8922,8 @@ local_size = (32, 16, 1)
              773:     27(ptr) AccessChain 10(dti) 26
              774:      6(int) Load 773
              775:    161(ptr) AccessChain 24(data) 25 774 158
-             776:   19(fvec4) Load 775
-             777:   19(fvec4) GroupNonUniformQuadSwap 35 776 26
+             776: 19(f64vec4) Load 775
+             777: 19(f64vec4) GroupNonUniformQuadSwap 35 776 26
              778:    161(ptr) AccessChain 24(data) 25 772 158
                               Store 778 777
              779:     27(ptr) AccessChain 10(dti) 26
@@ -8931,8 +8931,8 @@ local_size = (32, 16, 1)
              781:     27(ptr) AccessChain 10(dti) 26
              782:      6(int) Load 781
              783:    170(ptr) AccessChain 24(data) 25 782 158 26
-             784:   18(float) Load 783
-             785:   18(float) GroupNonUniformQuadSwap 35 784 26
+             784:18(float64_t) Load 783
+             785:18(float64_t) GroupNonUniformQuadSwap 35 784 26
              786:    170(ptr) AccessChain 24(data) 25 780 158 26
                               Store 786 785
              787:     27(ptr) AccessChain 10(dti) 26
@@ -8940,24 +8940,24 @@ local_size = (32, 16, 1)
              789:     27(ptr) AccessChain 10(dti) 26
              790:      6(int) Load 789
              791:    161(ptr) AccessChain 24(data) 25 790 158
-             792:   19(fvec4) Load 791
-             793:  179(fvec2) VectorShuffle 792 792 0 1
-             794:  179(fvec2) GroupNonUniformQuadSwap 35 793 26
+             792: 19(f64vec4) Load 791
+             793:179(f64vec2) VectorShuffle 792 792 0 1
+             794:179(f64vec2) GroupNonUniformQuadSwap 35 793 26
              795:    161(ptr) AccessChain 24(data) 25 788 158
-             796:   19(fvec4) Load 795
-             797:   19(fvec4) VectorShuffle 796 794 4 5 2 3
+             796: 19(f64vec4) Load 795
+             797: 19(f64vec4) VectorShuffle 796 794 4 5 2 3
                               Store 795 797
              798:     27(ptr) AccessChain 10(dti) 26
              799:      6(int) Load 798
              800:     27(ptr) AccessChain 10(dti) 26
              801:      6(int) Load 800
              802:    161(ptr) AccessChain 24(data) 25 801 158
-             803:   19(fvec4) Load 802
-             804:  191(fvec3) VectorShuffle 803 803 0 1 2
-             805:  191(fvec3) GroupNonUniformQuadSwap 35 804 26
+             803: 19(f64vec4) Load 802
+             804:191(f64vec3) VectorShuffle 803 803 0 1 2
+             805:191(f64vec3) GroupNonUniformQuadSwap 35 804 26
              806:    161(ptr) AccessChain 24(data) 25 799 158
-             807:   19(fvec4) Load 806
-             808:   19(fvec4) VectorShuffle 807 805 4 5 6 3
+             807: 19(f64vec4) Load 806
+             808: 19(f64vec4) VectorShuffle 807 805 4 5 6 3
                               Store 806 808
              809:     27(ptr) AccessChain 10(dti) 26
              810:      6(int) Load 809
@@ -9090,8 +9090,8 @@ local_size = (32, 16, 1)
              925:     27(ptr) AccessChain 10(dti) 26
              926:      6(int) Load 925
              927:    161(ptr) AccessChain 24(data) 25 926 158
-             928:   19(fvec4) Load 927
-             929:   19(fvec4) GroupNonUniformQuadSwap 35 928 205
+             928: 19(f64vec4) Load 927
+             929: 19(f64vec4) GroupNonUniformQuadSwap 35 928 205
              930:    161(ptr) AccessChain 24(data) 25 924 158
                               Store 930 929
              931:     27(ptr) AccessChain 10(dti) 26
@@ -9099,8 +9099,8 @@ local_size = (32, 16, 1)
              933:     27(ptr) AccessChain 10(dti) 26
              934:      6(int) Load 933
              935:    170(ptr) AccessChain 24(data) 25 934 158 26
-             936:   18(float) Load 935
-             937:   18(float) GroupNonUniformQuadSwap 35 936 205
+             936:18(float64_t) Load 935
+             937:18(float64_t) GroupNonUniformQuadSwap 35 936 205
              938:    170(ptr) AccessChain 24(data) 25 932 158 26
                               Store 938 937
              939:     27(ptr) AccessChain 10(dti) 26
@@ -9108,24 +9108,24 @@ local_size = (32, 16, 1)
              941:     27(ptr) AccessChain 10(dti) 26
              942:      6(int) Load 941
              943:    161(ptr) AccessChain 24(data) 25 942 158
-             944:   19(fvec4) Load 943
-             945:  179(fvec2) VectorShuffle 944 944 0 1
-             946:  179(fvec2) GroupNonUniformQuadSwap 35 945 205
+             944: 19(f64vec4) Load 943
+             945:179(f64vec2) VectorShuffle 944 944 0 1
+             946:179(f64vec2) GroupNonUniformQuadSwap 35 945 205
              947:    161(ptr) AccessChain 24(data) 25 940 158
-             948:   19(fvec4) Load 947
-             949:   19(fvec4) VectorShuffle 948 946 4 5 2 3
+             948: 19(f64vec4) Load 947
+             949: 19(f64vec4) VectorShuffle 948 946 4 5 2 3
                               Store 947 949
              950:     27(ptr) AccessChain 10(dti) 26
              951:      6(int) Load 950
              952:     27(ptr) AccessChain 10(dti) 26
              953:      6(int) Load 952
              954:    161(ptr) AccessChain 24(data) 25 953 158
-             955:   19(fvec4) Load 954
-             956:  191(fvec3) VectorShuffle 955 955 0 1 2
-             957:  191(fvec3) GroupNonUniformQuadSwap 35 956 205
+             955: 19(f64vec4) Load 954
+             956:191(f64vec3) VectorShuffle 955 955 0 1 2
+             957:191(f64vec3) GroupNonUniformQuadSwap 35 956 205
              958:    161(ptr) AccessChain 24(data) 25 951 158
-             959:   19(fvec4) Load 958
-             960:   19(fvec4) VectorShuffle 959 957 4 5 6 3
+             959: 19(f64vec4) Load 958
+             960: 19(f64vec4) VectorShuffle 959 957 4 5 6 3
                               Store 958 960
              961:     27(ptr) AccessChain 10(dti) 26
              962:      6(int) Load 961
@@ -9258,8 +9258,8 @@ local_size = (32, 16, 1)
             1077:     27(ptr) AccessChain 10(dti) 26
             1078:      6(int) Load 1077
             1079:    161(ptr) AccessChain 24(data) 25 1078 158
-            1080:   19(fvec4) Load 1079
-            1081:   19(fvec4) GroupNonUniformQuadSwap 35 1080 358
+            1080: 19(f64vec4) Load 1079
+            1081: 19(f64vec4) GroupNonUniformQuadSwap 35 1080 358
             1082:    161(ptr) AccessChain 24(data) 25 1076 158
                               Store 1082 1081
             1083:     27(ptr) AccessChain 10(dti) 26
@@ -9267,8 +9267,8 @@ local_size = (32, 16, 1)
             1085:     27(ptr) AccessChain 10(dti) 26
             1086:      6(int) Load 1085
             1087:    170(ptr) AccessChain 24(data) 25 1086 158 26
-            1088:   18(float) Load 1087
-            1089:   18(float) GroupNonUniformQuadSwap 35 1088 358
+            1088:18(float64_t) Load 1087
+            1089:18(float64_t) GroupNonUniformQuadSwap 35 1088 358
             1090:    170(ptr) AccessChain 24(data) 25 1084 158 26
                               Store 1090 1089
             1091:     27(ptr) AccessChain 10(dti) 26
@@ -9276,24 +9276,24 @@ local_size = (32, 16, 1)
             1093:     27(ptr) AccessChain 10(dti) 26
             1094:      6(int) Load 1093
             1095:    161(ptr) AccessChain 24(data) 25 1094 158
-            1096:   19(fvec4) Load 1095
-            1097:  179(fvec2) VectorShuffle 1096 1096 0 1
-            1098:  179(fvec2) GroupNonUniformQuadSwap 35 1097 358
+            1096: 19(f64vec4) Load 1095
+            1097:179(f64vec2) VectorShuffle 1096 1096 0 1
+            1098:179(f64vec2) GroupNonUniformQuadSwap 35 1097 358
             1099:    161(ptr) AccessChain 24(data) 25 1092 158
-            1100:   19(fvec4) Load 1099
-            1101:   19(fvec4) VectorShuffle 1100 1098 4 5 2 3
+            1100: 19(f64vec4) Load 1099
+            1101: 19(f64vec4) VectorShuffle 1100 1098 4 5 2 3
                               Store 1099 1101
             1102:     27(ptr) AccessChain 10(dti) 26
             1103:      6(int) Load 1102
             1104:     27(ptr) AccessChain 10(dti) 26
             1105:      6(int) Load 1104
             1106:    161(ptr) AccessChain 24(data) 25 1105 158
-            1107:   19(fvec4) Load 1106
-            1108:  191(fvec3) VectorShuffle 1107 1107 0 1 2
-            1109:  191(fvec3) GroupNonUniformQuadSwap 35 1108 358
+            1107: 19(f64vec4) Load 1106
+            1108:191(f64vec3) VectorShuffle 1107 1107 0 1 2
+            1109:191(f64vec3) GroupNonUniformQuadSwap 35 1108 358
             1110:    161(ptr) AccessChain 24(data) 25 1103 158
-            1111:   19(fvec4) Load 1110
-            1112:   19(fvec4) VectorShuffle 1111 1109 4 5 6 3
+            1111: 19(f64vec4) Load 1110
+            1112: 19(f64vec4) VectorShuffle 1111 1109 4 5 6 3
                               Store 1110 1112
                               Return
                               FunctionEnd

--- a/Test/baseResults/hlsl.wavereduction.comp.out
+++ b/Test/baseResults/hlsl.wavereduction.comp.out
@@ -6234,8 +6234,8 @@ local_size = (32, 16, 1)
               16:             TypeFloat 32
               17:             TypeVector 16(float) 4
               18:             TypeFloat 64
-              19:             TypeVector 18(float) 4
-       20(Types):             TypeStruct 13(ivec4) 15(ivec4) 17(fvec4) 19(fvec4)
+              19:             TypeVector 18(float64_t) 4
+       20(Types):             TypeStruct 13(ivec4) 15(ivec4) 17(fvec4) 19(f64vec4)
               21:             TypeRuntimeArray 20(Types)
         22(data):             TypeStruct 21
               23:             TypePointer Uniform 22(data)
@@ -6258,10 +6258,10 @@ local_size = (32, 16, 1)
              136:             TypeVector 16(float) 2
              148:             TypeVector 16(float) 3
              158:     14(int) Constant 3
-             161:             TypePointer Uniform 19(fvec4)
-             170:             TypePointer Uniform 18(float)
-             179:             TypeVector 18(float) 2
-             191:             TypeVector 18(float) 3
+             161:             TypePointer Uniform 19(f64vec4)
+             170:             TypePointer Uniform 18(float64_t)
+             179:             TypeVector 18(float64_t) 2
+             191:             TypeVector 18(float64_t) 3
              889:             TypeBool
              895:             TypePointer Input 7(ivec3)
         896(dti):    895(ptr) Variable Input
@@ -6410,8 +6410,8 @@ local_size = (32, 16, 1)
              159:     27(ptr) AccessChain 10(dti) 26
              160:      6(int) Load 159
              162:    161(ptr) AccessChain 24(data) 25 160 158
-             163:   19(fvec4) Load 162
-             164:   19(fvec4) GroupNonUniformFAdd 35 Reduce 163
+             163: 19(f64vec4) Load 162
+             164: 19(f64vec4) GroupNonUniformFAdd 35 Reduce 163
              165:    161(ptr) AccessChain 24(data) 25 157 158
                               Store 165 164
              166:     27(ptr) AccessChain 10(dti) 26
@@ -6419,8 +6419,8 @@ local_size = (32, 16, 1)
              168:     27(ptr) AccessChain 10(dti) 26
              169:      6(int) Load 168
              171:    170(ptr) AccessChain 24(data) 25 169 158 26
-             172:   18(float) Load 171
-             173:   18(float) GroupNonUniformFAdd 35 Reduce 172
+             172:18(float64_t) Load 171
+             173:18(float64_t) GroupNonUniformFAdd 35 Reduce 172
              174:    170(ptr) AccessChain 24(data) 25 167 158 26
                               Store 174 173
              175:     27(ptr) AccessChain 10(dti) 26
@@ -6428,24 +6428,24 @@ local_size = (32, 16, 1)
              177:     27(ptr) AccessChain 10(dti) 26
              178:      6(int) Load 177
              180:    161(ptr) AccessChain 24(data) 25 178 158
-             181:   19(fvec4) Load 180
-             182:  179(fvec2) VectorShuffle 181 181 0 1
-             183:  179(fvec2) GroupNonUniformFAdd 35 Reduce 182
+             181: 19(f64vec4) Load 180
+             182:179(f64vec2) VectorShuffle 181 181 0 1
+             183:179(f64vec2) GroupNonUniformFAdd 35 Reduce 182
              184:    161(ptr) AccessChain 24(data) 25 176 158
-             185:   19(fvec4) Load 184
-             186:   19(fvec4) VectorShuffle 185 183 4 5 2 3
+             185: 19(f64vec4) Load 184
+             186: 19(f64vec4) VectorShuffle 185 183 4 5 2 3
                               Store 184 186
              187:     27(ptr) AccessChain 10(dti) 26
              188:      6(int) Load 187
              189:     27(ptr) AccessChain 10(dti) 26
              190:      6(int) Load 189
              192:    161(ptr) AccessChain 24(data) 25 190 158
-             193:   19(fvec4) Load 192
-             194:  191(fvec3) VectorShuffle 193 193 0 1 2
-             195:  191(fvec3) GroupNonUniformFAdd 35 Reduce 194
+             193: 19(f64vec4) Load 192
+             194:191(f64vec3) VectorShuffle 193 193 0 1 2
+             195:191(f64vec3) GroupNonUniformFAdd 35 Reduce 194
              196:    161(ptr) AccessChain 24(data) 25 188 158
-             197:   19(fvec4) Load 196
-             198:   19(fvec4) VectorShuffle 197 195 4 5 6 3
+             197: 19(f64vec4) Load 196
+             198: 19(f64vec4) VectorShuffle 197 195 4 5 6 3
                               Store 196 198
              199:     27(ptr) AccessChain 10(dti) 26
              200:      6(int) Load 199
@@ -6578,8 +6578,8 @@ local_size = (32, 16, 1)
              315:     27(ptr) AccessChain 10(dti) 26
              316:      6(int) Load 315
              317:    161(ptr) AccessChain 24(data) 25 316 158
-             318:   19(fvec4) Load 317
-             319:   19(fvec4) GroupNonUniformFMul 35 Reduce 318
+             318: 19(f64vec4) Load 317
+             319: 19(f64vec4) GroupNonUniformFMul 35 Reduce 318
              320:    161(ptr) AccessChain 24(data) 25 314 158
                               Store 320 319
              321:     27(ptr) AccessChain 10(dti) 26
@@ -6587,8 +6587,8 @@ local_size = (32, 16, 1)
              323:     27(ptr) AccessChain 10(dti) 26
              324:      6(int) Load 323
              325:    170(ptr) AccessChain 24(data) 25 324 158 26
-             326:   18(float) Load 325
-             327:   18(float) GroupNonUniformFMul 35 Reduce 326
+             326:18(float64_t) Load 325
+             327:18(float64_t) GroupNonUniformFMul 35 Reduce 326
              328:    170(ptr) AccessChain 24(data) 25 322 158 26
                               Store 328 327
              329:     27(ptr) AccessChain 10(dti) 26
@@ -6596,24 +6596,24 @@ local_size = (32, 16, 1)
              331:     27(ptr) AccessChain 10(dti) 26
              332:      6(int) Load 331
              333:    161(ptr) AccessChain 24(data) 25 332 158
-             334:   19(fvec4) Load 333
-             335:  179(fvec2) VectorShuffle 334 334 0 1
-             336:  179(fvec2) GroupNonUniformFMul 35 Reduce 335
+             334: 19(f64vec4) Load 333
+             335:179(f64vec2) VectorShuffle 334 334 0 1
+             336:179(f64vec2) GroupNonUniformFMul 35 Reduce 335
              337:    161(ptr) AccessChain 24(data) 25 330 158
-             338:   19(fvec4) Load 337
-             339:   19(fvec4) VectorShuffle 338 336 4 5 2 3
+             338: 19(f64vec4) Load 337
+             339: 19(f64vec4) VectorShuffle 338 336 4 5 2 3
                               Store 337 339
              340:     27(ptr) AccessChain 10(dti) 26
              341:      6(int) Load 340
              342:     27(ptr) AccessChain 10(dti) 26
              343:      6(int) Load 342
              344:    161(ptr) AccessChain 24(data) 25 343 158
-             345:   19(fvec4) Load 344
-             346:  191(fvec3) VectorShuffle 345 345 0 1 2
-             347:  191(fvec3) GroupNonUniformFMul 35 Reduce 346
+             345: 19(f64vec4) Load 344
+             346:191(f64vec3) VectorShuffle 345 345 0 1 2
+             347:191(f64vec3) GroupNonUniformFMul 35 Reduce 346
              348:    161(ptr) AccessChain 24(data) 25 341 158
-             349:   19(fvec4) Load 348
-             350:   19(fvec4) VectorShuffle 349 347 4 5 6 3
+             349: 19(f64vec4) Load 348
+             350: 19(f64vec4) VectorShuffle 349 347 4 5 6 3
                               Store 348 350
              351:     27(ptr) AccessChain 10(dti) 26
              352:      6(int) Load 351
@@ -6746,8 +6746,8 @@ local_size = (32, 16, 1)
              467:     27(ptr) AccessChain 10(dti) 26
              468:      6(int) Load 467
              469:    161(ptr) AccessChain 24(data) 25 468 158
-             470:   19(fvec4) Load 469
-             471:   19(fvec4) GroupNonUniformFMin 35 Reduce 470
+             470: 19(f64vec4) Load 469
+             471: 19(f64vec4) GroupNonUniformFMin 35 Reduce 470
              472:    161(ptr) AccessChain 24(data) 25 466 158
                               Store 472 471
              473:     27(ptr) AccessChain 10(dti) 26
@@ -6755,8 +6755,8 @@ local_size = (32, 16, 1)
              475:     27(ptr) AccessChain 10(dti) 26
              476:      6(int) Load 475
              477:    170(ptr) AccessChain 24(data) 25 476 158 26
-             478:   18(float) Load 477
-             479:   18(float) GroupNonUniformFMin 35 Reduce 478
+             478:18(float64_t) Load 477
+             479:18(float64_t) GroupNonUniformFMin 35 Reduce 478
              480:    170(ptr) AccessChain 24(data) 25 474 158 26
                               Store 480 479
              481:     27(ptr) AccessChain 10(dti) 26
@@ -6764,24 +6764,24 @@ local_size = (32, 16, 1)
              483:     27(ptr) AccessChain 10(dti) 26
              484:      6(int) Load 483
              485:    161(ptr) AccessChain 24(data) 25 484 158
-             486:   19(fvec4) Load 485
-             487:  179(fvec2) VectorShuffle 486 486 0 1
-             488:  179(fvec2) GroupNonUniformFMin 35 Reduce 487
+             486: 19(f64vec4) Load 485
+             487:179(f64vec2) VectorShuffle 486 486 0 1
+             488:179(f64vec2) GroupNonUniformFMin 35 Reduce 487
              489:    161(ptr) AccessChain 24(data) 25 482 158
-             490:   19(fvec4) Load 489
-             491:   19(fvec4) VectorShuffle 490 488 4 5 2 3
+             490: 19(f64vec4) Load 489
+             491: 19(f64vec4) VectorShuffle 490 488 4 5 2 3
                               Store 489 491
              492:     27(ptr) AccessChain 10(dti) 26
              493:      6(int) Load 492
              494:     27(ptr) AccessChain 10(dti) 26
              495:      6(int) Load 494
              496:    161(ptr) AccessChain 24(data) 25 495 158
-             497:   19(fvec4) Load 496
-             498:  191(fvec3) VectorShuffle 497 497 0 1 2
-             499:  191(fvec3) GroupNonUniformFMin 35 Reduce 498
+             497: 19(f64vec4) Load 496
+             498:191(f64vec3) VectorShuffle 497 497 0 1 2
+             499:191(f64vec3) GroupNonUniformFMin 35 Reduce 498
              500:    161(ptr) AccessChain 24(data) 25 493 158
-             501:   19(fvec4) Load 500
-             502:   19(fvec4) VectorShuffle 501 499 4 5 6 3
+             501: 19(f64vec4) Load 500
+             502: 19(f64vec4) VectorShuffle 501 499 4 5 6 3
                               Store 500 502
              503:     27(ptr) AccessChain 10(dti) 26
              504:      6(int) Load 503
@@ -6914,8 +6914,8 @@ local_size = (32, 16, 1)
              619:     27(ptr) AccessChain 10(dti) 26
              620:      6(int) Load 619
              621:    161(ptr) AccessChain 24(data) 25 620 158
-             622:   19(fvec4) Load 621
-             623:   19(fvec4) GroupNonUniformFMax 35 Reduce 622
+             622: 19(f64vec4) Load 621
+             623: 19(f64vec4) GroupNonUniformFMax 35 Reduce 622
              624:    161(ptr) AccessChain 24(data) 25 618 158
                               Store 624 623
              625:     27(ptr) AccessChain 10(dti) 26
@@ -6923,8 +6923,8 @@ local_size = (32, 16, 1)
              627:     27(ptr) AccessChain 10(dti) 26
              628:      6(int) Load 627
              629:    170(ptr) AccessChain 24(data) 25 628 158 26
-             630:   18(float) Load 629
-             631:   18(float) GroupNonUniformFMax 35 Reduce 630
+             630:18(float64_t) Load 629
+             631:18(float64_t) GroupNonUniformFMax 35 Reduce 630
              632:    170(ptr) AccessChain 24(data) 25 626 158 26
                               Store 632 631
              633:     27(ptr) AccessChain 10(dti) 26
@@ -6932,24 +6932,24 @@ local_size = (32, 16, 1)
              635:     27(ptr) AccessChain 10(dti) 26
              636:      6(int) Load 635
              637:    161(ptr) AccessChain 24(data) 25 636 158
-             638:   19(fvec4) Load 637
-             639:  179(fvec2) VectorShuffle 638 638 0 1
-             640:  179(fvec2) GroupNonUniformFMax 35 Reduce 639
+             638: 19(f64vec4) Load 637
+             639:179(f64vec2) VectorShuffle 638 638 0 1
+             640:179(f64vec2) GroupNonUniformFMax 35 Reduce 639
              641:    161(ptr) AccessChain 24(data) 25 634 158
-             642:   19(fvec4) Load 641
-             643:   19(fvec4) VectorShuffle 642 640 4 5 2 3
+             642: 19(f64vec4) Load 641
+             643: 19(f64vec4) VectorShuffle 642 640 4 5 2 3
                               Store 641 643
              644:     27(ptr) AccessChain 10(dti) 26
              645:      6(int) Load 644
              646:     27(ptr) AccessChain 10(dti) 26
              647:      6(int) Load 646
              648:    161(ptr) AccessChain 24(data) 25 647 158
-             649:   19(fvec4) Load 648
-             650:  191(fvec3) VectorShuffle 649 649 0 1 2
-             651:  191(fvec3) GroupNonUniformFMax 35 Reduce 650
+             649: 19(f64vec4) Load 648
+             650:191(f64vec3) VectorShuffle 649 649 0 1 2
+             651:191(f64vec3) GroupNonUniformFMax 35 Reduce 650
              652:    161(ptr) AccessChain 24(data) 25 645 158
-             653:   19(fvec4) Load 652
-             654:   19(fvec4) VectorShuffle 653 651 4 5 6 3
+             653: 19(f64vec4) Load 652
+             654: 19(f64vec4) VectorShuffle 653 651 4 5 6 3
                               Store 652 654
              655:     27(ptr) AccessChain 10(dti) 26
              656:      6(int) Load 655

--- a/Test/baseResults/hlsl.wavevote.comp.out
+++ b/Test/baseResults/hlsl.wavevote.comp.out
@@ -238,7 +238,7 @@ local_size = (32, 16, 1)
                8:             TypePointer Function 7(ivec3)
                9:             TypeFunction 2 8(ptr)
               13:             TypeInt 64 0
-              14:             TypeRuntimeArray 13(int)
+              14:             TypeRuntimeArray 13(int64_t)
         15(data):             TypeStruct 14
               16:             TypePointer Uniform 15(data)
         17(data):     16(ptr) Variable Uniform
@@ -249,8 +249,8 @@ local_size = (32, 16, 1)
               26:             TypeBool
               28:      6(int) Constant 3
               30:             TypeVector 6(int) 4
-              32:             TypeVector 13(int) 4
-              35:             TypePointer Uniform 13(int)
+              32:             TypeVector 13(int64_t) 4
+              35:             TypePointer Uniform 13(int64_t)
               37:      6(int) Constant 1
               48:      6(int) Constant 2
               69:             TypePointer Input 7(ivec3)
@@ -276,8 +276,8 @@ local_size = (32, 16, 1)
               27:    26(bool) IEqual 25 20
               29:    26(bool) GroupNonUniformAny 28 27
               31:   30(ivec4) GroupNonUniformBallot 28 29
-              33:   32(ivec4) UConvert 31
-              34:     13(int) CompositeExtract 33 0
+              33: 32(i64vec4) UConvert 31
+              34: 13(int64_t) CompositeExtract 33 0
               36:     35(ptr) AccessChain 17(data) 19 23
                               Store 36 34
               38:     21(ptr) AccessChain 10(dti) 37
@@ -287,8 +287,8 @@ local_size = (32, 16, 1)
               42:    26(bool) IEqual 41 20
               43:    26(bool) GroupNonUniformAll 28 42
               44:   30(ivec4) GroupNonUniformBallot 28 43
-              45:   32(ivec4) UConvert 44
-              46:     13(int) CompositeExtract 45 0
+              45: 32(i64vec4) UConvert 44
+              46: 13(int64_t) CompositeExtract 45 0
               47:     35(ptr) AccessChain 17(data) 19 39
                               Store 47 46
               49:     21(ptr) AccessChain 10(dti) 48
@@ -298,8 +298,8 @@ local_size = (32, 16, 1)
               53:    26(bool) IEqual 52 20
               54:    26(bool) GroupNonUniformAllEqual 28 53
               55:   30(ivec4) GroupNonUniformBallot 28 54
-              56:   32(ivec4) UConvert 55
-              57:     13(int) CompositeExtract 56 0
+              56: 32(i64vec4) UConvert 55
+              57: 13(int64_t) CompositeExtract 56 0
               58:     35(ptr) AccessChain 17(data) 19 50
                               Store 58 57
               59:     21(ptr) AccessChain 10(dti) 48
@@ -308,8 +308,8 @@ local_size = (32, 16, 1)
               62:      6(int) Load 61
               63:    26(bool) GroupNonUniformAllEqual 28 62
               64:   30(ivec4) GroupNonUniformBallot 28 63
-              65:   32(ivec4) UConvert 64
-              66:     13(int) CompositeExtract 65 0
+              65: 32(i64vec4) UConvert 64
+              66: 13(int64_t) CompositeExtract 65 0
               67:     35(ptr) AccessChain 17(data) 19 60
                               Store 67 66
                               Return

--- a/Test/baseResults/remap.hlsl.templatetypes.none.frag.out
+++ b/Test/baseResults/remap.hlsl.templatetypes.none.frag.out
@@ -68,8 +68,8 @@ remap.hlsl.templatetypes.none.frag
               29:     26(int) Constant 1
               30:             TypePointer Function 6(float)
               32:             TypeFloat 64
-              33:             TypePointer Function 32(float)
-              35:   32(float) Constant 0 1072693248
+              33:             TypePointer Function 32(float64_t)
+              35:32(float64_t) Constant 0 1072693248
               36:             TypeInt 32 0
               37:             TypePointer Function 36(int)
               39:     36(int) Constant 1
@@ -84,10 +84,10 @@ remap.hlsl.templatetypes.none.frag
               50:             TypeVector 6(float) 2
               51:             TypePointer Function 50(fvec2)
               53:   50(fvec2) ConstantComposite 14 15
-              54:             TypeVector 32(float) 2
-              55:             TypePointer Function 54(fvec2)
-              57:   32(float) Constant 0 1073741824
-              58:   54(fvec2) ConstantComposite 35 57
+              54:             TypeVector 32(float64_t) 2
+              55:             TypePointer Function 54(f64vec2)
+              57:32(float64_t) Constant 0 1073741824
+              58: 54(f64vec2) ConstantComposite 35 57
               59:             TypeVector 36(int) 2
               60:             TypePointer Function 59(ivec2)
               62:     36(int) Constant 2
@@ -102,10 +102,10 @@ remap.hlsl.templatetypes.none.frag
               73:             TypeVector 6(float) 3
               74:             TypePointer Function 73(fvec3)
               76:   73(fvec3) ConstantComposite 14 15 16
-              77:             TypeVector 32(float) 3
-              78:             TypePointer Function 77(fvec3)
-              80:   32(float) Constant 0 1074266112
-              81:   77(fvec3) ConstantComposite 35 57 80
+              77:             TypeVector 32(float64_t) 3
+              78:             TypePointer Function 77(f64vec3)
+              80:32(float64_t) Constant 0 1074266112
+              81: 77(f64vec3) ConstantComposite 35 57 80
               82:             TypeVector 36(int) 3
               83:             TypePointer Function 82(ivec3)
               85:     36(int) Constant 3
@@ -117,10 +117,10 @@ remap.hlsl.templatetypes.none.frag
               92:             TypePointer Function 91(ivec4)
               94:     26(int) Constant 4
               95:   91(ivec4) ConstantComposite 29 48 71 94
-              97:             TypeVector 32(float) 4
-              98:             TypePointer Function 97(fvec4)
-             100:   32(float) Constant 0 1074790400
-             101:   97(fvec4) ConstantComposite 35 57 80 100
+              97:             TypeVector 32(float64_t) 4
+              98:             TypePointer Function 97(f64vec4)
+             100:32(float64_t) Constant 0 1074790400
+             101: 97(f64vec4) ConstantComposite 35 57 80 100
              102:             TypeVector 36(int) 4
              103:             TypePointer Function 102(ivec4)
              105:     36(int) Constant 4

--- a/Test/baseResults/remap.literal64.none.spv.out
+++ b/Test/baseResults/remap.literal64.none.spv.out
@@ -8,7 +8,7 @@ remap.literal64.none.spv
                1:             TypeVoid
                2:             TypeInt 64 1
                3:             TypeFunction 1
-               4:      2(int) Constant 0 0
+               4:  2(int64_t) Constant 0 0
                5:           1 Function None 3
                6:             Label
                               SelectionMerge 7 None

--- a/Test/baseResults/spv.400.frag.out
+++ b/Test/baseResults/spv.400.frag.out
@@ -85,18 +85,18 @@ spv.400.frag
               33:     32(int) Constant 0
               34:             TypePointer Output 10(float)
               39:             TypeFloat 64
-              40:             TypePointer Function 39(float)
-              42:   39(float) Constant 2507418074 1073430332
-              43:             TypeVector 39(float) 2
-              44:             TypePointer Function 43(fvec2)
-              46:   39(float) Constant 796182188 1073367658
-              47:   43(fvec2) ConstantComposite 46 46
-              48:             TypeVector 39(float) 3
-              49:             TypePointer Function 48(fvec3)
-              51:   39(float) Constant 1719614413 1073127582
-              52:   48(fvec3) ConstantComposite 51 51 51
-              53:             TypeVector 39(float) 4
-              54:             TypePointer Function 53(fvec4)
+              40:             TypePointer Function 39(float64_t)
+              42:39(float64_t) Constant 2507418074 1073430332
+              43:             TypeVector 39(float64_t) 2
+              44:             TypePointer Function 43(f64vec2)
+              46:39(float64_t) Constant 796182188 1073367658
+              47: 43(f64vec2) ConstantComposite 46 46
+              48:             TypeVector 39(float64_t) 3
+              49:             TypePointer Function 48(f64vec3)
+              51:39(float64_t) Constant 1719614413 1073127582
+              52: 48(f64vec3) ConstantComposite 51 51 51
+              53:             TypeVector 39(float64_t) 4
+              54:             TypePointer Function 53(f64vec4)
              428:             TypeBool
              429:             TypePointer Function 428(bool)
              437:             TypeVector 428(bool) 2
@@ -110,23 +110,23 @@ spv.400.frag
              581:  446(bvec3) ConstantComposite 563 563 563
              590:  455(bvec4) ConstantComposite 563 563 563 563
              715:   10(float) Constant 1067869798
-             734:             TypeMatrix 43(fvec2) 2
+             734:             TypeMatrix 43(f64vec2) 2
              735:             TypePointer Function 734
-             740:             TypeMatrix 48(fvec3) 3
+             740:             TypeMatrix 48(f64vec3) 3
              741:             TypePointer Function 740
-             746:             TypeMatrix 53(fvec4) 4
+             746:             TypeMatrix 53(f64vec4) 4
              747:             TypePointer Function 746
-             752:             TypeMatrix 48(fvec3) 2
+             752:             TypeMatrix 48(f64vec3) 2
              753:             TypePointer Function 752
-             758:             TypeMatrix 43(fvec2) 3
+             758:             TypeMatrix 43(f64vec2) 3
              759:             TypePointer Function 758
-             764:             TypeMatrix 53(fvec4) 2
+             764:             TypeMatrix 53(f64vec4) 2
              765:             TypePointer Function 764
-             770:             TypeMatrix 43(fvec2) 4
+             770:             TypeMatrix 43(f64vec2) 4
              771:             TypePointer Function 770
-             776:             TypeMatrix 53(fvec4) 3
+             776:             TypeMatrix 53(f64vec4) 3
              777:             TypePointer Function 776
-             782:             TypeMatrix 48(fvec3) 4
+             782:             TypeMatrix 48(f64vec3) 4
              783:             TypePointer Function 782
              951:     32(int) Constant 1
              955:     32(int) Constant 2
@@ -290,597 +290,597 @@ spv.400.frag
                               Store 41(doublev) 42
                               Store 45(dvec2v) 47
                               Store 50(dvec3v) 52
-              56:   39(float) Load 41(doublev)
-              57:   53(fvec4) CompositeConstruct 56 56 56 56
-              58:   53(fvec4) ExtInst 1(GLSL.std.450) 31(Sqrt) 57
+              56:39(float64_t) Load 41(doublev)
+              57: 53(f64vec4) CompositeConstruct 56 56 56 56
+              58: 53(f64vec4) ExtInst 1(GLSL.std.450) 31(Sqrt) 57
                               Store 55(dvec4v) 58
-              59:   39(float) Load 41(doublev)
-              60:   39(float) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 59
-              61:   39(float) Load 41(doublev)
-              62:   39(float) FAdd 61 60
+              59:39(float64_t) Load 41(doublev)
+              60:39(float64_t) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 59
+              61:39(float64_t) Load 41(doublev)
+              62:39(float64_t) FAdd 61 60
                               Store 41(doublev) 62
-              63:   43(fvec2) Load 45(dvec2v)
-              64:   43(fvec2) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 63
-              65:   43(fvec2) Load 45(dvec2v)
-              66:   43(fvec2) FAdd 65 64
+              63: 43(f64vec2) Load 45(dvec2v)
+              64: 43(f64vec2) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 63
+              65: 43(f64vec2) Load 45(dvec2v)
+              66: 43(f64vec2) FAdd 65 64
                               Store 45(dvec2v) 66
-              67:   48(fvec3) Load 50(dvec3v)
-              68:   48(fvec3) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 67
-              69:   48(fvec3) Load 50(dvec3v)
-              70:   48(fvec3) FAdd 69 68
+              67: 48(f64vec3) Load 50(dvec3v)
+              68: 48(f64vec3) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 67
+              69: 48(f64vec3) Load 50(dvec3v)
+              70: 48(f64vec3) FAdd 69 68
                               Store 50(dvec3v) 70
-              71:   53(fvec4) Load 55(dvec4v)
-              72:   53(fvec4) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 71
-              73:   53(fvec4) Load 55(dvec4v)
-              74:   53(fvec4) FAdd 73 72
+              71: 53(f64vec4) Load 55(dvec4v)
+              72: 53(f64vec4) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 71
+              73: 53(f64vec4) Load 55(dvec4v)
+              74: 53(f64vec4) FAdd 73 72
                               Store 55(dvec4v) 74
-              75:   39(float) Load 41(doublev)
-              76:   39(float) ExtInst 1(GLSL.std.450) 4(FAbs) 75
-              77:   39(float) Load 41(doublev)
-              78:   39(float) FAdd 77 76
+              75:39(float64_t) Load 41(doublev)
+              76:39(float64_t) ExtInst 1(GLSL.std.450) 4(FAbs) 75
+              77:39(float64_t) Load 41(doublev)
+              78:39(float64_t) FAdd 77 76
                               Store 41(doublev) 78
-              79:   43(fvec2) Load 45(dvec2v)
-              80:   43(fvec2) ExtInst 1(GLSL.std.450) 4(FAbs) 79
-              81:   43(fvec2) Load 45(dvec2v)
-              82:   43(fvec2) FAdd 81 80
+              79: 43(f64vec2) Load 45(dvec2v)
+              80: 43(f64vec2) ExtInst 1(GLSL.std.450) 4(FAbs) 79
+              81: 43(f64vec2) Load 45(dvec2v)
+              82: 43(f64vec2) FAdd 81 80
                               Store 45(dvec2v) 82
-              83:   48(fvec3) Load 50(dvec3v)
-              84:   48(fvec3) ExtInst 1(GLSL.std.450) 4(FAbs) 83
-              85:   48(fvec3) Load 50(dvec3v)
-              86:   48(fvec3) FAdd 85 84
+              83: 48(f64vec3) Load 50(dvec3v)
+              84: 48(f64vec3) ExtInst 1(GLSL.std.450) 4(FAbs) 83
+              85: 48(f64vec3) Load 50(dvec3v)
+              86: 48(f64vec3) FAdd 85 84
                               Store 50(dvec3v) 86
-              87:   53(fvec4) Load 55(dvec4v)
-              88:   53(fvec4) ExtInst 1(GLSL.std.450) 4(FAbs) 87
-              89:   53(fvec4) Load 55(dvec4v)
-              90:   53(fvec4) FAdd 89 88
+              87: 53(f64vec4) Load 55(dvec4v)
+              88: 53(f64vec4) ExtInst 1(GLSL.std.450) 4(FAbs) 87
+              89: 53(f64vec4) Load 55(dvec4v)
+              90: 53(f64vec4) FAdd 89 88
                               Store 55(dvec4v) 90
-              91:   39(float) Load 41(doublev)
-              92:   39(float) ExtInst 1(GLSL.std.450) 6(FSign) 91
-              93:   39(float) Load 41(doublev)
-              94:   39(float) FAdd 93 92
+              91:39(float64_t) Load 41(doublev)
+              92:39(float64_t) ExtInst 1(GLSL.std.450) 6(FSign) 91
+              93:39(float64_t) Load 41(doublev)
+              94:39(float64_t) FAdd 93 92
                               Store 41(doublev) 94
-              95:   43(fvec2) Load 45(dvec2v)
-              96:   43(fvec2) ExtInst 1(GLSL.std.450) 6(FSign) 95
-              97:   43(fvec2) Load 45(dvec2v)
-              98:   43(fvec2) FAdd 97 96
+              95: 43(f64vec2) Load 45(dvec2v)
+              96: 43(f64vec2) ExtInst 1(GLSL.std.450) 6(FSign) 95
+              97: 43(f64vec2) Load 45(dvec2v)
+              98: 43(f64vec2) FAdd 97 96
                               Store 45(dvec2v) 98
-              99:   48(fvec3) Load 50(dvec3v)
-             100:   48(fvec3) ExtInst 1(GLSL.std.450) 6(FSign) 99
-             101:   48(fvec3) Load 50(dvec3v)
-             102:   48(fvec3) FAdd 101 100
+              99: 48(f64vec3) Load 50(dvec3v)
+             100: 48(f64vec3) ExtInst 1(GLSL.std.450) 6(FSign) 99
+             101: 48(f64vec3) Load 50(dvec3v)
+             102: 48(f64vec3) FAdd 101 100
                               Store 50(dvec3v) 102
-             103:   53(fvec4) Load 55(dvec4v)
-             104:   53(fvec4) ExtInst 1(GLSL.std.450) 6(FSign) 103
-             105:   53(fvec4) Load 55(dvec4v)
-             106:   53(fvec4) FAdd 105 104
+             103: 53(f64vec4) Load 55(dvec4v)
+             104: 53(f64vec4) ExtInst 1(GLSL.std.450) 6(FSign) 103
+             105: 53(f64vec4) Load 55(dvec4v)
+             106: 53(f64vec4) FAdd 105 104
                               Store 55(dvec4v) 106
-             107:   39(float) Load 41(doublev)
-             108:   39(float) ExtInst 1(GLSL.std.450) 8(Floor) 107
-             109:   39(float) Load 41(doublev)
-             110:   39(float) FAdd 109 108
+             107:39(float64_t) Load 41(doublev)
+             108:39(float64_t) ExtInst 1(GLSL.std.450) 8(Floor) 107
+             109:39(float64_t) Load 41(doublev)
+             110:39(float64_t) FAdd 109 108
                               Store 41(doublev) 110
-             111:   43(fvec2) Load 45(dvec2v)
-             112:   43(fvec2) ExtInst 1(GLSL.std.450) 8(Floor) 111
-             113:   43(fvec2) Load 45(dvec2v)
-             114:   43(fvec2) FAdd 113 112
+             111: 43(f64vec2) Load 45(dvec2v)
+             112: 43(f64vec2) ExtInst 1(GLSL.std.450) 8(Floor) 111
+             113: 43(f64vec2) Load 45(dvec2v)
+             114: 43(f64vec2) FAdd 113 112
                               Store 45(dvec2v) 114
-             115:   48(fvec3) Load 50(dvec3v)
-             116:   48(fvec3) ExtInst 1(GLSL.std.450) 8(Floor) 115
-             117:   48(fvec3) Load 50(dvec3v)
-             118:   48(fvec3) FAdd 117 116
+             115: 48(f64vec3) Load 50(dvec3v)
+             116: 48(f64vec3) ExtInst 1(GLSL.std.450) 8(Floor) 115
+             117: 48(f64vec3) Load 50(dvec3v)
+             118: 48(f64vec3) FAdd 117 116
                               Store 50(dvec3v) 118
-             119:   53(fvec4) Load 55(dvec4v)
-             120:   53(fvec4) ExtInst 1(GLSL.std.450) 8(Floor) 119
-             121:   53(fvec4) Load 55(dvec4v)
-             122:   53(fvec4) FAdd 121 120
+             119: 53(f64vec4) Load 55(dvec4v)
+             120: 53(f64vec4) ExtInst 1(GLSL.std.450) 8(Floor) 119
+             121: 53(f64vec4) Load 55(dvec4v)
+             122: 53(f64vec4) FAdd 121 120
                               Store 55(dvec4v) 122
-             123:   39(float) Load 41(doublev)
-             124:   39(float) ExtInst 1(GLSL.std.450) 3(Trunc) 123
-             125:   39(float) Load 41(doublev)
-             126:   39(float) FAdd 125 124
+             123:39(float64_t) Load 41(doublev)
+             124:39(float64_t) ExtInst 1(GLSL.std.450) 3(Trunc) 123
+             125:39(float64_t) Load 41(doublev)
+             126:39(float64_t) FAdd 125 124
                               Store 41(doublev) 126
-             127:   43(fvec2) Load 45(dvec2v)
-             128:   43(fvec2) ExtInst 1(GLSL.std.450) 3(Trunc) 127
-             129:   43(fvec2) Load 45(dvec2v)
-             130:   43(fvec2) FAdd 129 128
+             127: 43(f64vec2) Load 45(dvec2v)
+             128: 43(f64vec2) ExtInst 1(GLSL.std.450) 3(Trunc) 127
+             129: 43(f64vec2) Load 45(dvec2v)
+             130: 43(f64vec2) FAdd 129 128
                               Store 45(dvec2v) 130
-             131:   48(fvec3) Load 50(dvec3v)
-             132:   48(fvec3) ExtInst 1(GLSL.std.450) 3(Trunc) 131
-             133:   48(fvec3) Load 50(dvec3v)
-             134:   48(fvec3) FAdd 133 132
+             131: 48(f64vec3) Load 50(dvec3v)
+             132: 48(f64vec3) ExtInst 1(GLSL.std.450) 3(Trunc) 131
+             133: 48(f64vec3) Load 50(dvec3v)
+             134: 48(f64vec3) FAdd 133 132
                               Store 50(dvec3v) 134
-             135:   53(fvec4) Load 55(dvec4v)
-             136:   53(fvec4) ExtInst 1(GLSL.std.450) 3(Trunc) 135
-             137:   53(fvec4) Load 55(dvec4v)
-             138:   53(fvec4) FAdd 137 136
+             135: 53(f64vec4) Load 55(dvec4v)
+             136: 53(f64vec4) ExtInst 1(GLSL.std.450) 3(Trunc) 135
+             137: 53(f64vec4) Load 55(dvec4v)
+             138: 53(f64vec4) FAdd 137 136
                               Store 55(dvec4v) 138
-             139:   39(float) Load 41(doublev)
-             140:   39(float) ExtInst 1(GLSL.std.450) 1(Round) 139
-             141:   39(float) Load 41(doublev)
-             142:   39(float) FAdd 141 140
+             139:39(float64_t) Load 41(doublev)
+             140:39(float64_t) ExtInst 1(GLSL.std.450) 1(Round) 139
+             141:39(float64_t) Load 41(doublev)
+             142:39(float64_t) FAdd 141 140
                               Store 41(doublev) 142
-             143:   43(fvec2) Load 45(dvec2v)
-             144:   43(fvec2) ExtInst 1(GLSL.std.450) 1(Round) 143
-             145:   43(fvec2) Load 45(dvec2v)
-             146:   43(fvec2) FAdd 145 144
+             143: 43(f64vec2) Load 45(dvec2v)
+             144: 43(f64vec2) ExtInst 1(GLSL.std.450) 1(Round) 143
+             145: 43(f64vec2) Load 45(dvec2v)
+             146: 43(f64vec2) FAdd 145 144
                               Store 45(dvec2v) 146
-             147:   48(fvec3) Load 50(dvec3v)
-             148:   48(fvec3) ExtInst 1(GLSL.std.450) 1(Round) 147
-             149:   48(fvec3) Load 50(dvec3v)
-             150:   48(fvec3) FAdd 149 148
+             147: 48(f64vec3) Load 50(dvec3v)
+             148: 48(f64vec3) ExtInst 1(GLSL.std.450) 1(Round) 147
+             149: 48(f64vec3) Load 50(dvec3v)
+             150: 48(f64vec3) FAdd 149 148
                               Store 50(dvec3v) 150
-             151:   53(fvec4) Load 55(dvec4v)
-             152:   53(fvec4) ExtInst 1(GLSL.std.450) 1(Round) 151
-             153:   53(fvec4) Load 55(dvec4v)
-             154:   53(fvec4) FAdd 153 152
+             151: 53(f64vec4) Load 55(dvec4v)
+             152: 53(f64vec4) ExtInst 1(GLSL.std.450) 1(Round) 151
+             153: 53(f64vec4) Load 55(dvec4v)
+             154: 53(f64vec4) FAdd 153 152
                               Store 55(dvec4v) 154
-             155:   39(float) Load 41(doublev)
-             156:   39(float) ExtInst 1(GLSL.std.450) 2(RoundEven) 155
-             157:   39(float) Load 41(doublev)
-             158:   39(float) FAdd 157 156
+             155:39(float64_t) Load 41(doublev)
+             156:39(float64_t) ExtInst 1(GLSL.std.450) 2(RoundEven) 155
+             157:39(float64_t) Load 41(doublev)
+             158:39(float64_t) FAdd 157 156
                               Store 41(doublev) 158
-             159:   43(fvec2) Load 45(dvec2v)
-             160:   43(fvec2) ExtInst 1(GLSL.std.450) 2(RoundEven) 159
-             161:   43(fvec2) Load 45(dvec2v)
-             162:   43(fvec2) FAdd 161 160
+             159: 43(f64vec2) Load 45(dvec2v)
+             160: 43(f64vec2) ExtInst 1(GLSL.std.450) 2(RoundEven) 159
+             161: 43(f64vec2) Load 45(dvec2v)
+             162: 43(f64vec2) FAdd 161 160
                               Store 45(dvec2v) 162
-             163:   48(fvec3) Load 50(dvec3v)
-             164:   48(fvec3) ExtInst 1(GLSL.std.450) 2(RoundEven) 163
-             165:   48(fvec3) Load 50(dvec3v)
-             166:   48(fvec3) FAdd 165 164
+             163: 48(f64vec3) Load 50(dvec3v)
+             164: 48(f64vec3) ExtInst 1(GLSL.std.450) 2(RoundEven) 163
+             165: 48(f64vec3) Load 50(dvec3v)
+             166: 48(f64vec3) FAdd 165 164
                               Store 50(dvec3v) 166
-             167:   53(fvec4) Load 55(dvec4v)
-             168:   53(fvec4) ExtInst 1(GLSL.std.450) 2(RoundEven) 167
-             169:   53(fvec4) Load 55(dvec4v)
-             170:   53(fvec4) FAdd 169 168
+             167: 53(f64vec4) Load 55(dvec4v)
+             168: 53(f64vec4) ExtInst 1(GLSL.std.450) 2(RoundEven) 167
+             169: 53(f64vec4) Load 55(dvec4v)
+             170: 53(f64vec4) FAdd 169 168
                               Store 55(dvec4v) 170
-             171:   39(float) Load 41(doublev)
-             172:   39(float) ExtInst 1(GLSL.std.450) 9(Ceil) 171
-             173:   39(float) Load 41(doublev)
-             174:   39(float) FAdd 173 172
+             171:39(float64_t) Load 41(doublev)
+             172:39(float64_t) ExtInst 1(GLSL.std.450) 9(Ceil) 171
+             173:39(float64_t) Load 41(doublev)
+             174:39(float64_t) FAdd 173 172
                               Store 41(doublev) 174
-             175:   43(fvec2) Load 45(dvec2v)
-             176:   43(fvec2) ExtInst 1(GLSL.std.450) 9(Ceil) 175
-             177:   43(fvec2) Load 45(dvec2v)
-             178:   43(fvec2) FAdd 177 176
+             175: 43(f64vec2) Load 45(dvec2v)
+             176: 43(f64vec2) ExtInst 1(GLSL.std.450) 9(Ceil) 175
+             177: 43(f64vec2) Load 45(dvec2v)
+             178: 43(f64vec2) FAdd 177 176
                               Store 45(dvec2v) 178
-             179:   48(fvec3) Load 50(dvec3v)
-             180:   48(fvec3) ExtInst 1(GLSL.std.450) 9(Ceil) 179
-             181:   48(fvec3) Load 50(dvec3v)
-             182:   48(fvec3) FAdd 181 180
+             179: 48(f64vec3) Load 50(dvec3v)
+             180: 48(f64vec3) ExtInst 1(GLSL.std.450) 9(Ceil) 179
+             181: 48(f64vec3) Load 50(dvec3v)
+             182: 48(f64vec3) FAdd 181 180
                               Store 50(dvec3v) 182
-             183:   53(fvec4) Load 55(dvec4v)
-             184:   53(fvec4) ExtInst 1(GLSL.std.450) 9(Ceil) 183
-             185:   53(fvec4) Load 55(dvec4v)
-             186:   53(fvec4) FAdd 185 184
+             183: 53(f64vec4) Load 55(dvec4v)
+             184: 53(f64vec4) ExtInst 1(GLSL.std.450) 9(Ceil) 183
+             185: 53(f64vec4) Load 55(dvec4v)
+             186: 53(f64vec4) FAdd 185 184
                               Store 55(dvec4v) 186
-             187:   39(float) Load 41(doublev)
-             188:   39(float) ExtInst 1(GLSL.std.450) 10(Fract) 187
-             189:   39(float) Load 41(doublev)
-             190:   39(float) FAdd 189 188
+             187:39(float64_t) Load 41(doublev)
+             188:39(float64_t) ExtInst 1(GLSL.std.450) 10(Fract) 187
+             189:39(float64_t) Load 41(doublev)
+             190:39(float64_t) FAdd 189 188
                               Store 41(doublev) 190
-             191:   43(fvec2) Load 45(dvec2v)
-             192:   43(fvec2) ExtInst 1(GLSL.std.450) 10(Fract) 191
-             193:   43(fvec2) Load 45(dvec2v)
-             194:   43(fvec2) FAdd 193 192
+             191: 43(f64vec2) Load 45(dvec2v)
+             192: 43(f64vec2) ExtInst 1(GLSL.std.450) 10(Fract) 191
+             193: 43(f64vec2) Load 45(dvec2v)
+             194: 43(f64vec2) FAdd 193 192
                               Store 45(dvec2v) 194
-             195:   48(fvec3) Load 50(dvec3v)
-             196:   48(fvec3) ExtInst 1(GLSL.std.450) 10(Fract) 195
-             197:   48(fvec3) Load 50(dvec3v)
-             198:   48(fvec3) FAdd 197 196
+             195: 48(f64vec3) Load 50(dvec3v)
+             196: 48(f64vec3) ExtInst 1(GLSL.std.450) 10(Fract) 195
+             197: 48(f64vec3) Load 50(dvec3v)
+             198: 48(f64vec3) FAdd 197 196
                               Store 50(dvec3v) 198
-             199:   53(fvec4) Load 55(dvec4v)
-             200:   53(fvec4) ExtInst 1(GLSL.std.450) 10(Fract) 199
-             201:   53(fvec4) Load 55(dvec4v)
-             202:   53(fvec4) FAdd 201 200
+             199: 53(f64vec4) Load 55(dvec4v)
+             200: 53(f64vec4) ExtInst 1(GLSL.std.450) 10(Fract) 199
+             201: 53(f64vec4) Load 55(dvec4v)
+             202: 53(f64vec4) FAdd 201 200
                               Store 55(dvec4v) 202
-             203:   39(float) Load 41(doublev)
-             204:   39(float) Load 41(doublev)
-             205:   39(float) FMod 203 204
-             206:   39(float) Load 41(doublev)
-             207:   39(float) FAdd 206 205
+             203:39(float64_t) Load 41(doublev)
+             204:39(float64_t) Load 41(doublev)
+             205:39(float64_t) FMod 203 204
+             206:39(float64_t) Load 41(doublev)
+             207:39(float64_t) FAdd 206 205
                               Store 41(doublev) 207
-             208:   43(fvec2) Load 45(dvec2v)
-             209:   39(float) Load 41(doublev)
-             210:   43(fvec2) CompositeConstruct 209 209
-             211:   43(fvec2) FMod 208 210
-             212:   43(fvec2) Load 45(dvec2v)
-             213:   43(fvec2) FAdd 212 211
+             208: 43(f64vec2) Load 45(dvec2v)
+             209:39(float64_t) Load 41(doublev)
+             210: 43(f64vec2) CompositeConstruct 209 209
+             211: 43(f64vec2) FMod 208 210
+             212: 43(f64vec2) Load 45(dvec2v)
+             213: 43(f64vec2) FAdd 212 211
                               Store 45(dvec2v) 213
-             214:   48(fvec3) Load 50(dvec3v)
-             215:   39(float) Load 41(doublev)
-             216:   48(fvec3) CompositeConstruct 215 215 215
-             217:   48(fvec3) FMod 214 216
-             218:   48(fvec3) Load 50(dvec3v)
-             219:   48(fvec3) FAdd 218 217
+             214: 48(f64vec3) Load 50(dvec3v)
+             215:39(float64_t) Load 41(doublev)
+             216: 48(f64vec3) CompositeConstruct 215 215 215
+             217: 48(f64vec3) FMod 214 216
+             218: 48(f64vec3) Load 50(dvec3v)
+             219: 48(f64vec3) FAdd 218 217
                               Store 50(dvec3v) 219
-             220:   53(fvec4) Load 55(dvec4v)
-             221:   39(float) Load 41(doublev)
-             222:   53(fvec4) CompositeConstruct 221 221 221 221
-             223:   53(fvec4) FMod 220 222
-             224:   53(fvec4) Load 55(dvec4v)
-             225:   53(fvec4) FAdd 224 223
+             220: 53(f64vec4) Load 55(dvec4v)
+             221:39(float64_t) Load 41(doublev)
+             222: 53(f64vec4) CompositeConstruct 221 221 221 221
+             223: 53(f64vec4) FMod 220 222
+             224: 53(f64vec4) Load 55(dvec4v)
+             225: 53(f64vec4) FAdd 224 223
                               Store 55(dvec4v) 225
-             226:   43(fvec2) Load 45(dvec2v)
-             227:   43(fvec2) Load 45(dvec2v)
-             228:   43(fvec2) FMod 226 227
-             229:   43(fvec2) Load 45(dvec2v)
-             230:   43(fvec2) FAdd 229 228
+             226: 43(f64vec2) Load 45(dvec2v)
+             227: 43(f64vec2) Load 45(dvec2v)
+             228: 43(f64vec2) FMod 226 227
+             229: 43(f64vec2) Load 45(dvec2v)
+             230: 43(f64vec2) FAdd 229 228
                               Store 45(dvec2v) 230
-             231:   48(fvec3) Load 50(dvec3v)
-             232:   48(fvec3) Load 50(dvec3v)
-             233:   48(fvec3) FMod 231 232
-             234:   48(fvec3) Load 50(dvec3v)
-             235:   48(fvec3) FAdd 234 233
+             231: 48(f64vec3) Load 50(dvec3v)
+             232: 48(f64vec3) Load 50(dvec3v)
+             233: 48(f64vec3) FMod 231 232
+             234: 48(f64vec3) Load 50(dvec3v)
+             235: 48(f64vec3) FAdd 234 233
                               Store 50(dvec3v) 235
-             236:   53(fvec4) Load 55(dvec4v)
-             237:   53(fvec4) Load 55(dvec4v)
-             238:   53(fvec4) FMod 236 237
-             239:   53(fvec4) Load 55(dvec4v)
-             240:   53(fvec4) FAdd 239 238
+             236: 53(f64vec4) Load 55(dvec4v)
+             237: 53(f64vec4) Load 55(dvec4v)
+             238: 53(f64vec4) FMod 236 237
+             239: 53(f64vec4) Load 55(dvec4v)
+             240: 53(f64vec4) FAdd 239 238
                               Store 55(dvec4v) 240
-             241:   39(float) Load 41(doublev)
-             242:   39(float) ExtInst 1(GLSL.std.450) 35(Modf) 241 41(doublev)
-             243:   39(float) Load 41(doublev)
-             244:   39(float) FAdd 243 242
+             241:39(float64_t) Load 41(doublev)
+             242:39(float64_t) ExtInst 1(GLSL.std.450) 35(Modf) 241 41(doublev)
+             243:39(float64_t) Load 41(doublev)
+             244:39(float64_t) FAdd 243 242
                               Store 41(doublev) 244
-             245:   43(fvec2) Load 45(dvec2v)
-             246:   43(fvec2) ExtInst 1(GLSL.std.450) 35(Modf) 245 45(dvec2v)
-             247:   43(fvec2) Load 45(dvec2v)
-             248:   43(fvec2) FAdd 247 246
+             245: 43(f64vec2) Load 45(dvec2v)
+             246: 43(f64vec2) ExtInst 1(GLSL.std.450) 35(Modf) 245 45(dvec2v)
+             247: 43(f64vec2) Load 45(dvec2v)
+             248: 43(f64vec2) FAdd 247 246
                               Store 45(dvec2v) 248
-             249:   48(fvec3) Load 50(dvec3v)
-             250:   48(fvec3) ExtInst 1(GLSL.std.450) 35(Modf) 249 50(dvec3v)
-             251:   48(fvec3) Load 50(dvec3v)
-             252:   48(fvec3) FAdd 251 250
+             249: 48(f64vec3) Load 50(dvec3v)
+             250: 48(f64vec3) ExtInst 1(GLSL.std.450) 35(Modf) 249 50(dvec3v)
+             251: 48(f64vec3) Load 50(dvec3v)
+             252: 48(f64vec3) FAdd 251 250
                               Store 50(dvec3v) 252
-             253:   53(fvec4) Load 55(dvec4v)
-             254:   53(fvec4) ExtInst 1(GLSL.std.450) 35(Modf) 253 55(dvec4v)
-             255:   53(fvec4) Load 55(dvec4v)
-             256:   53(fvec4) FAdd 255 254
+             253: 53(f64vec4) Load 55(dvec4v)
+             254: 53(f64vec4) ExtInst 1(GLSL.std.450) 35(Modf) 253 55(dvec4v)
+             255: 53(f64vec4) Load 55(dvec4v)
+             256: 53(f64vec4) FAdd 255 254
                               Store 55(dvec4v) 256
-             257:   39(float) Load 41(doublev)
-             258:   39(float) Load 41(doublev)
-             259:   39(float) ExtInst 1(GLSL.std.450) 37(FMin) 257 258
-             260:   39(float) Load 41(doublev)
-             261:   39(float) FAdd 260 259
+             257:39(float64_t) Load 41(doublev)
+             258:39(float64_t) Load 41(doublev)
+             259:39(float64_t) ExtInst 1(GLSL.std.450) 37(FMin) 257 258
+             260:39(float64_t) Load 41(doublev)
+             261:39(float64_t) FAdd 260 259
                               Store 41(doublev) 261
-             262:   43(fvec2) Load 45(dvec2v)
-             263:   39(float) Load 41(doublev)
-             264:   43(fvec2) CompositeConstruct 263 263
-             265:   43(fvec2) ExtInst 1(GLSL.std.450) 37(FMin) 262 264
-             266:   43(fvec2) Load 45(dvec2v)
-             267:   43(fvec2) FAdd 266 265
+             262: 43(f64vec2) Load 45(dvec2v)
+             263:39(float64_t) Load 41(doublev)
+             264: 43(f64vec2) CompositeConstruct 263 263
+             265: 43(f64vec2) ExtInst 1(GLSL.std.450) 37(FMin) 262 264
+             266: 43(f64vec2) Load 45(dvec2v)
+             267: 43(f64vec2) FAdd 266 265
                               Store 45(dvec2v) 267
-             268:   48(fvec3) Load 50(dvec3v)
-             269:   39(float) Load 41(doublev)
-             270:   48(fvec3) CompositeConstruct 269 269 269
-             271:   48(fvec3) ExtInst 1(GLSL.std.450) 37(FMin) 268 270
-             272:   48(fvec3) Load 50(dvec3v)
-             273:   48(fvec3) FAdd 272 271
+             268: 48(f64vec3) Load 50(dvec3v)
+             269:39(float64_t) Load 41(doublev)
+             270: 48(f64vec3) CompositeConstruct 269 269 269
+             271: 48(f64vec3) ExtInst 1(GLSL.std.450) 37(FMin) 268 270
+             272: 48(f64vec3) Load 50(dvec3v)
+             273: 48(f64vec3) FAdd 272 271
                               Store 50(dvec3v) 273
-             274:   53(fvec4) Load 55(dvec4v)
-             275:   39(float) Load 41(doublev)
-             276:   53(fvec4) CompositeConstruct 275 275 275 275
-             277:   53(fvec4) ExtInst 1(GLSL.std.450) 37(FMin) 274 276
-             278:   53(fvec4) Load 55(dvec4v)
-             279:   53(fvec4) FAdd 278 277
+             274: 53(f64vec4) Load 55(dvec4v)
+             275:39(float64_t) Load 41(doublev)
+             276: 53(f64vec4) CompositeConstruct 275 275 275 275
+             277: 53(f64vec4) ExtInst 1(GLSL.std.450) 37(FMin) 274 276
+             278: 53(f64vec4) Load 55(dvec4v)
+             279: 53(f64vec4) FAdd 278 277
                               Store 55(dvec4v) 279
-             280:   43(fvec2) Load 45(dvec2v)
-             281:   43(fvec2) Load 45(dvec2v)
-             282:   43(fvec2) ExtInst 1(GLSL.std.450) 37(FMin) 280 281
-             283:   43(fvec2) Load 45(dvec2v)
-             284:   43(fvec2) FAdd 283 282
+             280: 43(f64vec2) Load 45(dvec2v)
+             281: 43(f64vec2) Load 45(dvec2v)
+             282: 43(f64vec2) ExtInst 1(GLSL.std.450) 37(FMin) 280 281
+             283: 43(f64vec2) Load 45(dvec2v)
+             284: 43(f64vec2) FAdd 283 282
                               Store 45(dvec2v) 284
-             285:   48(fvec3) Load 50(dvec3v)
-             286:   48(fvec3) Load 50(dvec3v)
-             287:   48(fvec3) ExtInst 1(GLSL.std.450) 37(FMin) 285 286
-             288:   48(fvec3) Load 50(dvec3v)
-             289:   48(fvec3) FAdd 288 287
+             285: 48(f64vec3) Load 50(dvec3v)
+             286: 48(f64vec3) Load 50(dvec3v)
+             287: 48(f64vec3) ExtInst 1(GLSL.std.450) 37(FMin) 285 286
+             288: 48(f64vec3) Load 50(dvec3v)
+             289: 48(f64vec3) FAdd 288 287
                               Store 50(dvec3v) 289
-             290:   53(fvec4) Load 55(dvec4v)
-             291:   53(fvec4) Load 55(dvec4v)
-             292:   53(fvec4) ExtInst 1(GLSL.std.450) 37(FMin) 290 291
-             293:   53(fvec4) Load 55(dvec4v)
-             294:   53(fvec4) FAdd 293 292
+             290: 53(f64vec4) Load 55(dvec4v)
+             291: 53(f64vec4) Load 55(dvec4v)
+             292: 53(f64vec4) ExtInst 1(GLSL.std.450) 37(FMin) 290 291
+             293: 53(f64vec4) Load 55(dvec4v)
+             294: 53(f64vec4) FAdd 293 292
                               Store 55(dvec4v) 294
-             295:   39(float) Load 41(doublev)
-             296:   39(float) Load 41(doublev)
-             297:   39(float) ExtInst 1(GLSL.std.450) 40(FMax) 295 296
-             298:   39(float) Load 41(doublev)
-             299:   39(float) FAdd 298 297
+             295:39(float64_t) Load 41(doublev)
+             296:39(float64_t) Load 41(doublev)
+             297:39(float64_t) ExtInst 1(GLSL.std.450) 40(FMax) 295 296
+             298:39(float64_t) Load 41(doublev)
+             299:39(float64_t) FAdd 298 297
                               Store 41(doublev) 299
-             300:   43(fvec2) Load 45(dvec2v)
-             301:   39(float) Load 41(doublev)
-             302:   43(fvec2) CompositeConstruct 301 301
-             303:   43(fvec2) ExtInst 1(GLSL.std.450) 40(FMax) 300 302
-             304:   43(fvec2) Load 45(dvec2v)
-             305:   43(fvec2) FAdd 304 303
+             300: 43(f64vec2) Load 45(dvec2v)
+             301:39(float64_t) Load 41(doublev)
+             302: 43(f64vec2) CompositeConstruct 301 301
+             303: 43(f64vec2) ExtInst 1(GLSL.std.450) 40(FMax) 300 302
+             304: 43(f64vec2) Load 45(dvec2v)
+             305: 43(f64vec2) FAdd 304 303
                               Store 45(dvec2v) 305
-             306:   48(fvec3) Load 50(dvec3v)
-             307:   39(float) Load 41(doublev)
-             308:   48(fvec3) CompositeConstruct 307 307 307
-             309:   48(fvec3) ExtInst 1(GLSL.std.450) 40(FMax) 306 308
-             310:   48(fvec3) Load 50(dvec3v)
-             311:   48(fvec3) FAdd 310 309
+             306: 48(f64vec3) Load 50(dvec3v)
+             307:39(float64_t) Load 41(doublev)
+             308: 48(f64vec3) CompositeConstruct 307 307 307
+             309: 48(f64vec3) ExtInst 1(GLSL.std.450) 40(FMax) 306 308
+             310: 48(f64vec3) Load 50(dvec3v)
+             311: 48(f64vec3) FAdd 310 309
                               Store 50(dvec3v) 311
-             312:   53(fvec4) Load 55(dvec4v)
-             313:   39(float) Load 41(doublev)
-             314:   53(fvec4) CompositeConstruct 313 313 313 313
-             315:   53(fvec4) ExtInst 1(GLSL.std.450) 40(FMax) 312 314
-             316:   53(fvec4) Load 55(dvec4v)
-             317:   53(fvec4) FAdd 316 315
+             312: 53(f64vec4) Load 55(dvec4v)
+             313:39(float64_t) Load 41(doublev)
+             314: 53(f64vec4) CompositeConstruct 313 313 313 313
+             315: 53(f64vec4) ExtInst 1(GLSL.std.450) 40(FMax) 312 314
+             316: 53(f64vec4) Load 55(dvec4v)
+             317: 53(f64vec4) FAdd 316 315
                               Store 55(dvec4v) 317
-             318:   43(fvec2) Load 45(dvec2v)
-             319:   43(fvec2) Load 45(dvec2v)
-             320:   43(fvec2) ExtInst 1(GLSL.std.450) 40(FMax) 318 319
-             321:   43(fvec2) Load 45(dvec2v)
-             322:   43(fvec2) FAdd 321 320
+             318: 43(f64vec2) Load 45(dvec2v)
+             319: 43(f64vec2) Load 45(dvec2v)
+             320: 43(f64vec2) ExtInst 1(GLSL.std.450) 40(FMax) 318 319
+             321: 43(f64vec2) Load 45(dvec2v)
+             322: 43(f64vec2) FAdd 321 320
                               Store 45(dvec2v) 322
-             323:   48(fvec3) Load 50(dvec3v)
-             324:   48(fvec3) Load 50(dvec3v)
-             325:   48(fvec3) ExtInst 1(GLSL.std.450) 40(FMax) 323 324
-             326:   48(fvec3) Load 50(dvec3v)
-             327:   48(fvec3) FAdd 326 325
+             323: 48(f64vec3) Load 50(dvec3v)
+             324: 48(f64vec3) Load 50(dvec3v)
+             325: 48(f64vec3) ExtInst 1(GLSL.std.450) 40(FMax) 323 324
+             326: 48(f64vec3) Load 50(dvec3v)
+             327: 48(f64vec3) FAdd 326 325
                               Store 50(dvec3v) 327
-             328:   53(fvec4) Load 55(dvec4v)
-             329:   53(fvec4) Load 55(dvec4v)
-             330:   53(fvec4) ExtInst 1(GLSL.std.450) 40(FMax) 328 329
-             331:   53(fvec4) Load 55(dvec4v)
-             332:   53(fvec4) FAdd 331 330
+             328: 53(f64vec4) Load 55(dvec4v)
+             329: 53(f64vec4) Load 55(dvec4v)
+             330: 53(f64vec4) ExtInst 1(GLSL.std.450) 40(FMax) 328 329
+             331: 53(f64vec4) Load 55(dvec4v)
+             332: 53(f64vec4) FAdd 331 330
                               Store 55(dvec4v) 332
-             333:   39(float) Load 41(doublev)
-             334:   39(float) Load 41(doublev)
-             335:   39(float) Load 41(doublev)
-             336:   39(float) ExtInst 1(GLSL.std.450) 43(FClamp) 333 334 335
-             337:   39(float) Load 41(doublev)
-             338:   39(float) FAdd 337 336
+             333:39(float64_t) Load 41(doublev)
+             334:39(float64_t) Load 41(doublev)
+             335:39(float64_t) Load 41(doublev)
+             336:39(float64_t) ExtInst 1(GLSL.std.450) 43(FClamp) 333 334 335
+             337:39(float64_t) Load 41(doublev)
+             338:39(float64_t) FAdd 337 336
                               Store 41(doublev) 338
-             339:   43(fvec2) Load 45(dvec2v)
-             340:   39(float) Load 41(doublev)
-             341:   39(float) Load 41(doublev)
-             342:   43(fvec2) CompositeConstruct 340 340
-             343:   43(fvec2) CompositeConstruct 341 341
-             344:   43(fvec2) ExtInst 1(GLSL.std.450) 43(FClamp) 339 342 343
-             345:   43(fvec2) Load 45(dvec2v)
-             346:   43(fvec2) FAdd 345 344
+             339: 43(f64vec2) Load 45(dvec2v)
+             340:39(float64_t) Load 41(doublev)
+             341:39(float64_t) Load 41(doublev)
+             342: 43(f64vec2) CompositeConstruct 340 340
+             343: 43(f64vec2) CompositeConstruct 341 341
+             344: 43(f64vec2) ExtInst 1(GLSL.std.450) 43(FClamp) 339 342 343
+             345: 43(f64vec2) Load 45(dvec2v)
+             346: 43(f64vec2) FAdd 345 344
                               Store 45(dvec2v) 346
-             347:   48(fvec3) Load 50(dvec3v)
-             348:   39(float) Load 41(doublev)
-             349:   39(float) Load 41(doublev)
-             350:   48(fvec3) CompositeConstruct 348 348 348
-             351:   48(fvec3) CompositeConstruct 349 349 349
-             352:   48(fvec3) ExtInst 1(GLSL.std.450) 43(FClamp) 347 350 351
-             353:   48(fvec3) Load 50(dvec3v)
-             354:   48(fvec3) FAdd 353 352
+             347: 48(f64vec3) Load 50(dvec3v)
+             348:39(float64_t) Load 41(doublev)
+             349:39(float64_t) Load 41(doublev)
+             350: 48(f64vec3) CompositeConstruct 348 348 348
+             351: 48(f64vec3) CompositeConstruct 349 349 349
+             352: 48(f64vec3) ExtInst 1(GLSL.std.450) 43(FClamp) 347 350 351
+             353: 48(f64vec3) Load 50(dvec3v)
+             354: 48(f64vec3) FAdd 353 352
                               Store 50(dvec3v) 354
-             355:   53(fvec4) Load 55(dvec4v)
-             356:   39(float) Load 41(doublev)
-             357:   39(float) Load 41(doublev)
-             358:   53(fvec4) CompositeConstruct 356 356 356 356
-             359:   53(fvec4) CompositeConstruct 357 357 357 357
-             360:   53(fvec4) ExtInst 1(GLSL.std.450) 43(FClamp) 355 358 359
-             361:   53(fvec4) Load 55(dvec4v)
-             362:   53(fvec4) FAdd 361 360
+             355: 53(f64vec4) Load 55(dvec4v)
+             356:39(float64_t) Load 41(doublev)
+             357:39(float64_t) Load 41(doublev)
+             358: 53(f64vec4) CompositeConstruct 356 356 356 356
+             359: 53(f64vec4) CompositeConstruct 357 357 357 357
+             360: 53(f64vec4) ExtInst 1(GLSL.std.450) 43(FClamp) 355 358 359
+             361: 53(f64vec4) Load 55(dvec4v)
+             362: 53(f64vec4) FAdd 361 360
                               Store 55(dvec4v) 362
-             363:   43(fvec2) Load 45(dvec2v)
-             364:   43(fvec2) Load 45(dvec2v)
-             365:   43(fvec2) Load 45(dvec2v)
-             366:   43(fvec2) ExtInst 1(GLSL.std.450) 43(FClamp) 363 364 365
-             367:   43(fvec2) Load 45(dvec2v)
-             368:   43(fvec2) FAdd 367 366
+             363: 43(f64vec2) Load 45(dvec2v)
+             364: 43(f64vec2) Load 45(dvec2v)
+             365: 43(f64vec2) Load 45(dvec2v)
+             366: 43(f64vec2) ExtInst 1(GLSL.std.450) 43(FClamp) 363 364 365
+             367: 43(f64vec2) Load 45(dvec2v)
+             368: 43(f64vec2) FAdd 367 366
                               Store 45(dvec2v) 368
-             369:   48(fvec3) Load 50(dvec3v)
-             370:   48(fvec3) Load 50(dvec3v)
-             371:   48(fvec3) Load 50(dvec3v)
-             372:   48(fvec3) ExtInst 1(GLSL.std.450) 43(FClamp) 369 370 371
-             373:   48(fvec3) Load 50(dvec3v)
-             374:   48(fvec3) FAdd 373 372
+             369: 48(f64vec3) Load 50(dvec3v)
+             370: 48(f64vec3) Load 50(dvec3v)
+             371: 48(f64vec3) Load 50(dvec3v)
+             372: 48(f64vec3) ExtInst 1(GLSL.std.450) 43(FClamp) 369 370 371
+             373: 48(f64vec3) Load 50(dvec3v)
+             374: 48(f64vec3) FAdd 373 372
                               Store 50(dvec3v) 374
-             375:   53(fvec4) Load 55(dvec4v)
-             376:   53(fvec4) Load 55(dvec4v)
-             377:   53(fvec4) Load 55(dvec4v)
-             378:   53(fvec4) ExtInst 1(GLSL.std.450) 43(FClamp) 375 376 377
-             379:   53(fvec4) Load 55(dvec4v)
-             380:   53(fvec4) FAdd 379 378
+             375: 53(f64vec4) Load 55(dvec4v)
+             376: 53(f64vec4) Load 55(dvec4v)
+             377: 53(f64vec4) Load 55(dvec4v)
+             378: 53(f64vec4) ExtInst 1(GLSL.std.450) 43(FClamp) 375 376 377
+             379: 53(f64vec4) Load 55(dvec4v)
+             380: 53(f64vec4) FAdd 379 378
                               Store 55(dvec4v) 380
-             381:   39(float) Load 41(doublev)
-             382:   39(float) Load 41(doublev)
-             383:   39(float) Load 41(doublev)
-             384:   39(float) ExtInst 1(GLSL.std.450) 46(FMix) 381 382 383
-             385:   39(float) Load 41(doublev)
-             386:   39(float) FAdd 385 384
+             381:39(float64_t) Load 41(doublev)
+             382:39(float64_t) Load 41(doublev)
+             383:39(float64_t) Load 41(doublev)
+             384:39(float64_t) ExtInst 1(GLSL.std.450) 46(FMix) 381 382 383
+             385:39(float64_t) Load 41(doublev)
+             386:39(float64_t) FAdd 385 384
                               Store 41(doublev) 386
-             387:   43(fvec2) Load 45(dvec2v)
-             388:   43(fvec2) Load 45(dvec2v)
-             389:   39(float) Load 41(doublev)
-             390:   43(fvec2) CompositeConstruct 389 389
-             391:   43(fvec2) ExtInst 1(GLSL.std.450) 46(FMix) 387 388 390
-             392:   43(fvec2) Load 45(dvec2v)
-             393:   43(fvec2) FAdd 392 391
+             387: 43(f64vec2) Load 45(dvec2v)
+             388: 43(f64vec2) Load 45(dvec2v)
+             389:39(float64_t) Load 41(doublev)
+             390: 43(f64vec2) CompositeConstruct 389 389
+             391: 43(f64vec2) ExtInst 1(GLSL.std.450) 46(FMix) 387 388 390
+             392: 43(f64vec2) Load 45(dvec2v)
+             393: 43(f64vec2) FAdd 392 391
                               Store 45(dvec2v) 393
-             394:   48(fvec3) Load 50(dvec3v)
-             395:   48(fvec3) Load 50(dvec3v)
-             396:   39(float) Load 41(doublev)
-             397:   48(fvec3) CompositeConstruct 396 396 396
-             398:   48(fvec3) ExtInst 1(GLSL.std.450) 46(FMix) 394 395 397
-             399:   48(fvec3) Load 50(dvec3v)
-             400:   48(fvec3) FAdd 399 398
+             394: 48(f64vec3) Load 50(dvec3v)
+             395: 48(f64vec3) Load 50(dvec3v)
+             396:39(float64_t) Load 41(doublev)
+             397: 48(f64vec3) CompositeConstruct 396 396 396
+             398: 48(f64vec3) ExtInst 1(GLSL.std.450) 46(FMix) 394 395 397
+             399: 48(f64vec3) Load 50(dvec3v)
+             400: 48(f64vec3) FAdd 399 398
                               Store 50(dvec3v) 400
-             401:   53(fvec4) Load 55(dvec4v)
-             402:   53(fvec4) Load 55(dvec4v)
-             403:   39(float) Load 41(doublev)
-             404:   53(fvec4) CompositeConstruct 403 403 403 403
-             405:   53(fvec4) ExtInst 1(GLSL.std.450) 46(FMix) 401 402 404
-             406:   53(fvec4) Load 55(dvec4v)
-             407:   53(fvec4) FAdd 406 405
+             401: 53(f64vec4) Load 55(dvec4v)
+             402: 53(f64vec4) Load 55(dvec4v)
+             403:39(float64_t) Load 41(doublev)
+             404: 53(f64vec4) CompositeConstruct 403 403 403 403
+             405: 53(f64vec4) ExtInst 1(GLSL.std.450) 46(FMix) 401 402 404
+             406: 53(f64vec4) Load 55(dvec4v)
+             407: 53(f64vec4) FAdd 406 405
                               Store 55(dvec4v) 407
-             408:   43(fvec2) Load 45(dvec2v)
-             409:   43(fvec2) Load 45(dvec2v)
-             410:   43(fvec2) Load 45(dvec2v)
-             411:   43(fvec2) ExtInst 1(GLSL.std.450) 46(FMix) 408 409 410
-             412:   43(fvec2) Load 45(dvec2v)
-             413:   43(fvec2) FAdd 412 411
+             408: 43(f64vec2) Load 45(dvec2v)
+             409: 43(f64vec2) Load 45(dvec2v)
+             410: 43(f64vec2) Load 45(dvec2v)
+             411: 43(f64vec2) ExtInst 1(GLSL.std.450) 46(FMix) 408 409 410
+             412: 43(f64vec2) Load 45(dvec2v)
+             413: 43(f64vec2) FAdd 412 411
                               Store 45(dvec2v) 413
-             414:   48(fvec3) Load 50(dvec3v)
-             415:   48(fvec3) Load 50(dvec3v)
-             416:   48(fvec3) Load 50(dvec3v)
-             417:   48(fvec3) ExtInst 1(GLSL.std.450) 46(FMix) 414 415 416
-             418:   48(fvec3) Load 50(dvec3v)
-             419:   48(fvec3) FAdd 418 417
+             414: 48(f64vec3) Load 50(dvec3v)
+             415: 48(f64vec3) Load 50(dvec3v)
+             416: 48(f64vec3) Load 50(dvec3v)
+             417: 48(f64vec3) ExtInst 1(GLSL.std.450) 46(FMix) 414 415 416
+             418: 48(f64vec3) Load 50(dvec3v)
+             419: 48(f64vec3) FAdd 418 417
                               Store 50(dvec3v) 419
-             420:   53(fvec4) Load 55(dvec4v)
-             421:   53(fvec4) Load 55(dvec4v)
-             422:   53(fvec4) Load 55(dvec4v)
-             423:   53(fvec4) ExtInst 1(GLSL.std.450) 46(FMix) 420 421 422
-             424:   53(fvec4) Load 55(dvec4v)
-             425:   53(fvec4) FAdd 424 423
+             420: 53(f64vec4) Load 55(dvec4v)
+             421: 53(f64vec4) Load 55(dvec4v)
+             422: 53(f64vec4) Load 55(dvec4v)
+             423: 53(f64vec4) ExtInst 1(GLSL.std.450) 46(FMix) 420 421 422
+             424: 53(f64vec4) Load 55(dvec4v)
+             425: 53(f64vec4) FAdd 424 423
                               Store 55(dvec4v) 425
-             426:   39(float) Load 41(doublev)
-             427:   39(float) Load 41(doublev)
+             426:39(float64_t) Load 41(doublev)
+             427:39(float64_t) Load 41(doublev)
              431:   428(bool) Load 430(boolv)
-             432:   39(float) Select 431 427 426
-             433:   39(float) Load 41(doublev)
-             434:   39(float) FAdd 433 432
+             432:39(float64_t) Select 431 427 426
+             433:39(float64_t) Load 41(doublev)
+             434:39(float64_t) FAdd 433 432
                               Store 41(doublev) 434
-             435:   43(fvec2) Load 45(dvec2v)
-             436:   43(fvec2) Load 45(dvec2v)
+             435: 43(f64vec2) Load 45(dvec2v)
+             436: 43(f64vec2) Load 45(dvec2v)
              440:  437(bvec2) Load 439(bvec2v)
-             441:   43(fvec2) Select 440 436 435
-             442:   43(fvec2) Load 45(dvec2v)
-             443:   43(fvec2) FAdd 442 441
+             441: 43(f64vec2) Select 440 436 435
+             442: 43(f64vec2) Load 45(dvec2v)
+             443: 43(f64vec2) FAdd 442 441
                               Store 45(dvec2v) 443
-             444:   48(fvec3) Load 50(dvec3v)
-             445:   48(fvec3) Load 50(dvec3v)
+             444: 48(f64vec3) Load 50(dvec3v)
+             445: 48(f64vec3) Load 50(dvec3v)
              449:  446(bvec3) Load 448(bvec3v)
-             450:   48(fvec3) Select 449 445 444
-             451:   48(fvec3) Load 50(dvec3v)
-             452:   48(fvec3) FAdd 451 450
+             450: 48(f64vec3) Select 449 445 444
+             451: 48(f64vec3) Load 50(dvec3v)
+             452: 48(f64vec3) FAdd 451 450
                               Store 50(dvec3v) 452
-             453:   53(fvec4) Load 55(dvec4v)
-             454:   53(fvec4) Load 55(dvec4v)
+             453: 53(f64vec4) Load 55(dvec4v)
+             454: 53(f64vec4) Load 55(dvec4v)
              458:  455(bvec4) Load 457(bvec4v)
-             459:   53(fvec4) Select 458 454 453
-             460:   53(fvec4) Load 55(dvec4v)
-             461:   53(fvec4) FAdd 460 459
+             459: 53(f64vec4) Select 458 454 453
+             460: 53(f64vec4) Load 55(dvec4v)
+             461: 53(f64vec4) FAdd 460 459
                               Store 55(dvec4v) 461
-             462:   39(float) Load 41(doublev)
-             463:   39(float) Load 41(doublev)
-             464:   39(float) ExtInst 1(GLSL.std.450) 48(Step) 462 463
-             465:   39(float) Load 41(doublev)
-             466:   39(float) FAdd 465 464
+             462:39(float64_t) Load 41(doublev)
+             463:39(float64_t) Load 41(doublev)
+             464:39(float64_t) ExtInst 1(GLSL.std.450) 48(Step) 462 463
+             465:39(float64_t) Load 41(doublev)
+             466:39(float64_t) FAdd 465 464
                               Store 41(doublev) 466
-             467:   43(fvec2) Load 45(dvec2v)
-             468:   43(fvec2) Load 45(dvec2v)
-             469:   43(fvec2) ExtInst 1(GLSL.std.450) 48(Step) 467 468
-             470:   43(fvec2) Load 45(dvec2v)
-             471:   43(fvec2) FAdd 470 469
+             467: 43(f64vec2) Load 45(dvec2v)
+             468: 43(f64vec2) Load 45(dvec2v)
+             469: 43(f64vec2) ExtInst 1(GLSL.std.450) 48(Step) 467 468
+             470: 43(f64vec2) Load 45(dvec2v)
+             471: 43(f64vec2) FAdd 470 469
                               Store 45(dvec2v) 471
-             472:   48(fvec3) Load 50(dvec3v)
-             473:   48(fvec3) Load 50(dvec3v)
-             474:   48(fvec3) ExtInst 1(GLSL.std.450) 48(Step) 472 473
-             475:   48(fvec3) Load 50(dvec3v)
-             476:   48(fvec3) FAdd 475 474
+             472: 48(f64vec3) Load 50(dvec3v)
+             473: 48(f64vec3) Load 50(dvec3v)
+             474: 48(f64vec3) ExtInst 1(GLSL.std.450) 48(Step) 472 473
+             475: 48(f64vec3) Load 50(dvec3v)
+             476: 48(f64vec3) FAdd 475 474
                               Store 50(dvec3v) 476
-             477:   53(fvec4) Load 55(dvec4v)
-             478:   53(fvec4) Load 55(dvec4v)
-             479:   53(fvec4) ExtInst 1(GLSL.std.450) 48(Step) 477 478
-             480:   53(fvec4) Load 55(dvec4v)
-             481:   53(fvec4) FAdd 480 479
+             477: 53(f64vec4) Load 55(dvec4v)
+             478: 53(f64vec4) Load 55(dvec4v)
+             479: 53(f64vec4) ExtInst 1(GLSL.std.450) 48(Step) 477 478
+             480: 53(f64vec4) Load 55(dvec4v)
+             481: 53(f64vec4) FAdd 480 479
                               Store 55(dvec4v) 481
-             482:   39(float) Load 41(doublev)
-             483:   43(fvec2) Load 45(dvec2v)
-             484:   43(fvec2) CompositeConstruct 482 482
-             485:   43(fvec2) ExtInst 1(GLSL.std.450) 48(Step) 484 483
-             486:   43(fvec2) Load 45(dvec2v)
-             487:   43(fvec2) FAdd 486 485
+             482:39(float64_t) Load 41(doublev)
+             483: 43(f64vec2) Load 45(dvec2v)
+             484: 43(f64vec2) CompositeConstruct 482 482
+             485: 43(f64vec2) ExtInst 1(GLSL.std.450) 48(Step) 484 483
+             486: 43(f64vec2) Load 45(dvec2v)
+             487: 43(f64vec2) FAdd 486 485
                               Store 45(dvec2v) 487
-             488:   39(float) Load 41(doublev)
-             489:   48(fvec3) Load 50(dvec3v)
-             490:   48(fvec3) CompositeConstruct 488 488 488
-             491:   48(fvec3) ExtInst 1(GLSL.std.450) 48(Step) 490 489
-             492:   48(fvec3) Load 50(dvec3v)
-             493:   48(fvec3) FAdd 492 491
+             488:39(float64_t) Load 41(doublev)
+             489: 48(f64vec3) Load 50(dvec3v)
+             490: 48(f64vec3) CompositeConstruct 488 488 488
+             491: 48(f64vec3) ExtInst 1(GLSL.std.450) 48(Step) 490 489
+             492: 48(f64vec3) Load 50(dvec3v)
+             493: 48(f64vec3) FAdd 492 491
                               Store 50(dvec3v) 493
-             494:   39(float) Load 41(doublev)
-             495:   53(fvec4) Load 55(dvec4v)
-             496:   53(fvec4) CompositeConstruct 494 494 494 494
-             497:   53(fvec4) ExtInst 1(GLSL.std.450) 48(Step) 496 495
-             498:   53(fvec4) Load 55(dvec4v)
-             499:   53(fvec4) FAdd 498 497
+             494:39(float64_t) Load 41(doublev)
+             495: 53(f64vec4) Load 55(dvec4v)
+             496: 53(f64vec4) CompositeConstruct 494 494 494 494
+             497: 53(f64vec4) ExtInst 1(GLSL.std.450) 48(Step) 496 495
+             498: 53(f64vec4) Load 55(dvec4v)
+             499: 53(f64vec4) FAdd 498 497
                               Store 55(dvec4v) 499
-             500:   39(float) Load 41(doublev)
-             501:   39(float) Load 41(doublev)
-             502:   39(float) Load 41(doublev)
-             503:   39(float) ExtInst 1(GLSL.std.450) 49(SmoothStep) 500 501 502
-             504:   39(float) Load 41(doublev)
-             505:   39(float) FAdd 504 503
+             500:39(float64_t) Load 41(doublev)
+             501:39(float64_t) Load 41(doublev)
+             502:39(float64_t) Load 41(doublev)
+             503:39(float64_t) ExtInst 1(GLSL.std.450) 49(SmoothStep) 500 501 502
+             504:39(float64_t) Load 41(doublev)
+             505:39(float64_t) FAdd 504 503
                               Store 41(doublev) 505
-             506:   43(fvec2) Load 45(dvec2v)
-             507:   43(fvec2) Load 45(dvec2v)
-             508:   43(fvec2) Load 45(dvec2v)
-             509:   43(fvec2) ExtInst 1(GLSL.std.450) 49(SmoothStep) 506 507 508
-             510:   43(fvec2) Load 45(dvec2v)
-             511:   43(fvec2) FAdd 510 509
+             506: 43(f64vec2) Load 45(dvec2v)
+             507: 43(f64vec2) Load 45(dvec2v)
+             508: 43(f64vec2) Load 45(dvec2v)
+             509: 43(f64vec2) ExtInst 1(GLSL.std.450) 49(SmoothStep) 506 507 508
+             510: 43(f64vec2) Load 45(dvec2v)
+             511: 43(f64vec2) FAdd 510 509
                               Store 45(dvec2v) 511
-             512:   48(fvec3) Load 50(dvec3v)
-             513:   48(fvec3) Load 50(dvec3v)
-             514:   48(fvec3) Load 50(dvec3v)
-             515:   48(fvec3) ExtInst 1(GLSL.std.450) 49(SmoothStep) 512 513 514
-             516:   48(fvec3) Load 50(dvec3v)
-             517:   48(fvec3) FAdd 516 515
+             512: 48(f64vec3) Load 50(dvec3v)
+             513: 48(f64vec3) Load 50(dvec3v)
+             514: 48(f64vec3) Load 50(dvec3v)
+             515: 48(f64vec3) ExtInst 1(GLSL.std.450) 49(SmoothStep) 512 513 514
+             516: 48(f64vec3) Load 50(dvec3v)
+             517: 48(f64vec3) FAdd 516 515
                               Store 50(dvec3v) 517
-             518:   53(fvec4) Load 55(dvec4v)
-             519:   53(fvec4) Load 55(dvec4v)
-             520:   53(fvec4) Load 55(dvec4v)
-             521:   53(fvec4) ExtInst 1(GLSL.std.450) 49(SmoothStep) 518 519 520
-             522:   53(fvec4) Load 55(dvec4v)
-             523:   53(fvec4) FAdd 522 521
+             518: 53(f64vec4) Load 55(dvec4v)
+             519: 53(f64vec4) Load 55(dvec4v)
+             520: 53(f64vec4) Load 55(dvec4v)
+             521: 53(f64vec4) ExtInst 1(GLSL.std.450) 49(SmoothStep) 518 519 520
+             522: 53(f64vec4) Load 55(dvec4v)
+             523: 53(f64vec4) FAdd 522 521
                               Store 55(dvec4v) 523
-             524:   39(float) Load 41(doublev)
-             525:   39(float) Load 41(doublev)
-             526:   43(fvec2) Load 45(dvec2v)
-             527:   43(fvec2) CompositeConstruct 524 524
-             528:   43(fvec2) CompositeConstruct 525 525
-             529:   43(fvec2) ExtInst 1(GLSL.std.450) 49(SmoothStep) 527 528 526
-             530:   43(fvec2) Load 45(dvec2v)
-             531:   43(fvec2) FAdd 530 529
+             524:39(float64_t) Load 41(doublev)
+             525:39(float64_t) Load 41(doublev)
+             526: 43(f64vec2) Load 45(dvec2v)
+             527: 43(f64vec2) CompositeConstruct 524 524
+             528: 43(f64vec2) CompositeConstruct 525 525
+             529: 43(f64vec2) ExtInst 1(GLSL.std.450) 49(SmoothStep) 527 528 526
+             530: 43(f64vec2) Load 45(dvec2v)
+             531: 43(f64vec2) FAdd 530 529
                               Store 45(dvec2v) 531
-             532:   39(float) Load 41(doublev)
-             533:   39(float) Load 41(doublev)
-             534:   48(fvec3) Load 50(dvec3v)
-             535:   48(fvec3) CompositeConstruct 532 532 532
-             536:   48(fvec3) CompositeConstruct 533 533 533
-             537:   48(fvec3) ExtInst 1(GLSL.std.450) 49(SmoothStep) 535 536 534
-             538:   48(fvec3) Load 50(dvec3v)
-             539:   48(fvec3) FAdd 538 537
+             532:39(float64_t) Load 41(doublev)
+             533:39(float64_t) Load 41(doublev)
+             534: 48(f64vec3) Load 50(dvec3v)
+             535: 48(f64vec3) CompositeConstruct 532 532 532
+             536: 48(f64vec3) CompositeConstruct 533 533 533
+             537: 48(f64vec3) ExtInst 1(GLSL.std.450) 49(SmoothStep) 535 536 534
+             538: 48(f64vec3) Load 50(dvec3v)
+             539: 48(f64vec3) FAdd 538 537
                               Store 50(dvec3v) 539
-             540:   39(float) Load 41(doublev)
-             541:   39(float) Load 41(doublev)
-             542:   53(fvec4) Load 55(dvec4v)
-             543:   53(fvec4) CompositeConstruct 540 540 540 540
-             544:   53(fvec4) CompositeConstruct 541 541 541 541
-             545:   53(fvec4) ExtInst 1(GLSL.std.450) 49(SmoothStep) 543 544 542
-             546:   53(fvec4) Load 55(dvec4v)
-             547:   53(fvec4) FAdd 546 545
+             540:39(float64_t) Load 41(doublev)
+             541:39(float64_t) Load 41(doublev)
+             542: 53(f64vec4) Load 55(dvec4v)
+             543: 53(f64vec4) CompositeConstruct 540 540 540 540
+             544: 53(f64vec4) CompositeConstruct 541 541 541 541
+             545: 53(f64vec4) ExtInst 1(GLSL.std.450) 49(SmoothStep) 543 544 542
+             546: 53(f64vec4) Load 55(dvec4v)
+             547: 53(f64vec4) FAdd 546 545
                               Store 55(dvec4v) 547
-             548:   39(float) Load 41(doublev)
+             548:39(float64_t) Load 41(doublev)
              549:   428(bool) IsNan 548
                               Store 430(boolv) 549
-             550:   43(fvec2) Load 45(dvec2v)
+             550: 43(f64vec2) Load 45(dvec2v)
              551:  437(bvec2) IsNan 550
                               Store 439(bvec2v) 551
-             552:   48(fvec3) Load 50(dvec3v)
+             552: 48(f64vec3) Load 50(dvec3v)
              553:  446(bvec3) IsNan 552
                               Store 448(bvec3v) 553
-             554:   53(fvec4) Load 55(dvec4v)
+             554: 53(f64vec4) Load 55(dvec4v)
              555:  455(bvec4) IsNan 554
                               Store 457(bvec4v) 555
              556:   428(bool) Load 430(boolv)
                               SelectionMerge 559 None
                               BranchConditional 556 558 562
              558:               Label
-             560:   39(float)   Load 41(doublev)
+             560:39(float64_t)   Load 41(doublev)
              561:   428(bool)   IsInf 560
                                 Store 557 561
                                 Branch 559
@@ -894,7 +894,7 @@ spv.400.frag
                               SelectionMerge 568 None
                               BranchConditional 565 567 571
              567:               Label
-             569:   43(fvec2)   Load 45(dvec2v)
+             569: 43(f64vec2)   Load 45(dvec2v)
              570:  437(bvec2)   IsInf 569
                                 Store 566 570
                                 Branch 568
@@ -908,7 +908,7 @@ spv.400.frag
                               SelectionMerge 577 None
                               BranchConditional 574 576 580
              576:               Label
-             578:   48(fvec3)   Load 50(dvec3v)
+             578: 48(f64vec3)   Load 50(dvec3v)
              579:  446(bvec3)   IsInf 578
                                 Store 575 579
                                 Branch 577
@@ -922,7 +922,7 @@ spv.400.frag
                               SelectionMerge 586 None
                               BranchConditional 583 585 589
              585:               Label
-             587:   53(fvec4)   Load 55(dvec4v)
+             587: 53(f64vec4)   Load 55(dvec4v)
              588:  455(bvec4)   IsInf 587
                                 Store 584 588
                                 Branch 586
@@ -932,333 +932,333 @@ spv.400.frag
              586:             Label
              591:  455(bvec4) Load 584
                               Store 457(bvec4v) 591
-             592:   39(float) Load 41(doublev)
-             593:   39(float) ExtInst 1(GLSL.std.450) 66(Length) 592
-             594:   39(float) Load 41(doublev)
-             595:   39(float) FAdd 594 593
+             592:39(float64_t) Load 41(doublev)
+             593:39(float64_t) ExtInst 1(GLSL.std.450) 66(Length) 592
+             594:39(float64_t) Load 41(doublev)
+             595:39(float64_t) FAdd 594 593
                               Store 41(doublev) 595
-             596:   43(fvec2) Load 45(dvec2v)
-             597:   39(float) ExtInst 1(GLSL.std.450) 66(Length) 596
-             598:   39(float) Load 41(doublev)
-             599:   39(float) FAdd 598 597
+             596: 43(f64vec2) Load 45(dvec2v)
+             597:39(float64_t) ExtInst 1(GLSL.std.450) 66(Length) 596
+             598:39(float64_t) Load 41(doublev)
+             599:39(float64_t) FAdd 598 597
                               Store 41(doublev) 599
-             600:   48(fvec3) Load 50(dvec3v)
-             601:   39(float) ExtInst 1(GLSL.std.450) 66(Length) 600
-             602:   39(float) Load 41(doublev)
-             603:   39(float) FAdd 602 601
+             600: 48(f64vec3) Load 50(dvec3v)
+             601:39(float64_t) ExtInst 1(GLSL.std.450) 66(Length) 600
+             602:39(float64_t) Load 41(doublev)
+             603:39(float64_t) FAdd 602 601
                               Store 41(doublev) 603
-             604:   53(fvec4) Load 55(dvec4v)
-             605:   39(float) ExtInst 1(GLSL.std.450) 66(Length) 604
-             606:   39(float) Load 41(doublev)
-             607:   39(float) FAdd 606 605
+             604: 53(f64vec4) Load 55(dvec4v)
+             605:39(float64_t) ExtInst 1(GLSL.std.450) 66(Length) 604
+             606:39(float64_t) Load 41(doublev)
+             607:39(float64_t) FAdd 606 605
                               Store 41(doublev) 607
-             608:   39(float) Load 41(doublev)
-             609:   39(float) Load 41(doublev)
-             610:   39(float) ExtInst 1(GLSL.std.450) 67(Distance) 608 609
-             611:   39(float) Load 41(doublev)
-             612:   39(float) FAdd 611 610
+             608:39(float64_t) Load 41(doublev)
+             609:39(float64_t) Load 41(doublev)
+             610:39(float64_t) ExtInst 1(GLSL.std.450) 67(Distance) 608 609
+             611:39(float64_t) Load 41(doublev)
+             612:39(float64_t) FAdd 611 610
                               Store 41(doublev) 612
-             613:   43(fvec2) Load 45(dvec2v)
-             614:   43(fvec2) Load 45(dvec2v)
-             615:   39(float) ExtInst 1(GLSL.std.450) 67(Distance) 613 614
-             616:   39(float) Load 41(doublev)
-             617:   39(float) FAdd 616 615
+             613: 43(f64vec2) Load 45(dvec2v)
+             614: 43(f64vec2) Load 45(dvec2v)
+             615:39(float64_t) ExtInst 1(GLSL.std.450) 67(Distance) 613 614
+             616:39(float64_t) Load 41(doublev)
+             617:39(float64_t) FAdd 616 615
                               Store 41(doublev) 617
-             618:   48(fvec3) Load 50(dvec3v)
-             619:   48(fvec3) Load 50(dvec3v)
-             620:   39(float) ExtInst 1(GLSL.std.450) 67(Distance) 618 619
-             621:   39(float) Load 41(doublev)
-             622:   39(float) FAdd 621 620
+             618: 48(f64vec3) Load 50(dvec3v)
+             619: 48(f64vec3) Load 50(dvec3v)
+             620:39(float64_t) ExtInst 1(GLSL.std.450) 67(Distance) 618 619
+             621:39(float64_t) Load 41(doublev)
+             622:39(float64_t) FAdd 621 620
                               Store 41(doublev) 622
-             623:   53(fvec4) Load 55(dvec4v)
-             624:   53(fvec4) Load 55(dvec4v)
-             625:   39(float) ExtInst 1(GLSL.std.450) 67(Distance) 623 624
-             626:   39(float) Load 41(doublev)
-             627:   39(float) FAdd 626 625
+             623: 53(f64vec4) Load 55(dvec4v)
+             624: 53(f64vec4) Load 55(dvec4v)
+             625:39(float64_t) ExtInst 1(GLSL.std.450) 67(Distance) 623 624
+             626:39(float64_t) Load 41(doublev)
+             627:39(float64_t) FAdd 626 625
                               Store 41(doublev) 627
-             628:   39(float) Load 41(doublev)
-             629:   39(float) Load 41(doublev)
-             630:   39(float) FMul 628 629
-             631:   39(float) Load 41(doublev)
-             632:   39(float) FAdd 631 630
+             628:39(float64_t) Load 41(doublev)
+             629:39(float64_t) Load 41(doublev)
+             630:39(float64_t) FMul 628 629
+             631:39(float64_t) Load 41(doublev)
+             632:39(float64_t) FAdd 631 630
                               Store 41(doublev) 632
-             633:   43(fvec2) Load 45(dvec2v)
-             634:   43(fvec2) Load 45(dvec2v)
-             635:   39(float) Dot 633 634
-             636:   39(float) Load 41(doublev)
-             637:   39(float) FAdd 636 635
+             633: 43(f64vec2) Load 45(dvec2v)
+             634: 43(f64vec2) Load 45(dvec2v)
+             635:39(float64_t) Dot 633 634
+             636:39(float64_t) Load 41(doublev)
+             637:39(float64_t) FAdd 636 635
                               Store 41(doublev) 637
-             638:   48(fvec3) Load 50(dvec3v)
-             639:   48(fvec3) Load 50(dvec3v)
-             640:   39(float) Dot 638 639
-             641:   39(float) Load 41(doublev)
-             642:   39(float) FAdd 641 640
+             638: 48(f64vec3) Load 50(dvec3v)
+             639: 48(f64vec3) Load 50(dvec3v)
+             640:39(float64_t) Dot 638 639
+             641:39(float64_t) Load 41(doublev)
+             642:39(float64_t) FAdd 641 640
                               Store 41(doublev) 642
-             643:   53(fvec4) Load 55(dvec4v)
-             644:   53(fvec4) Load 55(dvec4v)
-             645:   39(float) Dot 643 644
-             646:   39(float) Load 41(doublev)
-             647:   39(float) FAdd 646 645
+             643: 53(f64vec4) Load 55(dvec4v)
+             644: 53(f64vec4) Load 55(dvec4v)
+             645:39(float64_t) Dot 643 644
+             646:39(float64_t) Load 41(doublev)
+             647:39(float64_t) FAdd 646 645
                               Store 41(doublev) 647
-             648:   48(fvec3) Load 50(dvec3v)
-             649:   48(fvec3) Load 50(dvec3v)
-             650:   48(fvec3) ExtInst 1(GLSL.std.450) 68(Cross) 648 649
-             651:   48(fvec3) Load 50(dvec3v)
-             652:   48(fvec3) FAdd 651 650
+             648: 48(f64vec3) Load 50(dvec3v)
+             649: 48(f64vec3) Load 50(dvec3v)
+             650: 48(f64vec3) ExtInst 1(GLSL.std.450) 68(Cross) 648 649
+             651: 48(f64vec3) Load 50(dvec3v)
+             652: 48(f64vec3) FAdd 651 650
                               Store 50(dvec3v) 652
-             653:   39(float) Load 41(doublev)
-             654:   39(float) ExtInst 1(GLSL.std.450) 69(Normalize) 653
-             655:   39(float) Load 41(doublev)
-             656:   39(float) FAdd 655 654
+             653:39(float64_t) Load 41(doublev)
+             654:39(float64_t) ExtInst 1(GLSL.std.450) 69(Normalize) 653
+             655:39(float64_t) Load 41(doublev)
+             656:39(float64_t) FAdd 655 654
                               Store 41(doublev) 656
-             657:   43(fvec2) Load 45(dvec2v)
-             658:   43(fvec2) ExtInst 1(GLSL.std.450) 69(Normalize) 657
-             659:   43(fvec2) Load 45(dvec2v)
-             660:   43(fvec2) FAdd 659 658
+             657: 43(f64vec2) Load 45(dvec2v)
+             658: 43(f64vec2) ExtInst 1(GLSL.std.450) 69(Normalize) 657
+             659: 43(f64vec2) Load 45(dvec2v)
+             660: 43(f64vec2) FAdd 659 658
                               Store 45(dvec2v) 660
-             661:   48(fvec3) Load 50(dvec3v)
-             662:   48(fvec3) ExtInst 1(GLSL.std.450) 69(Normalize) 661
-             663:   48(fvec3) Load 50(dvec3v)
-             664:   48(fvec3) FAdd 663 662
+             661: 48(f64vec3) Load 50(dvec3v)
+             662: 48(f64vec3) ExtInst 1(GLSL.std.450) 69(Normalize) 661
+             663: 48(f64vec3) Load 50(dvec3v)
+             664: 48(f64vec3) FAdd 663 662
                               Store 50(dvec3v) 664
-             665:   53(fvec4) Load 55(dvec4v)
-             666:   53(fvec4) ExtInst 1(GLSL.std.450) 69(Normalize) 665
-             667:   53(fvec4) Load 55(dvec4v)
-             668:   53(fvec4) FAdd 667 666
+             665: 53(f64vec4) Load 55(dvec4v)
+             666: 53(f64vec4) ExtInst 1(GLSL.std.450) 69(Normalize) 665
+             667: 53(f64vec4) Load 55(dvec4v)
+             668: 53(f64vec4) FAdd 667 666
                               Store 55(dvec4v) 668
-             669:   39(float) Load 41(doublev)
-             670:   39(float) Load 41(doublev)
-             671:   39(float) Load 41(doublev)
-             672:   39(float) ExtInst 1(GLSL.std.450) 70(FaceForward) 669 670 671
-             673:   39(float) Load 41(doublev)
-             674:   39(float) FAdd 673 672
+             669:39(float64_t) Load 41(doublev)
+             670:39(float64_t) Load 41(doublev)
+             671:39(float64_t) Load 41(doublev)
+             672:39(float64_t) ExtInst 1(GLSL.std.450) 70(FaceForward) 669 670 671
+             673:39(float64_t) Load 41(doublev)
+             674:39(float64_t) FAdd 673 672
                               Store 41(doublev) 674
-             675:   43(fvec2) Load 45(dvec2v)
-             676:   43(fvec2) Load 45(dvec2v)
-             677:   43(fvec2) Load 45(dvec2v)
-             678:   43(fvec2) ExtInst 1(GLSL.std.450) 70(FaceForward) 675 676 677
-             679:   43(fvec2) Load 45(dvec2v)
-             680:   43(fvec2) FAdd 679 678
+             675: 43(f64vec2) Load 45(dvec2v)
+             676: 43(f64vec2) Load 45(dvec2v)
+             677: 43(f64vec2) Load 45(dvec2v)
+             678: 43(f64vec2) ExtInst 1(GLSL.std.450) 70(FaceForward) 675 676 677
+             679: 43(f64vec2) Load 45(dvec2v)
+             680: 43(f64vec2) FAdd 679 678
                               Store 45(dvec2v) 680
-             681:   48(fvec3) Load 50(dvec3v)
-             682:   48(fvec3) Load 50(dvec3v)
-             683:   48(fvec3) Load 50(dvec3v)
-             684:   48(fvec3) ExtInst 1(GLSL.std.450) 70(FaceForward) 681 682 683
-             685:   48(fvec3) Load 50(dvec3v)
-             686:   48(fvec3) FAdd 685 684
+             681: 48(f64vec3) Load 50(dvec3v)
+             682: 48(f64vec3) Load 50(dvec3v)
+             683: 48(f64vec3) Load 50(dvec3v)
+             684: 48(f64vec3) ExtInst 1(GLSL.std.450) 70(FaceForward) 681 682 683
+             685: 48(f64vec3) Load 50(dvec3v)
+             686: 48(f64vec3) FAdd 685 684
                               Store 50(dvec3v) 686
-             687:   53(fvec4) Load 55(dvec4v)
-             688:   53(fvec4) Load 55(dvec4v)
-             689:   53(fvec4) Load 55(dvec4v)
-             690:   53(fvec4) ExtInst 1(GLSL.std.450) 70(FaceForward) 687 688 689
-             691:   53(fvec4) Load 55(dvec4v)
-             692:   53(fvec4) FAdd 691 690
+             687: 53(f64vec4) Load 55(dvec4v)
+             688: 53(f64vec4) Load 55(dvec4v)
+             689: 53(f64vec4) Load 55(dvec4v)
+             690: 53(f64vec4) ExtInst 1(GLSL.std.450) 70(FaceForward) 687 688 689
+             691: 53(f64vec4) Load 55(dvec4v)
+             692: 53(f64vec4) FAdd 691 690
                               Store 55(dvec4v) 692
-             693:   39(float) Load 41(doublev)
-             694:   39(float) Load 41(doublev)
-             695:   39(float) ExtInst 1(GLSL.std.450) 71(Reflect) 693 694
-             696:   39(float) Load 41(doublev)
-             697:   39(float) FAdd 696 695
+             693:39(float64_t) Load 41(doublev)
+             694:39(float64_t) Load 41(doublev)
+             695:39(float64_t) ExtInst 1(GLSL.std.450) 71(Reflect) 693 694
+             696:39(float64_t) Load 41(doublev)
+             697:39(float64_t) FAdd 696 695
                               Store 41(doublev) 697
-             698:   43(fvec2) Load 45(dvec2v)
-             699:   43(fvec2) Load 45(dvec2v)
-             700:   43(fvec2) ExtInst 1(GLSL.std.450) 71(Reflect) 698 699
-             701:   43(fvec2) Load 45(dvec2v)
-             702:   43(fvec2) FAdd 701 700
+             698: 43(f64vec2) Load 45(dvec2v)
+             699: 43(f64vec2) Load 45(dvec2v)
+             700: 43(f64vec2) ExtInst 1(GLSL.std.450) 71(Reflect) 698 699
+             701: 43(f64vec2) Load 45(dvec2v)
+             702: 43(f64vec2) FAdd 701 700
                               Store 45(dvec2v) 702
-             703:   48(fvec3) Load 50(dvec3v)
-             704:   48(fvec3) Load 50(dvec3v)
-             705:   48(fvec3) ExtInst 1(GLSL.std.450) 71(Reflect) 703 704
-             706:   48(fvec3) Load 50(dvec3v)
-             707:   48(fvec3) FAdd 706 705
+             703: 48(f64vec3) Load 50(dvec3v)
+             704: 48(f64vec3) Load 50(dvec3v)
+             705: 48(f64vec3) ExtInst 1(GLSL.std.450) 71(Reflect) 703 704
+             706: 48(f64vec3) Load 50(dvec3v)
+             707: 48(f64vec3) FAdd 706 705
                               Store 50(dvec3v) 707
-             708:   53(fvec4) Load 55(dvec4v)
-             709:   53(fvec4) Load 55(dvec4v)
-             710:   53(fvec4) ExtInst 1(GLSL.std.450) 71(Reflect) 708 709
-             711:   53(fvec4) Load 55(dvec4v)
-             712:   53(fvec4) FAdd 711 710
+             708: 53(f64vec4) Load 55(dvec4v)
+             709: 53(f64vec4) Load 55(dvec4v)
+             710: 53(f64vec4) ExtInst 1(GLSL.std.450) 71(Reflect) 708 709
+             711: 53(f64vec4) Load 55(dvec4v)
+             712: 53(f64vec4) FAdd 711 710
                               Store 55(dvec4v) 712
-             713:   39(float) Load 41(doublev)
-             714:   39(float) Load 41(doublev)
-             716:   39(float) ExtInst 1(GLSL.std.450) 72(Refract) 713 714 715
-             717:   39(float) Load 41(doublev)
-             718:   39(float) FAdd 717 716
+             713:39(float64_t) Load 41(doublev)
+             714:39(float64_t) Load 41(doublev)
+             716:39(float64_t) ExtInst 1(GLSL.std.450) 72(Refract) 713 714 715
+             717:39(float64_t) Load 41(doublev)
+             718:39(float64_t) FAdd 717 716
                               Store 41(doublev) 718
-             719:   43(fvec2) Load 45(dvec2v)
-             720:   43(fvec2) Load 45(dvec2v)
-             721:   43(fvec2) ExtInst 1(GLSL.std.450) 72(Refract) 719 720 715
-             722:   43(fvec2) Load 45(dvec2v)
-             723:   43(fvec2) FAdd 722 721
+             719: 43(f64vec2) Load 45(dvec2v)
+             720: 43(f64vec2) Load 45(dvec2v)
+             721: 43(f64vec2) ExtInst 1(GLSL.std.450) 72(Refract) 719 720 715
+             722: 43(f64vec2) Load 45(dvec2v)
+             723: 43(f64vec2) FAdd 722 721
                               Store 45(dvec2v) 723
-             724:   48(fvec3) Load 50(dvec3v)
-             725:   48(fvec3) Load 50(dvec3v)
-             726:   48(fvec3) ExtInst 1(GLSL.std.450) 72(Refract) 724 725 715
-             727:   48(fvec3) Load 50(dvec3v)
-             728:   48(fvec3) FAdd 727 726
+             724: 48(f64vec3) Load 50(dvec3v)
+             725: 48(f64vec3) Load 50(dvec3v)
+             726: 48(f64vec3) ExtInst 1(GLSL.std.450) 72(Refract) 724 725 715
+             727: 48(f64vec3) Load 50(dvec3v)
+             728: 48(f64vec3) FAdd 727 726
                               Store 50(dvec3v) 728
-             729:   53(fvec4) Load 55(dvec4v)
-             730:   53(fvec4) Load 55(dvec4v)
-             731:   53(fvec4) ExtInst 1(GLSL.std.450) 72(Refract) 729 730 715
-             732:   53(fvec4) Load 55(dvec4v)
-             733:   53(fvec4) FAdd 732 731
+             729: 53(f64vec4) Load 55(dvec4v)
+             730: 53(f64vec4) Load 55(dvec4v)
+             731: 53(f64vec4) ExtInst 1(GLSL.std.450) 72(Refract) 729 730 715
+             732: 53(f64vec4) Load 55(dvec4v)
+             733: 53(f64vec4) FAdd 732 731
                               Store 55(dvec4v) 733
-             737:   43(fvec2) Load 45(dvec2v)
-             738:   43(fvec2) Load 45(dvec2v)
+             737: 43(f64vec2) Load 45(dvec2v)
+             738: 43(f64vec2) Load 45(dvec2v)
              739:         734 OuterProduct 737 738
                               Store 736(dmat2v) 739
-             743:   48(fvec3) Load 50(dvec3v)
-             744:   48(fvec3) Load 50(dvec3v)
+             743: 48(f64vec3) Load 50(dvec3v)
+             744: 48(f64vec3) Load 50(dvec3v)
              745:         740 OuterProduct 743 744
                               Store 742(dmat3v) 745
-             749:   53(fvec4) Load 55(dvec4v)
-             750:   53(fvec4) Load 55(dvec4v)
+             749: 53(f64vec4) Load 55(dvec4v)
+             750: 53(f64vec4) Load 55(dvec4v)
              751:         746 OuterProduct 749 750
                               Store 748(dmat4v) 751
-             755:   48(fvec3) Load 50(dvec3v)
-             756:   43(fvec2) Load 45(dvec2v)
+             755: 48(f64vec3) Load 50(dvec3v)
+             756: 43(f64vec2) Load 45(dvec2v)
              757:         752 OuterProduct 755 756
                               Store 754(dmat2x3v) 757
-             761:   43(fvec2) Load 45(dvec2v)
-             762:   48(fvec3) Load 50(dvec3v)
+             761: 43(f64vec2) Load 45(dvec2v)
+             762: 48(f64vec3) Load 50(dvec3v)
              763:         758 OuterProduct 761 762
                               Store 760(dmat3x2v) 763
-             767:   53(fvec4) Load 55(dvec4v)
-             768:   43(fvec2) Load 45(dvec2v)
+             767: 53(f64vec4) Load 55(dvec4v)
+             768: 43(f64vec2) Load 45(dvec2v)
              769:         764 OuterProduct 767 768
                               Store 766(dmat2x4v) 769
-             773:   43(fvec2) Load 45(dvec2v)
-             774:   53(fvec4) Load 55(dvec4v)
+             773: 43(f64vec2) Load 45(dvec2v)
+             774: 53(f64vec4) Load 55(dvec4v)
              775:         770 OuterProduct 773 774
                               Store 772(dmat4x2v) 775
-             779:   53(fvec4) Load 55(dvec4v)
-             780:   48(fvec3) Load 50(dvec3v)
+             779: 53(f64vec4) Load 55(dvec4v)
+             780: 48(f64vec3) Load 50(dvec3v)
              781:         776 OuterProduct 779 780
                               Store 778(dmat3x4v) 781
-             785:   48(fvec3) Load 50(dvec3v)
-             786:   53(fvec4) Load 55(dvec4v)
+             785: 48(f64vec3) Load 50(dvec3v)
+             786: 53(f64vec4) Load 55(dvec4v)
              787:         782 OuterProduct 785 786
                               Store 784(dmat4x3v) 787
              788:         734 Load 736(dmat2v)
              789:         734 Load 736(dmat2v)
-             790:   43(fvec2) CompositeExtract 788 0
-             791:   43(fvec2) CompositeExtract 789 0
-             792:   43(fvec2) FMul 790 791
-             793:   43(fvec2) CompositeExtract 788 1
-             794:   43(fvec2) CompositeExtract 789 1
-             795:   43(fvec2) FMul 793 794
+             790: 43(f64vec2) CompositeExtract 788 0
+             791: 43(f64vec2) CompositeExtract 789 0
+             792: 43(f64vec2) FMul 790 791
+             793: 43(f64vec2) CompositeExtract 788 1
+             794: 43(f64vec2) CompositeExtract 789 1
+             795: 43(f64vec2) FMul 793 794
              796:         734 CompositeConstruct 792 795
              797:         734 Load 736(dmat2v)
              798:         734 MatrixTimesMatrix 797 796
                               Store 736(dmat2v) 798
              799:         740 Load 742(dmat3v)
              800:         740 Load 742(dmat3v)
-             801:   48(fvec3) CompositeExtract 799 0
-             802:   48(fvec3) CompositeExtract 800 0
-             803:   48(fvec3) FMul 801 802
-             804:   48(fvec3) CompositeExtract 799 1
-             805:   48(fvec3) CompositeExtract 800 1
-             806:   48(fvec3) FMul 804 805
-             807:   48(fvec3) CompositeExtract 799 2
-             808:   48(fvec3) CompositeExtract 800 2
-             809:   48(fvec3) FMul 807 808
+             801: 48(f64vec3) CompositeExtract 799 0
+             802: 48(f64vec3) CompositeExtract 800 0
+             803: 48(f64vec3) FMul 801 802
+             804: 48(f64vec3) CompositeExtract 799 1
+             805: 48(f64vec3) CompositeExtract 800 1
+             806: 48(f64vec3) FMul 804 805
+             807: 48(f64vec3) CompositeExtract 799 2
+             808: 48(f64vec3) CompositeExtract 800 2
+             809: 48(f64vec3) FMul 807 808
              810:         740 CompositeConstruct 803 806 809
              811:         740 Load 742(dmat3v)
              812:         740 MatrixTimesMatrix 811 810
                               Store 742(dmat3v) 812
              813:         746 Load 748(dmat4v)
              814:         746 Load 748(dmat4v)
-             815:   53(fvec4) CompositeExtract 813 0
-             816:   53(fvec4) CompositeExtract 814 0
-             817:   53(fvec4) FMul 815 816
-             818:   53(fvec4) CompositeExtract 813 1
-             819:   53(fvec4) CompositeExtract 814 1
-             820:   53(fvec4) FMul 818 819
-             821:   53(fvec4) CompositeExtract 813 2
-             822:   53(fvec4) CompositeExtract 814 2
-             823:   53(fvec4) FMul 821 822
-             824:   53(fvec4) CompositeExtract 813 3
-             825:   53(fvec4) CompositeExtract 814 3
-             826:   53(fvec4) FMul 824 825
+             815: 53(f64vec4) CompositeExtract 813 0
+             816: 53(f64vec4) CompositeExtract 814 0
+             817: 53(f64vec4) FMul 815 816
+             818: 53(f64vec4) CompositeExtract 813 1
+             819: 53(f64vec4) CompositeExtract 814 1
+             820: 53(f64vec4) FMul 818 819
+             821: 53(f64vec4) CompositeExtract 813 2
+             822: 53(f64vec4) CompositeExtract 814 2
+             823: 53(f64vec4) FMul 821 822
+             824: 53(f64vec4) CompositeExtract 813 3
+             825: 53(f64vec4) CompositeExtract 814 3
+             826: 53(f64vec4) FMul 824 825
              827:         746 CompositeConstruct 817 820 823 826
              828:         746 Load 748(dmat4v)
              829:         746 MatrixTimesMatrix 828 827
                               Store 748(dmat4v) 829
              830:         752 Load 754(dmat2x3v)
              831:         752 Load 754(dmat2x3v)
-             832:   48(fvec3) CompositeExtract 830 0
-             833:   48(fvec3) CompositeExtract 831 0
-             834:   48(fvec3) FMul 832 833
-             835:   48(fvec3) CompositeExtract 830 1
-             836:   48(fvec3) CompositeExtract 831 1
-             837:   48(fvec3) FMul 835 836
+             832: 48(f64vec3) CompositeExtract 830 0
+             833: 48(f64vec3) CompositeExtract 831 0
+             834: 48(f64vec3) FMul 832 833
+             835: 48(f64vec3) CompositeExtract 830 1
+             836: 48(f64vec3) CompositeExtract 831 1
+             837: 48(f64vec3) FMul 835 836
              838:         752 CompositeConstruct 834 837
                               Store 754(dmat2x3v) 838
              839:         764 Load 766(dmat2x4v)
              840:         764 Load 766(dmat2x4v)
-             841:   53(fvec4) CompositeExtract 839 0
-             842:   53(fvec4) CompositeExtract 840 0
-             843:   53(fvec4) FMul 841 842
-             844:   53(fvec4) CompositeExtract 839 1
-             845:   53(fvec4) CompositeExtract 840 1
-             846:   53(fvec4) FMul 844 845
+             841: 53(f64vec4) CompositeExtract 839 0
+             842: 53(f64vec4) CompositeExtract 840 0
+             843: 53(f64vec4) FMul 841 842
+             844: 53(f64vec4) CompositeExtract 839 1
+             845: 53(f64vec4) CompositeExtract 840 1
+             846: 53(f64vec4) FMul 844 845
              847:         764 CompositeConstruct 843 846
                               Store 766(dmat2x4v) 847
              848:         758 Load 760(dmat3x2v)
              849:         758 Load 760(dmat3x2v)
-             850:   43(fvec2) CompositeExtract 848 0
-             851:   43(fvec2) CompositeExtract 849 0
-             852:   43(fvec2) FMul 850 851
-             853:   43(fvec2) CompositeExtract 848 1
-             854:   43(fvec2) CompositeExtract 849 1
-             855:   43(fvec2) FMul 853 854
-             856:   43(fvec2) CompositeExtract 848 2
-             857:   43(fvec2) CompositeExtract 849 2
-             858:   43(fvec2) FMul 856 857
+             850: 43(f64vec2) CompositeExtract 848 0
+             851: 43(f64vec2) CompositeExtract 849 0
+             852: 43(f64vec2) FMul 850 851
+             853: 43(f64vec2) CompositeExtract 848 1
+             854: 43(f64vec2) CompositeExtract 849 1
+             855: 43(f64vec2) FMul 853 854
+             856: 43(f64vec2) CompositeExtract 848 2
+             857: 43(f64vec2) CompositeExtract 849 2
+             858: 43(f64vec2) FMul 856 857
              859:         758 CompositeConstruct 852 855 858
                               Store 760(dmat3x2v) 859
              860:         776 Load 778(dmat3x4v)
              861:         776 Load 778(dmat3x4v)
-             862:   53(fvec4) CompositeExtract 860 0
-             863:   53(fvec4) CompositeExtract 861 0
-             864:   53(fvec4) FMul 862 863
-             865:   53(fvec4) CompositeExtract 860 1
-             866:   53(fvec4) CompositeExtract 861 1
-             867:   53(fvec4) FMul 865 866
-             868:   53(fvec4) CompositeExtract 860 2
-             869:   53(fvec4) CompositeExtract 861 2
-             870:   53(fvec4) FMul 868 869
+             862: 53(f64vec4) CompositeExtract 860 0
+             863: 53(f64vec4) CompositeExtract 861 0
+             864: 53(f64vec4) FMul 862 863
+             865: 53(f64vec4) CompositeExtract 860 1
+             866: 53(f64vec4) CompositeExtract 861 1
+             867: 53(f64vec4) FMul 865 866
+             868: 53(f64vec4) CompositeExtract 860 2
+             869: 53(f64vec4) CompositeExtract 861 2
+             870: 53(f64vec4) FMul 868 869
              871:         776 CompositeConstruct 864 867 870
                               Store 778(dmat3x4v) 871
              872:         770 Load 772(dmat4x2v)
              873:         770 Load 772(dmat4x2v)
-             874:   43(fvec2) CompositeExtract 872 0
-             875:   43(fvec2) CompositeExtract 873 0
-             876:   43(fvec2) FMul 874 875
-             877:   43(fvec2) CompositeExtract 872 1
-             878:   43(fvec2) CompositeExtract 873 1
-             879:   43(fvec2) FMul 877 878
-             880:   43(fvec2) CompositeExtract 872 2
-             881:   43(fvec2) CompositeExtract 873 2
-             882:   43(fvec2) FMul 880 881
-             883:   43(fvec2) CompositeExtract 872 3
-             884:   43(fvec2) CompositeExtract 873 3
-             885:   43(fvec2) FMul 883 884
+             874: 43(f64vec2) CompositeExtract 872 0
+             875: 43(f64vec2) CompositeExtract 873 0
+             876: 43(f64vec2) FMul 874 875
+             877: 43(f64vec2) CompositeExtract 872 1
+             878: 43(f64vec2) CompositeExtract 873 1
+             879: 43(f64vec2) FMul 877 878
+             880: 43(f64vec2) CompositeExtract 872 2
+             881: 43(f64vec2) CompositeExtract 873 2
+             882: 43(f64vec2) FMul 880 881
+             883: 43(f64vec2) CompositeExtract 872 3
+             884: 43(f64vec2) CompositeExtract 873 3
+             885: 43(f64vec2) FMul 883 884
              886:         770 CompositeConstruct 876 879 882 885
                               Store 772(dmat4x2v) 886
              887:         782 Load 784(dmat4x3v)
              888:         782 Load 784(dmat4x3v)
-             889:   48(fvec3) CompositeExtract 887 0
-             890:   48(fvec3) CompositeExtract 888 0
-             891:   48(fvec3) FMul 889 890
-             892:   48(fvec3) CompositeExtract 887 1
-             893:   48(fvec3) CompositeExtract 888 1
-             894:   48(fvec3) FMul 892 893
-             895:   48(fvec3) CompositeExtract 887 2
-             896:   48(fvec3) CompositeExtract 888 2
-             897:   48(fvec3) FMul 895 896
-             898:   48(fvec3) CompositeExtract 887 3
-             899:   48(fvec3) CompositeExtract 888 3
-             900:   48(fvec3) FMul 898 899
+             889: 48(f64vec3) CompositeExtract 887 0
+             890: 48(f64vec3) CompositeExtract 888 0
+             891: 48(f64vec3) FMul 889 890
+             892: 48(f64vec3) CompositeExtract 887 1
+             893: 48(f64vec3) CompositeExtract 888 1
+             894: 48(f64vec3) FMul 892 893
+             895: 48(f64vec3) CompositeExtract 887 2
+             896: 48(f64vec3) CompositeExtract 888 2
+             897: 48(f64vec3) FMul 895 896
+             898: 48(f64vec3) CompositeExtract 887 3
+             899: 48(f64vec3) CompositeExtract 888 3
+             900: 48(f64vec3) FMul 898 899
              901:         782 CompositeConstruct 891 894 897 900
                               Store 784(dmat4x3v) 901
              902:         734 Load 736(dmat2v)
@@ -1295,19 +1295,19 @@ spv.400.frag
              925:         782 Transpose 924
                               Store 784(dmat4x3v) 925
              926:         734 Load 736(dmat2v)
-             927:   39(float) ExtInst 1(GLSL.std.450) 33(Determinant) 926
-             928:   39(float) Load 41(doublev)
-             929:   39(float) FAdd 928 927
+             927:39(float64_t) ExtInst 1(GLSL.std.450) 33(Determinant) 926
+             928:39(float64_t) Load 41(doublev)
+             929:39(float64_t) FAdd 928 927
                               Store 41(doublev) 929
              930:         740 Load 742(dmat3v)
-             931:   39(float) ExtInst 1(GLSL.std.450) 33(Determinant) 930
-             932:   39(float) Load 41(doublev)
-             933:   39(float) FAdd 932 931
+             931:39(float64_t) ExtInst 1(GLSL.std.450) 33(Determinant) 930
+             932:39(float64_t) Load 41(doublev)
+             933:39(float64_t) FAdd 932 931
                               Store 41(doublev) 933
              934:         746 Load 748(dmat4v)
-             935:   39(float) ExtInst 1(GLSL.std.450) 33(Determinant) 934
-             936:   39(float) Load 41(doublev)
-             937:   39(float) FAdd 936 935
+             935:39(float64_t) ExtInst 1(GLSL.std.450) 33(Determinant) 934
+             936:39(float64_t) Load 41(doublev)
+             937:39(float64_t) FAdd 936 935
                               Store 41(doublev) 937
              938:         734 Load 736(dmat2v)
              939:         734 ExtInst 1(GLSL.std.450) 34(MatrixInverse) 938
@@ -1324,62 +1324,62 @@ spv.400.frag
              948:         746 Load 748(dmat4v)
              949:         746 MatrixTimesMatrix 948 947
                               Store 748(dmat4v) 949
-             950:   39(float) Load 41(doublev)
+             950:39(float64_t) Load 41(doublev)
              952:     40(ptr) AccessChain 45(dvec2v) 951
-             953:   39(float) Load 952
-             954:   39(float) FAdd 950 953
+             953:39(float64_t) Load 952
+             954:39(float64_t) FAdd 950 953
              956:     40(ptr) AccessChain 50(dvec3v) 955
-             957:   39(float) Load 956
-             958:   39(float) FAdd 954 957
+             957:39(float64_t) Load 956
+             958:39(float64_t) FAdd 954 957
              960:     40(ptr) AccessChain 55(dvec4v) 959
-             961:   39(float) Load 960
-             962:   39(float) FAdd 958 961
+             961:39(float64_t) Load 960
+             962:39(float64_t) FAdd 958 961
              964:     40(ptr) AccessChain 736(dmat2v) 963 951
-             965:   39(float) Load 964
-             966:   39(float) FAdd 962 965
+             965:39(float64_t) Load 964
+             966:39(float64_t) FAdd 962 965
              968:     40(ptr) AccessChain 742(dmat3v) 967 955
-             969:   39(float) Load 968
-             970:   39(float) FAdd 966 969
+             969:39(float64_t) Load 968
+             970:39(float64_t) FAdd 966 969
              971:     40(ptr) AccessChain 748(dmat4v) 25 959
-             972:   39(float) Load 971
-             973:   39(float) FAdd 970 972
+             972:39(float64_t) Load 971
+             973:39(float64_t) FAdd 970 972
              974:     40(ptr) AccessChain 754(dmat2x3v) 963 951
-             975:   39(float) Load 974
-             976:   39(float) FAdd 973 975
+             975:39(float64_t) Load 974
+             976:39(float64_t) FAdd 973 975
              977:     40(ptr) AccessChain 760(dmat3x2v) 963 951
-             978:   39(float) Load 977
-             979:   39(float) FAdd 976 978
+             978:39(float64_t) Load 977
+             979:39(float64_t) FAdd 976 978
              980:     40(ptr) AccessChain 778(dmat3x4v) 967 955
-             981:   39(float) Load 980
-             982:   39(float) FAdd 979 981
+             981:39(float64_t) Load 980
+             982:39(float64_t) FAdd 979 981
              983:     40(ptr) AccessChain 784(dmat4x3v) 967 955
-             984:   39(float) Load 983
-             985:   39(float) FAdd 982 984
+             984:39(float64_t) Load 983
+             985:39(float64_t) FAdd 982 984
              986:     40(ptr) AccessChain 766(dmat2x4v) 963 951
-             987:   39(float) Load 986
-             988:   39(float) FAdd 985 987
+             987:39(float64_t) Load 986
+             988:39(float64_t) FAdd 985 987
              989:     40(ptr) AccessChain 772(dmat4x2v) 963 951
-             990:   39(float) Load 989
-             991:   39(float) FAdd 988 990
+             990:39(float64_t) Load 989
+             991:39(float64_t) FAdd 988 990
              992:   428(bool) Load 430(boolv)
              994:   10(float) Select 992 993 21
-             995:   39(float) FConvert 994
-             996:   39(float) FAdd 991 995
+             995:39(float64_t) FConvert 994
+             996:39(float64_t) FAdd 991 995
              997:    429(ptr) AccessChain 439(bvec2v) 33
              998:   428(bool) Load 997
              999:   10(float) Select 998 993 21
-            1000:   39(float) FConvert 999
-            1001:   39(float) FAdd 996 1000
+            1000:39(float64_t) FConvert 999
+            1001:39(float64_t) FAdd 996 1000
             1002:    429(ptr) AccessChain 448(bvec3v) 33
             1003:   428(bool) Load 1002
             1004:   10(float) Select 1003 993 21
-            1005:   39(float) FConvert 1004
-            1006:   39(float) FAdd 1001 1005
+            1005:39(float64_t) FConvert 1004
+            1006:39(float64_t) FAdd 1001 1005
             1007:    429(ptr) AccessChain 457(bvec4v) 33
             1008:   428(bool) Load 1007
             1009:   10(float) Select 1008 993 21
-            1010:   39(float) FConvert 1009
-            1011:   39(float) FAdd 1006 1010
+            1010:39(float64_t) FConvert 1009
+            1011:39(float64_t) FAdd 1006 1010
             1012:   10(float) FConvert 1011
             1013:   11(fvec4) Load 13(outp)
             1014:   11(fvec4) VectorTimesScalar 1013 1012

--- a/Test/baseResults/spv.atomicInt64.comp.out
+++ b/Test/baseResults/spv.atomicInt64.comp.out
@@ -33,29 +33,29 @@ spv.atomicInt64.comp
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeInt 64 1
-               7:             TypePointer Function 6(int)
-               9:      6(int) Constant 0 0
+               7:             TypePointer Function 6(int64_t)
+               9:  6(int64_t) Constant 0 0
               10:             TypeInt 64 0
-              11:             TypePointer Function 10(int)
-              13:     10(int) Constant 0 0
-      14(Buffer):             TypeStruct 6(int) 10(int)
+              11:             TypePointer Function 10(int64_t)
+              13: 10(int64_t) Constant 0 0
+      14(Buffer):             TypeStruct 6(int64_t) 10(int64_t)
               15:             TypePointer Uniform 14(Buffer)
          16(buf):     15(ptr) Variable Uniform
               17:             TypeInt 32 1
               18:     17(int) Constant 0
-              19:             TypePointer Uniform 6(int)
-              21:      6(int) Constant 4294967272 4294967295
+              19:             TypePointer Uniform 6(int64_t)
+              21:  6(int64_t) Constant 4294967272 4294967295
               22:             TypeInt 32 0
               23:     22(int) Constant 1
               24:     22(int) Constant 0
               28:     17(int) Constant 1
-              29:             TypePointer Uniform 10(int)
-              31:     10(int) Constant 15 240
-      84(Struct):             TypeStruct 6(int) 10(int)
+              29:             TypePointer Uniform 10(int64_t)
+              31: 10(int64_t) Constant 15 240
+      84(Struct):             TypeStruct 6(int64_t) 10(int64_t)
               85:             TypePointer Workgroup 84(Struct)
            86(s):     85(ptr) Variable Workgroup
-              87:             TypePointer Workgroup 6(int)
-              92:             TypePointer Workgroup 10(int)
+              87:             TypePointer Workgroup 6(int64_t)
+              92:             TypePointer Workgroup 10(int64_t)
              146:             TypeVector 22(int) 3
              147:     22(int) Constant 16
              148:  146(ivec3) ConstantComposite 147 147 23
@@ -66,149 +66,149 @@ spv.atomicInt64.comp
                               Store 8(i64) 9
                               Store 12(u64) 13
               20:     19(ptr) AccessChain 16(buf) 18
-              25:      6(int) AtomicSMin 20 23 24 21
-              26:      6(int) Load 8(i64)
-              27:      6(int) IAdd 26 25
+              25:  6(int64_t) AtomicSMin 20 23 24 21
+              26:  6(int64_t) Load 8(i64)
+              27:  6(int64_t) IAdd 26 25
                               Store 8(i64) 27
               30:     29(ptr) AccessChain 16(buf) 28
-              32:     10(int) AtomicUMin 30 23 24 31
-              33:     10(int) Load 12(u64)
-              34:     10(int) IAdd 33 32
+              32: 10(int64_t) AtomicUMin 30 23 24 31
+              33: 10(int64_t) Load 12(u64)
+              34: 10(int64_t) IAdd 33 32
                               Store 12(u64) 34
               35:     19(ptr) AccessChain 16(buf) 18
-              36:      6(int) AtomicSMax 35 23 24 21
-              37:      6(int) Load 8(i64)
-              38:      6(int) IAdd 37 36
+              36:  6(int64_t) AtomicSMax 35 23 24 21
+              37:  6(int64_t) Load 8(i64)
+              38:  6(int64_t) IAdd 37 36
                               Store 8(i64) 38
               39:     29(ptr) AccessChain 16(buf) 28
-              40:     10(int) AtomicUMax 39 23 24 31
-              41:     10(int) Load 12(u64)
-              42:     10(int) IAdd 41 40
+              40: 10(int64_t) AtomicUMax 39 23 24 31
+              41: 10(int64_t) Load 12(u64)
+              42: 10(int64_t) IAdd 41 40
                               Store 12(u64) 42
               43:     19(ptr) AccessChain 16(buf) 18
-              44:      6(int) AtomicAnd 43 23 24 21
-              45:      6(int) Load 8(i64)
-              46:      6(int) IAdd 45 44
+              44:  6(int64_t) AtomicAnd 43 23 24 21
+              45:  6(int64_t) Load 8(i64)
+              46:  6(int64_t) IAdd 45 44
                               Store 8(i64) 46
               47:     29(ptr) AccessChain 16(buf) 28
-              48:     10(int) AtomicAnd 47 23 24 31
-              49:     10(int) Load 12(u64)
-              50:     10(int) IAdd 49 48
+              48: 10(int64_t) AtomicAnd 47 23 24 31
+              49: 10(int64_t) Load 12(u64)
+              50: 10(int64_t) IAdd 49 48
                               Store 12(u64) 50
               51:     19(ptr) AccessChain 16(buf) 18
-              52:      6(int) AtomicOr 51 23 24 21
-              53:      6(int) Load 8(i64)
-              54:      6(int) IAdd 53 52
+              52:  6(int64_t) AtomicOr 51 23 24 21
+              53:  6(int64_t) Load 8(i64)
+              54:  6(int64_t) IAdd 53 52
                               Store 8(i64) 54
               55:     29(ptr) AccessChain 16(buf) 28
-              56:     10(int) AtomicOr 55 23 24 31
-              57:     10(int) Load 12(u64)
-              58:     10(int) IAdd 57 56
+              56: 10(int64_t) AtomicOr 55 23 24 31
+              57: 10(int64_t) Load 12(u64)
+              58: 10(int64_t) IAdd 57 56
                               Store 12(u64) 58
               59:     19(ptr) AccessChain 16(buf) 18
-              60:      6(int) AtomicXor 59 23 24 21
-              61:      6(int) Load 8(i64)
-              62:      6(int) IAdd 61 60
+              60:  6(int64_t) AtomicXor 59 23 24 21
+              61:  6(int64_t) Load 8(i64)
+              62:  6(int64_t) IAdd 61 60
                               Store 8(i64) 62
               63:     29(ptr) AccessChain 16(buf) 28
-              64:     10(int) AtomicXor 63 23 24 31
-              65:     10(int) Load 12(u64)
-              66:     10(int) IAdd 65 64
+              64: 10(int64_t) AtomicXor 63 23 24 31
+              65: 10(int64_t) Load 12(u64)
+              66: 10(int64_t) IAdd 65 64
                               Store 12(u64) 66
               67:     19(ptr) AccessChain 16(buf) 18
-              68:      6(int) AtomicIAdd 67 23 24 21
-              69:      6(int) Load 8(i64)
-              70:      6(int) IAdd 69 68
+              68:  6(int64_t) AtomicIAdd 67 23 24 21
+              69:  6(int64_t) Load 8(i64)
+              70:  6(int64_t) IAdd 69 68
                               Store 8(i64) 70
               71:     19(ptr) AccessChain 16(buf) 18
-              72:      6(int) AtomicExchange 71 23 24 21
-              73:      6(int) Load 8(i64)
-              74:      6(int) IAdd 73 72
+              72:  6(int64_t) AtomicExchange 71 23 24 21
+              73:  6(int64_t) Load 8(i64)
+              74:  6(int64_t) IAdd 73 72
                               Store 8(i64) 74
               75:     19(ptr) AccessChain 16(buf) 18
-              76:      6(int) Load 8(i64)
-              77:      6(int) AtomicCompareExchange 75 23 24 24 76 21
-              78:      6(int) Load 8(i64)
-              79:      6(int) IAdd 78 77
+              76:  6(int64_t) Load 8(i64)
+              77:  6(int64_t) AtomicCompareExchange 75 23 24 24 76 21
+              78:  6(int64_t) Load 8(i64)
+              79:  6(int64_t) IAdd 78 77
                               Store 8(i64) 79
-              80:      6(int) Load 8(i64)
+              80:  6(int64_t) Load 8(i64)
               81:     19(ptr) AccessChain 16(buf) 18
                               Store 81 80
-              82:     10(int) Load 12(u64)
+              82: 10(int64_t) Load 12(u64)
               83:     29(ptr) AccessChain 16(buf) 28
                               Store 83 82
                               Store 8(i64) 9
                               Store 12(u64) 13
               88:     87(ptr) AccessChain 86(s) 18
-              89:      6(int) AtomicSMin 88 23 24 21
-              90:      6(int) Load 8(i64)
-              91:      6(int) IAdd 90 89
+              89:  6(int64_t) AtomicSMin 88 23 24 21
+              90:  6(int64_t) Load 8(i64)
+              91:  6(int64_t) IAdd 90 89
                               Store 8(i64) 91
               93:     92(ptr) AccessChain 86(s) 28
-              94:     10(int) AtomicUMin 93 23 24 31
-              95:     10(int) Load 12(u64)
-              96:     10(int) IAdd 95 94
+              94: 10(int64_t) AtomicUMin 93 23 24 31
+              95: 10(int64_t) Load 12(u64)
+              96: 10(int64_t) IAdd 95 94
                               Store 12(u64) 96
               97:     87(ptr) AccessChain 86(s) 18
-              98:      6(int) AtomicSMax 97 23 24 21
-              99:      6(int) Load 8(i64)
-             100:      6(int) IAdd 99 98
+              98:  6(int64_t) AtomicSMax 97 23 24 21
+              99:  6(int64_t) Load 8(i64)
+             100:  6(int64_t) IAdd 99 98
                               Store 8(i64) 100
              101:     92(ptr) AccessChain 86(s) 28
-             102:     10(int) AtomicUMax 101 23 24 31
-             103:     10(int) Load 12(u64)
-             104:     10(int) IAdd 103 102
+             102: 10(int64_t) AtomicUMax 101 23 24 31
+             103: 10(int64_t) Load 12(u64)
+             104: 10(int64_t) IAdd 103 102
                               Store 12(u64) 104
              105:     87(ptr) AccessChain 86(s) 18
-             106:      6(int) AtomicAnd 105 23 24 21
-             107:      6(int) Load 8(i64)
-             108:      6(int) IAdd 107 106
+             106:  6(int64_t) AtomicAnd 105 23 24 21
+             107:  6(int64_t) Load 8(i64)
+             108:  6(int64_t) IAdd 107 106
                               Store 8(i64) 108
              109:     92(ptr) AccessChain 86(s) 28
-             110:     10(int) AtomicAnd 109 23 24 31
-             111:     10(int) Load 12(u64)
-             112:     10(int) IAdd 111 110
+             110: 10(int64_t) AtomicAnd 109 23 24 31
+             111: 10(int64_t) Load 12(u64)
+             112: 10(int64_t) IAdd 111 110
                               Store 12(u64) 112
              113:     87(ptr) AccessChain 86(s) 18
-             114:      6(int) AtomicOr 113 23 24 21
-             115:      6(int) Load 8(i64)
-             116:      6(int) IAdd 115 114
+             114:  6(int64_t) AtomicOr 113 23 24 21
+             115:  6(int64_t) Load 8(i64)
+             116:  6(int64_t) IAdd 115 114
                               Store 8(i64) 116
              117:     92(ptr) AccessChain 86(s) 28
-             118:     10(int) AtomicOr 117 23 24 31
-             119:     10(int) Load 12(u64)
-             120:     10(int) IAdd 119 118
+             118: 10(int64_t) AtomicOr 117 23 24 31
+             119: 10(int64_t) Load 12(u64)
+             120: 10(int64_t) IAdd 119 118
                               Store 12(u64) 120
              121:     87(ptr) AccessChain 86(s) 18
-             122:      6(int) AtomicXor 121 23 24 21
-             123:      6(int) Load 8(i64)
-             124:      6(int) IAdd 123 122
+             122:  6(int64_t) AtomicXor 121 23 24 21
+             123:  6(int64_t) Load 8(i64)
+             124:  6(int64_t) IAdd 123 122
                               Store 8(i64) 124
              125:     92(ptr) AccessChain 86(s) 28
-             126:     10(int) AtomicXor 125 23 24 31
-             127:     10(int) Load 12(u64)
-             128:     10(int) IAdd 127 126
+             126: 10(int64_t) AtomicXor 125 23 24 31
+             127: 10(int64_t) Load 12(u64)
+             128: 10(int64_t) IAdd 127 126
                               Store 12(u64) 128
              129:     87(ptr) AccessChain 86(s) 18
-             130:      6(int) AtomicIAdd 129 23 24 21
-             131:      6(int) Load 8(i64)
-             132:      6(int) IAdd 131 130
+             130:  6(int64_t) AtomicIAdd 129 23 24 21
+             131:  6(int64_t) Load 8(i64)
+             132:  6(int64_t) IAdd 131 130
                               Store 8(i64) 132
              133:     87(ptr) AccessChain 86(s) 18
-             134:      6(int) AtomicExchange 133 23 24 21
-             135:      6(int) Load 8(i64)
-             136:      6(int) IAdd 135 134
+             134:  6(int64_t) AtomicExchange 133 23 24 21
+             135:  6(int64_t) Load 8(i64)
+             136:  6(int64_t) IAdd 135 134
                               Store 8(i64) 136
              137:     87(ptr) AccessChain 86(s) 18
-             138:      6(int) Load 8(i64)
-             139:      6(int) AtomicCompareExchange 137 23 24 24 138 21
-             140:      6(int) Load 8(i64)
-             141:      6(int) IAdd 140 139
+             138:  6(int64_t) Load 8(i64)
+             139:  6(int64_t) AtomicCompareExchange 137 23 24 24 138 21
+             140:  6(int64_t) Load 8(i64)
+             141:  6(int64_t) IAdd 140 139
                               Store 8(i64) 141
-             142:      6(int) Load 8(i64)
+             142:  6(int64_t) Load 8(i64)
              143:     87(ptr) AccessChain 86(s) 18
                               Store 143 142
-             144:     10(int) Load 12(u64)
+             144: 10(int64_t) Load 12(u64)
              145:     92(ptr) AccessChain 86(s) 28
                               Store 145 144
                               Return

--- a/Test/baseResults/spv.double.comp.out
+++ b/Test/baseResults/spv.double.comp.out
@@ -34,13 +34,13 @@ spv.double.comp
                3:             TypeFunction 2
                6:             TypeFloat 32
                7:             TypeFloat 64
-      8(bufName):             TypeStruct 6(float) 7(float)
+      8(bufName):             TypeStruct 6(float) 7(float64_t)
                9:             TypePointer Uniform 8(bufName)
      10(bufInst):      9(ptr) Variable Uniform
               11:             TypeInt 32 1
               12:     11(int) Constant 1
-              13:    7(float) Constant 1413754136 1074340347
-              14:             TypePointer Uniform 7(float)
+              13:7(float64_t) Constant 1413754136 1074340347
+              14:             TypePointer Uniform 7(float64_t)
               16:     11(int) Constant 0
               17:    6(float) Constant 1095307129
               18:             TypePointer Uniform 6(float)
@@ -51,19 +51,19 @@ spv.double.comp
               25:             TypePointer Input 24(ivec3)
 26(gl_GlobalInvocationID):     25(ptr) Variable Input
               27:             TypeVector 23(int) 2
-              31:             TypePointer Function 7(float)
+              31:             TypePointer Function 7(float64_t)
 33(gl_LocalInvocationID):     25(ptr) Variable Input
               37:     11(int) Constant 8
               40:             TypeVector 6(float) 2
               42:    6(float) Constant 1090519040
-              47:             TypeVector 7(float) 4
-              48:             TypePointer Function 47(fvec4)
-              50:    7(float) Constant 2576980378 1071225241
-              51:    7(float) Constant 2576980378 1070176665
-              52:    7(float) Constant 858993459 1070805811
-              53:   47(fvec4) ConstantComposite 50 51 52 50
-              55:    7(float) Constant 0 1072693248
-              56:    7(float) Constant 3229815407 1074340298
+              47:             TypeVector 7(float64_t) 4
+              48:             TypePointer Function 47(f64vec4)
+              50:7(float64_t) Constant 2576980378 1071225241
+              51:7(float64_t) Constant 2576980378 1070176665
+              52:7(float64_t) Constant 858993459 1070805811
+              53: 47(f64vec4) ConstantComposite 50 51 52 50
+              55:7(float64_t) Constant 0 1072693248
+              56:7(float64_t) Constant 3229815407 1074340298
               57:             TypeImage 6(float) 2D nonsampled format:Unknown
               58:             TypePointer UniformConstant 57
      59(destTex):     58(ptr) Variable UniformConstant
@@ -90,7 +90,7 @@ spv.double.comp
               43:   40(fvec2) CompositeConstruct 42 42
               44:   40(fvec2) FDiv 41 43
               45:    6(float) ExtInst 1(GLSL.std.450) 66(Length) 44
-              46:    7(float) FConvert 45
+              46:7(float64_t) FConvert 45
                               Store 32(localCoef) 46
                               Store 49(aa) 53
                               Store 54(globalCoef) 55

--- a/Test/baseResults/spv.explicittypes.frag.out
+++ b/Test/baseResults/spv.explicittypes.frag.out
@@ -140,13 +140,13 @@ spv.explicittypes.frag
                2:             TypeVoid
                3:             TypeFunction 2
               16:             TypeInt 64 1
-              17:             TypePointer Function 16(int)
+              17:             TypePointer Function 16(int64_t)
               19:             TypeInt 32 0
               20:     19(int) Constant 3
-              21:             TypeArray 16(int) 20
-              22:     16(int) Constant 4008636143 4008636142
-              23:     16(int) Constant 4294967295 4294967295
-              24:     16(int) Constant 0 1
+              21:             TypeArray 16(int64_t) 20
+              22: 16(int64_t) Constant 4008636143 4008636142
+              23: 16(int64_t) Constant 4294967295 4294967295
+              24: 16(int64_t) Constant 0 1
               25:          21 ConstantComposite 22 23 24
     26(Uniforms):             TypeStruct 19(int)
               27:             TypePointer Uniform 26(Uniforms)
@@ -156,11 +156,11 @@ spv.explicittypes.frag
               31:             TypePointer Uniform 19(int)
               34:             TypePointer Function 21
               38:             TypeInt 64 0
-              39:             TypePointer Function 38(int)
-              41:             TypeArray 38(int) 20
-              42:     38(int) Constant 4294967295 4294967295
-              43:     38(int) Constant 0 1
-              44:     38(int) Constant 4294967295 1
+              39:             TypePointer Function 38(int64_t)
+              41:             TypeArray 38(int64_t) 20
+              42: 38(int64_t) Constant 4294967295 4294967295
+              43: 38(int64_t) Constant 0 1
+              44: 38(int64_t) Constant 4294967295 1
               45:          41 ConstantComposite 42 43 44
               48:             TypePointer Function 41
               52:             TypePointer Function 29(int)
@@ -177,78 +177,78 @@ spv.explicittypes.frag
               70:          67 ConstantComposite 68 68 69
               73:             TypePointer Function 67
               77:             TypeInt 16 1
-              78:             TypePointer Function 77(int)
-              80:             TypeArray 77(int) 20
-              81:     77(int) Constant 4294962927
-              82:     77(int) Constant 4294967295
-              83:     77(int) Constant 16384
+              78:             TypePointer Function 77(int16_t)
+              80:             TypeArray 77(int16_t) 20
+              81: 77(int16_t) Constant 4294962927
+              82: 77(int16_t) Constant 4294967295
+              83: 77(int16_t) Constant 16384
               84:          80 ConstantComposite 81 82 83
               87:             TypePointer Function 80
               91:             TypeInt 16 0
-              92:             TypePointer Function 91(int)
-              94:             TypeArray 91(int) 20
-              95:     91(int) Constant 65535
-              96:     91(int) Constant 32767
+              92:             TypePointer Function 91(int16_t)
+              94:             TypeArray 91(int16_t) 20
+              95: 91(int16_t) Constant 65535
+              96: 91(int16_t) Constant 32767
               97:          94 ConstantComposite 95 95 96
              100:             TypePointer Function 94
              104:             TypeInt 8 1
-             105:             TypePointer Function 104(int)
-             107:             TypeArray 104(int) 20
-             108:    104(int) Constant 4294967279
-             109:    104(int) Constant 4294967295
-             110:    104(int) Constant 0
+             105:             TypePointer Function 104(int8_t)
+             107:             TypeArray 104(int8_t) 20
+             108: 104(int8_t) Constant 4294967279
+             109: 104(int8_t) Constant 4294967295
+             110: 104(int8_t) Constant 0
              111:         107 ConstantComposite 108 109 110
              114:             TypePointer Function 107
              118:             TypeInt 8 0
-             119:             TypePointer Function 118(int)
-             121:             TypeArray 118(int) 20
-             122:    118(int) Constant 255
-             123:    118(int) Constant 127
+             119:             TypePointer Function 118(int8_t)
+             121:             TypeArray 118(int8_t) 20
+             122: 118(int8_t) Constant 255
+             123: 118(int8_t) Constant 127
              124:         121 ConstantComposite 122 122 123
              127:             TypePointer Function 121
-             131:             TypeVector 118(int) 2
-             132:             TypePointer Function 131(ivec2)
-             134:             TypeVector 104(int) 2
-             135:             TypePointer Function 134(ivec2)
-             139:             TypeVector 77(int) 2
-             140:             TypePointer Function 139(ivec2)
+             131:             TypeVector 118(int8_t) 2
+             132:             TypePointer Function 131(i8vec2)
+             134:             TypeVector 104(int8_t) 2
+             135:             TypePointer Function 134(i8vec2)
+             139:             TypeVector 77(int16_t) 2
+             140:             TypePointer Function 139(i16vec2)
              147:             TypeVector 29(int) 2
              148:             TypePointer Function 147(ivec2)
              155:             TypeVector 19(int) 2
              156:             TypePointer Function 155(ivec2)
-             161:             TypeVector 16(int) 2
-             162:             TypePointer Function 161(ivec2)
-             166:             TypeVector 38(int) 2
-             167:             TypePointer Function 166(ivec2)
+             161:             TypeVector 16(int64_t) 2
+             162:             TypePointer Function 161(i64vec2)
+             166:             TypeVector 38(int64_t) 2
+             167:             TypePointer Function 166(i64vec2)
              179:             TypeFloat 16
-             180:             TypeVector 179(float) 2
-             181:             TypePointer Function 180(fvec2)
+             180:             TypeVector 179(float16_t) 2
+             181:             TypePointer Function 180(f16vec2)
              185:             TypeFloat 32
              186:             TypeVector 185(float) 2
              187:             TypePointer Function 186(fvec2)
              191:             TypeFloat 64
-             192:             TypeVector 191(float) 2
-             193:             TypePointer Function 192(fvec2)
-             220:             TypeVector 91(int) 2
-             221:             TypePointer Function 220(ivec2)
+             192:             TypeVector 191(float64_t) 2
+             193:             TypePointer Function 192(f64vec2)
+             220:             TypeVector 91(int16_t) 2
+             221:             TypePointer Function 220(i16vec2)
              249:             TypeBool
              250:             TypeVector 249(bool) 2
              251:             TypePointer Function 250(bvec2)
-             254:    104(int) Constant 1
-             255:  134(ivec2) ConstantComposite 110 110
-             256:  134(ivec2) ConstantComposite 254 254
-             259:    118(int) Constant 0
-             260:    118(int) Constant 1
-             261:  131(ivec2) ConstantComposite 259 259
-             262:  131(ivec2) ConstantComposite 260 260
-             365:     77(int) Constant 0
-             366:     77(int) Constant 1
-             367:  139(ivec2) ConstantComposite 365 365
-             368:  139(ivec2) ConstantComposite 366 366
-             371:     91(int) Constant 0
-             372:     91(int) Constant 1
-             373:  220(ivec2) ConstantComposite 371 371
-             374:  220(ivec2) ConstantComposite 372 372
+             254: 104(int8_t) Constant 1
+             255: 134(i8vec2) ConstantComposite 110 110
+             256: 134(i8vec2) ConstantComposite 254 254
+             259: 118(int8_t) Constant 0
+             260: 118(int8_t) Constant 1
+             261: 131(i8vec2) ConstantComposite 259 259
+             262: 131(i8vec2) ConstantComposite 260 260
+             365: 77(int16_t) Constant 0
+             366: 77(int16_t) Constant 1
+             367:139(i16vec2) ConstantComposite 365 365
+             368:139(i16vec2) ConstantComposite 366 366
+             371: 91(int16_t) Constant 0
+             372: 91(int16_t) Constant 1
+             373:220(i16vec2) ConstantComposite 371 371
+             374:220(i16vec2) ConstantComposite 372 372
              467:     29(int) Constant 1
              468:  147(ivec2) ConstantComposite 30 30
              469:  147(ivec2) ConstantComposite 467 467
@@ -256,23 +256,23 @@ spv.explicittypes.frag
              473:     19(int) Constant 1
              474:  155(ivec2) ConstantComposite 472 472
              475:  155(ivec2) ConstantComposite 473 473
-             550:     16(int) Constant 0 0
-             551:     16(int) Constant 1 0
-             552:  161(ivec2) ConstantComposite 550 550
-             553:  161(ivec2) ConstantComposite 551 551
-             556:     38(int) Constant 0 0
-             557:     38(int) Constant 1 0
-             558:  166(ivec2) ConstantComposite 556 556
-             559:  166(ivec2) ConstantComposite 557 557
-             565:             TypeVector 77(int) 3
-             566:             TypeVector 77(int) 4
-             567:             TypeVector 91(int) 3
-             568:             TypeVector 91(int) 4
+             550: 16(int64_t) Constant 0 0
+             551: 16(int64_t) Constant 1 0
+             552:161(i64vec2) ConstantComposite 550 550
+             553:161(i64vec2) ConstantComposite 551 551
+             556: 38(int64_t) Constant 0 0
+             557: 38(int64_t) Constant 1 0
+             558:166(i64vec2) ConstantComposite 556 556
+             559:166(i64vec2) ConstantComposite 557 557
+             565:             TypeVector 77(int16_t) 3
+             566:             TypeVector 77(int16_t) 4
+             567:             TypeVector 91(int16_t) 3
+             568:             TypeVector 91(int16_t) 4
              569:             TypeVector 29(int) 3
              570:             TypeVector 29(int) 4
              571:             TypeVector 19(int) 3
              572:             TypeVector 19(int) 4
-      573(Block):             TypeStruct 77(int) 139(ivec2) 565(ivec3) 566(ivec4) 91(int) 220(ivec2) 567(ivec3) 568(ivec4) 29(int) 147(ivec2) 569(ivec3) 570(ivec4) 19(int) 155(ivec2) 571(ivec3) 572(ivec4)
+      573(Block):             TypeStruct 77(int16_t) 139(i16vec2) 565(i16vec3) 566(i16vec4) 91(int16_t) 220(i16vec2) 567(i16vec3) 568(i16vec4) 29(int) 147(ivec2) 569(ivec3) 570(ivec4) 19(int) 155(ivec2) 571(ivec3) 572(ivec4)
              574:             TypePointer Uniform 573(Block)
       575(block):    574(ptr) Variable Uniform
          4(main):           2 Function None 3
@@ -301,13 +301,13 @@ spv.explicittypes.frag
               33:     19(int) Load 32
                               Store 35(indexable) 25
               36:     17(ptr) AccessChain 35(indexable) 33
-              37:     16(int) Load 36
+              37: 16(int64_t) Load 36
                               Store 18(i64) 37
               46:     31(ptr) AccessChain 28 30
               47:     19(int) Load 46
                               Store 49(indexable) 45
               50:     39(ptr) AccessChain 49(indexable) 47
-              51:     38(int) Load 50
+              51: 38(int64_t) Load 50
                               Store 40(u64) 51
               59:     31(ptr) AccessChain 28 30
               60:     19(int) Load 59
@@ -325,25 +325,25 @@ spv.explicittypes.frag
               86:     19(int) Load 85
                               Store 88(indexable) 84
               89:     78(ptr) AccessChain 88(indexable) 86
-              90:     77(int) Load 89
+              90: 77(int16_t) Load 89
                               Store 79(i16) 90
               98:     31(ptr) AccessChain 28 30
               99:     19(int) Load 98
                               Store 101(indexable) 97
              102:     92(ptr) AccessChain 101(indexable) 99
-             103:     91(int) Load 102
+             103: 91(int16_t) Load 102
                               Store 93(u16) 103
              112:     31(ptr) AccessChain 28 30
              113:     19(int) Load 112
                               Store 115(indexable) 111
              116:    105(ptr) AccessChain 115(indexable) 113
-             117:    104(int) Load 116
+             117: 104(int8_t) Load 116
                               Store 106(i8) 117
              125:     31(ptr) AccessChain 28 30
              126:     19(int) Load 125
                               Store 128(indexable) 124
              129:    119(ptr) AccessChain 128(indexable) 126
-             130:    118(int) Load 129
+             130: 118(int8_t) Load 129
                               Store 120(u8) 130
                               Return
                               FunctionEnd
@@ -361,133 +361,133 @@ spv.explicittypes.frag
        194(f64v):    193(ptr) Variable Function
        222(u16v):    221(ptr) Variable Function
          252(bv):    251(ptr) Variable Function
-             137:  134(ivec2) Load 136(i8v)
-             138:  131(ivec2) Bitcast 137
+             137: 134(i8vec2) Load 136(i8v)
+             138: 131(i8vec2) Bitcast 137
                               Store 133(u8v) 138
-             142:  134(ivec2) Load 136(i8v)
-             143:  139(ivec2) SConvert 142
+             142: 134(i8vec2) Load 136(i8v)
+             143:139(i16vec2) SConvert 142
                               Store 141(i16v) 143
-             144:  131(ivec2) Load 133(u8v)
-             145:  139(ivec2) UConvert 144
-             146:  139(ivec2) Bitcast 145
+             144: 131(i8vec2) Load 133(u8v)
+             145:139(i16vec2) UConvert 144
+             146:139(i16vec2) Bitcast 145
                               Store 141(i16v) 146
-             150:  134(ivec2) Load 136(i8v)
+             150: 134(i8vec2) Load 136(i8v)
              151:  147(ivec2) SConvert 150
                               Store 149(i32v) 151
-             152:  131(ivec2) Load 133(u8v)
+             152: 131(i8vec2) Load 133(u8v)
              153:  147(ivec2) UConvert 152
              154:  147(ivec2) Bitcast 153
                               Store 149(i32v) 154
-             158:  134(ivec2) Load 136(i8v)
+             158: 134(i8vec2) Load 136(i8v)
              159:  147(ivec2) SConvert 158
              160:  155(ivec2) Bitcast 159
                               Store 157(u32v) 160
-             164:  134(ivec2) Load 136(i8v)
-             165:  161(ivec2) SConvert 164
+             164: 134(i8vec2) Load 136(i8v)
+             165:161(i64vec2) SConvert 164
                               Store 163(i64v) 165
-             169:  134(ivec2) Load 136(i8v)
-             170:  161(ivec2) SConvert 169
-             171:  166(ivec2) Bitcast 170
+             169: 134(i8vec2) Load 136(i8v)
+             170:161(i64vec2) SConvert 169
+             171:166(i64vec2) Bitcast 170
                               Store 168(u64v) 171
-             172:  131(ivec2) Load 133(u8v)
+             172: 131(i8vec2) Load 133(u8v)
              173:  155(ivec2) UConvert 172
                               Store 157(u32v) 173
-             174:  131(ivec2) Load 133(u8v)
-             175:  161(ivec2) UConvert 174
-             176:  161(ivec2) Bitcast 175
+             174: 131(i8vec2) Load 133(u8v)
+             175:161(i64vec2) UConvert 174
+             176:161(i64vec2) Bitcast 175
                               Store 163(i64v) 176
-             177:  131(ivec2) Load 133(u8v)
-             178:  166(ivec2) UConvert 177
+             177: 131(i8vec2) Load 133(u8v)
+             178:166(i64vec2) UConvert 177
                               Store 168(u64v) 178
-             183:  134(ivec2) Load 136(i8v)
-             184:  180(fvec2) ConvertSToF 183
+             183: 134(i8vec2) Load 136(i8v)
+             184:180(f16vec2) ConvertSToF 183
                               Store 182(f16v) 184
-             189:  134(ivec2) Load 136(i8v)
+             189: 134(i8vec2) Load 136(i8v)
              190:  186(fvec2) ConvertSToF 189
                               Store 188(f32v) 190
-             195:  134(ivec2) Load 136(i8v)
-             196:  192(fvec2) ConvertSToF 195
+             195: 134(i8vec2) Load 136(i8v)
+             196:192(f64vec2) ConvertSToF 195
                               Store 194(f64v) 196
-             197:  131(ivec2) Load 133(u8v)
-             198:  180(fvec2) ConvertUToF 197
+             197: 131(i8vec2) Load 133(u8v)
+             198:180(f16vec2) ConvertUToF 197
                               Store 182(f16v) 198
-             199:  131(ivec2) Load 133(u8v)
+             199: 131(i8vec2) Load 133(u8v)
              200:  186(fvec2) ConvertUToF 199
                               Store 188(f32v) 200
-             201:  131(ivec2) Load 133(u8v)
-             202:  192(fvec2) ConvertUToF 201
+             201: 131(i8vec2) Load 133(u8v)
+             202:192(f64vec2) ConvertUToF 201
                               Store 194(f64v) 202
-             203:  131(ivec2) Load 133(u8v)
-             204:  134(ivec2) Bitcast 203
+             203: 131(i8vec2) Load 133(u8v)
+             204: 134(i8vec2) Bitcast 203
                               Store 136(i8v) 204
-             205:  134(ivec2) Load 136(i8v)
-             206:  139(ivec2) SConvert 205
+             205: 134(i8vec2) Load 136(i8v)
+             206:139(i16vec2) SConvert 205
                               Store 141(i16v) 206
-             207:  131(ivec2) Load 133(u8v)
-             208:  139(ivec2) UConvert 207
-             209:  139(ivec2) Bitcast 208
+             207: 131(i8vec2) Load 133(u8v)
+             208:139(i16vec2) UConvert 207
+             209:139(i16vec2) Bitcast 208
                               Store 141(i16v) 209
-             210:  134(ivec2) Load 136(i8v)
+             210: 134(i8vec2) Load 136(i8v)
              211:  147(ivec2) SConvert 210
                               Store 149(i32v) 211
-             212:  131(ivec2) Load 133(u8v)
+             212: 131(i8vec2) Load 133(u8v)
              213:  147(ivec2) UConvert 212
              214:  147(ivec2) Bitcast 213
                               Store 149(i32v) 214
-             215:  134(ivec2) Load 136(i8v)
-             216:  161(ivec2) SConvert 215
+             215: 134(i8vec2) Load 136(i8v)
+             216:161(i64vec2) SConvert 215
                               Store 163(i64v) 216
-             217:  134(ivec2) Load 136(i8v)
-             218:  161(ivec2) SConvert 217
-             219:  166(ivec2) Bitcast 218
+             217: 134(i8vec2) Load 136(i8v)
+             218:161(i64vec2) SConvert 217
+             219:166(i64vec2) Bitcast 218
                               Store 168(u64v) 219
-             223:  134(ivec2) Load 136(i8v)
-             224:  139(ivec2) SConvert 223
-             225:  220(ivec2) Bitcast 224
+             223: 134(i8vec2) Load 136(i8v)
+             224:139(i16vec2) SConvert 223
+             225:220(i16vec2) Bitcast 224
                               Store 222(u16v) 225
-             226:  131(ivec2) Load 133(u8v)
-             227:  220(ivec2) UConvert 226
+             226: 131(i8vec2) Load 133(u8v)
+             227:220(i16vec2) UConvert 226
                               Store 222(u16v) 227
-             228:  131(ivec2) Load 133(u8v)
+             228: 131(i8vec2) Load 133(u8v)
              229:  155(ivec2) UConvert 228
                               Store 157(u32v) 229
-             230:  131(ivec2) Load 133(u8v)
-             231:  161(ivec2) UConvert 230
-             232:  161(ivec2) Bitcast 231
+             230: 131(i8vec2) Load 133(u8v)
+             231:161(i64vec2) UConvert 230
+             232:161(i64vec2) Bitcast 231
                               Store 163(i64v) 232
-             233:  131(ivec2) Load 133(u8v)
-             234:  161(ivec2) UConvert 233
-             235:  161(ivec2) Bitcast 234
-             236:  166(ivec2) Bitcast 235
+             233: 131(i8vec2) Load 133(u8v)
+             234:161(i64vec2) UConvert 233
+             235:161(i64vec2) Bitcast 234
+             236:166(i64vec2) Bitcast 235
                               Store 168(u64v) 236
-             237:  134(ivec2) Load 136(i8v)
-             238:  180(fvec2) ConvertSToF 237
+             237: 134(i8vec2) Load 136(i8v)
+             238:180(f16vec2) ConvertSToF 237
                               Store 182(f16v) 238
-             239:  134(ivec2) Load 136(i8v)
+             239: 134(i8vec2) Load 136(i8v)
              240:  186(fvec2) ConvertSToF 239
                               Store 188(f32v) 240
-             241:  134(ivec2) Load 136(i8v)
-             242:  192(fvec2) ConvertSToF 241
+             241: 134(i8vec2) Load 136(i8v)
+             242:192(f64vec2) ConvertSToF 241
                               Store 194(f64v) 242
-             243:  131(ivec2) Load 133(u8v)
-             244:  180(fvec2) ConvertUToF 243
+             243: 131(i8vec2) Load 133(u8v)
+             244:180(f16vec2) ConvertUToF 243
                               Store 182(f16v) 244
-             245:  131(ivec2) Load 133(u8v)
+             245: 131(i8vec2) Load 133(u8v)
              246:  186(fvec2) ConvertUToF 245
                               Store 188(f32v) 246
-             247:  131(ivec2) Load 133(u8v)
-             248:  192(fvec2) ConvertUToF 247
+             247: 131(i8vec2) Load 133(u8v)
+             248:192(f64vec2) ConvertUToF 247
                               Store 194(f64v) 248
              253:  250(bvec2) Load 252(bv)
-             257:  134(ivec2) Select 253 256 255
+             257: 134(i8vec2) Select 253 256 255
                               Store 136(i8v) 257
              258:  250(bvec2) Load 252(bv)
-             263:  131(ivec2) Select 258 262 261
+             263: 131(i8vec2) Select 258 262 261
                               Store 133(u8v) 263
-             264:  134(ivec2) Load 136(i8v)
+             264: 134(i8vec2) Load 136(i8v)
              265:  250(bvec2) INotEqual 264 261
                               Store 252(bv) 265
-             266:  131(ivec2) Load 133(u8v)
+             266: 131(i8vec2) Load 133(u8v)
              267:  250(bvec2) INotEqual 266 261
                               Store 252(bv) 267
                               Return
@@ -506,135 +506,135 @@ spv.explicittypes.frag
         347(i8v):    135(ptr) Variable Function
         353(u8v):    132(ptr) Variable Function
          363(bv):    251(ptr) Variable Function
-             270:  139(ivec2) Load 269(i16v)
+             270:139(i16vec2) Load 269(i16v)
              271:  147(ivec2) SConvert 270
                               Store 268(i32v) 271
-             273:  220(ivec2) Load 272(u16v)
+             273:220(i16vec2) Load 272(u16v)
              274:  147(ivec2) UConvert 273
              275:  147(ivec2) Bitcast 274
                               Store 268(i32v) 275
-             276:  139(ivec2) Load 269(i16v)
-             277:  220(ivec2) Bitcast 276
+             276:139(i16vec2) Load 269(i16v)
+             277:220(i16vec2) Bitcast 276
                               Store 272(u16v) 277
-             279:  139(ivec2) Load 269(i16v)
+             279:139(i16vec2) Load 269(i16v)
              280:  147(ivec2) SConvert 279
              281:  155(ivec2) Bitcast 280
                               Store 278(u32v) 281
-             283:  139(ivec2) Load 269(i16v)
-             284:  161(ivec2) SConvert 283
+             283:139(i16vec2) Load 269(i16v)
+             284:161(i64vec2) SConvert 283
                               Store 282(i64v) 284
-             286:  139(ivec2) Load 269(i16v)
-             287:  161(ivec2) SConvert 286
-             288:  166(ivec2) Bitcast 287
+             286:139(i16vec2) Load 269(i16v)
+             287:161(i64vec2) SConvert 286
+             288:166(i64vec2) Bitcast 287
                               Store 285(u64v) 288
-             289:  220(ivec2) Load 272(u16v)
+             289:220(i16vec2) Load 272(u16v)
              290:  155(ivec2) UConvert 289
                               Store 278(u32v) 290
-             291:  220(ivec2) Load 272(u16v)
-             292:  161(ivec2) UConvert 291
-             293:  161(ivec2) Bitcast 292
+             291:220(i16vec2) Load 272(u16v)
+             292:161(i64vec2) UConvert 291
+             293:161(i64vec2) Bitcast 292
                               Store 282(i64v) 293
-             294:  220(ivec2) Load 272(u16v)
-             295:  166(ivec2) UConvert 294
+             294:220(i16vec2) Load 272(u16v)
+             295:166(i64vec2) UConvert 294
                               Store 285(u64v) 295
-             297:  139(ivec2) Load 269(i16v)
-             298:  180(fvec2) ConvertSToF 297
+             297:139(i16vec2) Load 269(i16v)
+             298:180(f16vec2) ConvertSToF 297
                               Store 296(f16v) 298
-             300:  139(ivec2) Load 269(i16v)
+             300:139(i16vec2) Load 269(i16v)
              301:  186(fvec2) ConvertSToF 300
                               Store 299(f32v) 301
-             303:  139(ivec2) Load 269(i16v)
-             304:  192(fvec2) ConvertSToF 303
+             303:139(i16vec2) Load 269(i16v)
+             304:192(f64vec2) ConvertSToF 303
                               Store 302(f64v) 304
-             305:  220(ivec2) Load 272(u16v)
-             306:  180(fvec2) ConvertUToF 305
+             305:220(i16vec2) Load 272(u16v)
+             306:180(f16vec2) ConvertUToF 305
                               Store 296(f16v) 306
-             307:  220(ivec2) Load 272(u16v)
+             307:220(i16vec2) Load 272(u16v)
              308:  186(fvec2) ConvertUToF 307
                               Store 299(f32v) 308
-             309:  220(ivec2) Load 272(u16v)
-             310:  192(fvec2) ConvertUToF 309
+             309:220(i16vec2) Load 272(u16v)
+             310:192(f64vec2) ConvertUToF 309
                               Store 302(f64v) 310
-             311:  139(ivec2) Load 269(i16v)
+             311:139(i16vec2) Load 269(i16v)
              312:  147(ivec2) SConvert 311
                               Store 268(i32v) 312
-             313:  220(ivec2) Load 272(u16v)
+             313:220(i16vec2) Load 272(u16v)
              314:  147(ivec2) UConvert 313
              315:  147(ivec2) Bitcast 314
                               Store 268(i32v) 315
-             316:  139(ivec2) Load 269(i16v)
-             317:  220(ivec2) Bitcast 316
+             316:139(i16vec2) Load 269(i16v)
+             317:220(i16vec2) Bitcast 316
                               Store 272(u16v) 317
-             318:  139(ivec2) Load 269(i16v)
+             318:139(i16vec2) Load 269(i16v)
              319:  147(ivec2) SConvert 318
              320:  155(ivec2) Bitcast 319
                               Store 278(u32v) 320
-             321:  139(ivec2) Load 269(i16v)
-             322:  161(ivec2) SConvert 321
+             321:139(i16vec2) Load 269(i16v)
+             322:161(i64vec2) SConvert 321
                               Store 282(i64v) 322
-             323:  139(ivec2) Load 269(i16v)
-             324:  161(ivec2) SConvert 323
-             325:  166(ivec2) Bitcast 324
+             323:139(i16vec2) Load 269(i16v)
+             324:161(i64vec2) SConvert 323
+             325:166(i64vec2) Bitcast 324
                               Store 285(u64v) 325
-             326:  220(ivec2) Load 272(u16v)
+             326:220(i16vec2) Load 272(u16v)
              327:  155(ivec2) UConvert 326
                               Store 278(u32v) 327
-             328:  220(ivec2) Load 272(u16v)
-             329:  161(ivec2) UConvert 328
-             330:  161(ivec2) Bitcast 329
+             328:220(i16vec2) Load 272(u16v)
+             329:161(i64vec2) UConvert 328
+             330:161(i64vec2) Bitcast 329
                               Store 282(i64v) 330
-             331:  220(ivec2) Load 272(u16v)
-             332:  161(ivec2) UConvert 331
-             333:  161(ivec2) Bitcast 332
-             334:  166(ivec2) Bitcast 333
+             331:220(i16vec2) Load 272(u16v)
+             332:161(i64vec2) UConvert 331
+             333:161(i64vec2) Bitcast 332
+             334:166(i64vec2) Bitcast 333
                               Store 285(u64v) 334
-             335:  139(ivec2) Load 269(i16v)
-             336:  180(fvec2) ConvertSToF 335
+             335:139(i16vec2) Load 269(i16v)
+             336:180(f16vec2) ConvertSToF 335
                               Store 296(f16v) 336
-             337:  139(ivec2) Load 269(i16v)
+             337:139(i16vec2) Load 269(i16v)
              338:  186(fvec2) ConvertSToF 337
                               Store 299(f32v) 338
-             339:  139(ivec2) Load 269(i16v)
-             340:  192(fvec2) ConvertSToF 339
+             339:139(i16vec2) Load 269(i16v)
+             340:192(f64vec2) ConvertSToF 339
                               Store 302(f64v) 340
-             341:  220(ivec2) Load 272(u16v)
-             342:  180(fvec2) ConvertUToF 341
+             341:220(i16vec2) Load 272(u16v)
+             342:180(f16vec2) ConvertUToF 341
                               Store 296(f16v) 342
-             343:  220(ivec2) Load 272(u16v)
+             343:220(i16vec2) Load 272(u16v)
              344:  186(fvec2) ConvertUToF 343
                               Store 299(f32v) 344
-             345:  220(ivec2) Load 272(u16v)
-             346:  192(fvec2) ConvertUToF 345
+             345:220(i16vec2) Load 272(u16v)
+             346:192(f64vec2) ConvertUToF 345
                               Store 302(f64v) 346
-             348:  139(ivec2) Load 269(i16v)
-             349:  134(ivec2) SConvert 348
+             348:139(i16vec2) Load 269(i16v)
+             349: 134(i8vec2) SConvert 348
                               Store 347(i8v) 349
-             350:  220(ivec2) Load 272(u16v)
-             351:  134(ivec2) UConvert 350
-             352:  134(ivec2) Bitcast 351
+             350:220(i16vec2) Load 272(u16v)
+             351: 134(i8vec2) UConvert 350
+             352: 134(i8vec2) Bitcast 351
                               Store 347(i8v) 352
-             354:  139(ivec2) Load 269(i16v)
-             355:  134(ivec2) SConvert 354
-             356:  131(ivec2) Bitcast 355
+             354:139(i16vec2) Load 269(i16v)
+             355: 134(i8vec2) SConvert 354
+             356: 131(i8vec2) Bitcast 355
                               Store 353(u8v) 356
-             357:  220(ivec2) Load 272(u16v)
-             358:  131(ivec2) UConvert 357
+             357:220(i16vec2) Load 272(u16v)
+             358: 131(i8vec2) UConvert 357
                               Store 353(u8v) 358
-             359:  220(ivec2) Load 272(u16v)
-             360:  131(ivec2) UConvert 359
-             361:  139(ivec2) UConvert 360
-             362:  139(ivec2) Bitcast 361
+             359:220(i16vec2) Load 272(u16v)
+             360: 131(i8vec2) UConvert 359
+             361:139(i16vec2) UConvert 360
+             362:139(i16vec2) Bitcast 361
                               Store 269(i16v) 362
              364:  250(bvec2) Load 363(bv)
-             369:  139(ivec2) Select 364 368 367
+             369:139(i16vec2) Select 364 368 367
                               Store 269(i16v) 369
              370:  250(bvec2) Load 363(bv)
-             375:  220(ivec2) Select 370 374 373
+             375:220(i16vec2) Select 370 374 373
                               Store 272(u16v) 375
-             376:  139(ivec2) Load 269(i16v)
+             376:139(i16vec2) Load 269(i16v)
              377:  250(bvec2) INotEqual 376 373
                               Store 363(bv) 377
-             378:  220(ivec2) Load 272(u16v)
+             378:220(i16vec2) Load 272(u16v)
              379:  250(bvec2) INotEqual 378 373
                               Store 363(bv) 379
                               Return
@@ -657,44 +657,44 @@ spv.explicittypes.frag
              383:  155(ivec2) Bitcast 382
                               Store 380(u32v) 383
              385:  147(ivec2) Load 381(i32v)
-             386:  161(ivec2) SConvert 385
+             386:161(i64vec2) SConvert 385
                               Store 384(i64v) 386
              388:  147(ivec2) Load 381(i32v)
-             389:  161(ivec2) SConvert 388
-             390:  166(ivec2) Bitcast 389
+             389:161(i64vec2) SConvert 388
+             390:166(i64vec2) Bitcast 389
                               Store 387(u64v) 390
              391:  155(ivec2) Load 380(u32v)
-             392:  161(ivec2) UConvert 391
-             393:  161(ivec2) Bitcast 392
+             392:161(i64vec2) UConvert 391
+             393:161(i64vec2) Bitcast 392
                               Store 384(i64v) 393
              394:  155(ivec2) Load 380(u32v)
-             395:  166(ivec2) UConvert 394
+             395:166(i64vec2) UConvert 394
                               Store 387(u64v) 395
              397:  147(ivec2) Load 381(i32v)
              398:  186(fvec2) ConvertSToF 397
                               Store 396(f32v) 398
              400:  147(ivec2) Load 381(i32v)
-             401:  192(fvec2) ConvertSToF 400
+             401:192(f64vec2) ConvertSToF 400
                               Store 399(f64v) 401
              402:  155(ivec2) Load 380(u32v)
              403:  186(fvec2) ConvertUToF 402
                               Store 396(f32v) 403
              404:  155(ivec2) Load 380(u32v)
-             405:  192(fvec2) ConvertUToF 404
+             405:192(f64vec2) ConvertUToF 404
                               Store 399(f64v) 405
              407:  147(ivec2) Load 381(i32v)
-             408:  134(ivec2) SConvert 407
+             408: 134(i8vec2) SConvert 407
                               Store 406(i8v) 408
              409:  155(ivec2) Load 380(u32v)
-             410:  134(ivec2) UConvert 409
-             411:  134(ivec2) Bitcast 410
+             410: 134(i8vec2) UConvert 409
+             411: 134(i8vec2) Bitcast 410
                               Store 406(i8v) 411
              413:  147(ivec2) Load 381(i32v)
-             414:  139(ivec2) SConvert 413
+             414:139(i16vec2) SConvert 413
                               Store 412(i16v) 414
              415:  155(ivec2) Load 380(u32v)
-             416:  139(ivec2) UConvert 415
-             417:  139(ivec2) Bitcast 416
+             416:139(i16vec2) UConvert 415
+             417:139(i16vec2) Bitcast 416
                               Store 412(i16v) 417
              418:  147(ivec2) Load 381(i32v)
              419:     29(int) CompositeExtract 418 0
@@ -705,25 +705,25 @@ spv.explicittypes.frag
              423:  147(ivec2) Bitcast 422
                               Store 381(i32v) 423
              424:  147(ivec2) Load 381(i32v)
-             425:  161(ivec2) SConvert 424
+             425:161(i64vec2) SConvert 424
                               Store 384(i64v) 425
              426:  155(ivec2) Load 380(u32v)
-             427:  161(ivec2) UConvert 426
-             428:  161(ivec2) Bitcast 427
+             427:161(i64vec2) UConvert 426
+             428:161(i64vec2) Bitcast 427
                               Store 384(i64v) 428
              430:  147(ivec2) Load 381(i32v)
-             431:  134(ivec2) SConvert 430
-             432:  131(ivec2) Bitcast 431
+             431: 134(i8vec2) SConvert 430
+             432: 131(i8vec2) Bitcast 431
                               Store 429(u8v) 432
              433:  155(ivec2) Load 380(u32v)
-             434:  131(ivec2) UConvert 433
+             434: 131(i8vec2) UConvert 433
                               Store 429(u8v) 434
              436:  147(ivec2) Load 381(i32v)
-             437:  139(ivec2) SConvert 436
-             438:  220(ivec2) Bitcast 437
+             437:139(i16vec2) SConvert 436
+             438:220(i16vec2) Bitcast 437
                               Store 435(u16v) 438
              439:  155(ivec2) Load 380(u32v)
-             440:  220(ivec2) UConvert 439
+             440:220(i16vec2) UConvert 439
                               Store 435(u16v) 440
              441:  147(ivec2) Load 381(i32v)
              442:  155(ivec2) Bitcast 441
@@ -734,29 +734,29 @@ spv.explicittypes.frag
              446:  155(ivec2) CompositeConstruct 444 445
                               Store 380(u32v) 446
              447:  147(ivec2) Load 381(i32v)
-             448:  161(ivec2) SConvert 447
-             449:  166(ivec2) Bitcast 448
+             448:161(i64vec2) SConvert 447
+             449:166(i64vec2) Bitcast 448
                               Store 387(u64v) 449
              450:  155(ivec2) Load 380(u32v)
-             451:  166(ivec2) UConvert 450
+             451:166(i64vec2) UConvert 450
                               Store 387(u64v) 451
              453:  147(ivec2) Load 381(i32v)
-             454:  180(fvec2) ConvertSToF 453
+             454:180(f16vec2) ConvertSToF 453
                               Store 452(f16v) 454
              455:  147(ivec2) Load 381(i32v)
              456:  186(fvec2) ConvertSToF 455
                               Store 396(f32v) 456
              457:  147(ivec2) Load 381(i32v)
-             458:  192(fvec2) ConvertSToF 457
+             458:192(f64vec2) ConvertSToF 457
                               Store 399(f64v) 458
              459:  155(ivec2) Load 380(u32v)
-             460:  180(fvec2) ConvertUToF 459
+             460:180(f16vec2) ConvertUToF 459
                               Store 452(f16v) 460
              461:  155(ivec2) Load 380(u32v)
              462:  186(fvec2) ConvertUToF 461
                               Store 396(f32v) 462
              463:  155(ivec2) Load 380(u32v)
-             464:  192(fvec2) ConvertUToF 463
+             464:192(f64vec2) ConvertUToF 463
                               Store 399(f64v) 464
              466:  250(bvec2) Load 465(bv)
              470:  147(ivec2) Select 466 469 468
@@ -786,96 +786,96 @@ spv.explicittypes.frag
        534(f16v):    181(ptr) Variable Function
        537(f32v):    187(ptr) Variable Function
          548(bv):    251(ptr) Variable Function
-             483:  161(ivec2) Load 482(i64v)
-             484:  166(ivec2) Bitcast 483
+             483:161(i64vec2) Load 482(i64v)
+             484:166(i64vec2) Bitcast 483
                               Store 481(u64v) 484
-             486:  161(ivec2) Load 482(i64v)
-             487:  192(fvec2) ConvertSToF 486
+             486:161(i64vec2) Load 482(i64v)
+             487:192(f64vec2) ConvertSToF 486
                               Store 485(f64v) 487
-             488:  166(ivec2) Load 481(u64v)
-             489:  192(fvec2) ConvertUToF 488
+             488:166(i64vec2) Load 481(u64v)
+             489:192(f64vec2) ConvertUToF 488
                               Store 485(f64v) 489
-             491:  161(ivec2) Load 482(i64v)
-             492:  134(ivec2) SConvert 491
+             491:161(i64vec2) Load 482(i64v)
+             492: 134(i8vec2) SConvert 491
                               Store 490(i8v) 492
-             493:  166(ivec2) Load 481(u64v)
-             494:  134(ivec2) UConvert 493
-             495:  134(ivec2) Bitcast 494
+             493:166(i64vec2) Load 481(u64v)
+             494: 134(i8vec2) UConvert 493
+             495: 134(i8vec2) Bitcast 494
                               Store 490(i8v) 495
-             497:  161(ivec2) Load 482(i64v)
-             498:  139(ivec2) SConvert 497
+             497:161(i64vec2) Load 482(i64v)
+             498:139(i16vec2) SConvert 497
                               Store 496(i16v) 498
-             499:  166(ivec2) Load 481(u64v)
-             500:  139(ivec2) UConvert 499
-             501:  139(ivec2) Bitcast 500
+             499:166(i64vec2) Load 481(u64v)
+             500:139(i16vec2) UConvert 499
+             501:139(i16vec2) Bitcast 500
                               Store 496(i16v) 501
-             503:  161(ivec2) Load 482(i64v)
+             503:161(i64vec2) Load 482(i64v)
              504:  147(ivec2) SConvert 503
                               Store 502(i32v) 504
-             505:  166(ivec2) Load 481(u64v)
+             505:166(i64vec2) Load 481(u64v)
              506:  147(ivec2) UConvert 505
              507:  147(ivec2) Bitcast 506
                               Store 502(i32v) 507
-             508:  166(ivec2) Load 481(u64v)
-             509:  161(ivec2) Bitcast 508
+             508:166(i64vec2) Load 481(u64v)
+             509:161(i64vec2) Bitcast 508
                               Store 482(i64v) 509
-             511:  161(ivec2) Load 482(i64v)
-             512:  134(ivec2) SConvert 511
-             513:  131(ivec2) Bitcast 512
+             511:161(i64vec2) Load 482(i64v)
+             512: 134(i8vec2) SConvert 511
+             513: 131(i8vec2) Bitcast 512
                               Store 510(u8v) 513
-             514:  166(ivec2) Load 481(u64v)
-             515:  131(ivec2) UConvert 514
+             514:166(i64vec2) Load 481(u64v)
+             515: 131(i8vec2) UConvert 514
                               Store 510(u8v) 515
-             517:  161(ivec2) Load 482(i64v)
-             518:  139(ivec2) SConvert 517
-             519:  220(ivec2) Bitcast 518
+             517:161(i64vec2) Load 482(i64v)
+             518:139(i16vec2) SConvert 517
+             519:220(i16vec2) Bitcast 518
                               Store 516(u16v) 519
-             520:  166(ivec2) Load 481(u64v)
-             521:  220(ivec2) UConvert 520
+             520:166(i64vec2) Load 481(u64v)
+             521:220(i16vec2) UConvert 520
                               Store 516(u16v) 521
-             523:  161(ivec2) Load 482(i64v)
+             523:161(i64vec2) Load 482(i64v)
              524:  147(ivec2) SConvert 523
              525:  155(ivec2) Bitcast 524
                               Store 522(u32v) 525
-             526:  166(ivec2) Load 481(u64v)
+             526:166(i64vec2) Load 481(u64v)
              527:  155(ivec2) UConvert 526
                               Store 522(u32v) 527
-             528:  161(ivec2) Load 482(i64v)
-             529:  166(ivec2) Bitcast 528
+             528:161(i64vec2) Load 482(i64v)
+             529:166(i64vec2) Bitcast 528
                               Store 481(u64v) 529
-             530:  166(ivec2) Load 481(u64v)
-             531:     38(int) CompositeExtract 530 0
-             532:     38(int) CompositeExtract 530 1
-             533:  166(ivec2) CompositeConstruct 531 532
+             530:166(i64vec2) Load 481(u64v)
+             531: 38(int64_t) CompositeExtract 530 0
+             532: 38(int64_t) CompositeExtract 530 1
+             533:166(i64vec2) CompositeConstruct 531 532
                               Store 481(u64v) 533
-             535:  161(ivec2) Load 482(i64v)
-             536:  180(fvec2) ConvertSToF 535
+             535:161(i64vec2) Load 482(i64v)
+             536:180(f16vec2) ConvertSToF 535
                               Store 534(f16v) 536
-             538:  161(ivec2) Load 482(i64v)
+             538:161(i64vec2) Load 482(i64v)
              539:  186(fvec2) ConvertSToF 538
                               Store 537(f32v) 539
-             540:  161(ivec2) Load 482(i64v)
-             541:  192(fvec2) ConvertSToF 540
+             540:161(i64vec2) Load 482(i64v)
+             541:192(f64vec2) ConvertSToF 540
                               Store 485(f64v) 541
-             542:  166(ivec2) Load 481(u64v)
-             543:  180(fvec2) ConvertUToF 542
+             542:166(i64vec2) Load 481(u64v)
+             543:180(f16vec2) ConvertUToF 542
                               Store 534(f16v) 543
-             544:  166(ivec2) Load 481(u64v)
+             544:166(i64vec2) Load 481(u64v)
              545:  186(fvec2) ConvertUToF 544
                               Store 537(f32v) 545
-             546:  166(ivec2) Load 481(u64v)
-             547:  192(fvec2) ConvertUToF 546
+             546:166(i64vec2) Load 481(u64v)
+             547:192(f64vec2) ConvertUToF 546
                               Store 485(f64v) 547
              549:  250(bvec2) Load 548(bv)
-             554:  161(ivec2) Select 549 553 552
+             554:161(i64vec2) Select 549 553 552
                               Store 482(i64v) 554
              555:  250(bvec2) Load 548(bv)
-             560:  166(ivec2) Select 555 559 558
+             560:166(i64vec2) Select 555 559 558
                               Store 481(u64v) 560
-             561:  161(ivec2) Load 482(i64v)
+             561:161(i64vec2) Load 482(i64v)
              562:  250(bvec2) INotEqual 561 558
                               Store 548(bv) 562
-             563:  166(ivec2) Load 481(u64v)
+             563:166(i64vec2) Load 481(u64v)
              564:  250(bvec2) INotEqual 563 558
                               Store 548(bv) 564
                               Return

--- a/Test/baseResults/spv.float16.frag.out
+++ b/Test/baseResults/spv.float16.frag.out
@@ -156,86 +156,86 @@ spv.float16.frag
                2:             TypeVoid
                3:             TypeFunction 2
               28:             TypeFloat 16
-              29:             TypeVector 28(float) 2
-              30:             TypePointer Function 29(fvec2)
-              32:   28(float) Constant 16
+              29:             TypeVector 28(float16_t) 2
+              30:             TypePointer Function 29(f16vec2)
+              32:28(float16_t) Constant 16
               33:             TypeInt 32 0
               34:     33(int) Constant 0
-              35:             TypePointer Function 28(float)
-              37:   28(float) Constant 46080
-              38:   28(float) Constant 10158
-              39:   29(fvec2) ConstantComposite 37 38
-              56:   28(float) Constant 15360
-              62:             TypeMatrix 29(fvec2) 2
+              35:             TypePointer Function 28(float16_t)
+              37:28(float16_t) Constant 46080
+              38:28(float16_t) Constant 10158
+              39: 29(f16vec2) ConstantComposite 37 38
+              56:28(float16_t) Constant 15360
+              62:             TypeMatrix 29(f16vec2) 2
               63:             TypePointer Function 62
               90:     33(int) Constant 1
              109:             TypeBool
              110:             TypePointer Function 109(bool)
-             151:             TypeVector 28(float) 3
-             152:             TypePointer Function 151(fvec3)
+             151:             TypeVector 28(float16_t) 3
+             152:             TypePointer Function 151(f16vec3)
              154:             TypeVector 109(bool) 3
              155:             TypePointer Function 154(bvec3)
-             158:   28(float) Constant 0
-             159:  151(fvec3) ConstantComposite 158 158 158
-             160:  151(fvec3) ConstantComposite 56 56 56
+             158:28(float16_t) Constant 0
+             159:151(f16vec3) ConstantComposite 158 158 158
+             160:151(f16vec3) ConstantComposite 56 56 56
              164:             TypeFloat 32
              165:             TypeVector 164(float) 3
              166:             TypePointer Function 165(fvec3)
              172:             TypeFloat 64
-             173:             TypeVector 172(float) 3
-             174:             TypePointer Function 173(fvec3)
+             173:             TypeVector 172(float64_t) 3
+             174:             TypePointer Function 173(f64vec3)
              183:             TypeInt 32 1
              184:             TypeVector 183(int) 3
              185:             TypePointer Function 184(ivec3)
              191:             TypeVector 33(int) 3
              192:             TypePointer Function 191(ivec3)
              198:             TypeInt 64 1
-             199:             TypeVector 198(int) 3
-             200:             TypePointer Function 199(ivec3)
+             199:             TypeVector 198(int64_t) 3
+             200:             TypePointer Function 199(i64vec3)
              206:             TypeInt 64 0
-             207:             TypeVector 206(int) 3
-             208:             TypePointer Function 207(ivec3)
-             214:             TypeVector 28(float) 4
-             215:             TypePointer Function 214(fvec4)
-    364(ResType):             TypeStruct 151(fvec3) 184(ivec3)
+             207:             TypeVector 206(int64_t) 3
+             208:             TypePointer Function 207(i64vec3)
+             214:             TypeVector 28(float16_t) 4
+             215:             TypePointer Function 214(f16vec4)
+    364(ResType):             TypeStruct 151(f16vec3) 184(ivec3)
              371:             TypePointer Function 33(int)
-             406:             TypeMatrix 151(fvec3) 2
+             406:             TypeMatrix 151(f16vec3) 2
              407:             TypePointer Function 406
-             425:             TypeMatrix 29(fvec2) 3
+             425:             TypeMatrix 29(f16vec2) 3
              426:             TypePointer Function 425
-             431:             TypeMatrix 151(fvec3) 3
+             431:             TypeMatrix 151(f16vec3) 3
              432:             TypePointer Function 431
-             436:             TypeMatrix 214(fvec4) 4
+             436:             TypeMatrix 214(f16vec4) 4
              437:             TypePointer Function 436
-             464:             TypePointer Input 151(fvec3)
+             464:             TypePointer Input 151(f16vec3)
       465(if16v):    464(ptr) Variable Input
-             466:             TypePointer Input 28(float)
+             466:             TypePointer Input 28(float16_t)
              503:    183(int) Constant 1
-             508:   28(float) Constant 14336
-             509:   29(fvec2) ConstantComposite 508 508
+             508:28(float16_t) Constant 14336
+             509: 29(f16vec2) ConstantComposite 508 508
              511:     33(int) Constant 2
-             512:             TypeArray 28(float) 511
+             512:             TypeArray 28(float16_t) 511
              513:             TypeArray 406 511
-          514(S):             TypeStruct 28(float) 29(fvec2) 151(fvec3)
+          514(S):             TypeStruct 28(float16_t) 29(f16vec2) 151(f16vec3)
              515:             TypeArray 514(S) 511
-         516(B1):             TypeStruct 28(float) 29(fvec2) 151(fvec3) 512 406 513 514(S) 515
+         516(B1):             TypeStruct 28(float16_t) 29(f16vec2) 151(f16vec3) 512 406 513 514(S) 515
              517:             TypePointer Uniform 516(B1)
              518:    517(ptr) Variable Uniform
-             519:             TypeArray 28(float) 511
+             519:             TypeArray 28(float16_t) 511
              520:             TypeArray 406 511
-          521(S):             TypeStruct 28(float) 29(fvec2) 151(fvec3)
+          521(S):             TypeStruct 28(float16_t) 29(f16vec2) 151(f16vec3)
              522:             TypeArray 521(S) 511
-         523(B2):             TypeStruct 28(float) 29(fvec2) 151(fvec3) 519 406 520 521(S) 522
+         523(B2):             TypeStruct 28(float16_t) 29(f16vec2) 151(f16vec3) 519 406 520 521(S) 522
              524:             TypePointer Uniform 523(B2)
              525:    524(ptr) Variable Uniform
-       526(sf16):   28(float) SpecConstant 12288
+       526(sf16):28(float16_t) SpecConstant 12288
          527(sf):  164(float) SpecConstant 1048576000
-         528(sd):  172(float) SpecConstant 0 1071644672
+         528(sd):172(float64_t) SpecConstant 0 1071644672
              529:  164(float) SpecConstantOp 115 526(sf16)
              530:  164(float) SpecConstantOp 115 526(sf16)
-             531:  172(float) SpecConstantOp 115 530
-             532:   28(float) SpecConstantOp 115 527(sf)
-             533:   28(float) SpecConstantOp 115 528(sd)
+             531:172(float64_t) SpecConstantOp 115 530
+             532:28(float16_t) SpecConstantOp 115 527(sf)
+             533:28(float16_t) SpecConstantOp 115 528(sd)
          4(main):           2 Function None 3
                5:             Label
                               Return
@@ -245,8 +245,8 @@ spv.float16.frag
         31(f16v):     30(ptr) Variable Function
               36:     35(ptr) AccessChain 31(f16v) 34
                               Store 36 32
-              40:   29(fvec2) Load 31(f16v)
-              41:   29(fvec2) FAdd 40 39
+              40: 29(f16vec2) Load 31(f16v)
+              41: 29(f16vec2) FAdd 40 39
                               Store 31(f16v) 41
                               Return
                               FunctionEnd
@@ -256,125 +256,125 @@ spv.float16.frag
         64(f16m):     63(ptr) Variable Function
          87(f16):     35(ptr) Variable Function
           111(b):    110(ptr) Variable Function
-              43:   29(fvec2) Load 42(f16v)
-              44:   29(fvec2) Load 42(f16v)
-              45:   29(fvec2) FAdd 44 43
+              43: 29(f16vec2) Load 42(f16v)
+              44: 29(f16vec2) Load 42(f16v)
+              45: 29(f16vec2) FAdd 44 43
                               Store 42(f16v) 45
-              46:   29(fvec2) Load 42(f16v)
-              47:   29(fvec2) Load 42(f16v)
-              48:   29(fvec2) FSub 47 46
+              46: 29(f16vec2) Load 42(f16v)
+              47: 29(f16vec2) Load 42(f16v)
+              48: 29(f16vec2) FSub 47 46
                               Store 42(f16v) 48
-              49:   29(fvec2) Load 42(f16v)
-              50:   29(fvec2) Load 42(f16v)
-              51:   29(fvec2) FMul 50 49
+              49: 29(f16vec2) Load 42(f16v)
+              50: 29(f16vec2) Load 42(f16v)
+              51: 29(f16vec2) FMul 50 49
                               Store 42(f16v) 51
-              52:   29(fvec2) Load 42(f16v)
-              53:   29(fvec2) Load 42(f16v)
-              54:   29(fvec2) FDiv 53 52
+              52: 29(f16vec2) Load 42(f16v)
+              53: 29(f16vec2) Load 42(f16v)
+              54: 29(f16vec2) FDiv 53 52
                               Store 42(f16v) 54
-              55:   29(fvec2) Load 42(f16v)
-              57:   29(fvec2) CompositeConstruct 56 56
-              58:   29(fvec2) FAdd 55 57
+              55: 29(f16vec2) Load 42(f16v)
+              57: 29(f16vec2) CompositeConstruct 56 56
+              58: 29(f16vec2) FAdd 55 57
                               Store 42(f16v) 58
-              59:   29(fvec2) Load 42(f16v)
-              60:   29(fvec2) CompositeConstruct 56 56
-              61:   29(fvec2) FSub 59 60
+              59: 29(f16vec2) Load 42(f16v)
+              60: 29(f16vec2) CompositeConstruct 56 56
+              61: 29(f16vec2) FSub 59 60
                               Store 42(f16v) 61
               65:          62 Load 64(f16m)
-              66:   29(fvec2) CompositeConstruct 56 56
-              67:   29(fvec2) CompositeExtract 65 0
-              68:   29(fvec2) FAdd 67 66
-              69:   29(fvec2) CompositeExtract 65 1
-              70:   29(fvec2) FAdd 69 66
+              66: 29(f16vec2) CompositeConstruct 56 56
+              67: 29(f16vec2) CompositeExtract 65 0
+              68: 29(f16vec2) FAdd 67 66
+              69: 29(f16vec2) CompositeExtract 65 1
+              70: 29(f16vec2) FAdd 69 66
               71:          62 CompositeConstruct 68 70
                               Store 64(f16m) 71
               72:          62 Load 64(f16m)
-              73:   29(fvec2) CompositeConstruct 56 56
-              74:   29(fvec2) CompositeExtract 72 0
-              75:   29(fvec2) FSub 74 73
-              76:   29(fvec2) CompositeExtract 72 1
-              77:   29(fvec2) FSub 76 73
+              73: 29(f16vec2) CompositeConstruct 56 56
+              74: 29(f16vec2) CompositeExtract 72 0
+              75: 29(f16vec2) FSub 74 73
+              76: 29(f16vec2) CompositeExtract 72 1
+              77: 29(f16vec2) FSub 76 73
               78:          62 CompositeConstruct 75 77
                               Store 64(f16m) 78
-              79:   29(fvec2) Load 42(f16v)
-              80:   29(fvec2) FNegate 79
+              79: 29(f16vec2) Load 42(f16v)
+              80: 29(f16vec2) FNegate 79
                               Store 42(f16v) 80
               81:          62 Load 64(f16m)
-              82:   29(fvec2) CompositeExtract 81 0
-              83:   29(fvec2) FNegate 82
-              84:   29(fvec2) CompositeExtract 81 1
-              85:   29(fvec2) FNegate 84
+              82: 29(f16vec2) CompositeExtract 81 0
+              83: 29(f16vec2) FNegate 82
+              84: 29(f16vec2) CompositeExtract 81 1
+              85: 29(f16vec2) FNegate 84
               86:          62 CompositeConstruct 83 85
                               Store 64(f16m) 86
               88:     35(ptr) AccessChain 42(f16v) 34
-              89:   28(float) Load 88
+              89:28(float16_t) Load 88
               91:     35(ptr) AccessChain 42(f16v) 90
-              92:   28(float) Load 91
-              93:   28(float) FAdd 89 92
+              92:28(float16_t) Load 91
+              93:28(float16_t) FAdd 89 92
                               Store 87(f16) 93
               94:     35(ptr) AccessChain 42(f16v) 34
-              95:   28(float) Load 94
+              95:28(float16_t) Load 94
               96:     35(ptr) AccessChain 42(f16v) 90
-              97:   28(float) Load 96
-              98:   28(float) FSub 95 97
+              97:28(float16_t) Load 96
+              98:28(float16_t) FSub 95 97
                               Store 87(f16) 98
               99:     35(ptr) AccessChain 42(f16v) 34
-             100:   28(float) Load 99
+             100:28(float16_t) Load 99
              101:     35(ptr) AccessChain 42(f16v) 90
-             102:   28(float) Load 101
-             103:   28(float) FMul 100 102
+             102:28(float16_t) Load 101
+             103:28(float16_t) FMul 100 102
                               Store 87(f16) 103
              104:     35(ptr) AccessChain 42(f16v) 34
-             105:   28(float) Load 104
+             105:28(float16_t) Load 104
              106:     35(ptr) AccessChain 42(f16v) 90
-             107:   28(float) Load 106
-             108:   28(float) FDiv 105 107
+             107:28(float16_t) Load 106
+             108:28(float16_t) FDiv 105 107
                               Store 87(f16) 108
              112:     35(ptr) AccessChain 42(f16v) 34
-             113:   28(float) Load 112
-             114:   28(float) Load 87(f16)
+             113:28(float16_t) Load 112
+             114:28(float16_t) Load 87(f16)
              115:   109(bool) FOrdNotEqual 113 114
                               Store 111(b) 115
              116:     35(ptr) AccessChain 42(f16v) 90
-             117:   28(float) Load 116
-             118:   28(float) Load 87(f16)
+             117:28(float16_t) Load 116
+             118:28(float16_t) Load 87(f16)
              119:   109(bool) FOrdEqual 117 118
                               Store 111(b) 119
              120:     35(ptr) AccessChain 42(f16v) 34
-             121:   28(float) Load 120
-             122:   28(float) Load 87(f16)
+             121:28(float16_t) Load 120
+             122:28(float16_t) Load 87(f16)
              123:   109(bool) FOrdGreaterThan 121 122
                               Store 111(b) 123
              124:     35(ptr) AccessChain 42(f16v) 90
-             125:   28(float) Load 124
-             126:   28(float) Load 87(f16)
+             125:28(float16_t) Load 124
+             126:28(float16_t) Load 87(f16)
              127:   109(bool) FOrdLessThan 125 126
                               Store 111(b) 127
              128:     35(ptr) AccessChain 42(f16v) 34
-             129:   28(float) Load 128
-             130:   28(float) Load 87(f16)
+             129:28(float16_t) Load 128
+             130:28(float16_t) Load 87(f16)
              131:   109(bool) FOrdGreaterThanEqual 129 130
                               Store 111(b) 131
              132:     35(ptr) AccessChain 42(f16v) 90
-             133:   28(float) Load 132
-             134:   28(float) Load 87(f16)
+             133:28(float16_t) Load 132
+             134:28(float16_t) Load 87(f16)
              135:   109(bool) FOrdLessThanEqual 133 134
                               Store 111(b) 135
-             136:   29(fvec2) Load 42(f16v)
-             137:   28(float) Load 87(f16)
-             138:   29(fvec2) VectorTimesScalar 136 137
+             136: 29(f16vec2) Load 42(f16v)
+             137:28(float16_t) Load 87(f16)
+             138: 29(f16vec2) VectorTimesScalar 136 137
                               Store 42(f16v) 138
              139:          62 Load 64(f16m)
-             140:   28(float) Load 87(f16)
+             140:28(float16_t) Load 87(f16)
              141:          62 MatrixTimesScalar 139 140
                               Store 64(f16m) 141
              142:          62 Load 64(f16m)
-             143:   29(fvec2) Load 42(f16v)
-             144:   29(fvec2) MatrixTimesVector 142 143
+             143: 29(f16vec2) Load 42(f16v)
+             144: 29(f16vec2) MatrixTimesVector 142 143
                               Store 42(f16v) 144
-             145:   29(fvec2) Load 42(f16v)
+             145: 29(f16vec2) Load 42(f16v)
              146:          62 Load 64(f16m)
-             147:   29(fvec2) VectorTimesMatrix 145 146
+             147: 29(f16vec2) VectorTimesMatrix 145 146
                               Store 42(f16v) 147
              148:          62 Load 64(f16m)
              149:          62 Load 64(f16m)
@@ -393,49 +393,49 @@ spv.float16.frag
        201(i64v):    200(ptr) Variable Function
        209(u64v):    208(ptr) Variable Function
              157:  154(bvec3) Load 156(bv)
-             161:  151(fvec3) Select 157 160 159
+             161:151(f16vec3) Select 157 160 159
                               Store 153(f16v) 161
-             162:  151(fvec3) Load 153(f16v)
+             162:151(f16vec3) Load 153(f16v)
              163:  154(bvec3) FOrdNotEqual 162 159
                               Store 156(bv) 163
              168:  165(fvec3) Load 167(fv)
-             169:  151(fvec3) FConvert 168
+             169:151(f16vec3) FConvert 168
                               Store 153(f16v) 169
-             170:  151(fvec3) Load 153(f16v)
+             170:151(f16vec3) Load 153(f16v)
              171:  165(fvec3) FConvert 170
                               Store 167(fv) 171
-             176:  173(fvec3) Load 175(dv)
-             177:  151(fvec3) FConvert 176
+             176:173(f64vec3) Load 175(dv)
+             177:151(f16vec3) FConvert 176
                               Store 153(f16v) 177
-             178:  173(fvec3) Load 175(dv)
-             179:  172(float) CompositeExtract 178 0
-             180:  172(float) CompositeExtract 178 1
-             181:  172(float) CompositeExtract 178 2
-             182:  173(fvec3) CompositeConstruct 179 180 181
+             178:173(f64vec3) Load 175(dv)
+             179:172(float64_t) CompositeExtract 178 0
+             180:172(float64_t) CompositeExtract 178 1
+             181:172(float64_t) CompositeExtract 178 2
+             182:173(f64vec3) CompositeConstruct 179 180 181
                               Store 175(dv) 182
              187:  184(ivec3) Load 186(iv)
-             188:  151(fvec3) ConvertSToF 187
+             188:151(f16vec3) ConvertSToF 187
                               Store 153(f16v) 188
-             189:  151(fvec3) Load 153(f16v)
+             189:151(f16vec3) Load 153(f16v)
              190:  184(ivec3) ConvertFToS 189
                               Store 186(iv) 190
              194:  191(ivec3) Load 193(uv)
-             195:  151(fvec3) ConvertUToF 194
+             195:151(f16vec3) ConvertUToF 194
                               Store 153(f16v) 195
-             196:  151(fvec3) Load 153(f16v)
+             196:151(f16vec3) Load 153(f16v)
              197:  191(ivec3) ConvertFToU 196
                               Store 193(uv) 197
-             202:  199(ivec3) Load 201(i64v)
-             203:  151(fvec3) ConvertSToF 202
+             202:199(i64vec3) Load 201(i64v)
+             203:151(f16vec3) ConvertSToF 202
                               Store 153(f16v) 203
-             204:  151(fvec3) Load 153(f16v)
-             205:  199(ivec3) ConvertFToS 204
+             204:151(f16vec3) Load 153(f16v)
+             205:199(i64vec3) ConvertFToS 204
                               Store 201(i64v) 205
-             210:  207(ivec3) Load 209(u64v)
-             211:  151(fvec3) ConvertUToF 210
+             210:207(i64vec3) Load 209(u64v)
+             211:151(f16vec3) ConvertUToF 210
                               Store 153(f16v) 211
-             212:  151(fvec3) Load 153(f16v)
-             213:  207(ivec3) ConvertFToU 212
+             212:151(f16vec3) Load 153(f16v)
+             213:207(i64vec3) ConvertFToU 212
                               Store 209(u64v) 213
                               Return
                               FunctionEnd
@@ -443,51 +443,51 @@ spv.float16.frag
               13:             Label
       216(f16v2):    215(ptr) Variable Function
       217(f16v1):    215(ptr) Variable Function
-             218:  214(fvec4) Load 217(f16v1)
-             219:  214(fvec4) ExtInst 1(GLSL.std.450) 11(Radians) 218
+             218:214(f16vec4) Load 217(f16v1)
+             219:214(f16vec4) ExtInst 1(GLSL.std.450) 11(Radians) 218
                               Store 216(f16v2) 219
-             220:  214(fvec4) Load 217(f16v1)
-             221:  214(fvec4) ExtInst 1(GLSL.std.450) 12(Degrees) 220
+             220:214(f16vec4) Load 217(f16v1)
+             221:214(f16vec4) ExtInst 1(GLSL.std.450) 12(Degrees) 220
                               Store 216(f16v2) 221
-             222:  214(fvec4) Load 217(f16v1)
-             223:  214(fvec4) ExtInst 1(GLSL.std.450) 13(Sin) 222
+             222:214(f16vec4) Load 217(f16v1)
+             223:214(f16vec4) ExtInst 1(GLSL.std.450) 13(Sin) 222
                               Store 216(f16v2) 223
-             224:  214(fvec4) Load 217(f16v1)
-             225:  214(fvec4) ExtInst 1(GLSL.std.450) 14(Cos) 224
+             224:214(f16vec4) Load 217(f16v1)
+             225:214(f16vec4) ExtInst 1(GLSL.std.450) 14(Cos) 224
                               Store 216(f16v2) 225
-             226:  214(fvec4) Load 217(f16v1)
-             227:  214(fvec4) ExtInst 1(GLSL.std.450) 15(Tan) 226
+             226:214(f16vec4) Load 217(f16v1)
+             227:214(f16vec4) ExtInst 1(GLSL.std.450) 15(Tan) 226
                               Store 216(f16v2) 227
-             228:  214(fvec4) Load 217(f16v1)
-             229:  214(fvec4) ExtInst 1(GLSL.std.450) 16(Asin) 228
+             228:214(f16vec4) Load 217(f16v1)
+             229:214(f16vec4) ExtInst 1(GLSL.std.450) 16(Asin) 228
                               Store 216(f16v2) 229
-             230:  214(fvec4) Load 217(f16v1)
-             231:  214(fvec4) ExtInst 1(GLSL.std.450) 17(Acos) 230
+             230:214(f16vec4) Load 217(f16v1)
+             231:214(f16vec4) ExtInst 1(GLSL.std.450) 17(Acos) 230
                               Store 216(f16v2) 231
-             232:  214(fvec4) Load 217(f16v1)
-             233:  214(fvec4) Load 216(f16v2)
-             234:  214(fvec4) ExtInst 1(GLSL.std.450) 25(Atan2) 232 233
+             232:214(f16vec4) Load 217(f16v1)
+             233:214(f16vec4) Load 216(f16v2)
+             234:214(f16vec4) ExtInst 1(GLSL.std.450) 25(Atan2) 232 233
                               Store 216(f16v2) 234
-             235:  214(fvec4) Load 217(f16v1)
-             236:  214(fvec4) ExtInst 1(GLSL.std.450) 18(Atan) 235
+             235:214(f16vec4) Load 217(f16v1)
+             236:214(f16vec4) ExtInst 1(GLSL.std.450) 18(Atan) 235
                               Store 216(f16v2) 236
-             237:  214(fvec4) Load 217(f16v1)
-             238:  214(fvec4) ExtInst 1(GLSL.std.450) 19(Sinh) 237
+             237:214(f16vec4) Load 217(f16v1)
+             238:214(f16vec4) ExtInst 1(GLSL.std.450) 19(Sinh) 237
                               Store 216(f16v2) 238
-             239:  214(fvec4) Load 217(f16v1)
-             240:  214(fvec4) ExtInst 1(GLSL.std.450) 20(Cosh) 239
+             239:214(f16vec4) Load 217(f16v1)
+             240:214(f16vec4) ExtInst 1(GLSL.std.450) 20(Cosh) 239
                               Store 216(f16v2) 240
-             241:  214(fvec4) Load 217(f16v1)
-             242:  214(fvec4) ExtInst 1(GLSL.std.450) 21(Tanh) 241
+             241:214(f16vec4) Load 217(f16v1)
+             242:214(f16vec4) ExtInst 1(GLSL.std.450) 21(Tanh) 241
                               Store 216(f16v2) 242
-             243:  214(fvec4) Load 217(f16v1)
-             244:  214(fvec4) ExtInst 1(GLSL.std.450) 22(Asinh) 243
+             243:214(f16vec4) Load 217(f16v1)
+             244:214(f16vec4) ExtInst 1(GLSL.std.450) 22(Asinh) 243
                               Store 216(f16v2) 244
-             245:  214(fvec4) Load 217(f16v1)
-             246:  214(fvec4) ExtInst 1(GLSL.std.450) 23(Acosh) 245
+             245:214(f16vec4) Load 217(f16v1)
+             246:214(f16vec4) ExtInst 1(GLSL.std.450) 23(Acosh) 245
                               Store 216(f16v2) 246
-             247:  214(fvec4) Load 217(f16v1)
-             248:  214(fvec4) ExtInst 1(GLSL.std.450) 24(Atanh) 247
+             247:214(f16vec4) Load 217(f16v1)
+             248:214(f16vec4) ExtInst 1(GLSL.std.450) 24(Atanh) 247
                               Store 216(f16v2) 248
                               Return
                               FunctionEnd
@@ -495,27 +495,27 @@ spv.float16.frag
               15:             Label
       249(f16v2):     30(ptr) Variable Function
       250(f16v1):     30(ptr) Variable Function
-             251:   29(fvec2) Load 250(f16v1)
-             252:   29(fvec2) Load 249(f16v2)
-             253:   29(fvec2) ExtInst 1(GLSL.std.450) 26(Pow) 251 252
+             251: 29(f16vec2) Load 250(f16v1)
+             252: 29(f16vec2) Load 249(f16v2)
+             253: 29(f16vec2) ExtInst 1(GLSL.std.450) 26(Pow) 251 252
                               Store 249(f16v2) 253
-             254:   29(fvec2) Load 250(f16v1)
-             255:   29(fvec2) ExtInst 1(GLSL.std.450) 27(Exp) 254
+             254: 29(f16vec2) Load 250(f16v1)
+             255: 29(f16vec2) ExtInst 1(GLSL.std.450) 27(Exp) 254
                               Store 249(f16v2) 255
-             256:   29(fvec2) Load 250(f16v1)
-             257:   29(fvec2) ExtInst 1(GLSL.std.450) 28(Log) 256
+             256: 29(f16vec2) Load 250(f16v1)
+             257: 29(f16vec2) ExtInst 1(GLSL.std.450) 28(Log) 256
                               Store 249(f16v2) 257
-             258:   29(fvec2) Load 250(f16v1)
-             259:   29(fvec2) ExtInst 1(GLSL.std.450) 29(Exp2) 258
+             258: 29(f16vec2) Load 250(f16v1)
+             259: 29(f16vec2) ExtInst 1(GLSL.std.450) 29(Exp2) 258
                               Store 249(f16v2) 259
-             260:   29(fvec2) Load 250(f16v1)
-             261:   29(fvec2) ExtInst 1(GLSL.std.450) 30(Log2) 260
+             260: 29(f16vec2) Load 250(f16v1)
+             261: 29(f16vec2) ExtInst 1(GLSL.std.450) 30(Log2) 260
                               Store 249(f16v2) 261
-             262:   29(fvec2) Load 250(f16v1)
-             263:   29(fvec2) ExtInst 1(GLSL.std.450) 31(Sqrt) 262
+             262: 29(f16vec2) Load 250(f16v1)
+             263: 29(f16vec2) ExtInst 1(GLSL.std.450) 31(Sqrt) 262
                               Store 249(f16v2) 263
-             264:   29(fvec2) Load 250(f16v1)
-             265:   29(fvec2) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 264
+             264: 29(f16vec2) Load 250(f16v1)
+             265: 29(f16vec2) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 264
                               Store 249(f16v2) 265
                               Return
                               FunctionEnd
@@ -528,132 +528,132 @@ spv.float16.frag
          332(bv):    155(ptr) Variable Function
           353(b):    110(ptr) Variable Function
          363(iv):    185(ptr) Variable Function
-             268:  151(fvec3) Load 267(f16v1)
-             269:  151(fvec3) ExtInst 1(GLSL.std.450) 4(FAbs) 268
+             268:151(f16vec3) Load 267(f16v1)
+             269:151(f16vec3) ExtInst 1(GLSL.std.450) 4(FAbs) 268
                               Store 266(f16v2) 269
-             270:  151(fvec3) Load 267(f16v1)
-             271:  151(fvec3) ExtInst 1(GLSL.std.450) 6(FSign) 270
+             270:151(f16vec3) Load 267(f16v1)
+             271:151(f16vec3) ExtInst 1(GLSL.std.450) 6(FSign) 270
                               Store 266(f16v2) 271
-             272:  151(fvec3) Load 267(f16v1)
-             273:  151(fvec3) ExtInst 1(GLSL.std.450) 8(Floor) 272
+             272:151(f16vec3) Load 267(f16v1)
+             273:151(f16vec3) ExtInst 1(GLSL.std.450) 8(Floor) 272
                               Store 266(f16v2) 273
-             274:  151(fvec3) Load 267(f16v1)
-             275:  151(fvec3) ExtInst 1(GLSL.std.450) 3(Trunc) 274
+             274:151(f16vec3) Load 267(f16v1)
+             275:151(f16vec3) ExtInst 1(GLSL.std.450) 3(Trunc) 274
                               Store 266(f16v2) 275
-             276:  151(fvec3) Load 267(f16v1)
-             277:  151(fvec3) ExtInst 1(GLSL.std.450) 1(Round) 276
+             276:151(f16vec3) Load 267(f16v1)
+             277:151(f16vec3) ExtInst 1(GLSL.std.450) 1(Round) 276
                               Store 266(f16v2) 277
-             278:  151(fvec3) Load 267(f16v1)
-             279:  151(fvec3) ExtInst 1(GLSL.std.450) 2(RoundEven) 278
+             278:151(f16vec3) Load 267(f16v1)
+             279:151(f16vec3) ExtInst 1(GLSL.std.450) 2(RoundEven) 278
                               Store 266(f16v2) 279
-             280:  151(fvec3) Load 267(f16v1)
-             281:  151(fvec3) ExtInst 1(GLSL.std.450) 9(Ceil) 280
+             280:151(f16vec3) Load 267(f16v1)
+             281:151(f16vec3) ExtInst 1(GLSL.std.450) 9(Ceil) 280
                               Store 266(f16v2) 281
-             282:  151(fvec3) Load 267(f16v1)
-             283:  151(fvec3) ExtInst 1(GLSL.std.450) 10(Fract) 282
+             282:151(f16vec3) Load 267(f16v1)
+             283:151(f16vec3) ExtInst 1(GLSL.std.450) 10(Fract) 282
                               Store 266(f16v2) 283
-             284:  151(fvec3) Load 267(f16v1)
-             285:  151(fvec3) Load 266(f16v2)
-             286:  151(fvec3) FMod 284 285
+             284:151(f16vec3) Load 267(f16v1)
+             285:151(f16vec3) Load 266(f16v2)
+             286:151(f16vec3) FMod 284 285
                               Store 266(f16v2) 286
-             287:  151(fvec3) Load 267(f16v1)
-             289:   28(float) Load 288(f16)
-             290:  151(fvec3) CompositeConstruct 289 289 289
-             291:  151(fvec3) FMod 287 290
+             287:151(f16vec3) Load 267(f16v1)
+             289:28(float16_t) Load 288(f16)
+             290:151(f16vec3) CompositeConstruct 289 289 289
+             291:151(f16vec3) FMod 287 290
                               Store 266(f16v2) 291
-             293:  151(fvec3) Load 267(f16v1)
-             294:  151(fvec3) ExtInst 1(GLSL.std.450) 35(Modf) 293 266(f16v2)
+             293:151(f16vec3) Load 267(f16v1)
+             294:151(f16vec3) ExtInst 1(GLSL.std.450) 35(Modf) 293 266(f16v2)
                               Store 292(f16v3) 294
-             295:  151(fvec3) Load 267(f16v1)
-             296:  151(fvec3) Load 266(f16v2)
-             297:  151(fvec3) ExtInst 1(GLSL.std.450) 37(FMin) 295 296
+             295:151(f16vec3) Load 267(f16v1)
+             296:151(f16vec3) Load 266(f16v2)
+             297:151(f16vec3) ExtInst 1(GLSL.std.450) 37(FMin) 295 296
                               Store 292(f16v3) 297
-             298:  151(fvec3) Load 267(f16v1)
-             299:   28(float) Load 288(f16)
-             300:  151(fvec3) CompositeConstruct 299 299 299
-             301:  151(fvec3) ExtInst 1(GLSL.std.450) 37(FMin) 298 300
+             298:151(f16vec3) Load 267(f16v1)
+             299:28(float16_t) Load 288(f16)
+             300:151(f16vec3) CompositeConstruct 299 299 299
+             301:151(f16vec3) ExtInst 1(GLSL.std.450) 37(FMin) 298 300
                               Store 292(f16v3) 301
-             302:  151(fvec3) Load 267(f16v1)
-             303:  151(fvec3) Load 266(f16v2)
-             304:  151(fvec3) ExtInst 1(GLSL.std.450) 40(FMax) 302 303
+             302:151(f16vec3) Load 267(f16v1)
+             303:151(f16vec3) Load 266(f16v2)
+             304:151(f16vec3) ExtInst 1(GLSL.std.450) 40(FMax) 302 303
                               Store 292(f16v3) 304
-             305:  151(fvec3) Load 267(f16v1)
-             306:   28(float) Load 288(f16)
-             307:  151(fvec3) CompositeConstruct 306 306 306
-             308:  151(fvec3) ExtInst 1(GLSL.std.450) 40(FMax) 305 307
+             305:151(f16vec3) Load 267(f16v1)
+             306:28(float16_t) Load 288(f16)
+             307:151(f16vec3) CompositeConstruct 306 306 306
+             308:151(f16vec3) ExtInst 1(GLSL.std.450) 40(FMax) 305 307
                               Store 292(f16v3) 308
-             309:  151(fvec3) Load 267(f16v1)
-             310:   28(float) Load 288(f16)
+             309:151(f16vec3) Load 267(f16v1)
+             310:28(float16_t) Load 288(f16)
              311:     35(ptr) AccessChain 266(f16v2) 34
-             312:   28(float) Load 311
-             313:  151(fvec3) CompositeConstruct 310 310 310
-             314:  151(fvec3) CompositeConstruct 312 312 312
-             315:  151(fvec3) ExtInst 1(GLSL.std.450) 43(FClamp) 309 313 314
+             312:28(float16_t) Load 311
+             313:151(f16vec3) CompositeConstruct 310 310 310
+             314:151(f16vec3) CompositeConstruct 312 312 312
+             315:151(f16vec3) ExtInst 1(GLSL.std.450) 43(FClamp) 309 313 314
                               Store 292(f16v3) 315
-             316:  151(fvec3) Load 267(f16v1)
-             317:  151(fvec3) Load 266(f16v2)
-             318:   28(float) Load 288(f16)
-             319:  151(fvec3) CompositeConstruct 318 318 318
-             320:  151(fvec3) ExtInst 1(GLSL.std.450) 43(FClamp) 316 317 319
+             316:151(f16vec3) Load 267(f16v1)
+             317:151(f16vec3) Load 266(f16v2)
+             318:28(float16_t) Load 288(f16)
+             319:151(f16vec3) CompositeConstruct 318 318 318
+             320:151(f16vec3) ExtInst 1(GLSL.std.450) 43(FClamp) 316 317 319
                               Store 292(f16v3) 320
-             321:  151(fvec3) Load 267(f16v1)
-             322:  151(fvec3) Load 266(f16v2)
-             323:   28(float) Load 288(f16)
-             324:  151(fvec3) CompositeConstruct 323 323 323
-             325:  151(fvec3) ExtInst 1(GLSL.std.450) 46(FMix) 321 322 324
+             321:151(f16vec3) Load 267(f16v1)
+             322:151(f16vec3) Load 266(f16v2)
+             323:28(float16_t) Load 288(f16)
+             324:151(f16vec3) CompositeConstruct 323 323 323
+             325:151(f16vec3) ExtInst 1(GLSL.std.450) 46(FMix) 321 322 324
                               Store 292(f16v3) 325
-             326:  151(fvec3) Load 267(f16v1)
-             327:  151(fvec3) Load 266(f16v2)
-             328:  151(fvec3) Load 292(f16v3)
-             329:  151(fvec3) ExtInst 1(GLSL.std.450) 46(FMix) 326 327 328
+             326:151(f16vec3) Load 267(f16v1)
+             327:151(f16vec3) Load 266(f16v2)
+             328:151(f16vec3) Load 292(f16v3)
+             329:151(f16vec3) ExtInst 1(GLSL.std.450) 46(FMix) 326 327 328
                               Store 292(f16v3) 329
-             330:  151(fvec3) Load 267(f16v1)
-             331:  151(fvec3) Load 266(f16v2)
+             330:151(f16vec3) Load 267(f16v1)
+             331:151(f16vec3) Load 266(f16v2)
              333:  154(bvec3) Load 332(bv)
-             334:  151(fvec3) Select 333 331 330
+             334:151(f16vec3) Select 333 331 330
                               Store 292(f16v3) 334
-             335:  151(fvec3) Load 267(f16v1)
-             336:  151(fvec3) Load 266(f16v2)
-             337:  151(fvec3) ExtInst 1(GLSL.std.450) 48(Step) 335 336
+             335:151(f16vec3) Load 267(f16v1)
+             336:151(f16vec3) Load 266(f16v2)
+             337:151(f16vec3) ExtInst 1(GLSL.std.450) 48(Step) 335 336
                               Store 292(f16v3) 337
-             338:   28(float) Load 288(f16)
-             339:  151(fvec3) Load 292(f16v3)
-             340:  151(fvec3) CompositeConstruct 338 338 338
-             341:  151(fvec3) ExtInst 1(GLSL.std.450) 48(Step) 340 339
+             338:28(float16_t) Load 288(f16)
+             339:151(f16vec3) Load 292(f16v3)
+             340:151(f16vec3) CompositeConstruct 338 338 338
+             341:151(f16vec3) ExtInst 1(GLSL.std.450) 48(Step) 340 339
                               Store 292(f16v3) 341
-             342:  151(fvec3) Load 267(f16v1)
-             343:  151(fvec3) Load 266(f16v2)
-             344:  151(fvec3) Load 292(f16v3)
-             345:  151(fvec3) ExtInst 1(GLSL.std.450) 49(SmoothStep) 342 343 344
+             342:151(f16vec3) Load 267(f16v1)
+             343:151(f16vec3) Load 266(f16v2)
+             344:151(f16vec3) Load 292(f16v3)
+             345:151(f16vec3) ExtInst 1(GLSL.std.450) 49(SmoothStep) 342 343 344
                               Store 292(f16v3) 345
-             346:   28(float) Load 288(f16)
+             346:28(float16_t) Load 288(f16)
              347:     35(ptr) AccessChain 267(f16v1) 34
-             348:   28(float) Load 347
-             349:  151(fvec3) Load 266(f16v2)
-             350:  151(fvec3) CompositeConstruct 346 346 346
-             351:  151(fvec3) CompositeConstruct 348 348 348
-             352:  151(fvec3) ExtInst 1(GLSL.std.450) 49(SmoothStep) 350 351 349
+             348:28(float16_t) Load 347
+             349:151(f16vec3) Load 266(f16v2)
+             350:151(f16vec3) CompositeConstruct 346 346 346
+             351:151(f16vec3) CompositeConstruct 348 348 348
+             352:151(f16vec3) ExtInst 1(GLSL.std.450) 49(SmoothStep) 350 351 349
                               Store 292(f16v3) 352
-             354:   28(float) Load 288(f16)
+             354:28(float16_t) Load 288(f16)
              355:   109(bool) IsNan 354
                               Store 353(b) 355
-             356:  151(fvec3) Load 267(f16v1)
+             356:151(f16vec3) Load 267(f16v1)
              357:  154(bvec3) IsInf 356
                               Store 332(bv) 357
-             358:  151(fvec3) Load 267(f16v1)
-             359:  151(fvec3) Load 266(f16v2)
-             360:  151(fvec3) Load 292(f16v3)
-             361:  151(fvec3) ExtInst 1(GLSL.std.450) 50(Fma) 358 359 360
+             358:151(f16vec3) Load 267(f16v1)
+             359:151(f16vec3) Load 266(f16v2)
+             360:151(f16vec3) Load 292(f16v3)
+             361:151(f16vec3) ExtInst 1(GLSL.std.450) 50(Fma) 358 359 360
                               Store 292(f16v3) 361
-             362:  151(fvec3) Load 267(f16v1)
+             362:151(f16vec3) Load 267(f16v1)
              365:364(ResType) ExtInst 1(GLSL.std.450) 52(FrexpStruct) 362
              366:  184(ivec3) CompositeExtract 365 1
                               Store 363(iv) 366
-             367:  151(fvec3) CompositeExtract 365 0
+             367:151(f16vec3) CompositeExtract 365 0
                               Store 266(f16v2) 367
-             368:  151(fvec3) Load 267(f16v1)
+             368:151(f16vec3) Load 267(f16v1)
              369:  184(ivec3) Load 363(iv)
-             370:  151(fvec3) ExtInst 1(GLSL.std.450) 53(Ldexp) 368 369
+             370:151(f16vec3) ExtInst 1(GLSL.std.450) 53(Ldexp) 368 369
                               Store 266(f16v2) 370
                               Return
                               FunctionEnd
@@ -661,11 +661,11 @@ spv.float16.frag
               19:             Label
           372(u):    371(ptr) Variable Function
        373(f16v):     30(ptr) Variable Function
-             374:   29(fvec2) Load 373(f16v)
+             374: 29(f16vec2) Load 373(f16v)
              375:     33(int) Bitcast 374
                               Store 372(u) 375
              376:     33(int) Load 372(u)
-             377:   29(fvec2) Bitcast 376
+             377: 29(f16vec2) Bitcast 376
                               Store 373(f16v) 377
                               Return
                               FunctionEnd
@@ -675,37 +675,37 @@ spv.float16.frag
       379(f16v1):    152(ptr) Variable Function
       383(f16v2):    152(ptr) Variable Function
       389(f16v3):    152(ptr) Variable Function
-             380:  151(fvec3) Load 379(f16v1)
-             381:   28(float) ExtInst 1(GLSL.std.450) 66(Length) 380
+             380:151(f16vec3) Load 379(f16v1)
+             381:28(float16_t) ExtInst 1(GLSL.std.450) 66(Length) 380
                               Store 378(f16) 381
-             382:  151(fvec3) Load 379(f16v1)
-             384:  151(fvec3) Load 383(f16v2)
-             385:   28(float) ExtInst 1(GLSL.std.450) 67(Distance) 382 384
+             382:151(f16vec3) Load 379(f16v1)
+             384:151(f16vec3) Load 383(f16v2)
+             385:28(float16_t) ExtInst 1(GLSL.std.450) 67(Distance) 382 384
                               Store 378(f16) 385
-             386:  151(fvec3) Load 379(f16v1)
-             387:  151(fvec3) Load 383(f16v2)
-             388:   28(float) Dot 386 387
+             386:151(f16vec3) Load 379(f16v1)
+             387:151(f16vec3) Load 383(f16v2)
+             388:28(float16_t) Dot 386 387
                               Store 378(f16) 388
-             390:  151(fvec3) Load 379(f16v1)
-             391:  151(fvec3) Load 383(f16v2)
-             392:  151(fvec3) ExtInst 1(GLSL.std.450) 68(Cross) 390 391
+             390:151(f16vec3) Load 379(f16v1)
+             391:151(f16vec3) Load 383(f16v2)
+             392:151(f16vec3) ExtInst 1(GLSL.std.450) 68(Cross) 390 391
                               Store 389(f16v3) 392
-             393:  151(fvec3) Load 379(f16v1)
-             394:  151(fvec3) ExtInst 1(GLSL.std.450) 69(Normalize) 393
+             393:151(f16vec3) Load 379(f16v1)
+             394:151(f16vec3) ExtInst 1(GLSL.std.450) 69(Normalize) 393
                               Store 383(f16v2) 394
-             395:  151(fvec3) Load 379(f16v1)
-             396:  151(fvec3) Load 383(f16v2)
-             397:  151(fvec3) Load 389(f16v3)
-             398:  151(fvec3) ExtInst 1(GLSL.std.450) 70(FaceForward) 395 396 397
+             395:151(f16vec3) Load 379(f16v1)
+             396:151(f16vec3) Load 383(f16v2)
+             397:151(f16vec3) Load 389(f16v3)
+             398:151(f16vec3) ExtInst 1(GLSL.std.450) 70(FaceForward) 395 396 397
                               Store 389(f16v3) 398
-             399:  151(fvec3) Load 379(f16v1)
-             400:  151(fvec3) Load 383(f16v2)
-             401:  151(fvec3) ExtInst 1(GLSL.std.450) 71(Reflect) 399 400
+             399:151(f16vec3) Load 379(f16v1)
+             400:151(f16vec3) Load 383(f16v2)
+             401:151(f16vec3) ExtInst 1(GLSL.std.450) 71(Reflect) 399 400
                               Store 389(f16v3) 401
-             402:  151(fvec3) Load 379(f16v1)
-             403:  151(fvec3) Load 383(f16v2)
-             404:   28(float) Load 378(f16)
-             405:  151(fvec3) ExtInst 1(GLSL.std.450) 72(Refract) 402 403 404
+             402:151(f16vec3) Load 379(f16v1)
+             403:151(f16vec3) Load 383(f16v2)
+             404:28(float16_t) Load 378(f16)
+             405:151(f16vec3) ExtInst 1(GLSL.std.450) 72(Refract) 402 403 404
                               Store 389(f16v3) 405
                               Return
                               FunctionEnd
@@ -723,23 +723,23 @@ spv.float16.frag
       439(f16m7):    437(ptr) Variable Function
              410:         406 Load 409(f16m1)
              412:         406 Load 411(f16m2)
-             413:  151(fvec3) CompositeExtract 410 0
-             414:  151(fvec3) CompositeExtract 412 0
-             415:  151(fvec3) FMul 413 414
-             416:  151(fvec3) CompositeExtract 410 1
-             417:  151(fvec3) CompositeExtract 412 1
-             418:  151(fvec3) FMul 416 417
+             413:151(f16vec3) CompositeExtract 410 0
+             414:151(f16vec3) CompositeExtract 412 0
+             415:151(f16vec3) FMul 413 414
+             416:151(f16vec3) CompositeExtract 410 1
+             417:151(f16vec3) CompositeExtract 412 1
+             418:151(f16vec3) FMul 416 417
              419:         406 CompositeConstruct 415 418
                               Store 408(f16m3) 419
-             421:  151(fvec3) Load 420(f16v1)
-             423:   29(fvec2) Load 422(f16v2)
+             421:151(f16vec3) Load 420(f16v1)
+             423: 29(f16vec2) Load 422(f16v2)
              424:         406 OuterProduct 421 423
                               Store 409(f16m1) 424
              428:         406 Load 409(f16m1)
              429:         425 Transpose 428
                               Store 427(f16m4) 429
              434:         431 Load 433(f16m5)
-             435:   28(float) ExtInst 1(GLSL.std.450) 33(Determinant) 434
+             435:28(float16_t) ExtInst 1(GLSL.std.450) 33(Determinant) 434
                               Store 430(f16) 435
              440:         436 Load 439(f16m7)
              441:         436 ExtInst 1(GLSL.std.450) 34(MatrixInverse) 440
@@ -751,28 +751,28 @@ spv.float16.frag
          442(bv):    155(ptr) Variable Function
       443(f16v1):    152(ptr) Variable Function
       445(f16v2):    152(ptr) Variable Function
-             444:  151(fvec3) Load 443(f16v1)
-             446:  151(fvec3) Load 445(f16v2)
+             444:151(f16vec3) Load 443(f16v1)
+             446:151(f16vec3) Load 445(f16v2)
              447:  154(bvec3) FOrdLessThan 444 446
                               Store 442(bv) 447
-             448:  151(fvec3) Load 443(f16v1)
-             449:  151(fvec3) Load 445(f16v2)
+             448:151(f16vec3) Load 443(f16v1)
+             449:151(f16vec3) Load 445(f16v2)
              450:  154(bvec3) FOrdLessThanEqual 448 449
                               Store 442(bv) 450
-             451:  151(fvec3) Load 443(f16v1)
-             452:  151(fvec3) Load 445(f16v2)
+             451:151(f16vec3) Load 443(f16v1)
+             452:151(f16vec3) Load 445(f16v2)
              453:  154(bvec3) FOrdGreaterThan 451 452
                               Store 442(bv) 453
-             454:  151(fvec3) Load 443(f16v1)
-             455:  151(fvec3) Load 445(f16v2)
+             454:151(f16vec3) Load 443(f16v1)
+             455:151(f16vec3) Load 445(f16v2)
              456:  154(bvec3) FOrdGreaterThanEqual 454 455
                               Store 442(bv) 456
-             457:  151(fvec3) Load 443(f16v1)
-             458:  151(fvec3) Load 445(f16v2)
+             457:151(f16vec3) Load 443(f16v1)
+             458:151(f16vec3) Load 445(f16v2)
              459:  154(bvec3) FOrdEqual 457 458
                               Store 442(bv) 459
-             460:  151(fvec3) Load 443(f16v1)
-             461:  151(fvec3) Load 445(f16v2)
+             460:151(f16vec3) Load 443(f16v1)
+             461:151(f16vec3) Load 445(f16v2)
              462:  154(bvec3) FOrdNotEqual 460 461
                               Store 442(bv) 462
                               Return
@@ -781,57 +781,57 @@ spv.float16.frag
               27:             Label
        463(f16v):    152(ptr) Variable Function
              467:    466(ptr) AccessChain 465(if16v) 34
-             468:   28(float) Load 467
-             469:   28(float) DPdx 468
+             468:28(float16_t) Load 467
+             469:28(float16_t) DPdx 468
              470:     35(ptr) AccessChain 463(f16v) 34
                               Store 470 469
              471:    466(ptr) AccessChain 465(if16v) 90
-             472:   28(float) Load 471
-             473:   28(float) DPdy 472
+             472:28(float16_t) Load 471
+             473:28(float16_t) DPdy 472
              474:     35(ptr) AccessChain 463(f16v) 90
                               Store 474 473
-             475:  151(fvec3) Load 465(if16v)
-             476:   29(fvec2) VectorShuffle 475 475 0 1
-             477:   29(fvec2) DPdxFine 476
-             478:  151(fvec3) Load 463(f16v)
-             479:  151(fvec3) VectorShuffle 478 477 3 4 2
+             475:151(f16vec3) Load 465(if16v)
+             476: 29(f16vec2) VectorShuffle 475 475 0 1
+             477: 29(f16vec2) DPdxFine 476
+             478:151(f16vec3) Load 463(f16v)
+             479:151(f16vec3) VectorShuffle 478 477 3 4 2
                               Store 463(f16v) 479
-             480:  151(fvec3) Load 465(if16v)
-             481:   29(fvec2) VectorShuffle 480 480 0 1
-             482:   29(fvec2) DPdyFine 481
-             483:  151(fvec3) Load 463(f16v)
-             484:  151(fvec3) VectorShuffle 483 482 3 4 2
+             480:151(f16vec3) Load 465(if16v)
+             481: 29(f16vec2) VectorShuffle 480 480 0 1
+             482: 29(f16vec2) DPdyFine 481
+             483:151(f16vec3) Load 463(f16v)
+             484:151(f16vec3) VectorShuffle 483 482 3 4 2
                               Store 463(f16v) 484
-             485:  151(fvec3) Load 465(if16v)
-             486:  151(fvec3) DPdxCoarse 485
+             485:151(f16vec3) Load 465(if16v)
+             486:151(f16vec3) DPdxCoarse 485
                               Store 463(f16v) 486
-             487:  151(fvec3) Load 465(if16v)
-             488:  151(fvec3) DPdxCoarse 487
+             487:151(f16vec3) Load 465(if16v)
+             488:151(f16vec3) DPdxCoarse 487
                               Store 463(f16v) 488
              489:    466(ptr) AccessChain 465(if16v) 34
-             490:   28(float) Load 489
-             491:   28(float) Fwidth 490
+             490:28(float16_t) Load 489
+             491:28(float16_t) Fwidth 490
              492:     35(ptr) AccessChain 463(f16v) 34
                               Store 492 491
-             493:  151(fvec3) Load 465(if16v)
-             494:   29(fvec2) VectorShuffle 493 493 0 1
-             495:   29(fvec2) FwidthFine 494
-             496:  151(fvec3) Load 463(f16v)
-             497:  151(fvec3) VectorShuffle 496 495 3 4 2
+             493:151(f16vec3) Load 465(if16v)
+             494: 29(f16vec2) VectorShuffle 493 493 0 1
+             495: 29(f16vec2) FwidthFine 494
+             496:151(f16vec3) Load 463(f16v)
+             497:151(f16vec3) VectorShuffle 496 495 3 4 2
                               Store 463(f16v) 497
-             498:  151(fvec3) Load 465(if16v)
-             499:  151(fvec3) FwidthCoarse 498
+             498:151(f16vec3) Load 465(if16v)
+             499:151(f16vec3) FwidthCoarse 498
                               Store 463(f16v) 499
              500:    466(ptr) AccessChain 465(if16v) 34
-             501:   28(float) ExtInst 1(GLSL.std.450) 76(InterpolateAtCentroid) 500
+             501:28(float16_t) ExtInst 1(GLSL.std.450) 76(InterpolateAtCentroid) 500
              502:     35(ptr) AccessChain 463(f16v) 34
                               Store 502 501
-             504:  151(fvec3) ExtInst 1(GLSL.std.450) 77(InterpolateAtSample) 465(if16v) 503
-             505:   29(fvec2) VectorShuffle 504 504 0 1
-             506:  151(fvec3) Load 463(f16v)
-             507:  151(fvec3) VectorShuffle 506 505 3 4 2
+             504:151(f16vec3) ExtInst 1(GLSL.std.450) 77(InterpolateAtSample) 465(if16v) 503
+             505: 29(f16vec2) VectorShuffle 504 504 0 1
+             506:151(f16vec3) Load 463(f16v)
+             507:151(f16vec3) VectorShuffle 506 505 3 4 2
                               Store 463(f16v) 507
-             510:  151(fvec3) ExtInst 1(GLSL.std.450) 78(InterpolateAtOffset) 465(if16v) 509
+             510:151(f16vec3) ExtInst 1(GLSL.std.450) 78(InterpolateAtOffset) 465(if16v) 509
                               Store 463(f16v) 510
                               Return
                               FunctionEnd

--- a/Test/baseResults/spv.float16Fetch.frag.out
+++ b/Test/baseResults/spv.float16Fetch.frag.out
@@ -321,8 +321,8 @@ spv.float16Fetch.frag
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 16
-               7:             TypeVector 6(float) 4
-               8:             TypeFunction 7(fvec4)
+               7:             TypeVector 6(float16_t) 4
+               8:             TypeFunction 7(f16vec4)
               47:             TypeInt 32 1
               48:             TypeVector 47(int) 4
               49:             TypeFunction 48(ivec4)
@@ -330,92 +330,92 @@ spv.float16Fetch.frag
               53:             TypeVector 52(float) 2
               54:             TypeFunction 53(fvec2)
               57:             TypeFunction 47(int)
-              64:             TypePointer Function 7(fvec4)
+              64:             TypePointer Function 7(f16vec4)
               65:             TypeFunction 2 64(ptr)
-             120:    6(float) Constant 0
-             121:    7(fvec4) ConstantComposite 120 120 120 120
-             122:             TypeImage 6(float) 1D sampled format:Unknown
+             120:6(float16_t) Constant 0
+             121:  7(f16vec4) ConstantComposite 120 120 120 120
+             122:             TypeImage 6(float16_t) 1D sampled format:Unknown
              123:             TypeSampledImage 122
              124:             TypePointer UniformConstant 123
         125(s1D):    124(ptr) Variable UniformConstant
              127:             TypePointer Input 52(float)
          128(c1):    127(ptr) Variable Input
-             134:             TypePointer Input 6(float)
+             134:             TypePointer Input 6(float16_t)
       135(f16c1):    134(ptr) Variable Input
     137(f16bias):    134(ptr) Variable Input
-             142:             TypeImage 6(float) 2D sampled format:Unknown
+             142:             TypeImage 6(float16_t) 2D sampled format:Unknown
              143:             TypeSampledImage 142
              144:             TypePointer UniformConstant 143
         145(s2D):    144(ptr) Variable UniformConstant
              147:             TypePointer Input 53(fvec2)
          148(c2):    147(ptr) Variable Input
-             154:             TypeVector 6(float) 2
-             155:             TypePointer Input 154(fvec2)
+             154:             TypeVector 6(float16_t) 2
+             155:             TypePointer Input 154(f16vec2)
       156(f16c2):    155(ptr) Variable Input
-             162:             TypeImage 6(float) 3D sampled format:Unknown
+             162:             TypeImage 6(float16_t) 3D sampled format:Unknown
              163:             TypeSampledImage 162
              164:             TypePointer UniformConstant 163
         165(s3D):    164(ptr) Variable UniformConstant
              167:             TypeVector 52(float) 3
              168:             TypePointer Input 167(fvec3)
          169(c3):    168(ptr) Variable Input
-             175:             TypeVector 6(float) 3
-             176:             TypePointer Input 175(fvec3)
+             175:             TypeVector 6(float16_t) 3
+             176:             TypePointer Input 175(f16vec3)
       177(f16c3):    176(ptr) Variable Input
-             183:             TypeImage 6(float) Cube sampled format:Unknown
+             183:             TypeImage 6(float16_t) Cube sampled format:Unknown
              184:             TypeSampledImage 183
              185:             TypePointer UniformConstant 184
       186(sCube):    185(ptr) Variable UniformConstant
-             198:             TypeImage 6(float) 1D depth sampled format:Unknown
+             198:             TypeImage 6(float16_t) 1D depth sampled format:Unknown
              199:             TypeSampledImage 198
              200:             TypePointer UniformConstant 199
   201(s1DShadow):    200(ptr) Variable UniformConstant
              206:             TypeInt 32 0
              207:    206(int) Constant 0
-             208:             TypePointer Function 6(float)
+             208:             TypePointer Function 6(float16_t)
     215(compare):    127(ptr) Variable Input
-             223:             TypeImage 6(float) 2D depth sampled format:Unknown
+             223:             TypeImage 6(float16_t) 2D depth sampled format:Unknown
              224:             TypeSampledImage 223
              225:             TypePointer UniformConstant 224
   226(s2DShadow):    225(ptr) Variable UniformConstant
-             244:             TypeImage 6(float) Cube depth sampled format:Unknown
+             244:             TypeImage 6(float16_t) Cube depth sampled format:Unknown
              245:             TypeSampledImage 244
              246:             TypePointer UniformConstant 245
 247(sCubeShadow):    246(ptr) Variable UniformConstant
              249:             TypeVector 52(float) 4
              250:             TypePointer Input 249(fvec4)
          251(c4):    250(ptr) Variable Input
-             268:             TypeImage 6(float) 1D array sampled format:Unknown
+             268:             TypeImage 6(float16_t) 1D array sampled format:Unknown
              269:             TypeSampledImage 268
              270:             TypePointer UniformConstant 269
    271(s1DArray):    270(ptr) Variable UniformConstant
-             283:             TypeImage 6(float) 2D array sampled format:Unknown
+             283:             TypeImage 6(float16_t) 2D array sampled format:Unknown
              284:             TypeSampledImage 283
              285:             TypePointer UniformConstant 284
    286(s2DArray):    285(ptr) Variable UniformConstant
-             298:             TypeImage 6(float) Cube array sampled format:Unknown
+             298:             TypeImage 6(float16_t) Cube array sampled format:Unknown
              299:             TypeSampledImage 298
              300:             TypePointer UniformConstant 299
  301(sCubeArray):    300(ptr) Variable UniformConstant
-             308:             TypePointer Input 7(fvec4)
+             308:             TypePointer Input 7(f16vec4)
       309(f16c4):    308(ptr) Variable Input
-             315:             TypeImage 6(float) 1D depth array sampled format:Unknown
+             315:             TypeImage 6(float16_t) 1D depth array sampled format:Unknown
              316:             TypeSampledImage 315
              317:             TypePointer UniformConstant 316
 318(s1DArrayShadow):    317(ptr) Variable UniformConstant
-             336:             TypeImage 6(float) 2D depth array sampled format:Unknown
+             336:             TypeImage 6(float16_t) 2D depth array sampled format:Unknown
              337:             TypeSampledImage 336
              338:             TypePointer UniformConstant 337
 339(s2DArrayShadow):    338(ptr) Variable UniformConstant
-             356:             TypeImage 6(float) Rect sampled format:Unknown
+             356:             TypeImage 6(float16_t) Rect sampled format:Unknown
              357:             TypeSampledImage 356
              358:             TypePointer UniformConstant 357
     359(s2DRect):    358(ptr) Variable UniformConstant
-             370:             TypeImage 6(float) Rect depth sampled format:Unknown
+             370:             TypeImage 6(float16_t) Rect depth sampled format:Unknown
              371:             TypeSampledImage 370
              372:             TypePointer UniformConstant 371
 373(s2DRectShadow):    372(ptr) Variable UniformConstant
-             390:             TypeImage 6(float) Cube depth array sampled format:Unknown
+             390:             TypeImage 6(float16_t) Cube depth array sampled format:Unknown
              391:             TypeSampledImage 390
              392:             TypePointer UniformConstant 391
 393(sCubeArrayShadow):    392(ptr) Variable UniformConstant
@@ -426,15 +426,15 @@ spv.float16Fetch.frag
              722:  721(ivec2) ConstantComposite 709 709
              734:             TypeVector 47(int) 3
              735:  734(ivec3) ConstantComposite 709 709 709
-            1297:             TypeImage 6(float) Buffer sampled format:Unknown
+            1297:             TypeImage 6(float16_t) Buffer sampled format:Unknown
             1298:             TypeSampledImage 1297
             1299:             TypePointer UniformConstant 1298
    1300(sBuffer):   1299(ptr) Variable UniformConstant
-            1308:             TypeImage 6(float) 2D multi-sampled sampled format:Unknown
+            1308:             TypeImage 6(float16_t) 2D multi-sampled sampled format:Unknown
             1309:             TypeSampledImage 1308
             1310:             TypePointer UniformConstant 1309
      1311(s2DMS):   1310(ptr) Variable UniformConstant
-            1319:             TypeImage 6(float) 2D array multi-sampled sampled format:Unknown
+            1319:             TypeImage 6(float16_t) 2D array multi-sampled sampled format:Unknown
             1320:             TypeSampledImage 1319
             1321:             TypePointer UniformConstant 1320
 1322(s2DMSArray):   1321(ptr) Variable UniformConstant
@@ -455,41 +455,41 @@ spv.float16Fetch.frag
             2732:             TypePointer Function 53(fvec2)
             2734:   52(float) Constant 0
             2735:   53(fvec2) ConstantComposite 2734 2734
-            2953:             TypeImage 6(float) 1D nonsampled format:Rgba16f
+            2953:             TypeImage 6(float16_t) 1D nonsampled format:Rgba16f
             2954:             TypePointer UniformConstant 2953
        2955(i1D):   2954(ptr) Variable UniformConstant
-            2962:             TypeImage 6(float) 2D nonsampled format:Rgba16f
+            2962:             TypeImage 6(float16_t) 2D nonsampled format:Rgba16f
             2963:             TypePointer UniformConstant 2962
        2964(i2D):   2963(ptr) Variable UniformConstant
-            2971:             TypeImage 6(float) 3D nonsampled format:Rgba16f
+            2971:             TypeImage 6(float16_t) 3D nonsampled format:Rgba16f
             2972:             TypePointer UniformConstant 2971
        2973(i3D):   2972(ptr) Variable UniformConstant
-            2980:             TypeImage 6(float) Rect nonsampled format:Rgba16f
+            2980:             TypeImage 6(float16_t) Rect nonsampled format:Rgba16f
             2981:             TypePointer UniformConstant 2980
    2982(i2DRect):   2981(ptr) Variable UniformConstant
-            2989:             TypeImage 6(float) Cube nonsampled format:Rgba16f
+            2989:             TypeImage 6(float16_t) Cube nonsampled format:Rgba16f
             2990:             TypePointer UniformConstant 2989
      2991(iCube):   2990(ptr) Variable UniformConstant
-            2998:             TypeImage 6(float) Buffer nonsampled format:Rgba16f
+            2998:             TypeImage 6(float16_t) Buffer nonsampled format:Rgba16f
             2999:             TypePointer UniformConstant 2998
    3000(iBuffer):   2999(ptr) Variable UniformConstant
-            3007:             TypeImage 6(float) 1D array nonsampled format:Rgba16f
+            3007:             TypeImage 6(float16_t) 1D array nonsampled format:Rgba16f
             3008:             TypePointer UniformConstant 3007
   3009(i1DArray):   3008(ptr) Variable UniformConstant
-            3016:             TypeImage 6(float) 2D array nonsampled format:Rgba16f
+            3016:             TypeImage 6(float16_t) 2D array nonsampled format:Rgba16f
             3017:             TypePointer UniformConstant 3016
   3018(i2DArray):   3017(ptr) Variable UniformConstant
-            3025:             TypeImage 6(float) Cube array nonsampled format:Rgba16f
+            3025:             TypeImage 6(float16_t) Cube array nonsampled format:Rgba16f
             3026:             TypePointer UniformConstant 3025
 3027(iCubeArray):   3026(ptr) Variable UniformConstant
-            3034:             TypeImage 6(float) 2D multi-sampled nonsampled format:Rgba16f
+            3034:             TypeImage 6(float16_t) 2D multi-sampled nonsampled format:Rgba16f
             3035:             TypePointer UniformConstant 3034
      3036(i2DMS):   3035(ptr) Variable UniformConstant
-            3043:             TypeImage 6(float) 2D array multi-sampled nonsampled format:Rgba16f
+            3043:             TypeImage 6(float16_t) 2D array multi-sampled nonsampled format:Rgba16f
             3044:             TypePointer UniformConstant 3043
 3045(i2DMSArray):   3044(ptr) Variable UniformConstant
-   3102(ResType):             TypeStruct 47(int) 7(fvec4)
-   3138(ResType):             TypeStruct 47(int) 6(float)
+   3102(ResType):             TypeStruct 47(int) 7(f16vec4)
+   3138(ResType):             TypeStruct 47(int) 6(float16_t)
   4257(lodClamp):    127(ptr) Variable Input
 4264(f16lodClamp):    134(ptr) Variable Input
             5453:             TypePointer UniformConstant 122
@@ -512,11 +512,11 @@ spv.float16Fetch.frag
 5623(tCubeArray):   5622(ptr) Variable UniformConstant
             5680:             TypePointer UniformConstant 356
    5681(t2DRect):   5680(ptr) Variable UniformConstant
-            5739:             TypeImage 6(float) SubpassData nonsampled format:Unknown
+            5739:             TypeImage 6(float16_t) SubpassData nonsampled format:Unknown
             5740:             TypePointer UniformConstant 5739
    5741(subpass):   5740(ptr) Variable UniformConstant
             5743:  721(ivec2) ConstantComposite 2187 2187
-            5745:             TypeImage 6(float) SubpassData multi-sampled nonsampled format:Unknown
+            5745:             TypeImage 6(float16_t) SubpassData multi-sampled nonsampled format:Unknown
             5746:             TypePointer UniformConstant 5745
  5747(subpassMS):   5746(ptr) Variable UniformConstant
             5912:             TypePointer Output 249(fvec4)
@@ -533,555 +533,555 @@ spv.float16Fetch.frag
     5753(result):     64(ptr) Variable Function
      5834(param):     64(ptr) Variable Function
                               Store 5753(result) 121
-            5754:    7(fvec4) FunctionCall 9(testTexture()
-            5755:    7(fvec4) Load 5753(result)
-            5756:    7(fvec4) FAdd 5755 5754
+            5754:  7(f16vec4) FunctionCall 9(testTexture()
+            5755:  7(f16vec4) Load 5753(result)
+            5756:  7(f16vec4) FAdd 5755 5754
                               Store 5753(result) 5756
-            5757:    7(fvec4) FunctionCall 11(testTextureProj()
-            5758:    7(fvec4) Load 5753(result)
-            5759:    7(fvec4) FAdd 5758 5757
+            5757:  7(f16vec4) FunctionCall 11(testTextureProj()
+            5758:  7(f16vec4) Load 5753(result)
+            5759:  7(f16vec4) FAdd 5758 5757
                               Store 5753(result) 5759
-            5760:    7(fvec4) FunctionCall 13(testTextureLod()
-            5761:    7(fvec4) Load 5753(result)
-            5762:    7(fvec4) FAdd 5761 5760
+            5760:  7(f16vec4) FunctionCall 13(testTextureLod()
+            5761:  7(f16vec4) Load 5753(result)
+            5762:  7(f16vec4) FAdd 5761 5760
                               Store 5753(result) 5762
-            5763:    7(fvec4) FunctionCall 15(testTextureOffset()
-            5764:    7(fvec4) Load 5753(result)
-            5765:    7(fvec4) FAdd 5764 5763
+            5763:  7(f16vec4) FunctionCall 15(testTextureOffset()
+            5764:  7(f16vec4) Load 5753(result)
+            5765:  7(f16vec4) FAdd 5764 5763
                               Store 5753(result) 5765
-            5766:    7(fvec4) FunctionCall 19(testTextureLodOffset()
-            5767:    7(fvec4) Load 5753(result)
-            5768:    7(fvec4) FAdd 5767 5766
+            5766:  7(f16vec4) FunctionCall 19(testTextureLodOffset()
+            5767:  7(f16vec4) Load 5753(result)
+            5768:  7(f16vec4) FAdd 5767 5766
                               Store 5753(result) 5768
-            5769:    7(fvec4) FunctionCall 21(testTextureProjLodOffset()
-            5770:    7(fvec4) Load 5753(result)
-            5771:    7(fvec4) FAdd 5770 5769
+            5769:  7(f16vec4) FunctionCall 21(testTextureProjLodOffset()
+            5770:  7(f16vec4) Load 5753(result)
+            5771:  7(f16vec4) FAdd 5770 5769
                               Store 5753(result) 5771
-            5772:    7(fvec4) FunctionCall 23(testTexelFetch()
-            5773:    7(fvec4) Load 5753(result)
-            5774:    7(fvec4) FAdd 5773 5772
+            5772:  7(f16vec4) FunctionCall 23(testTexelFetch()
+            5773:  7(f16vec4) Load 5753(result)
+            5774:  7(f16vec4) FAdd 5773 5772
                               Store 5753(result) 5774
-            5775:    7(fvec4) FunctionCall 25(testTexelFetchOffset()
-            5776:    7(fvec4) Load 5753(result)
-            5777:    7(fvec4) FAdd 5776 5775
+            5775:  7(f16vec4) FunctionCall 25(testTexelFetchOffset()
+            5776:  7(f16vec4) Load 5753(result)
+            5777:  7(f16vec4) FAdd 5776 5775
                               Store 5753(result) 5777
-            5778:    7(fvec4) FunctionCall 27(testTextureGrad()
-            5779:    7(fvec4) Load 5753(result)
-            5780:    7(fvec4) FAdd 5779 5778
+            5778:  7(f16vec4) FunctionCall 27(testTextureGrad()
+            5779:  7(f16vec4) Load 5753(result)
+            5780:  7(f16vec4) FAdd 5779 5778
                               Store 5753(result) 5780
-            5781:    7(fvec4) FunctionCall 29(testTextureGradOffset()
-            5782:    7(fvec4) Load 5753(result)
-            5783:    7(fvec4) FAdd 5782 5781
+            5781:  7(f16vec4) FunctionCall 29(testTextureGradOffset()
+            5782:  7(f16vec4) Load 5753(result)
+            5783:  7(f16vec4) FAdd 5782 5781
                               Store 5753(result) 5783
-            5784:    7(fvec4) FunctionCall 31(testTextureProjGrad()
-            5785:    7(fvec4) Load 5753(result)
-            5786:    7(fvec4) FAdd 5785 5784
+            5784:  7(f16vec4) FunctionCall 31(testTextureProjGrad()
+            5785:  7(f16vec4) Load 5753(result)
+            5786:  7(f16vec4) FAdd 5785 5784
                               Store 5753(result) 5786
-            5787:    7(fvec4) FunctionCall 33(testTextureProjGradoffset()
-            5788:    7(fvec4) Load 5753(result)
-            5789:    7(fvec4) FAdd 5788 5787
+            5787:  7(f16vec4) FunctionCall 33(testTextureProjGradoffset()
+            5788:  7(f16vec4) Load 5753(result)
+            5789:  7(f16vec4) FAdd 5788 5787
                               Store 5753(result) 5789
-            5790:    7(fvec4) FunctionCall 35(testTextureGather()
-            5791:    7(fvec4) Load 5753(result)
-            5792:    7(fvec4) FAdd 5791 5790
+            5790:  7(f16vec4) FunctionCall 35(testTextureGather()
+            5791:  7(f16vec4) Load 5753(result)
+            5792:  7(f16vec4) FAdd 5791 5790
                               Store 5753(result) 5792
-            5793:    7(fvec4) FunctionCall 37(testTextureGatherOffset()
-            5794:    7(fvec4) Load 5753(result)
-            5795:    7(fvec4) FAdd 5794 5793
+            5793:  7(f16vec4) FunctionCall 37(testTextureGatherOffset()
+            5794:  7(f16vec4) Load 5753(result)
+            5795:  7(f16vec4) FAdd 5794 5793
                               Store 5753(result) 5795
-            5796:    7(fvec4) FunctionCall 39(testTextureGatherOffsets()
-            5797:    7(fvec4) Load 5753(result)
-            5798:    7(fvec4) FAdd 5797 5796
+            5796:  7(f16vec4) FunctionCall 39(testTextureGatherOffsets()
+            5797:  7(f16vec4) Load 5753(result)
+            5798:  7(f16vec4) FAdd 5797 5796
                               Store 5753(result) 5798
-            5799:    7(fvec4) FunctionCall 41(testTextureGatherLod()
-            5800:    7(fvec4) Load 5753(result)
-            5801:    7(fvec4) FAdd 5800 5799
+            5799:  7(f16vec4) FunctionCall 41(testTextureGatherLod()
+            5800:  7(f16vec4) Load 5753(result)
+            5801:  7(f16vec4) FAdd 5800 5799
                               Store 5753(result) 5801
-            5802:    7(fvec4) FunctionCall 43(testTextureGatherLodOffset()
-            5803:    7(fvec4) Load 5753(result)
-            5804:    7(fvec4) FAdd 5803 5802
+            5802:  7(f16vec4) FunctionCall 43(testTextureGatherLodOffset()
+            5803:  7(f16vec4) Load 5753(result)
+            5804:  7(f16vec4) FAdd 5803 5802
                               Store 5753(result) 5804
-            5805:    7(fvec4) FunctionCall 45(testTextureGatherLodOffsets()
-            5806:    7(fvec4) Load 5753(result)
-            5807:    7(fvec4) FAdd 5806 5805
+            5805:  7(f16vec4) FunctionCall 45(testTextureGatherLodOffsets()
+            5806:  7(f16vec4) Load 5753(result)
+            5807:  7(f16vec4) FAdd 5806 5805
                               Store 5753(result) 5807
             5808:   48(ivec4) FunctionCall 50(testTextureSize()
-            5809:    7(fvec4) ConvertSToF 5808
-            5810:    7(fvec4) Load 5753(result)
-            5811:    7(fvec4) FAdd 5810 5809
+            5809:  7(f16vec4) ConvertSToF 5808
+            5810:  7(f16vec4) Load 5753(result)
+            5811:  7(f16vec4) FAdd 5810 5809
                               Store 5753(result) 5811
             5812:   53(fvec2) FunctionCall 55(testTextureQueryLod()
-            5813:  154(fvec2) FConvert 5812
-            5814:    7(fvec4) Load 5753(result)
-            5815:  154(fvec2) VectorShuffle 5814 5814 0 1
-            5816:  154(fvec2) FAdd 5815 5813
-            5817:    7(fvec4) Load 5753(result)
-            5818:    7(fvec4) VectorShuffle 5817 5816 4 5 2 3
+            5813:154(f16vec2) FConvert 5812
+            5814:  7(f16vec4) Load 5753(result)
+            5815:154(f16vec2) VectorShuffle 5814 5814 0 1
+            5816:154(f16vec2) FAdd 5815 5813
+            5817:  7(f16vec4) Load 5753(result)
+            5818:  7(f16vec4) VectorShuffle 5817 5816 4 5 2 3
                               Store 5753(result) 5818
             5819:     47(int) FunctionCall 58(testTextureQueryLevels()
-            5820:    6(float) ConvertSToF 5819
+            5820:6(float16_t) ConvertSToF 5819
             5821:    208(ptr) AccessChain 5753(result) 207
-            5822:    6(float) Load 5821
-            5823:    6(float) FAdd 5822 5820
+            5822:6(float16_t) Load 5821
+            5823:6(float16_t) FAdd 5822 5820
             5824:    208(ptr) AccessChain 5753(result) 207
                               Store 5824 5823
             5825:     47(int) FunctionCall 60(testTextureSamples()
-            5826:    6(float) ConvertSToF 5825
+            5826:6(float16_t) ConvertSToF 5825
             5827:    208(ptr) AccessChain 5753(result) 207
-            5828:    6(float) Load 5827
-            5829:    6(float) FAdd 5828 5826
+            5828:6(float16_t) Load 5827
+            5829:6(float16_t) FAdd 5828 5826
             5830:    208(ptr) AccessChain 5753(result) 207
                               Store 5830 5829
-            5831:    7(fvec4) FunctionCall 62(testImageLoad()
-            5832:    7(fvec4) Load 5753(result)
-            5833:    7(fvec4) FAdd 5832 5831
+            5831:  7(f16vec4) FunctionCall 62(testImageLoad()
+            5832:  7(f16vec4) Load 5753(result)
+            5833:  7(f16vec4) FAdd 5832 5831
                               Store 5753(result) 5833
-            5835:    7(fvec4) Load 5753(result)
+            5835:  7(f16vec4) Load 5753(result)
                               Store 5834(param) 5835
             5836:           2 FunctionCall 67(testImageStore(vf164;) 5834(param)
-            5837:    7(fvec4) FunctionCall 69(testSparseTexture()
-            5838:    7(fvec4) Load 5753(result)
-            5839:    7(fvec4) FAdd 5838 5837
+            5837:  7(f16vec4) FunctionCall 69(testSparseTexture()
+            5838:  7(f16vec4) Load 5753(result)
+            5839:  7(f16vec4) FAdd 5838 5837
                               Store 5753(result) 5839
-            5840:    7(fvec4) FunctionCall 71(testSparseTextureLod()
-            5841:    7(fvec4) Load 5753(result)
-            5842:    7(fvec4) FAdd 5841 5840
+            5840:  7(f16vec4) FunctionCall 71(testSparseTextureLod()
+            5841:  7(f16vec4) Load 5753(result)
+            5842:  7(f16vec4) FAdd 5841 5840
                               Store 5753(result) 5842
-            5843:    7(fvec4) FunctionCall 73(testSparseTextureOffset()
-            5844:    7(fvec4) Load 5753(result)
-            5845:    7(fvec4) FAdd 5844 5843
+            5843:  7(f16vec4) FunctionCall 73(testSparseTextureOffset()
+            5844:  7(f16vec4) Load 5753(result)
+            5845:  7(f16vec4) FAdd 5844 5843
                               Store 5753(result) 5845
-            5846:    7(fvec4) FunctionCall 75(testSparseTextureLodOffset()
-            5847:    7(fvec4) Load 5753(result)
-            5848:    7(fvec4) FAdd 5847 5846
+            5846:  7(f16vec4) FunctionCall 75(testSparseTextureLodOffset()
+            5847:  7(f16vec4) Load 5753(result)
+            5848:  7(f16vec4) FAdd 5847 5846
                               Store 5753(result) 5848
-            5849:    7(fvec4) FunctionCall 77(testSparseTextureGrad()
-            5850:    7(fvec4) Load 5753(result)
-            5851:    7(fvec4) FAdd 5850 5849
+            5849:  7(f16vec4) FunctionCall 77(testSparseTextureGrad()
+            5850:  7(f16vec4) Load 5753(result)
+            5851:  7(f16vec4) FAdd 5850 5849
                               Store 5753(result) 5851
-            5852:    7(fvec4) FunctionCall 79(testSparseTextureGradOffset()
-            5853:    7(fvec4) Load 5753(result)
-            5854:    7(fvec4) FAdd 5853 5852
+            5852:  7(f16vec4) FunctionCall 79(testSparseTextureGradOffset()
+            5853:  7(f16vec4) Load 5753(result)
+            5854:  7(f16vec4) FAdd 5853 5852
                               Store 5753(result) 5854
-            5855:    7(fvec4) FunctionCall 81(testSparseTexelFetch()
-            5856:    7(fvec4) Load 5753(result)
-            5857:    7(fvec4) FAdd 5856 5855
+            5855:  7(f16vec4) FunctionCall 81(testSparseTexelFetch()
+            5856:  7(f16vec4) Load 5753(result)
+            5857:  7(f16vec4) FAdd 5856 5855
                               Store 5753(result) 5857
-            5858:    7(fvec4) FunctionCall 83(testSparseTexelFetchOffset()
-            5859:    7(fvec4) Load 5753(result)
-            5860:    7(fvec4) FAdd 5859 5858
+            5858:  7(f16vec4) FunctionCall 83(testSparseTexelFetchOffset()
+            5859:  7(f16vec4) Load 5753(result)
+            5860:  7(f16vec4) FAdd 5859 5858
                               Store 5753(result) 5860
-            5861:    7(fvec4) FunctionCall 85(testSparseTextureGather()
-            5862:    7(fvec4) Load 5753(result)
-            5863:    7(fvec4) FAdd 5862 5861
+            5861:  7(f16vec4) FunctionCall 85(testSparseTextureGather()
+            5862:  7(f16vec4) Load 5753(result)
+            5863:  7(f16vec4) FAdd 5862 5861
                               Store 5753(result) 5863
-            5864:    7(fvec4) FunctionCall 87(testSparseTextureGatherOffset()
-            5865:    7(fvec4) Load 5753(result)
-            5866:    7(fvec4) FAdd 5865 5864
+            5864:  7(f16vec4) FunctionCall 87(testSparseTextureGatherOffset()
+            5865:  7(f16vec4) Load 5753(result)
+            5866:  7(f16vec4) FAdd 5865 5864
                               Store 5753(result) 5866
-            5867:    7(fvec4) FunctionCall 89(testSparseTextureGatherOffsets()
-            5868:    7(fvec4) Load 5753(result)
-            5869:    7(fvec4) FAdd 5868 5867
+            5867:  7(f16vec4) FunctionCall 89(testSparseTextureGatherOffsets()
+            5868:  7(f16vec4) Load 5753(result)
+            5869:  7(f16vec4) FAdd 5868 5867
                               Store 5753(result) 5869
-            5870:    7(fvec4) FunctionCall 91(testSparseTextureGatherLod()
-            5871:    7(fvec4) Load 5753(result)
-            5872:    7(fvec4) FAdd 5871 5870
+            5870:  7(f16vec4) FunctionCall 91(testSparseTextureGatherLod()
+            5871:  7(f16vec4) Load 5753(result)
+            5872:  7(f16vec4) FAdd 5871 5870
                               Store 5753(result) 5872
-            5873:    7(fvec4) FunctionCall 93(testSparseTextureGatherLodOffset()
-            5874:    7(fvec4) Load 5753(result)
-            5875:    7(fvec4) FAdd 5874 5873
+            5873:  7(f16vec4) FunctionCall 93(testSparseTextureGatherLodOffset()
+            5874:  7(f16vec4) Load 5753(result)
+            5875:  7(f16vec4) FAdd 5874 5873
                               Store 5753(result) 5875
-            5876:    7(fvec4) FunctionCall 95(testSparseTextureGatherLodOffsets()
-            5877:    7(fvec4) Load 5753(result)
-            5878:    7(fvec4) FAdd 5877 5876
+            5876:  7(f16vec4) FunctionCall 95(testSparseTextureGatherLodOffsets()
+            5877:  7(f16vec4) Load 5753(result)
+            5878:  7(f16vec4) FAdd 5877 5876
                               Store 5753(result) 5878
-            5879:    7(fvec4) FunctionCall 97(testSparseImageLoad()
-            5880:    7(fvec4) Load 5753(result)
-            5881:    7(fvec4) FAdd 5880 5879
+            5879:  7(f16vec4) FunctionCall 97(testSparseImageLoad()
+            5880:  7(f16vec4) Load 5753(result)
+            5881:  7(f16vec4) FAdd 5880 5879
                               Store 5753(result) 5881
-            5882:    7(fvec4) FunctionCall 99(testSparseTextureClamp()
-            5883:    7(fvec4) Load 5753(result)
-            5884:    7(fvec4) FAdd 5883 5882
+            5882:  7(f16vec4) FunctionCall 99(testSparseTextureClamp()
+            5883:  7(f16vec4) Load 5753(result)
+            5884:  7(f16vec4) FAdd 5883 5882
                               Store 5753(result) 5884
-            5885:    7(fvec4) FunctionCall 101(testTextureClamp()
-            5886:    7(fvec4) Load 5753(result)
-            5887:    7(fvec4) FAdd 5886 5885
+            5885:  7(f16vec4) FunctionCall 101(testTextureClamp()
+            5886:  7(f16vec4) Load 5753(result)
+            5887:  7(f16vec4) FAdd 5886 5885
                               Store 5753(result) 5887
-            5888:    7(fvec4) FunctionCall 103(testSparseTextureOffsetClamp()
-            5889:    7(fvec4) Load 5753(result)
-            5890:    7(fvec4) FAdd 5889 5888
+            5888:  7(f16vec4) FunctionCall 103(testSparseTextureOffsetClamp()
+            5889:  7(f16vec4) Load 5753(result)
+            5890:  7(f16vec4) FAdd 5889 5888
                               Store 5753(result) 5890
-            5891:    7(fvec4) FunctionCall 105(testTextureOffsetClamp()
-            5892:    7(fvec4) Load 5753(result)
-            5893:    7(fvec4) FAdd 5892 5891
+            5891:  7(f16vec4) FunctionCall 105(testTextureOffsetClamp()
+            5892:  7(f16vec4) Load 5753(result)
+            5893:  7(f16vec4) FAdd 5892 5891
                               Store 5753(result) 5893
-            5894:    7(fvec4) FunctionCall 77(testSparseTextureGrad()
-            5895:    7(fvec4) Load 5753(result)
-            5896:    7(fvec4) FAdd 5895 5894
+            5894:  7(f16vec4) FunctionCall 77(testSparseTextureGrad()
+            5895:  7(f16vec4) Load 5753(result)
+            5896:  7(f16vec4) FAdd 5895 5894
                               Store 5753(result) 5896
-            5897:    7(fvec4) FunctionCall 27(testTextureGrad()
-            5898:    7(fvec4) Load 5753(result)
-            5899:    7(fvec4) FAdd 5898 5897
+            5897:  7(f16vec4) FunctionCall 27(testTextureGrad()
+            5898:  7(f16vec4) Load 5753(result)
+            5899:  7(f16vec4) FAdd 5898 5897
                               Store 5753(result) 5899
-            5900:    7(fvec4) FunctionCall 111(testSparseTextureGradOffsetClamp()
-            5901:    7(fvec4) Load 5753(result)
-            5902:    7(fvec4) FAdd 5901 5900
+            5900:  7(f16vec4) FunctionCall 111(testSparseTextureGradOffsetClamp()
+            5901:  7(f16vec4) Load 5753(result)
+            5902:  7(f16vec4) FAdd 5901 5900
                               Store 5753(result) 5902
-            5903:    7(fvec4) FunctionCall 113(testTextureGradOffsetClamp()
-            5904:    7(fvec4) Load 5753(result)
-            5905:    7(fvec4) FAdd 5904 5903
+            5903:  7(f16vec4) FunctionCall 113(testTextureGradOffsetClamp()
+            5904:  7(f16vec4) Load 5753(result)
+            5905:  7(f16vec4) FAdd 5904 5903
                               Store 5753(result) 5905
-            5906:    7(fvec4) FunctionCall 115(testCombinedTextureSampler()
-            5907:    7(fvec4) Load 5753(result)
-            5908:    7(fvec4) FAdd 5907 5906
+            5906:  7(f16vec4) FunctionCall 115(testCombinedTextureSampler()
+            5907:  7(f16vec4) Load 5753(result)
+            5908:  7(f16vec4) FAdd 5907 5906
                               Store 5753(result) 5908
-            5909:    7(fvec4) FunctionCall 117(testSubpassLoad()
-            5910:    7(fvec4) Load 5753(result)
-            5911:    7(fvec4) FAdd 5910 5909
+            5909:  7(f16vec4) FunctionCall 117(testSubpassLoad()
+            5910:  7(f16vec4) Load 5753(result)
+            5911:  7(f16vec4) FAdd 5910 5909
                               Store 5753(result) 5911
-            5914:    7(fvec4) Load 5753(result)
+            5914:  7(f16vec4) Load 5753(result)
             5915:  249(fvec4) FConvert 5914
                               Store 5913(fragColor) 5915
                               Return
                               FunctionEnd
- 9(testTexture():    7(fvec4) Function None 8
+ 9(testTexture():  7(f16vec4) Function None 8
               10:             Label
       119(texel):     64(ptr) Variable Function
                               Store 119(texel) 121
              126:         123 Load 125(s1D)
              129:   52(float) Load 128(c1)
-             130:    7(fvec4) ImageSampleImplicitLod 126 129
-             131:    7(fvec4) Load 119(texel)
-             132:    7(fvec4) FAdd 131 130
+             130:  7(f16vec4) ImageSampleImplicitLod 126 129
+             131:  7(f16vec4) Load 119(texel)
+             132:  7(f16vec4) FAdd 131 130
                               Store 119(texel) 132
              133:         123 Load 125(s1D)
-             136:    6(float) Load 135(f16c1)
-             138:    6(float) Load 137(f16bias)
-             139:    7(fvec4) ImageSampleImplicitLod 133 136 Bias 138
-             140:    7(fvec4) Load 119(texel)
-             141:    7(fvec4) FAdd 140 139
+             136:6(float16_t) Load 135(f16c1)
+             138:6(float16_t) Load 137(f16bias)
+             139:  7(f16vec4) ImageSampleImplicitLod 133 136 Bias 138
+             140:  7(f16vec4) Load 119(texel)
+             141:  7(f16vec4) FAdd 140 139
                               Store 119(texel) 141
              146:         143 Load 145(s2D)
              149:   53(fvec2) Load 148(c2)
-             150:    7(fvec4) ImageSampleImplicitLod 146 149
-             151:    7(fvec4) Load 119(texel)
-             152:    7(fvec4) FAdd 151 150
+             150:  7(f16vec4) ImageSampleImplicitLod 146 149
+             151:  7(f16vec4) Load 119(texel)
+             152:  7(f16vec4) FAdd 151 150
                               Store 119(texel) 152
              153:         143 Load 145(s2D)
-             157:  154(fvec2) Load 156(f16c2)
-             158:    6(float) Load 137(f16bias)
-             159:    7(fvec4) ImageSampleImplicitLod 153 157 Bias 158
-             160:    7(fvec4) Load 119(texel)
-             161:    7(fvec4) FAdd 160 159
+             157:154(f16vec2) Load 156(f16c2)
+             158:6(float16_t) Load 137(f16bias)
+             159:  7(f16vec4) ImageSampleImplicitLod 153 157 Bias 158
+             160:  7(f16vec4) Load 119(texel)
+             161:  7(f16vec4) FAdd 160 159
                               Store 119(texel) 161
              166:         163 Load 165(s3D)
              170:  167(fvec3) Load 169(c3)
-             171:    7(fvec4) ImageSampleImplicitLod 166 170
-             172:    7(fvec4) Load 119(texel)
-             173:    7(fvec4) FAdd 172 171
+             171:  7(f16vec4) ImageSampleImplicitLod 166 170
+             172:  7(f16vec4) Load 119(texel)
+             173:  7(f16vec4) FAdd 172 171
                               Store 119(texel) 173
              174:         163 Load 165(s3D)
-             178:  175(fvec3) Load 177(f16c3)
-             179:    6(float) Load 137(f16bias)
-             180:    7(fvec4) ImageSampleImplicitLod 174 178 Bias 179
-             181:    7(fvec4) Load 119(texel)
-             182:    7(fvec4) FAdd 181 180
+             178:175(f16vec3) Load 177(f16c3)
+             179:6(float16_t) Load 137(f16bias)
+             180:  7(f16vec4) ImageSampleImplicitLod 174 178 Bias 179
+             181:  7(f16vec4) Load 119(texel)
+             182:  7(f16vec4) FAdd 181 180
                               Store 119(texel) 182
              187:         184 Load 186(sCube)
              188:  167(fvec3) Load 169(c3)
-             189:    7(fvec4) ImageSampleImplicitLod 187 188
-             190:    7(fvec4) Load 119(texel)
-             191:    7(fvec4) FAdd 190 189
+             189:  7(f16vec4) ImageSampleImplicitLod 187 188
+             190:  7(f16vec4) Load 119(texel)
+             191:  7(f16vec4) FAdd 190 189
                               Store 119(texel) 191
              192:         184 Load 186(sCube)
-             193:  175(fvec3) Load 177(f16c3)
-             194:    6(float) Load 137(f16bias)
-             195:    7(fvec4) ImageSampleImplicitLod 192 193 Bias 194
-             196:    7(fvec4) Load 119(texel)
-             197:    7(fvec4) FAdd 196 195
+             193:175(f16vec3) Load 177(f16c3)
+             194:6(float16_t) Load 137(f16bias)
+             195:  7(f16vec4) ImageSampleImplicitLod 192 193 Bias 194
+             196:  7(f16vec4) Load 119(texel)
+             197:  7(f16vec4) FAdd 196 195
                               Store 119(texel) 197
              202:         199 Load 201(s1DShadow)
              203:  167(fvec3) Load 169(c3)
              204:   52(float) CompositeExtract 203 2
-             205:    6(float) ImageSampleDrefImplicitLod 202 203 204
+             205:6(float16_t) ImageSampleDrefImplicitLod 202 203 204
              209:    208(ptr) AccessChain 119(texel) 207
-             210:    6(float) Load 209
-             211:    6(float) FAdd 210 205
+             210:6(float16_t) Load 209
+             211:6(float16_t) FAdd 210 205
              212:    208(ptr) AccessChain 119(texel) 207
                               Store 212 211
              213:         199 Load 201(s1DShadow)
-             214:  154(fvec2) Load 156(f16c2)
+             214:154(f16vec2) Load 156(f16c2)
              216:   52(float) Load 215(compare)
-             217:    6(float) Load 137(f16bias)
-             218:    6(float) ImageSampleDrefImplicitLod 213 214 216 Bias 217
+             217:6(float16_t) Load 137(f16bias)
+             218:6(float16_t) ImageSampleDrefImplicitLod 213 214 216 Bias 217
              219:    208(ptr) AccessChain 119(texel) 207
-             220:    6(float) Load 219
-             221:    6(float) FAdd 220 218
+             220:6(float16_t) Load 219
+             221:6(float16_t) FAdd 220 218
              222:    208(ptr) AccessChain 119(texel) 207
                               Store 222 221
              227:         224 Load 226(s2DShadow)
              228:  167(fvec3) Load 169(c3)
              229:   52(float) CompositeExtract 228 2
-             230:    6(float) ImageSampleDrefImplicitLod 227 228 229
+             230:6(float16_t) ImageSampleDrefImplicitLod 227 228 229
              231:    208(ptr) AccessChain 119(texel) 207
-             232:    6(float) Load 231
-             233:    6(float) FAdd 232 230
+             232:6(float16_t) Load 231
+             233:6(float16_t) FAdd 232 230
              234:    208(ptr) AccessChain 119(texel) 207
                               Store 234 233
              235:         224 Load 226(s2DShadow)
-             236:  154(fvec2) Load 156(f16c2)
+             236:154(f16vec2) Load 156(f16c2)
              237:   52(float) Load 215(compare)
-             238:    6(float) Load 137(f16bias)
-             239:    6(float) ImageSampleDrefImplicitLod 235 236 237 Bias 238
+             238:6(float16_t) Load 137(f16bias)
+             239:6(float16_t) ImageSampleDrefImplicitLod 235 236 237 Bias 238
              240:    208(ptr) AccessChain 119(texel) 207
-             241:    6(float) Load 240
-             242:    6(float) FAdd 241 239
+             241:6(float16_t) Load 240
+             242:6(float16_t) FAdd 241 239
              243:    208(ptr) AccessChain 119(texel) 207
                               Store 243 242
              248:         245 Load 247(sCubeShadow)
              252:  249(fvec4) Load 251(c4)
              253:   52(float) CompositeExtract 252 3
-             254:    6(float) ImageSampleDrefImplicitLod 248 252 253
+             254:6(float16_t) ImageSampleDrefImplicitLod 248 252 253
              255:    208(ptr) AccessChain 119(texel) 207
-             256:    6(float) Load 255
-             257:    6(float) FAdd 256 254
+             256:6(float16_t) Load 255
+             257:6(float16_t) FAdd 256 254
              258:    208(ptr) AccessChain 119(texel) 207
                               Store 258 257
              259:         245 Load 247(sCubeShadow)
-             260:  175(fvec3) Load 177(f16c3)
+             260:175(f16vec3) Load 177(f16c3)
              261:   52(float) Load 215(compare)
-             262:    6(float) Load 137(f16bias)
-             263:    6(float) ImageSampleDrefImplicitLod 259 260 261 Bias 262
+             262:6(float16_t) Load 137(f16bias)
+             263:6(float16_t) ImageSampleDrefImplicitLod 259 260 261 Bias 262
              264:    208(ptr) AccessChain 119(texel) 207
-             265:    6(float) Load 264
-             266:    6(float) FAdd 265 263
+             265:6(float16_t) Load 264
+             266:6(float16_t) FAdd 265 263
              267:    208(ptr) AccessChain 119(texel) 207
                               Store 267 266
              272:         269 Load 271(s1DArray)
              273:   53(fvec2) Load 148(c2)
-             274:    7(fvec4) ImageSampleImplicitLod 272 273
-             275:    7(fvec4) Load 119(texel)
-             276:    7(fvec4) FAdd 275 274
+             274:  7(f16vec4) ImageSampleImplicitLod 272 273
+             275:  7(f16vec4) Load 119(texel)
+             276:  7(f16vec4) FAdd 275 274
                               Store 119(texel) 276
              277:         269 Load 271(s1DArray)
-             278:  154(fvec2) Load 156(f16c2)
-             279:    6(float) Load 137(f16bias)
-             280:    7(fvec4) ImageSampleImplicitLod 277 278 Bias 279
-             281:    7(fvec4) Load 119(texel)
-             282:    7(fvec4) FAdd 281 280
+             278:154(f16vec2) Load 156(f16c2)
+             279:6(float16_t) Load 137(f16bias)
+             280:  7(f16vec4) ImageSampleImplicitLod 277 278 Bias 279
+             281:  7(f16vec4) Load 119(texel)
+             282:  7(f16vec4) FAdd 281 280
                               Store 119(texel) 282
              287:         284 Load 286(s2DArray)
              288:  167(fvec3) Load 169(c3)
-             289:    7(fvec4) ImageSampleImplicitLod 287 288
-             290:    7(fvec4) Load 119(texel)
-             291:    7(fvec4) FAdd 290 289
+             289:  7(f16vec4) ImageSampleImplicitLod 287 288
+             290:  7(f16vec4) Load 119(texel)
+             291:  7(f16vec4) FAdd 290 289
                               Store 119(texel) 291
              292:         284 Load 286(s2DArray)
-             293:  175(fvec3) Load 177(f16c3)
-             294:    6(float) Load 137(f16bias)
-             295:    7(fvec4) ImageSampleImplicitLod 292 293 Bias 294
-             296:    7(fvec4) Load 119(texel)
-             297:    7(fvec4) FAdd 296 295
+             293:175(f16vec3) Load 177(f16c3)
+             294:6(float16_t) Load 137(f16bias)
+             295:  7(f16vec4) ImageSampleImplicitLod 292 293 Bias 294
+             296:  7(f16vec4) Load 119(texel)
+             297:  7(f16vec4) FAdd 296 295
                               Store 119(texel) 297
              302:         299 Load 301(sCubeArray)
              303:  249(fvec4) Load 251(c4)
-             304:    7(fvec4) ImageSampleImplicitLod 302 303
-             305:    7(fvec4) Load 119(texel)
-             306:    7(fvec4) FAdd 305 304
+             304:  7(f16vec4) ImageSampleImplicitLod 302 303
+             305:  7(f16vec4) Load 119(texel)
+             306:  7(f16vec4) FAdd 305 304
                               Store 119(texel) 306
              307:         299 Load 301(sCubeArray)
-             310:    7(fvec4) Load 309(f16c4)
-             311:    6(float) Load 137(f16bias)
-             312:    7(fvec4) ImageSampleImplicitLod 307 310 Bias 311
-             313:    7(fvec4) Load 119(texel)
-             314:    7(fvec4) FAdd 313 312
+             310:  7(f16vec4) Load 309(f16c4)
+             311:6(float16_t) Load 137(f16bias)
+             312:  7(f16vec4) ImageSampleImplicitLod 307 310 Bias 311
+             313:  7(f16vec4) Load 119(texel)
+             314:  7(f16vec4) FAdd 313 312
                               Store 119(texel) 314
              319:         316 Load 318(s1DArrayShadow)
              320:  167(fvec3) Load 169(c3)
              321:   52(float) CompositeExtract 320 2
-             322:    6(float) ImageSampleDrefImplicitLod 319 320 321
+             322:6(float16_t) ImageSampleDrefImplicitLod 319 320 321
              323:    208(ptr) AccessChain 119(texel) 207
-             324:    6(float) Load 323
-             325:    6(float) FAdd 324 322
+             324:6(float16_t) Load 323
+             325:6(float16_t) FAdd 324 322
              326:    208(ptr) AccessChain 119(texel) 207
                               Store 326 325
              327:         316 Load 318(s1DArrayShadow)
-             328:  154(fvec2) Load 156(f16c2)
+             328:154(f16vec2) Load 156(f16c2)
              329:   52(float) Load 215(compare)
-             330:    6(float) Load 137(f16bias)
-             331:    6(float) ImageSampleDrefImplicitLod 327 328 329 Bias 330
+             330:6(float16_t) Load 137(f16bias)
+             331:6(float16_t) ImageSampleDrefImplicitLod 327 328 329 Bias 330
              332:    208(ptr) AccessChain 119(texel) 207
-             333:    6(float) Load 332
-             334:    6(float) FAdd 333 331
+             333:6(float16_t) Load 332
+             334:6(float16_t) FAdd 333 331
              335:    208(ptr) AccessChain 119(texel) 207
                               Store 335 334
              340:         337 Load 339(s2DArrayShadow)
              341:  249(fvec4) Load 251(c4)
              342:   52(float) CompositeExtract 341 3
-             343:    6(float) ImageSampleDrefImplicitLod 340 341 342
+             343:6(float16_t) ImageSampleDrefImplicitLod 340 341 342
              344:    208(ptr) AccessChain 119(texel) 207
-             345:    6(float) Load 344
-             346:    6(float) FAdd 345 343
+             345:6(float16_t) Load 344
+             346:6(float16_t) FAdd 345 343
              347:    208(ptr) AccessChain 119(texel) 207
                               Store 347 346
              348:         337 Load 339(s2DArrayShadow)
-             349:  175(fvec3) Load 177(f16c3)
+             349:175(f16vec3) Load 177(f16c3)
              350:   52(float) Load 215(compare)
-             351:    6(float) ImageSampleDrefImplicitLod 348 349 350
+             351:6(float16_t) ImageSampleDrefImplicitLod 348 349 350
              352:    208(ptr) AccessChain 119(texel) 207
-             353:    6(float) Load 352
-             354:    6(float) FAdd 353 351
+             353:6(float16_t) Load 352
+             354:6(float16_t) FAdd 353 351
              355:    208(ptr) AccessChain 119(texel) 207
                               Store 355 354
              360:         357 Load 359(s2DRect)
              361:   53(fvec2) Load 148(c2)
-             362:    7(fvec4) ImageSampleImplicitLod 360 361
-             363:    7(fvec4) Load 119(texel)
-             364:    7(fvec4) FAdd 363 362
+             362:  7(f16vec4) ImageSampleImplicitLod 360 361
+             363:  7(f16vec4) Load 119(texel)
+             364:  7(f16vec4) FAdd 363 362
                               Store 119(texel) 364
              365:         357 Load 359(s2DRect)
-             366:  154(fvec2) Load 156(f16c2)
-             367:    7(fvec4) ImageSampleImplicitLod 365 366
-             368:    7(fvec4) Load 119(texel)
-             369:    7(fvec4) FAdd 368 367
+             366:154(f16vec2) Load 156(f16c2)
+             367:  7(f16vec4) ImageSampleImplicitLod 365 366
+             368:  7(f16vec4) Load 119(texel)
+             369:  7(f16vec4) FAdd 368 367
                               Store 119(texel) 369
              374:         371 Load 373(s2DRectShadow)
              375:  167(fvec3) Load 169(c3)
              376:   52(float) CompositeExtract 375 2
-             377:    6(float) ImageSampleDrefImplicitLod 374 375 376
+             377:6(float16_t) ImageSampleDrefImplicitLod 374 375 376
              378:    208(ptr) AccessChain 119(texel) 207
-             379:    6(float) Load 378
-             380:    6(float) FAdd 379 377
+             379:6(float16_t) Load 378
+             380:6(float16_t) FAdd 379 377
              381:    208(ptr) AccessChain 119(texel) 207
                               Store 381 380
              382:         371 Load 373(s2DRectShadow)
-             383:  154(fvec2) Load 156(f16c2)
+             383:154(f16vec2) Load 156(f16c2)
              384:   52(float) Load 215(compare)
-             385:    6(float) ImageSampleDrefImplicitLod 382 383 384
+             385:6(float16_t) ImageSampleDrefImplicitLod 382 383 384
              386:    208(ptr) AccessChain 119(texel) 207
-             387:    6(float) Load 386
-             388:    6(float) FAdd 387 385
+             387:6(float16_t) Load 386
+             388:6(float16_t) FAdd 387 385
              389:    208(ptr) AccessChain 119(texel) 207
                               Store 389 388
              394:         391 Load 393(sCubeArrayShadow)
              395:  249(fvec4) Load 251(c4)
              396:   52(float) Load 215(compare)
-             397:    6(float) ImageSampleDrefImplicitLod 394 395 396
+             397:6(float16_t) ImageSampleDrefImplicitLod 394 395 396
              398:    208(ptr) AccessChain 119(texel) 207
-             399:    6(float) Load 398
-             400:    6(float) FAdd 399 397
+             399:6(float16_t) Load 398
+             400:6(float16_t) FAdd 399 397
              401:    208(ptr) AccessChain 119(texel) 207
                               Store 401 400
              402:         391 Load 393(sCubeArrayShadow)
-             403:    7(fvec4) Load 309(f16c4)
+             403:  7(f16vec4) Load 309(f16c4)
              404:   52(float) Load 215(compare)
-             405:    6(float) ImageSampleDrefImplicitLod 402 403 404
+             405:6(float16_t) ImageSampleDrefImplicitLod 402 403 404
              406:    208(ptr) AccessChain 119(texel) 207
-             407:    6(float) Load 406
-             408:    6(float) FAdd 407 405
+             407:6(float16_t) Load 406
+             408:6(float16_t) FAdd 407 405
              409:    208(ptr) AccessChain 119(texel) 207
                               Store 409 408
-             410:    7(fvec4) Load 119(texel)
+             410:  7(f16vec4) Load 119(texel)
                               ReturnValue 410
                               FunctionEnd
-11(testTextureProj():    7(fvec4) Function None 8
+11(testTextureProj():  7(f16vec4) Function None 8
               12:             Label
       413(texel):     64(ptr) Variable Function
                               Store 413(texel) 121
              414:         123 Load 125(s1D)
              415:   53(fvec2) Load 148(c2)
-             416:    7(fvec4) ImageSampleProjImplicitLod 414 415
-             417:    7(fvec4) Load 413(texel)
-             418:    7(fvec4) FAdd 417 416
+             416:  7(f16vec4) ImageSampleProjImplicitLod 414 415
+             417:  7(f16vec4) Load 413(texel)
+             418:  7(f16vec4) FAdd 417 416
                               Store 413(texel) 418
              419:         123 Load 125(s1D)
-             420:  154(fvec2) Load 156(f16c2)
-             421:    6(float) Load 137(f16bias)
-             422:    7(fvec4) ImageSampleProjImplicitLod 419 420 Bias 421
-             423:    7(fvec4) Load 413(texel)
-             424:    7(fvec4) FAdd 423 422
+             420:154(f16vec2) Load 156(f16c2)
+             421:6(float16_t) Load 137(f16bias)
+             422:  7(f16vec4) ImageSampleProjImplicitLod 419 420 Bias 421
+             423:  7(f16vec4) Load 413(texel)
+             424:  7(f16vec4) FAdd 423 422
                               Store 413(texel) 424
              425:         123 Load 125(s1D)
              426:  249(fvec4) Load 251(c4)
              427:   52(float) CompositeExtract 426 3
              428:  249(fvec4) CompositeInsert 427 426 1
-             429:    7(fvec4) ImageSampleProjImplicitLod 425 428
-             430:    7(fvec4) Load 413(texel)
-             431:    7(fvec4) FAdd 430 429
+             429:  7(f16vec4) ImageSampleProjImplicitLod 425 428
+             430:  7(f16vec4) Load 413(texel)
+             431:  7(f16vec4) FAdd 430 429
                               Store 413(texel) 431
              432:         123 Load 125(s1D)
-             433:    7(fvec4) Load 309(f16c4)
-             434:    6(float) Load 137(f16bias)
-             435:    6(float) CompositeExtract 433 3
-             436:    7(fvec4) CompositeInsert 435 433 1
-             437:    7(fvec4) ImageSampleProjImplicitLod 432 436 Bias 434
-             438:    7(fvec4) Load 413(texel)
-             439:    7(fvec4) FAdd 438 437
+             433:  7(f16vec4) Load 309(f16c4)
+             434:6(float16_t) Load 137(f16bias)
+             435:6(float16_t) CompositeExtract 433 3
+             436:  7(f16vec4) CompositeInsert 435 433 1
+             437:  7(f16vec4) ImageSampleProjImplicitLod 432 436 Bias 434
+             438:  7(f16vec4) Load 413(texel)
+             439:  7(f16vec4) FAdd 438 437
                               Store 413(texel) 439
              440:         143 Load 145(s2D)
              441:  167(fvec3) Load 169(c3)
-             442:    7(fvec4) ImageSampleProjImplicitLod 440 441
-             443:    7(fvec4) Load 413(texel)
-             444:    7(fvec4) FAdd 443 442
+             442:  7(f16vec4) ImageSampleProjImplicitLod 440 441
+             443:  7(f16vec4) Load 413(texel)
+             444:  7(f16vec4) FAdd 443 442
                               Store 413(texel) 444
              445:         143 Load 145(s2D)
-             446:  175(fvec3) Load 177(f16c3)
-             447:    6(float) Load 137(f16bias)
-             448:    7(fvec4) ImageSampleProjImplicitLod 445 446 Bias 447
-             449:    7(fvec4) Load 413(texel)
-             450:    7(fvec4) FAdd 449 448
+             446:175(f16vec3) Load 177(f16c3)
+             447:6(float16_t) Load 137(f16bias)
+             448:  7(f16vec4) ImageSampleProjImplicitLod 445 446 Bias 447
+             449:  7(f16vec4) Load 413(texel)
+             450:  7(f16vec4) FAdd 449 448
                               Store 413(texel) 450
              451:         143 Load 145(s2D)
              452:  249(fvec4) Load 251(c4)
              453:   52(float) CompositeExtract 452 3
              454:  249(fvec4) CompositeInsert 453 452 2
-             455:    7(fvec4) ImageSampleProjImplicitLod 451 454
-             456:    7(fvec4) Load 413(texel)
-             457:    7(fvec4) FAdd 456 455
+             455:  7(f16vec4) ImageSampleProjImplicitLod 451 454
+             456:  7(f16vec4) Load 413(texel)
+             457:  7(f16vec4) FAdd 456 455
                               Store 413(texel) 457
              458:         143 Load 145(s2D)
-             459:    7(fvec4) Load 309(f16c4)
-             460:    6(float) Load 137(f16bias)
-             461:    6(float) CompositeExtract 459 3
-             462:    7(fvec4) CompositeInsert 461 459 2
-             463:    7(fvec4) ImageSampleProjImplicitLod 458 462 Bias 460
-             464:    7(fvec4) Load 413(texel)
-             465:    7(fvec4) FAdd 464 463
+             459:  7(f16vec4) Load 309(f16c4)
+             460:6(float16_t) Load 137(f16bias)
+             461:6(float16_t) CompositeExtract 459 3
+             462:  7(f16vec4) CompositeInsert 461 459 2
+             463:  7(f16vec4) ImageSampleProjImplicitLod 458 462 Bias 460
+             464:  7(f16vec4) Load 413(texel)
+             465:  7(f16vec4) FAdd 464 463
                               Store 413(texel) 465
              466:         163 Load 165(s3D)
              467:  249(fvec4) Load 251(c4)
-             468:    7(fvec4) ImageSampleProjImplicitLod 466 467
-             469:    7(fvec4) Load 413(texel)
-             470:    7(fvec4) FAdd 469 468
+             468:  7(f16vec4) ImageSampleProjImplicitLod 466 467
+             469:  7(f16vec4) Load 413(texel)
+             470:  7(f16vec4) FAdd 469 468
                               Store 413(texel) 470
              471:         163 Load 165(s3D)
-             472:    7(fvec4) Load 309(f16c4)
-             473:    6(float) Load 137(f16bias)
-             474:    7(fvec4) ImageSampleProjImplicitLod 471 472 Bias 473
-             475:    7(fvec4) Load 413(texel)
-             476:    7(fvec4) FAdd 475 474
+             472:  7(f16vec4) Load 309(f16c4)
+             473:6(float16_t) Load 137(f16bias)
+             474:  7(f16vec4) ImageSampleProjImplicitLod 471 472 Bias 473
+             475:  7(f16vec4) Load 413(texel)
+             476:  7(f16vec4) FAdd 475 474
                               Store 413(texel) 476
              477:         199 Load 201(s1DShadow)
              478:  249(fvec4) Load 251(c4)
              479:   52(float) CompositeExtract 478 2
              480:   52(float) CompositeExtract 478 3
              481:  249(fvec4) CompositeInsert 480 478 1
-             482:    6(float) ImageSampleProjDrefImplicitLod 477 481 479
+             482:6(float16_t) ImageSampleProjDrefImplicitLod 477 481 479
              483:    208(ptr) AccessChain 413(texel) 207
-             484:    6(float) Load 483
-             485:    6(float) FAdd 484 482
+             484:6(float16_t) Load 483
+             485:6(float16_t) FAdd 484 482
              486:    208(ptr) AccessChain 413(texel) 207
                               Store 486 485
              487:         199 Load 201(s1DShadow)
-             488:  175(fvec3) Load 177(f16c3)
+             488:175(f16vec3) Load 177(f16c3)
              489:   52(float) Load 215(compare)
-             490:    6(float) Load 137(f16bias)
-             491:    6(float) CompositeExtract 488 2
-             492:  175(fvec3) CompositeInsert 491 488 1
-             493:    6(float) ImageSampleProjDrefImplicitLod 487 492 489 Bias 490
+             490:6(float16_t) Load 137(f16bias)
+             491:6(float16_t) CompositeExtract 488 2
+             492:175(f16vec3) CompositeInsert 491 488 1
+             493:6(float16_t) ImageSampleProjDrefImplicitLod 487 492 489 Bias 490
              494:    208(ptr) AccessChain 413(texel) 207
-             495:    6(float) Load 494
-             496:    6(float) FAdd 495 493
+             495:6(float16_t) Load 494
+             496:6(float16_t) FAdd 495 493
              497:    208(ptr) AccessChain 413(texel) 207
                               Store 497 496
              498:         224 Load 226(s2DShadow)
@@ -1089,538 +1089,538 @@ spv.float16Fetch.frag
              500:   52(float) CompositeExtract 499 2
              501:   52(float) CompositeExtract 499 3
              502:  249(fvec4) CompositeInsert 501 499 2
-             503:    6(float) ImageSampleProjDrefImplicitLod 498 502 500
+             503:6(float16_t) ImageSampleProjDrefImplicitLod 498 502 500
              504:    208(ptr) AccessChain 413(texel) 207
-             505:    6(float) Load 504
-             506:    6(float) FAdd 505 503
+             505:6(float16_t) Load 504
+             506:6(float16_t) FAdd 505 503
              507:    208(ptr) AccessChain 413(texel) 207
                               Store 507 506
              508:         224 Load 226(s2DShadow)
-             509:  175(fvec3) Load 177(f16c3)
+             509:175(f16vec3) Load 177(f16c3)
              510:   52(float) Load 215(compare)
-             511:    6(float) Load 137(f16bias)
-             512:    6(float) ImageSampleProjDrefImplicitLod 508 509 510 Bias 511
+             511:6(float16_t) Load 137(f16bias)
+             512:6(float16_t) ImageSampleProjDrefImplicitLod 508 509 510 Bias 511
              513:    208(ptr) AccessChain 413(texel) 207
-             514:    6(float) Load 513
-             515:    6(float) FAdd 514 512
+             514:6(float16_t) Load 513
+             515:6(float16_t) FAdd 514 512
              516:    208(ptr) AccessChain 413(texel) 207
                               Store 516 515
              517:         357 Load 359(s2DRect)
              518:  167(fvec3) Load 169(c3)
-             519:    7(fvec4) ImageSampleProjImplicitLod 517 518
-             520:    7(fvec4) Load 413(texel)
-             521:    7(fvec4) FAdd 520 519
+             519:  7(f16vec4) ImageSampleProjImplicitLod 517 518
+             520:  7(f16vec4) Load 413(texel)
+             521:  7(f16vec4) FAdd 520 519
                               Store 413(texel) 521
              522:         357 Load 359(s2DRect)
-             523:  175(fvec3) Load 177(f16c3)
-             524:    7(fvec4) ImageSampleProjImplicitLod 522 523
-             525:    7(fvec4) Load 413(texel)
-             526:    7(fvec4) FAdd 525 524
+             523:175(f16vec3) Load 177(f16c3)
+             524:  7(f16vec4) ImageSampleProjImplicitLod 522 523
+             525:  7(f16vec4) Load 413(texel)
+             526:  7(f16vec4) FAdd 525 524
                               Store 413(texel) 526
              527:         357 Load 359(s2DRect)
              528:  249(fvec4) Load 251(c4)
              529:   52(float) CompositeExtract 528 3
              530:  249(fvec4) CompositeInsert 529 528 2
-             531:    7(fvec4) ImageSampleProjImplicitLod 527 530
-             532:    7(fvec4) Load 413(texel)
-             533:    7(fvec4) FAdd 532 531
+             531:  7(f16vec4) ImageSampleProjImplicitLod 527 530
+             532:  7(f16vec4) Load 413(texel)
+             533:  7(f16vec4) FAdd 532 531
                               Store 413(texel) 533
              534:         357 Load 359(s2DRect)
-             535:    7(fvec4) Load 309(f16c4)
-             536:    6(float) CompositeExtract 535 3
-             537:    7(fvec4) CompositeInsert 536 535 2
-             538:    7(fvec4) ImageSampleProjImplicitLod 534 537
-             539:    7(fvec4) Load 413(texel)
-             540:    7(fvec4) FAdd 539 538
+             535:  7(f16vec4) Load 309(f16c4)
+             536:6(float16_t) CompositeExtract 535 3
+             537:  7(f16vec4) CompositeInsert 536 535 2
+             538:  7(f16vec4) ImageSampleProjImplicitLod 534 537
+             539:  7(f16vec4) Load 413(texel)
+             540:  7(f16vec4) FAdd 539 538
                               Store 413(texel) 540
              541:         371 Load 373(s2DRectShadow)
              542:  249(fvec4) Load 251(c4)
              543:   52(float) CompositeExtract 542 2
              544:   52(float) CompositeExtract 542 3
              545:  249(fvec4) CompositeInsert 544 542 2
-             546:    6(float) ImageSampleProjDrefImplicitLod 541 545 543
+             546:6(float16_t) ImageSampleProjDrefImplicitLod 541 545 543
              547:    208(ptr) AccessChain 413(texel) 207
-             548:    6(float) Load 547
-             549:    6(float) FAdd 548 546
+             548:6(float16_t) Load 547
+             549:6(float16_t) FAdd 548 546
              550:    208(ptr) AccessChain 413(texel) 207
                               Store 550 549
              551:         371 Load 373(s2DRectShadow)
-             552:  175(fvec3) Load 177(f16c3)
+             552:175(f16vec3) Load 177(f16c3)
              553:   52(float) Load 215(compare)
-             554:    6(float) ImageSampleProjDrefImplicitLod 551 552 553
+             554:6(float16_t) ImageSampleProjDrefImplicitLod 551 552 553
              555:    208(ptr) AccessChain 413(texel) 207
-             556:    6(float) Load 555
-             557:    6(float) FAdd 556 554
+             556:6(float16_t) Load 555
+             557:6(float16_t) FAdd 556 554
              558:    208(ptr) AccessChain 413(texel) 207
                               Store 558 557
-             559:    7(fvec4) Load 413(texel)
+             559:  7(f16vec4) Load 413(texel)
                               ReturnValue 559
                               FunctionEnd
-13(testTextureLod():    7(fvec4) Function None 8
+13(testTextureLod():  7(f16vec4) Function None 8
               14:             Label
       562(texel):     64(ptr) Variable Function
                               Store 562(texel) 121
              563:         123 Load 125(s1D)
              564:   52(float) Load 128(c1)
              566:   52(float) Load 565(lod)
-             567:    7(fvec4) ImageSampleExplicitLod 563 564 Lod 566
-             568:    7(fvec4) Load 562(texel)
-             569:    7(fvec4) FAdd 568 567
+             567:  7(f16vec4) ImageSampleExplicitLod 563 564 Lod 566
+             568:  7(f16vec4) Load 562(texel)
+             569:  7(f16vec4) FAdd 568 567
                               Store 562(texel) 569
              570:         123 Load 125(s1D)
-             571:    6(float) Load 135(f16c1)
-             573:    6(float) Load 572(f16lod)
-             574:    7(fvec4) ImageSampleExplicitLod 570 571 Lod 573
-             575:    7(fvec4) Load 562(texel)
-             576:    7(fvec4) FAdd 575 574
+             571:6(float16_t) Load 135(f16c1)
+             573:6(float16_t) Load 572(f16lod)
+             574:  7(f16vec4) ImageSampleExplicitLod 570 571 Lod 573
+             575:  7(f16vec4) Load 562(texel)
+             576:  7(f16vec4) FAdd 575 574
                               Store 562(texel) 576
              577:         143 Load 145(s2D)
              578:   53(fvec2) Load 148(c2)
              579:   52(float) Load 565(lod)
-             580:    7(fvec4) ImageSampleExplicitLod 577 578 Lod 579
-             581:    7(fvec4) Load 562(texel)
-             582:    7(fvec4) FAdd 581 580
+             580:  7(f16vec4) ImageSampleExplicitLod 577 578 Lod 579
+             581:  7(f16vec4) Load 562(texel)
+             582:  7(f16vec4) FAdd 581 580
                               Store 562(texel) 582
              583:         143 Load 145(s2D)
-             584:  154(fvec2) Load 156(f16c2)
-             585:    6(float) Load 572(f16lod)
-             586:    7(fvec4) ImageSampleExplicitLod 583 584 Lod 585
-             587:    7(fvec4) Load 562(texel)
-             588:    7(fvec4) FAdd 587 586
+             584:154(f16vec2) Load 156(f16c2)
+             585:6(float16_t) Load 572(f16lod)
+             586:  7(f16vec4) ImageSampleExplicitLod 583 584 Lod 585
+             587:  7(f16vec4) Load 562(texel)
+             588:  7(f16vec4) FAdd 587 586
                               Store 562(texel) 588
              589:         163 Load 165(s3D)
              590:  167(fvec3) Load 169(c3)
              591:   52(float) Load 565(lod)
-             592:    7(fvec4) ImageSampleExplicitLod 589 590 Lod 591
-             593:    7(fvec4) Load 562(texel)
-             594:    7(fvec4) FAdd 593 592
+             592:  7(f16vec4) ImageSampleExplicitLod 589 590 Lod 591
+             593:  7(f16vec4) Load 562(texel)
+             594:  7(f16vec4) FAdd 593 592
                               Store 562(texel) 594
              595:         163 Load 165(s3D)
-             596:  175(fvec3) Load 177(f16c3)
-             597:    6(float) Load 572(f16lod)
-             598:    7(fvec4) ImageSampleExplicitLod 595 596 Lod 597
-             599:    7(fvec4) Load 562(texel)
-             600:    7(fvec4) FAdd 599 598
+             596:175(f16vec3) Load 177(f16c3)
+             597:6(float16_t) Load 572(f16lod)
+             598:  7(f16vec4) ImageSampleExplicitLod 595 596 Lod 597
+             599:  7(f16vec4) Load 562(texel)
+             600:  7(f16vec4) FAdd 599 598
                               Store 562(texel) 600
              601:         184 Load 186(sCube)
              602:  167(fvec3) Load 169(c3)
              603:   52(float) Load 565(lod)
-             604:    7(fvec4) ImageSampleExplicitLod 601 602 Lod 603
-             605:    7(fvec4) Load 562(texel)
-             606:    7(fvec4) FAdd 605 604
+             604:  7(f16vec4) ImageSampleExplicitLod 601 602 Lod 603
+             605:  7(f16vec4) Load 562(texel)
+             606:  7(f16vec4) FAdd 605 604
                               Store 562(texel) 606
              607:         184 Load 186(sCube)
-             608:  175(fvec3) Load 177(f16c3)
-             609:    6(float) Load 572(f16lod)
-             610:    7(fvec4) ImageSampleExplicitLod 607 608 Lod 609
-             611:    7(fvec4) Load 562(texel)
-             612:    7(fvec4) FAdd 611 610
+             608:175(f16vec3) Load 177(f16c3)
+             609:6(float16_t) Load 572(f16lod)
+             610:  7(f16vec4) ImageSampleExplicitLod 607 608 Lod 609
+             611:  7(f16vec4) Load 562(texel)
+             612:  7(f16vec4) FAdd 611 610
                               Store 562(texel) 612
              613:         199 Load 201(s1DShadow)
              614:  167(fvec3) Load 169(c3)
              615:   52(float) Load 565(lod)
              616:   52(float) CompositeExtract 614 2
-             617:    6(float) ImageSampleDrefExplicitLod 613 614 616 Lod 615
+             617:6(float16_t) ImageSampleDrefExplicitLod 613 614 616 Lod 615
              618:    208(ptr) AccessChain 562(texel) 207
-             619:    6(float) Load 618
-             620:    6(float) FAdd 619 617
+             619:6(float16_t) Load 618
+             620:6(float16_t) FAdd 619 617
              621:    208(ptr) AccessChain 562(texel) 207
                               Store 621 620
              622:         199 Load 201(s1DShadow)
-             623:  154(fvec2) Load 156(f16c2)
+             623:154(f16vec2) Load 156(f16c2)
              624:   52(float) Load 215(compare)
-             625:    6(float) Load 572(f16lod)
-             626:    6(float) ImageSampleDrefExplicitLod 622 623 624 Lod 625
+             625:6(float16_t) Load 572(f16lod)
+             626:6(float16_t) ImageSampleDrefExplicitLod 622 623 624 Lod 625
              627:    208(ptr) AccessChain 562(texel) 207
-             628:    6(float) Load 627
-             629:    6(float) FAdd 628 626
+             628:6(float16_t) Load 627
+             629:6(float16_t) FAdd 628 626
              630:    208(ptr) AccessChain 562(texel) 207
                               Store 630 629
              631:         224 Load 226(s2DShadow)
              632:  167(fvec3) Load 169(c3)
              633:   52(float) Load 565(lod)
              634:   52(float) CompositeExtract 632 2
-             635:    6(float) ImageSampleDrefExplicitLod 631 632 634 Lod 633
+             635:6(float16_t) ImageSampleDrefExplicitLod 631 632 634 Lod 633
              636:    208(ptr) AccessChain 562(texel) 207
-             637:    6(float) Load 636
-             638:    6(float) FAdd 637 635
+             637:6(float16_t) Load 636
+             638:6(float16_t) FAdd 637 635
              639:    208(ptr) AccessChain 562(texel) 207
                               Store 639 638
              640:         224 Load 226(s2DShadow)
-             641:  154(fvec2) Load 156(f16c2)
+             641:154(f16vec2) Load 156(f16c2)
              642:   52(float) Load 215(compare)
-             643:    6(float) Load 572(f16lod)
-             644:    6(float) ImageSampleDrefExplicitLod 640 641 642 Lod 643
+             643:6(float16_t) Load 572(f16lod)
+             644:6(float16_t) ImageSampleDrefExplicitLod 640 641 642 Lod 643
              645:    208(ptr) AccessChain 562(texel) 207
-             646:    6(float) Load 645
-             647:    6(float) FAdd 646 644
+             646:6(float16_t) Load 645
+             647:6(float16_t) FAdd 646 644
              648:    208(ptr) AccessChain 562(texel) 207
                               Store 648 647
              649:         269 Load 271(s1DArray)
              650:   53(fvec2) Load 148(c2)
              651:   52(float) Load 565(lod)
-             652:    7(fvec4) ImageSampleExplicitLod 649 650 Lod 651
-             653:    7(fvec4) Load 562(texel)
-             654:    7(fvec4) FAdd 653 652
+             652:  7(f16vec4) ImageSampleExplicitLod 649 650 Lod 651
+             653:  7(f16vec4) Load 562(texel)
+             654:  7(f16vec4) FAdd 653 652
                               Store 562(texel) 654
              655:         269 Load 271(s1DArray)
-             656:  154(fvec2) Load 156(f16c2)
-             657:    6(float) Load 572(f16lod)
-             658:    7(fvec4) ImageSampleExplicitLod 655 656 Lod 657
-             659:    7(fvec4) Load 562(texel)
-             660:    7(fvec4) FAdd 659 658
+             656:154(f16vec2) Load 156(f16c2)
+             657:6(float16_t) Load 572(f16lod)
+             658:  7(f16vec4) ImageSampleExplicitLod 655 656 Lod 657
+             659:  7(f16vec4) Load 562(texel)
+             660:  7(f16vec4) FAdd 659 658
                               Store 562(texel) 660
              661:         284 Load 286(s2DArray)
              662:  167(fvec3) Load 169(c3)
              663:   52(float) Load 565(lod)
-             664:    7(fvec4) ImageSampleExplicitLod 661 662 Lod 663
-             665:    7(fvec4) Load 562(texel)
-             666:    7(fvec4) FAdd 665 664
+             664:  7(f16vec4) ImageSampleExplicitLod 661 662 Lod 663
+             665:  7(f16vec4) Load 562(texel)
+             666:  7(f16vec4) FAdd 665 664
                               Store 562(texel) 666
              667:         284 Load 286(s2DArray)
-             668:  175(fvec3) Load 177(f16c3)
-             669:    6(float) Load 572(f16lod)
-             670:    7(fvec4) ImageSampleExplicitLod 667 668 Lod 669
-             671:    7(fvec4) Load 562(texel)
-             672:    7(fvec4) FAdd 671 670
+             668:175(f16vec3) Load 177(f16c3)
+             669:6(float16_t) Load 572(f16lod)
+             670:  7(f16vec4) ImageSampleExplicitLod 667 668 Lod 669
+             671:  7(f16vec4) Load 562(texel)
+             672:  7(f16vec4) FAdd 671 670
                               Store 562(texel) 672
              673:         316 Load 318(s1DArrayShadow)
              674:  167(fvec3) Load 169(c3)
              675:   52(float) Load 565(lod)
              676:   52(float) CompositeExtract 674 2
-             677:    6(float) ImageSampleDrefExplicitLod 673 674 676 Lod 675
+             677:6(float16_t) ImageSampleDrefExplicitLod 673 674 676 Lod 675
              678:    208(ptr) AccessChain 562(texel) 207
-             679:    6(float) Load 678
-             680:    6(float) FAdd 679 677
+             679:6(float16_t) Load 678
+             680:6(float16_t) FAdd 679 677
              681:    208(ptr) AccessChain 562(texel) 207
                               Store 681 680
              682:         316 Load 318(s1DArrayShadow)
-             683:  154(fvec2) Load 156(f16c2)
+             683:154(f16vec2) Load 156(f16c2)
              684:   52(float) Load 215(compare)
-             685:    6(float) Load 572(f16lod)
-             686:    6(float) ImageSampleDrefExplicitLod 682 683 684 Lod 685
+             685:6(float16_t) Load 572(f16lod)
+             686:6(float16_t) ImageSampleDrefExplicitLod 682 683 684 Lod 685
              687:    208(ptr) AccessChain 562(texel) 207
-             688:    6(float) Load 687
-             689:    6(float) FAdd 688 686
+             688:6(float16_t) Load 687
+             689:6(float16_t) FAdd 688 686
              690:    208(ptr) AccessChain 562(texel) 207
                               Store 690 689
              691:         299 Load 301(sCubeArray)
              692:  249(fvec4) Load 251(c4)
              693:   52(float) Load 565(lod)
-             694:    7(fvec4) ImageSampleExplicitLod 691 692 Lod 693
-             695:    7(fvec4) Load 562(texel)
-             696:    7(fvec4) FAdd 695 694
+             694:  7(f16vec4) ImageSampleExplicitLod 691 692 Lod 693
+             695:  7(f16vec4) Load 562(texel)
+             696:  7(f16vec4) FAdd 695 694
                               Store 562(texel) 696
              697:         299 Load 301(sCubeArray)
-             698:    7(fvec4) Load 309(f16c4)
-             699:    6(float) Load 572(f16lod)
-             700:    7(fvec4) ImageSampleExplicitLod 697 698 Lod 699
-             701:    7(fvec4) Load 562(texel)
-             702:    7(fvec4) FAdd 701 700
+             698:  7(f16vec4) Load 309(f16c4)
+             699:6(float16_t) Load 572(f16lod)
+             700:  7(f16vec4) ImageSampleExplicitLod 697 698 Lod 699
+             701:  7(f16vec4) Load 562(texel)
+             702:  7(f16vec4) FAdd 701 700
                               Store 562(texel) 702
-             703:    7(fvec4) Load 562(texel)
+             703:  7(f16vec4) Load 562(texel)
                               ReturnValue 703
                               FunctionEnd
-15(testTextureOffset():    7(fvec4) Function None 8
+15(testTextureOffset():  7(f16vec4) Function None 8
               16:             Label
       706(texel):     64(ptr) Variable Function
                               Store 706(texel) 121
              707:         123 Load 125(s1D)
              708:   52(float) Load 128(c1)
-             710:    7(fvec4) ImageSampleImplicitLod 707 708 ConstOffset 709
-             711:    7(fvec4) Load 706(texel)
-             712:    7(fvec4) FAdd 711 710
+             710:  7(f16vec4) ImageSampleImplicitLod 707 708 ConstOffset 709
+             711:  7(f16vec4) Load 706(texel)
+             712:  7(f16vec4) FAdd 711 710
                               Store 706(texel) 712
              713:         123 Load 125(s1D)
-             714:    6(float) Load 135(f16c1)
-             715:    6(float) Load 137(f16bias)
-             716:    7(fvec4) ImageSampleImplicitLod 713 714 Bias ConstOffset 715 709
-             717:    7(fvec4) Load 706(texel)
-             718:    7(fvec4) FAdd 717 716
+             714:6(float16_t) Load 135(f16c1)
+             715:6(float16_t) Load 137(f16bias)
+             716:  7(f16vec4) ImageSampleImplicitLod 713 714 Bias ConstOffset 715 709
+             717:  7(f16vec4) Load 706(texel)
+             718:  7(f16vec4) FAdd 717 716
                               Store 706(texel) 718
              719:         143 Load 145(s2D)
              720:   53(fvec2) Load 148(c2)
-             723:    7(fvec4) ImageSampleImplicitLod 719 720 ConstOffset 722
-             724:    7(fvec4) Load 706(texel)
-             725:    7(fvec4) FAdd 724 723
+             723:  7(f16vec4) ImageSampleImplicitLod 719 720 ConstOffset 722
+             724:  7(f16vec4) Load 706(texel)
+             725:  7(f16vec4) FAdd 724 723
                               Store 706(texel) 725
              726:         143 Load 145(s2D)
-             727:  154(fvec2) Load 156(f16c2)
-             728:    6(float) Load 137(f16bias)
-             729:    7(fvec4) ImageSampleImplicitLod 726 727 Bias ConstOffset 728 722
-             730:    7(fvec4) Load 706(texel)
-             731:    7(fvec4) FAdd 730 729
+             727:154(f16vec2) Load 156(f16c2)
+             728:6(float16_t) Load 137(f16bias)
+             729:  7(f16vec4) ImageSampleImplicitLod 726 727 Bias ConstOffset 728 722
+             730:  7(f16vec4) Load 706(texel)
+             731:  7(f16vec4) FAdd 730 729
                               Store 706(texel) 731
              732:         163 Load 165(s3D)
              733:  167(fvec3) Load 169(c3)
-             736:    7(fvec4) ImageSampleImplicitLod 732 733 ConstOffset 735
-             737:    7(fvec4) Load 706(texel)
-             738:    7(fvec4) FAdd 737 736
+             736:  7(f16vec4) ImageSampleImplicitLod 732 733 ConstOffset 735
+             737:  7(f16vec4) Load 706(texel)
+             738:  7(f16vec4) FAdd 737 736
                               Store 706(texel) 738
              739:         163 Load 165(s3D)
-             740:  175(fvec3) Load 177(f16c3)
-             741:    6(float) Load 137(f16bias)
-             742:    7(fvec4) ImageSampleImplicitLod 739 740 Bias ConstOffset 741 735
-             743:    7(fvec4) Load 706(texel)
-             744:    7(fvec4) FAdd 743 742
+             740:175(f16vec3) Load 177(f16c3)
+             741:6(float16_t) Load 137(f16bias)
+             742:  7(f16vec4) ImageSampleImplicitLod 739 740 Bias ConstOffset 741 735
+             743:  7(f16vec4) Load 706(texel)
+             744:  7(f16vec4) FAdd 743 742
                               Store 706(texel) 744
              745:         357 Load 359(s2DRect)
              746:   53(fvec2) Load 148(c2)
-             747:    7(fvec4) ImageSampleImplicitLod 745 746 ConstOffset 722
-             748:    7(fvec4) Load 706(texel)
-             749:    7(fvec4) FAdd 748 747
+             747:  7(f16vec4) ImageSampleImplicitLod 745 746 ConstOffset 722
+             748:  7(f16vec4) Load 706(texel)
+             749:  7(f16vec4) FAdd 748 747
                               Store 706(texel) 749
              750:         357 Load 359(s2DRect)
-             751:  154(fvec2) Load 156(f16c2)
-             752:    7(fvec4) ImageSampleImplicitLod 750 751 ConstOffset 722
-             753:    7(fvec4) Load 706(texel)
-             754:    7(fvec4) FAdd 753 752
+             751:154(f16vec2) Load 156(f16c2)
+             752:  7(f16vec4) ImageSampleImplicitLod 750 751 ConstOffset 722
+             753:  7(f16vec4) Load 706(texel)
+             754:  7(f16vec4) FAdd 753 752
                               Store 706(texel) 754
              755:         371 Load 373(s2DRectShadow)
              756:  167(fvec3) Load 169(c3)
              757:   52(float) CompositeExtract 756 2
-             758:    6(float) ImageSampleDrefImplicitLod 755 756 757 ConstOffset 722
+             758:6(float16_t) ImageSampleDrefImplicitLod 755 756 757 ConstOffset 722
              759:    208(ptr) AccessChain 706(texel) 207
-             760:    6(float) Load 759
-             761:    6(float) FAdd 760 758
+             760:6(float16_t) Load 759
+             761:6(float16_t) FAdd 760 758
              762:    208(ptr) AccessChain 706(texel) 207
                               Store 762 761
              763:         371 Load 373(s2DRectShadow)
-             764:  154(fvec2) Load 156(f16c2)
+             764:154(f16vec2) Load 156(f16c2)
              765:   52(float) Load 215(compare)
-             766:    6(float) ImageSampleDrefImplicitLod 763 764 765 ConstOffset 722
+             766:6(float16_t) ImageSampleDrefImplicitLod 763 764 765 ConstOffset 722
              767:    208(ptr) AccessChain 706(texel) 207
-             768:    6(float) Load 767
-             769:    6(float) FAdd 768 766
+             768:6(float16_t) Load 767
+             769:6(float16_t) FAdd 768 766
              770:    208(ptr) AccessChain 706(texel) 207
                               Store 770 769
              771:         199 Load 201(s1DShadow)
              772:  167(fvec3) Load 169(c3)
              773:   52(float) CompositeExtract 772 2
-             774:    6(float) ImageSampleDrefImplicitLod 771 772 773 ConstOffset 709
+             774:6(float16_t) ImageSampleDrefImplicitLod 771 772 773 ConstOffset 709
              775:    208(ptr) AccessChain 706(texel) 207
-             776:    6(float) Load 775
-             777:    6(float) FAdd 776 774
+             776:6(float16_t) Load 775
+             777:6(float16_t) FAdd 776 774
              778:    208(ptr) AccessChain 706(texel) 207
                               Store 778 777
              779:         199 Load 201(s1DShadow)
-             780:  154(fvec2) Load 156(f16c2)
+             780:154(f16vec2) Load 156(f16c2)
              781:   52(float) Load 215(compare)
-             782:    6(float) Load 137(f16bias)
-             783:    6(float) ImageSampleDrefImplicitLod 779 780 781 Bias ConstOffset 782 709
+             782:6(float16_t) Load 137(f16bias)
+             783:6(float16_t) ImageSampleDrefImplicitLod 779 780 781 Bias ConstOffset 782 709
              784:    208(ptr) AccessChain 706(texel) 207
-             785:    6(float) Load 784
-             786:    6(float) FAdd 785 783
+             785:6(float16_t) Load 784
+             786:6(float16_t) FAdd 785 783
              787:    208(ptr) AccessChain 706(texel) 207
                               Store 787 786
              788:         224 Load 226(s2DShadow)
              789:  167(fvec3) Load 169(c3)
              790:   52(float) CompositeExtract 789 2
-             791:    6(float) ImageSampleDrefImplicitLod 788 789 790 ConstOffset 722
+             791:6(float16_t) ImageSampleDrefImplicitLod 788 789 790 ConstOffset 722
              792:    208(ptr) AccessChain 706(texel) 207
-             793:    6(float) Load 792
-             794:    6(float) FAdd 793 791
+             793:6(float16_t) Load 792
+             794:6(float16_t) FAdd 793 791
              795:    208(ptr) AccessChain 706(texel) 207
                               Store 795 794
              796:         224 Load 226(s2DShadow)
-             797:  154(fvec2) Load 156(f16c2)
+             797:154(f16vec2) Load 156(f16c2)
              798:   52(float) Load 215(compare)
-             799:    6(float) Load 137(f16bias)
-             800:    6(float) ImageSampleDrefImplicitLod 796 797 798 Bias ConstOffset 799 722
+             799:6(float16_t) Load 137(f16bias)
+             800:6(float16_t) ImageSampleDrefImplicitLod 796 797 798 Bias ConstOffset 799 722
              801:    208(ptr) AccessChain 706(texel) 207
-             802:    6(float) Load 801
-             803:    6(float) FAdd 802 800
+             802:6(float16_t) Load 801
+             803:6(float16_t) FAdd 802 800
              804:    208(ptr) AccessChain 706(texel) 207
                               Store 804 803
              805:         269 Load 271(s1DArray)
              806:   53(fvec2) Load 148(c2)
-             807:    7(fvec4) ImageSampleImplicitLod 805 806 ConstOffset 709
-             808:    7(fvec4) Load 706(texel)
-             809:    7(fvec4) FAdd 808 807
+             807:  7(f16vec4) ImageSampleImplicitLod 805 806 ConstOffset 709
+             808:  7(f16vec4) Load 706(texel)
+             809:  7(f16vec4) FAdd 808 807
                               Store 706(texel) 809
              810:         269 Load 271(s1DArray)
-             811:  154(fvec2) Load 156(f16c2)
-             812:    6(float) Load 137(f16bias)
-             813:    7(fvec4) ImageSampleImplicitLod 810 811 Bias ConstOffset 812 709
-             814:    7(fvec4) Load 706(texel)
-             815:    7(fvec4) FAdd 814 813
+             811:154(f16vec2) Load 156(f16c2)
+             812:6(float16_t) Load 137(f16bias)
+             813:  7(f16vec4) ImageSampleImplicitLod 810 811 Bias ConstOffset 812 709
+             814:  7(f16vec4) Load 706(texel)
+             815:  7(f16vec4) FAdd 814 813
                               Store 706(texel) 815
              816:         284 Load 286(s2DArray)
              817:  167(fvec3) Load 169(c3)
-             818:    7(fvec4) ImageSampleImplicitLod 816 817 ConstOffset 722
-             819:    7(fvec4) Load 706(texel)
-             820:    7(fvec4) FAdd 819 818
+             818:  7(f16vec4) ImageSampleImplicitLod 816 817 ConstOffset 722
+             819:  7(f16vec4) Load 706(texel)
+             820:  7(f16vec4) FAdd 819 818
                               Store 706(texel) 820
              821:         284 Load 286(s2DArray)
-             822:  175(fvec3) Load 177(f16c3)
-             823:    6(float) Load 137(f16bias)
-             824:    7(fvec4) ImageSampleImplicitLod 821 822 Bias ConstOffset 823 722
-             825:    7(fvec4) Load 706(texel)
-             826:    7(fvec4) FAdd 825 824
+             822:175(f16vec3) Load 177(f16c3)
+             823:6(float16_t) Load 137(f16bias)
+             824:  7(f16vec4) ImageSampleImplicitLod 821 822 Bias ConstOffset 823 722
+             825:  7(f16vec4) Load 706(texel)
+             826:  7(f16vec4) FAdd 825 824
                               Store 706(texel) 826
              827:         316 Load 318(s1DArrayShadow)
              828:  167(fvec3) Load 169(c3)
              829:   52(float) CompositeExtract 828 2
-             830:    6(float) ImageSampleDrefImplicitLod 827 828 829 ConstOffset 709
+             830:6(float16_t) ImageSampleDrefImplicitLod 827 828 829 ConstOffset 709
              831:    208(ptr) AccessChain 706(texel) 207
-             832:    6(float) Load 831
-             833:    6(float) FAdd 832 830
+             832:6(float16_t) Load 831
+             833:6(float16_t) FAdd 832 830
              834:    208(ptr) AccessChain 706(texel) 207
                               Store 834 833
              835:         316 Load 318(s1DArrayShadow)
-             836:  154(fvec2) Load 156(f16c2)
+             836:154(f16vec2) Load 156(f16c2)
              837:   52(float) Load 215(compare)
-             838:    6(float) Load 137(f16bias)
-             839:    6(float) ImageSampleDrefImplicitLod 835 836 837 Bias ConstOffset 838 709
+             838:6(float16_t) Load 137(f16bias)
+             839:6(float16_t) ImageSampleDrefImplicitLod 835 836 837 Bias ConstOffset 838 709
              840:    208(ptr) AccessChain 706(texel) 207
-             841:    6(float) Load 840
-             842:    6(float) FAdd 841 839
+             841:6(float16_t) Load 840
+             842:6(float16_t) FAdd 841 839
              843:    208(ptr) AccessChain 706(texel) 207
                               Store 843 842
              844:         337 Load 339(s2DArrayShadow)
              845:  249(fvec4) Load 251(c4)
              846:   52(float) CompositeExtract 845 3
-             847:    6(float) ImageSampleDrefImplicitLod 844 845 846 ConstOffset 722
+             847:6(float16_t) ImageSampleDrefImplicitLod 844 845 846 ConstOffset 722
              848:    208(ptr) AccessChain 706(texel) 207
-             849:    6(float) Load 848
-             850:    6(float) FAdd 849 847
+             849:6(float16_t) Load 848
+             850:6(float16_t) FAdd 849 847
              851:    208(ptr) AccessChain 706(texel) 207
                               Store 851 850
              852:         337 Load 339(s2DArrayShadow)
-             853:  175(fvec3) Load 177(f16c3)
+             853:175(f16vec3) Load 177(f16c3)
              854:   52(float) Load 215(compare)
-             855:    6(float) ImageSampleDrefImplicitLod 852 853 854 ConstOffset 722
+             855:6(float16_t) ImageSampleDrefImplicitLod 852 853 854 ConstOffset 722
              856:    208(ptr) AccessChain 706(texel) 207
-             857:    6(float) Load 856
-             858:    6(float) FAdd 857 855
+             857:6(float16_t) Load 856
+             858:6(float16_t) FAdd 857 855
              859:    208(ptr) AccessChain 706(texel) 207
                               Store 859 858
-             860:    7(fvec4) Load 706(texel)
+             860:  7(f16vec4) Load 706(texel)
                               ReturnValue 860
                               FunctionEnd
-17(testTextureProjOffset():    7(fvec4) Function None 8
+17(testTextureProjOffset():  7(f16vec4) Function None 8
               18:             Label
       863(texel):     64(ptr) Variable Function
                               Store 863(texel) 121
              864:         123 Load 125(s1D)
              865:   53(fvec2) Load 148(c2)
-             866:    7(fvec4) ImageSampleProjImplicitLod 864 865 ConstOffset 709
-             867:    7(fvec4) Load 863(texel)
-             868:    7(fvec4) FAdd 867 866
+             866:  7(f16vec4) ImageSampleProjImplicitLod 864 865 ConstOffset 709
+             867:  7(f16vec4) Load 863(texel)
+             868:  7(f16vec4) FAdd 867 866
                               Store 863(texel) 868
              869:         123 Load 125(s1D)
-             870:  154(fvec2) Load 156(f16c2)
-             871:    6(float) Load 137(f16bias)
-             872:    7(fvec4) ImageSampleProjImplicitLod 869 870 Bias ConstOffset 871 709
-             873:    7(fvec4) Load 863(texel)
-             874:    7(fvec4) FAdd 873 872
+             870:154(f16vec2) Load 156(f16c2)
+             871:6(float16_t) Load 137(f16bias)
+             872:  7(f16vec4) ImageSampleProjImplicitLod 869 870 Bias ConstOffset 871 709
+             873:  7(f16vec4) Load 863(texel)
+             874:  7(f16vec4) FAdd 873 872
                               Store 863(texel) 874
              875:         123 Load 125(s1D)
              876:  249(fvec4) Load 251(c4)
              877:   52(float) CompositeExtract 876 3
              878:  249(fvec4) CompositeInsert 877 876 1
-             879:    7(fvec4) ImageSampleProjImplicitLod 875 878 ConstOffset 709
-             880:    7(fvec4) Load 863(texel)
-             881:    7(fvec4) FAdd 880 879
+             879:  7(f16vec4) ImageSampleProjImplicitLod 875 878 ConstOffset 709
+             880:  7(f16vec4) Load 863(texel)
+             881:  7(f16vec4) FAdd 880 879
                               Store 863(texel) 881
              882:         123 Load 125(s1D)
-             883:    7(fvec4) Load 309(f16c4)
-             884:    6(float) Load 137(f16bias)
-             885:    6(float) CompositeExtract 883 3
-             886:    7(fvec4) CompositeInsert 885 883 1
-             887:    7(fvec4) ImageSampleProjImplicitLod 882 886 Bias ConstOffset 884 709
-             888:    7(fvec4) Load 863(texel)
-             889:    7(fvec4) FAdd 888 887
+             883:  7(f16vec4) Load 309(f16c4)
+             884:6(float16_t) Load 137(f16bias)
+             885:6(float16_t) CompositeExtract 883 3
+             886:  7(f16vec4) CompositeInsert 885 883 1
+             887:  7(f16vec4) ImageSampleProjImplicitLod 882 886 Bias ConstOffset 884 709
+             888:  7(f16vec4) Load 863(texel)
+             889:  7(f16vec4) FAdd 888 887
                               Store 863(texel) 889
              890:         143 Load 145(s2D)
              891:  167(fvec3) Load 169(c3)
-             892:    7(fvec4) ImageSampleProjImplicitLod 890 891 ConstOffset 722
-             893:    7(fvec4) Load 863(texel)
-             894:    7(fvec4) FAdd 893 892
+             892:  7(f16vec4) ImageSampleProjImplicitLod 890 891 ConstOffset 722
+             893:  7(f16vec4) Load 863(texel)
+             894:  7(f16vec4) FAdd 893 892
                               Store 863(texel) 894
              895:         143 Load 145(s2D)
-             896:  175(fvec3) Load 177(f16c3)
-             897:    6(float) Load 137(f16bias)
-             898:    7(fvec4) ImageSampleProjImplicitLod 895 896 Bias ConstOffset 897 722
-             899:    7(fvec4) Load 863(texel)
-             900:    7(fvec4) FAdd 899 898
+             896:175(f16vec3) Load 177(f16c3)
+             897:6(float16_t) Load 137(f16bias)
+             898:  7(f16vec4) ImageSampleProjImplicitLod 895 896 Bias ConstOffset 897 722
+             899:  7(f16vec4) Load 863(texel)
+             900:  7(f16vec4) FAdd 899 898
                               Store 863(texel) 900
              901:         143 Load 145(s2D)
              902:  249(fvec4) Load 251(c4)
              903:   52(float) CompositeExtract 902 3
              904:  249(fvec4) CompositeInsert 903 902 2
-             905:    7(fvec4) ImageSampleProjImplicitLod 901 904 ConstOffset 722
-             906:    7(fvec4) Load 863(texel)
-             907:    7(fvec4) FAdd 906 905
+             905:  7(f16vec4) ImageSampleProjImplicitLod 901 904 ConstOffset 722
+             906:  7(f16vec4) Load 863(texel)
+             907:  7(f16vec4) FAdd 906 905
                               Store 863(texel) 907
              908:         143 Load 145(s2D)
-             909:    7(fvec4) Load 309(f16c4)
-             910:    6(float) Load 137(f16bias)
-             911:    6(float) CompositeExtract 909 3
-             912:    7(fvec4) CompositeInsert 911 909 2
-             913:    7(fvec4) ImageSampleProjImplicitLod 908 912 Bias ConstOffset 910 722
-             914:    7(fvec4) Load 863(texel)
-             915:    7(fvec4) FAdd 914 913
+             909:  7(f16vec4) Load 309(f16c4)
+             910:6(float16_t) Load 137(f16bias)
+             911:6(float16_t) CompositeExtract 909 3
+             912:  7(f16vec4) CompositeInsert 911 909 2
+             913:  7(f16vec4) ImageSampleProjImplicitLod 908 912 Bias ConstOffset 910 722
+             914:  7(f16vec4) Load 863(texel)
+             915:  7(f16vec4) FAdd 914 913
                               Store 863(texel) 915
              916:         163 Load 165(s3D)
              917:  249(fvec4) Load 251(c4)
-             918:    7(fvec4) ImageSampleProjImplicitLod 916 917 ConstOffset 735
-             919:    7(fvec4) Load 863(texel)
-             920:    7(fvec4) FAdd 919 918
+             918:  7(f16vec4) ImageSampleProjImplicitLod 916 917 ConstOffset 735
+             919:  7(f16vec4) Load 863(texel)
+             920:  7(f16vec4) FAdd 919 918
                               Store 863(texel) 920
              921:         163 Load 165(s3D)
-             922:    7(fvec4) Load 309(f16c4)
-             923:    6(float) Load 137(f16bias)
-             924:    7(fvec4) ImageSampleProjImplicitLod 921 922 Bias ConstOffset 923 735
-             925:    7(fvec4) Load 863(texel)
-             926:    7(fvec4) FAdd 925 924
+             922:  7(f16vec4) Load 309(f16c4)
+             923:6(float16_t) Load 137(f16bias)
+             924:  7(f16vec4) ImageSampleProjImplicitLod 921 922 Bias ConstOffset 923 735
+             925:  7(f16vec4) Load 863(texel)
+             926:  7(f16vec4) FAdd 925 924
                               Store 863(texel) 926
              927:         357 Load 359(s2DRect)
              928:  167(fvec3) Load 169(c3)
-             929:    7(fvec4) ImageSampleProjImplicitLod 927 928 ConstOffset 722
-             930:    7(fvec4) Load 863(texel)
-             931:    7(fvec4) FAdd 930 929
+             929:  7(f16vec4) ImageSampleProjImplicitLod 927 928 ConstOffset 722
+             930:  7(f16vec4) Load 863(texel)
+             931:  7(f16vec4) FAdd 930 929
                               Store 863(texel) 931
              932:         357 Load 359(s2DRect)
-             933:  175(fvec3) Load 177(f16c3)
-             934:    7(fvec4) ImageSampleProjImplicitLod 932 933 ConstOffset 722
-             935:    7(fvec4) Load 863(texel)
-             936:    7(fvec4) FAdd 935 934
+             933:175(f16vec3) Load 177(f16c3)
+             934:  7(f16vec4) ImageSampleProjImplicitLod 932 933 ConstOffset 722
+             935:  7(f16vec4) Load 863(texel)
+             936:  7(f16vec4) FAdd 935 934
                               Store 863(texel) 936
              937:         357 Load 359(s2DRect)
              938:  249(fvec4) Load 251(c4)
              939:   52(float) CompositeExtract 938 3
              940:  249(fvec4) CompositeInsert 939 938 2
-             941:    7(fvec4) ImageSampleProjImplicitLod 937 940 ConstOffset 722
-             942:    7(fvec4) Load 863(texel)
-             943:    7(fvec4) FAdd 942 941
+             941:  7(f16vec4) ImageSampleProjImplicitLod 937 940 ConstOffset 722
+             942:  7(f16vec4) Load 863(texel)
+             943:  7(f16vec4) FAdd 942 941
                               Store 863(texel) 943
              944:         357 Load 359(s2DRect)
-             945:    7(fvec4) Load 309(f16c4)
-             946:    6(float) CompositeExtract 945 3
-             947:    7(fvec4) CompositeInsert 946 945 2
-             948:    7(fvec4) ImageSampleProjImplicitLod 944 947 ConstOffset 722
-             949:    7(fvec4) Load 863(texel)
-             950:    7(fvec4) FAdd 949 948
+             945:  7(f16vec4) Load 309(f16c4)
+             946:6(float16_t) CompositeExtract 945 3
+             947:  7(f16vec4) CompositeInsert 946 945 2
+             948:  7(f16vec4) ImageSampleProjImplicitLod 944 947 ConstOffset 722
+             949:  7(f16vec4) Load 863(texel)
+             950:  7(f16vec4) FAdd 949 948
                               Store 863(texel) 950
              951:         371 Load 373(s2DRectShadow)
              952:  249(fvec4) Load 251(c4)
              953:   52(float) CompositeExtract 952 2
              954:   52(float) CompositeExtract 952 3
              955:  249(fvec4) CompositeInsert 954 952 2
-             956:    6(float) ImageSampleProjDrefImplicitLod 951 955 953 ConstOffset 722
+             956:6(float16_t) ImageSampleProjDrefImplicitLod 951 955 953 ConstOffset 722
              957:    208(ptr) AccessChain 863(texel) 207
-             958:    6(float) Load 957
-             959:    6(float) FAdd 958 956
+             958:6(float16_t) Load 957
+             959:6(float16_t) FAdd 958 956
              960:    208(ptr) AccessChain 863(texel) 207
                               Store 960 959
              961:         371 Load 373(s2DRectShadow)
-             962:  175(fvec3) Load 177(f16c3)
+             962:175(f16vec3) Load 177(f16c3)
              963:   52(float) Load 215(compare)
-             964:    6(float) ImageSampleProjDrefImplicitLod 961 962 963 ConstOffset 722
+             964:6(float16_t) ImageSampleProjDrefImplicitLod 961 962 963 ConstOffset 722
              965:    208(ptr) AccessChain 863(texel) 207
-             966:    6(float) Load 965
-             967:    6(float) FAdd 966 964
+             966:6(float16_t) Load 965
+             967:6(float16_t) FAdd 966 964
              968:    208(ptr) AccessChain 863(texel) 207
                               Store 968 967
              969:         199 Load 201(s1DShadow)
@@ -1628,22 +1628,22 @@ spv.float16Fetch.frag
              971:   52(float) CompositeExtract 970 2
              972:   52(float) CompositeExtract 970 3
              973:  249(fvec4) CompositeInsert 972 970 1
-             974:    6(float) ImageSampleProjDrefImplicitLod 969 973 971 ConstOffset 709
+             974:6(float16_t) ImageSampleProjDrefImplicitLod 969 973 971 ConstOffset 709
              975:    208(ptr) AccessChain 863(texel) 207
-             976:    6(float) Load 975
-             977:    6(float) FAdd 976 974
+             976:6(float16_t) Load 975
+             977:6(float16_t) FAdd 976 974
              978:    208(ptr) AccessChain 863(texel) 207
                               Store 978 977
              979:         199 Load 201(s1DShadow)
-             980:  175(fvec3) Load 177(f16c3)
+             980:175(f16vec3) Load 177(f16c3)
              981:   52(float) Load 215(compare)
-             982:    6(float) Load 137(f16bias)
-             983:    6(float) CompositeExtract 980 2
-             984:  175(fvec3) CompositeInsert 983 980 1
-             985:    6(float) ImageSampleProjDrefImplicitLod 979 984 981 Bias ConstOffset 982 709
+             982:6(float16_t) Load 137(f16bias)
+             983:6(float16_t) CompositeExtract 980 2
+             984:175(f16vec3) CompositeInsert 983 980 1
+             985:6(float16_t) ImageSampleProjDrefImplicitLod 979 984 981 Bias ConstOffset 982 709
              986:    208(ptr) AccessChain 863(texel) 207
-             987:    6(float) Load 986
-             988:    6(float) FAdd 987 985
+             987:6(float16_t) Load 986
+             988:6(float16_t) FAdd 987 985
              989:    208(ptr) AccessChain 863(texel) 207
                               Store 989 988
              990:         224 Load 226(s2DShadow)
@@ -1651,243 +1651,243 @@ spv.float16Fetch.frag
              992:   52(float) CompositeExtract 991 2
              993:   52(float) CompositeExtract 991 3
              994:  249(fvec4) CompositeInsert 993 991 2
-             995:    6(float) ImageSampleProjDrefImplicitLod 990 994 992 ConstOffset 722
+             995:6(float16_t) ImageSampleProjDrefImplicitLod 990 994 992 ConstOffset 722
              996:    208(ptr) AccessChain 863(texel) 207
-             997:    6(float) Load 996
-             998:    6(float) FAdd 997 995
+             997:6(float16_t) Load 996
+             998:6(float16_t) FAdd 997 995
              999:    208(ptr) AccessChain 863(texel) 207
                               Store 999 998
             1000:         224 Load 226(s2DShadow)
-            1001:  175(fvec3) Load 177(f16c3)
+            1001:175(f16vec3) Load 177(f16c3)
             1002:   52(float) Load 215(compare)
-            1003:    6(float) Load 137(f16bias)
-            1004:    6(float) ImageSampleProjDrefImplicitLod 1000 1001 1002 Bias ConstOffset 1003 722
+            1003:6(float16_t) Load 137(f16bias)
+            1004:6(float16_t) ImageSampleProjDrefImplicitLod 1000 1001 1002 Bias ConstOffset 1003 722
             1005:    208(ptr) AccessChain 863(texel) 207
-            1006:    6(float) Load 1005
-            1007:    6(float) FAdd 1006 1004
+            1006:6(float16_t) Load 1005
+            1007:6(float16_t) FAdd 1006 1004
             1008:    208(ptr) AccessChain 863(texel) 207
                               Store 1008 1007
-            1009:    7(fvec4) Load 863(texel)
+            1009:  7(f16vec4) Load 863(texel)
                               ReturnValue 1009
                               FunctionEnd
-19(testTextureLodOffset():    7(fvec4) Function None 8
+19(testTextureLodOffset():  7(f16vec4) Function None 8
               20:             Label
      1012(texel):     64(ptr) Variable Function
                               Store 1012(texel) 121
             1013:         123 Load 125(s1D)
             1014:   52(float) Load 128(c1)
             1015:   52(float) Load 565(lod)
-            1016:    7(fvec4) ImageSampleExplicitLod 1013 1014 Lod ConstOffset 1015 709
-            1017:    7(fvec4) Load 1012(texel)
-            1018:    7(fvec4) FAdd 1017 1016
+            1016:  7(f16vec4) ImageSampleExplicitLod 1013 1014 Lod ConstOffset 1015 709
+            1017:  7(f16vec4) Load 1012(texel)
+            1018:  7(f16vec4) FAdd 1017 1016
                               Store 1012(texel) 1018
             1019:         123 Load 125(s1D)
-            1020:    6(float) Load 135(f16c1)
-            1021:    6(float) Load 572(f16lod)
-            1022:    7(fvec4) ImageSampleExplicitLod 1019 1020 Lod ConstOffset 1021 709
-            1023:    7(fvec4) Load 1012(texel)
-            1024:    7(fvec4) FAdd 1023 1022
+            1020:6(float16_t) Load 135(f16c1)
+            1021:6(float16_t) Load 572(f16lod)
+            1022:  7(f16vec4) ImageSampleExplicitLod 1019 1020 Lod ConstOffset 1021 709
+            1023:  7(f16vec4) Load 1012(texel)
+            1024:  7(f16vec4) FAdd 1023 1022
                               Store 1012(texel) 1024
             1025:         143 Load 145(s2D)
             1026:   53(fvec2) Load 148(c2)
             1027:   52(float) Load 565(lod)
-            1028:    7(fvec4) ImageSampleExplicitLod 1025 1026 Lod ConstOffset 1027 722
-            1029:    7(fvec4) Load 1012(texel)
-            1030:    7(fvec4) FAdd 1029 1028
+            1028:  7(f16vec4) ImageSampleExplicitLod 1025 1026 Lod ConstOffset 1027 722
+            1029:  7(f16vec4) Load 1012(texel)
+            1030:  7(f16vec4) FAdd 1029 1028
                               Store 1012(texel) 1030
             1031:         143 Load 145(s2D)
-            1032:  154(fvec2) Load 156(f16c2)
-            1033:    6(float) Load 572(f16lod)
-            1034:    7(fvec4) ImageSampleExplicitLod 1031 1032 Lod ConstOffset 1033 722
-            1035:    7(fvec4) Load 1012(texel)
-            1036:    7(fvec4) FAdd 1035 1034
+            1032:154(f16vec2) Load 156(f16c2)
+            1033:6(float16_t) Load 572(f16lod)
+            1034:  7(f16vec4) ImageSampleExplicitLod 1031 1032 Lod ConstOffset 1033 722
+            1035:  7(f16vec4) Load 1012(texel)
+            1036:  7(f16vec4) FAdd 1035 1034
                               Store 1012(texel) 1036
             1037:         163 Load 165(s3D)
             1038:  167(fvec3) Load 169(c3)
             1039:   52(float) Load 565(lod)
-            1040:    7(fvec4) ImageSampleExplicitLod 1037 1038 Lod ConstOffset 1039 735
-            1041:    7(fvec4) Load 1012(texel)
-            1042:    7(fvec4) FAdd 1041 1040
+            1040:  7(f16vec4) ImageSampleExplicitLod 1037 1038 Lod ConstOffset 1039 735
+            1041:  7(f16vec4) Load 1012(texel)
+            1042:  7(f16vec4) FAdd 1041 1040
                               Store 1012(texel) 1042
             1043:         163 Load 165(s3D)
-            1044:  175(fvec3) Load 177(f16c3)
-            1045:    6(float) Load 572(f16lod)
-            1046:    7(fvec4) ImageSampleExplicitLod 1043 1044 Lod ConstOffset 1045 735
-            1047:    7(fvec4) Load 1012(texel)
-            1048:    7(fvec4) FAdd 1047 1046
+            1044:175(f16vec3) Load 177(f16c3)
+            1045:6(float16_t) Load 572(f16lod)
+            1046:  7(f16vec4) ImageSampleExplicitLod 1043 1044 Lod ConstOffset 1045 735
+            1047:  7(f16vec4) Load 1012(texel)
+            1048:  7(f16vec4) FAdd 1047 1046
                               Store 1012(texel) 1048
             1049:         199 Load 201(s1DShadow)
             1050:  167(fvec3) Load 169(c3)
             1051:   52(float) Load 565(lod)
             1052:   52(float) CompositeExtract 1050 2
-            1053:    6(float) ImageSampleDrefExplicitLod 1049 1050 1052 Lod ConstOffset 1051 709
+            1053:6(float16_t) ImageSampleDrefExplicitLod 1049 1050 1052 Lod ConstOffset 1051 709
             1054:    208(ptr) AccessChain 1012(texel) 207
-            1055:    6(float) Load 1054
-            1056:    6(float) FAdd 1055 1053
+            1055:6(float16_t) Load 1054
+            1056:6(float16_t) FAdd 1055 1053
             1057:    208(ptr) AccessChain 1012(texel) 207
                               Store 1057 1056
             1058:         199 Load 201(s1DShadow)
-            1059:  154(fvec2) Load 156(f16c2)
+            1059:154(f16vec2) Load 156(f16c2)
             1060:   52(float) Load 215(compare)
-            1061:    6(float) Load 572(f16lod)
-            1062:    6(float) ImageSampleDrefExplicitLod 1058 1059 1060 Lod ConstOffset 1061 709
+            1061:6(float16_t) Load 572(f16lod)
+            1062:6(float16_t) ImageSampleDrefExplicitLod 1058 1059 1060 Lod ConstOffset 1061 709
             1063:    208(ptr) AccessChain 1012(texel) 207
-            1064:    6(float) Load 1063
-            1065:    6(float) FAdd 1064 1062
+            1064:6(float16_t) Load 1063
+            1065:6(float16_t) FAdd 1064 1062
             1066:    208(ptr) AccessChain 1012(texel) 207
                               Store 1066 1065
             1067:         224 Load 226(s2DShadow)
             1068:  167(fvec3) Load 169(c3)
             1069:   52(float) Load 565(lod)
             1070:   52(float) CompositeExtract 1068 2
-            1071:    6(float) ImageSampleDrefExplicitLod 1067 1068 1070 Lod ConstOffset 1069 722
+            1071:6(float16_t) ImageSampleDrefExplicitLod 1067 1068 1070 Lod ConstOffset 1069 722
             1072:    208(ptr) AccessChain 1012(texel) 207
-            1073:    6(float) Load 1072
-            1074:    6(float) FAdd 1073 1071
+            1073:6(float16_t) Load 1072
+            1074:6(float16_t) FAdd 1073 1071
             1075:    208(ptr) AccessChain 1012(texel) 207
                               Store 1075 1074
             1076:         224 Load 226(s2DShadow)
-            1077:  154(fvec2) Load 156(f16c2)
+            1077:154(f16vec2) Load 156(f16c2)
             1078:   52(float) Load 215(compare)
-            1079:    6(float) Load 572(f16lod)
-            1080:    6(float) ImageSampleDrefExplicitLod 1076 1077 1078 Lod ConstOffset 1079 722
+            1079:6(float16_t) Load 572(f16lod)
+            1080:6(float16_t) ImageSampleDrefExplicitLod 1076 1077 1078 Lod ConstOffset 1079 722
             1081:    208(ptr) AccessChain 1012(texel) 207
-            1082:    6(float) Load 1081
-            1083:    6(float) FAdd 1082 1080
+            1082:6(float16_t) Load 1081
+            1083:6(float16_t) FAdd 1082 1080
             1084:    208(ptr) AccessChain 1012(texel) 207
                               Store 1084 1083
             1085:         269 Load 271(s1DArray)
             1086:   53(fvec2) Load 148(c2)
             1087:   52(float) Load 565(lod)
-            1088:    7(fvec4) ImageSampleExplicitLod 1085 1086 Lod ConstOffset 1087 709
-            1089:    7(fvec4) Load 1012(texel)
-            1090:    7(fvec4) FAdd 1089 1088
+            1088:  7(f16vec4) ImageSampleExplicitLod 1085 1086 Lod ConstOffset 1087 709
+            1089:  7(f16vec4) Load 1012(texel)
+            1090:  7(f16vec4) FAdd 1089 1088
                               Store 1012(texel) 1090
             1091:         269 Load 271(s1DArray)
-            1092:  154(fvec2) Load 156(f16c2)
-            1093:    6(float) Load 572(f16lod)
-            1094:    7(fvec4) ImageSampleExplicitLod 1091 1092 Lod ConstOffset 1093 709
-            1095:    7(fvec4) Load 1012(texel)
-            1096:    7(fvec4) FAdd 1095 1094
+            1092:154(f16vec2) Load 156(f16c2)
+            1093:6(float16_t) Load 572(f16lod)
+            1094:  7(f16vec4) ImageSampleExplicitLod 1091 1092 Lod ConstOffset 1093 709
+            1095:  7(f16vec4) Load 1012(texel)
+            1096:  7(f16vec4) FAdd 1095 1094
                               Store 1012(texel) 1096
             1097:         284 Load 286(s2DArray)
             1098:  167(fvec3) Load 169(c3)
             1099:   52(float) Load 565(lod)
-            1100:    7(fvec4) ImageSampleExplicitLod 1097 1098 Lod ConstOffset 1099 722
-            1101:    7(fvec4) Load 1012(texel)
-            1102:    7(fvec4) FAdd 1101 1100
+            1100:  7(f16vec4) ImageSampleExplicitLod 1097 1098 Lod ConstOffset 1099 722
+            1101:  7(f16vec4) Load 1012(texel)
+            1102:  7(f16vec4) FAdd 1101 1100
                               Store 1012(texel) 1102
             1103:         284 Load 286(s2DArray)
-            1104:  175(fvec3) Load 177(f16c3)
-            1105:    6(float) Load 572(f16lod)
-            1106:    7(fvec4) ImageSampleExplicitLod 1103 1104 Lod ConstOffset 1105 722
-            1107:    7(fvec4) Load 1012(texel)
-            1108:    7(fvec4) FAdd 1107 1106
+            1104:175(f16vec3) Load 177(f16c3)
+            1105:6(float16_t) Load 572(f16lod)
+            1106:  7(f16vec4) ImageSampleExplicitLod 1103 1104 Lod ConstOffset 1105 722
+            1107:  7(f16vec4) Load 1012(texel)
+            1108:  7(f16vec4) FAdd 1107 1106
                               Store 1012(texel) 1108
             1109:         316 Load 318(s1DArrayShadow)
             1110:  167(fvec3) Load 169(c3)
             1111:   52(float) Load 565(lod)
             1112:   52(float) CompositeExtract 1110 2
-            1113:    6(float) ImageSampleDrefExplicitLod 1109 1110 1112 Lod ConstOffset 1111 709
+            1113:6(float16_t) ImageSampleDrefExplicitLod 1109 1110 1112 Lod ConstOffset 1111 709
             1114:    208(ptr) AccessChain 1012(texel) 207
-            1115:    6(float) Load 1114
-            1116:    6(float) FAdd 1115 1113
+            1115:6(float16_t) Load 1114
+            1116:6(float16_t) FAdd 1115 1113
             1117:    208(ptr) AccessChain 1012(texel) 207
                               Store 1117 1116
             1118:         316 Load 318(s1DArrayShadow)
-            1119:  154(fvec2) Load 156(f16c2)
+            1119:154(f16vec2) Load 156(f16c2)
             1120:   52(float) Load 215(compare)
-            1121:    6(float) Load 572(f16lod)
-            1122:    6(float) ImageSampleDrefExplicitLod 1118 1119 1120 Lod ConstOffset 1121 709
+            1121:6(float16_t) Load 572(f16lod)
+            1122:6(float16_t) ImageSampleDrefExplicitLod 1118 1119 1120 Lod ConstOffset 1121 709
             1123:    208(ptr) AccessChain 1012(texel) 207
-            1124:    6(float) Load 1123
-            1125:    6(float) FAdd 1124 1122
+            1124:6(float16_t) Load 1123
+            1125:6(float16_t) FAdd 1124 1122
             1126:    208(ptr) AccessChain 1012(texel) 207
                               Store 1126 1125
-            1127:    7(fvec4) Load 1012(texel)
+            1127:  7(f16vec4) Load 1012(texel)
                               ReturnValue 1127
                               FunctionEnd
-21(testTextureProjLodOffset():    7(fvec4) Function None 8
+21(testTextureProjLodOffset():  7(f16vec4) Function None 8
               22:             Label
      1130(texel):     64(ptr) Variable Function
                               Store 1130(texel) 121
             1131:         123 Load 125(s1D)
             1132:   53(fvec2) Load 148(c2)
             1133:   52(float) Load 565(lod)
-            1134:    7(fvec4) ImageSampleProjExplicitLod 1131 1132 Lod ConstOffset 1133 709
-            1135:    7(fvec4) Load 1130(texel)
-            1136:    7(fvec4) FAdd 1135 1134
+            1134:  7(f16vec4) ImageSampleProjExplicitLod 1131 1132 Lod ConstOffset 1133 709
+            1135:  7(f16vec4) Load 1130(texel)
+            1136:  7(f16vec4) FAdd 1135 1134
                               Store 1130(texel) 1136
             1137:         123 Load 125(s1D)
-            1138:  154(fvec2) Load 156(f16c2)
-            1139:    6(float) Load 572(f16lod)
-            1140:    7(fvec4) ImageSampleProjExplicitLod 1137 1138 Lod ConstOffset 1139 709
-            1141:    7(fvec4) Load 1130(texel)
-            1142:    7(fvec4) FAdd 1141 1140
+            1138:154(f16vec2) Load 156(f16c2)
+            1139:6(float16_t) Load 572(f16lod)
+            1140:  7(f16vec4) ImageSampleProjExplicitLod 1137 1138 Lod ConstOffset 1139 709
+            1141:  7(f16vec4) Load 1130(texel)
+            1142:  7(f16vec4) FAdd 1141 1140
                               Store 1130(texel) 1142
             1143:         123 Load 125(s1D)
             1144:  249(fvec4) Load 251(c4)
             1145:   52(float) Load 565(lod)
             1146:   52(float) CompositeExtract 1144 3
             1147:  249(fvec4) CompositeInsert 1146 1144 1
-            1148:    7(fvec4) ImageSampleProjExplicitLod 1143 1147 Lod ConstOffset 1145 709
-            1149:    7(fvec4) Load 1130(texel)
-            1150:    7(fvec4) FAdd 1149 1148
+            1148:  7(f16vec4) ImageSampleProjExplicitLod 1143 1147 Lod ConstOffset 1145 709
+            1149:  7(f16vec4) Load 1130(texel)
+            1150:  7(f16vec4) FAdd 1149 1148
                               Store 1130(texel) 1150
             1151:         123 Load 125(s1D)
-            1152:    7(fvec4) Load 309(f16c4)
-            1153:    6(float) Load 572(f16lod)
-            1154:    6(float) CompositeExtract 1152 3
-            1155:    7(fvec4) CompositeInsert 1154 1152 1
-            1156:    7(fvec4) ImageSampleProjExplicitLod 1151 1155 Lod ConstOffset 1153 709
-            1157:    7(fvec4) Load 1130(texel)
-            1158:    7(fvec4) FAdd 1157 1156
+            1152:  7(f16vec4) Load 309(f16c4)
+            1153:6(float16_t) Load 572(f16lod)
+            1154:6(float16_t) CompositeExtract 1152 3
+            1155:  7(f16vec4) CompositeInsert 1154 1152 1
+            1156:  7(f16vec4) ImageSampleProjExplicitLod 1151 1155 Lod ConstOffset 1153 709
+            1157:  7(f16vec4) Load 1130(texel)
+            1158:  7(f16vec4) FAdd 1157 1156
                               Store 1130(texel) 1158
             1159:         143 Load 145(s2D)
             1160:  167(fvec3) Load 169(c3)
             1161:   52(float) Load 565(lod)
-            1162:    7(fvec4) ImageSampleProjExplicitLod 1159 1160 Lod ConstOffset 1161 722
-            1163:    7(fvec4) Load 1130(texel)
-            1164:    7(fvec4) FAdd 1163 1162
+            1162:  7(f16vec4) ImageSampleProjExplicitLod 1159 1160 Lod ConstOffset 1161 722
+            1163:  7(f16vec4) Load 1130(texel)
+            1164:  7(f16vec4) FAdd 1163 1162
                               Store 1130(texel) 1164
             1165:         143 Load 145(s2D)
-            1166:  175(fvec3) Load 177(f16c3)
-            1167:    6(float) Load 572(f16lod)
-            1168:    7(fvec4) ImageSampleProjExplicitLod 1165 1166 Lod ConstOffset 1167 722
-            1169:    7(fvec4) Load 1130(texel)
-            1170:    7(fvec4) FAdd 1169 1168
+            1166:175(f16vec3) Load 177(f16c3)
+            1167:6(float16_t) Load 572(f16lod)
+            1168:  7(f16vec4) ImageSampleProjExplicitLod 1165 1166 Lod ConstOffset 1167 722
+            1169:  7(f16vec4) Load 1130(texel)
+            1170:  7(f16vec4) FAdd 1169 1168
                               Store 1130(texel) 1170
             1171:         143 Load 145(s2D)
             1172:  249(fvec4) Load 251(c4)
             1173:   52(float) Load 565(lod)
             1174:   52(float) CompositeExtract 1172 3
             1175:  249(fvec4) CompositeInsert 1174 1172 2
-            1176:    7(fvec4) ImageSampleProjExplicitLod 1171 1175 Lod ConstOffset 1173 722
-            1177:    7(fvec4) Load 1130(texel)
-            1178:    7(fvec4) FAdd 1177 1176
+            1176:  7(f16vec4) ImageSampleProjExplicitLod 1171 1175 Lod ConstOffset 1173 722
+            1177:  7(f16vec4) Load 1130(texel)
+            1178:  7(f16vec4) FAdd 1177 1176
                               Store 1130(texel) 1178
             1179:         143 Load 145(s2D)
-            1180:    7(fvec4) Load 309(f16c4)
-            1181:    6(float) Load 572(f16lod)
-            1182:    6(float) CompositeExtract 1180 3
-            1183:    7(fvec4) CompositeInsert 1182 1180 2
-            1184:    7(fvec4) ImageSampleProjExplicitLod 1179 1183 Lod ConstOffset 1181 722
-            1185:    7(fvec4) Load 1130(texel)
-            1186:    7(fvec4) FAdd 1185 1184
+            1180:  7(f16vec4) Load 309(f16c4)
+            1181:6(float16_t) Load 572(f16lod)
+            1182:6(float16_t) CompositeExtract 1180 3
+            1183:  7(f16vec4) CompositeInsert 1182 1180 2
+            1184:  7(f16vec4) ImageSampleProjExplicitLod 1179 1183 Lod ConstOffset 1181 722
+            1185:  7(f16vec4) Load 1130(texel)
+            1186:  7(f16vec4) FAdd 1185 1184
                               Store 1130(texel) 1186
             1187:         163 Load 165(s3D)
             1188:  249(fvec4) Load 251(c4)
             1189:   52(float) Load 565(lod)
-            1190:    7(fvec4) ImageSampleProjExplicitLod 1187 1188 Lod ConstOffset 1189 735
-            1191:    7(fvec4) Load 1130(texel)
-            1192:    7(fvec4) FAdd 1191 1190
+            1190:  7(f16vec4) ImageSampleProjExplicitLod 1187 1188 Lod ConstOffset 1189 735
+            1191:  7(f16vec4) Load 1130(texel)
+            1192:  7(f16vec4) FAdd 1191 1190
                               Store 1130(texel) 1192
             1193:         163 Load 165(s3D)
-            1194:    7(fvec4) Load 309(f16c4)
-            1195:    6(float) Load 572(f16lod)
-            1196:    7(fvec4) ImageSampleProjExplicitLod 1193 1194 Lod ConstOffset 1195 735
-            1197:    7(fvec4) Load 1130(texel)
-            1198:    7(fvec4) FAdd 1197 1196
+            1194:  7(f16vec4) Load 309(f16c4)
+            1195:6(float16_t) Load 572(f16lod)
+            1196:  7(f16vec4) ImageSampleProjExplicitLod 1193 1194 Lod ConstOffset 1195 735
+            1197:  7(f16vec4) Load 1130(texel)
+            1198:  7(f16vec4) FAdd 1197 1196
                               Store 1130(texel) 1198
             1199:         199 Load 201(s1DShadow)
             1200:  249(fvec4) Load 251(c4)
@@ -1895,22 +1895,22 @@ spv.float16Fetch.frag
             1202:   52(float) CompositeExtract 1200 2
             1203:   52(float) CompositeExtract 1200 3
             1204:  249(fvec4) CompositeInsert 1203 1200 1
-            1205:    6(float) ImageSampleProjDrefExplicitLod 1199 1204 1202 Lod ConstOffset 1201 709
+            1205:6(float16_t) ImageSampleProjDrefExplicitLod 1199 1204 1202 Lod ConstOffset 1201 709
             1206:    208(ptr) AccessChain 1130(texel) 207
-            1207:    6(float) Load 1206
-            1208:    6(float) FAdd 1207 1205
+            1207:6(float16_t) Load 1206
+            1208:6(float16_t) FAdd 1207 1205
             1209:    208(ptr) AccessChain 1130(texel) 207
                               Store 1209 1208
             1210:         199 Load 201(s1DShadow)
-            1211:  175(fvec3) Load 177(f16c3)
+            1211:175(f16vec3) Load 177(f16c3)
             1212:   52(float) Load 215(compare)
-            1213:    6(float) Load 572(f16lod)
-            1214:    6(float) CompositeExtract 1211 2
-            1215:  175(fvec3) CompositeInsert 1214 1211 1
-            1216:    6(float) ImageSampleProjDrefExplicitLod 1210 1215 1212 Lod ConstOffset 1213 709
+            1213:6(float16_t) Load 572(f16lod)
+            1214:6(float16_t) CompositeExtract 1211 2
+            1215:175(f16vec3) CompositeInsert 1214 1211 1
+            1216:6(float16_t) ImageSampleProjDrefExplicitLod 1210 1215 1212 Lod ConstOffset 1213 709
             1217:    208(ptr) AccessChain 1130(texel) 207
-            1218:    6(float) Load 1217
-            1219:    6(float) FAdd 1218 1216
+            1218:6(float16_t) Load 1217
+            1219:6(float16_t) FAdd 1218 1216
             1220:    208(ptr) AccessChain 1130(texel) 207
                               Store 1220 1219
             1221:         224 Load 226(s2DShadow)
@@ -1919,26 +1919,26 @@ spv.float16Fetch.frag
             1224:   52(float) CompositeExtract 1222 2
             1225:   52(float) CompositeExtract 1222 3
             1226:  249(fvec4) CompositeInsert 1225 1222 2
-            1227:    6(float) ImageSampleProjDrefExplicitLod 1221 1226 1224 Lod ConstOffset 1223 722
+            1227:6(float16_t) ImageSampleProjDrefExplicitLod 1221 1226 1224 Lod ConstOffset 1223 722
             1228:    208(ptr) AccessChain 1130(texel) 207
-            1229:    6(float) Load 1228
-            1230:    6(float) FAdd 1229 1227
+            1229:6(float16_t) Load 1228
+            1230:6(float16_t) FAdd 1229 1227
             1231:    208(ptr) AccessChain 1130(texel) 207
                               Store 1231 1230
             1232:         224 Load 226(s2DShadow)
-            1233:  175(fvec3) Load 177(f16c3)
+            1233:175(f16vec3) Load 177(f16c3)
             1234:   52(float) Load 215(compare)
-            1235:    6(float) Load 572(f16lod)
-            1236:    6(float) ImageSampleProjDrefExplicitLod 1232 1233 1234 Lod ConstOffset 1235 722
+            1235:6(float16_t) Load 572(f16lod)
+            1236:6(float16_t) ImageSampleProjDrefExplicitLod 1232 1233 1234 Lod ConstOffset 1235 722
             1237:    208(ptr) AccessChain 1130(texel) 207
-            1238:    6(float) Load 1237
-            1239:    6(float) FAdd 1238 1236
+            1238:6(float16_t) Load 1237
+            1239:6(float16_t) FAdd 1238 1236
             1240:    208(ptr) AccessChain 1130(texel) 207
                               Store 1240 1239
-            1241:    7(fvec4) Load 1130(texel)
+            1241:  7(f16vec4) Load 1130(texel)
                               ReturnValue 1241
                               FunctionEnd
-23(testTexelFetch():    7(fvec4) Function None 8
+23(testTexelFetch():  7(f16vec4) Function None 8
               24:             Label
      1244(texel):     64(ptr) Variable Function
                               Store 1244(texel) 121
@@ -1948,9 +1948,9 @@ spv.float16Fetch.frag
             1248:   52(float) Load 565(lod)
             1249:     47(int) ConvertFToS 1248
             1250:         122 Image 1245
-            1251:    7(fvec4) ImageFetch 1250 1247 Lod 1249
-            1252:    7(fvec4) Load 1244(texel)
-            1253:    7(fvec4) FAdd 1252 1251
+            1251:  7(f16vec4) ImageFetch 1250 1247 Lod 1249
+            1252:  7(f16vec4) Load 1244(texel)
+            1253:  7(f16vec4) FAdd 1252 1251
                               Store 1244(texel) 1253
             1254:         143 Load 145(s2D)
             1255:   53(fvec2) Load 148(c2)
@@ -1958,9 +1958,9 @@ spv.float16Fetch.frag
             1257:   52(float) Load 565(lod)
             1258:     47(int) ConvertFToS 1257
             1259:         142 Image 1254
-            1260:    7(fvec4) ImageFetch 1259 1256 Lod 1258
-            1261:    7(fvec4) Load 1244(texel)
-            1262:    7(fvec4) FAdd 1261 1260
+            1260:  7(f16vec4) ImageFetch 1259 1256 Lod 1258
+            1261:  7(f16vec4) Load 1244(texel)
+            1262:  7(f16vec4) FAdd 1261 1260
                               Store 1244(texel) 1262
             1263:         163 Load 165(s3D)
             1264:  167(fvec3) Load 169(c3)
@@ -1968,17 +1968,17 @@ spv.float16Fetch.frag
             1266:   52(float) Load 565(lod)
             1267:     47(int) ConvertFToS 1266
             1268:         162 Image 1263
-            1269:    7(fvec4) ImageFetch 1268 1265 Lod 1267
-            1270:    7(fvec4) Load 1244(texel)
-            1271:    7(fvec4) FAdd 1270 1269
+            1269:  7(f16vec4) ImageFetch 1268 1265 Lod 1267
+            1270:  7(f16vec4) Load 1244(texel)
+            1271:  7(f16vec4) FAdd 1270 1269
                               Store 1244(texel) 1271
             1272:         357 Load 359(s2DRect)
             1273:   53(fvec2) Load 148(c2)
             1274:  721(ivec2) ConvertFToS 1273
             1275:         356 Image 1272
-            1276:    7(fvec4) ImageFetch 1275 1274
-            1277:    7(fvec4) Load 1244(texel)
-            1278:    7(fvec4) FAdd 1277 1276
+            1276:  7(f16vec4) ImageFetch 1275 1274
+            1277:  7(f16vec4) Load 1244(texel)
+            1278:  7(f16vec4) FAdd 1277 1276
                               Store 1244(texel) 1278
             1279:         269 Load 271(s1DArray)
             1280:   53(fvec2) Load 148(c2)
@@ -1986,9 +1986,9 @@ spv.float16Fetch.frag
             1282:   52(float) Load 565(lod)
             1283:     47(int) ConvertFToS 1282
             1284:         268 Image 1279
-            1285:    7(fvec4) ImageFetch 1284 1281 Lod 1283
-            1286:    7(fvec4) Load 1244(texel)
-            1287:    7(fvec4) FAdd 1286 1285
+            1285:  7(f16vec4) ImageFetch 1284 1281 Lod 1283
+            1286:  7(f16vec4) Load 1244(texel)
+            1287:  7(f16vec4) FAdd 1286 1285
                               Store 1244(texel) 1287
             1288:         284 Load 286(s2DArray)
             1289:  167(fvec3) Load 169(c3)
@@ -1996,38 +1996,38 @@ spv.float16Fetch.frag
             1291:   52(float) Load 565(lod)
             1292:     47(int) ConvertFToS 1291
             1293:         283 Image 1288
-            1294:    7(fvec4) ImageFetch 1293 1290 Lod 1292
-            1295:    7(fvec4) Load 1244(texel)
-            1296:    7(fvec4) FAdd 1295 1294
+            1294:  7(f16vec4) ImageFetch 1293 1290 Lod 1292
+            1295:  7(f16vec4) Load 1244(texel)
+            1296:  7(f16vec4) FAdd 1295 1294
                               Store 1244(texel) 1296
             1301:        1298 Load 1300(sBuffer)
             1302:   52(float) Load 128(c1)
             1303:     47(int) ConvertFToS 1302
             1304:        1297 Image 1301
-            1305:    7(fvec4) ImageFetch 1304 1303
-            1306:    7(fvec4) Load 1244(texel)
-            1307:    7(fvec4) FAdd 1306 1305
+            1305:  7(f16vec4) ImageFetch 1304 1303
+            1306:  7(f16vec4) Load 1244(texel)
+            1307:  7(f16vec4) FAdd 1306 1305
                               Store 1244(texel) 1307
             1312:        1309 Load 1311(s2DMS)
             1313:   53(fvec2) Load 148(c2)
             1314:  721(ivec2) ConvertFToS 1313
             1315:        1308 Image 1312
-            1316:    7(fvec4) ImageFetch 1315 1314 Sample 709
-            1317:    7(fvec4) Load 1244(texel)
-            1318:    7(fvec4) FAdd 1317 1316
+            1316:  7(f16vec4) ImageFetch 1315 1314 Sample 709
+            1317:  7(f16vec4) Load 1244(texel)
+            1318:  7(f16vec4) FAdd 1317 1316
                               Store 1244(texel) 1318
             1323:        1320 Load 1322(s2DMSArray)
             1324:  167(fvec3) Load 169(c3)
             1325:  734(ivec3) ConvertFToS 1324
             1327:        1319 Image 1323
-            1328:    7(fvec4) ImageFetch 1327 1325 Sample 1326
-            1329:    7(fvec4) Load 1244(texel)
-            1330:    7(fvec4) FAdd 1329 1328
+            1328:  7(f16vec4) ImageFetch 1327 1325 Sample 1326
+            1329:  7(f16vec4) Load 1244(texel)
+            1330:  7(f16vec4) FAdd 1329 1328
                               Store 1244(texel) 1330
-            1331:    7(fvec4) Load 1244(texel)
+            1331:  7(f16vec4) Load 1244(texel)
                               ReturnValue 1331
                               FunctionEnd
-25(testTexelFetchOffset():    7(fvec4) Function None 8
+25(testTexelFetchOffset():  7(f16vec4) Function None 8
               26:             Label
      1334(texel):     64(ptr) Variable Function
                               Store 1334(texel) 121
@@ -2037,9 +2037,9 @@ spv.float16Fetch.frag
             1338:   52(float) Load 565(lod)
             1339:     47(int) ConvertFToS 1338
             1340:         122 Image 1335
-            1341:    7(fvec4) ImageFetch 1340 1337 Lod ConstOffset 1339 709
-            1342:    7(fvec4) Load 1334(texel)
-            1343:    7(fvec4) FAdd 1342 1341
+            1341:  7(f16vec4) ImageFetch 1340 1337 Lod ConstOffset 1339 709
+            1342:  7(f16vec4) Load 1334(texel)
+            1343:  7(f16vec4) FAdd 1342 1341
                               Store 1334(texel) 1343
             1344:         143 Load 145(s2D)
             1345:   53(fvec2) Load 148(c2)
@@ -2047,9 +2047,9 @@ spv.float16Fetch.frag
             1347:   52(float) Load 565(lod)
             1348:     47(int) ConvertFToS 1347
             1349:         142 Image 1344
-            1350:    7(fvec4) ImageFetch 1349 1346 Lod ConstOffset 1348 722
-            1351:    7(fvec4) Load 1334(texel)
-            1352:    7(fvec4) FAdd 1351 1350
+            1350:  7(f16vec4) ImageFetch 1349 1346 Lod ConstOffset 1348 722
+            1351:  7(f16vec4) Load 1334(texel)
+            1352:  7(f16vec4) FAdd 1351 1350
                               Store 1334(texel) 1352
             1353:         163 Load 165(s3D)
             1354:  167(fvec3) Load 169(c3)
@@ -2057,17 +2057,17 @@ spv.float16Fetch.frag
             1356:   52(float) Load 565(lod)
             1357:     47(int) ConvertFToS 1356
             1358:         162 Image 1353
-            1359:    7(fvec4) ImageFetch 1358 1355 Lod ConstOffset 1357 735
-            1360:    7(fvec4) Load 1334(texel)
-            1361:    7(fvec4) FAdd 1360 1359
+            1359:  7(f16vec4) ImageFetch 1358 1355 Lod ConstOffset 1357 735
+            1360:  7(f16vec4) Load 1334(texel)
+            1361:  7(f16vec4) FAdd 1360 1359
                               Store 1334(texel) 1361
             1362:         357 Load 359(s2DRect)
             1363:   53(fvec2) Load 148(c2)
             1364:  721(ivec2) ConvertFToS 1363
             1365:         356 Image 1362
-            1366:    7(fvec4) ImageFetch 1365 1364 ConstOffset 722
-            1367:    7(fvec4) Load 1334(texel)
-            1368:    7(fvec4) FAdd 1367 1366
+            1366:  7(f16vec4) ImageFetch 1365 1364 ConstOffset 722
+            1367:  7(f16vec4) Load 1334(texel)
+            1368:  7(f16vec4) FAdd 1367 1366
                               Store 1334(texel) 1368
             1369:         269 Load 271(s1DArray)
             1370:   53(fvec2) Load 148(c2)
@@ -2075,9 +2075,9 @@ spv.float16Fetch.frag
             1372:   52(float) Load 565(lod)
             1373:     47(int) ConvertFToS 1372
             1374:         268 Image 1369
-            1375:    7(fvec4) ImageFetch 1374 1371 Lod ConstOffset 1373 709
-            1376:    7(fvec4) Load 1334(texel)
-            1377:    7(fvec4) FAdd 1376 1375
+            1375:  7(f16vec4) ImageFetch 1374 1371 Lod ConstOffset 1373 709
+            1376:  7(f16vec4) Load 1334(texel)
+            1377:  7(f16vec4) FAdd 1376 1375
                               Store 1334(texel) 1377
             1378:         284 Load 286(s2DArray)
             1379:  167(fvec3) Load 169(c3)
@@ -2085,14 +2085,14 @@ spv.float16Fetch.frag
             1381:   52(float) Load 565(lod)
             1382:     47(int) ConvertFToS 1381
             1383:         283 Image 1378
-            1384:    7(fvec4) ImageFetch 1383 1380 Lod ConstOffset 1382 722
-            1385:    7(fvec4) Load 1334(texel)
-            1386:    7(fvec4) FAdd 1385 1384
+            1384:  7(f16vec4) ImageFetch 1383 1380 Lod ConstOffset 1382 722
+            1385:  7(f16vec4) Load 1334(texel)
+            1386:  7(f16vec4) FAdd 1385 1384
                               Store 1334(texel) 1386
-            1387:    7(fvec4) Load 1334(texel)
+            1387:  7(f16vec4) Load 1334(texel)
                               ReturnValue 1387
                               FunctionEnd
-27(testTextureGrad():    7(fvec4) Function None 8
+27(testTextureGrad():  7(f16vec4) Function None 8
               28:             Label
      1390(texel):     64(ptr) Variable Function
                               Store 1390(texel) 121
@@ -2100,102 +2100,102 @@ spv.float16Fetch.frag
             1392:   52(float) Load 128(c1)
             1394:   52(float) Load 1393(dPdxy1)
             1395:   52(float) Load 1393(dPdxy1)
-            1396:    7(fvec4) ImageSampleExplicitLod 1391 1392 Grad 1394 1395
-            1397:    7(fvec4) Load 1390(texel)
-            1398:    7(fvec4) FAdd 1397 1396
+            1396:  7(f16vec4) ImageSampleExplicitLod 1391 1392 Grad 1394 1395
+            1397:  7(f16vec4) Load 1390(texel)
+            1398:  7(f16vec4) FAdd 1397 1396
                               Store 1390(texel) 1398
             1399:         123 Load 125(s1D)
-            1400:    6(float) Load 135(f16c1)
-            1402:    6(float) Load 1401(f16dPdxy1)
-            1403:    6(float) Load 1401(f16dPdxy1)
-            1404:    7(fvec4) ImageSampleExplicitLod 1399 1400 Grad 1402 1403
-            1405:    7(fvec4) Load 1390(texel)
-            1406:    7(fvec4) FAdd 1405 1404
+            1400:6(float16_t) Load 135(f16c1)
+            1402:6(float16_t) Load 1401(f16dPdxy1)
+            1403:6(float16_t) Load 1401(f16dPdxy1)
+            1404:  7(f16vec4) ImageSampleExplicitLod 1399 1400 Grad 1402 1403
+            1405:  7(f16vec4) Load 1390(texel)
+            1406:  7(f16vec4) FAdd 1405 1404
                               Store 1390(texel) 1406
             1407:         143 Load 145(s2D)
             1408:   53(fvec2) Load 148(c2)
             1410:   53(fvec2) Load 1409(dPdxy2)
             1411:   53(fvec2) Load 1409(dPdxy2)
-            1412:    7(fvec4) ImageSampleExplicitLod 1407 1408 Grad 1410 1411
-            1413:    7(fvec4) Load 1390(texel)
-            1414:    7(fvec4) FAdd 1413 1412
+            1412:  7(f16vec4) ImageSampleExplicitLod 1407 1408 Grad 1410 1411
+            1413:  7(f16vec4) Load 1390(texel)
+            1414:  7(f16vec4) FAdd 1413 1412
                               Store 1390(texel) 1414
             1415:         143 Load 145(s2D)
-            1416:  154(fvec2) Load 156(f16c2)
-            1418:  154(fvec2) Load 1417(f16dPdxy2)
-            1419:  154(fvec2) Load 1417(f16dPdxy2)
-            1420:    7(fvec4) ImageSampleExplicitLod 1415 1416 Grad 1418 1419
-            1421:    7(fvec4) Load 1390(texel)
-            1422:    7(fvec4) FAdd 1421 1420
+            1416:154(f16vec2) Load 156(f16c2)
+            1418:154(f16vec2) Load 1417(f16dPdxy2)
+            1419:154(f16vec2) Load 1417(f16dPdxy2)
+            1420:  7(f16vec4) ImageSampleExplicitLod 1415 1416 Grad 1418 1419
+            1421:  7(f16vec4) Load 1390(texel)
+            1422:  7(f16vec4) FAdd 1421 1420
                               Store 1390(texel) 1422
             1423:         163 Load 165(s3D)
             1424:  167(fvec3) Load 169(c3)
             1426:  167(fvec3) Load 1425(dPdxy3)
             1427:  167(fvec3) Load 1425(dPdxy3)
-            1428:    7(fvec4) ImageSampleExplicitLod 1423 1424 Grad 1426 1427
-            1429:    7(fvec4) Load 1390(texel)
-            1430:    7(fvec4) FAdd 1429 1428
+            1428:  7(f16vec4) ImageSampleExplicitLod 1423 1424 Grad 1426 1427
+            1429:  7(f16vec4) Load 1390(texel)
+            1430:  7(f16vec4) FAdd 1429 1428
                               Store 1390(texel) 1430
             1431:         163 Load 165(s3D)
-            1432:  175(fvec3) Load 177(f16c3)
-            1434:  175(fvec3) Load 1433(f16dPdxy3)
-            1435:  175(fvec3) Load 1433(f16dPdxy3)
-            1436:    7(fvec4) ImageSampleExplicitLod 1431 1432 Grad 1434 1435
-            1437:    7(fvec4) Load 1390(texel)
-            1438:    7(fvec4) FAdd 1437 1436
+            1432:175(f16vec3) Load 177(f16c3)
+            1434:175(f16vec3) Load 1433(f16dPdxy3)
+            1435:175(f16vec3) Load 1433(f16dPdxy3)
+            1436:  7(f16vec4) ImageSampleExplicitLod 1431 1432 Grad 1434 1435
+            1437:  7(f16vec4) Load 1390(texel)
+            1438:  7(f16vec4) FAdd 1437 1436
                               Store 1390(texel) 1438
             1439:         184 Load 186(sCube)
             1440:  167(fvec3) Load 169(c3)
             1441:  167(fvec3) Load 1425(dPdxy3)
             1442:  167(fvec3) Load 1425(dPdxy3)
-            1443:    7(fvec4) ImageSampleExplicitLod 1439 1440 Grad 1441 1442
-            1444:    7(fvec4) Load 1390(texel)
-            1445:    7(fvec4) FAdd 1444 1443
+            1443:  7(f16vec4) ImageSampleExplicitLod 1439 1440 Grad 1441 1442
+            1444:  7(f16vec4) Load 1390(texel)
+            1445:  7(f16vec4) FAdd 1444 1443
                               Store 1390(texel) 1445
             1446:         184 Load 186(sCube)
-            1447:  175(fvec3) Load 177(f16c3)
-            1448:  175(fvec3) Load 1433(f16dPdxy3)
-            1449:  175(fvec3) Load 1433(f16dPdxy3)
-            1450:    7(fvec4) ImageSampleExplicitLod 1446 1447 Grad 1448 1449
-            1451:    7(fvec4) Load 1390(texel)
-            1452:    7(fvec4) FAdd 1451 1450
+            1447:175(f16vec3) Load 177(f16c3)
+            1448:175(f16vec3) Load 1433(f16dPdxy3)
+            1449:175(f16vec3) Load 1433(f16dPdxy3)
+            1450:  7(f16vec4) ImageSampleExplicitLod 1446 1447 Grad 1448 1449
+            1451:  7(f16vec4) Load 1390(texel)
+            1452:  7(f16vec4) FAdd 1451 1450
                               Store 1390(texel) 1452
             1453:         357 Load 359(s2DRect)
             1454:   53(fvec2) Load 148(c2)
             1455:   53(fvec2) Load 1409(dPdxy2)
             1456:   53(fvec2) Load 1409(dPdxy2)
-            1457:    7(fvec4) ImageSampleExplicitLod 1453 1454 Grad 1455 1456
-            1458:    7(fvec4) Load 1390(texel)
-            1459:    7(fvec4) FAdd 1458 1457
+            1457:  7(f16vec4) ImageSampleExplicitLod 1453 1454 Grad 1455 1456
+            1458:  7(f16vec4) Load 1390(texel)
+            1459:  7(f16vec4) FAdd 1458 1457
                               Store 1390(texel) 1459
             1460:         357 Load 359(s2DRect)
-            1461:  154(fvec2) Load 156(f16c2)
-            1462:  154(fvec2) Load 1417(f16dPdxy2)
-            1463:  154(fvec2) Load 1417(f16dPdxy2)
-            1464:    7(fvec4) ImageSampleExplicitLod 1460 1461 Grad 1462 1463
-            1465:    7(fvec4) Load 1390(texel)
-            1466:    7(fvec4) FAdd 1465 1464
+            1461:154(f16vec2) Load 156(f16c2)
+            1462:154(f16vec2) Load 1417(f16dPdxy2)
+            1463:154(f16vec2) Load 1417(f16dPdxy2)
+            1464:  7(f16vec4) ImageSampleExplicitLod 1460 1461 Grad 1462 1463
+            1465:  7(f16vec4) Load 1390(texel)
+            1466:  7(f16vec4) FAdd 1465 1464
                               Store 1390(texel) 1466
             1467:         371 Load 373(s2DRectShadow)
             1468:  167(fvec3) Load 169(c3)
             1469:   53(fvec2) Load 1409(dPdxy2)
             1470:   53(fvec2) Load 1409(dPdxy2)
             1471:   52(float) CompositeExtract 1468 2
-            1472:    6(float) ImageSampleDrefExplicitLod 1467 1468 1471 Grad 1469 1470
+            1472:6(float16_t) ImageSampleDrefExplicitLod 1467 1468 1471 Grad 1469 1470
             1473:    208(ptr) AccessChain 1390(texel) 207
-            1474:    6(float) Load 1473
-            1475:    6(float) FAdd 1474 1472
+            1474:6(float16_t) Load 1473
+            1475:6(float16_t) FAdd 1474 1472
             1476:    208(ptr) AccessChain 1390(texel) 207
                               Store 1476 1475
             1477:         371 Load 373(s2DRectShadow)
-            1478:  154(fvec2) Load 156(f16c2)
+            1478:154(f16vec2) Load 156(f16c2)
             1479:   52(float) Load 215(compare)
-            1480:  154(fvec2) Load 1417(f16dPdxy2)
-            1481:  154(fvec2) Load 1417(f16dPdxy2)
-            1482:    6(float) ImageSampleDrefExplicitLod 1477 1478 1479 Grad 1480 1481
+            1480:154(f16vec2) Load 1417(f16dPdxy2)
+            1481:154(f16vec2) Load 1417(f16dPdxy2)
+            1482:6(float16_t) ImageSampleDrefExplicitLod 1477 1478 1479 Grad 1480 1481
             1483:    208(ptr) AccessChain 1390(texel) 207
-            1484:    6(float) Load 1483
-            1485:    6(float) FAdd 1484 1482
+            1484:6(float16_t) Load 1483
+            1485:6(float16_t) FAdd 1484 1482
             1486:    208(ptr) AccessChain 1390(texel) 207
                               Store 1486 1485
             1487:         199 Load 201(s1DShadow)
@@ -2203,21 +2203,21 @@ spv.float16Fetch.frag
             1489:   52(float) Load 1393(dPdxy1)
             1490:   52(float) Load 1393(dPdxy1)
             1491:   52(float) CompositeExtract 1488 2
-            1492:    6(float) ImageSampleDrefExplicitLod 1487 1488 1491 Grad 1489 1490
+            1492:6(float16_t) ImageSampleDrefExplicitLod 1487 1488 1491 Grad 1489 1490
             1493:    208(ptr) AccessChain 1390(texel) 207
-            1494:    6(float) Load 1493
-            1495:    6(float) FAdd 1494 1492
+            1494:6(float16_t) Load 1493
+            1495:6(float16_t) FAdd 1494 1492
             1496:    208(ptr) AccessChain 1390(texel) 207
                               Store 1496 1495
             1497:         199 Load 201(s1DShadow)
-            1498:  154(fvec2) Load 156(f16c2)
+            1498:154(f16vec2) Load 156(f16c2)
             1499:   52(float) Load 215(compare)
-            1500:    6(float) Load 1401(f16dPdxy1)
-            1501:    6(float) Load 1401(f16dPdxy1)
-            1502:    6(float) ImageSampleDrefExplicitLod 1497 1498 1499 Grad 1500 1501
+            1500:6(float16_t) Load 1401(f16dPdxy1)
+            1501:6(float16_t) Load 1401(f16dPdxy1)
+            1502:6(float16_t) ImageSampleDrefExplicitLod 1497 1498 1499 Grad 1500 1501
             1503:    208(ptr) AccessChain 1390(texel) 207
-            1504:    6(float) Load 1503
-            1505:    6(float) FAdd 1504 1502
+            1504:6(float16_t) Load 1503
+            1505:6(float16_t) FAdd 1504 1502
             1506:    208(ptr) AccessChain 1390(texel) 207
                               Store 1506 1505
             1507:         224 Load 226(s2DShadow)
@@ -2225,21 +2225,21 @@ spv.float16Fetch.frag
             1509:   53(fvec2) Load 1409(dPdxy2)
             1510:   53(fvec2) Load 1409(dPdxy2)
             1511:   52(float) CompositeExtract 1508 2
-            1512:    6(float) ImageSampleDrefExplicitLod 1507 1508 1511 Grad 1509 1510
+            1512:6(float16_t) ImageSampleDrefExplicitLod 1507 1508 1511 Grad 1509 1510
             1513:    208(ptr) AccessChain 1390(texel) 207
-            1514:    6(float) Load 1513
-            1515:    6(float) FAdd 1514 1512
+            1514:6(float16_t) Load 1513
+            1515:6(float16_t) FAdd 1514 1512
             1516:    208(ptr) AccessChain 1390(texel) 207
                               Store 1516 1515
             1517:         224 Load 226(s2DShadow)
-            1518:  154(fvec2) Load 156(f16c2)
+            1518:154(f16vec2) Load 156(f16c2)
             1519:   52(float) Load 215(compare)
-            1520:  154(fvec2) Load 1417(f16dPdxy2)
-            1521:  154(fvec2) Load 1417(f16dPdxy2)
-            1522:    6(float) ImageSampleDrefExplicitLod 1517 1518 1519 Grad 1520 1521
+            1520:154(f16vec2) Load 1417(f16dPdxy2)
+            1521:154(f16vec2) Load 1417(f16dPdxy2)
+            1522:6(float16_t) ImageSampleDrefExplicitLod 1517 1518 1519 Grad 1520 1521
             1523:    208(ptr) AccessChain 1390(texel) 207
-            1524:    6(float) Load 1523
-            1525:    6(float) FAdd 1524 1522
+            1524:6(float16_t) Load 1523
+            1525:6(float16_t) FAdd 1524 1522
             1526:    208(ptr) AccessChain 1390(texel) 207
                               Store 1526 1525
             1527:         245 Load 247(sCubeShadow)
@@ -2247,75 +2247,75 @@ spv.float16Fetch.frag
             1529:  167(fvec3) Load 1425(dPdxy3)
             1530:  167(fvec3) Load 1425(dPdxy3)
             1531:   52(float) CompositeExtract 1528 3
-            1532:    6(float) ImageSampleDrefExplicitLod 1527 1528 1531 Grad 1529 1530
+            1532:6(float16_t) ImageSampleDrefExplicitLod 1527 1528 1531 Grad 1529 1530
             1533:    208(ptr) AccessChain 1390(texel) 207
-            1534:    6(float) Load 1533
-            1535:    6(float) FAdd 1534 1532
+            1534:6(float16_t) Load 1533
+            1535:6(float16_t) FAdd 1534 1532
             1536:    208(ptr) AccessChain 1390(texel) 207
                               Store 1536 1535
             1537:         245 Load 247(sCubeShadow)
-            1538:  175(fvec3) Load 177(f16c3)
+            1538:175(f16vec3) Load 177(f16c3)
             1539:   52(float) Load 215(compare)
-            1540:  175(fvec3) Load 1433(f16dPdxy3)
-            1541:  175(fvec3) Load 1433(f16dPdxy3)
-            1542:    6(float) ImageSampleDrefExplicitLod 1537 1538 1539 Grad 1540 1541
+            1540:175(f16vec3) Load 1433(f16dPdxy3)
+            1541:175(f16vec3) Load 1433(f16dPdxy3)
+            1542:6(float16_t) ImageSampleDrefExplicitLod 1537 1538 1539 Grad 1540 1541
             1543:    208(ptr) AccessChain 1390(texel) 207
-            1544:    6(float) Load 1543
-            1545:    6(float) FAdd 1544 1542
+            1544:6(float16_t) Load 1543
+            1545:6(float16_t) FAdd 1544 1542
             1546:    208(ptr) AccessChain 1390(texel) 207
                               Store 1546 1545
             1547:         269 Load 271(s1DArray)
             1548:   53(fvec2) Load 148(c2)
             1549:   52(float) Load 1393(dPdxy1)
             1550:   52(float) Load 1393(dPdxy1)
-            1551:    7(fvec4) ImageSampleExplicitLod 1547 1548 Grad 1549 1550
-            1552:    7(fvec4) Load 1390(texel)
-            1553:    7(fvec4) FAdd 1552 1551
+            1551:  7(f16vec4) ImageSampleExplicitLod 1547 1548 Grad 1549 1550
+            1552:  7(f16vec4) Load 1390(texel)
+            1553:  7(f16vec4) FAdd 1552 1551
                               Store 1390(texel) 1553
             1554:         269 Load 271(s1DArray)
-            1555:  154(fvec2) Load 156(f16c2)
-            1556:    6(float) Load 1401(f16dPdxy1)
-            1557:    6(float) Load 1401(f16dPdxy1)
-            1558:    7(fvec4) ImageSampleExplicitLod 1554 1555 Grad 1556 1557
-            1559:    7(fvec4) Load 1390(texel)
-            1560:    7(fvec4) FAdd 1559 1558
+            1555:154(f16vec2) Load 156(f16c2)
+            1556:6(float16_t) Load 1401(f16dPdxy1)
+            1557:6(float16_t) Load 1401(f16dPdxy1)
+            1558:  7(f16vec4) ImageSampleExplicitLod 1554 1555 Grad 1556 1557
+            1559:  7(f16vec4) Load 1390(texel)
+            1560:  7(f16vec4) FAdd 1559 1558
                               Store 1390(texel) 1560
             1561:         284 Load 286(s2DArray)
             1562:  167(fvec3) Load 169(c3)
             1563:   53(fvec2) Load 1409(dPdxy2)
             1564:   53(fvec2) Load 1409(dPdxy2)
-            1565:    7(fvec4) ImageSampleExplicitLod 1561 1562 Grad 1563 1564
-            1566:    7(fvec4) Load 1390(texel)
-            1567:    7(fvec4) FAdd 1566 1565
+            1565:  7(f16vec4) ImageSampleExplicitLod 1561 1562 Grad 1563 1564
+            1566:  7(f16vec4) Load 1390(texel)
+            1567:  7(f16vec4) FAdd 1566 1565
                               Store 1390(texel) 1567
             1568:         284 Load 286(s2DArray)
-            1569:  175(fvec3) Load 177(f16c3)
-            1570:  154(fvec2) Load 1417(f16dPdxy2)
-            1571:  154(fvec2) Load 1417(f16dPdxy2)
-            1572:    7(fvec4) ImageSampleExplicitLod 1568 1569 Grad 1570 1571
-            1573:    7(fvec4) Load 1390(texel)
-            1574:    7(fvec4) FAdd 1573 1572
+            1569:175(f16vec3) Load 177(f16c3)
+            1570:154(f16vec2) Load 1417(f16dPdxy2)
+            1571:154(f16vec2) Load 1417(f16dPdxy2)
+            1572:  7(f16vec4) ImageSampleExplicitLod 1568 1569 Grad 1570 1571
+            1573:  7(f16vec4) Load 1390(texel)
+            1574:  7(f16vec4) FAdd 1573 1572
                               Store 1390(texel) 1574
             1575:         316 Load 318(s1DArrayShadow)
             1576:  167(fvec3) Load 169(c3)
             1577:   52(float) Load 1393(dPdxy1)
             1578:   52(float) Load 1393(dPdxy1)
             1579:   52(float) CompositeExtract 1576 2
-            1580:    6(float) ImageSampleDrefExplicitLod 1575 1576 1579 Grad 1577 1578
+            1580:6(float16_t) ImageSampleDrefExplicitLod 1575 1576 1579 Grad 1577 1578
             1581:    208(ptr) AccessChain 1390(texel) 207
-            1582:    6(float) Load 1581
-            1583:    6(float) FAdd 1582 1580
+            1582:6(float16_t) Load 1581
+            1583:6(float16_t) FAdd 1582 1580
             1584:    208(ptr) AccessChain 1390(texel) 207
                               Store 1584 1583
             1585:         316 Load 318(s1DArrayShadow)
-            1586:  154(fvec2) Load 156(f16c2)
+            1586:154(f16vec2) Load 156(f16c2)
             1587:   52(float) Load 215(compare)
-            1588:    6(float) Load 1401(f16dPdxy1)
-            1589:    6(float) Load 1401(f16dPdxy1)
-            1590:    6(float) ImageSampleDrefExplicitLod 1585 1586 1587 Grad 1588 1589
+            1588:6(float16_t) Load 1401(f16dPdxy1)
+            1589:6(float16_t) Load 1401(f16dPdxy1)
+            1590:6(float16_t) ImageSampleDrefExplicitLod 1585 1586 1587 Grad 1588 1589
             1591:    208(ptr) AccessChain 1390(texel) 207
-            1592:    6(float) Load 1591
-            1593:    6(float) FAdd 1592 1590
+            1592:6(float16_t) Load 1591
+            1593:6(float16_t) FAdd 1592 1590
             1594:    208(ptr) AccessChain 1390(texel) 207
                               Store 1594 1593
             1595:         337 Load 339(s2DArrayShadow)
@@ -2323,43 +2323,43 @@ spv.float16Fetch.frag
             1597:   53(fvec2) Load 1409(dPdxy2)
             1598:   53(fvec2) Load 1409(dPdxy2)
             1599:   52(float) CompositeExtract 1596 3
-            1600:    6(float) ImageSampleDrefExplicitLod 1595 1596 1599 Grad 1597 1598
+            1600:6(float16_t) ImageSampleDrefExplicitLod 1595 1596 1599 Grad 1597 1598
             1601:    208(ptr) AccessChain 1390(texel) 207
-            1602:    6(float) Load 1601
-            1603:    6(float) FAdd 1602 1600
+            1602:6(float16_t) Load 1601
+            1603:6(float16_t) FAdd 1602 1600
             1604:    208(ptr) AccessChain 1390(texel) 207
                               Store 1604 1603
             1605:         337 Load 339(s2DArrayShadow)
-            1606:  175(fvec3) Load 177(f16c3)
+            1606:175(f16vec3) Load 177(f16c3)
             1607:   52(float) Load 215(compare)
-            1608:  154(fvec2) Load 1417(f16dPdxy2)
-            1609:  154(fvec2) Load 1417(f16dPdxy2)
-            1610:    6(float) ImageSampleDrefExplicitLod 1605 1606 1607 Grad 1608 1609
+            1608:154(f16vec2) Load 1417(f16dPdxy2)
+            1609:154(f16vec2) Load 1417(f16dPdxy2)
+            1610:6(float16_t) ImageSampleDrefExplicitLod 1605 1606 1607 Grad 1608 1609
             1611:    208(ptr) AccessChain 1390(texel) 207
-            1612:    6(float) Load 1611
-            1613:    6(float) FAdd 1612 1610
+            1612:6(float16_t) Load 1611
+            1613:6(float16_t) FAdd 1612 1610
             1614:    208(ptr) AccessChain 1390(texel) 207
                               Store 1614 1613
             1615:         299 Load 301(sCubeArray)
             1616:  249(fvec4) Load 251(c4)
             1617:  167(fvec3) Load 1425(dPdxy3)
             1618:  167(fvec3) Load 1425(dPdxy3)
-            1619:    7(fvec4) ImageSampleExplicitLod 1615 1616 Grad 1617 1618
-            1620:    7(fvec4) Load 1390(texel)
-            1621:    7(fvec4) FAdd 1620 1619
+            1619:  7(f16vec4) ImageSampleExplicitLod 1615 1616 Grad 1617 1618
+            1620:  7(f16vec4) Load 1390(texel)
+            1621:  7(f16vec4) FAdd 1620 1619
                               Store 1390(texel) 1621
             1622:         299 Load 301(sCubeArray)
-            1623:    7(fvec4) Load 309(f16c4)
-            1624:  175(fvec3) Load 1433(f16dPdxy3)
-            1625:  175(fvec3) Load 1433(f16dPdxy3)
-            1626:    7(fvec4) ImageSampleExplicitLod 1622 1623 Grad 1624 1625
-            1627:    7(fvec4) Load 1390(texel)
-            1628:    7(fvec4) FAdd 1627 1626
+            1623:  7(f16vec4) Load 309(f16c4)
+            1624:175(f16vec3) Load 1433(f16dPdxy3)
+            1625:175(f16vec3) Load 1433(f16dPdxy3)
+            1626:  7(f16vec4) ImageSampleExplicitLod 1622 1623 Grad 1624 1625
+            1627:  7(f16vec4) Load 1390(texel)
+            1628:  7(f16vec4) FAdd 1627 1626
                               Store 1390(texel) 1628
-            1629:    7(fvec4) Load 1390(texel)
+            1629:  7(f16vec4) Load 1390(texel)
                               ReturnValue 1629
                               FunctionEnd
-29(testTextureGradOffset():    7(fvec4) Function None 8
+29(testTextureGradOffset():  7(f16vec4) Function None 8
               30:             Label
      1632(texel):     64(ptr) Variable Function
                               Store 1632(texel) 121
@@ -2367,86 +2367,86 @@ spv.float16Fetch.frag
             1634:   52(float) Load 128(c1)
             1635:   52(float) Load 1393(dPdxy1)
             1636:   52(float) Load 1393(dPdxy1)
-            1637:    7(fvec4) ImageSampleExplicitLod 1633 1634 Grad ConstOffset 1635 1636 709
-            1638:    7(fvec4) Load 1632(texel)
-            1639:    7(fvec4) FAdd 1638 1637
+            1637:  7(f16vec4) ImageSampleExplicitLod 1633 1634 Grad ConstOffset 1635 1636 709
+            1638:  7(f16vec4) Load 1632(texel)
+            1639:  7(f16vec4) FAdd 1638 1637
                               Store 1632(texel) 1639
             1640:         123 Load 125(s1D)
-            1641:    6(float) Load 135(f16c1)
-            1642:    6(float) Load 1401(f16dPdxy1)
-            1643:    6(float) Load 1401(f16dPdxy1)
-            1644:    7(fvec4) ImageSampleExplicitLod 1640 1641 Grad ConstOffset 1642 1643 709
-            1645:    7(fvec4) Load 1632(texel)
-            1646:    7(fvec4) FAdd 1645 1644
+            1641:6(float16_t) Load 135(f16c1)
+            1642:6(float16_t) Load 1401(f16dPdxy1)
+            1643:6(float16_t) Load 1401(f16dPdxy1)
+            1644:  7(f16vec4) ImageSampleExplicitLod 1640 1641 Grad ConstOffset 1642 1643 709
+            1645:  7(f16vec4) Load 1632(texel)
+            1646:  7(f16vec4) FAdd 1645 1644
                               Store 1632(texel) 1646
             1647:         143 Load 145(s2D)
             1648:   53(fvec2) Load 148(c2)
             1649:   53(fvec2) Load 1409(dPdxy2)
             1650:   53(fvec2) Load 1409(dPdxy2)
-            1651:    7(fvec4) ImageSampleExplicitLod 1647 1648 Grad ConstOffset 1649 1650 722
-            1652:    7(fvec4) Load 1632(texel)
-            1653:    7(fvec4) FAdd 1652 1651
+            1651:  7(f16vec4) ImageSampleExplicitLod 1647 1648 Grad ConstOffset 1649 1650 722
+            1652:  7(f16vec4) Load 1632(texel)
+            1653:  7(f16vec4) FAdd 1652 1651
                               Store 1632(texel) 1653
             1654:         143 Load 145(s2D)
-            1655:  154(fvec2) Load 156(f16c2)
-            1656:  154(fvec2) Load 1417(f16dPdxy2)
-            1657:  154(fvec2) Load 1417(f16dPdxy2)
-            1658:    7(fvec4) ImageSampleExplicitLod 1654 1655 Grad ConstOffset 1656 1657 722
-            1659:    7(fvec4) Load 1632(texel)
-            1660:    7(fvec4) FAdd 1659 1658
+            1655:154(f16vec2) Load 156(f16c2)
+            1656:154(f16vec2) Load 1417(f16dPdxy2)
+            1657:154(f16vec2) Load 1417(f16dPdxy2)
+            1658:  7(f16vec4) ImageSampleExplicitLod 1654 1655 Grad ConstOffset 1656 1657 722
+            1659:  7(f16vec4) Load 1632(texel)
+            1660:  7(f16vec4) FAdd 1659 1658
                               Store 1632(texel) 1660
             1661:         163 Load 165(s3D)
             1662:  167(fvec3) Load 169(c3)
             1663:  167(fvec3) Load 1425(dPdxy3)
             1664:  167(fvec3) Load 1425(dPdxy3)
-            1665:    7(fvec4) ImageSampleExplicitLod 1661 1662 Grad ConstOffset 1663 1664 735
-            1666:    7(fvec4) Load 1632(texel)
-            1667:    7(fvec4) FAdd 1666 1665
+            1665:  7(f16vec4) ImageSampleExplicitLod 1661 1662 Grad ConstOffset 1663 1664 735
+            1666:  7(f16vec4) Load 1632(texel)
+            1667:  7(f16vec4) FAdd 1666 1665
                               Store 1632(texel) 1667
             1668:         163 Load 165(s3D)
-            1669:  175(fvec3) Load 177(f16c3)
-            1670:  175(fvec3) Load 1433(f16dPdxy3)
-            1671:  175(fvec3) Load 1433(f16dPdxy3)
-            1672:    7(fvec4) ImageSampleExplicitLod 1668 1669 Grad ConstOffset 1670 1671 735
-            1673:    7(fvec4) Load 1632(texel)
-            1674:    7(fvec4) FAdd 1673 1672
+            1669:175(f16vec3) Load 177(f16c3)
+            1670:175(f16vec3) Load 1433(f16dPdxy3)
+            1671:175(f16vec3) Load 1433(f16dPdxy3)
+            1672:  7(f16vec4) ImageSampleExplicitLod 1668 1669 Grad ConstOffset 1670 1671 735
+            1673:  7(f16vec4) Load 1632(texel)
+            1674:  7(f16vec4) FAdd 1673 1672
                               Store 1632(texel) 1674
             1675:         357 Load 359(s2DRect)
             1676:   53(fvec2) Load 148(c2)
             1677:   53(fvec2) Load 1409(dPdxy2)
             1678:   53(fvec2) Load 1409(dPdxy2)
-            1679:    7(fvec4) ImageSampleExplicitLod 1675 1676 Grad ConstOffset 1677 1678 722
-            1680:    7(fvec4) Load 1632(texel)
-            1681:    7(fvec4) FAdd 1680 1679
+            1679:  7(f16vec4) ImageSampleExplicitLod 1675 1676 Grad ConstOffset 1677 1678 722
+            1680:  7(f16vec4) Load 1632(texel)
+            1681:  7(f16vec4) FAdd 1680 1679
                               Store 1632(texel) 1681
             1682:         357 Load 359(s2DRect)
-            1683:  154(fvec2) Load 156(f16c2)
-            1684:  154(fvec2) Load 1417(f16dPdxy2)
-            1685:  154(fvec2) Load 1417(f16dPdxy2)
-            1686:    7(fvec4) ImageSampleExplicitLod 1682 1683 Grad ConstOffset 1684 1685 722
-            1687:    7(fvec4) Load 1632(texel)
-            1688:    7(fvec4) FAdd 1687 1686
+            1683:154(f16vec2) Load 156(f16c2)
+            1684:154(f16vec2) Load 1417(f16dPdxy2)
+            1685:154(f16vec2) Load 1417(f16dPdxy2)
+            1686:  7(f16vec4) ImageSampleExplicitLod 1682 1683 Grad ConstOffset 1684 1685 722
+            1687:  7(f16vec4) Load 1632(texel)
+            1688:  7(f16vec4) FAdd 1687 1686
                               Store 1632(texel) 1688
             1689:         371 Load 373(s2DRectShadow)
             1690:  167(fvec3) Load 169(c3)
             1691:   53(fvec2) Load 1409(dPdxy2)
             1692:   53(fvec2) Load 1409(dPdxy2)
             1693:   52(float) CompositeExtract 1690 2
-            1694:    6(float) ImageSampleDrefExplicitLod 1689 1690 1693 Grad ConstOffset 1691 1692 722
+            1694:6(float16_t) ImageSampleDrefExplicitLod 1689 1690 1693 Grad ConstOffset 1691 1692 722
             1695:    208(ptr) AccessChain 1632(texel) 207
-            1696:    6(float) Load 1695
-            1697:    6(float) FAdd 1696 1694
+            1696:6(float16_t) Load 1695
+            1697:6(float16_t) FAdd 1696 1694
             1698:    208(ptr) AccessChain 1632(texel) 207
                               Store 1698 1697
             1699:         371 Load 373(s2DRectShadow)
-            1700:  154(fvec2) Load 156(f16c2)
+            1700:154(f16vec2) Load 156(f16c2)
             1701:   52(float) Load 215(compare)
-            1702:  154(fvec2) Load 1417(f16dPdxy2)
-            1703:  154(fvec2) Load 1417(f16dPdxy2)
-            1704:    6(float) ImageSampleDrefExplicitLod 1699 1700 1701 Grad ConstOffset 1702 1703 722
+            1702:154(f16vec2) Load 1417(f16dPdxy2)
+            1703:154(f16vec2) Load 1417(f16dPdxy2)
+            1704:6(float16_t) ImageSampleDrefExplicitLod 1699 1700 1701 Grad ConstOffset 1702 1703 722
             1705:    208(ptr) AccessChain 1632(texel) 207
-            1706:    6(float) Load 1705
-            1707:    6(float) FAdd 1706 1704
+            1706:6(float16_t) Load 1705
+            1707:6(float16_t) FAdd 1706 1704
             1708:    208(ptr) AccessChain 1632(texel) 207
                               Store 1708 1707
             1709:         199 Load 201(s1DShadow)
@@ -2454,21 +2454,21 @@ spv.float16Fetch.frag
             1711:   52(float) Load 1393(dPdxy1)
             1712:   52(float) Load 1393(dPdxy1)
             1713:   52(float) CompositeExtract 1710 2
-            1714:    6(float) ImageSampleDrefExplicitLod 1709 1710 1713 Grad ConstOffset 1711 1712 709
+            1714:6(float16_t) ImageSampleDrefExplicitLod 1709 1710 1713 Grad ConstOffset 1711 1712 709
             1715:    208(ptr) AccessChain 1632(texel) 207
-            1716:    6(float) Load 1715
-            1717:    6(float) FAdd 1716 1714
+            1716:6(float16_t) Load 1715
+            1717:6(float16_t) FAdd 1716 1714
             1718:    208(ptr) AccessChain 1632(texel) 207
                               Store 1718 1717
             1719:         199 Load 201(s1DShadow)
-            1720:  154(fvec2) Load 156(f16c2)
+            1720:154(f16vec2) Load 156(f16c2)
             1721:   52(float) Load 215(compare)
-            1722:    6(float) Load 1401(f16dPdxy1)
-            1723:    6(float) Load 1401(f16dPdxy1)
-            1724:    6(float) ImageSampleDrefExplicitLod 1719 1720 1721 Grad ConstOffset 1722 1723 709
+            1722:6(float16_t) Load 1401(f16dPdxy1)
+            1723:6(float16_t) Load 1401(f16dPdxy1)
+            1724:6(float16_t) ImageSampleDrefExplicitLod 1719 1720 1721 Grad ConstOffset 1722 1723 709
             1725:    208(ptr) AccessChain 1632(texel) 207
-            1726:    6(float) Load 1725
-            1727:    6(float) FAdd 1726 1724
+            1726:6(float16_t) Load 1725
+            1727:6(float16_t) FAdd 1726 1724
             1728:    208(ptr) AccessChain 1632(texel) 207
                               Store 1728 1727
             1729:         224 Load 226(s2DShadow)
@@ -2476,75 +2476,75 @@ spv.float16Fetch.frag
             1731:   53(fvec2) Load 1409(dPdxy2)
             1732:   53(fvec2) Load 1409(dPdxy2)
             1733:   52(float) CompositeExtract 1730 2
-            1734:    6(float) ImageSampleDrefExplicitLod 1729 1730 1733 Grad ConstOffset 1731 1732 722
+            1734:6(float16_t) ImageSampleDrefExplicitLod 1729 1730 1733 Grad ConstOffset 1731 1732 722
             1735:    208(ptr) AccessChain 1632(texel) 207
-            1736:    6(float) Load 1735
-            1737:    6(float) FAdd 1736 1734
+            1736:6(float16_t) Load 1735
+            1737:6(float16_t) FAdd 1736 1734
             1738:    208(ptr) AccessChain 1632(texel) 207
                               Store 1738 1737
             1739:         224 Load 226(s2DShadow)
-            1740:  154(fvec2) Load 156(f16c2)
+            1740:154(f16vec2) Load 156(f16c2)
             1741:   52(float) Load 215(compare)
-            1742:  154(fvec2) Load 1417(f16dPdxy2)
-            1743:  154(fvec2) Load 1417(f16dPdxy2)
-            1744:    6(float) ImageSampleDrefExplicitLod 1739 1740 1741 Grad ConstOffset 1742 1743 722
+            1742:154(f16vec2) Load 1417(f16dPdxy2)
+            1743:154(f16vec2) Load 1417(f16dPdxy2)
+            1744:6(float16_t) ImageSampleDrefExplicitLod 1739 1740 1741 Grad ConstOffset 1742 1743 722
             1745:    208(ptr) AccessChain 1632(texel) 207
-            1746:    6(float) Load 1745
-            1747:    6(float) FAdd 1746 1744
+            1746:6(float16_t) Load 1745
+            1747:6(float16_t) FAdd 1746 1744
             1748:    208(ptr) AccessChain 1632(texel) 207
                               Store 1748 1747
             1749:         269 Load 271(s1DArray)
             1750:   53(fvec2) Load 148(c2)
             1751:   52(float) Load 1393(dPdxy1)
             1752:   52(float) Load 1393(dPdxy1)
-            1753:    7(fvec4) ImageSampleExplicitLod 1749 1750 Grad ConstOffset 1751 1752 709
-            1754:    7(fvec4) Load 1632(texel)
-            1755:    7(fvec4) FAdd 1754 1753
+            1753:  7(f16vec4) ImageSampleExplicitLod 1749 1750 Grad ConstOffset 1751 1752 709
+            1754:  7(f16vec4) Load 1632(texel)
+            1755:  7(f16vec4) FAdd 1754 1753
                               Store 1632(texel) 1755
             1756:         269 Load 271(s1DArray)
-            1757:  154(fvec2) Load 156(f16c2)
-            1758:    6(float) Load 1401(f16dPdxy1)
-            1759:    6(float) Load 1401(f16dPdxy1)
-            1760:    7(fvec4) ImageSampleExplicitLod 1756 1757 Grad ConstOffset 1758 1759 709
-            1761:    7(fvec4) Load 1632(texel)
-            1762:    7(fvec4) FAdd 1761 1760
+            1757:154(f16vec2) Load 156(f16c2)
+            1758:6(float16_t) Load 1401(f16dPdxy1)
+            1759:6(float16_t) Load 1401(f16dPdxy1)
+            1760:  7(f16vec4) ImageSampleExplicitLod 1756 1757 Grad ConstOffset 1758 1759 709
+            1761:  7(f16vec4) Load 1632(texel)
+            1762:  7(f16vec4) FAdd 1761 1760
                               Store 1632(texel) 1762
             1763:         284 Load 286(s2DArray)
             1764:  167(fvec3) Load 169(c3)
             1765:   53(fvec2) Load 1409(dPdxy2)
             1766:   53(fvec2) Load 1409(dPdxy2)
-            1767:    7(fvec4) ImageSampleExplicitLod 1763 1764 Grad ConstOffset 1765 1766 722
-            1768:    7(fvec4) Load 1632(texel)
-            1769:    7(fvec4) FAdd 1768 1767
+            1767:  7(f16vec4) ImageSampleExplicitLod 1763 1764 Grad ConstOffset 1765 1766 722
+            1768:  7(f16vec4) Load 1632(texel)
+            1769:  7(f16vec4) FAdd 1768 1767
                               Store 1632(texel) 1769
             1770:         284 Load 286(s2DArray)
-            1771:  175(fvec3) Load 177(f16c3)
-            1772:  154(fvec2) Load 1417(f16dPdxy2)
-            1773:  154(fvec2) Load 1417(f16dPdxy2)
-            1774:    7(fvec4) ImageSampleExplicitLod 1770 1771 Grad ConstOffset 1772 1773 722
-            1775:    7(fvec4) Load 1632(texel)
-            1776:    7(fvec4) FAdd 1775 1774
+            1771:175(f16vec3) Load 177(f16c3)
+            1772:154(f16vec2) Load 1417(f16dPdxy2)
+            1773:154(f16vec2) Load 1417(f16dPdxy2)
+            1774:  7(f16vec4) ImageSampleExplicitLod 1770 1771 Grad ConstOffset 1772 1773 722
+            1775:  7(f16vec4) Load 1632(texel)
+            1776:  7(f16vec4) FAdd 1775 1774
                               Store 1632(texel) 1776
             1777:         316 Load 318(s1DArrayShadow)
             1778:  167(fvec3) Load 169(c3)
             1779:   52(float) Load 1393(dPdxy1)
             1780:   52(float) Load 1393(dPdxy1)
             1781:   52(float) CompositeExtract 1778 2
-            1782:    6(float) ImageSampleDrefExplicitLod 1777 1778 1781 Grad ConstOffset 1779 1780 709
+            1782:6(float16_t) ImageSampleDrefExplicitLod 1777 1778 1781 Grad ConstOffset 1779 1780 709
             1783:    208(ptr) AccessChain 1632(texel) 207
-            1784:    6(float) Load 1783
-            1785:    6(float) FAdd 1784 1782
+            1784:6(float16_t) Load 1783
+            1785:6(float16_t) FAdd 1784 1782
             1786:    208(ptr) AccessChain 1632(texel) 207
                               Store 1786 1785
             1787:         316 Load 318(s1DArrayShadow)
-            1788:  154(fvec2) Load 156(f16c2)
+            1788:154(f16vec2) Load 156(f16c2)
             1789:   52(float) Load 215(compare)
-            1790:    6(float) Load 1401(f16dPdxy1)
-            1791:    6(float) Load 1401(f16dPdxy1)
-            1792:    6(float) ImageSampleDrefExplicitLod 1787 1788 1789 Grad ConstOffset 1790 1791 709
+            1790:6(float16_t) Load 1401(f16dPdxy1)
+            1791:6(float16_t) Load 1401(f16dPdxy1)
+            1792:6(float16_t) ImageSampleDrefExplicitLod 1787 1788 1789 Grad ConstOffset 1790 1791 709
             1793:    208(ptr) AccessChain 1632(texel) 207
-            1794:    6(float) Load 1793
-            1795:    6(float) FAdd 1794 1792
+            1794:6(float16_t) Load 1793
+            1795:6(float16_t) FAdd 1794 1792
             1796:    208(ptr) AccessChain 1632(texel) 207
                               Store 1796 1795
             1797:         337 Load 339(s2DArrayShadow)
@@ -2552,27 +2552,27 @@ spv.float16Fetch.frag
             1799:   53(fvec2) Load 1409(dPdxy2)
             1800:   53(fvec2) Load 1409(dPdxy2)
             1801:   52(float) CompositeExtract 1798 3
-            1802:    6(float) ImageSampleDrefExplicitLod 1797 1798 1801 Grad ConstOffset 1799 1800 722
+            1802:6(float16_t) ImageSampleDrefExplicitLod 1797 1798 1801 Grad ConstOffset 1799 1800 722
             1803:    208(ptr) AccessChain 1632(texel) 207
-            1804:    6(float) Load 1803
-            1805:    6(float) FAdd 1804 1802
+            1804:6(float16_t) Load 1803
+            1805:6(float16_t) FAdd 1804 1802
             1806:    208(ptr) AccessChain 1632(texel) 207
                               Store 1806 1805
             1807:         337 Load 339(s2DArrayShadow)
-            1808:  175(fvec3) Load 177(f16c3)
+            1808:175(f16vec3) Load 177(f16c3)
             1809:   52(float) Load 215(compare)
-            1810:  154(fvec2) Load 1417(f16dPdxy2)
-            1811:  154(fvec2) Load 1417(f16dPdxy2)
-            1812:    6(float) ImageSampleDrefExplicitLod 1807 1808 1809 Grad ConstOffset 1810 1811 722
+            1810:154(f16vec2) Load 1417(f16dPdxy2)
+            1811:154(f16vec2) Load 1417(f16dPdxy2)
+            1812:6(float16_t) ImageSampleDrefExplicitLod 1807 1808 1809 Grad ConstOffset 1810 1811 722
             1813:    208(ptr) AccessChain 1632(texel) 207
-            1814:    6(float) Load 1813
-            1815:    6(float) FAdd 1814 1812
+            1814:6(float16_t) Load 1813
+            1815:6(float16_t) FAdd 1814 1812
             1816:    208(ptr) AccessChain 1632(texel) 207
                               Store 1816 1815
-            1817:    7(fvec4) Load 1632(texel)
+            1817:  7(f16vec4) Load 1632(texel)
                               ReturnValue 1817
                               FunctionEnd
-31(testTextureProjGrad():    7(fvec4) Function None 8
+31(testTextureProjGrad():  7(f16vec4) Function None 8
               32:             Label
      1820(texel):     64(ptr) Variable Function
                               Store 1820(texel) 121
@@ -2580,17 +2580,17 @@ spv.float16Fetch.frag
             1822:   53(fvec2) Load 148(c2)
             1823:   52(float) Load 1393(dPdxy1)
             1824:   52(float) Load 1393(dPdxy1)
-            1825:    7(fvec4) ImageSampleProjExplicitLod 1821 1822 Grad 1823 1824
-            1826:    7(fvec4) Load 1820(texel)
-            1827:    7(fvec4) FAdd 1826 1825
+            1825:  7(f16vec4) ImageSampleProjExplicitLod 1821 1822 Grad 1823 1824
+            1826:  7(f16vec4) Load 1820(texel)
+            1827:  7(f16vec4) FAdd 1826 1825
                               Store 1820(texel) 1827
             1828:         123 Load 125(s1D)
-            1829:  154(fvec2) Load 156(f16c2)
-            1830:    6(float) Load 1401(f16dPdxy1)
-            1831:    6(float) Load 1401(f16dPdxy1)
-            1832:    7(fvec4) ImageSampleProjExplicitLod 1828 1829 Grad 1830 1831
-            1833:    7(fvec4) Load 1820(texel)
-            1834:    7(fvec4) FAdd 1833 1832
+            1829:154(f16vec2) Load 156(f16c2)
+            1830:6(float16_t) Load 1401(f16dPdxy1)
+            1831:6(float16_t) Load 1401(f16dPdxy1)
+            1832:  7(f16vec4) ImageSampleProjExplicitLod 1828 1829 Grad 1830 1831
+            1833:  7(f16vec4) Load 1820(texel)
+            1834:  7(f16vec4) FAdd 1833 1832
                               Store 1820(texel) 1834
             1835:         123 Load 125(s1D)
             1836:  249(fvec4) Load 251(c4)
@@ -2598,35 +2598,35 @@ spv.float16Fetch.frag
             1838:   52(float) Load 1393(dPdxy1)
             1839:   52(float) CompositeExtract 1836 3
             1840:  249(fvec4) CompositeInsert 1839 1836 1
-            1841:    7(fvec4) ImageSampleProjExplicitLod 1835 1840 Grad 1837 1838
-            1842:    7(fvec4) Load 1820(texel)
-            1843:    7(fvec4) FAdd 1842 1841
+            1841:  7(f16vec4) ImageSampleProjExplicitLod 1835 1840 Grad 1837 1838
+            1842:  7(f16vec4) Load 1820(texel)
+            1843:  7(f16vec4) FAdd 1842 1841
                               Store 1820(texel) 1843
             1844:         123 Load 125(s1D)
-            1845:    7(fvec4) Load 309(f16c4)
-            1846:    6(float) Load 1401(f16dPdxy1)
-            1847:    6(float) Load 1401(f16dPdxy1)
-            1848:    6(float) CompositeExtract 1845 3
-            1849:    7(fvec4) CompositeInsert 1848 1845 1
-            1850:    7(fvec4) ImageSampleProjExplicitLod 1844 1849 Grad 1846 1847
-            1851:    7(fvec4) Load 1820(texel)
-            1852:    7(fvec4) FAdd 1851 1850
+            1845:  7(f16vec4) Load 309(f16c4)
+            1846:6(float16_t) Load 1401(f16dPdxy1)
+            1847:6(float16_t) Load 1401(f16dPdxy1)
+            1848:6(float16_t) CompositeExtract 1845 3
+            1849:  7(f16vec4) CompositeInsert 1848 1845 1
+            1850:  7(f16vec4) ImageSampleProjExplicitLod 1844 1849 Grad 1846 1847
+            1851:  7(f16vec4) Load 1820(texel)
+            1852:  7(f16vec4) FAdd 1851 1850
                               Store 1820(texel) 1852
             1853:         143 Load 145(s2D)
             1854:  167(fvec3) Load 169(c3)
             1855:   53(fvec2) Load 1409(dPdxy2)
             1856:   53(fvec2) Load 1409(dPdxy2)
-            1857:    7(fvec4) ImageSampleProjExplicitLod 1853 1854 Grad 1855 1856
-            1858:    7(fvec4) Load 1820(texel)
-            1859:    7(fvec4) FAdd 1858 1857
+            1857:  7(f16vec4) ImageSampleProjExplicitLod 1853 1854 Grad 1855 1856
+            1858:  7(f16vec4) Load 1820(texel)
+            1859:  7(f16vec4) FAdd 1858 1857
                               Store 1820(texel) 1859
             1860:         143 Load 145(s2D)
-            1861:  175(fvec3) Load 177(f16c3)
-            1862:  154(fvec2) Load 1417(f16dPdxy2)
-            1863:  154(fvec2) Load 1417(f16dPdxy2)
-            1864:    7(fvec4) ImageSampleProjExplicitLod 1860 1861 Grad 1862 1863
-            1865:    7(fvec4) Load 1820(texel)
-            1866:    7(fvec4) FAdd 1865 1864
+            1861:175(f16vec3) Load 177(f16c3)
+            1862:154(f16vec2) Load 1417(f16dPdxy2)
+            1863:154(f16vec2) Load 1417(f16dPdxy2)
+            1864:  7(f16vec4) ImageSampleProjExplicitLod 1860 1861 Grad 1862 1863
+            1865:  7(f16vec4) Load 1820(texel)
+            1866:  7(f16vec4) FAdd 1865 1864
                               Store 1820(texel) 1866
             1867:         143 Load 145(s2D)
             1868:  249(fvec4) Load 251(c4)
@@ -2634,51 +2634,51 @@ spv.float16Fetch.frag
             1870:   53(fvec2) Load 1409(dPdxy2)
             1871:   52(float) CompositeExtract 1868 3
             1872:  249(fvec4) CompositeInsert 1871 1868 2
-            1873:    7(fvec4) ImageSampleProjExplicitLod 1867 1872 Grad 1869 1870
-            1874:    7(fvec4) Load 1820(texel)
-            1875:    7(fvec4) FAdd 1874 1873
+            1873:  7(f16vec4) ImageSampleProjExplicitLod 1867 1872 Grad 1869 1870
+            1874:  7(f16vec4) Load 1820(texel)
+            1875:  7(f16vec4) FAdd 1874 1873
                               Store 1820(texel) 1875
             1876:         143 Load 145(s2D)
-            1877:    7(fvec4) Load 309(f16c4)
-            1878:  154(fvec2) Load 1417(f16dPdxy2)
-            1879:  154(fvec2) Load 1417(f16dPdxy2)
-            1880:    6(float) CompositeExtract 1877 3
-            1881:    7(fvec4) CompositeInsert 1880 1877 2
-            1882:    7(fvec4) ImageSampleProjExplicitLod 1876 1881 Grad 1878 1879
-            1883:    7(fvec4) Load 1820(texel)
-            1884:    7(fvec4) FAdd 1883 1882
+            1877:  7(f16vec4) Load 309(f16c4)
+            1878:154(f16vec2) Load 1417(f16dPdxy2)
+            1879:154(f16vec2) Load 1417(f16dPdxy2)
+            1880:6(float16_t) CompositeExtract 1877 3
+            1881:  7(f16vec4) CompositeInsert 1880 1877 2
+            1882:  7(f16vec4) ImageSampleProjExplicitLod 1876 1881 Grad 1878 1879
+            1883:  7(f16vec4) Load 1820(texel)
+            1884:  7(f16vec4) FAdd 1883 1882
                               Store 1820(texel) 1884
             1885:         163 Load 165(s3D)
             1886:  249(fvec4) Load 251(c4)
             1887:  167(fvec3) Load 1425(dPdxy3)
             1888:  167(fvec3) Load 1425(dPdxy3)
-            1889:    7(fvec4) ImageSampleProjExplicitLod 1885 1886 Grad 1887 1888
-            1890:    7(fvec4) Load 1820(texel)
-            1891:    7(fvec4) FAdd 1890 1889
+            1889:  7(f16vec4) ImageSampleProjExplicitLod 1885 1886 Grad 1887 1888
+            1890:  7(f16vec4) Load 1820(texel)
+            1891:  7(f16vec4) FAdd 1890 1889
                               Store 1820(texel) 1891
             1892:         163 Load 165(s3D)
-            1893:    7(fvec4) Load 309(f16c4)
-            1894:  175(fvec3) Load 1433(f16dPdxy3)
-            1895:  175(fvec3) Load 1433(f16dPdxy3)
-            1896:    7(fvec4) ImageSampleProjExplicitLod 1892 1893 Grad 1894 1895
-            1897:    7(fvec4) Load 1820(texel)
-            1898:    7(fvec4) FAdd 1897 1896
+            1893:  7(f16vec4) Load 309(f16c4)
+            1894:175(f16vec3) Load 1433(f16dPdxy3)
+            1895:175(f16vec3) Load 1433(f16dPdxy3)
+            1896:  7(f16vec4) ImageSampleProjExplicitLod 1892 1893 Grad 1894 1895
+            1897:  7(f16vec4) Load 1820(texel)
+            1898:  7(f16vec4) FAdd 1897 1896
                               Store 1820(texel) 1898
             1899:         357 Load 359(s2DRect)
             1900:  167(fvec3) Load 169(c3)
             1901:   53(fvec2) Load 1409(dPdxy2)
             1902:   53(fvec2) Load 1409(dPdxy2)
-            1903:    7(fvec4) ImageSampleProjExplicitLod 1899 1900 Grad 1901 1902
-            1904:    7(fvec4) Load 1820(texel)
-            1905:    7(fvec4) FAdd 1904 1903
+            1903:  7(f16vec4) ImageSampleProjExplicitLod 1899 1900 Grad 1901 1902
+            1904:  7(f16vec4) Load 1820(texel)
+            1905:  7(f16vec4) FAdd 1904 1903
                               Store 1820(texel) 1905
             1906:         357 Load 359(s2DRect)
-            1907:  175(fvec3) Load 177(f16c3)
-            1908:  154(fvec2) Load 1417(f16dPdxy2)
-            1909:  154(fvec2) Load 1417(f16dPdxy2)
-            1910:    7(fvec4) ImageSampleProjExplicitLod 1906 1907 Grad 1908 1909
-            1911:    7(fvec4) Load 1820(texel)
-            1912:    7(fvec4) FAdd 1911 1910
+            1907:175(f16vec3) Load 177(f16c3)
+            1908:154(f16vec2) Load 1417(f16dPdxy2)
+            1909:154(f16vec2) Load 1417(f16dPdxy2)
+            1910:  7(f16vec4) ImageSampleProjExplicitLod 1906 1907 Grad 1908 1909
+            1911:  7(f16vec4) Load 1820(texel)
+            1912:  7(f16vec4) FAdd 1911 1910
                               Store 1820(texel) 1912
             1913:         357 Load 359(s2DRect)
             1914:  249(fvec4) Load 251(c4)
@@ -2686,19 +2686,19 @@ spv.float16Fetch.frag
             1916:   53(fvec2) Load 1409(dPdxy2)
             1917:   52(float) CompositeExtract 1914 3
             1918:  249(fvec4) CompositeInsert 1917 1914 2
-            1919:    7(fvec4) ImageSampleProjExplicitLod 1913 1918 Grad 1915 1916
-            1920:    7(fvec4) Load 1820(texel)
-            1921:    7(fvec4) FAdd 1920 1919
+            1919:  7(f16vec4) ImageSampleProjExplicitLod 1913 1918 Grad 1915 1916
+            1920:  7(f16vec4) Load 1820(texel)
+            1921:  7(f16vec4) FAdd 1920 1919
                               Store 1820(texel) 1921
             1922:         357 Load 359(s2DRect)
-            1923:    7(fvec4) Load 309(f16c4)
-            1924:  154(fvec2) Load 1417(f16dPdxy2)
-            1925:  154(fvec2) Load 1417(f16dPdxy2)
-            1926:    6(float) CompositeExtract 1923 3
-            1927:    7(fvec4) CompositeInsert 1926 1923 2
-            1928:    7(fvec4) ImageSampleProjExplicitLod 1922 1927 Grad 1924 1925
-            1929:    7(fvec4) Load 1820(texel)
-            1930:    7(fvec4) FAdd 1929 1928
+            1923:  7(f16vec4) Load 309(f16c4)
+            1924:154(f16vec2) Load 1417(f16dPdxy2)
+            1925:154(f16vec2) Load 1417(f16dPdxy2)
+            1926:6(float16_t) CompositeExtract 1923 3
+            1927:  7(f16vec4) CompositeInsert 1926 1923 2
+            1928:  7(f16vec4) ImageSampleProjExplicitLod 1922 1927 Grad 1924 1925
+            1929:  7(f16vec4) Load 1820(texel)
+            1930:  7(f16vec4) FAdd 1929 1928
                               Store 1820(texel) 1930
             1931:         371 Load 373(s2DRectShadow)
             1932:  249(fvec4) Load 251(c4)
@@ -2707,21 +2707,21 @@ spv.float16Fetch.frag
             1935:   52(float) CompositeExtract 1932 2
             1936:   52(float) CompositeExtract 1932 3
             1937:  249(fvec4) CompositeInsert 1936 1932 2
-            1938:    6(float) ImageSampleProjDrefExplicitLod 1931 1937 1935 Grad 1933 1934
+            1938:6(float16_t) ImageSampleProjDrefExplicitLod 1931 1937 1935 Grad 1933 1934
             1939:    208(ptr) AccessChain 1820(texel) 207
-            1940:    6(float) Load 1939
-            1941:    6(float) FAdd 1940 1938
+            1940:6(float16_t) Load 1939
+            1941:6(float16_t) FAdd 1940 1938
             1942:    208(ptr) AccessChain 1820(texel) 207
                               Store 1942 1941
             1943:         371 Load 373(s2DRectShadow)
-            1944:  175(fvec3) Load 177(f16c3)
+            1944:175(f16vec3) Load 177(f16c3)
             1945:   52(float) Load 215(compare)
-            1946:  154(fvec2) Load 1417(f16dPdxy2)
-            1947:  154(fvec2) Load 1417(f16dPdxy2)
-            1948:    6(float) ImageSampleProjDrefExplicitLod 1943 1944 1945 Grad 1946 1947
+            1946:154(f16vec2) Load 1417(f16dPdxy2)
+            1947:154(f16vec2) Load 1417(f16dPdxy2)
+            1948:6(float16_t) ImageSampleProjDrefExplicitLod 1943 1944 1945 Grad 1946 1947
             1949:    208(ptr) AccessChain 1820(texel) 207
-            1950:    6(float) Load 1949
-            1951:    6(float) FAdd 1950 1948
+            1950:6(float16_t) Load 1949
+            1951:6(float16_t) FAdd 1950 1948
             1952:    208(ptr) AccessChain 1820(texel) 207
                               Store 1952 1951
             1953:         199 Load 201(s1DShadow)
@@ -2731,23 +2731,23 @@ spv.float16Fetch.frag
             1957:   52(float) CompositeExtract 1954 2
             1958:   52(float) CompositeExtract 1954 3
             1959:  249(fvec4) CompositeInsert 1958 1954 1
-            1960:    6(float) ImageSampleProjDrefExplicitLod 1953 1959 1957 Grad 1955 1956
+            1960:6(float16_t) ImageSampleProjDrefExplicitLod 1953 1959 1957 Grad 1955 1956
             1961:    208(ptr) AccessChain 1820(texel) 207
-            1962:    6(float) Load 1961
-            1963:    6(float) FAdd 1962 1960
+            1962:6(float16_t) Load 1961
+            1963:6(float16_t) FAdd 1962 1960
             1964:    208(ptr) AccessChain 1820(texel) 207
                               Store 1964 1963
             1965:         199 Load 201(s1DShadow)
-            1966:  175(fvec3) Load 177(f16c3)
+            1966:175(f16vec3) Load 177(f16c3)
             1967:   52(float) Load 215(compare)
-            1968:    6(float) Load 1401(f16dPdxy1)
-            1969:    6(float) Load 1401(f16dPdxy1)
-            1970:    6(float) CompositeExtract 1966 2
-            1971:  175(fvec3) CompositeInsert 1970 1966 1
-            1972:    6(float) ImageSampleProjDrefExplicitLod 1965 1971 1967 Grad 1968 1969
+            1968:6(float16_t) Load 1401(f16dPdxy1)
+            1969:6(float16_t) Load 1401(f16dPdxy1)
+            1970:6(float16_t) CompositeExtract 1966 2
+            1971:175(f16vec3) CompositeInsert 1970 1966 1
+            1972:6(float16_t) ImageSampleProjDrefExplicitLod 1965 1971 1967 Grad 1968 1969
             1973:    208(ptr) AccessChain 1820(texel) 207
-            1974:    6(float) Load 1973
-            1975:    6(float) FAdd 1974 1972
+            1974:6(float16_t) Load 1973
+            1975:6(float16_t) FAdd 1974 1972
             1976:    208(ptr) AccessChain 1820(texel) 207
                               Store 1976 1975
             1977:         224 Load 226(s2DShadow)
@@ -2757,27 +2757,27 @@ spv.float16Fetch.frag
             1981:   52(float) CompositeExtract 1978 2
             1982:   52(float) CompositeExtract 1978 3
             1983:  249(fvec4) CompositeInsert 1982 1978 2
-            1984:    6(float) ImageSampleProjDrefExplicitLod 1977 1983 1981 Grad 1979 1980
+            1984:6(float16_t) ImageSampleProjDrefExplicitLod 1977 1983 1981 Grad 1979 1980
             1985:    208(ptr) AccessChain 1820(texel) 207
-            1986:    6(float) Load 1985
-            1987:    6(float) FAdd 1986 1984
+            1986:6(float16_t) Load 1985
+            1987:6(float16_t) FAdd 1986 1984
             1988:    208(ptr) AccessChain 1820(texel) 207
                               Store 1988 1987
             1989:         224 Load 226(s2DShadow)
-            1990:  175(fvec3) Load 177(f16c3)
+            1990:175(f16vec3) Load 177(f16c3)
             1991:   52(float) Load 215(compare)
-            1992:  154(fvec2) Load 1417(f16dPdxy2)
-            1993:  154(fvec2) Load 1417(f16dPdxy2)
-            1994:    6(float) ImageSampleProjDrefExplicitLod 1989 1990 1991 Grad 1992 1993
+            1992:154(f16vec2) Load 1417(f16dPdxy2)
+            1993:154(f16vec2) Load 1417(f16dPdxy2)
+            1994:6(float16_t) ImageSampleProjDrefExplicitLod 1989 1990 1991 Grad 1992 1993
             1995:    208(ptr) AccessChain 1820(texel) 207
-            1996:    6(float) Load 1995
-            1997:    6(float) FAdd 1996 1994
+            1996:6(float16_t) Load 1995
+            1997:6(float16_t) FAdd 1996 1994
             1998:    208(ptr) AccessChain 1820(texel) 207
                               Store 1998 1997
-            1999:    7(fvec4) Load 1820(texel)
+            1999:  7(f16vec4) Load 1820(texel)
                               ReturnValue 1999
                               FunctionEnd
-33(testTextureProjGradoffset():    7(fvec4) Function None 8
+33(testTextureProjGradoffset():  7(f16vec4) Function None 8
               34:             Label
      2002(texel):     64(ptr) Variable Function
                               Store 2002(texel) 121
@@ -2785,17 +2785,17 @@ spv.float16Fetch.frag
             2004:   53(fvec2) Load 148(c2)
             2005:   52(float) Load 1393(dPdxy1)
             2006:   52(float) Load 1393(dPdxy1)
-            2007:    7(fvec4) ImageSampleProjExplicitLod 2003 2004 Grad ConstOffset 2005 2006 709
-            2008:    7(fvec4) Load 2002(texel)
-            2009:    7(fvec4) FAdd 2008 2007
+            2007:  7(f16vec4) ImageSampleProjExplicitLod 2003 2004 Grad ConstOffset 2005 2006 709
+            2008:  7(f16vec4) Load 2002(texel)
+            2009:  7(f16vec4) FAdd 2008 2007
                               Store 2002(texel) 2009
             2010:         123 Load 125(s1D)
-            2011:  154(fvec2) Load 156(f16c2)
-            2012:    6(float) Load 1401(f16dPdxy1)
-            2013:    6(float) Load 1401(f16dPdxy1)
-            2014:    7(fvec4) ImageSampleProjExplicitLod 2010 2011 Grad ConstOffset 2012 2013 709
-            2015:    7(fvec4) Load 2002(texel)
-            2016:    7(fvec4) FAdd 2015 2014
+            2011:154(f16vec2) Load 156(f16c2)
+            2012:6(float16_t) Load 1401(f16dPdxy1)
+            2013:6(float16_t) Load 1401(f16dPdxy1)
+            2014:  7(f16vec4) ImageSampleProjExplicitLod 2010 2011 Grad ConstOffset 2012 2013 709
+            2015:  7(f16vec4) Load 2002(texel)
+            2016:  7(f16vec4) FAdd 2015 2014
                               Store 2002(texel) 2016
             2017:         123 Load 125(s1D)
             2018:  249(fvec4) Load 251(c4)
@@ -2803,35 +2803,35 @@ spv.float16Fetch.frag
             2020:   52(float) Load 1393(dPdxy1)
             2021:   52(float) CompositeExtract 2018 3
             2022:  249(fvec4) CompositeInsert 2021 2018 1
-            2023:    7(fvec4) ImageSampleProjExplicitLod 2017 2022 Grad ConstOffset 2019 2020 709
-            2024:    7(fvec4) Load 2002(texel)
-            2025:    7(fvec4) FAdd 2024 2023
+            2023:  7(f16vec4) ImageSampleProjExplicitLod 2017 2022 Grad ConstOffset 2019 2020 709
+            2024:  7(f16vec4) Load 2002(texel)
+            2025:  7(f16vec4) FAdd 2024 2023
                               Store 2002(texel) 2025
             2026:         123 Load 125(s1D)
-            2027:    7(fvec4) Load 309(f16c4)
-            2028:    6(float) Load 1401(f16dPdxy1)
-            2029:    6(float) Load 1401(f16dPdxy1)
-            2030:    6(float) CompositeExtract 2027 3
-            2031:    7(fvec4) CompositeInsert 2030 2027 1
-            2032:    7(fvec4) ImageSampleProjExplicitLod 2026 2031 Grad ConstOffset 2028 2029 709
-            2033:    7(fvec4) Load 2002(texel)
-            2034:    7(fvec4) FAdd 2033 2032
+            2027:  7(f16vec4) Load 309(f16c4)
+            2028:6(float16_t) Load 1401(f16dPdxy1)
+            2029:6(float16_t) Load 1401(f16dPdxy1)
+            2030:6(float16_t) CompositeExtract 2027 3
+            2031:  7(f16vec4) CompositeInsert 2030 2027 1
+            2032:  7(f16vec4) ImageSampleProjExplicitLod 2026 2031 Grad ConstOffset 2028 2029 709
+            2033:  7(f16vec4) Load 2002(texel)
+            2034:  7(f16vec4) FAdd 2033 2032
                               Store 2002(texel) 2034
             2035:         143 Load 145(s2D)
             2036:  167(fvec3) Load 169(c3)
             2037:   53(fvec2) Load 1409(dPdxy2)
             2038:   53(fvec2) Load 1409(dPdxy2)
-            2039:    7(fvec4) ImageSampleProjExplicitLod 2035 2036 Grad ConstOffset 2037 2038 722
-            2040:    7(fvec4) Load 2002(texel)
-            2041:    7(fvec4) FAdd 2040 2039
+            2039:  7(f16vec4) ImageSampleProjExplicitLod 2035 2036 Grad ConstOffset 2037 2038 722
+            2040:  7(f16vec4) Load 2002(texel)
+            2041:  7(f16vec4) FAdd 2040 2039
                               Store 2002(texel) 2041
             2042:         143 Load 145(s2D)
-            2043:  175(fvec3) Load 177(f16c3)
-            2044:  154(fvec2) Load 1417(f16dPdxy2)
-            2045:  154(fvec2) Load 1417(f16dPdxy2)
-            2046:    7(fvec4) ImageSampleProjExplicitLod 2042 2043 Grad ConstOffset 2044 2045 722
-            2047:    7(fvec4) Load 2002(texel)
-            2048:    7(fvec4) FAdd 2047 2046
+            2043:175(f16vec3) Load 177(f16c3)
+            2044:154(f16vec2) Load 1417(f16dPdxy2)
+            2045:154(f16vec2) Load 1417(f16dPdxy2)
+            2046:  7(f16vec4) ImageSampleProjExplicitLod 2042 2043 Grad ConstOffset 2044 2045 722
+            2047:  7(f16vec4) Load 2002(texel)
+            2048:  7(f16vec4) FAdd 2047 2046
                               Store 2002(texel) 2048
             2049:         143 Load 145(s2D)
             2050:  249(fvec4) Load 251(c4)
@@ -2839,35 +2839,35 @@ spv.float16Fetch.frag
             2052:   53(fvec2) Load 1409(dPdxy2)
             2053:   52(float) CompositeExtract 2050 3
             2054:  249(fvec4) CompositeInsert 2053 2050 2
-            2055:    7(fvec4) ImageSampleProjExplicitLod 2049 2054 Grad ConstOffset 2051 2052 722
-            2056:    7(fvec4) Load 2002(texel)
-            2057:    7(fvec4) FAdd 2056 2055
+            2055:  7(f16vec4) ImageSampleProjExplicitLod 2049 2054 Grad ConstOffset 2051 2052 722
+            2056:  7(f16vec4) Load 2002(texel)
+            2057:  7(f16vec4) FAdd 2056 2055
                               Store 2002(texel) 2057
             2058:         143 Load 145(s2D)
-            2059:    7(fvec4) Load 309(f16c4)
-            2060:  154(fvec2) Load 1417(f16dPdxy2)
-            2061:  154(fvec2) Load 1417(f16dPdxy2)
-            2062:    6(float) CompositeExtract 2059 3
-            2063:    7(fvec4) CompositeInsert 2062 2059 2
-            2064:    7(fvec4) ImageSampleProjExplicitLod 2058 2063 Grad ConstOffset 2060 2061 722
-            2065:    7(fvec4) Load 2002(texel)
-            2066:    7(fvec4) FAdd 2065 2064
+            2059:  7(f16vec4) Load 309(f16c4)
+            2060:154(f16vec2) Load 1417(f16dPdxy2)
+            2061:154(f16vec2) Load 1417(f16dPdxy2)
+            2062:6(float16_t) CompositeExtract 2059 3
+            2063:  7(f16vec4) CompositeInsert 2062 2059 2
+            2064:  7(f16vec4) ImageSampleProjExplicitLod 2058 2063 Grad ConstOffset 2060 2061 722
+            2065:  7(f16vec4) Load 2002(texel)
+            2066:  7(f16vec4) FAdd 2065 2064
                               Store 2002(texel) 2066
             2067:         357 Load 359(s2DRect)
             2068:  167(fvec3) Load 169(c3)
             2069:   53(fvec2) Load 1409(dPdxy2)
             2070:   53(fvec2) Load 1409(dPdxy2)
-            2071:    7(fvec4) ImageSampleProjExplicitLod 2067 2068 Grad ConstOffset 2069 2070 722
-            2072:    7(fvec4) Load 2002(texel)
-            2073:    7(fvec4) FAdd 2072 2071
+            2071:  7(f16vec4) ImageSampleProjExplicitLod 2067 2068 Grad ConstOffset 2069 2070 722
+            2072:  7(f16vec4) Load 2002(texel)
+            2073:  7(f16vec4) FAdd 2072 2071
                               Store 2002(texel) 2073
             2074:         357 Load 359(s2DRect)
-            2075:  175(fvec3) Load 177(f16c3)
-            2076:  154(fvec2) Load 1417(f16dPdxy2)
-            2077:  154(fvec2) Load 1417(f16dPdxy2)
-            2078:    7(fvec4) ImageSampleProjExplicitLod 2074 2075 Grad ConstOffset 2076 2077 722
-            2079:    7(fvec4) Load 2002(texel)
-            2080:    7(fvec4) FAdd 2079 2078
+            2075:175(f16vec3) Load 177(f16c3)
+            2076:154(f16vec2) Load 1417(f16dPdxy2)
+            2077:154(f16vec2) Load 1417(f16dPdxy2)
+            2078:  7(f16vec4) ImageSampleProjExplicitLod 2074 2075 Grad ConstOffset 2076 2077 722
+            2079:  7(f16vec4) Load 2002(texel)
+            2080:  7(f16vec4) FAdd 2079 2078
                               Store 2002(texel) 2080
             2081:         357 Load 359(s2DRect)
             2082:  249(fvec4) Load 251(c4)
@@ -2875,19 +2875,19 @@ spv.float16Fetch.frag
             2084:   53(fvec2) Load 1409(dPdxy2)
             2085:   52(float) CompositeExtract 2082 3
             2086:  249(fvec4) CompositeInsert 2085 2082 2
-            2087:    7(fvec4) ImageSampleProjExplicitLod 2081 2086 Grad ConstOffset 2083 2084 722
-            2088:    7(fvec4) Load 2002(texel)
-            2089:    7(fvec4) FAdd 2088 2087
+            2087:  7(f16vec4) ImageSampleProjExplicitLod 2081 2086 Grad ConstOffset 2083 2084 722
+            2088:  7(f16vec4) Load 2002(texel)
+            2089:  7(f16vec4) FAdd 2088 2087
                               Store 2002(texel) 2089
             2090:         357 Load 359(s2DRect)
-            2091:    7(fvec4) Load 309(f16c4)
-            2092:  154(fvec2) Load 1417(f16dPdxy2)
-            2093:  154(fvec2) Load 1417(f16dPdxy2)
-            2094:    6(float) CompositeExtract 2091 3
-            2095:    7(fvec4) CompositeInsert 2094 2091 2
-            2096:    7(fvec4) ImageSampleProjExplicitLod 2090 2095 Grad ConstOffset 2092 2093 722
-            2097:    7(fvec4) Load 2002(texel)
-            2098:    7(fvec4) FAdd 2097 2096
+            2091:  7(f16vec4) Load 309(f16c4)
+            2092:154(f16vec2) Load 1417(f16dPdxy2)
+            2093:154(f16vec2) Load 1417(f16dPdxy2)
+            2094:6(float16_t) CompositeExtract 2091 3
+            2095:  7(f16vec4) CompositeInsert 2094 2091 2
+            2096:  7(f16vec4) ImageSampleProjExplicitLod 2090 2095 Grad ConstOffset 2092 2093 722
+            2097:  7(f16vec4) Load 2002(texel)
+            2098:  7(f16vec4) FAdd 2097 2096
                               Store 2002(texel) 2098
             2099:         371 Load 373(s2DRectShadow)
             2100:  249(fvec4) Load 251(c4)
@@ -2896,38 +2896,38 @@ spv.float16Fetch.frag
             2103:   52(float) CompositeExtract 2100 2
             2104:   52(float) CompositeExtract 2100 3
             2105:  249(fvec4) CompositeInsert 2104 2100 2
-            2106:    6(float) ImageSampleProjDrefExplicitLod 2099 2105 2103 Grad ConstOffset 2101 2102 722
+            2106:6(float16_t) ImageSampleProjDrefExplicitLod 2099 2105 2103 Grad ConstOffset 2101 2102 722
             2107:    208(ptr) AccessChain 2002(texel) 207
-            2108:    6(float) Load 2107
-            2109:    6(float) FAdd 2108 2106
+            2108:6(float16_t) Load 2107
+            2109:6(float16_t) FAdd 2108 2106
             2110:    208(ptr) AccessChain 2002(texel) 207
                               Store 2110 2109
             2111:         371 Load 373(s2DRectShadow)
-            2112:  175(fvec3) Load 177(f16c3)
+            2112:175(f16vec3) Load 177(f16c3)
             2113:   52(float) Load 215(compare)
-            2114:  154(fvec2) Load 1417(f16dPdxy2)
-            2115:  154(fvec2) Load 1417(f16dPdxy2)
-            2116:    6(float) ImageSampleProjDrefExplicitLod 2111 2112 2113 Grad ConstOffset 2114 2115 722
+            2114:154(f16vec2) Load 1417(f16dPdxy2)
+            2115:154(f16vec2) Load 1417(f16dPdxy2)
+            2116:6(float16_t) ImageSampleProjDrefExplicitLod 2111 2112 2113 Grad ConstOffset 2114 2115 722
             2117:    208(ptr) AccessChain 2002(texel) 207
-            2118:    6(float) Load 2117
-            2119:    6(float) FAdd 2118 2116
+            2118:6(float16_t) Load 2117
+            2119:6(float16_t) FAdd 2118 2116
             2120:    208(ptr) AccessChain 2002(texel) 207
                               Store 2120 2119
             2121:         163 Load 165(s3D)
             2122:  249(fvec4) Load 251(c4)
             2123:  167(fvec3) Load 1425(dPdxy3)
             2124:  167(fvec3) Load 1425(dPdxy3)
-            2125:    7(fvec4) ImageSampleProjExplicitLod 2121 2122 Grad ConstOffset 2123 2124 735
-            2126:    7(fvec4) Load 2002(texel)
-            2127:    7(fvec4) FAdd 2126 2125
+            2125:  7(f16vec4) ImageSampleProjExplicitLod 2121 2122 Grad ConstOffset 2123 2124 735
+            2126:  7(f16vec4) Load 2002(texel)
+            2127:  7(f16vec4) FAdd 2126 2125
                               Store 2002(texel) 2127
             2128:         163 Load 165(s3D)
-            2129:    7(fvec4) Load 309(f16c4)
-            2130:  175(fvec3) Load 1433(f16dPdxy3)
-            2131:  175(fvec3) Load 1433(f16dPdxy3)
-            2132:    7(fvec4) ImageSampleProjExplicitLod 2128 2129 Grad ConstOffset 2130 2131 735
-            2133:    7(fvec4) Load 2002(texel)
-            2134:    7(fvec4) FAdd 2133 2132
+            2129:  7(f16vec4) Load 309(f16c4)
+            2130:175(f16vec3) Load 1433(f16dPdxy3)
+            2131:175(f16vec3) Load 1433(f16dPdxy3)
+            2132:  7(f16vec4) ImageSampleProjExplicitLod 2128 2129 Grad ConstOffset 2130 2131 735
+            2133:  7(f16vec4) Load 2002(texel)
+            2134:  7(f16vec4) FAdd 2133 2132
                               Store 2002(texel) 2134
             2135:         199 Load 201(s1DShadow)
             2136:  249(fvec4) Load 251(c4)
@@ -2936,23 +2936,23 @@ spv.float16Fetch.frag
             2139:   52(float) CompositeExtract 2136 2
             2140:   52(float) CompositeExtract 2136 3
             2141:  249(fvec4) CompositeInsert 2140 2136 1
-            2142:    6(float) ImageSampleProjDrefExplicitLod 2135 2141 2139 Grad ConstOffset 2137 2138 709
+            2142:6(float16_t) ImageSampleProjDrefExplicitLod 2135 2141 2139 Grad ConstOffset 2137 2138 709
             2143:    208(ptr) AccessChain 2002(texel) 207
-            2144:    6(float) Load 2143
-            2145:    6(float) FAdd 2144 2142
+            2144:6(float16_t) Load 2143
+            2145:6(float16_t) FAdd 2144 2142
             2146:    208(ptr) AccessChain 2002(texel) 207
                               Store 2146 2145
             2147:         199 Load 201(s1DShadow)
-            2148:  175(fvec3) Load 177(f16c3)
+            2148:175(f16vec3) Load 177(f16c3)
             2149:   52(float) Load 215(compare)
-            2150:    6(float) Load 1401(f16dPdxy1)
-            2151:    6(float) Load 1401(f16dPdxy1)
-            2152:    6(float) CompositeExtract 2148 2
-            2153:  175(fvec3) CompositeInsert 2152 2148 1
-            2154:    6(float) ImageSampleProjDrefExplicitLod 2147 2153 2149 Grad ConstOffset 2150 2151 709
+            2150:6(float16_t) Load 1401(f16dPdxy1)
+            2151:6(float16_t) Load 1401(f16dPdxy1)
+            2152:6(float16_t) CompositeExtract 2148 2
+            2153:175(f16vec3) CompositeInsert 2152 2148 1
+            2154:6(float16_t) ImageSampleProjDrefExplicitLod 2147 2153 2149 Grad ConstOffset 2150 2151 709
             2155:    208(ptr) AccessChain 2002(texel) 207
-            2156:    6(float) Load 2155
-            2157:    6(float) FAdd 2156 2154
+            2156:6(float16_t) Load 2155
+            2157:6(float16_t) FAdd 2156 2154
             2158:    208(ptr) AccessChain 2002(texel) 207
                               Store 2158 2157
             2159:         224 Load 226(s2DShadow)
@@ -2962,472 +2962,472 @@ spv.float16Fetch.frag
             2163:   52(float) CompositeExtract 2160 2
             2164:   52(float) CompositeExtract 2160 3
             2165:  249(fvec4) CompositeInsert 2164 2160 2
-            2166:    6(float) ImageSampleProjDrefExplicitLod 2159 2165 2163 Grad ConstOffset 2161 2162 722
+            2166:6(float16_t) ImageSampleProjDrefExplicitLod 2159 2165 2163 Grad ConstOffset 2161 2162 722
             2167:    208(ptr) AccessChain 2002(texel) 207
-            2168:    6(float) Load 2167
-            2169:    6(float) FAdd 2168 2166
+            2168:6(float16_t) Load 2167
+            2169:6(float16_t) FAdd 2168 2166
             2170:    208(ptr) AccessChain 2002(texel) 207
                               Store 2170 2169
             2171:         224 Load 226(s2DShadow)
-            2172:  175(fvec3) Load 177(f16c3)
+            2172:175(f16vec3) Load 177(f16c3)
             2173:   52(float) Load 215(compare)
-            2174:  154(fvec2) Load 1417(f16dPdxy2)
-            2175:  154(fvec2) Load 1417(f16dPdxy2)
-            2176:    6(float) ImageSampleProjDrefExplicitLod 2171 2172 2173 Grad ConstOffset 2174 2175 722
+            2174:154(f16vec2) Load 1417(f16dPdxy2)
+            2175:154(f16vec2) Load 1417(f16dPdxy2)
+            2176:6(float16_t) ImageSampleProjDrefExplicitLod 2171 2172 2173 Grad ConstOffset 2174 2175 722
             2177:    208(ptr) AccessChain 2002(texel) 207
-            2178:    6(float) Load 2177
-            2179:    6(float) FAdd 2178 2176
+            2178:6(float16_t) Load 2177
+            2179:6(float16_t) FAdd 2178 2176
             2180:    208(ptr) AccessChain 2002(texel) 207
                               Store 2180 2179
-            2181:    7(fvec4) Load 2002(texel)
+            2181:  7(f16vec4) Load 2002(texel)
                               ReturnValue 2181
                               FunctionEnd
-35(testTextureGather():    7(fvec4) Function None 8
+35(testTextureGather():  7(f16vec4) Function None 8
               36:             Label
      2184(texel):     64(ptr) Variable Function
                               Store 2184(texel) 121
             2185:         143 Load 145(s2D)
             2186:   53(fvec2) Load 148(c2)
-            2188:    7(fvec4) ImageGather 2185 2186 2187
-            2189:    7(fvec4) Load 2184(texel)
-            2190:    7(fvec4) FAdd 2189 2188
+            2188:  7(f16vec4) ImageGather 2185 2186 2187
+            2189:  7(f16vec4) Load 2184(texel)
+            2190:  7(f16vec4) FAdd 2189 2188
                               Store 2184(texel) 2190
             2191:         143 Load 145(s2D)
-            2192:  154(fvec2) Load 156(f16c2)
-            2193:    6(float) Load 137(f16bias)
-            2194:    7(fvec4) ImageGather 2191 2192 2187 Bias 2193
-            2195:    7(fvec4) Load 2184(texel)
-            2196:    7(fvec4) FAdd 2195 2194
+            2192:154(f16vec2) Load 156(f16c2)
+            2193:6(float16_t) Load 137(f16bias)
+            2194:  7(f16vec4) ImageGather 2191 2192 2187 Bias 2193
+            2195:  7(f16vec4) Load 2184(texel)
+            2196:  7(f16vec4) FAdd 2195 2194
                               Store 2184(texel) 2196
             2197:         284 Load 286(s2DArray)
             2198:  167(fvec3) Load 169(c3)
-            2199:    7(fvec4) ImageGather 2197 2198 2187
-            2200:    7(fvec4) Load 2184(texel)
-            2201:    7(fvec4) FAdd 2200 2199
+            2199:  7(f16vec4) ImageGather 2197 2198 2187
+            2200:  7(f16vec4) Load 2184(texel)
+            2201:  7(f16vec4) FAdd 2200 2199
                               Store 2184(texel) 2201
             2202:         284 Load 286(s2DArray)
-            2203:  175(fvec3) Load 177(f16c3)
-            2204:    6(float) Load 137(f16bias)
-            2205:    7(fvec4) ImageGather 2202 2203 2187 Bias 2204
-            2206:    7(fvec4) Load 2184(texel)
-            2207:    7(fvec4) FAdd 2206 2205
+            2203:175(f16vec3) Load 177(f16c3)
+            2204:6(float16_t) Load 137(f16bias)
+            2205:  7(f16vec4) ImageGather 2202 2203 2187 Bias 2204
+            2206:  7(f16vec4) Load 2184(texel)
+            2207:  7(f16vec4) FAdd 2206 2205
                               Store 2184(texel) 2207
             2208:         184 Load 186(sCube)
             2209:  167(fvec3) Load 169(c3)
-            2210:    7(fvec4) ImageGather 2208 2209 2187
-            2211:    7(fvec4) Load 2184(texel)
-            2212:    7(fvec4) FAdd 2211 2210
+            2210:  7(f16vec4) ImageGather 2208 2209 2187
+            2211:  7(f16vec4) Load 2184(texel)
+            2212:  7(f16vec4) FAdd 2211 2210
                               Store 2184(texel) 2212
             2213:         184 Load 186(sCube)
-            2214:  175(fvec3) Load 177(f16c3)
-            2215:    6(float) Load 137(f16bias)
-            2216:    7(fvec4) ImageGather 2213 2214 2187 Bias 2215
-            2217:    7(fvec4) Load 2184(texel)
-            2218:    7(fvec4) FAdd 2217 2216
+            2214:175(f16vec3) Load 177(f16c3)
+            2215:6(float16_t) Load 137(f16bias)
+            2216:  7(f16vec4) ImageGather 2213 2214 2187 Bias 2215
+            2217:  7(f16vec4) Load 2184(texel)
+            2218:  7(f16vec4) FAdd 2217 2216
                               Store 2184(texel) 2218
             2219:         299 Load 301(sCubeArray)
             2220:  249(fvec4) Load 251(c4)
-            2221:    7(fvec4) ImageGather 2219 2220 2187
-            2222:    7(fvec4) Load 2184(texel)
-            2223:    7(fvec4) FAdd 2222 2221
+            2221:  7(f16vec4) ImageGather 2219 2220 2187
+            2222:  7(f16vec4) Load 2184(texel)
+            2223:  7(f16vec4) FAdd 2222 2221
                               Store 2184(texel) 2223
             2224:         299 Load 301(sCubeArray)
-            2225:    7(fvec4) Load 309(f16c4)
-            2226:    6(float) Load 137(f16bias)
-            2227:    7(fvec4) ImageGather 2224 2225 2187 Bias 2226
-            2228:    7(fvec4) Load 2184(texel)
-            2229:    7(fvec4) FAdd 2228 2227
+            2225:  7(f16vec4) Load 309(f16c4)
+            2226:6(float16_t) Load 137(f16bias)
+            2227:  7(f16vec4) ImageGather 2224 2225 2187 Bias 2226
+            2228:  7(f16vec4) Load 2184(texel)
+            2229:  7(f16vec4) FAdd 2228 2227
                               Store 2184(texel) 2229
             2230:         357 Load 359(s2DRect)
             2231:   53(fvec2) Load 148(c2)
-            2232:    7(fvec4) ImageGather 2230 2231 2187
-            2233:    7(fvec4) Load 2184(texel)
-            2234:    7(fvec4) FAdd 2233 2232
+            2232:  7(f16vec4) ImageGather 2230 2231 2187
+            2233:  7(f16vec4) Load 2184(texel)
+            2234:  7(f16vec4) FAdd 2233 2232
                               Store 2184(texel) 2234
             2235:         357 Load 359(s2DRect)
-            2236:  154(fvec2) Load 156(f16c2)
-            2237:    7(fvec4) ImageGather 2235 2236 2187
-            2238:    7(fvec4) Load 2184(texel)
-            2239:    7(fvec4) FAdd 2238 2237
+            2236:154(f16vec2) Load 156(f16c2)
+            2237:  7(f16vec4) ImageGather 2235 2236 2187
+            2238:  7(f16vec4) Load 2184(texel)
+            2239:  7(f16vec4) FAdd 2238 2237
                               Store 2184(texel) 2239
             2240:         224 Load 226(s2DShadow)
             2241:   53(fvec2) Load 148(c2)
             2242:   52(float) Load 215(compare)
-            2243:    7(fvec4) ImageDrefGather 2240 2241 2242
-            2244:    7(fvec4) Load 2184(texel)
-            2245:    7(fvec4) FAdd 2244 2243
+            2243:  7(f16vec4) ImageDrefGather 2240 2241 2242
+            2244:  7(f16vec4) Load 2184(texel)
+            2245:  7(f16vec4) FAdd 2244 2243
                               Store 2184(texel) 2245
             2246:         224 Load 226(s2DShadow)
-            2247:  154(fvec2) Load 156(f16c2)
+            2247:154(f16vec2) Load 156(f16c2)
             2248:   52(float) Load 215(compare)
-            2249:    7(fvec4) ImageDrefGather 2246 2247 2248
-            2250:    7(fvec4) Load 2184(texel)
-            2251:    7(fvec4) FAdd 2250 2249
+            2249:  7(f16vec4) ImageDrefGather 2246 2247 2248
+            2250:  7(f16vec4) Load 2184(texel)
+            2251:  7(f16vec4) FAdd 2250 2249
                               Store 2184(texel) 2251
             2252:         337 Load 339(s2DArrayShadow)
             2253:  167(fvec3) Load 169(c3)
             2254:   52(float) Load 215(compare)
-            2255:    7(fvec4) ImageDrefGather 2252 2253 2254
-            2256:    7(fvec4) Load 2184(texel)
-            2257:    7(fvec4) FAdd 2256 2255
+            2255:  7(f16vec4) ImageDrefGather 2252 2253 2254
+            2256:  7(f16vec4) Load 2184(texel)
+            2257:  7(f16vec4) FAdd 2256 2255
                               Store 2184(texel) 2257
             2258:         337 Load 339(s2DArrayShadow)
-            2259:  175(fvec3) Load 177(f16c3)
+            2259:175(f16vec3) Load 177(f16c3)
             2260:   52(float) Load 215(compare)
-            2261:    7(fvec4) ImageDrefGather 2258 2259 2260
-            2262:    7(fvec4) Load 2184(texel)
-            2263:    7(fvec4) FAdd 2262 2261
+            2261:  7(f16vec4) ImageDrefGather 2258 2259 2260
+            2262:  7(f16vec4) Load 2184(texel)
+            2263:  7(f16vec4) FAdd 2262 2261
                               Store 2184(texel) 2263
             2264:         245 Load 247(sCubeShadow)
             2265:  167(fvec3) Load 169(c3)
             2266:   52(float) Load 215(compare)
-            2267:    7(fvec4) ImageDrefGather 2264 2265 2266
-            2268:    7(fvec4) Load 2184(texel)
-            2269:    7(fvec4) FAdd 2268 2267
+            2267:  7(f16vec4) ImageDrefGather 2264 2265 2266
+            2268:  7(f16vec4) Load 2184(texel)
+            2269:  7(f16vec4) FAdd 2268 2267
                               Store 2184(texel) 2269
             2270:         245 Load 247(sCubeShadow)
-            2271:  175(fvec3) Load 177(f16c3)
+            2271:175(f16vec3) Load 177(f16c3)
             2272:   52(float) Load 215(compare)
-            2273:    7(fvec4) ImageDrefGather 2270 2271 2272
-            2274:    7(fvec4) Load 2184(texel)
-            2275:    7(fvec4) FAdd 2274 2273
+            2273:  7(f16vec4) ImageDrefGather 2270 2271 2272
+            2274:  7(f16vec4) Load 2184(texel)
+            2275:  7(f16vec4) FAdd 2274 2273
                               Store 2184(texel) 2275
             2276:         391 Load 393(sCubeArrayShadow)
             2277:  249(fvec4) Load 251(c4)
             2278:   52(float) Load 215(compare)
-            2279:    7(fvec4) ImageDrefGather 2276 2277 2278
-            2280:    7(fvec4) Load 2184(texel)
-            2281:    7(fvec4) FAdd 2280 2279
+            2279:  7(f16vec4) ImageDrefGather 2276 2277 2278
+            2280:  7(f16vec4) Load 2184(texel)
+            2281:  7(f16vec4) FAdd 2280 2279
                               Store 2184(texel) 2281
             2282:         391 Load 393(sCubeArrayShadow)
-            2283:    7(fvec4) Load 309(f16c4)
+            2283:  7(f16vec4) Load 309(f16c4)
             2284:   52(float) Load 215(compare)
-            2285:    7(fvec4) ImageDrefGather 2282 2283 2284
-            2286:    7(fvec4) Load 2184(texel)
-            2287:    7(fvec4) FAdd 2286 2285
+            2285:  7(f16vec4) ImageDrefGather 2282 2283 2284
+            2286:  7(f16vec4) Load 2184(texel)
+            2287:  7(f16vec4) FAdd 2286 2285
                               Store 2184(texel) 2287
             2288:         371 Load 373(s2DRectShadow)
             2289:   53(fvec2) Load 148(c2)
             2290:   52(float) Load 215(compare)
-            2291:    7(fvec4) ImageDrefGather 2288 2289 2290
-            2292:    7(fvec4) Load 2184(texel)
-            2293:    7(fvec4) FAdd 2292 2291
+            2291:  7(f16vec4) ImageDrefGather 2288 2289 2290
+            2292:  7(f16vec4) Load 2184(texel)
+            2293:  7(f16vec4) FAdd 2292 2291
                               Store 2184(texel) 2293
             2294:         371 Load 373(s2DRectShadow)
-            2295:  154(fvec2) Load 156(f16c2)
+            2295:154(f16vec2) Load 156(f16c2)
             2296:   52(float) Load 215(compare)
-            2297:    7(fvec4) ImageDrefGather 2294 2295 2296
-            2298:    7(fvec4) Load 2184(texel)
-            2299:    7(fvec4) FAdd 2298 2297
+            2297:  7(f16vec4) ImageDrefGather 2294 2295 2296
+            2298:  7(f16vec4) Load 2184(texel)
+            2299:  7(f16vec4) FAdd 2298 2297
                               Store 2184(texel) 2299
-            2300:    7(fvec4) Load 2184(texel)
+            2300:  7(f16vec4) Load 2184(texel)
                               ReturnValue 2300
                               FunctionEnd
-37(testTextureGatherOffset():    7(fvec4) Function None 8
+37(testTextureGatherOffset():  7(f16vec4) Function None 8
               38:             Label
      2303(texel):     64(ptr) Variable Function
                               Store 2303(texel) 121
             2304:         143 Load 145(s2D)
             2305:   53(fvec2) Load 148(c2)
-            2306:    7(fvec4) ImageGather 2304 2305 2187 ConstOffset 722
-            2307:    7(fvec4) Load 2303(texel)
-            2308:    7(fvec4) FAdd 2307 2306
+            2306:  7(f16vec4) ImageGather 2304 2305 2187 ConstOffset 722
+            2307:  7(f16vec4) Load 2303(texel)
+            2308:  7(f16vec4) FAdd 2307 2306
                               Store 2303(texel) 2308
             2309:         143 Load 145(s2D)
-            2310:  154(fvec2) Load 156(f16c2)
-            2311:    6(float) Load 137(f16bias)
-            2312:    7(fvec4) ImageGather 2309 2310 2187 Bias ConstOffset 2311 722
-            2313:    7(fvec4) Load 2303(texel)
-            2314:    7(fvec4) FAdd 2313 2312
+            2310:154(f16vec2) Load 156(f16c2)
+            2311:6(float16_t) Load 137(f16bias)
+            2312:  7(f16vec4) ImageGather 2309 2310 2187 Bias ConstOffset 2311 722
+            2313:  7(f16vec4) Load 2303(texel)
+            2314:  7(f16vec4) FAdd 2313 2312
                               Store 2303(texel) 2314
             2315:         284 Load 286(s2DArray)
             2316:  167(fvec3) Load 169(c3)
-            2317:    7(fvec4) ImageGather 2315 2316 2187 ConstOffset 722
-            2318:    7(fvec4) Load 2303(texel)
-            2319:    7(fvec4) FAdd 2318 2317
+            2317:  7(f16vec4) ImageGather 2315 2316 2187 ConstOffset 722
+            2318:  7(f16vec4) Load 2303(texel)
+            2319:  7(f16vec4) FAdd 2318 2317
                               Store 2303(texel) 2319
             2320:         284 Load 286(s2DArray)
-            2321:  175(fvec3) Load 177(f16c3)
-            2322:    6(float) Load 137(f16bias)
-            2323:    7(fvec4) ImageGather 2320 2321 2187 Bias ConstOffset 2322 722
-            2324:    7(fvec4) Load 2303(texel)
-            2325:    7(fvec4) FAdd 2324 2323
+            2321:175(f16vec3) Load 177(f16c3)
+            2322:6(float16_t) Load 137(f16bias)
+            2323:  7(f16vec4) ImageGather 2320 2321 2187 Bias ConstOffset 2322 722
+            2324:  7(f16vec4) Load 2303(texel)
+            2325:  7(f16vec4) FAdd 2324 2323
                               Store 2303(texel) 2325
             2326:         357 Load 359(s2DRect)
             2327:   53(fvec2) Load 148(c2)
-            2328:    7(fvec4) ImageGather 2326 2327 2187 ConstOffset 722
-            2329:    7(fvec4) Load 2303(texel)
-            2330:    7(fvec4) FAdd 2329 2328
+            2328:  7(f16vec4) ImageGather 2326 2327 2187 ConstOffset 722
+            2329:  7(f16vec4) Load 2303(texel)
+            2330:  7(f16vec4) FAdd 2329 2328
                               Store 2303(texel) 2330
             2331:         357 Load 359(s2DRect)
-            2332:  154(fvec2) Load 156(f16c2)
-            2333:    7(fvec4) ImageGather 2331 2332 2187 ConstOffset 722
-            2334:    7(fvec4) Load 2303(texel)
-            2335:    7(fvec4) FAdd 2334 2333
+            2332:154(f16vec2) Load 156(f16c2)
+            2333:  7(f16vec4) ImageGather 2331 2332 2187 ConstOffset 722
+            2334:  7(f16vec4) Load 2303(texel)
+            2335:  7(f16vec4) FAdd 2334 2333
                               Store 2303(texel) 2335
             2336:         224 Load 226(s2DShadow)
             2337:   53(fvec2) Load 148(c2)
             2338:   52(float) Load 215(compare)
-            2339:    7(fvec4) ImageDrefGather 2336 2337 2338 ConstOffset 722
-            2340:    7(fvec4) Load 2303(texel)
-            2341:    7(fvec4) FAdd 2340 2339
+            2339:  7(f16vec4) ImageDrefGather 2336 2337 2338 ConstOffset 722
+            2340:  7(f16vec4) Load 2303(texel)
+            2341:  7(f16vec4) FAdd 2340 2339
                               Store 2303(texel) 2341
             2342:         224 Load 226(s2DShadow)
-            2343:  154(fvec2) Load 156(f16c2)
+            2343:154(f16vec2) Load 156(f16c2)
             2344:   52(float) Load 215(compare)
-            2345:    7(fvec4) ImageDrefGather 2342 2343 2344 ConstOffset 722
-            2346:    7(fvec4) Load 2303(texel)
-            2347:    7(fvec4) FAdd 2346 2345
+            2345:  7(f16vec4) ImageDrefGather 2342 2343 2344 ConstOffset 722
+            2346:  7(f16vec4) Load 2303(texel)
+            2347:  7(f16vec4) FAdd 2346 2345
                               Store 2303(texel) 2347
             2348:         337 Load 339(s2DArrayShadow)
             2349:  167(fvec3) Load 169(c3)
             2350:   52(float) Load 215(compare)
-            2351:    7(fvec4) ImageDrefGather 2348 2349 2350 ConstOffset 722
-            2352:    7(fvec4) Load 2303(texel)
-            2353:    7(fvec4) FAdd 2352 2351
+            2351:  7(f16vec4) ImageDrefGather 2348 2349 2350 ConstOffset 722
+            2352:  7(f16vec4) Load 2303(texel)
+            2353:  7(f16vec4) FAdd 2352 2351
                               Store 2303(texel) 2353
             2354:         337 Load 339(s2DArrayShadow)
-            2355:  175(fvec3) Load 177(f16c3)
+            2355:175(f16vec3) Load 177(f16c3)
             2356:   52(float) Load 215(compare)
-            2357:    7(fvec4) ImageDrefGather 2354 2355 2356 ConstOffset 722
-            2358:    7(fvec4) Load 2303(texel)
-            2359:    7(fvec4) FAdd 2358 2357
+            2357:  7(f16vec4) ImageDrefGather 2354 2355 2356 ConstOffset 722
+            2358:  7(f16vec4) Load 2303(texel)
+            2359:  7(f16vec4) FAdd 2358 2357
                               Store 2303(texel) 2359
             2360:         371 Load 373(s2DRectShadow)
             2361:   53(fvec2) Load 148(c2)
             2362:   52(float) Load 215(compare)
-            2363:    7(fvec4) ImageDrefGather 2360 2361 2362 ConstOffset 722
-            2364:    7(fvec4) Load 2303(texel)
-            2365:    7(fvec4) FAdd 2364 2363
+            2363:  7(f16vec4) ImageDrefGather 2360 2361 2362 ConstOffset 722
+            2364:  7(f16vec4) Load 2303(texel)
+            2365:  7(f16vec4) FAdd 2364 2363
                               Store 2303(texel) 2365
             2366:         371 Load 373(s2DRectShadow)
-            2367:  154(fvec2) Load 156(f16c2)
+            2367:154(f16vec2) Load 156(f16c2)
             2368:   52(float) Load 215(compare)
-            2369:    7(fvec4) ImageDrefGather 2366 2367 2368 ConstOffset 722
-            2370:    7(fvec4) Load 2303(texel)
-            2371:    7(fvec4) FAdd 2370 2369
+            2369:  7(f16vec4) ImageDrefGather 2366 2367 2368 ConstOffset 722
+            2370:  7(f16vec4) Load 2303(texel)
+            2371:  7(f16vec4) FAdd 2370 2369
                               Store 2303(texel) 2371
-            2372:    7(fvec4) Load 2303(texel)
+            2372:  7(f16vec4) Load 2303(texel)
                               ReturnValue 2372
                               FunctionEnd
-39(testTextureGatherOffsets():    7(fvec4) Function None 8
+39(testTextureGatherOffsets():  7(f16vec4) Function None 8
               40:             Label
      2375(texel):     64(ptr) Variable Function
                               Store 2375(texel) 121
             2376:         143 Load 145(s2D)
             2377:   53(fvec2) Load 148(c2)
-            2381:    7(fvec4) ImageGather 2376 2377 2187 ConstOffsets 2380
-            2382:    7(fvec4) Load 2375(texel)
-            2383:    7(fvec4) FAdd 2382 2381
+            2381:  7(f16vec4) ImageGather 2376 2377 2187 ConstOffsets 2380
+            2382:  7(f16vec4) Load 2375(texel)
+            2383:  7(f16vec4) FAdd 2382 2381
                               Store 2375(texel) 2383
             2384:         143 Load 145(s2D)
-            2385:  154(fvec2) Load 156(f16c2)
-            2386:    6(float) Load 137(f16bias)
-            2387:    7(fvec4) ImageGather 2384 2385 2187 Bias ConstOffsets 2386 2380
-            2388:    7(fvec4) Load 2375(texel)
-            2389:    7(fvec4) FAdd 2388 2387
+            2385:154(f16vec2) Load 156(f16c2)
+            2386:6(float16_t) Load 137(f16bias)
+            2387:  7(f16vec4) ImageGather 2384 2385 2187 Bias ConstOffsets 2386 2380
+            2388:  7(f16vec4) Load 2375(texel)
+            2389:  7(f16vec4) FAdd 2388 2387
                               Store 2375(texel) 2389
             2390:         284 Load 286(s2DArray)
             2391:  167(fvec3) Load 169(c3)
-            2392:    7(fvec4) ImageGather 2390 2391 2187 ConstOffsets 2380
-            2393:    7(fvec4) Load 2375(texel)
-            2394:    7(fvec4) FAdd 2393 2392
+            2392:  7(f16vec4) ImageGather 2390 2391 2187 ConstOffsets 2380
+            2393:  7(f16vec4) Load 2375(texel)
+            2394:  7(f16vec4) FAdd 2393 2392
                               Store 2375(texel) 2394
             2395:         284 Load 286(s2DArray)
-            2396:  175(fvec3) Load 177(f16c3)
-            2397:    6(float) Load 137(f16bias)
-            2398:    7(fvec4) ImageGather 2395 2396 2187 Bias ConstOffsets 2397 2380
-            2399:    7(fvec4) Load 2375(texel)
-            2400:    7(fvec4) FAdd 2399 2398
+            2396:175(f16vec3) Load 177(f16c3)
+            2397:6(float16_t) Load 137(f16bias)
+            2398:  7(f16vec4) ImageGather 2395 2396 2187 Bias ConstOffsets 2397 2380
+            2399:  7(f16vec4) Load 2375(texel)
+            2400:  7(f16vec4) FAdd 2399 2398
                               Store 2375(texel) 2400
             2401:         357 Load 359(s2DRect)
             2402:   53(fvec2) Load 148(c2)
-            2403:    7(fvec4) ImageGather 2401 2402 2187 ConstOffsets 2380
-            2404:    7(fvec4) Load 2375(texel)
-            2405:    7(fvec4) FAdd 2404 2403
+            2403:  7(f16vec4) ImageGather 2401 2402 2187 ConstOffsets 2380
+            2404:  7(f16vec4) Load 2375(texel)
+            2405:  7(f16vec4) FAdd 2404 2403
                               Store 2375(texel) 2405
             2406:         357 Load 359(s2DRect)
-            2407:  154(fvec2) Load 156(f16c2)
-            2408:    7(fvec4) ImageGather 2406 2407 2187 ConstOffsets 2380
-            2409:    7(fvec4) Load 2375(texel)
-            2410:    7(fvec4) FAdd 2409 2408
+            2407:154(f16vec2) Load 156(f16c2)
+            2408:  7(f16vec4) ImageGather 2406 2407 2187 ConstOffsets 2380
+            2409:  7(f16vec4) Load 2375(texel)
+            2410:  7(f16vec4) FAdd 2409 2408
                               Store 2375(texel) 2410
             2411:         224 Load 226(s2DShadow)
             2412:   53(fvec2) Load 148(c2)
             2413:   52(float) Load 215(compare)
-            2414:    7(fvec4) ImageDrefGather 2411 2412 2413 ConstOffsets 2380
-            2415:    7(fvec4) Load 2375(texel)
-            2416:    7(fvec4) FAdd 2415 2414
+            2414:  7(f16vec4) ImageDrefGather 2411 2412 2413 ConstOffsets 2380
+            2415:  7(f16vec4) Load 2375(texel)
+            2416:  7(f16vec4) FAdd 2415 2414
                               Store 2375(texel) 2416
             2417:         224 Load 226(s2DShadow)
-            2418:  154(fvec2) Load 156(f16c2)
+            2418:154(f16vec2) Load 156(f16c2)
             2419:   52(float) Load 215(compare)
-            2420:    7(fvec4) ImageDrefGather 2417 2418 2419 ConstOffsets 2380
-            2421:    7(fvec4) Load 2375(texel)
-            2422:    7(fvec4) FAdd 2421 2420
+            2420:  7(f16vec4) ImageDrefGather 2417 2418 2419 ConstOffsets 2380
+            2421:  7(f16vec4) Load 2375(texel)
+            2422:  7(f16vec4) FAdd 2421 2420
                               Store 2375(texel) 2422
             2423:         337 Load 339(s2DArrayShadow)
             2424:  167(fvec3) Load 169(c3)
             2425:   52(float) Load 215(compare)
-            2426:    7(fvec4) ImageDrefGather 2423 2424 2425 ConstOffsets 2380
-            2427:    7(fvec4) Load 2375(texel)
-            2428:    7(fvec4) FAdd 2427 2426
+            2426:  7(f16vec4) ImageDrefGather 2423 2424 2425 ConstOffsets 2380
+            2427:  7(f16vec4) Load 2375(texel)
+            2428:  7(f16vec4) FAdd 2427 2426
                               Store 2375(texel) 2428
             2429:         337 Load 339(s2DArrayShadow)
-            2430:  175(fvec3) Load 177(f16c3)
+            2430:175(f16vec3) Load 177(f16c3)
             2431:   52(float) Load 215(compare)
-            2432:    7(fvec4) ImageDrefGather 2429 2430 2431 ConstOffsets 2380
-            2433:    7(fvec4) Load 2375(texel)
-            2434:    7(fvec4) FAdd 2433 2432
+            2432:  7(f16vec4) ImageDrefGather 2429 2430 2431 ConstOffsets 2380
+            2433:  7(f16vec4) Load 2375(texel)
+            2434:  7(f16vec4) FAdd 2433 2432
                               Store 2375(texel) 2434
             2435:         371 Load 373(s2DRectShadow)
             2436:   53(fvec2) Load 148(c2)
             2437:   52(float) Load 215(compare)
-            2438:    7(fvec4) ImageDrefGather 2435 2436 2437 ConstOffsets 2380
-            2439:    7(fvec4) Load 2375(texel)
-            2440:    7(fvec4) FAdd 2439 2438
+            2438:  7(f16vec4) ImageDrefGather 2435 2436 2437 ConstOffsets 2380
+            2439:  7(f16vec4) Load 2375(texel)
+            2440:  7(f16vec4) FAdd 2439 2438
                               Store 2375(texel) 2440
             2441:         371 Load 373(s2DRectShadow)
-            2442:  154(fvec2) Load 156(f16c2)
+            2442:154(f16vec2) Load 156(f16c2)
             2443:   52(float) Load 215(compare)
-            2444:    7(fvec4) ImageDrefGather 2441 2442 2443 ConstOffsets 2380
-            2445:    7(fvec4) Load 2375(texel)
-            2446:    7(fvec4) FAdd 2445 2444
+            2444:  7(f16vec4) ImageDrefGather 2441 2442 2443 ConstOffsets 2380
+            2445:  7(f16vec4) Load 2375(texel)
+            2446:  7(f16vec4) FAdd 2445 2444
                               Store 2375(texel) 2446
-            2447:    7(fvec4) Load 2375(texel)
+            2447:  7(f16vec4) Load 2375(texel)
                               ReturnValue 2447
                               FunctionEnd
-41(testTextureGatherLod():    7(fvec4) Function None 8
+41(testTextureGatherLod():  7(f16vec4) Function None 8
               42:             Label
      2450(texel):     64(ptr) Variable Function
                               Store 2450(texel) 121
             2451:         143 Load 145(s2D)
             2452:   53(fvec2) Load 148(c2)
             2453:   52(float) Load 565(lod)
-            2454:    7(fvec4) ImageGather 2451 2452 2187 Lod 2453
-            2455:    7(fvec4) Load 2450(texel)
-            2456:    7(fvec4) FAdd 2455 2454
+            2454:  7(f16vec4) ImageGather 2451 2452 2187 Lod 2453
+            2455:  7(f16vec4) Load 2450(texel)
+            2456:  7(f16vec4) FAdd 2455 2454
                               Store 2450(texel) 2456
             2457:         143 Load 145(s2D)
-            2458:  154(fvec2) Load 156(f16c2)
-            2459:    6(float) Load 572(f16lod)
-            2460:    7(fvec4) ImageGather 2457 2458 2187 Lod 2459
-            2461:    7(fvec4) Load 2450(texel)
-            2462:    7(fvec4) FAdd 2461 2460
+            2458:154(f16vec2) Load 156(f16c2)
+            2459:6(float16_t) Load 572(f16lod)
+            2460:  7(f16vec4) ImageGather 2457 2458 2187 Lod 2459
+            2461:  7(f16vec4) Load 2450(texel)
+            2462:  7(f16vec4) FAdd 2461 2460
                               Store 2450(texel) 2462
             2463:         284 Load 286(s2DArray)
             2464:  167(fvec3) Load 169(c3)
             2465:   52(float) Load 565(lod)
-            2466:    7(fvec4) ImageGather 2463 2464 2187 Lod 2465
-            2467:    7(fvec4) Load 2450(texel)
-            2468:    7(fvec4) FAdd 2467 2466
+            2466:  7(f16vec4) ImageGather 2463 2464 2187 Lod 2465
+            2467:  7(f16vec4) Load 2450(texel)
+            2468:  7(f16vec4) FAdd 2467 2466
                               Store 2450(texel) 2468
             2469:         284 Load 286(s2DArray)
-            2470:  175(fvec3) Load 177(f16c3)
-            2471:    6(float) Load 572(f16lod)
-            2472:    7(fvec4) ImageGather 2469 2470 2187 Lod 2471
-            2473:    7(fvec4) Load 2450(texel)
-            2474:    7(fvec4) FAdd 2473 2472
+            2470:175(f16vec3) Load 177(f16c3)
+            2471:6(float16_t) Load 572(f16lod)
+            2472:  7(f16vec4) ImageGather 2469 2470 2187 Lod 2471
+            2473:  7(f16vec4) Load 2450(texel)
+            2474:  7(f16vec4) FAdd 2473 2472
                               Store 2450(texel) 2474
             2475:         184 Load 186(sCube)
             2476:  167(fvec3) Load 169(c3)
             2477:   52(float) Load 565(lod)
-            2478:    7(fvec4) ImageGather 2475 2476 2187 Lod 2477
-            2479:    7(fvec4) Load 2450(texel)
-            2480:    7(fvec4) FAdd 2479 2478
+            2478:  7(f16vec4) ImageGather 2475 2476 2187 Lod 2477
+            2479:  7(f16vec4) Load 2450(texel)
+            2480:  7(f16vec4) FAdd 2479 2478
                               Store 2450(texel) 2480
             2481:         184 Load 186(sCube)
-            2482:  175(fvec3) Load 177(f16c3)
-            2483:    6(float) Load 572(f16lod)
-            2484:    7(fvec4) ImageGather 2481 2482 2187 Lod 2483
-            2485:    7(fvec4) Load 2450(texel)
-            2486:    7(fvec4) FAdd 2485 2484
+            2482:175(f16vec3) Load 177(f16c3)
+            2483:6(float16_t) Load 572(f16lod)
+            2484:  7(f16vec4) ImageGather 2481 2482 2187 Lod 2483
+            2485:  7(f16vec4) Load 2450(texel)
+            2486:  7(f16vec4) FAdd 2485 2484
                               Store 2450(texel) 2486
             2487:         299 Load 301(sCubeArray)
             2488:  249(fvec4) Load 251(c4)
             2489:   52(float) Load 565(lod)
-            2490:    7(fvec4) ImageGather 2487 2488 2187 Lod 2489
-            2491:    7(fvec4) Load 2450(texel)
-            2492:    7(fvec4) FAdd 2491 2490
+            2490:  7(f16vec4) ImageGather 2487 2488 2187 Lod 2489
+            2491:  7(f16vec4) Load 2450(texel)
+            2492:  7(f16vec4) FAdd 2491 2490
                               Store 2450(texel) 2492
             2493:         299 Load 301(sCubeArray)
-            2494:    7(fvec4) Load 309(f16c4)
-            2495:    6(float) Load 572(f16lod)
-            2496:    7(fvec4) ImageGather 2493 2494 2187 Lod 2495
-            2497:    7(fvec4) Load 2450(texel)
-            2498:    7(fvec4) FAdd 2497 2496
+            2494:  7(f16vec4) Load 309(f16c4)
+            2495:6(float16_t) Load 572(f16lod)
+            2496:  7(f16vec4) ImageGather 2493 2494 2187 Lod 2495
+            2497:  7(f16vec4) Load 2450(texel)
+            2498:  7(f16vec4) FAdd 2497 2496
                               Store 2450(texel) 2498
-            2499:    7(fvec4) Load 2450(texel)
+            2499:  7(f16vec4) Load 2450(texel)
                               ReturnValue 2499
                               FunctionEnd
-43(testTextureGatherLodOffset():    7(fvec4) Function None 8
+43(testTextureGatherLodOffset():  7(f16vec4) Function None 8
               44:             Label
      2502(texel):     64(ptr) Variable Function
                               Store 2502(texel) 121
             2503:         143 Load 145(s2D)
             2504:   53(fvec2) Load 148(c2)
             2505:   52(float) Load 565(lod)
-            2506:    7(fvec4) ImageGather 2503 2504 2187 Lod ConstOffset 2505 722
-            2507:    7(fvec4) Load 2502(texel)
-            2508:    7(fvec4) FAdd 2507 2506
+            2506:  7(f16vec4) ImageGather 2503 2504 2187 Lod ConstOffset 2505 722
+            2507:  7(f16vec4) Load 2502(texel)
+            2508:  7(f16vec4) FAdd 2507 2506
                               Store 2502(texel) 2508
             2509:         143 Load 145(s2D)
-            2510:  154(fvec2) Load 156(f16c2)
-            2511:    6(float) Load 572(f16lod)
-            2512:    7(fvec4) ImageGather 2509 2510 2187 Lod ConstOffset 2511 722
-            2513:    7(fvec4) Load 2502(texel)
-            2514:    7(fvec4) FAdd 2513 2512
+            2510:154(f16vec2) Load 156(f16c2)
+            2511:6(float16_t) Load 572(f16lod)
+            2512:  7(f16vec4) ImageGather 2509 2510 2187 Lod ConstOffset 2511 722
+            2513:  7(f16vec4) Load 2502(texel)
+            2514:  7(f16vec4) FAdd 2513 2512
                               Store 2502(texel) 2514
             2515:         284 Load 286(s2DArray)
             2516:  167(fvec3) Load 169(c3)
             2517:   52(float) Load 565(lod)
-            2518:    7(fvec4) ImageGather 2515 2516 2187 Lod ConstOffset 2517 722
-            2519:    7(fvec4) Load 2502(texel)
-            2520:    7(fvec4) FAdd 2519 2518
+            2518:  7(f16vec4) ImageGather 2515 2516 2187 Lod ConstOffset 2517 722
+            2519:  7(f16vec4) Load 2502(texel)
+            2520:  7(f16vec4) FAdd 2519 2518
                               Store 2502(texel) 2520
             2521:         284 Load 286(s2DArray)
-            2522:  175(fvec3) Load 177(f16c3)
-            2523:    6(float) Load 572(f16lod)
-            2524:    7(fvec4) ImageGather 2521 2522 2187 Lod ConstOffset 2523 722
-            2525:    7(fvec4) Load 2502(texel)
-            2526:    7(fvec4) FAdd 2525 2524
+            2522:175(f16vec3) Load 177(f16c3)
+            2523:6(float16_t) Load 572(f16lod)
+            2524:  7(f16vec4) ImageGather 2521 2522 2187 Lod ConstOffset 2523 722
+            2525:  7(f16vec4) Load 2502(texel)
+            2526:  7(f16vec4) FAdd 2525 2524
                               Store 2502(texel) 2526
-            2527:    7(fvec4) Load 2502(texel)
+            2527:  7(f16vec4) Load 2502(texel)
                               ReturnValue 2527
                               FunctionEnd
-45(testTextureGatherLodOffsets():    7(fvec4) Function None 8
+45(testTextureGatherLodOffsets():  7(f16vec4) Function None 8
               46:             Label
      2530(texel):     64(ptr) Variable Function
                               Store 2530(texel) 121
             2531:         143 Load 145(s2D)
             2532:   53(fvec2) Load 148(c2)
             2533:   52(float) Load 565(lod)
-            2534:    7(fvec4) ImageGather 2531 2532 2187 Lod ConstOffsets 2533 2380
-            2535:    7(fvec4) Load 2530(texel)
-            2536:    7(fvec4) FAdd 2535 2534
+            2534:  7(f16vec4) ImageGather 2531 2532 2187 Lod ConstOffsets 2533 2380
+            2535:  7(f16vec4) Load 2530(texel)
+            2536:  7(f16vec4) FAdd 2535 2534
                               Store 2530(texel) 2536
             2537:         143 Load 145(s2D)
-            2538:  154(fvec2) Load 156(f16c2)
-            2539:    6(float) Load 572(f16lod)
-            2540:    7(fvec4) ImageGather 2537 2538 2187 Lod ConstOffsets 2539 2380
-            2541:    7(fvec4) Load 2530(texel)
-            2542:    7(fvec4) FAdd 2541 2540
+            2538:154(f16vec2) Load 156(f16c2)
+            2539:6(float16_t) Load 572(f16lod)
+            2540:  7(f16vec4) ImageGather 2537 2538 2187 Lod ConstOffsets 2539 2380
+            2541:  7(f16vec4) Load 2530(texel)
+            2542:  7(f16vec4) FAdd 2541 2540
                               Store 2530(texel) 2542
             2543:         284 Load 286(s2DArray)
             2544:  167(fvec3) Load 169(c3)
             2545:   52(float) Load 565(lod)
-            2546:    7(fvec4) ImageGather 2543 2544 2187 Lod ConstOffsets 2545 2380
-            2547:    7(fvec4) Load 2530(texel)
-            2548:    7(fvec4) FAdd 2547 2546
+            2546:  7(f16vec4) ImageGather 2543 2544 2187 Lod ConstOffsets 2545 2380
+            2547:  7(f16vec4) Load 2530(texel)
+            2548:  7(f16vec4) FAdd 2547 2546
                               Store 2530(texel) 2548
             2549:         284 Load 286(s2DArray)
-            2550:  175(fvec3) Load 177(f16c3)
-            2551:    6(float) Load 572(f16lod)
-            2552:    7(fvec4) ImageGather 2549 2550 2187 Lod ConstOffsets 2551 2380
-            2553:    7(fvec4) Load 2530(texel)
-            2554:    7(fvec4) FAdd 2553 2552
+            2550:175(f16vec3) Load 177(f16c3)
+            2551:6(float16_t) Load 572(f16lod)
+            2552:  7(f16vec4) ImageGather 2549 2550 2187 Lod ConstOffsets 2551 2380
+            2553:  7(f16vec4) Load 2530(texel)
+            2554:  7(f16vec4) FAdd 2553 2552
                               Store 2530(texel) 2554
-            2555:    7(fvec4) Load 2530(texel)
+            2555:  7(f16vec4) Load 2530(texel)
                               ReturnValue 2555
                               FunctionEnd
 50(testTextureSize():   48(ivec4) Function None 49
@@ -3633,8 +3633,8 @@ spv.float16Fetch.frag
             2740:   53(fvec2) FAdd 2739 2738
                               Store 2733(lod) 2740
             2741:         123 Load 125(s1D)
-            2742:    6(float) Load 135(f16c1)
-            2743:  154(fvec2) ImageQueryLod 2741 2742
+            2742:6(float16_t) Load 135(f16c1)
+            2743:154(f16vec2) ImageQueryLod 2741 2742
             2744:   53(fvec2) Load 2733(lod)
             2745:   53(fvec2) FAdd 2744 2743
                               Store 2733(lod) 2745
@@ -3645,8 +3645,8 @@ spv.float16Fetch.frag
             2750:   53(fvec2) FAdd 2749 2748
                               Store 2733(lod) 2750
             2751:         143 Load 145(s2D)
-            2752:  154(fvec2) Load 156(f16c2)
-            2753:  154(fvec2) ImageQueryLod 2751 2752
+            2752:154(f16vec2) Load 156(f16c2)
+            2753:154(f16vec2) ImageQueryLod 2751 2752
             2754:   53(fvec2) Load 2733(lod)
             2755:   53(fvec2) FAdd 2754 2753
                               Store 2733(lod) 2755
@@ -3657,8 +3657,8 @@ spv.float16Fetch.frag
             2760:   53(fvec2) FAdd 2759 2758
                               Store 2733(lod) 2760
             2761:         163 Load 165(s3D)
-            2762:  175(fvec3) Load 177(f16c3)
-            2763:  154(fvec2) ImageQueryLod 2761 2762
+            2762:175(f16vec3) Load 177(f16c3)
+            2763:154(f16vec2) ImageQueryLod 2761 2762
             2764:   53(fvec2) Load 2733(lod)
             2765:   53(fvec2) FAdd 2764 2763
                               Store 2733(lod) 2765
@@ -3669,8 +3669,8 @@ spv.float16Fetch.frag
             2770:   53(fvec2) FAdd 2769 2768
                               Store 2733(lod) 2770
             2771:         184 Load 186(sCube)
-            2772:  175(fvec3) Load 177(f16c3)
-            2773:  154(fvec2) ImageQueryLod 2771 2772
+            2772:175(f16vec3) Load 177(f16c3)
+            2773:154(f16vec2) ImageQueryLod 2771 2772
             2774:   53(fvec2) Load 2733(lod)
             2775:   53(fvec2) FAdd 2774 2773
                               Store 2733(lod) 2775
@@ -3681,8 +3681,8 @@ spv.float16Fetch.frag
             2780:   53(fvec2) FAdd 2779 2778
                               Store 2733(lod) 2780
             2781:         269 Load 271(s1DArray)
-            2782:    6(float) Load 135(f16c1)
-            2783:  154(fvec2) ImageQueryLod 2781 2782
+            2782:6(float16_t) Load 135(f16c1)
+            2783:154(f16vec2) ImageQueryLod 2781 2782
             2784:   53(fvec2) Load 2733(lod)
             2785:   53(fvec2) FAdd 2784 2783
                               Store 2733(lod) 2785
@@ -3693,8 +3693,8 @@ spv.float16Fetch.frag
             2790:   53(fvec2) FAdd 2789 2788
                               Store 2733(lod) 2790
             2791:         284 Load 286(s2DArray)
-            2792:  154(fvec2) Load 156(f16c2)
-            2793:  154(fvec2) ImageQueryLod 2791 2792
+            2792:154(f16vec2) Load 156(f16c2)
+            2793:154(f16vec2) ImageQueryLod 2791 2792
             2794:   53(fvec2) Load 2733(lod)
             2795:   53(fvec2) FAdd 2794 2793
                               Store 2733(lod) 2795
@@ -3705,8 +3705,8 @@ spv.float16Fetch.frag
             2800:   53(fvec2) FAdd 2799 2798
                               Store 2733(lod) 2800
             2801:         299 Load 301(sCubeArray)
-            2802:  175(fvec3) Load 177(f16c3)
-            2803:  154(fvec2) ImageQueryLod 2801 2802
+            2802:175(f16vec3) Load 177(f16c3)
+            2803:154(f16vec2) ImageQueryLod 2801 2802
             2804:   53(fvec2) Load 2733(lod)
             2805:   53(fvec2) FAdd 2804 2803
                               Store 2733(lod) 2805
@@ -3717,8 +3717,8 @@ spv.float16Fetch.frag
             2810:   53(fvec2) FAdd 2809 2808
                               Store 2733(lod) 2810
             2811:         199 Load 201(s1DShadow)
-            2812:    6(float) Load 135(f16c1)
-            2813:  154(fvec2) ImageQueryLod 2811 2812
+            2812:6(float16_t) Load 135(f16c1)
+            2813:154(f16vec2) ImageQueryLod 2811 2812
             2814:   53(fvec2) Load 2733(lod)
             2815:   53(fvec2) FAdd 2814 2813
                               Store 2733(lod) 2815
@@ -3729,8 +3729,8 @@ spv.float16Fetch.frag
             2820:   53(fvec2) FAdd 2819 2818
                               Store 2733(lod) 2820
             2821:         224 Load 226(s2DShadow)
-            2822:  154(fvec2) Load 156(f16c2)
-            2823:  154(fvec2) ImageQueryLod 2821 2822
+            2822:154(f16vec2) Load 156(f16c2)
+            2823:154(f16vec2) ImageQueryLod 2821 2822
             2824:   53(fvec2) Load 2733(lod)
             2825:   53(fvec2) FAdd 2824 2823
                               Store 2733(lod) 2825
@@ -3741,8 +3741,8 @@ spv.float16Fetch.frag
             2830:   53(fvec2) FAdd 2829 2828
                               Store 2733(lod) 2830
             2831:         391 Load 393(sCubeArrayShadow)
-            2832:  175(fvec3) Load 177(f16c3)
-            2833:  154(fvec2) ImageQueryLod 2831 2832
+            2832:175(f16vec3) Load 177(f16c3)
+            2833:154(f16vec2) ImageQueryLod 2831 2832
             2834:   53(fvec2) Load 2733(lod)
             2835:   53(fvec2) FAdd 2834 2833
                               Store 2733(lod) 2835
@@ -3753,8 +3753,8 @@ spv.float16Fetch.frag
             2840:   53(fvec2) FAdd 2839 2838
                               Store 2733(lod) 2840
             2841:         316 Load 318(s1DArrayShadow)
-            2842:    6(float) Load 135(f16c1)
-            2843:  154(fvec2) ImageQueryLod 2841 2842
+            2842:6(float16_t) Load 135(f16c1)
+            2843:154(f16vec2) ImageQueryLod 2841 2842
             2844:   53(fvec2) Load 2733(lod)
             2845:   53(fvec2) FAdd 2844 2843
                               Store 2733(lod) 2845
@@ -3765,8 +3765,8 @@ spv.float16Fetch.frag
             2850:   53(fvec2) FAdd 2849 2848
                               Store 2733(lod) 2850
             2851:         337 Load 339(s2DArrayShadow)
-            2852:  154(fvec2) Load 156(f16c2)
-            2853:  154(fvec2) ImageQueryLod 2851 2852
+            2852:154(f16vec2) Load 156(f16c2)
+            2853:154(f16vec2) ImageQueryLod 2851 2852
             2854:   53(fvec2) Load 2733(lod)
             2855:   53(fvec2) FAdd 2854 2853
                               Store 2733(lod) 2855
@@ -3777,8 +3777,8 @@ spv.float16Fetch.frag
             2860:   53(fvec2) FAdd 2859 2858
                               Store 2733(lod) 2860
             2861:         391 Load 393(sCubeArrayShadow)
-            2862:  175(fvec3) Load 177(f16c3)
-            2863:  154(fvec2) ImageQueryLod 2861 2862
+            2862:175(f16vec3) Load 177(f16c3)
+            2863:154(f16vec2) ImageQueryLod 2861 2862
             2864:   53(fvec2) Load 2733(lod)
             2865:   53(fvec2) FAdd 2864 2863
                               Store 2733(lod) 2865
@@ -3889,88 +3889,88 @@ spv.float16Fetch.frag
             2949:     47(int) Load 2938(samples)
                               ReturnValue 2949
                               FunctionEnd
-62(testImageLoad():    7(fvec4) Function None 8
+62(testImageLoad():  7(f16vec4) Function None 8
               63:             Label
      2952(texel):     64(ptr) Variable Function
                               Store 2952(texel) 121
             2956:        2953 Load 2955(i1D)
             2957:   52(float) Load 128(c1)
             2958:     47(int) ConvertFToS 2957
-            2959:    7(fvec4) ImageRead 2956 2958
-            2960:    7(fvec4) Load 2952(texel)
-            2961:    7(fvec4) FAdd 2960 2959
+            2959:  7(f16vec4) ImageRead 2956 2958
+            2960:  7(f16vec4) Load 2952(texel)
+            2961:  7(f16vec4) FAdd 2960 2959
                               Store 2952(texel) 2961
             2965:        2962 Load 2964(i2D)
             2966:   53(fvec2) Load 148(c2)
             2967:  721(ivec2) ConvertFToS 2966
-            2968:    7(fvec4) ImageRead 2965 2967
-            2969:    7(fvec4) Load 2952(texel)
-            2970:    7(fvec4) FAdd 2969 2968
+            2968:  7(f16vec4) ImageRead 2965 2967
+            2969:  7(f16vec4) Load 2952(texel)
+            2970:  7(f16vec4) FAdd 2969 2968
                               Store 2952(texel) 2970
             2974:        2971 Load 2973(i3D)
             2975:  167(fvec3) Load 169(c3)
             2976:  734(ivec3) ConvertFToS 2975
-            2977:    7(fvec4) ImageRead 2974 2976
-            2978:    7(fvec4) Load 2952(texel)
-            2979:    7(fvec4) FAdd 2978 2977
+            2977:  7(f16vec4) ImageRead 2974 2976
+            2978:  7(f16vec4) Load 2952(texel)
+            2979:  7(f16vec4) FAdd 2978 2977
                               Store 2952(texel) 2979
             2983:        2980 Load 2982(i2DRect)
             2984:   53(fvec2) Load 148(c2)
             2985:  721(ivec2) ConvertFToS 2984
-            2986:    7(fvec4) ImageRead 2983 2985
-            2987:    7(fvec4) Load 2952(texel)
-            2988:    7(fvec4) FAdd 2987 2986
+            2986:  7(f16vec4) ImageRead 2983 2985
+            2987:  7(f16vec4) Load 2952(texel)
+            2988:  7(f16vec4) FAdd 2987 2986
                               Store 2952(texel) 2988
             2992:        2989 Load 2991(iCube)
             2993:  167(fvec3) Load 169(c3)
             2994:  734(ivec3) ConvertFToS 2993
-            2995:    7(fvec4) ImageRead 2992 2994
-            2996:    7(fvec4) Load 2952(texel)
-            2997:    7(fvec4) FAdd 2996 2995
+            2995:  7(f16vec4) ImageRead 2992 2994
+            2996:  7(f16vec4) Load 2952(texel)
+            2997:  7(f16vec4) FAdd 2996 2995
                               Store 2952(texel) 2997
             3001:        2998 Load 3000(iBuffer)
             3002:   52(float) Load 128(c1)
             3003:     47(int) ConvertFToS 3002
-            3004:    7(fvec4) ImageRead 3001 3003
-            3005:    7(fvec4) Load 2952(texel)
-            3006:    7(fvec4) FAdd 3005 3004
+            3004:  7(f16vec4) ImageRead 3001 3003
+            3005:  7(f16vec4) Load 2952(texel)
+            3006:  7(f16vec4) FAdd 3005 3004
                               Store 2952(texel) 3006
             3010:        3007 Load 3009(i1DArray)
             3011:   53(fvec2) Load 148(c2)
             3012:  721(ivec2) ConvertFToS 3011
-            3013:    7(fvec4) ImageRead 3010 3012
-            3014:    7(fvec4) Load 2952(texel)
-            3015:    7(fvec4) FAdd 3014 3013
+            3013:  7(f16vec4) ImageRead 3010 3012
+            3014:  7(f16vec4) Load 2952(texel)
+            3015:  7(f16vec4) FAdd 3014 3013
                               Store 2952(texel) 3015
             3019:        3016 Load 3018(i2DArray)
             3020:  167(fvec3) Load 169(c3)
             3021:  734(ivec3) ConvertFToS 3020
-            3022:    7(fvec4) ImageRead 3019 3021
-            3023:    7(fvec4) Load 2952(texel)
-            3024:    7(fvec4) FAdd 3023 3022
+            3022:  7(f16vec4) ImageRead 3019 3021
+            3023:  7(f16vec4) Load 2952(texel)
+            3024:  7(f16vec4) FAdd 3023 3022
                               Store 2952(texel) 3024
             3028:        3025 Load 3027(iCubeArray)
             3029:  167(fvec3) Load 169(c3)
             3030:  734(ivec3) ConvertFToS 3029
-            3031:    7(fvec4) ImageRead 3028 3030
-            3032:    7(fvec4) Load 2952(texel)
-            3033:    7(fvec4) FAdd 3032 3031
+            3031:  7(f16vec4) ImageRead 3028 3030
+            3032:  7(f16vec4) Load 2952(texel)
+            3033:  7(f16vec4) FAdd 3032 3031
                               Store 2952(texel) 3033
             3037:        3034 Load 3036(i2DMS)
             3038:   53(fvec2) Load 148(c2)
             3039:  721(ivec2) ConvertFToS 3038
-            3040:    7(fvec4) ImageRead 3037 3039 Sample 709
-            3041:    7(fvec4) Load 2952(texel)
-            3042:    7(fvec4) FAdd 3041 3040
+            3040:  7(f16vec4) ImageRead 3037 3039 Sample 709
+            3041:  7(f16vec4) Load 2952(texel)
+            3042:  7(f16vec4) FAdd 3041 3040
                               Store 2952(texel) 3042
             3046:        3043 Load 3045(i2DMSArray)
             3047:  167(fvec3) Load 169(c3)
             3048:  734(ivec3) ConvertFToS 3047
-            3049:    7(fvec4) ImageRead 3046 3048 Sample 709
-            3050:    7(fvec4) Load 2952(texel)
-            3051:    7(fvec4) FAdd 3050 3049
+            3049:  7(f16vec4) ImageRead 3046 3048 Sample 709
+            3050:  7(f16vec4) Load 2952(texel)
+            3051:  7(f16vec4) FAdd 3050 3049
                               Store 2952(texel) 3051
-            3052:    7(fvec4) Load 2952(texel)
+            3052:  7(f16vec4) Load 2952(texel)
                               ReturnValue 3052
                               FunctionEnd
 67(testImageStore(vf164;):           2 Function None 65
@@ -3979,101 +3979,101 @@ spv.float16Fetch.frag
             3055:        2953 Load 2955(i1D)
             3056:   52(float) Load 128(c1)
             3057:     47(int) ConvertFToS 3056
-            3058:    7(fvec4) Load 66(data)
+            3058:  7(f16vec4) Load 66(data)
                               ImageWrite 3055 3057 3058
             3059:        2962 Load 2964(i2D)
             3060:   53(fvec2) Load 148(c2)
             3061:  721(ivec2) ConvertFToS 3060
-            3062:    7(fvec4) Load 66(data)
+            3062:  7(f16vec4) Load 66(data)
                               ImageWrite 3059 3061 3062
             3063:        2971 Load 2973(i3D)
             3064:  167(fvec3) Load 169(c3)
             3065:  734(ivec3) ConvertFToS 3064
-            3066:    7(fvec4) Load 66(data)
+            3066:  7(f16vec4) Load 66(data)
                               ImageWrite 3063 3065 3066
             3067:        2980 Load 2982(i2DRect)
             3068:   53(fvec2) Load 148(c2)
             3069:  721(ivec2) ConvertFToS 3068
-            3070:    7(fvec4) Load 66(data)
+            3070:  7(f16vec4) Load 66(data)
                               ImageWrite 3067 3069 3070
             3071:        2989 Load 2991(iCube)
             3072:  167(fvec3) Load 169(c3)
             3073:  734(ivec3) ConvertFToS 3072
-            3074:    7(fvec4) Load 66(data)
+            3074:  7(f16vec4) Load 66(data)
                               ImageWrite 3071 3073 3074
             3075:        2998 Load 3000(iBuffer)
             3076:   52(float) Load 128(c1)
             3077:     47(int) ConvertFToS 3076
-            3078:    7(fvec4) Load 66(data)
+            3078:  7(f16vec4) Load 66(data)
                               ImageWrite 3075 3077 3078
             3079:        3007 Load 3009(i1DArray)
             3080:   53(fvec2) Load 148(c2)
             3081:  721(ivec2) ConvertFToS 3080
-            3082:    7(fvec4) Load 66(data)
+            3082:  7(f16vec4) Load 66(data)
                               ImageWrite 3079 3081 3082
             3083:        3016 Load 3018(i2DArray)
             3084:  167(fvec3) Load 169(c3)
             3085:  734(ivec3) ConvertFToS 3084
-            3086:    7(fvec4) Load 66(data)
+            3086:  7(f16vec4) Load 66(data)
                               ImageWrite 3083 3085 3086
             3087:        3025 Load 3027(iCubeArray)
             3088:  167(fvec3) Load 169(c3)
             3089:  734(ivec3) ConvertFToS 3088
-            3090:    7(fvec4) Load 66(data)
+            3090:  7(f16vec4) Load 66(data)
                               ImageWrite 3087 3089 3090
             3091:        3034 Load 3036(i2DMS)
             3092:   53(fvec2) Load 148(c2)
             3093:  721(ivec2) ConvertFToS 3092
-            3094:    7(fvec4) Load 66(data)
+            3094:  7(f16vec4) Load 66(data)
                               ImageWrite 3091 3093 3094 Sample 709
             3095:        3043 Load 3045(i2DMSArray)
             3096:  167(fvec3) Load 169(c3)
             3097:  734(ivec3) ConvertFToS 3096
-            3098:    7(fvec4) Load 66(data)
+            3098:  7(f16vec4) Load 66(data)
                               ImageWrite 3095 3097 3098 Sample 709
                               Return
                               FunctionEnd
-69(testSparseTexture():    7(fvec4) Function None 8
+69(testSparseTexture():  7(f16vec4) Function None 8
               70:             Label
      3099(texel):     64(ptr) Variable Function
                               Store 3099(texel) 121
             3100:         143 Load 145(s2D)
             3101:   53(fvec2) Load 148(c2)
             3103:3102(ResType) ImageSparseSampleImplicitLod 3100 3101
-            3104:    7(fvec4) CompositeExtract 3103 1
+            3104:  7(f16vec4) CompositeExtract 3103 1
                               Store 3099(texel) 3104
             3105:     47(int) CompositeExtract 3103 0
             3106:         143 Load 145(s2D)
-            3107:  154(fvec2) Load 156(f16c2)
-            3108:    6(float) Load 137(f16bias)
+            3107:154(f16vec2) Load 156(f16c2)
+            3108:6(float16_t) Load 137(f16bias)
             3109:3102(ResType) ImageSparseSampleImplicitLod 3106 3107 Bias 3108
-            3110:    7(fvec4) CompositeExtract 3109 1
+            3110:  7(f16vec4) CompositeExtract 3109 1
                               Store 3099(texel) 3110
             3111:     47(int) CompositeExtract 3109 0
             3112:         163 Load 165(s3D)
             3113:  167(fvec3) Load 169(c3)
             3114:3102(ResType) ImageSparseSampleImplicitLod 3112 3113
-            3115:    7(fvec4) CompositeExtract 3114 1
+            3115:  7(f16vec4) CompositeExtract 3114 1
                               Store 3099(texel) 3115
             3116:     47(int) CompositeExtract 3114 0
             3117:         163 Load 165(s3D)
-            3118:  175(fvec3) Load 177(f16c3)
-            3119:    6(float) Load 137(f16bias)
+            3118:175(f16vec3) Load 177(f16c3)
+            3119:6(float16_t) Load 137(f16bias)
             3120:3102(ResType) ImageSparseSampleImplicitLod 3117 3118 Bias 3119
-            3121:    7(fvec4) CompositeExtract 3120 1
+            3121:  7(f16vec4) CompositeExtract 3120 1
                               Store 3099(texel) 3121
             3122:     47(int) CompositeExtract 3120 0
             3123:         184 Load 186(sCube)
             3124:  167(fvec3) Load 169(c3)
             3125:3102(ResType) ImageSparseSampleImplicitLod 3123 3124
-            3126:    7(fvec4) CompositeExtract 3125 1
+            3126:  7(f16vec4) CompositeExtract 3125 1
                               Store 3099(texel) 3126
             3127:     47(int) CompositeExtract 3125 0
             3128:         184 Load 186(sCube)
-            3129:  175(fvec3) Load 177(f16c3)
-            3130:    6(float) Load 137(f16bias)
+            3129:175(f16vec3) Load 177(f16c3)
+            3130:6(float16_t) Load 137(f16bias)
             3131:3102(ResType) ImageSparseSampleImplicitLod 3128 3129 Bias 3130
-            3132:    7(fvec4) CompositeExtract 3131 1
+            3132:  7(f16vec4) CompositeExtract 3131 1
                               Store 3099(texel) 3132
             3133:     47(int) CompositeExtract 3131 0
             3134:         224 Load 226(s2DShadow)
@@ -4081,16 +4081,16 @@ spv.float16Fetch.frag
             3136:    208(ptr) AccessChain 3099(texel) 207
             3137:   52(float) CompositeExtract 3135 2
             3139:3138(ResType) ImageSparseSampleDrefImplicitLod 3134 3135 3137
-            3140:    6(float) CompositeExtract 3139 1
+            3140:6(float16_t) CompositeExtract 3139 1
                               Store 3136 3140
             3141:     47(int) CompositeExtract 3139 0
             3142:         224 Load 226(s2DShadow)
-            3143:  154(fvec2) Load 156(f16c2)
+            3143:154(f16vec2) Load 156(f16c2)
             3144:   52(float) Load 215(compare)
             3145:    208(ptr) AccessChain 3099(texel) 207
-            3146:    6(float) Load 137(f16bias)
+            3146:6(float16_t) Load 137(f16bias)
             3147:3138(ResType) ImageSparseSampleDrefImplicitLod 3142 3143 3144 Bias 3146
-            3148:    6(float) CompositeExtract 3147 1
+            3148:6(float16_t) CompositeExtract 3147 1
                               Store 3145 3148
             3149:     47(int) CompositeExtract 3147 0
             3150:         245 Load 247(sCubeShadow)
@@ -4098,42 +4098,42 @@ spv.float16Fetch.frag
             3152:    208(ptr) AccessChain 3099(texel) 207
             3153:   52(float) CompositeExtract 3151 3
             3154:3138(ResType) ImageSparseSampleDrefImplicitLod 3150 3151 3153
-            3155:    6(float) CompositeExtract 3154 1
+            3155:6(float16_t) CompositeExtract 3154 1
                               Store 3152 3155
             3156:     47(int) CompositeExtract 3154 0
             3157:         245 Load 247(sCubeShadow)
-            3158:  175(fvec3) Load 177(f16c3)
+            3158:175(f16vec3) Load 177(f16c3)
             3159:   52(float) Load 215(compare)
             3160:    208(ptr) AccessChain 3099(texel) 207
-            3161:    6(float) Load 137(f16bias)
+            3161:6(float16_t) Load 137(f16bias)
             3162:3138(ResType) ImageSparseSampleDrefImplicitLod 3157 3158 3159 Bias 3161
-            3163:    6(float) CompositeExtract 3162 1
+            3163:6(float16_t) CompositeExtract 3162 1
                               Store 3160 3163
             3164:     47(int) CompositeExtract 3162 0
             3165:         284 Load 286(s2DArray)
             3166:  167(fvec3) Load 169(c3)
             3167:3102(ResType) ImageSparseSampleImplicitLod 3165 3166
-            3168:    7(fvec4) CompositeExtract 3167 1
+            3168:  7(f16vec4) CompositeExtract 3167 1
                               Store 3099(texel) 3168
             3169:     47(int) CompositeExtract 3167 0
             3170:         284 Load 286(s2DArray)
-            3171:  175(fvec3) Load 177(f16c3)
-            3172:    6(float) Load 137(f16bias)
+            3171:175(f16vec3) Load 177(f16c3)
+            3172:6(float16_t) Load 137(f16bias)
             3173:3102(ResType) ImageSparseSampleImplicitLod 3170 3171 Bias 3172
-            3174:    7(fvec4) CompositeExtract 3173 1
+            3174:  7(f16vec4) CompositeExtract 3173 1
                               Store 3099(texel) 3174
             3175:     47(int) CompositeExtract 3173 0
             3176:         299 Load 301(sCubeArray)
             3177:  249(fvec4) Load 251(c4)
             3178:3102(ResType) ImageSparseSampleImplicitLod 3176 3177
-            3179:    7(fvec4) CompositeExtract 3178 1
+            3179:  7(f16vec4) CompositeExtract 3178 1
                               Store 3099(texel) 3179
             3180:     47(int) CompositeExtract 3178 0
             3181:         299 Load 301(sCubeArray)
-            3182:    7(fvec4) Load 309(f16c4)
-            3183:    6(float) Load 137(f16bias)
+            3182:  7(f16vec4) Load 309(f16c4)
+            3183:6(float16_t) Load 137(f16bias)
             3184:3102(ResType) ImageSparseSampleImplicitLod 3181 3182 Bias 3183
-            3185:    7(fvec4) CompositeExtract 3184 1
+            3185:  7(f16vec4) CompositeExtract 3184 1
                               Store 3099(texel) 3185
             3186:     47(int) CompositeExtract 3184 0
             3187:         337 Load 339(s2DArrayShadow)
@@ -4141,27 +4141,27 @@ spv.float16Fetch.frag
             3189:    208(ptr) AccessChain 3099(texel) 207
             3190:   52(float) CompositeExtract 3188 3
             3191:3138(ResType) ImageSparseSampleDrefImplicitLod 3187 3188 3190
-            3192:    6(float) CompositeExtract 3191 1
+            3192:6(float16_t) CompositeExtract 3191 1
                               Store 3189 3192
             3193:     47(int) CompositeExtract 3191 0
             3194:         337 Load 339(s2DArrayShadow)
-            3195:  175(fvec3) Load 177(f16c3)
+            3195:175(f16vec3) Load 177(f16c3)
             3196:   52(float) Load 215(compare)
             3197:    208(ptr) AccessChain 3099(texel) 207
             3198:3138(ResType) ImageSparseSampleDrefImplicitLod 3194 3195 3196
-            3199:    6(float) CompositeExtract 3198 1
+            3199:6(float16_t) CompositeExtract 3198 1
                               Store 3197 3199
             3200:     47(int) CompositeExtract 3198 0
             3201:         357 Load 359(s2DRect)
             3202:   53(fvec2) Load 148(c2)
             3203:3102(ResType) ImageSparseSampleImplicitLod 3201 3202
-            3204:    7(fvec4) CompositeExtract 3203 1
+            3204:  7(f16vec4) CompositeExtract 3203 1
                               Store 3099(texel) 3204
             3205:     47(int) CompositeExtract 3203 0
             3206:         357 Load 359(s2DRect)
-            3207:  154(fvec2) Load 156(f16c2)
+            3207:154(f16vec2) Load 156(f16c2)
             3208:3102(ResType) ImageSparseSampleImplicitLod 3206 3207
-            3209:    7(fvec4) CompositeExtract 3208 1
+            3209:  7(f16vec4) CompositeExtract 3208 1
                               Store 3099(texel) 3209
             3210:     47(int) CompositeExtract 3208 0
             3211:         371 Load 373(s2DRectShadow)
@@ -4169,15 +4169,15 @@ spv.float16Fetch.frag
             3213:    208(ptr) AccessChain 3099(texel) 207
             3214:   52(float) CompositeExtract 3212 2
             3215:3138(ResType) ImageSparseSampleDrefImplicitLod 3211 3212 3214
-            3216:    6(float) CompositeExtract 3215 1
+            3216:6(float16_t) CompositeExtract 3215 1
                               Store 3213 3216
             3217:     47(int) CompositeExtract 3215 0
             3218:         371 Load 373(s2DRectShadow)
-            3219:  154(fvec2) Load 156(f16c2)
+            3219:154(f16vec2) Load 156(f16c2)
             3220:   52(float) Load 215(compare)
             3221:    208(ptr) AccessChain 3099(texel) 207
             3222:3138(ResType) ImageSparseSampleDrefImplicitLod 3218 3219 3220
-            3223:    6(float) CompositeExtract 3222 1
+            3223:6(float16_t) CompositeExtract 3222 1
                               Store 3221 3223
             3224:     47(int) CompositeExtract 3222 0
             3225:         391 Load 393(sCubeArrayShadow)
@@ -4185,21 +4185,21 @@ spv.float16Fetch.frag
             3227:   52(float) Load 215(compare)
             3228:    208(ptr) AccessChain 3099(texel) 207
             3229:3138(ResType) ImageSparseSampleDrefImplicitLod 3225 3226 3227
-            3230:    6(float) CompositeExtract 3229 1
+            3230:6(float16_t) CompositeExtract 3229 1
                               Store 3228 3230
             3231:     47(int) CompositeExtract 3229 0
             3232:         391 Load 393(sCubeArrayShadow)
-            3233:    7(fvec4) Load 309(f16c4)
+            3233:  7(f16vec4) Load 309(f16c4)
             3234:   52(float) Load 215(compare)
             3235:    208(ptr) AccessChain 3099(texel) 207
             3236:3138(ResType) ImageSparseSampleDrefImplicitLod 3232 3233 3234
-            3237:    6(float) CompositeExtract 3236 1
+            3237:6(float16_t) CompositeExtract 3236 1
                               Store 3235 3237
             3238:     47(int) CompositeExtract 3236 0
-            3239:    7(fvec4) Load 3099(texel)
+            3239:  7(f16vec4) Load 3099(texel)
                               ReturnValue 3239
                               FunctionEnd
-71(testSparseTextureLod():    7(fvec4) Function None 8
+71(testSparseTextureLod():  7(f16vec4) Function None 8
               72:             Label
      3242(texel):     64(ptr) Variable Function
                               Store 3242(texel) 121
@@ -4207,42 +4207,42 @@ spv.float16Fetch.frag
             3244:   53(fvec2) Load 148(c2)
             3245:   52(float) Load 565(lod)
             3246:3102(ResType) ImageSparseSampleExplicitLod 3243 3244 Lod 3245
-            3247:    7(fvec4) CompositeExtract 3246 1
+            3247:  7(f16vec4) CompositeExtract 3246 1
                               Store 3242(texel) 3247
             3248:     47(int) CompositeExtract 3246 0
             3249:         143 Load 145(s2D)
-            3250:  154(fvec2) Load 156(f16c2)
-            3251:    6(float) Load 572(f16lod)
+            3250:154(f16vec2) Load 156(f16c2)
+            3251:6(float16_t) Load 572(f16lod)
             3252:3102(ResType) ImageSparseSampleExplicitLod 3249 3250 Lod 3251
-            3253:    7(fvec4) CompositeExtract 3252 1
+            3253:  7(f16vec4) CompositeExtract 3252 1
                               Store 3242(texel) 3253
             3254:     47(int) CompositeExtract 3252 0
             3255:         163 Load 165(s3D)
             3256:  167(fvec3) Load 169(c3)
             3257:   52(float) Load 565(lod)
             3258:3102(ResType) ImageSparseSampleExplicitLod 3255 3256 Lod 3257
-            3259:    7(fvec4) CompositeExtract 3258 1
+            3259:  7(f16vec4) CompositeExtract 3258 1
                               Store 3242(texel) 3259
             3260:     47(int) CompositeExtract 3258 0
             3261:         163 Load 165(s3D)
-            3262:  175(fvec3) Load 177(f16c3)
-            3263:    6(float) Load 572(f16lod)
+            3262:175(f16vec3) Load 177(f16c3)
+            3263:6(float16_t) Load 572(f16lod)
             3264:3102(ResType) ImageSparseSampleExplicitLod 3261 3262 Lod 3263
-            3265:    7(fvec4) CompositeExtract 3264 1
+            3265:  7(f16vec4) CompositeExtract 3264 1
                               Store 3242(texel) 3265
             3266:     47(int) CompositeExtract 3264 0
             3267:         184 Load 186(sCube)
             3268:  167(fvec3) Load 169(c3)
             3269:   52(float) Load 565(lod)
             3270:3102(ResType) ImageSparseSampleExplicitLod 3267 3268 Lod 3269
-            3271:    7(fvec4) CompositeExtract 3270 1
+            3271:  7(f16vec4) CompositeExtract 3270 1
                               Store 3242(texel) 3271
             3272:     47(int) CompositeExtract 3270 0
             3273:         184 Load 186(sCube)
-            3274:  175(fvec3) Load 177(f16c3)
-            3275:    6(float) Load 572(f16lod)
+            3274:175(f16vec3) Load 177(f16c3)
+            3275:6(float16_t) Load 572(f16lod)
             3276:3102(ResType) ImageSparseSampleExplicitLod 3273 3274 Lod 3275
-            3277:    7(fvec4) CompositeExtract 3276 1
+            3277:  7(f16vec4) CompositeExtract 3276 1
                               Store 3242(texel) 3277
             3278:     47(int) CompositeExtract 3276 0
             3279:         224 Load 226(s2DShadow)
@@ -4251,89 +4251,89 @@ spv.float16Fetch.frag
             3282:    208(ptr) AccessChain 3242(texel) 207
             3283:   52(float) CompositeExtract 3280 2
             3284:3138(ResType) ImageSparseSampleDrefExplicitLod 3279 3280 3283 Lod 3281
-            3285:    6(float) CompositeExtract 3284 1
+            3285:6(float16_t) CompositeExtract 3284 1
                               Store 3282 3285
             3286:     47(int) CompositeExtract 3284 0
             3287:         224 Load 226(s2DShadow)
-            3288:  154(fvec2) Load 156(f16c2)
+            3288:154(f16vec2) Load 156(f16c2)
             3289:   52(float) Load 215(compare)
-            3290:    6(float) Load 572(f16lod)
+            3290:6(float16_t) Load 572(f16lod)
             3291:    208(ptr) AccessChain 3242(texel) 207
             3292:3138(ResType) ImageSparseSampleDrefExplicitLod 3287 3288 3289 Lod 3290
-            3293:    6(float) CompositeExtract 3292 1
+            3293:6(float16_t) CompositeExtract 3292 1
                               Store 3291 3293
             3294:     47(int) CompositeExtract 3292 0
             3295:         284 Load 286(s2DArray)
             3296:  167(fvec3) Load 169(c3)
             3297:   52(float) Load 565(lod)
             3298:3102(ResType) ImageSparseSampleExplicitLod 3295 3296 Lod 3297
-            3299:    7(fvec4) CompositeExtract 3298 1
+            3299:  7(f16vec4) CompositeExtract 3298 1
                               Store 3242(texel) 3299
             3300:     47(int) CompositeExtract 3298 0
             3301:         284 Load 286(s2DArray)
-            3302:  175(fvec3) Load 177(f16c3)
-            3303:    6(float) Load 572(f16lod)
+            3302:175(f16vec3) Load 177(f16c3)
+            3303:6(float16_t) Load 572(f16lod)
             3304:3102(ResType) ImageSparseSampleExplicitLod 3301 3302 Lod 3303
-            3305:    7(fvec4) CompositeExtract 3304 1
+            3305:  7(f16vec4) CompositeExtract 3304 1
                               Store 3242(texel) 3305
             3306:     47(int) CompositeExtract 3304 0
             3307:         299 Load 301(sCubeArray)
             3308:  249(fvec4) Load 251(c4)
             3309:   52(float) Load 565(lod)
             3310:3102(ResType) ImageSparseSampleExplicitLod 3307 3308 Lod 3309
-            3311:    7(fvec4) CompositeExtract 3310 1
+            3311:  7(f16vec4) CompositeExtract 3310 1
                               Store 3242(texel) 3311
             3312:     47(int) CompositeExtract 3310 0
             3313:         299 Load 301(sCubeArray)
-            3314:    7(fvec4) Load 309(f16c4)
-            3315:    6(float) Load 572(f16lod)
+            3314:  7(f16vec4) Load 309(f16c4)
+            3315:6(float16_t) Load 572(f16lod)
             3316:3102(ResType) ImageSparseSampleExplicitLod 3313 3314 Lod 3315
-            3317:    7(fvec4) CompositeExtract 3316 1
+            3317:  7(f16vec4) CompositeExtract 3316 1
                               Store 3242(texel) 3317
             3318:     47(int) CompositeExtract 3316 0
-            3319:    7(fvec4) Load 3242(texel)
+            3319:  7(f16vec4) Load 3242(texel)
                               ReturnValue 3319
                               FunctionEnd
-73(testSparseTextureOffset():    7(fvec4) Function None 8
+73(testSparseTextureOffset():  7(f16vec4) Function None 8
               74:             Label
      3322(texel):     64(ptr) Variable Function
                               Store 3322(texel) 121
             3323:         143 Load 145(s2D)
             3324:   53(fvec2) Load 148(c2)
             3325:3102(ResType) ImageSparseSampleImplicitLod 3323 3324 ConstOffset 722
-            3326:    7(fvec4) CompositeExtract 3325 1
+            3326:  7(f16vec4) CompositeExtract 3325 1
                               Store 3322(texel) 3326
             3327:     47(int) CompositeExtract 3325 0
             3328:         143 Load 145(s2D)
-            3329:  154(fvec2) Load 156(f16c2)
-            3330:    6(float) Load 137(f16bias)
+            3329:154(f16vec2) Load 156(f16c2)
+            3330:6(float16_t) Load 137(f16bias)
             3331:3102(ResType) ImageSparseSampleImplicitLod 3328 3329 Bias ConstOffset 3330 722
-            3332:    7(fvec4) CompositeExtract 3331 1
+            3332:  7(f16vec4) CompositeExtract 3331 1
                               Store 3322(texel) 3332
             3333:     47(int) CompositeExtract 3331 0
             3334:         163 Load 165(s3D)
             3335:  167(fvec3) Load 169(c3)
             3336:3102(ResType) ImageSparseSampleImplicitLod 3334 3335 ConstOffset 735
-            3337:    7(fvec4) CompositeExtract 3336 1
+            3337:  7(f16vec4) CompositeExtract 3336 1
                               Store 3322(texel) 3337
             3338:     47(int) CompositeExtract 3336 0
             3339:         163 Load 165(s3D)
-            3340:  175(fvec3) Load 177(f16c3)
-            3341:    6(float) Load 137(f16bias)
+            3340:175(f16vec3) Load 177(f16c3)
+            3341:6(float16_t) Load 137(f16bias)
             3342:3102(ResType) ImageSparseSampleImplicitLod 3339 3340 Bias ConstOffset 3341 735
-            3343:    7(fvec4) CompositeExtract 3342 1
+            3343:  7(f16vec4) CompositeExtract 3342 1
                               Store 3322(texel) 3343
             3344:     47(int) CompositeExtract 3342 0
             3345:         357 Load 359(s2DRect)
             3346:   53(fvec2) Load 148(c2)
             3347:3102(ResType) ImageSparseSampleImplicitLod 3345 3346 ConstOffset 722
-            3348:    7(fvec4) CompositeExtract 3347 1
+            3348:  7(f16vec4) CompositeExtract 3347 1
                               Store 3322(texel) 3348
             3349:     47(int) CompositeExtract 3347 0
             3350:         357 Load 359(s2DRect)
-            3351:  154(fvec2) Load 156(f16c2)
+            3351:154(f16vec2) Load 156(f16c2)
             3352:3102(ResType) ImageSparseSampleImplicitLod 3350 3351 ConstOffset 722
-            3353:    7(fvec4) CompositeExtract 3352 1
+            3353:  7(f16vec4) CompositeExtract 3352 1
                               Store 3322(texel) 3353
             3354:     47(int) CompositeExtract 3352 0
             3355:         371 Load 373(s2DRectShadow)
@@ -4341,15 +4341,15 @@ spv.float16Fetch.frag
             3357:    208(ptr) AccessChain 3322(texel) 207
             3358:   52(float) CompositeExtract 3356 2
             3359:3138(ResType) ImageSparseSampleDrefImplicitLod 3355 3356 3358 ConstOffset 722
-            3360:    6(float) CompositeExtract 3359 1
+            3360:6(float16_t) CompositeExtract 3359 1
                               Store 3357 3360
             3361:     47(int) CompositeExtract 3359 0
             3362:         371 Load 373(s2DRectShadow)
-            3363:  154(fvec2) Load 156(f16c2)
+            3363:154(f16vec2) Load 156(f16c2)
             3364:   52(float) Load 215(compare)
             3365:    208(ptr) AccessChain 3322(texel) 207
             3366:3138(ResType) ImageSparseSampleDrefImplicitLod 3362 3363 3364 ConstOffset 722
-            3367:    6(float) CompositeExtract 3366 1
+            3367:6(float16_t) CompositeExtract 3366 1
                               Store 3365 3367
             3368:     47(int) CompositeExtract 3366 0
             3369:         224 Load 226(s2DShadow)
@@ -4357,29 +4357,29 @@ spv.float16Fetch.frag
             3371:    208(ptr) AccessChain 3322(texel) 207
             3372:   52(float) CompositeExtract 3370 2
             3373:3138(ResType) ImageSparseSampleDrefImplicitLod 3369 3370 3372 ConstOffset 722
-            3374:    6(float) CompositeExtract 3373 1
+            3374:6(float16_t) CompositeExtract 3373 1
                               Store 3371 3374
             3375:     47(int) CompositeExtract 3373 0
             3376:         224 Load 226(s2DShadow)
-            3377:  154(fvec2) Load 156(f16c2)
+            3377:154(f16vec2) Load 156(f16c2)
             3378:   52(float) Load 215(compare)
             3379:    208(ptr) AccessChain 3322(texel) 207
-            3380:    6(float) Load 137(f16bias)
+            3380:6(float16_t) Load 137(f16bias)
             3381:3138(ResType) ImageSparseSampleDrefImplicitLod 3376 3377 3378 Bias ConstOffset 3380 722
-            3382:    6(float) CompositeExtract 3381 1
+            3382:6(float16_t) CompositeExtract 3381 1
                               Store 3379 3382
             3383:     47(int) CompositeExtract 3381 0
             3384:         284 Load 286(s2DArray)
             3385:  167(fvec3) Load 169(c3)
             3386:3102(ResType) ImageSparseSampleImplicitLod 3384 3385 ConstOffset 722
-            3387:    7(fvec4) CompositeExtract 3386 1
+            3387:  7(f16vec4) CompositeExtract 3386 1
                               Store 3322(texel) 3387
             3388:     47(int) CompositeExtract 3386 0
             3389:         284 Load 286(s2DArray)
-            3390:  175(fvec3) Load 177(f16c3)
-            3391:    6(float) Load 137(f16bias)
+            3390:175(f16vec3) Load 177(f16c3)
+            3391:6(float16_t) Load 137(f16bias)
             3392:3102(ResType) ImageSparseSampleImplicitLod 3389 3390 Bias ConstOffset 3391 722
-            3393:    7(fvec4) CompositeExtract 3392 1
+            3393:  7(f16vec4) CompositeExtract 3392 1
                               Store 3322(texel) 3393
             3394:     47(int) CompositeExtract 3392 0
             3395:         337 Load 339(s2DArrayShadow)
@@ -4387,21 +4387,21 @@ spv.float16Fetch.frag
             3397:    208(ptr) AccessChain 3322(texel) 207
             3398:   52(float) CompositeExtract 3396 3
             3399:3138(ResType) ImageSparseSampleDrefImplicitLod 3395 3396 3398 ConstOffset 722
-            3400:    6(float) CompositeExtract 3399 1
+            3400:6(float16_t) CompositeExtract 3399 1
                               Store 3397 3400
             3401:     47(int) CompositeExtract 3399 0
             3402:         337 Load 339(s2DArrayShadow)
-            3403:  175(fvec3) Load 177(f16c3)
+            3403:175(f16vec3) Load 177(f16c3)
             3404:   52(float) Load 215(compare)
             3405:    208(ptr) AccessChain 3322(texel) 207
             3406:3138(ResType) ImageSparseSampleDrefImplicitLod 3402 3403 3404 ConstOffset 722
-            3407:    6(float) CompositeExtract 3406 1
+            3407:6(float16_t) CompositeExtract 3406 1
                               Store 3405 3407
             3408:     47(int) CompositeExtract 3406 0
-            3409:    7(fvec4) Load 3322(texel)
+            3409:  7(f16vec4) Load 3322(texel)
                               ReturnValue 3409
                               FunctionEnd
-75(testSparseTextureLodOffset():    7(fvec4) Function None 8
+75(testSparseTextureLodOffset():  7(f16vec4) Function None 8
               76:             Label
      3412(texel):     64(ptr) Variable Function
                               Store 3412(texel) 121
@@ -4409,28 +4409,28 @@ spv.float16Fetch.frag
             3414:   53(fvec2) Load 148(c2)
             3415:   52(float) Load 565(lod)
             3416:3102(ResType) ImageSparseSampleExplicitLod 3413 3414 Lod ConstOffset 3415 722
-            3417:    7(fvec4) CompositeExtract 3416 1
+            3417:  7(f16vec4) CompositeExtract 3416 1
                               Store 3412(texel) 3417
             3418:     47(int) CompositeExtract 3416 0
             3419:         143 Load 145(s2D)
-            3420:  154(fvec2) Load 156(f16c2)
-            3421:    6(float) Load 572(f16lod)
+            3420:154(f16vec2) Load 156(f16c2)
+            3421:6(float16_t) Load 572(f16lod)
             3422:3102(ResType) ImageSparseSampleExplicitLod 3419 3420 Lod ConstOffset 3421 722
-            3423:    7(fvec4) CompositeExtract 3422 1
+            3423:  7(f16vec4) CompositeExtract 3422 1
                               Store 3412(texel) 3423
             3424:     47(int) CompositeExtract 3422 0
             3425:         163 Load 165(s3D)
             3426:  167(fvec3) Load 169(c3)
             3427:   52(float) Load 565(lod)
             3428:3102(ResType) ImageSparseSampleExplicitLod 3425 3426 Lod ConstOffset 3427 735
-            3429:    7(fvec4) CompositeExtract 3428 1
+            3429:  7(f16vec4) CompositeExtract 3428 1
                               Store 3412(texel) 3429
             3430:     47(int) CompositeExtract 3428 0
             3431:         163 Load 165(s3D)
-            3432:  175(fvec3) Load 177(f16c3)
-            3433:    6(float) Load 572(f16lod)
+            3432:175(f16vec3) Load 177(f16c3)
+            3433:6(float16_t) Load 572(f16lod)
             3434:3102(ResType) ImageSparseSampleExplicitLod 3431 3432 Lod ConstOffset 3433 735
-            3435:    7(fvec4) CompositeExtract 3434 1
+            3435:  7(f16vec4) CompositeExtract 3434 1
                               Store 3412(texel) 3435
             3436:     47(int) CompositeExtract 3434 0
             3437:         224 Load 226(s2DShadow)
@@ -4439,36 +4439,36 @@ spv.float16Fetch.frag
             3440:    208(ptr) AccessChain 3412(texel) 207
             3441:   52(float) CompositeExtract 3438 2
             3442:3138(ResType) ImageSparseSampleDrefExplicitLod 3437 3438 3441 Lod ConstOffset 3439 722
-            3443:    6(float) CompositeExtract 3442 1
+            3443:6(float16_t) CompositeExtract 3442 1
                               Store 3440 3443
             3444:     47(int) CompositeExtract 3442 0
             3445:         224 Load 226(s2DShadow)
-            3446:  154(fvec2) Load 156(f16c2)
+            3446:154(f16vec2) Load 156(f16c2)
             3447:   52(float) Load 215(compare)
-            3448:    6(float) Load 572(f16lod)
+            3448:6(float16_t) Load 572(f16lod)
             3449:    208(ptr) AccessChain 3412(texel) 207
             3450:3138(ResType) ImageSparseSampleDrefExplicitLod 3445 3446 3447 Lod ConstOffset 3448 722
-            3451:    6(float) CompositeExtract 3450 1
+            3451:6(float16_t) CompositeExtract 3450 1
                               Store 3449 3451
             3452:     47(int) CompositeExtract 3450 0
             3453:         284 Load 286(s2DArray)
             3454:  167(fvec3) Load 169(c3)
             3455:   52(float) Load 565(lod)
             3456:3102(ResType) ImageSparseSampleExplicitLod 3453 3454 Lod ConstOffset 3455 722
-            3457:    7(fvec4) CompositeExtract 3456 1
+            3457:  7(f16vec4) CompositeExtract 3456 1
                               Store 3412(texel) 3457
             3458:     47(int) CompositeExtract 3456 0
             3459:         284 Load 286(s2DArray)
-            3460:  175(fvec3) Load 177(f16c3)
-            3461:    6(float) Load 572(f16lod)
+            3460:175(f16vec3) Load 177(f16c3)
+            3461:6(float16_t) Load 572(f16lod)
             3462:3102(ResType) ImageSparseSampleExplicitLod 3459 3460 Lod ConstOffset 3461 722
-            3463:    7(fvec4) CompositeExtract 3462 1
+            3463:  7(f16vec4) CompositeExtract 3462 1
                               Store 3412(texel) 3463
             3464:     47(int) CompositeExtract 3462 0
-            3465:    7(fvec4) Load 3412(texel)
+            3465:  7(f16vec4) Load 3412(texel)
                               ReturnValue 3465
                               FunctionEnd
-77(testSparseTextureGrad():    7(fvec4) Function None 8
+77(testSparseTextureGrad():  7(f16vec4) Function None 8
               78:             Label
      3468(texel):     64(ptr) Variable Function
                               Store 3468(texel) 121
@@ -4477,15 +4477,15 @@ spv.float16Fetch.frag
             3471:   53(fvec2) Load 1409(dPdxy2)
             3472:   53(fvec2) Load 1409(dPdxy2)
             3473:3102(ResType) ImageSparseSampleExplicitLod 3469 3470 Grad 3471 3472
-            3474:    7(fvec4) CompositeExtract 3473 1
+            3474:  7(f16vec4) CompositeExtract 3473 1
                               Store 3468(texel) 3474
             3475:     47(int) CompositeExtract 3473 0
             3476:         143 Load 145(s2D)
-            3477:  154(fvec2) Load 156(f16c2)
-            3478:  154(fvec2) Load 1417(f16dPdxy2)
-            3479:  154(fvec2) Load 1417(f16dPdxy2)
+            3477:154(f16vec2) Load 156(f16c2)
+            3478:154(f16vec2) Load 1417(f16dPdxy2)
+            3479:154(f16vec2) Load 1417(f16dPdxy2)
             3480:3102(ResType) ImageSparseSampleExplicitLod 3476 3477 Grad 3478 3479
-            3481:    7(fvec4) CompositeExtract 3480 1
+            3481:  7(f16vec4) CompositeExtract 3480 1
                               Store 3468(texel) 3481
             3482:     47(int) CompositeExtract 3480 0
             3483:         163 Load 165(s3D)
@@ -4493,15 +4493,15 @@ spv.float16Fetch.frag
             3485:  167(fvec3) Load 1425(dPdxy3)
             3486:  167(fvec3) Load 1425(dPdxy3)
             3487:3102(ResType) ImageSparseSampleExplicitLod 3483 3484 Grad 3485 3486
-            3488:    7(fvec4) CompositeExtract 3487 1
+            3488:  7(f16vec4) CompositeExtract 3487 1
                               Store 3468(texel) 3488
             3489:     47(int) CompositeExtract 3487 0
             3490:         163 Load 165(s3D)
-            3491:  175(fvec3) Load 177(f16c3)
-            3492:  175(fvec3) Load 1433(f16dPdxy3)
-            3493:  175(fvec3) Load 1433(f16dPdxy3)
+            3491:175(f16vec3) Load 177(f16c3)
+            3492:175(f16vec3) Load 1433(f16dPdxy3)
+            3493:175(f16vec3) Load 1433(f16dPdxy3)
             3494:3102(ResType) ImageSparseSampleExplicitLod 3490 3491 Grad 3492 3493
-            3495:    7(fvec4) CompositeExtract 3494 1
+            3495:  7(f16vec4) CompositeExtract 3494 1
                               Store 3468(texel) 3495
             3496:     47(int) CompositeExtract 3494 0
             3497:         184 Load 186(sCube)
@@ -4509,15 +4509,15 @@ spv.float16Fetch.frag
             3499:  167(fvec3) Load 1425(dPdxy3)
             3500:  167(fvec3) Load 1425(dPdxy3)
             3501:3102(ResType) ImageSparseSampleExplicitLod 3497 3498 Grad 3499 3500
-            3502:    7(fvec4) CompositeExtract 3501 1
+            3502:  7(f16vec4) CompositeExtract 3501 1
                               Store 3468(texel) 3502
             3503:     47(int) CompositeExtract 3501 0
             3504:         184 Load 186(sCube)
-            3505:  175(fvec3) Load 177(f16c3)
-            3506:  175(fvec3) Load 1433(f16dPdxy3)
-            3507:  175(fvec3) Load 1433(f16dPdxy3)
+            3505:175(f16vec3) Load 177(f16c3)
+            3506:175(f16vec3) Load 1433(f16dPdxy3)
+            3507:175(f16vec3) Load 1433(f16dPdxy3)
             3508:3102(ResType) ImageSparseSampleExplicitLod 3504 3505 Grad 3506 3507
-            3509:    7(fvec4) CompositeExtract 3508 1
+            3509:  7(f16vec4) CompositeExtract 3508 1
                               Store 3468(texel) 3509
             3510:     47(int) CompositeExtract 3508 0
             3511:         357 Load 359(s2DRect)
@@ -4525,15 +4525,15 @@ spv.float16Fetch.frag
             3513:   53(fvec2) Load 1409(dPdxy2)
             3514:   53(fvec2) Load 1409(dPdxy2)
             3515:3102(ResType) ImageSparseSampleExplicitLod 3511 3512 Grad 3513 3514
-            3516:    7(fvec4) CompositeExtract 3515 1
+            3516:  7(f16vec4) CompositeExtract 3515 1
                               Store 3468(texel) 3516
             3517:     47(int) CompositeExtract 3515 0
             3518:         357 Load 359(s2DRect)
-            3519:  154(fvec2) Load 156(f16c2)
-            3520:  154(fvec2) Load 1417(f16dPdxy2)
-            3521:  154(fvec2) Load 1417(f16dPdxy2)
+            3519:154(f16vec2) Load 156(f16c2)
+            3520:154(f16vec2) Load 1417(f16dPdxy2)
+            3521:154(f16vec2) Load 1417(f16dPdxy2)
             3522:3102(ResType) ImageSparseSampleExplicitLod 3518 3519 Grad 3520 3521
-            3523:    7(fvec4) CompositeExtract 3522 1
+            3523:  7(f16vec4) CompositeExtract 3522 1
                               Store 3468(texel) 3523
             3524:     47(int) CompositeExtract 3522 0
             3525:         371 Load 373(s2DRectShadow)
@@ -4543,17 +4543,17 @@ spv.float16Fetch.frag
             3529:    208(ptr) AccessChain 3468(texel) 207
             3530:   52(float) CompositeExtract 3526 2
             3531:3138(ResType) ImageSparseSampleDrefExplicitLod 3525 3526 3530 Grad 3527 3528
-            3532:    6(float) CompositeExtract 3531 1
+            3532:6(float16_t) CompositeExtract 3531 1
                               Store 3529 3532
             3533:     47(int) CompositeExtract 3531 0
             3534:         371 Load 373(s2DRectShadow)
-            3535:  154(fvec2) Load 156(f16c2)
+            3535:154(f16vec2) Load 156(f16c2)
             3536:   52(float) Load 215(compare)
-            3537:  154(fvec2) Load 1417(f16dPdxy2)
-            3538:  154(fvec2) Load 1417(f16dPdxy2)
+            3537:154(f16vec2) Load 1417(f16dPdxy2)
+            3538:154(f16vec2) Load 1417(f16dPdxy2)
             3539:    208(ptr) AccessChain 3468(texel) 207
             3540:3138(ResType) ImageSparseSampleDrefExplicitLod 3534 3535 3536 Grad 3537 3538
-            3541:    6(float) CompositeExtract 3540 1
+            3541:6(float16_t) CompositeExtract 3540 1
                               Store 3539 3541
             3542:     47(int) CompositeExtract 3540 0
             3543:         224 Load 226(s2DShadow)
@@ -4563,17 +4563,17 @@ spv.float16Fetch.frag
             3547:    208(ptr) AccessChain 3468(texel) 207
             3548:   52(float) CompositeExtract 3544 2
             3549:3138(ResType) ImageSparseSampleDrefExplicitLod 3543 3544 3548 Grad 3545 3546
-            3550:    6(float) CompositeExtract 3549 1
+            3550:6(float16_t) CompositeExtract 3549 1
                               Store 3547 3550
             3551:     47(int) CompositeExtract 3549 0
             3552:         224 Load 226(s2DShadow)
-            3553:  154(fvec2) Load 156(f16c2)
+            3553:154(f16vec2) Load 156(f16c2)
             3554:   52(float) Load 215(compare)
-            3555:  154(fvec2) Load 1417(f16dPdxy2)
-            3556:  154(fvec2) Load 1417(f16dPdxy2)
+            3555:154(f16vec2) Load 1417(f16dPdxy2)
+            3556:154(f16vec2) Load 1417(f16dPdxy2)
             3557:    208(ptr) AccessChain 3468(texel) 207
             3558:3138(ResType) ImageSparseSampleDrefExplicitLod 3552 3553 3554 Grad 3555 3556
-            3559:    6(float) CompositeExtract 3558 1
+            3559:6(float16_t) CompositeExtract 3558 1
                               Store 3557 3559
             3560:     47(int) CompositeExtract 3558 0
             3561:         245 Load 247(sCubeShadow)
@@ -4583,17 +4583,17 @@ spv.float16Fetch.frag
             3565:    208(ptr) AccessChain 3468(texel) 207
             3566:   52(float) CompositeExtract 3562 3
             3567:3138(ResType) ImageSparseSampleDrefExplicitLod 3561 3562 3566 Grad 3563 3564
-            3568:    6(float) CompositeExtract 3567 1
+            3568:6(float16_t) CompositeExtract 3567 1
                               Store 3565 3568
             3569:     47(int) CompositeExtract 3567 0
             3570:         245 Load 247(sCubeShadow)
-            3571:  175(fvec3) Load 177(f16c3)
+            3571:175(f16vec3) Load 177(f16c3)
             3572:   52(float) Load 215(compare)
-            3573:  175(fvec3) Load 1433(f16dPdxy3)
-            3574:  175(fvec3) Load 1433(f16dPdxy3)
+            3573:175(f16vec3) Load 1433(f16dPdxy3)
+            3574:175(f16vec3) Load 1433(f16dPdxy3)
             3575:    208(ptr) AccessChain 3468(texel) 207
             3576:3138(ResType) ImageSparseSampleDrefExplicitLod 3570 3571 3572 Grad 3573 3574
-            3577:    6(float) CompositeExtract 3576 1
+            3577:6(float16_t) CompositeExtract 3576 1
                               Store 3575 3577
             3578:     47(int) CompositeExtract 3576 0
             3579:         284 Load 286(s2DArray)
@@ -4601,15 +4601,15 @@ spv.float16Fetch.frag
             3581:   53(fvec2) Load 1409(dPdxy2)
             3582:   53(fvec2) Load 1409(dPdxy2)
             3583:3102(ResType) ImageSparseSampleExplicitLod 3579 3580 Grad 3581 3582
-            3584:    7(fvec4) CompositeExtract 3583 1
+            3584:  7(f16vec4) CompositeExtract 3583 1
                               Store 3468(texel) 3584
             3585:     47(int) CompositeExtract 3583 0
             3586:         284 Load 286(s2DArray)
-            3587:  175(fvec3) Load 177(f16c3)
-            3588:  154(fvec2) Load 1417(f16dPdxy2)
-            3589:  154(fvec2) Load 1417(f16dPdxy2)
+            3587:175(f16vec3) Load 177(f16c3)
+            3588:154(f16vec2) Load 1417(f16dPdxy2)
+            3589:154(f16vec2) Load 1417(f16dPdxy2)
             3590:3102(ResType) ImageSparseSampleExplicitLod 3586 3587 Grad 3588 3589
-            3591:    7(fvec4) CompositeExtract 3590 1
+            3591:  7(f16vec4) CompositeExtract 3590 1
                               Store 3468(texel) 3591
             3592:     47(int) CompositeExtract 3590 0
             3593:         337 Load 339(s2DArrayShadow)
@@ -4619,17 +4619,17 @@ spv.float16Fetch.frag
             3597:    208(ptr) AccessChain 3468(texel) 207
             3598:   52(float) CompositeExtract 3594 3
             3599:3138(ResType) ImageSparseSampleDrefExplicitLod 3593 3594 3598 Grad 3595 3596
-            3600:    6(float) CompositeExtract 3599 1
+            3600:6(float16_t) CompositeExtract 3599 1
                               Store 3597 3600
             3601:     47(int) CompositeExtract 3599 0
             3602:         337 Load 339(s2DArrayShadow)
-            3603:  175(fvec3) Load 177(f16c3)
+            3603:175(f16vec3) Load 177(f16c3)
             3604:   52(float) Load 215(compare)
-            3605:  154(fvec2) Load 1417(f16dPdxy2)
-            3606:  154(fvec2) Load 1417(f16dPdxy2)
+            3605:154(f16vec2) Load 1417(f16dPdxy2)
+            3606:154(f16vec2) Load 1417(f16dPdxy2)
             3607:    208(ptr) AccessChain 3468(texel) 207
             3608:3138(ResType) ImageSparseSampleDrefExplicitLod 3602 3603 3604 Grad 3605 3606
-            3609:    6(float) CompositeExtract 3608 1
+            3609:6(float16_t) CompositeExtract 3608 1
                               Store 3607 3609
             3610:     47(int) CompositeExtract 3608 0
             3611:         299 Load 301(sCubeArray)
@@ -4637,21 +4637,21 @@ spv.float16Fetch.frag
             3613:  167(fvec3) Load 1425(dPdxy3)
             3614:  167(fvec3) Load 1425(dPdxy3)
             3615:3102(ResType) ImageSparseSampleExplicitLod 3611 3612 Grad 3613 3614
-            3616:    7(fvec4) CompositeExtract 3615 1
+            3616:  7(f16vec4) CompositeExtract 3615 1
                               Store 3468(texel) 3616
             3617:     47(int) CompositeExtract 3615 0
             3618:         299 Load 301(sCubeArray)
-            3619:    7(fvec4) Load 309(f16c4)
-            3620:  175(fvec3) Load 1433(f16dPdxy3)
-            3621:  175(fvec3) Load 1433(f16dPdxy3)
+            3619:  7(f16vec4) Load 309(f16c4)
+            3620:175(f16vec3) Load 1433(f16dPdxy3)
+            3621:175(f16vec3) Load 1433(f16dPdxy3)
             3622:3102(ResType) ImageSparseSampleExplicitLod 3618 3619 Grad 3620 3621
-            3623:    7(fvec4) CompositeExtract 3622 1
+            3623:  7(f16vec4) CompositeExtract 3622 1
                               Store 3468(texel) 3623
             3624:     47(int) CompositeExtract 3622 0
-            3625:    7(fvec4) Load 3468(texel)
+            3625:  7(f16vec4) Load 3468(texel)
                               ReturnValue 3625
                               FunctionEnd
-79(testSparseTextureGradOffset():    7(fvec4) Function None 8
+79(testSparseTextureGradOffset():  7(f16vec4) Function None 8
               80:             Label
      3628(texel):     64(ptr) Variable Function
                               Store 3628(texel) 121
@@ -4660,15 +4660,15 @@ spv.float16Fetch.frag
             3631:   53(fvec2) Load 1409(dPdxy2)
             3632:   53(fvec2) Load 1409(dPdxy2)
             3633:3102(ResType) ImageSparseSampleExplicitLod 3629 3630 Grad ConstOffset 3631 3632 722
-            3634:    7(fvec4) CompositeExtract 3633 1
+            3634:  7(f16vec4) CompositeExtract 3633 1
                               Store 3628(texel) 3634
             3635:     47(int) CompositeExtract 3633 0
             3636:         143 Load 145(s2D)
-            3637:  154(fvec2) Load 156(f16c2)
-            3638:  154(fvec2) Load 1417(f16dPdxy2)
-            3639:  154(fvec2) Load 1417(f16dPdxy2)
+            3637:154(f16vec2) Load 156(f16c2)
+            3638:154(f16vec2) Load 1417(f16dPdxy2)
+            3639:154(f16vec2) Load 1417(f16dPdxy2)
             3640:3102(ResType) ImageSparseSampleExplicitLod 3636 3637 Grad ConstOffset 3638 3639 722
-            3641:    7(fvec4) CompositeExtract 3640 1
+            3641:  7(f16vec4) CompositeExtract 3640 1
                               Store 3628(texel) 3641
             3642:     47(int) CompositeExtract 3640 0
             3643:         163 Load 165(s3D)
@@ -4676,15 +4676,15 @@ spv.float16Fetch.frag
             3645:  167(fvec3) Load 1425(dPdxy3)
             3646:  167(fvec3) Load 1425(dPdxy3)
             3647:3102(ResType) ImageSparseSampleExplicitLod 3643 3644 Grad ConstOffset 3645 3646 735
-            3648:    7(fvec4) CompositeExtract 3647 1
+            3648:  7(f16vec4) CompositeExtract 3647 1
                               Store 3628(texel) 3648
             3649:     47(int) CompositeExtract 3647 0
             3650:         163 Load 165(s3D)
-            3651:  175(fvec3) Load 177(f16c3)
-            3652:  175(fvec3) Load 1433(f16dPdxy3)
-            3653:  175(fvec3) Load 1433(f16dPdxy3)
+            3651:175(f16vec3) Load 177(f16c3)
+            3652:175(f16vec3) Load 1433(f16dPdxy3)
+            3653:175(f16vec3) Load 1433(f16dPdxy3)
             3654:3102(ResType) ImageSparseSampleExplicitLod 3650 3651 Grad ConstOffset 3652 3653 735
-            3655:    7(fvec4) CompositeExtract 3654 1
+            3655:  7(f16vec4) CompositeExtract 3654 1
                               Store 3628(texel) 3655
             3656:     47(int) CompositeExtract 3654 0
             3657:         357 Load 359(s2DRect)
@@ -4692,15 +4692,15 @@ spv.float16Fetch.frag
             3659:   53(fvec2) Load 1409(dPdxy2)
             3660:   53(fvec2) Load 1409(dPdxy2)
             3661:3102(ResType) ImageSparseSampleExplicitLod 3657 3658 Grad ConstOffset 3659 3660 722
-            3662:    7(fvec4) CompositeExtract 3661 1
+            3662:  7(f16vec4) CompositeExtract 3661 1
                               Store 3628(texel) 3662
             3663:     47(int) CompositeExtract 3661 0
             3664:         357 Load 359(s2DRect)
-            3665:  154(fvec2) Load 156(f16c2)
-            3666:  154(fvec2) Load 1417(f16dPdxy2)
-            3667:  154(fvec2) Load 1417(f16dPdxy2)
+            3665:154(f16vec2) Load 156(f16c2)
+            3666:154(f16vec2) Load 1417(f16dPdxy2)
+            3667:154(f16vec2) Load 1417(f16dPdxy2)
             3668:3102(ResType) ImageSparseSampleExplicitLod 3664 3665 Grad ConstOffset 3666 3667 722
-            3669:    7(fvec4) CompositeExtract 3668 1
+            3669:  7(f16vec4) CompositeExtract 3668 1
                               Store 3628(texel) 3669
             3670:     47(int) CompositeExtract 3668 0
             3671:         371 Load 373(s2DRectShadow)
@@ -4710,17 +4710,17 @@ spv.float16Fetch.frag
             3675:    208(ptr) AccessChain 3628(texel) 207
             3676:   52(float) CompositeExtract 3672 2
             3677:3138(ResType) ImageSparseSampleDrefExplicitLod 3671 3672 3676 Grad ConstOffset 3673 3674 722
-            3678:    6(float) CompositeExtract 3677 1
+            3678:6(float16_t) CompositeExtract 3677 1
                               Store 3675 3678
             3679:     47(int) CompositeExtract 3677 0
             3680:         371 Load 373(s2DRectShadow)
-            3681:  154(fvec2) Load 156(f16c2)
+            3681:154(f16vec2) Load 156(f16c2)
             3682:   52(float) Load 215(compare)
-            3683:  154(fvec2) Load 1417(f16dPdxy2)
-            3684:  154(fvec2) Load 1417(f16dPdxy2)
+            3683:154(f16vec2) Load 1417(f16dPdxy2)
+            3684:154(f16vec2) Load 1417(f16dPdxy2)
             3685:    208(ptr) AccessChain 3628(texel) 207
             3686:3138(ResType) ImageSparseSampleDrefExplicitLod 3680 3681 3682 Grad ConstOffset 3683 3684 722
-            3687:    6(float) CompositeExtract 3686 1
+            3687:6(float16_t) CompositeExtract 3686 1
                               Store 3685 3687
             3688:     47(int) CompositeExtract 3686 0
             3689:         224 Load 226(s2DShadow)
@@ -4730,17 +4730,17 @@ spv.float16Fetch.frag
             3693:    208(ptr) AccessChain 3628(texel) 207
             3694:   52(float) CompositeExtract 3690 2
             3695:3138(ResType) ImageSparseSampleDrefExplicitLod 3689 3690 3694 Grad ConstOffset 3691 3692 722
-            3696:    6(float) CompositeExtract 3695 1
+            3696:6(float16_t) CompositeExtract 3695 1
                               Store 3693 3696
             3697:     47(int) CompositeExtract 3695 0
             3698:         224 Load 226(s2DShadow)
-            3699:  154(fvec2) Load 156(f16c2)
+            3699:154(f16vec2) Load 156(f16c2)
             3700:   52(float) Load 215(compare)
-            3701:  154(fvec2) Load 1417(f16dPdxy2)
-            3702:  154(fvec2) Load 1417(f16dPdxy2)
+            3701:154(f16vec2) Load 1417(f16dPdxy2)
+            3702:154(f16vec2) Load 1417(f16dPdxy2)
             3703:    208(ptr) AccessChain 3628(texel) 207
             3704:3138(ResType) ImageSparseSampleDrefExplicitLod 3698 3699 3700 Grad ConstOffset 3701 3702 722
-            3705:    6(float) CompositeExtract 3704 1
+            3705:6(float16_t) CompositeExtract 3704 1
                               Store 3703 3705
             3706:     47(int) CompositeExtract 3704 0
             3707:         284 Load 286(s2DArray)
@@ -4748,15 +4748,15 @@ spv.float16Fetch.frag
             3709:   53(fvec2) Load 1409(dPdxy2)
             3710:   53(fvec2) Load 1409(dPdxy2)
             3711:3102(ResType) ImageSparseSampleExplicitLod 3707 3708 Grad ConstOffset 3709 3710 722
-            3712:    7(fvec4) CompositeExtract 3711 1
+            3712:  7(f16vec4) CompositeExtract 3711 1
                               Store 3628(texel) 3712
             3713:     47(int) CompositeExtract 3711 0
             3714:         284 Load 286(s2DArray)
-            3715:  175(fvec3) Load 177(f16c3)
-            3716:  154(fvec2) Load 1417(f16dPdxy2)
-            3717:  154(fvec2) Load 1417(f16dPdxy2)
+            3715:175(f16vec3) Load 177(f16c3)
+            3716:154(f16vec2) Load 1417(f16dPdxy2)
+            3717:154(f16vec2) Load 1417(f16dPdxy2)
             3718:3102(ResType) ImageSparseSampleExplicitLod 3714 3715 Grad ConstOffset 3716 3717 722
-            3719:    7(fvec4) CompositeExtract 3718 1
+            3719:  7(f16vec4) CompositeExtract 3718 1
                               Store 3628(texel) 3719
             3720:     47(int) CompositeExtract 3718 0
             3721:         337 Load 339(s2DArrayShadow)
@@ -4766,23 +4766,23 @@ spv.float16Fetch.frag
             3725:    208(ptr) AccessChain 3628(texel) 207
             3726:   52(float) CompositeExtract 3722 3
             3727:3138(ResType) ImageSparseSampleDrefExplicitLod 3721 3722 3726 Grad ConstOffset 3723 3724 722
-            3728:    6(float) CompositeExtract 3727 1
+            3728:6(float16_t) CompositeExtract 3727 1
                               Store 3725 3728
             3729:     47(int) CompositeExtract 3727 0
             3730:         337 Load 339(s2DArrayShadow)
-            3731:  175(fvec3) Load 177(f16c3)
+            3731:175(f16vec3) Load 177(f16c3)
             3732:   52(float) Load 215(compare)
-            3733:  154(fvec2) Load 1417(f16dPdxy2)
-            3734:  154(fvec2) Load 1417(f16dPdxy2)
+            3733:154(f16vec2) Load 1417(f16dPdxy2)
+            3734:154(f16vec2) Load 1417(f16dPdxy2)
             3735:    208(ptr) AccessChain 3628(texel) 207
             3736:3138(ResType) ImageSparseSampleDrefExplicitLod 3730 3731 3732 Grad ConstOffset 3733 3734 722
-            3737:    6(float) CompositeExtract 3736 1
+            3737:6(float16_t) CompositeExtract 3736 1
                               Store 3735 3737
             3738:     47(int) CompositeExtract 3736 0
-            3739:    7(fvec4) Load 3628(texel)
+            3739:  7(f16vec4) Load 3628(texel)
                               ReturnValue 3739
                               FunctionEnd
-81(testSparseTexelFetch():    7(fvec4) Function None 8
+81(testSparseTexelFetch():  7(f16vec4) Function None 8
               82:             Label
      3742(texel):     64(ptr) Variable Function
                               Store 3742(texel) 121
@@ -4793,7 +4793,7 @@ spv.float16Fetch.frag
             3747:     47(int) ConvertFToS 3746
             3748:         142 Image 3743
             3749:3102(ResType) ImageSparseFetch 3748 3745 Lod 3747
-            3750:    7(fvec4) CompositeExtract 3749 1
+            3750:  7(f16vec4) CompositeExtract 3749 1
                               Store 3742(texel) 3750
             3751:     47(int) CompositeExtract 3749 0
             3752:         163 Load 165(s3D)
@@ -4803,7 +4803,7 @@ spv.float16Fetch.frag
             3756:     47(int) ConvertFToS 3755
             3757:         162 Image 3752
             3758:3102(ResType) ImageSparseFetch 3757 3754 Lod 3756
-            3759:    7(fvec4) CompositeExtract 3758 1
+            3759:  7(f16vec4) CompositeExtract 3758 1
                               Store 3742(texel) 3759
             3760:     47(int) CompositeExtract 3758 0
             3761:         357 Load 359(s2DRect)
@@ -4811,7 +4811,7 @@ spv.float16Fetch.frag
             3763:  721(ivec2) ConvertFToS 3762
             3764:         356 Image 3761
             3765:3102(ResType) ImageSparseFetch 3764 3763
-            3766:    7(fvec4) CompositeExtract 3765 1
+            3766:  7(f16vec4) CompositeExtract 3765 1
                               Store 3742(texel) 3766
             3767:     47(int) CompositeExtract 3765 0
             3768:         284 Load 286(s2DArray)
@@ -4821,7 +4821,7 @@ spv.float16Fetch.frag
             3772:     47(int) ConvertFToS 3771
             3773:         283 Image 3768
             3774:3102(ResType) ImageSparseFetch 3773 3770 Lod 3772
-            3775:    7(fvec4) CompositeExtract 3774 1
+            3775:  7(f16vec4) CompositeExtract 3774 1
                               Store 3742(texel) 3775
             3776:     47(int) CompositeExtract 3774 0
             3777:        1309 Load 1311(s2DMS)
@@ -4829,7 +4829,7 @@ spv.float16Fetch.frag
             3779:  721(ivec2) ConvertFToS 3778
             3780:        1308 Image 3777
             3781:3102(ResType) ImageSparseFetch 3780 3779 Sample 709
-            3782:    7(fvec4) CompositeExtract 3781 1
+            3782:  7(f16vec4) CompositeExtract 3781 1
                               Store 3742(texel) 3782
             3783:     47(int) CompositeExtract 3781 0
             3784:        1320 Load 1322(s2DMSArray)
@@ -4837,13 +4837,13 @@ spv.float16Fetch.frag
             3786:  734(ivec3) ConvertFToS 3785
             3787:        1319 Image 3784
             3788:3102(ResType) ImageSparseFetch 3787 3786 Sample 1326
-            3789:    7(fvec4) CompositeExtract 3788 1
+            3789:  7(f16vec4) CompositeExtract 3788 1
                               Store 3742(texel) 3789
             3790:     47(int) CompositeExtract 3788 0
-            3791:    7(fvec4) Load 3742(texel)
+            3791:  7(f16vec4) Load 3742(texel)
                               ReturnValue 3791
                               FunctionEnd
-83(testSparseTexelFetchOffset():    7(fvec4) Function None 8
+83(testSparseTexelFetchOffset():  7(f16vec4) Function None 8
               84:             Label
      3794(texel):     64(ptr) Variable Function
                               Store 3794(texel) 121
@@ -4854,7 +4854,7 @@ spv.float16Fetch.frag
             3799:     47(int) ConvertFToS 3798
             3800:         142 Image 3795
             3801:3102(ResType) ImageSparseFetch 3800 3797 Lod ConstOffset 3799 722
-            3802:    7(fvec4) CompositeExtract 3801 1
+            3802:  7(f16vec4) CompositeExtract 3801 1
                               Store 3794(texel) 3802
             3803:     47(int) CompositeExtract 3801 0
             3804:         163 Load 165(s3D)
@@ -4864,7 +4864,7 @@ spv.float16Fetch.frag
             3808:     47(int) ConvertFToS 3807
             3809:         162 Image 3804
             3810:3102(ResType) ImageSparseFetch 3809 3806 Lod ConstOffset 3808 735
-            3811:    7(fvec4) CompositeExtract 3810 1
+            3811:  7(f16vec4) CompositeExtract 3810 1
                               Store 3794(texel) 3811
             3812:     47(int) CompositeExtract 3810 0
             3813:         357 Load 359(s2DRect)
@@ -4872,7 +4872,7 @@ spv.float16Fetch.frag
             3815:  721(ivec2) ConvertFToS 3814
             3816:         356 Image 3813
             3817:3102(ResType) ImageSparseFetch 3816 3815 ConstOffset 722
-            3818:    7(fvec4) CompositeExtract 3817 1
+            3818:  7(f16vec4) CompositeExtract 3817 1
                               Store 3794(texel) 3818
             3819:     47(int) CompositeExtract 3817 0
             3820:         284 Load 286(s2DArray)
@@ -4882,328 +4882,328 @@ spv.float16Fetch.frag
             3824:     47(int) ConvertFToS 3823
             3825:         283 Image 3820
             3826:3102(ResType) ImageSparseFetch 3825 3822 Lod ConstOffset 3824 722
-            3827:    7(fvec4) CompositeExtract 3826 1
+            3827:  7(f16vec4) CompositeExtract 3826 1
                               Store 3794(texel) 3827
             3828:     47(int) CompositeExtract 3826 0
-            3829:    7(fvec4) Load 3794(texel)
+            3829:  7(f16vec4) Load 3794(texel)
                               ReturnValue 3829
                               FunctionEnd
-85(testSparseTextureGather():    7(fvec4) Function None 8
+85(testSparseTextureGather():  7(f16vec4) Function None 8
               86:             Label
      3832(texel):     64(ptr) Variable Function
                               Store 3832(texel) 121
             3833:         143 Load 145(s2D)
             3834:   53(fvec2) Load 148(c2)
             3835:3102(ResType) ImageSparseGather 3833 3834 2187
-            3836:    7(fvec4) CompositeExtract 3835 1
+            3836:  7(f16vec4) CompositeExtract 3835 1
                               Store 3832(texel) 3836
             3837:     47(int) CompositeExtract 3835 0
             3838:         143 Load 145(s2D)
-            3839:  154(fvec2) Load 156(f16c2)
-            3840:    6(float) Load 137(f16bias)
+            3839:154(f16vec2) Load 156(f16c2)
+            3840:6(float16_t) Load 137(f16bias)
             3841:3102(ResType) ImageSparseGather 3838 3839 2187 Bias 3840
-            3842:    7(fvec4) CompositeExtract 3841 1
+            3842:  7(f16vec4) CompositeExtract 3841 1
                               Store 3832(texel) 3842
             3843:     47(int) CompositeExtract 3841 0
             3844:         284 Load 286(s2DArray)
             3845:  167(fvec3) Load 169(c3)
             3846:3102(ResType) ImageSparseGather 3844 3845 2187
-            3847:    7(fvec4) CompositeExtract 3846 1
+            3847:  7(f16vec4) CompositeExtract 3846 1
                               Store 3832(texel) 3847
             3848:     47(int) CompositeExtract 3846 0
             3849:         284 Load 286(s2DArray)
-            3850:  175(fvec3) Load 177(f16c3)
-            3851:    6(float) Load 137(f16bias)
+            3850:175(f16vec3) Load 177(f16c3)
+            3851:6(float16_t) Load 137(f16bias)
             3852:3102(ResType) ImageSparseGather 3849 3850 2187 Bias 3851
-            3853:    7(fvec4) CompositeExtract 3852 1
+            3853:  7(f16vec4) CompositeExtract 3852 1
                               Store 3832(texel) 3853
             3854:     47(int) CompositeExtract 3852 0
             3855:         184 Load 186(sCube)
             3856:  167(fvec3) Load 169(c3)
             3857:3102(ResType) ImageSparseGather 3855 3856 2187
-            3858:    7(fvec4) CompositeExtract 3857 1
+            3858:  7(f16vec4) CompositeExtract 3857 1
                               Store 3832(texel) 3858
             3859:     47(int) CompositeExtract 3857 0
             3860:         184 Load 186(sCube)
-            3861:  175(fvec3) Load 177(f16c3)
-            3862:    6(float) Load 137(f16bias)
+            3861:175(f16vec3) Load 177(f16c3)
+            3862:6(float16_t) Load 137(f16bias)
             3863:3102(ResType) ImageSparseGather 3860 3861 2187 Bias 3862
-            3864:    7(fvec4) CompositeExtract 3863 1
+            3864:  7(f16vec4) CompositeExtract 3863 1
                               Store 3832(texel) 3864
             3865:     47(int) CompositeExtract 3863 0
             3866:         299 Load 301(sCubeArray)
             3867:  249(fvec4) Load 251(c4)
             3868:3102(ResType) ImageSparseGather 3866 3867 2187
-            3869:    7(fvec4) CompositeExtract 3868 1
+            3869:  7(f16vec4) CompositeExtract 3868 1
                               Store 3832(texel) 3869
             3870:     47(int) CompositeExtract 3868 0
             3871:         299 Load 301(sCubeArray)
-            3872:    7(fvec4) Load 309(f16c4)
-            3873:    6(float) Load 137(f16bias)
+            3872:  7(f16vec4) Load 309(f16c4)
+            3873:6(float16_t) Load 137(f16bias)
             3874:3102(ResType) ImageSparseGather 3871 3872 2187 Bias 3873
-            3875:    7(fvec4) CompositeExtract 3874 1
+            3875:  7(f16vec4) CompositeExtract 3874 1
                               Store 3832(texel) 3875
             3876:     47(int) CompositeExtract 3874 0
             3877:         357 Load 359(s2DRect)
             3878:   53(fvec2) Load 148(c2)
             3879:3102(ResType) ImageSparseGather 3877 3878 2187
-            3880:    7(fvec4) CompositeExtract 3879 1
+            3880:  7(f16vec4) CompositeExtract 3879 1
                               Store 3832(texel) 3880
             3881:     47(int) CompositeExtract 3879 0
             3882:         357 Load 359(s2DRect)
-            3883:  154(fvec2) Load 156(f16c2)
+            3883:154(f16vec2) Load 156(f16c2)
             3884:3102(ResType) ImageSparseGather 3882 3883 2187
-            3885:    7(fvec4) CompositeExtract 3884 1
+            3885:  7(f16vec4) CompositeExtract 3884 1
                               Store 3832(texel) 3885
             3886:     47(int) CompositeExtract 3884 0
             3887:         224 Load 226(s2DShadow)
             3888:   53(fvec2) Load 148(c2)
             3889:   52(float) Load 215(compare)
             3890:3102(ResType) ImageSparseDrefGather 3887 3888 3889
-            3891:    7(fvec4) CompositeExtract 3890 1
+            3891:  7(f16vec4) CompositeExtract 3890 1
                               Store 3832(texel) 3891
             3892:     47(int) CompositeExtract 3890 0
             3893:         224 Load 226(s2DShadow)
-            3894:  154(fvec2) Load 156(f16c2)
+            3894:154(f16vec2) Load 156(f16c2)
             3895:   52(float) Load 215(compare)
             3896:3102(ResType) ImageSparseDrefGather 3893 3894 3895
-            3897:    7(fvec4) CompositeExtract 3896 1
+            3897:  7(f16vec4) CompositeExtract 3896 1
                               Store 3832(texel) 3897
             3898:     47(int) CompositeExtract 3896 0
             3899:         337 Load 339(s2DArrayShadow)
             3900:  167(fvec3) Load 169(c3)
             3901:   52(float) Load 215(compare)
             3902:3102(ResType) ImageSparseDrefGather 3899 3900 3901
-            3903:    7(fvec4) CompositeExtract 3902 1
+            3903:  7(f16vec4) CompositeExtract 3902 1
                               Store 3832(texel) 3903
             3904:     47(int) CompositeExtract 3902 0
             3905:         337 Load 339(s2DArrayShadow)
-            3906:  175(fvec3) Load 177(f16c3)
+            3906:175(f16vec3) Load 177(f16c3)
             3907:   52(float) Load 215(compare)
             3908:3102(ResType) ImageSparseDrefGather 3905 3906 3907
-            3909:    7(fvec4) CompositeExtract 3908 1
+            3909:  7(f16vec4) CompositeExtract 3908 1
                               Store 3832(texel) 3909
             3910:     47(int) CompositeExtract 3908 0
             3911:         245 Load 247(sCubeShadow)
             3912:  167(fvec3) Load 169(c3)
             3913:   52(float) Load 215(compare)
             3914:3102(ResType) ImageSparseDrefGather 3911 3912 3913
-            3915:    7(fvec4) CompositeExtract 3914 1
+            3915:  7(f16vec4) CompositeExtract 3914 1
                               Store 3832(texel) 3915
             3916:     47(int) CompositeExtract 3914 0
             3917:         245 Load 247(sCubeShadow)
-            3918:  175(fvec3) Load 177(f16c3)
+            3918:175(f16vec3) Load 177(f16c3)
             3919:   52(float) Load 215(compare)
             3920:3102(ResType) ImageSparseDrefGather 3917 3918 3919
-            3921:    7(fvec4) CompositeExtract 3920 1
+            3921:  7(f16vec4) CompositeExtract 3920 1
                               Store 3832(texel) 3921
             3922:     47(int) CompositeExtract 3920 0
             3923:         391 Load 393(sCubeArrayShadow)
             3924:  249(fvec4) Load 251(c4)
             3925:   52(float) Load 215(compare)
             3926:3102(ResType) ImageSparseDrefGather 3923 3924 3925
-            3927:    7(fvec4) CompositeExtract 3926 1
+            3927:  7(f16vec4) CompositeExtract 3926 1
                               Store 3832(texel) 3927
             3928:     47(int) CompositeExtract 3926 0
             3929:         391 Load 393(sCubeArrayShadow)
-            3930:    7(fvec4) Load 309(f16c4)
+            3930:  7(f16vec4) Load 309(f16c4)
             3931:   52(float) Load 215(compare)
             3932:3102(ResType) ImageSparseDrefGather 3929 3930 3931
-            3933:    7(fvec4) CompositeExtract 3932 1
+            3933:  7(f16vec4) CompositeExtract 3932 1
                               Store 3832(texel) 3933
             3934:     47(int) CompositeExtract 3932 0
             3935:         371 Load 373(s2DRectShadow)
             3936:   53(fvec2) Load 148(c2)
             3937:   52(float) Load 215(compare)
             3938:3102(ResType) ImageSparseDrefGather 3935 3936 3937
-            3939:    7(fvec4) CompositeExtract 3938 1
+            3939:  7(f16vec4) CompositeExtract 3938 1
                               Store 3832(texel) 3939
             3940:     47(int) CompositeExtract 3938 0
             3941:         371 Load 373(s2DRectShadow)
-            3942:  154(fvec2) Load 156(f16c2)
+            3942:154(f16vec2) Load 156(f16c2)
             3943:   52(float) Load 215(compare)
             3944:3102(ResType) ImageSparseDrefGather 3941 3942 3943
-            3945:    7(fvec4) CompositeExtract 3944 1
+            3945:  7(f16vec4) CompositeExtract 3944 1
                               Store 3832(texel) 3945
             3946:     47(int) CompositeExtract 3944 0
-            3947:    7(fvec4) Load 3832(texel)
+            3947:  7(f16vec4) Load 3832(texel)
                               ReturnValue 3947
                               FunctionEnd
-87(testSparseTextureGatherOffset():    7(fvec4) Function None 8
+87(testSparseTextureGatherOffset():  7(f16vec4) Function None 8
               88:             Label
      3950(texel):     64(ptr) Variable Function
                               Store 3950(texel) 121
             3951:         143 Load 145(s2D)
             3952:   53(fvec2) Load 148(c2)
             3953:3102(ResType) ImageSparseGather 3951 3952 2187 ConstOffset 722
-            3954:    7(fvec4) CompositeExtract 3953 1
+            3954:  7(f16vec4) CompositeExtract 3953 1
                               Store 3950(texel) 3954
             3955:     47(int) CompositeExtract 3953 0
             3956:         143 Load 145(s2D)
-            3957:  154(fvec2) Load 156(f16c2)
-            3958:    6(float) Load 137(f16bias)
+            3957:154(f16vec2) Load 156(f16c2)
+            3958:6(float16_t) Load 137(f16bias)
             3959:3102(ResType) ImageSparseGather 3956 3957 2187 Bias ConstOffset 3958 722
-            3960:    7(fvec4) CompositeExtract 3959 1
+            3960:  7(f16vec4) CompositeExtract 3959 1
                               Store 3950(texel) 3960
             3961:     47(int) CompositeExtract 3959 0
             3962:         284 Load 286(s2DArray)
             3963:  167(fvec3) Load 169(c3)
             3964:3102(ResType) ImageSparseGather 3962 3963 2187 ConstOffset 722
-            3965:    7(fvec4) CompositeExtract 3964 1
+            3965:  7(f16vec4) CompositeExtract 3964 1
                               Store 3950(texel) 3965
             3966:     47(int) CompositeExtract 3964 0
             3967:         284 Load 286(s2DArray)
-            3968:  175(fvec3) Load 177(f16c3)
-            3969:    6(float) Load 137(f16bias)
+            3968:175(f16vec3) Load 177(f16c3)
+            3969:6(float16_t) Load 137(f16bias)
             3970:3102(ResType) ImageSparseGather 3967 3968 2187 Bias ConstOffset 3969 722
-            3971:    7(fvec4) CompositeExtract 3970 1
+            3971:  7(f16vec4) CompositeExtract 3970 1
                               Store 3950(texel) 3971
             3972:     47(int) CompositeExtract 3970 0
             3973:         357 Load 359(s2DRect)
             3974:   53(fvec2) Load 148(c2)
             3975:3102(ResType) ImageSparseGather 3973 3974 2187 ConstOffset 722
-            3976:    7(fvec4) CompositeExtract 3975 1
+            3976:  7(f16vec4) CompositeExtract 3975 1
                               Store 3950(texel) 3976
             3977:     47(int) CompositeExtract 3975 0
             3978:         357 Load 359(s2DRect)
-            3979:  154(fvec2) Load 156(f16c2)
+            3979:154(f16vec2) Load 156(f16c2)
             3980:3102(ResType) ImageSparseGather 3978 3979 2187 ConstOffset 722
-            3981:    7(fvec4) CompositeExtract 3980 1
+            3981:  7(f16vec4) CompositeExtract 3980 1
                               Store 3950(texel) 3981
             3982:     47(int) CompositeExtract 3980 0
             3983:         224 Load 226(s2DShadow)
             3984:   53(fvec2) Load 148(c2)
             3985:   52(float) Load 215(compare)
             3986:3102(ResType) ImageSparseDrefGather 3983 3984 3985 ConstOffset 722
-            3987:    7(fvec4) CompositeExtract 3986 1
+            3987:  7(f16vec4) CompositeExtract 3986 1
                               Store 3950(texel) 3987
             3988:     47(int) CompositeExtract 3986 0
             3989:         224 Load 226(s2DShadow)
-            3990:  154(fvec2) Load 156(f16c2)
+            3990:154(f16vec2) Load 156(f16c2)
             3991:   52(float) Load 215(compare)
             3992:3102(ResType) ImageSparseDrefGather 3989 3990 3991 ConstOffset 722
-            3993:    7(fvec4) CompositeExtract 3992 1
+            3993:  7(f16vec4) CompositeExtract 3992 1
                               Store 3950(texel) 3993
             3994:     47(int) CompositeExtract 3992 0
             3995:         337 Load 339(s2DArrayShadow)
             3996:  167(fvec3) Load 169(c3)
             3997:   52(float) Load 215(compare)
             3998:3102(ResType) ImageSparseDrefGather 3995 3996 3997 ConstOffset 722
-            3999:    7(fvec4) CompositeExtract 3998 1
+            3999:  7(f16vec4) CompositeExtract 3998 1
                               Store 3950(texel) 3999
             4000:     47(int) CompositeExtract 3998 0
             4001:         337 Load 339(s2DArrayShadow)
-            4002:  175(fvec3) Load 177(f16c3)
+            4002:175(f16vec3) Load 177(f16c3)
             4003:   52(float) Load 215(compare)
             4004:3102(ResType) ImageSparseDrefGather 4001 4002 4003 ConstOffset 722
-            4005:    7(fvec4) CompositeExtract 4004 1
+            4005:  7(f16vec4) CompositeExtract 4004 1
                               Store 3950(texel) 4005
             4006:     47(int) CompositeExtract 4004 0
             4007:         371 Load 373(s2DRectShadow)
             4008:   53(fvec2) Load 148(c2)
             4009:   52(float) Load 215(compare)
             4010:3102(ResType) ImageSparseDrefGather 4007 4008 4009 ConstOffset 722
-            4011:    7(fvec4) CompositeExtract 4010 1
+            4011:  7(f16vec4) CompositeExtract 4010 1
                               Store 3950(texel) 4011
             4012:     47(int) CompositeExtract 4010 0
             4013:         371 Load 373(s2DRectShadow)
-            4014:  154(fvec2) Load 156(f16c2)
+            4014:154(f16vec2) Load 156(f16c2)
             4015:   52(float) Load 215(compare)
             4016:3102(ResType) ImageSparseDrefGather 4013 4014 4015 ConstOffset 722
-            4017:    7(fvec4) CompositeExtract 4016 1
+            4017:  7(f16vec4) CompositeExtract 4016 1
                               Store 3950(texel) 4017
             4018:     47(int) CompositeExtract 4016 0
-            4019:    7(fvec4) Load 3950(texel)
+            4019:  7(f16vec4) Load 3950(texel)
                               ReturnValue 4019
                               FunctionEnd
-89(testSparseTextureGatherOffsets():    7(fvec4) Function None 8
+89(testSparseTextureGatherOffsets():  7(f16vec4) Function None 8
               90:             Label
      4022(texel):     64(ptr) Variable Function
                               Store 4022(texel) 121
             4023:         143 Load 145(s2D)
             4024:   53(fvec2) Load 148(c2)
             4025:3102(ResType) ImageSparseGather 4023 4024 2187 ConstOffsets 2380
-            4026:    7(fvec4) CompositeExtract 4025 1
+            4026:  7(f16vec4) CompositeExtract 4025 1
                               Store 4022(texel) 4026
             4027:     47(int) CompositeExtract 4025 0
             4028:         143 Load 145(s2D)
-            4029:  154(fvec2) Load 156(f16c2)
-            4030:    6(float) Load 137(f16bias)
+            4029:154(f16vec2) Load 156(f16c2)
+            4030:6(float16_t) Load 137(f16bias)
             4031:3102(ResType) ImageSparseGather 4028 4029 2187 Bias ConstOffsets 4030 2380
-            4032:    7(fvec4) CompositeExtract 4031 1
+            4032:  7(f16vec4) CompositeExtract 4031 1
                               Store 4022(texel) 4032
             4033:     47(int) CompositeExtract 4031 0
             4034:         284 Load 286(s2DArray)
             4035:  167(fvec3) Load 169(c3)
             4036:3102(ResType) ImageSparseGather 4034 4035 2187 ConstOffsets 2380
-            4037:    7(fvec4) CompositeExtract 4036 1
+            4037:  7(f16vec4) CompositeExtract 4036 1
                               Store 4022(texel) 4037
             4038:     47(int) CompositeExtract 4036 0
             4039:         284 Load 286(s2DArray)
-            4040:  175(fvec3) Load 177(f16c3)
-            4041:    6(float) Load 137(f16bias)
+            4040:175(f16vec3) Load 177(f16c3)
+            4041:6(float16_t) Load 137(f16bias)
             4042:3102(ResType) ImageSparseGather 4039 4040 2187 Bias ConstOffsets 4041 2380
-            4043:    7(fvec4) CompositeExtract 4042 1
+            4043:  7(f16vec4) CompositeExtract 4042 1
                               Store 4022(texel) 4043
             4044:     47(int) CompositeExtract 4042 0
             4045:         357 Load 359(s2DRect)
             4046:   53(fvec2) Load 148(c2)
             4047:3102(ResType) ImageSparseGather 4045 4046 2187 ConstOffsets 2380
-            4048:    7(fvec4) CompositeExtract 4047 1
+            4048:  7(f16vec4) CompositeExtract 4047 1
                               Store 4022(texel) 4048
             4049:     47(int) CompositeExtract 4047 0
             4050:         357 Load 359(s2DRect)
-            4051:  154(fvec2) Load 156(f16c2)
+            4051:154(f16vec2) Load 156(f16c2)
             4052:3102(ResType) ImageSparseGather 4050 4051 2187 ConstOffsets 2380
-            4053:    7(fvec4) CompositeExtract 4052 1
+            4053:  7(f16vec4) CompositeExtract 4052 1
                               Store 4022(texel) 4053
             4054:     47(int) CompositeExtract 4052 0
             4055:         224 Load 226(s2DShadow)
             4056:   53(fvec2) Load 148(c2)
             4057:   52(float) Load 215(compare)
             4058:3102(ResType) ImageSparseDrefGather 4055 4056 4057 ConstOffsets 2380
-            4059:    7(fvec4) CompositeExtract 4058 1
+            4059:  7(f16vec4) CompositeExtract 4058 1
                               Store 4022(texel) 4059
             4060:     47(int) CompositeExtract 4058 0
             4061:         224 Load 226(s2DShadow)
-            4062:  154(fvec2) Load 156(f16c2)
+            4062:154(f16vec2) Load 156(f16c2)
             4063:   52(float) Load 215(compare)
             4064:3102(ResType) ImageSparseDrefGather 4061 4062 4063 ConstOffsets 2380
-            4065:    7(fvec4) CompositeExtract 4064 1
+            4065:  7(f16vec4) CompositeExtract 4064 1
                               Store 4022(texel) 4065
             4066:     47(int) CompositeExtract 4064 0
             4067:         337 Load 339(s2DArrayShadow)
             4068:  167(fvec3) Load 169(c3)
             4069:   52(float) Load 215(compare)
             4070:3102(ResType) ImageSparseDrefGather 4067 4068 4069 ConstOffsets 2380
-            4071:    7(fvec4) CompositeExtract 4070 1
+            4071:  7(f16vec4) CompositeExtract 4070 1
                               Store 4022(texel) 4071
             4072:     47(int) CompositeExtract 4070 0
             4073:         337 Load 339(s2DArrayShadow)
-            4074:  175(fvec3) Load 177(f16c3)
+            4074:175(f16vec3) Load 177(f16c3)
             4075:   52(float) Load 215(compare)
             4076:3102(ResType) ImageSparseDrefGather 4073 4074 4075 ConstOffsets 2380
-            4077:    7(fvec4) CompositeExtract 4076 1
+            4077:  7(f16vec4) CompositeExtract 4076 1
                               Store 4022(texel) 4077
             4078:     47(int) CompositeExtract 4076 0
             4079:         371 Load 373(s2DRectShadow)
             4080:   53(fvec2) Load 148(c2)
             4081:   52(float) Load 215(compare)
             4082:3102(ResType) ImageSparseDrefGather 4079 4080 4081 ConstOffsets 2380
-            4083:    7(fvec4) CompositeExtract 4082 1
+            4083:  7(f16vec4) CompositeExtract 4082 1
                               Store 4022(texel) 4083
             4084:     47(int) CompositeExtract 4082 0
             4085:         371 Load 373(s2DRectShadow)
-            4086:  154(fvec2) Load 156(f16c2)
+            4086:154(f16vec2) Load 156(f16c2)
             4087:   52(float) Load 215(compare)
             4088:3102(ResType) ImageSparseDrefGather 4085 4086 4087 ConstOffsets 2380
-            4089:    7(fvec4) CompositeExtract 4088 1
+            4089:  7(f16vec4) CompositeExtract 4088 1
                               Store 4022(texel) 4089
             4090:     47(int) CompositeExtract 4088 0
-            4091:    7(fvec4) Load 4022(texel)
+            4091:  7(f16vec4) Load 4022(texel)
                               ReturnValue 4091
                               FunctionEnd
-91(testSparseTextureGatherLod():    7(fvec4) Function None 8
+91(testSparseTextureGatherLod():  7(f16vec4) Function None 8
               92:             Label
      4094(texel):     64(ptr) Variable Function
                               Store 4094(texel) 121
@@ -5211,62 +5211,62 @@ spv.float16Fetch.frag
             4096:   53(fvec2) Load 148(c2)
             4097:   52(float) Load 565(lod)
             4098:3102(ResType) ImageSparseGather 4095 4096 2187 Lod 4097
-            4099:    7(fvec4) CompositeExtract 4098 1
+            4099:  7(f16vec4) CompositeExtract 4098 1
                               Store 4094(texel) 4099
             4100:     47(int) CompositeExtract 4098 0
             4101:         143 Load 145(s2D)
-            4102:  154(fvec2) Load 156(f16c2)
-            4103:    6(float) Load 572(f16lod)
+            4102:154(f16vec2) Load 156(f16c2)
+            4103:6(float16_t) Load 572(f16lod)
             4104:3102(ResType) ImageSparseGather 4101 4102 2187 Lod 4103
-            4105:    7(fvec4) CompositeExtract 4104 1
+            4105:  7(f16vec4) CompositeExtract 4104 1
                               Store 4094(texel) 4105
             4106:     47(int) CompositeExtract 4104 0
             4107:         284 Load 286(s2DArray)
             4108:  167(fvec3) Load 169(c3)
             4109:   52(float) Load 565(lod)
             4110:3102(ResType) ImageSparseGather 4107 4108 2187 Lod 4109
-            4111:    7(fvec4) CompositeExtract 4110 1
+            4111:  7(f16vec4) CompositeExtract 4110 1
                               Store 4094(texel) 4111
             4112:     47(int) CompositeExtract 4110 0
             4113:         284 Load 286(s2DArray)
-            4114:  175(fvec3) Load 177(f16c3)
-            4115:    6(float) Load 572(f16lod)
+            4114:175(f16vec3) Load 177(f16c3)
+            4115:6(float16_t) Load 572(f16lod)
             4116:3102(ResType) ImageSparseGather 4113 4114 2187 Lod 4115
-            4117:    7(fvec4) CompositeExtract 4116 1
+            4117:  7(f16vec4) CompositeExtract 4116 1
                               Store 4094(texel) 4117
             4118:     47(int) CompositeExtract 4116 0
             4119:         184 Load 186(sCube)
             4120:  167(fvec3) Load 169(c3)
             4121:   52(float) Load 565(lod)
             4122:3102(ResType) ImageSparseGather 4119 4120 2187 Lod 4121
-            4123:    7(fvec4) CompositeExtract 4122 1
+            4123:  7(f16vec4) CompositeExtract 4122 1
                               Store 4094(texel) 4123
             4124:     47(int) CompositeExtract 4122 0
             4125:         184 Load 186(sCube)
-            4126:  175(fvec3) Load 177(f16c3)
-            4127:    6(float) Load 572(f16lod)
+            4126:175(f16vec3) Load 177(f16c3)
+            4127:6(float16_t) Load 572(f16lod)
             4128:3102(ResType) ImageSparseGather 4125 4126 2187 Lod 4127
-            4129:    7(fvec4) CompositeExtract 4128 1
+            4129:  7(f16vec4) CompositeExtract 4128 1
                               Store 4094(texel) 4129
             4130:     47(int) CompositeExtract 4128 0
             4131:         299 Load 301(sCubeArray)
             4132:  249(fvec4) Load 251(c4)
             4133:   52(float) Load 565(lod)
             4134:3102(ResType) ImageSparseGather 4131 4132 2187 Lod 4133
-            4135:    7(fvec4) CompositeExtract 4134 1
+            4135:  7(f16vec4) CompositeExtract 4134 1
                               Store 4094(texel) 4135
             4136:     47(int) CompositeExtract 4134 0
             4137:         299 Load 301(sCubeArray)
-            4138:    7(fvec4) Load 309(f16c4)
-            4139:    6(float) Load 572(f16lod)
+            4138:  7(f16vec4) Load 309(f16c4)
+            4139:6(float16_t) Load 572(f16lod)
             4140:3102(ResType) ImageSparseGather 4137 4138 2187 Lod 4139
-            4141:    7(fvec4) CompositeExtract 4140 1
+            4141:  7(f16vec4) CompositeExtract 4140 1
                               Store 4094(texel) 4141
             4142:     47(int) CompositeExtract 4140 0
-            4143:    7(fvec4) Load 4094(texel)
+            4143:  7(f16vec4) Load 4094(texel)
                               ReturnValue 4143
                               FunctionEnd
-93(testSparseTextureGatherLodOffset():    7(fvec4) Function None 8
+93(testSparseTextureGatherLodOffset():  7(f16vec4) Function None 8
               94:             Label
      4146(texel):     64(ptr) Variable Function
                               Store 4146(texel) 121
@@ -5274,34 +5274,34 @@ spv.float16Fetch.frag
             4148:   53(fvec2) Load 148(c2)
             4149:   52(float) Load 565(lod)
             4150:3102(ResType) ImageSparseGather 4147 4148 2187 Lod ConstOffset 4149 722
-            4151:    7(fvec4) CompositeExtract 4150 1
+            4151:  7(f16vec4) CompositeExtract 4150 1
                               Store 4146(texel) 4151
             4152:     47(int) CompositeExtract 4150 0
             4153:         143 Load 145(s2D)
-            4154:  154(fvec2) Load 156(f16c2)
-            4155:    6(float) Load 572(f16lod)
+            4154:154(f16vec2) Load 156(f16c2)
+            4155:6(float16_t) Load 572(f16lod)
             4156:3102(ResType) ImageSparseGather 4153 4154 2187 Lod ConstOffset 4155 722
-            4157:    7(fvec4) CompositeExtract 4156 1
+            4157:  7(f16vec4) CompositeExtract 4156 1
                               Store 4146(texel) 4157
             4158:     47(int) CompositeExtract 4156 0
             4159:         284 Load 286(s2DArray)
             4160:  167(fvec3) Load 169(c3)
             4161:   52(float) Load 565(lod)
             4162:3102(ResType) ImageSparseGather 4159 4160 2187 Lod ConstOffset 4161 722
-            4163:    7(fvec4) CompositeExtract 4162 1
+            4163:  7(f16vec4) CompositeExtract 4162 1
                               Store 4146(texel) 4163
             4164:     47(int) CompositeExtract 4162 0
             4165:         284 Load 286(s2DArray)
-            4166:  175(fvec3) Load 177(f16c3)
-            4167:    6(float) Load 572(f16lod)
+            4166:175(f16vec3) Load 177(f16c3)
+            4167:6(float16_t) Load 572(f16lod)
             4168:3102(ResType) ImageSparseGather 4165 4166 2187 Lod ConstOffset 4167 722
-            4169:    7(fvec4) CompositeExtract 4168 1
+            4169:  7(f16vec4) CompositeExtract 4168 1
                               Store 4146(texel) 4169
             4170:     47(int) CompositeExtract 4168 0
-            4171:    7(fvec4) Load 4146(texel)
+            4171:  7(f16vec4) Load 4146(texel)
                               ReturnValue 4171
                               FunctionEnd
-95(testSparseTextureGatherLodOffsets():    7(fvec4) Function None 8
+95(testSparseTextureGatherLodOffsets():  7(f16vec4) Function None 8
               96:             Label
      4174(texel):     64(ptr) Variable Function
                               Store 4174(texel) 121
@@ -5309,34 +5309,34 @@ spv.float16Fetch.frag
             4176:   53(fvec2) Load 148(c2)
             4177:   52(float) Load 565(lod)
             4178:3102(ResType) ImageSparseGather 4175 4176 2187 Lod ConstOffsets 4177 2380
-            4179:    7(fvec4) CompositeExtract 4178 1
+            4179:  7(f16vec4) CompositeExtract 4178 1
                               Store 4174(texel) 4179
             4180:     47(int) CompositeExtract 4178 0
             4181:         143 Load 145(s2D)
-            4182:  154(fvec2) Load 156(f16c2)
-            4183:    6(float) Load 572(f16lod)
+            4182:154(f16vec2) Load 156(f16c2)
+            4183:6(float16_t) Load 572(f16lod)
             4184:3102(ResType) ImageSparseGather 4181 4182 2187 Lod ConstOffsets 4183 2380
-            4185:    7(fvec4) CompositeExtract 4184 1
+            4185:  7(f16vec4) CompositeExtract 4184 1
                               Store 4174(texel) 4185
             4186:     47(int) CompositeExtract 4184 0
             4187:         284 Load 286(s2DArray)
             4188:  167(fvec3) Load 169(c3)
             4189:   52(float) Load 565(lod)
             4190:3102(ResType) ImageSparseGather 4187 4188 2187 Lod ConstOffsets 4189 2380
-            4191:    7(fvec4) CompositeExtract 4190 1
+            4191:  7(f16vec4) CompositeExtract 4190 1
                               Store 4174(texel) 4191
             4192:     47(int) CompositeExtract 4190 0
             4193:         284 Load 286(s2DArray)
-            4194:  175(fvec3) Load 177(f16c3)
-            4195:    6(float) Load 572(f16lod)
+            4194:175(f16vec3) Load 177(f16c3)
+            4195:6(float16_t) Load 572(f16lod)
             4196:3102(ResType) ImageSparseGather 4193 4194 2187 Lod ConstOffsets 4195 2380
-            4197:    7(fvec4) CompositeExtract 4196 1
+            4197:  7(f16vec4) CompositeExtract 4196 1
                               Store 4174(texel) 4197
             4198:     47(int) CompositeExtract 4196 0
-            4199:    7(fvec4) Load 4174(texel)
+            4199:  7(f16vec4) Load 4174(texel)
                               ReturnValue 4199
                               FunctionEnd
-97(testSparseImageLoad():    7(fvec4) Function None 8
+97(testSparseImageLoad():  7(f16vec4) Function None 8
               98:             Label
      4202(texel):     64(ptr) Variable Function
                               Store 4202(texel) 121
@@ -5344,62 +5344,62 @@ spv.float16Fetch.frag
             4204:   53(fvec2) Load 148(c2)
             4205:  721(ivec2) ConvertFToS 4204
             4206:3102(ResType) ImageSparseRead 4203 4205
-            4207:    7(fvec4) CompositeExtract 4206 1
+            4207:  7(f16vec4) CompositeExtract 4206 1
                               Store 4202(texel) 4207
             4208:     47(int) CompositeExtract 4206 0
             4209:        2971 Load 2973(i3D)
             4210:  167(fvec3) Load 169(c3)
             4211:  734(ivec3) ConvertFToS 4210
             4212:3102(ResType) ImageSparseRead 4209 4211
-            4213:    7(fvec4) CompositeExtract 4212 1
+            4213:  7(f16vec4) CompositeExtract 4212 1
                               Store 4202(texel) 4213
             4214:     47(int) CompositeExtract 4212 0
             4215:        2980 Load 2982(i2DRect)
             4216:   53(fvec2) Load 148(c2)
             4217:  721(ivec2) ConvertFToS 4216
             4218:3102(ResType) ImageSparseRead 4215 4217
-            4219:    7(fvec4) CompositeExtract 4218 1
+            4219:  7(f16vec4) CompositeExtract 4218 1
                               Store 4202(texel) 4219
             4220:     47(int) CompositeExtract 4218 0
             4221:        2989 Load 2991(iCube)
             4222:  167(fvec3) Load 169(c3)
             4223:  734(ivec3) ConvertFToS 4222
             4224:3102(ResType) ImageSparseRead 4221 4223
-            4225:    7(fvec4) CompositeExtract 4224 1
+            4225:  7(f16vec4) CompositeExtract 4224 1
                               Store 4202(texel) 4225
             4226:     47(int) CompositeExtract 4224 0
             4227:        3016 Load 3018(i2DArray)
             4228:  167(fvec3) Load 169(c3)
             4229:  734(ivec3) ConvertFToS 4228
             4230:3102(ResType) ImageSparseRead 4227 4229
-            4231:    7(fvec4) CompositeExtract 4230 1
+            4231:  7(f16vec4) CompositeExtract 4230 1
                               Store 4202(texel) 4231
             4232:     47(int) CompositeExtract 4230 0
             4233:        3025 Load 3027(iCubeArray)
             4234:  167(fvec3) Load 169(c3)
             4235:  734(ivec3) ConvertFToS 4234
             4236:3102(ResType) ImageSparseRead 4233 4235
-            4237:    7(fvec4) CompositeExtract 4236 1
+            4237:  7(f16vec4) CompositeExtract 4236 1
                               Store 4202(texel) 4237
             4238:     47(int) CompositeExtract 4236 0
             4239:        3034 Load 3036(i2DMS)
             4240:   53(fvec2) Load 148(c2)
             4241:  721(ivec2) ConvertFToS 4240
             4242:3102(ResType) ImageSparseRead 4239 4241 Sample 709
-            4243:    7(fvec4) CompositeExtract 4242 1
+            4243:  7(f16vec4) CompositeExtract 4242 1
                               Store 4202(texel) 4243
             4244:     47(int) CompositeExtract 4242 0
             4245:        3043 Load 3045(i2DMSArray)
             4246:  167(fvec3) Load 169(c3)
             4247:  734(ivec3) ConvertFToS 4246
             4248:3102(ResType) ImageSparseRead 4245 4247 Sample 1326
-            4249:    7(fvec4) CompositeExtract 4248 1
+            4249:  7(f16vec4) CompositeExtract 4248 1
                               Store 4202(texel) 4249
             4250:     47(int) CompositeExtract 4248 0
-            4251:    7(fvec4) Load 4202(texel)
+            4251:  7(f16vec4) Load 4202(texel)
                               ReturnValue 4251
                               FunctionEnd
-99(testSparseTextureClamp():    7(fvec4) Function None 8
+99(testSparseTextureClamp():  7(f16vec4) Function None 8
              100:             Label
      4254(texel):     64(ptr) Variable Function
                               Store 4254(texel) 121
@@ -5407,45 +5407,45 @@ spv.float16Fetch.frag
             4256:   53(fvec2) Load 148(c2)
             4258:   52(float) Load 4257(lodClamp)
             4259:3102(ResType) ImageSparseSampleImplicitLod 4255 4256 MinLod 4258
-            4260:    7(fvec4) CompositeExtract 4259 1
+            4260:  7(f16vec4) CompositeExtract 4259 1
                               Store 4254(texel) 4260
             4261:     47(int) CompositeExtract 4259 0
             4262:         143 Load 145(s2D)
-            4263:  154(fvec2) Load 156(f16c2)
-            4265:    6(float) Load 4264(f16lodClamp)
-            4266:    6(float) Load 137(f16bias)
+            4263:154(f16vec2) Load 156(f16c2)
+            4265:6(float16_t) Load 4264(f16lodClamp)
+            4266:6(float16_t) Load 137(f16bias)
             4267:3102(ResType) ImageSparseSampleImplicitLod 4262 4263 Bias MinLod 4266 4265
-            4268:    7(fvec4) CompositeExtract 4267 1
+            4268:  7(f16vec4) CompositeExtract 4267 1
                               Store 4254(texel) 4268
             4269:     47(int) CompositeExtract 4267 0
             4270:         163 Load 165(s3D)
             4271:  167(fvec3) Load 169(c3)
             4272:   52(float) Load 4257(lodClamp)
             4273:3102(ResType) ImageSparseSampleImplicitLod 4270 4271 MinLod 4272
-            4274:    7(fvec4) CompositeExtract 4273 1
+            4274:  7(f16vec4) CompositeExtract 4273 1
                               Store 4254(texel) 4274
             4275:     47(int) CompositeExtract 4273 0
             4276:         163 Load 165(s3D)
-            4277:  175(fvec3) Load 177(f16c3)
-            4278:    6(float) Load 4264(f16lodClamp)
-            4279:    6(float) Load 137(f16bias)
+            4277:175(f16vec3) Load 177(f16c3)
+            4278:6(float16_t) Load 4264(f16lodClamp)
+            4279:6(float16_t) Load 137(f16bias)
             4280:3102(ResType) ImageSparseSampleImplicitLod 4276 4277 Bias MinLod 4279 4278
-            4281:    7(fvec4) CompositeExtract 4280 1
+            4281:  7(f16vec4) CompositeExtract 4280 1
                               Store 4254(texel) 4281
             4282:     47(int) CompositeExtract 4280 0
             4283:         184 Load 186(sCube)
             4284:  167(fvec3) Load 169(c3)
             4285:   52(float) Load 4257(lodClamp)
             4286:3102(ResType) ImageSparseSampleImplicitLod 4283 4284 MinLod 4285
-            4287:    7(fvec4) CompositeExtract 4286 1
+            4287:  7(f16vec4) CompositeExtract 4286 1
                               Store 4254(texel) 4287
             4288:     47(int) CompositeExtract 4286 0
             4289:         184 Load 186(sCube)
-            4290:  175(fvec3) Load 177(f16c3)
-            4291:    6(float) Load 4264(f16lodClamp)
-            4292:    6(float) Load 137(f16bias)
+            4290:175(f16vec3) Load 177(f16c3)
+            4291:6(float16_t) Load 4264(f16lodClamp)
+            4292:6(float16_t) Load 137(f16bias)
             4293:3102(ResType) ImageSparseSampleImplicitLod 4289 4290 Bias MinLod 4292 4291
-            4294:    7(fvec4) CompositeExtract 4293 1
+            4294:  7(f16vec4) CompositeExtract 4293 1
                               Store 4254(texel) 4294
             4295:     47(int) CompositeExtract 4293 0
             4296:         224 Load 226(s2DShadow)
@@ -5454,17 +5454,17 @@ spv.float16Fetch.frag
             4299:    208(ptr) AccessChain 4254(texel) 207
             4300:   52(float) CompositeExtract 4297 2
             4301:3138(ResType) ImageSparseSampleDrefImplicitLod 4296 4297 4300 MinLod 4298
-            4302:    6(float) CompositeExtract 4301 1
+            4302:6(float16_t) CompositeExtract 4301 1
                               Store 4299 4302
             4303:     47(int) CompositeExtract 4301 0
             4304:         224 Load 226(s2DShadow)
-            4305:  154(fvec2) Load 156(f16c2)
+            4305:154(f16vec2) Load 156(f16c2)
             4306:   52(float) Load 215(compare)
-            4307:    6(float) Load 4264(f16lodClamp)
+            4307:6(float16_t) Load 4264(f16lodClamp)
             4308:    208(ptr) AccessChain 4254(texel) 207
-            4309:    6(float) Load 137(f16bias)
+            4309:6(float16_t) Load 137(f16bias)
             4310:3138(ResType) ImageSparseSampleDrefImplicitLod 4304 4305 4306 Bias MinLod 4309 4307
-            4311:    6(float) CompositeExtract 4310 1
+            4311:6(float16_t) CompositeExtract 4310 1
                               Store 4308 4311
             4312:     47(int) CompositeExtract 4310 0
             4313:         245 Load 247(sCubeShadow)
@@ -5473,47 +5473,47 @@ spv.float16Fetch.frag
             4316:    208(ptr) AccessChain 4254(texel) 207
             4317:   52(float) CompositeExtract 4314 3
             4318:3138(ResType) ImageSparseSampleDrefImplicitLod 4313 4314 4317 MinLod 4315
-            4319:    6(float) CompositeExtract 4318 1
+            4319:6(float16_t) CompositeExtract 4318 1
                               Store 4316 4319
             4320:     47(int) CompositeExtract 4318 0
             4321:         245 Load 247(sCubeShadow)
-            4322:  175(fvec3) Load 177(f16c3)
+            4322:175(f16vec3) Load 177(f16c3)
             4323:   52(float) Load 215(compare)
-            4324:    6(float) Load 4264(f16lodClamp)
+            4324:6(float16_t) Load 4264(f16lodClamp)
             4325:    208(ptr) AccessChain 4254(texel) 207
-            4326:    6(float) Load 137(f16bias)
+            4326:6(float16_t) Load 137(f16bias)
             4327:3138(ResType) ImageSparseSampleDrefImplicitLod 4321 4322 4323 Bias MinLod 4326 4324
-            4328:    6(float) CompositeExtract 4327 1
+            4328:6(float16_t) CompositeExtract 4327 1
                               Store 4325 4328
             4329:     47(int) CompositeExtract 4327 0
             4330:         284 Load 286(s2DArray)
             4331:  167(fvec3) Load 169(c3)
             4332:   52(float) Load 4257(lodClamp)
             4333:3102(ResType) ImageSparseSampleImplicitLod 4330 4331 MinLod 4332
-            4334:    7(fvec4) CompositeExtract 4333 1
+            4334:  7(f16vec4) CompositeExtract 4333 1
                               Store 4254(texel) 4334
             4335:     47(int) CompositeExtract 4333 0
             4336:         284 Load 286(s2DArray)
-            4337:  175(fvec3) Load 177(f16c3)
-            4338:    6(float) Load 4264(f16lodClamp)
-            4339:    6(float) Load 137(f16bias)
+            4337:175(f16vec3) Load 177(f16c3)
+            4338:6(float16_t) Load 4264(f16lodClamp)
+            4339:6(float16_t) Load 137(f16bias)
             4340:3102(ResType) ImageSparseSampleImplicitLod 4336 4337 Bias MinLod 4339 4338
-            4341:    7(fvec4) CompositeExtract 4340 1
+            4341:  7(f16vec4) CompositeExtract 4340 1
                               Store 4254(texel) 4341
             4342:     47(int) CompositeExtract 4340 0
             4343:         299 Load 301(sCubeArray)
             4344:  249(fvec4) Load 251(c4)
             4345:   52(float) Load 4257(lodClamp)
             4346:3102(ResType) ImageSparseSampleImplicitLod 4343 4344 MinLod 4345
-            4347:    7(fvec4) CompositeExtract 4346 1
+            4347:  7(f16vec4) CompositeExtract 4346 1
                               Store 4254(texel) 4347
             4348:     47(int) CompositeExtract 4346 0
             4349:         299 Load 301(sCubeArray)
-            4350:    7(fvec4) Load 309(f16c4)
-            4351:    6(float) Load 4264(f16lodClamp)
-            4352:    6(float) Load 137(f16bias)
+            4350:  7(f16vec4) Load 309(f16c4)
+            4351:6(float16_t) Load 4264(f16lodClamp)
+            4352:6(float16_t) Load 137(f16bias)
             4353:3102(ResType) ImageSparseSampleImplicitLod 4349 4350 Bias MinLod 4352 4351
-            4354:    7(fvec4) CompositeExtract 4353 1
+            4354:  7(f16vec4) CompositeExtract 4353 1
                               Store 4254(texel) 4354
             4355:     47(int) CompositeExtract 4353 0
             4356:         337 Load 339(s2DArrayShadow)
@@ -5522,16 +5522,16 @@ spv.float16Fetch.frag
             4359:    208(ptr) AccessChain 4254(texel) 207
             4360:   52(float) CompositeExtract 4357 3
             4361:3138(ResType) ImageSparseSampleDrefImplicitLod 4356 4357 4360 MinLod 4358
-            4362:    6(float) CompositeExtract 4361 1
+            4362:6(float16_t) CompositeExtract 4361 1
                               Store 4359 4362
             4363:     47(int) CompositeExtract 4361 0
             4364:         337 Load 339(s2DArrayShadow)
-            4365:  175(fvec3) Load 177(f16c3)
+            4365:175(f16vec3) Load 177(f16c3)
             4366:   52(float) Load 215(compare)
-            4367:    6(float) Load 4264(f16lodClamp)
+            4367:6(float16_t) Load 4264(f16lodClamp)
             4368:    208(ptr) AccessChain 4254(texel) 207
             4369:3138(ResType) ImageSparseSampleDrefImplicitLod 4364 4365 4366 MinLod 4367
-            4370:    6(float) CompositeExtract 4369 1
+            4370:6(float16_t) CompositeExtract 4369 1
                               Store 4368 4370
             4371:     47(int) CompositeExtract 4369 0
             4372:         391 Load 393(sCubeArrayShadow)
@@ -5540,258 +5540,258 @@ spv.float16Fetch.frag
             4375:   52(float) Load 4257(lodClamp)
             4376:    208(ptr) AccessChain 4254(texel) 207
             4377:3138(ResType) ImageSparseSampleDrefImplicitLod 4372 4373 4374 MinLod 4375
-            4378:    6(float) CompositeExtract 4377 1
+            4378:6(float16_t) CompositeExtract 4377 1
                               Store 4376 4378
             4379:     47(int) CompositeExtract 4377 0
             4380:         391 Load 393(sCubeArrayShadow)
-            4381:    7(fvec4) Load 309(f16c4)
+            4381:  7(f16vec4) Load 309(f16c4)
             4382:   52(float) Load 215(compare)
-            4383:    6(float) Load 4264(f16lodClamp)
+            4383:6(float16_t) Load 4264(f16lodClamp)
             4384:    208(ptr) AccessChain 4254(texel) 207
             4385:3138(ResType) ImageSparseSampleDrefImplicitLod 4380 4381 4382 MinLod 4383
-            4386:    6(float) CompositeExtract 4385 1
+            4386:6(float16_t) CompositeExtract 4385 1
                               Store 4384 4386
             4387:     47(int) CompositeExtract 4385 0
-            4388:    7(fvec4) Load 4254(texel)
+            4388:  7(f16vec4) Load 4254(texel)
                               ReturnValue 4388
                               FunctionEnd
-101(testTextureClamp():    7(fvec4) Function None 8
+101(testTextureClamp():  7(f16vec4) Function None 8
              102:             Label
      4391(texel):     64(ptr) Variable Function
                               Store 4391(texel) 121
             4392:         123 Load 125(s1D)
             4393:   52(float) Load 128(c1)
             4394:   52(float) Load 4257(lodClamp)
-            4395:    7(fvec4) ImageSampleImplicitLod 4392 4393 MinLod 4394
-            4396:    7(fvec4) Load 4391(texel)
-            4397:    7(fvec4) FAdd 4396 4395
+            4395:  7(f16vec4) ImageSampleImplicitLod 4392 4393 MinLod 4394
+            4396:  7(f16vec4) Load 4391(texel)
+            4397:  7(f16vec4) FAdd 4396 4395
                               Store 4391(texel) 4397
             4398:         123 Load 125(s1D)
-            4399:    6(float) Load 135(f16c1)
-            4400:    6(float) Load 4264(f16lodClamp)
-            4401:    6(float) Load 137(f16bias)
-            4402:    7(fvec4) ImageSampleImplicitLod 4398 4399 Bias MinLod 4401 4400
-            4403:    7(fvec4) Load 4391(texel)
-            4404:    7(fvec4) FAdd 4403 4402
+            4399:6(float16_t) Load 135(f16c1)
+            4400:6(float16_t) Load 4264(f16lodClamp)
+            4401:6(float16_t) Load 137(f16bias)
+            4402:  7(f16vec4) ImageSampleImplicitLod 4398 4399 Bias MinLod 4401 4400
+            4403:  7(f16vec4) Load 4391(texel)
+            4404:  7(f16vec4) FAdd 4403 4402
                               Store 4391(texel) 4404
             4405:         143 Load 145(s2D)
             4406:   53(fvec2) Load 148(c2)
             4407:   52(float) Load 4257(lodClamp)
-            4408:    7(fvec4) ImageSampleImplicitLod 4405 4406 MinLod 4407
-            4409:    7(fvec4) Load 4391(texel)
-            4410:    7(fvec4) FAdd 4409 4408
+            4408:  7(f16vec4) ImageSampleImplicitLod 4405 4406 MinLod 4407
+            4409:  7(f16vec4) Load 4391(texel)
+            4410:  7(f16vec4) FAdd 4409 4408
                               Store 4391(texel) 4410
             4411:         143 Load 145(s2D)
-            4412:  154(fvec2) Load 156(f16c2)
-            4413:    6(float) Load 4264(f16lodClamp)
-            4414:    6(float) Load 137(f16bias)
-            4415:    7(fvec4) ImageSampleImplicitLod 4411 4412 Bias MinLod 4414 4413
-            4416:    7(fvec4) Load 4391(texel)
-            4417:    7(fvec4) FAdd 4416 4415
+            4412:154(f16vec2) Load 156(f16c2)
+            4413:6(float16_t) Load 4264(f16lodClamp)
+            4414:6(float16_t) Load 137(f16bias)
+            4415:  7(f16vec4) ImageSampleImplicitLod 4411 4412 Bias MinLod 4414 4413
+            4416:  7(f16vec4) Load 4391(texel)
+            4417:  7(f16vec4) FAdd 4416 4415
                               Store 4391(texel) 4417
             4418:         163 Load 165(s3D)
             4419:  167(fvec3) Load 169(c3)
             4420:   52(float) Load 4257(lodClamp)
-            4421:    7(fvec4) ImageSampleImplicitLod 4418 4419 MinLod 4420
-            4422:    7(fvec4) Load 4391(texel)
-            4423:    7(fvec4) FAdd 4422 4421
+            4421:  7(f16vec4) ImageSampleImplicitLod 4418 4419 MinLod 4420
+            4422:  7(f16vec4) Load 4391(texel)
+            4423:  7(f16vec4) FAdd 4422 4421
                               Store 4391(texel) 4423
             4424:         163 Load 165(s3D)
-            4425:  175(fvec3) Load 177(f16c3)
-            4426:    6(float) Load 4264(f16lodClamp)
-            4427:    6(float) Load 137(f16bias)
-            4428:    7(fvec4) ImageSampleImplicitLod 4424 4425 Bias MinLod 4427 4426
-            4429:    7(fvec4) Load 4391(texel)
-            4430:    7(fvec4) FAdd 4429 4428
+            4425:175(f16vec3) Load 177(f16c3)
+            4426:6(float16_t) Load 4264(f16lodClamp)
+            4427:6(float16_t) Load 137(f16bias)
+            4428:  7(f16vec4) ImageSampleImplicitLod 4424 4425 Bias MinLod 4427 4426
+            4429:  7(f16vec4) Load 4391(texel)
+            4430:  7(f16vec4) FAdd 4429 4428
                               Store 4391(texel) 4430
             4431:         184 Load 186(sCube)
             4432:  167(fvec3) Load 169(c3)
             4433:   52(float) Load 4257(lodClamp)
-            4434:    7(fvec4) ImageSampleImplicitLod 4431 4432 MinLod 4433
-            4435:    7(fvec4) Load 4391(texel)
-            4436:    7(fvec4) FAdd 4435 4434
+            4434:  7(f16vec4) ImageSampleImplicitLod 4431 4432 MinLod 4433
+            4435:  7(f16vec4) Load 4391(texel)
+            4436:  7(f16vec4) FAdd 4435 4434
                               Store 4391(texel) 4436
             4437:         184 Load 186(sCube)
-            4438:  175(fvec3) Load 177(f16c3)
-            4439:    6(float) Load 4264(f16lodClamp)
-            4440:    6(float) Load 137(f16bias)
-            4441:    7(fvec4) ImageSampleImplicitLod 4437 4438 Bias MinLod 4440 4439
-            4442:    7(fvec4) Load 4391(texel)
-            4443:    7(fvec4) FAdd 4442 4441
+            4438:175(f16vec3) Load 177(f16c3)
+            4439:6(float16_t) Load 4264(f16lodClamp)
+            4440:6(float16_t) Load 137(f16bias)
+            4441:  7(f16vec4) ImageSampleImplicitLod 4437 4438 Bias MinLod 4440 4439
+            4442:  7(f16vec4) Load 4391(texel)
+            4443:  7(f16vec4) FAdd 4442 4441
                               Store 4391(texel) 4443
             4444:         199 Load 201(s1DShadow)
             4445:  167(fvec3) Load 169(c3)
             4446:   52(float) Load 4257(lodClamp)
             4447:   52(float) CompositeExtract 4445 2
-            4448:    6(float) ImageSampleDrefImplicitLod 4444 4445 4447 MinLod 4446
+            4448:6(float16_t) ImageSampleDrefImplicitLod 4444 4445 4447 MinLod 4446
             4449:    208(ptr) AccessChain 4391(texel) 207
-            4450:    6(float) Load 4449
-            4451:    6(float) FAdd 4450 4448
+            4450:6(float16_t) Load 4449
+            4451:6(float16_t) FAdd 4450 4448
             4452:    208(ptr) AccessChain 4391(texel) 207
                               Store 4452 4451
             4453:         199 Load 201(s1DShadow)
-            4454:  154(fvec2) Load 156(f16c2)
+            4454:154(f16vec2) Load 156(f16c2)
             4455:   52(float) Load 215(compare)
-            4456:    6(float) Load 4264(f16lodClamp)
-            4457:    6(float) Load 137(f16bias)
-            4458:    6(float) ImageSampleDrefImplicitLod 4453 4454 4455 Bias MinLod 4457 4456
+            4456:6(float16_t) Load 4264(f16lodClamp)
+            4457:6(float16_t) Load 137(f16bias)
+            4458:6(float16_t) ImageSampleDrefImplicitLod 4453 4454 4455 Bias MinLod 4457 4456
             4459:    208(ptr) AccessChain 4391(texel) 207
-            4460:    6(float) Load 4459
-            4461:    6(float) FAdd 4460 4458
+            4460:6(float16_t) Load 4459
+            4461:6(float16_t) FAdd 4460 4458
             4462:    208(ptr) AccessChain 4391(texel) 207
                               Store 4462 4461
             4463:         224 Load 226(s2DShadow)
             4464:  167(fvec3) Load 169(c3)
             4465:   52(float) Load 4257(lodClamp)
             4466:   52(float) CompositeExtract 4464 2
-            4467:    6(float) ImageSampleDrefImplicitLod 4463 4464 4466 MinLod 4465
+            4467:6(float16_t) ImageSampleDrefImplicitLod 4463 4464 4466 MinLod 4465
             4468:    208(ptr) AccessChain 4391(texel) 207
-            4469:    6(float) Load 4468
-            4470:    6(float) FAdd 4469 4467
+            4469:6(float16_t) Load 4468
+            4470:6(float16_t) FAdd 4469 4467
             4471:    208(ptr) AccessChain 4391(texel) 207
                               Store 4471 4470
             4472:         224 Load 226(s2DShadow)
-            4473:  154(fvec2) Load 156(f16c2)
+            4473:154(f16vec2) Load 156(f16c2)
             4474:   52(float) Load 215(compare)
-            4475:    6(float) Load 4264(f16lodClamp)
-            4476:    6(float) Load 137(f16bias)
-            4477:    6(float) ImageSampleDrefImplicitLod 4472 4473 4474 Bias MinLod 4476 4475
+            4475:6(float16_t) Load 4264(f16lodClamp)
+            4476:6(float16_t) Load 137(f16bias)
+            4477:6(float16_t) ImageSampleDrefImplicitLod 4472 4473 4474 Bias MinLod 4476 4475
             4478:    208(ptr) AccessChain 4391(texel) 207
-            4479:    6(float) Load 4478
-            4480:    6(float) FAdd 4479 4477
+            4479:6(float16_t) Load 4478
+            4480:6(float16_t) FAdd 4479 4477
             4481:    208(ptr) AccessChain 4391(texel) 207
                               Store 4481 4480
             4482:         245 Load 247(sCubeShadow)
             4483:  249(fvec4) Load 251(c4)
             4484:   52(float) Load 4257(lodClamp)
             4485:   52(float) CompositeExtract 4483 3
-            4486:    6(float) ImageSampleDrefImplicitLod 4482 4483 4485 MinLod 4484
+            4486:6(float16_t) ImageSampleDrefImplicitLod 4482 4483 4485 MinLod 4484
             4487:    208(ptr) AccessChain 4391(texel) 207
-            4488:    6(float) Load 4487
-            4489:    6(float) FAdd 4488 4486
+            4488:6(float16_t) Load 4487
+            4489:6(float16_t) FAdd 4488 4486
             4490:    208(ptr) AccessChain 4391(texel) 207
                               Store 4490 4489
             4491:         245 Load 247(sCubeShadow)
-            4492:  175(fvec3) Load 177(f16c3)
+            4492:175(f16vec3) Load 177(f16c3)
             4493:   52(float) Load 215(compare)
-            4494:    6(float) Load 4264(f16lodClamp)
-            4495:    6(float) Load 137(f16bias)
-            4496:    6(float) ImageSampleDrefImplicitLod 4491 4492 4493 Bias MinLod 4495 4494
+            4494:6(float16_t) Load 4264(f16lodClamp)
+            4495:6(float16_t) Load 137(f16bias)
+            4496:6(float16_t) ImageSampleDrefImplicitLod 4491 4492 4493 Bias MinLod 4495 4494
             4497:    208(ptr) AccessChain 4391(texel) 207
-            4498:    6(float) Load 4497
-            4499:    6(float) FAdd 4498 4496
+            4498:6(float16_t) Load 4497
+            4499:6(float16_t) FAdd 4498 4496
             4500:    208(ptr) AccessChain 4391(texel) 207
                               Store 4500 4499
             4501:         269 Load 271(s1DArray)
             4502:   53(fvec2) Load 148(c2)
             4503:   52(float) Load 4257(lodClamp)
-            4504:    7(fvec4) ImageSampleImplicitLod 4501 4502 MinLod 4503
-            4505:    7(fvec4) Load 4391(texel)
-            4506:    7(fvec4) FAdd 4505 4504
+            4504:  7(f16vec4) ImageSampleImplicitLod 4501 4502 MinLod 4503
+            4505:  7(f16vec4) Load 4391(texel)
+            4506:  7(f16vec4) FAdd 4505 4504
                               Store 4391(texel) 4506
             4507:         269 Load 271(s1DArray)
-            4508:  154(fvec2) Load 156(f16c2)
-            4509:    6(float) Load 4264(f16lodClamp)
-            4510:    6(float) Load 137(f16bias)
-            4511:    7(fvec4) ImageSampleImplicitLod 4507 4508 Bias MinLod 4510 4509
-            4512:    7(fvec4) Load 4391(texel)
-            4513:    7(fvec4) FAdd 4512 4511
+            4508:154(f16vec2) Load 156(f16c2)
+            4509:6(float16_t) Load 4264(f16lodClamp)
+            4510:6(float16_t) Load 137(f16bias)
+            4511:  7(f16vec4) ImageSampleImplicitLod 4507 4508 Bias MinLod 4510 4509
+            4512:  7(f16vec4) Load 4391(texel)
+            4513:  7(f16vec4) FAdd 4512 4511
                               Store 4391(texel) 4513
             4514:         284 Load 286(s2DArray)
             4515:  167(fvec3) Load 169(c3)
             4516:   52(float) Load 4257(lodClamp)
-            4517:    7(fvec4) ImageSampleImplicitLod 4514 4515 MinLod 4516
-            4518:    7(fvec4) Load 4391(texel)
-            4519:    7(fvec4) FAdd 4518 4517
+            4517:  7(f16vec4) ImageSampleImplicitLod 4514 4515 MinLod 4516
+            4518:  7(f16vec4) Load 4391(texel)
+            4519:  7(f16vec4) FAdd 4518 4517
                               Store 4391(texel) 4519
             4520:         284 Load 286(s2DArray)
-            4521:  175(fvec3) Load 177(f16c3)
-            4522:    6(float) Load 4264(f16lodClamp)
-            4523:    6(float) Load 137(f16bias)
-            4524:    7(fvec4) ImageSampleImplicitLod 4520 4521 Bias MinLod 4523 4522
-            4525:    7(fvec4) Load 4391(texel)
-            4526:    7(fvec4) FAdd 4525 4524
+            4521:175(f16vec3) Load 177(f16c3)
+            4522:6(float16_t) Load 4264(f16lodClamp)
+            4523:6(float16_t) Load 137(f16bias)
+            4524:  7(f16vec4) ImageSampleImplicitLod 4520 4521 Bias MinLod 4523 4522
+            4525:  7(f16vec4) Load 4391(texel)
+            4526:  7(f16vec4) FAdd 4525 4524
                               Store 4391(texel) 4526
             4527:         299 Load 301(sCubeArray)
             4528:  249(fvec4) Load 251(c4)
             4529:   52(float) Load 4257(lodClamp)
-            4530:    7(fvec4) ImageSampleImplicitLod 4527 4528 MinLod 4529
-            4531:    7(fvec4) Load 4391(texel)
-            4532:    7(fvec4) FAdd 4531 4530
+            4530:  7(f16vec4) ImageSampleImplicitLod 4527 4528 MinLod 4529
+            4531:  7(f16vec4) Load 4391(texel)
+            4532:  7(f16vec4) FAdd 4531 4530
                               Store 4391(texel) 4532
             4533:         299 Load 301(sCubeArray)
-            4534:    7(fvec4) Load 309(f16c4)
-            4535:    6(float) Load 4264(f16lodClamp)
-            4536:    6(float) Load 137(f16bias)
-            4537:    7(fvec4) ImageSampleImplicitLod 4533 4534 Bias MinLod 4536 4535
-            4538:    7(fvec4) Load 4391(texel)
-            4539:    7(fvec4) FAdd 4538 4537
+            4534:  7(f16vec4) Load 309(f16c4)
+            4535:6(float16_t) Load 4264(f16lodClamp)
+            4536:6(float16_t) Load 137(f16bias)
+            4537:  7(f16vec4) ImageSampleImplicitLod 4533 4534 Bias MinLod 4536 4535
+            4538:  7(f16vec4) Load 4391(texel)
+            4539:  7(f16vec4) FAdd 4538 4537
                               Store 4391(texel) 4539
             4540:         316 Load 318(s1DArrayShadow)
             4541:  167(fvec3) Load 169(c3)
             4542:   52(float) Load 4257(lodClamp)
             4543:   52(float) CompositeExtract 4541 2
-            4544:    6(float) ImageSampleDrefImplicitLod 4540 4541 4543 MinLod 4542
+            4544:6(float16_t) ImageSampleDrefImplicitLod 4540 4541 4543 MinLod 4542
             4545:    208(ptr) AccessChain 4391(texel) 207
-            4546:    6(float) Load 4545
-            4547:    6(float) FAdd 4546 4544
+            4546:6(float16_t) Load 4545
+            4547:6(float16_t) FAdd 4546 4544
             4548:    208(ptr) AccessChain 4391(texel) 207
                               Store 4548 4547
             4549:         316 Load 318(s1DArrayShadow)
-            4550:  154(fvec2) Load 156(f16c2)
+            4550:154(f16vec2) Load 156(f16c2)
             4551:   52(float) Load 215(compare)
-            4552:    6(float) Load 4264(f16lodClamp)
-            4553:    6(float) Load 137(f16bias)
-            4554:    6(float) ImageSampleDrefImplicitLod 4549 4550 4551 Bias MinLod 4553 4552
+            4552:6(float16_t) Load 4264(f16lodClamp)
+            4553:6(float16_t) Load 137(f16bias)
+            4554:6(float16_t) ImageSampleDrefImplicitLod 4549 4550 4551 Bias MinLod 4553 4552
             4555:    208(ptr) AccessChain 4391(texel) 207
-            4556:    6(float) Load 4555
-            4557:    6(float) FAdd 4556 4554
+            4556:6(float16_t) Load 4555
+            4557:6(float16_t) FAdd 4556 4554
             4558:    208(ptr) AccessChain 4391(texel) 207
                               Store 4558 4557
             4559:         337 Load 339(s2DArrayShadow)
             4560:  249(fvec4) Load 251(c4)
             4561:   52(float) Load 4257(lodClamp)
             4562:   52(float) CompositeExtract 4560 3
-            4563:    6(float) ImageSampleDrefImplicitLod 4559 4560 4562 MinLod 4561
+            4563:6(float16_t) ImageSampleDrefImplicitLod 4559 4560 4562 MinLod 4561
             4564:    208(ptr) AccessChain 4391(texel) 207
-            4565:    6(float) Load 4564
-            4566:    6(float) FAdd 4565 4563
+            4565:6(float16_t) Load 4564
+            4566:6(float16_t) FAdd 4565 4563
             4567:    208(ptr) AccessChain 4391(texel) 207
                               Store 4567 4566
             4568:         337 Load 339(s2DArrayShadow)
-            4569:  175(fvec3) Load 177(f16c3)
+            4569:175(f16vec3) Load 177(f16c3)
             4570:   52(float) Load 215(compare)
-            4571:    6(float) Load 4264(f16lodClamp)
-            4572:    6(float) ImageSampleDrefImplicitLod 4568 4569 4570 MinLod 4571
+            4571:6(float16_t) Load 4264(f16lodClamp)
+            4572:6(float16_t) ImageSampleDrefImplicitLod 4568 4569 4570 MinLod 4571
             4573:    208(ptr) AccessChain 4391(texel) 207
-            4574:    6(float) Load 4573
-            4575:    6(float) FAdd 4574 4572
+            4574:6(float16_t) Load 4573
+            4575:6(float16_t) FAdd 4574 4572
             4576:    208(ptr) AccessChain 4391(texel) 207
                               Store 4576 4575
             4577:         391 Load 393(sCubeArrayShadow)
             4578:  249(fvec4) Load 251(c4)
             4579:   52(float) Load 215(compare)
             4580:   52(float) Load 4257(lodClamp)
-            4581:    6(float) ImageSampleDrefImplicitLod 4577 4578 4579 MinLod 4580
+            4581:6(float16_t) ImageSampleDrefImplicitLod 4577 4578 4579 MinLod 4580
             4582:    208(ptr) AccessChain 4391(texel) 207
-            4583:    6(float) Load 4582
-            4584:    6(float) FAdd 4583 4581
+            4583:6(float16_t) Load 4582
+            4584:6(float16_t) FAdd 4583 4581
             4585:    208(ptr) AccessChain 4391(texel) 207
                               Store 4585 4584
             4586:         391 Load 393(sCubeArrayShadow)
-            4587:    7(fvec4) Load 309(f16c4)
+            4587:  7(f16vec4) Load 309(f16c4)
             4588:   52(float) Load 215(compare)
-            4589:    6(float) Load 4264(f16lodClamp)
-            4590:    6(float) ImageSampleDrefImplicitLod 4586 4587 4588 MinLod 4589
+            4589:6(float16_t) Load 4264(f16lodClamp)
+            4590:6(float16_t) ImageSampleDrefImplicitLod 4586 4587 4588 MinLod 4589
             4591:    208(ptr) AccessChain 4391(texel) 207
-            4592:    6(float) Load 4591
-            4593:    6(float) FAdd 4592 4590
+            4592:6(float16_t) Load 4591
+            4593:6(float16_t) FAdd 4592 4590
             4594:    208(ptr) AccessChain 4391(texel) 207
                               Store 4594 4593
-            4595:    7(fvec4) Load 4391(texel)
+            4595:  7(f16vec4) Load 4391(texel)
                               ReturnValue 4595
                               FunctionEnd
-103(testSparseTextureOffsetClamp():    7(fvec4) Function None 8
+103(testSparseTextureOffsetClamp():  7(f16vec4) Function None 8
              104:             Label
      4598(texel):     64(ptr) Variable Function
                               Store 4598(texel) 121
@@ -5799,30 +5799,30 @@ spv.float16Fetch.frag
             4600:   53(fvec2) Load 148(c2)
             4601:   52(float) Load 4257(lodClamp)
             4602:3102(ResType) ImageSparseSampleImplicitLod 4599 4600 ConstOffset MinLod 722 4601
-            4603:    7(fvec4) CompositeExtract 4602 1
+            4603:  7(f16vec4) CompositeExtract 4602 1
                               Store 4598(texel) 4603
             4604:     47(int) CompositeExtract 4602 0
             4605:         143 Load 145(s2D)
-            4606:  154(fvec2) Load 156(f16c2)
-            4607:    6(float) Load 4264(f16lodClamp)
-            4608:    6(float) Load 137(f16bias)
+            4606:154(f16vec2) Load 156(f16c2)
+            4607:6(float16_t) Load 4264(f16lodClamp)
+            4608:6(float16_t) Load 137(f16bias)
             4609:3102(ResType) ImageSparseSampleImplicitLod 4605 4606 Bias ConstOffset MinLod 4608 722 4607
-            4610:    7(fvec4) CompositeExtract 4609 1
+            4610:  7(f16vec4) CompositeExtract 4609 1
                               Store 4598(texel) 4610
             4611:     47(int) CompositeExtract 4609 0
             4612:         163 Load 165(s3D)
             4613:  167(fvec3) Load 169(c3)
             4614:   52(float) Load 4257(lodClamp)
             4615:3102(ResType) ImageSparseSampleImplicitLod 4612 4613 ConstOffset MinLod 735 4614
-            4616:    7(fvec4) CompositeExtract 4615 1
+            4616:  7(f16vec4) CompositeExtract 4615 1
                               Store 4598(texel) 4616
             4617:     47(int) CompositeExtract 4615 0
             4618:         163 Load 165(s3D)
-            4619:  175(fvec3) Load 177(f16c3)
-            4620:    6(float) Load 4264(f16lodClamp)
-            4621:    6(float) Load 137(f16bias)
+            4619:175(f16vec3) Load 177(f16c3)
+            4620:6(float16_t) Load 4264(f16lodClamp)
+            4621:6(float16_t) Load 137(f16bias)
             4622:3102(ResType) ImageSparseSampleImplicitLod 4618 4619 Bias ConstOffset MinLod 4621 735 4620
-            4623:    7(fvec4) CompositeExtract 4622 1
+            4623:  7(f16vec4) CompositeExtract 4622 1
                               Store 4598(texel) 4623
             4624:     47(int) CompositeExtract 4622 0
             4625:         224 Load 226(s2DShadow)
@@ -5831,32 +5831,32 @@ spv.float16Fetch.frag
             4628:    208(ptr) AccessChain 4598(texel) 207
             4629:   52(float) CompositeExtract 4626 2
             4630:3138(ResType) ImageSparseSampleDrefImplicitLod 4625 4626 4629 ConstOffset MinLod 722 4627
-            4631:    6(float) CompositeExtract 4630 1
+            4631:6(float16_t) CompositeExtract 4630 1
                               Store 4628 4631
             4632:     47(int) CompositeExtract 4630 0
             4633:         224 Load 226(s2DShadow)
-            4634:  154(fvec2) Load 156(f16c2)
+            4634:154(f16vec2) Load 156(f16c2)
             4635:   52(float) Load 215(compare)
-            4636:    6(float) Load 4264(f16lodClamp)
+            4636:6(float16_t) Load 4264(f16lodClamp)
             4637:    208(ptr) AccessChain 4598(texel) 207
-            4638:    6(float) Load 137(f16bias)
+            4638:6(float16_t) Load 137(f16bias)
             4639:3138(ResType) ImageSparseSampleDrefImplicitLod 4633 4634 4635 Bias ConstOffset MinLod 4638 722 4636
-            4640:    6(float) CompositeExtract 4639 1
+            4640:6(float16_t) CompositeExtract 4639 1
                               Store 4637 4640
             4641:     47(int) CompositeExtract 4639 0
             4642:         284 Load 286(s2DArray)
             4643:  167(fvec3) Load 169(c3)
             4644:   52(float) Load 4257(lodClamp)
             4645:3102(ResType) ImageSparseSampleImplicitLod 4642 4643 ConstOffset MinLod 722 4644
-            4646:    7(fvec4) CompositeExtract 4645 1
+            4646:  7(f16vec4) CompositeExtract 4645 1
                               Store 4598(texel) 4646
             4647:     47(int) CompositeExtract 4645 0
             4648:         284 Load 286(s2DArray)
-            4649:  175(fvec3) Load 177(f16c3)
-            4650:    6(float) Load 4264(f16lodClamp)
-            4651:    6(float) Load 137(f16bias)
+            4649:175(f16vec3) Load 177(f16c3)
+            4650:6(float16_t) Load 4264(f16lodClamp)
+            4651:6(float16_t) Load 137(f16bias)
             4652:3102(ResType) ImageSparseSampleImplicitLod 4648 4649 Bias ConstOffset MinLod 4651 722 4650
-            4653:    7(fvec4) CompositeExtract 4652 1
+            4653:  7(f16vec4) CompositeExtract 4652 1
                               Store 4598(texel) 4653
             4654:     47(int) CompositeExtract 4652 0
             4655:         337 Load 339(s2DArrayShadow)
@@ -5865,187 +5865,187 @@ spv.float16Fetch.frag
             4658:    208(ptr) AccessChain 4598(texel) 207
             4659:   52(float) CompositeExtract 4656 3
             4660:3138(ResType) ImageSparseSampleDrefImplicitLod 4655 4656 4659 ConstOffset MinLod 722 4657
-            4661:    6(float) CompositeExtract 4660 1
+            4661:6(float16_t) CompositeExtract 4660 1
                               Store 4658 4661
             4662:     47(int) CompositeExtract 4660 0
             4663:         337 Load 339(s2DArrayShadow)
-            4664:  175(fvec3) Load 177(f16c3)
+            4664:175(f16vec3) Load 177(f16c3)
             4665:   52(float) Load 215(compare)
-            4666:    6(float) Load 4264(f16lodClamp)
+            4666:6(float16_t) Load 4264(f16lodClamp)
             4667:    208(ptr) AccessChain 4598(texel) 207
             4668:3138(ResType) ImageSparseSampleDrefImplicitLod 4663 4664 4665 ConstOffset MinLod 722 4666
-            4669:    6(float) CompositeExtract 4668 1
+            4669:6(float16_t) CompositeExtract 4668 1
                               Store 4667 4669
             4670:     47(int) CompositeExtract 4668 0
-            4671:    7(fvec4) Load 4598(texel)
+            4671:  7(f16vec4) Load 4598(texel)
                               ReturnValue 4671
                               FunctionEnd
-105(testTextureOffsetClamp():    7(fvec4) Function None 8
+105(testTextureOffsetClamp():  7(f16vec4) Function None 8
              106:             Label
      4674(texel):     64(ptr) Variable Function
                               Store 4674(texel) 121
             4675:         123 Load 125(s1D)
             4676:   52(float) Load 128(c1)
             4677:   52(float) Load 4257(lodClamp)
-            4678:    7(fvec4) ImageSampleImplicitLod 4675 4676 ConstOffset MinLod 709 4677
-            4679:    7(fvec4) Load 4674(texel)
-            4680:    7(fvec4) FAdd 4679 4678
+            4678:  7(f16vec4) ImageSampleImplicitLod 4675 4676 ConstOffset MinLod 709 4677
+            4679:  7(f16vec4) Load 4674(texel)
+            4680:  7(f16vec4) FAdd 4679 4678
                               Store 4674(texel) 4680
             4681:         123 Load 125(s1D)
-            4682:    6(float) Load 135(f16c1)
-            4683:    6(float) Load 4264(f16lodClamp)
-            4684:    6(float) Load 137(f16bias)
-            4685:    7(fvec4) ImageSampleImplicitLod 4681 4682 Bias ConstOffset MinLod 4684 709 4683
-            4686:    7(fvec4) Load 4674(texel)
-            4687:    7(fvec4) FAdd 4686 4685
+            4682:6(float16_t) Load 135(f16c1)
+            4683:6(float16_t) Load 4264(f16lodClamp)
+            4684:6(float16_t) Load 137(f16bias)
+            4685:  7(f16vec4) ImageSampleImplicitLod 4681 4682 Bias ConstOffset MinLod 4684 709 4683
+            4686:  7(f16vec4) Load 4674(texel)
+            4687:  7(f16vec4) FAdd 4686 4685
                               Store 4674(texel) 4687
             4688:         143 Load 145(s2D)
             4689:   53(fvec2) Load 148(c2)
             4690:   52(float) Load 4257(lodClamp)
-            4691:    7(fvec4) ImageSampleImplicitLod 4688 4689 ConstOffset MinLod 722 4690
-            4692:    7(fvec4) Load 4674(texel)
-            4693:    7(fvec4) FAdd 4692 4691
+            4691:  7(f16vec4) ImageSampleImplicitLod 4688 4689 ConstOffset MinLod 722 4690
+            4692:  7(f16vec4) Load 4674(texel)
+            4693:  7(f16vec4) FAdd 4692 4691
                               Store 4674(texel) 4693
             4694:         143 Load 145(s2D)
-            4695:  154(fvec2) Load 156(f16c2)
-            4696:    6(float) Load 4264(f16lodClamp)
-            4697:    6(float) Load 137(f16bias)
-            4698:    7(fvec4) ImageSampleImplicitLod 4694 4695 Bias ConstOffset MinLod 4697 722 4696
-            4699:    7(fvec4) Load 4674(texel)
-            4700:    7(fvec4) FAdd 4699 4698
+            4695:154(f16vec2) Load 156(f16c2)
+            4696:6(float16_t) Load 4264(f16lodClamp)
+            4697:6(float16_t) Load 137(f16bias)
+            4698:  7(f16vec4) ImageSampleImplicitLod 4694 4695 Bias ConstOffset MinLod 4697 722 4696
+            4699:  7(f16vec4) Load 4674(texel)
+            4700:  7(f16vec4) FAdd 4699 4698
                               Store 4674(texel) 4700
             4701:         163 Load 165(s3D)
             4702:  167(fvec3) Load 169(c3)
             4703:   52(float) Load 4257(lodClamp)
-            4704:    7(fvec4) ImageSampleImplicitLod 4701 4702 ConstOffset MinLod 735 4703
-            4705:    7(fvec4) Load 4674(texel)
-            4706:    7(fvec4) FAdd 4705 4704
+            4704:  7(f16vec4) ImageSampleImplicitLod 4701 4702 ConstOffset MinLod 735 4703
+            4705:  7(f16vec4) Load 4674(texel)
+            4706:  7(f16vec4) FAdd 4705 4704
                               Store 4674(texel) 4706
             4707:         163 Load 165(s3D)
-            4708:  175(fvec3) Load 177(f16c3)
-            4709:    6(float) Load 4264(f16lodClamp)
-            4710:    6(float) Load 137(f16bias)
-            4711:    7(fvec4) ImageSampleImplicitLod 4707 4708 Bias ConstOffset MinLod 4710 735 4709
-            4712:    7(fvec4) Load 4674(texel)
-            4713:    7(fvec4) FAdd 4712 4711
+            4708:175(f16vec3) Load 177(f16c3)
+            4709:6(float16_t) Load 4264(f16lodClamp)
+            4710:6(float16_t) Load 137(f16bias)
+            4711:  7(f16vec4) ImageSampleImplicitLod 4707 4708 Bias ConstOffset MinLod 4710 735 4709
+            4712:  7(f16vec4) Load 4674(texel)
+            4713:  7(f16vec4) FAdd 4712 4711
                               Store 4674(texel) 4713
             4714:         199 Load 201(s1DShadow)
             4715:  167(fvec3) Load 169(c3)
             4716:   52(float) Load 4257(lodClamp)
             4717:   52(float) CompositeExtract 4715 2
-            4718:    6(float) ImageSampleDrefImplicitLod 4714 4715 4717 ConstOffset MinLod 709 4716
+            4718:6(float16_t) ImageSampleDrefImplicitLod 4714 4715 4717 ConstOffset MinLod 709 4716
             4719:    208(ptr) AccessChain 4674(texel) 207
-            4720:    6(float) Load 4719
-            4721:    6(float) FAdd 4720 4718
+            4720:6(float16_t) Load 4719
+            4721:6(float16_t) FAdd 4720 4718
             4722:    208(ptr) AccessChain 4674(texel) 207
                               Store 4722 4721
             4723:         199 Load 201(s1DShadow)
-            4724:  154(fvec2) Load 156(f16c2)
+            4724:154(f16vec2) Load 156(f16c2)
             4725:   52(float) Load 215(compare)
-            4726:    6(float) Load 4264(f16lodClamp)
-            4727:    6(float) Load 137(f16bias)
-            4728:    6(float) ImageSampleDrefImplicitLod 4723 4724 4725 Bias ConstOffset MinLod 4727 709 4726
+            4726:6(float16_t) Load 4264(f16lodClamp)
+            4727:6(float16_t) Load 137(f16bias)
+            4728:6(float16_t) ImageSampleDrefImplicitLod 4723 4724 4725 Bias ConstOffset MinLod 4727 709 4726
             4729:    208(ptr) AccessChain 4674(texel) 207
-            4730:    6(float) Load 4729
-            4731:    6(float) FAdd 4730 4728
+            4730:6(float16_t) Load 4729
+            4731:6(float16_t) FAdd 4730 4728
             4732:    208(ptr) AccessChain 4674(texel) 207
                               Store 4732 4731
             4733:         224 Load 226(s2DShadow)
             4734:  167(fvec3) Load 169(c3)
             4735:   52(float) Load 4257(lodClamp)
             4736:   52(float) CompositeExtract 4734 2
-            4737:    6(float) ImageSampleDrefImplicitLod 4733 4734 4736 ConstOffset MinLod 722 4735
+            4737:6(float16_t) ImageSampleDrefImplicitLod 4733 4734 4736 ConstOffset MinLod 722 4735
             4738:    208(ptr) AccessChain 4674(texel) 207
-            4739:    6(float) Load 4738
-            4740:    6(float) FAdd 4739 4737
+            4739:6(float16_t) Load 4738
+            4740:6(float16_t) FAdd 4739 4737
             4741:    208(ptr) AccessChain 4674(texel) 207
                               Store 4741 4740
             4742:         224 Load 226(s2DShadow)
-            4743:  154(fvec2) Load 156(f16c2)
+            4743:154(f16vec2) Load 156(f16c2)
             4744:   52(float) Load 215(compare)
-            4745:    6(float) Load 4264(f16lodClamp)
-            4746:    6(float) Load 137(f16bias)
-            4747:    6(float) ImageSampleDrefImplicitLod 4742 4743 4744 Bias ConstOffset MinLod 4746 722 4745
+            4745:6(float16_t) Load 4264(f16lodClamp)
+            4746:6(float16_t) Load 137(f16bias)
+            4747:6(float16_t) ImageSampleDrefImplicitLod 4742 4743 4744 Bias ConstOffset MinLod 4746 722 4745
             4748:    208(ptr) AccessChain 4674(texel) 207
-            4749:    6(float) Load 4748
-            4750:    6(float) FAdd 4749 4747
+            4749:6(float16_t) Load 4748
+            4750:6(float16_t) FAdd 4749 4747
             4751:    208(ptr) AccessChain 4674(texel) 207
                               Store 4751 4750
             4752:         269 Load 271(s1DArray)
             4753:   53(fvec2) Load 148(c2)
             4754:   52(float) Load 4257(lodClamp)
-            4755:    7(fvec4) ImageSampleImplicitLod 4752 4753 ConstOffset MinLod 709 4754
-            4756:    7(fvec4) Load 4674(texel)
-            4757:    7(fvec4) FAdd 4756 4755
+            4755:  7(f16vec4) ImageSampleImplicitLod 4752 4753 ConstOffset MinLod 709 4754
+            4756:  7(f16vec4) Load 4674(texel)
+            4757:  7(f16vec4) FAdd 4756 4755
                               Store 4674(texel) 4757
             4758:         269 Load 271(s1DArray)
-            4759:  154(fvec2) Load 156(f16c2)
-            4760:    6(float) Load 4264(f16lodClamp)
-            4761:    6(float) Load 137(f16bias)
-            4762:    7(fvec4) ImageSampleImplicitLod 4758 4759 Bias ConstOffset MinLod 4761 709 4760
-            4763:    7(fvec4) Load 4674(texel)
-            4764:    7(fvec4) FAdd 4763 4762
+            4759:154(f16vec2) Load 156(f16c2)
+            4760:6(float16_t) Load 4264(f16lodClamp)
+            4761:6(float16_t) Load 137(f16bias)
+            4762:  7(f16vec4) ImageSampleImplicitLod 4758 4759 Bias ConstOffset MinLod 4761 709 4760
+            4763:  7(f16vec4) Load 4674(texel)
+            4764:  7(f16vec4) FAdd 4763 4762
                               Store 4674(texel) 4764
             4765:         284 Load 286(s2DArray)
             4766:  167(fvec3) Load 169(c3)
             4767:   52(float) Load 4257(lodClamp)
-            4768:    7(fvec4) ImageSampleImplicitLod 4765 4766 ConstOffset MinLod 722 4767
-            4769:    7(fvec4) Load 4674(texel)
-            4770:    7(fvec4) FAdd 4769 4768
+            4768:  7(f16vec4) ImageSampleImplicitLod 4765 4766 ConstOffset MinLod 722 4767
+            4769:  7(f16vec4) Load 4674(texel)
+            4770:  7(f16vec4) FAdd 4769 4768
                               Store 4674(texel) 4770
             4771:         284 Load 286(s2DArray)
-            4772:  175(fvec3) Load 177(f16c3)
-            4773:    6(float) Load 4264(f16lodClamp)
-            4774:    6(float) Load 137(f16bias)
-            4775:    7(fvec4) ImageSampleImplicitLod 4771 4772 Bias ConstOffset MinLod 4774 722 4773
-            4776:    7(fvec4) Load 4674(texel)
-            4777:    7(fvec4) FAdd 4776 4775
+            4772:175(f16vec3) Load 177(f16c3)
+            4773:6(float16_t) Load 4264(f16lodClamp)
+            4774:6(float16_t) Load 137(f16bias)
+            4775:  7(f16vec4) ImageSampleImplicitLod 4771 4772 Bias ConstOffset MinLod 4774 722 4773
+            4776:  7(f16vec4) Load 4674(texel)
+            4777:  7(f16vec4) FAdd 4776 4775
                               Store 4674(texel) 4777
             4778:         316 Load 318(s1DArrayShadow)
             4779:  167(fvec3) Load 169(c3)
             4780:   52(float) Load 4257(lodClamp)
             4781:   52(float) CompositeExtract 4779 2
-            4782:    6(float) ImageSampleDrefImplicitLod 4778 4779 4781 ConstOffset MinLod 709 4780
+            4782:6(float16_t) ImageSampleDrefImplicitLod 4778 4779 4781 ConstOffset MinLod 709 4780
             4783:    208(ptr) AccessChain 4674(texel) 207
-            4784:    6(float) Load 4783
-            4785:    6(float) FAdd 4784 4782
+            4784:6(float16_t) Load 4783
+            4785:6(float16_t) FAdd 4784 4782
             4786:    208(ptr) AccessChain 4674(texel) 207
                               Store 4786 4785
             4787:         316 Load 318(s1DArrayShadow)
-            4788:  154(fvec2) Load 156(f16c2)
+            4788:154(f16vec2) Load 156(f16c2)
             4789:   52(float) Load 215(compare)
-            4790:    6(float) Load 4264(f16lodClamp)
-            4791:    6(float) Load 137(f16bias)
-            4792:    6(float) ImageSampleDrefImplicitLod 4787 4788 4789 Bias ConstOffset MinLod 4791 709 4790
+            4790:6(float16_t) Load 4264(f16lodClamp)
+            4791:6(float16_t) Load 137(f16bias)
+            4792:6(float16_t) ImageSampleDrefImplicitLod 4787 4788 4789 Bias ConstOffset MinLod 4791 709 4790
             4793:    208(ptr) AccessChain 4674(texel) 207
-            4794:    6(float) Load 4793
-            4795:    6(float) FAdd 4794 4792
+            4794:6(float16_t) Load 4793
+            4795:6(float16_t) FAdd 4794 4792
             4796:    208(ptr) AccessChain 4674(texel) 207
                               Store 4796 4795
             4797:         337 Load 339(s2DArrayShadow)
             4798:  249(fvec4) Load 251(c4)
             4799:   52(float) Load 4257(lodClamp)
             4800:   52(float) CompositeExtract 4798 3
-            4801:    6(float) ImageSampleDrefImplicitLod 4797 4798 4800 ConstOffset MinLod 722 4799
+            4801:6(float16_t) ImageSampleDrefImplicitLod 4797 4798 4800 ConstOffset MinLod 722 4799
             4802:    208(ptr) AccessChain 4674(texel) 207
-            4803:    6(float) Load 4802
-            4804:    6(float) FAdd 4803 4801
+            4803:6(float16_t) Load 4802
+            4804:6(float16_t) FAdd 4803 4801
             4805:    208(ptr) AccessChain 4674(texel) 207
                               Store 4805 4804
             4806:         337 Load 339(s2DArrayShadow)
-            4807:  175(fvec3) Load 177(f16c3)
+            4807:175(f16vec3) Load 177(f16c3)
             4808:   52(float) Load 215(compare)
-            4809:    6(float) Load 4264(f16lodClamp)
-            4810:    6(float) ImageSampleDrefImplicitLod 4806 4807 4808 ConstOffset MinLod 722 4809
+            4809:6(float16_t) Load 4264(f16lodClamp)
+            4810:6(float16_t) ImageSampleDrefImplicitLod 4806 4807 4808 ConstOffset MinLod 722 4809
             4811:    208(ptr) AccessChain 4674(texel) 207
-            4812:    6(float) Load 4811
-            4813:    6(float) FAdd 4812 4810
+            4812:6(float16_t) Load 4811
+            4813:6(float16_t) FAdd 4812 4810
             4814:    208(ptr) AccessChain 4674(texel) 207
                               Store 4814 4813
-            4815:    7(fvec4) Load 4674(texel)
+            4815:  7(f16vec4) Load 4674(texel)
                               ReturnValue 4815
                               FunctionEnd
-107(testSparseTextureGradClamp():    7(fvec4) Function None 8
+107(testSparseTextureGradClamp():  7(f16vec4) Function None 8
              108:             Label
      4818(texel):     64(ptr) Variable Function
                               Store 4818(texel) 121
@@ -6055,16 +6055,16 @@ spv.float16Fetch.frag
             4822:   53(fvec2) Load 1409(dPdxy2)
             4823:   52(float) Load 4257(lodClamp)
             4824:3102(ResType) ImageSparseSampleExplicitLod 4819 4820 Grad MinLod 4821 4822 4823
-            4825:    7(fvec4) CompositeExtract 4824 1
+            4825:  7(f16vec4) CompositeExtract 4824 1
                               Store 4818(texel) 4825
             4826:     47(int) CompositeExtract 4824 0
             4827:         143 Load 145(s2D)
-            4828:  154(fvec2) Load 156(f16c2)
-            4829:  154(fvec2) Load 1417(f16dPdxy2)
-            4830:  154(fvec2) Load 1417(f16dPdxy2)
-            4831:    6(float) Load 4264(f16lodClamp)
+            4828:154(f16vec2) Load 156(f16c2)
+            4829:154(f16vec2) Load 1417(f16dPdxy2)
+            4830:154(f16vec2) Load 1417(f16dPdxy2)
+            4831:6(float16_t) Load 4264(f16lodClamp)
             4832:3102(ResType) ImageSparseSampleExplicitLod 4827 4828 Grad MinLod 4829 4830 4831
-            4833:    7(fvec4) CompositeExtract 4832 1
+            4833:  7(f16vec4) CompositeExtract 4832 1
                               Store 4818(texel) 4833
             4834:     47(int) CompositeExtract 4832 0
             4835:         163 Load 165(s3D)
@@ -6073,16 +6073,16 @@ spv.float16Fetch.frag
             4838:  167(fvec3) Load 1425(dPdxy3)
             4839:   52(float) Load 4257(lodClamp)
             4840:3102(ResType) ImageSparseSampleExplicitLod 4835 4836 Grad MinLod 4837 4838 4839
-            4841:    7(fvec4) CompositeExtract 4840 1
+            4841:  7(f16vec4) CompositeExtract 4840 1
                               Store 4818(texel) 4841
             4842:     47(int) CompositeExtract 4840 0
             4843:         163 Load 165(s3D)
-            4844:  175(fvec3) Load 177(f16c3)
-            4845:  175(fvec3) Load 1433(f16dPdxy3)
-            4846:  175(fvec3) Load 1433(f16dPdxy3)
-            4847:    6(float) Load 4264(f16lodClamp)
+            4844:175(f16vec3) Load 177(f16c3)
+            4845:175(f16vec3) Load 1433(f16dPdxy3)
+            4846:175(f16vec3) Load 1433(f16dPdxy3)
+            4847:6(float16_t) Load 4264(f16lodClamp)
             4848:3102(ResType) ImageSparseSampleExplicitLod 4843 4844 Grad MinLod 4845 4846 4847
-            4849:    7(fvec4) CompositeExtract 4848 1
+            4849:  7(f16vec4) CompositeExtract 4848 1
                               Store 4818(texel) 4849
             4850:     47(int) CompositeExtract 4848 0
             4851:         184 Load 186(sCube)
@@ -6091,16 +6091,16 @@ spv.float16Fetch.frag
             4854:  167(fvec3) Load 1425(dPdxy3)
             4855:   52(float) Load 4257(lodClamp)
             4856:3102(ResType) ImageSparseSampleExplicitLod 4851 4852 Grad MinLod 4853 4854 4855
-            4857:    7(fvec4) CompositeExtract 4856 1
+            4857:  7(f16vec4) CompositeExtract 4856 1
                               Store 4818(texel) 4857
             4858:     47(int) CompositeExtract 4856 0
             4859:         184 Load 186(sCube)
-            4860:  175(fvec3) Load 177(f16c3)
-            4861:  175(fvec3) Load 1433(f16dPdxy3)
-            4862:  175(fvec3) Load 1433(f16dPdxy3)
-            4863:    6(float) Load 4264(f16lodClamp)
+            4860:175(f16vec3) Load 177(f16c3)
+            4861:175(f16vec3) Load 1433(f16dPdxy3)
+            4862:175(f16vec3) Load 1433(f16dPdxy3)
+            4863:6(float16_t) Load 4264(f16lodClamp)
             4864:3102(ResType) ImageSparseSampleExplicitLod 4859 4860 Grad MinLod 4861 4862 4863
-            4865:    7(fvec4) CompositeExtract 4864 1
+            4865:  7(f16vec4) CompositeExtract 4864 1
                               Store 4818(texel) 4865
             4866:     47(int) CompositeExtract 4864 0
             4867:         224 Load 226(s2DShadow)
@@ -6111,18 +6111,18 @@ spv.float16Fetch.frag
             4872:    208(ptr) AccessChain 4818(texel) 207
             4873:   52(float) CompositeExtract 4868 2
             4874:3138(ResType) ImageSparseSampleDrefExplicitLod 4867 4868 4873 Grad MinLod 4869 4870 4871
-            4875:    6(float) CompositeExtract 4874 1
+            4875:6(float16_t) CompositeExtract 4874 1
                               Store 4872 4875
             4876:     47(int) CompositeExtract 4874 0
             4877:         224 Load 226(s2DShadow)
-            4878:  154(fvec2) Load 156(f16c2)
+            4878:154(f16vec2) Load 156(f16c2)
             4879:   52(float) Load 215(compare)
-            4880:  154(fvec2) Load 1417(f16dPdxy2)
-            4881:  154(fvec2) Load 1417(f16dPdxy2)
-            4882:    6(float) Load 4264(f16lodClamp)
+            4880:154(f16vec2) Load 1417(f16dPdxy2)
+            4881:154(f16vec2) Load 1417(f16dPdxy2)
+            4882:6(float16_t) Load 4264(f16lodClamp)
             4883:    208(ptr) AccessChain 4818(texel) 207
             4884:3138(ResType) ImageSparseSampleDrefExplicitLod 4877 4878 4879 Grad MinLod 4880 4881 4882
-            4885:    6(float) CompositeExtract 4884 1
+            4885:6(float16_t) CompositeExtract 4884 1
                               Store 4883 4885
             4886:     47(int) CompositeExtract 4884 0
             4887:         245 Load 247(sCubeShadow)
@@ -6133,18 +6133,18 @@ spv.float16Fetch.frag
             4892:    208(ptr) AccessChain 4818(texel) 207
             4893:   52(float) CompositeExtract 4888 3
             4894:3138(ResType) ImageSparseSampleDrefExplicitLod 4887 4888 4893 Grad MinLod 4889 4890 4891
-            4895:    6(float) CompositeExtract 4894 1
+            4895:6(float16_t) CompositeExtract 4894 1
                               Store 4892 4895
             4896:     47(int) CompositeExtract 4894 0
             4897:         245 Load 247(sCubeShadow)
-            4898:  175(fvec3) Load 177(f16c3)
+            4898:175(f16vec3) Load 177(f16c3)
             4899:   52(float) Load 215(compare)
-            4900:  175(fvec3) Load 1433(f16dPdxy3)
-            4901:  175(fvec3) Load 1433(f16dPdxy3)
-            4902:    6(float) Load 4264(f16lodClamp)
+            4900:175(f16vec3) Load 1433(f16dPdxy3)
+            4901:175(f16vec3) Load 1433(f16dPdxy3)
+            4902:6(float16_t) Load 4264(f16lodClamp)
             4903:    208(ptr) AccessChain 4818(texel) 207
             4904:3138(ResType) ImageSparseSampleDrefExplicitLod 4897 4898 4899 Grad MinLod 4900 4901 4902
-            4905:    6(float) CompositeExtract 4904 1
+            4905:6(float16_t) CompositeExtract 4904 1
                               Store 4903 4905
             4906:     47(int) CompositeExtract 4904 0
             4907:         284 Load 286(s2DArray)
@@ -6153,16 +6153,16 @@ spv.float16Fetch.frag
             4910:   53(fvec2) Load 1409(dPdxy2)
             4911:   52(float) Load 4257(lodClamp)
             4912:3102(ResType) ImageSparseSampleExplicitLod 4907 4908 Grad MinLod 4909 4910 4911
-            4913:    7(fvec4) CompositeExtract 4912 1
+            4913:  7(f16vec4) CompositeExtract 4912 1
                               Store 4818(texel) 4913
             4914:     47(int) CompositeExtract 4912 0
             4915:         284 Load 286(s2DArray)
-            4916:  175(fvec3) Load 177(f16c3)
-            4917:  154(fvec2) Load 1417(f16dPdxy2)
-            4918:  154(fvec2) Load 1417(f16dPdxy2)
-            4919:    6(float) Load 4264(f16lodClamp)
+            4916:175(f16vec3) Load 177(f16c3)
+            4917:154(f16vec2) Load 1417(f16dPdxy2)
+            4918:154(f16vec2) Load 1417(f16dPdxy2)
+            4919:6(float16_t) Load 4264(f16lodClamp)
             4920:3102(ResType) ImageSparseSampleExplicitLod 4915 4916 Grad MinLod 4917 4918 4919
-            4921:    7(fvec4) CompositeExtract 4920 1
+            4921:  7(f16vec4) CompositeExtract 4920 1
                               Store 4818(texel) 4921
             4922:     47(int) CompositeExtract 4920 0
             4923:         337 Load 339(s2DArrayShadow)
@@ -6173,18 +6173,18 @@ spv.float16Fetch.frag
             4928:    208(ptr) AccessChain 4818(texel) 207
             4929:   52(float) CompositeExtract 4924 3
             4930:3138(ResType) ImageSparseSampleDrefExplicitLod 4923 4924 4929 Grad MinLod 4925 4926 4927
-            4931:    6(float) CompositeExtract 4930 1
+            4931:6(float16_t) CompositeExtract 4930 1
                               Store 4928 4931
             4932:     47(int) CompositeExtract 4930 0
             4933:         337 Load 339(s2DArrayShadow)
-            4934:  175(fvec3) Load 177(f16c3)
+            4934:175(f16vec3) Load 177(f16c3)
             4935:   52(float) Load 215(compare)
-            4936:  154(fvec2) Load 1417(f16dPdxy2)
-            4937:  154(fvec2) Load 1417(f16dPdxy2)
-            4938:    6(float) Load 4264(f16lodClamp)
+            4936:154(f16vec2) Load 1417(f16dPdxy2)
+            4937:154(f16vec2) Load 1417(f16dPdxy2)
+            4938:6(float16_t) Load 4264(f16lodClamp)
             4939:    208(ptr) AccessChain 4818(texel) 207
             4940:3138(ResType) ImageSparseSampleDrefExplicitLod 4933 4934 4935 Grad MinLod 4936 4937 4938
-            4941:    6(float) CompositeExtract 4940 1
+            4941:6(float16_t) CompositeExtract 4940 1
                               Store 4939 4941
             4942:     47(int) CompositeExtract 4940 0
             4943:         299 Load 301(sCubeArray)
@@ -6193,22 +6193,22 @@ spv.float16Fetch.frag
             4946:  167(fvec3) Load 1425(dPdxy3)
             4947:   52(float) Load 4257(lodClamp)
             4948:3102(ResType) ImageSparseSampleExplicitLod 4943 4944 Grad MinLod 4945 4946 4947
-            4949:    7(fvec4) CompositeExtract 4948 1
+            4949:  7(f16vec4) CompositeExtract 4948 1
                               Store 4818(texel) 4949
             4950:     47(int) CompositeExtract 4948 0
             4951:         299 Load 301(sCubeArray)
-            4952:    7(fvec4) Load 309(f16c4)
-            4953:  175(fvec3) Load 1433(f16dPdxy3)
-            4954:  175(fvec3) Load 1433(f16dPdxy3)
-            4955:    6(float) Load 4264(f16lodClamp)
+            4952:  7(f16vec4) Load 309(f16c4)
+            4953:175(f16vec3) Load 1433(f16dPdxy3)
+            4954:175(f16vec3) Load 1433(f16dPdxy3)
+            4955:6(float16_t) Load 4264(f16lodClamp)
             4956:3102(ResType) ImageSparseSampleExplicitLod 4951 4952 Grad MinLod 4953 4954 4955
-            4957:    7(fvec4) CompositeExtract 4956 1
+            4957:  7(f16vec4) CompositeExtract 4956 1
                               Store 4818(texel) 4957
             4958:     47(int) CompositeExtract 4956 0
-            4959:    7(fvec4) Load 4818(texel)
+            4959:  7(f16vec4) Load 4818(texel)
                               ReturnValue 4959
                               FunctionEnd
-109(testTextureGradClamp():    7(fvec4) Function None 8
+109(testTextureGradClamp():  7(f16vec4) Function None 8
              110:             Label
      4962(texel):     64(ptr) Variable Function
                               Store 4962(texel) 121
@@ -6217,72 +6217,72 @@ spv.float16Fetch.frag
             4965:   52(float) Load 1393(dPdxy1)
             4966:   52(float) Load 1393(dPdxy1)
             4967:   52(float) Load 4257(lodClamp)
-            4968:    7(fvec4) ImageSampleExplicitLod 4963 4964 Grad MinLod 4965 4966 4967
-            4969:    7(fvec4) Load 4962(texel)
-            4970:    7(fvec4) FAdd 4969 4968
+            4968:  7(f16vec4) ImageSampleExplicitLod 4963 4964 Grad MinLod 4965 4966 4967
+            4969:  7(f16vec4) Load 4962(texel)
+            4970:  7(f16vec4) FAdd 4969 4968
                               Store 4962(texel) 4970
             4971:         123 Load 125(s1D)
-            4972:    6(float) Load 135(f16c1)
-            4973:    6(float) Load 1401(f16dPdxy1)
-            4974:    6(float) Load 1401(f16dPdxy1)
-            4975:    6(float) Load 4264(f16lodClamp)
-            4976:    7(fvec4) ImageSampleExplicitLod 4971 4972 Grad MinLod 4973 4974 4975
-            4977:    7(fvec4) Load 4962(texel)
-            4978:    7(fvec4) FAdd 4977 4976
+            4972:6(float16_t) Load 135(f16c1)
+            4973:6(float16_t) Load 1401(f16dPdxy1)
+            4974:6(float16_t) Load 1401(f16dPdxy1)
+            4975:6(float16_t) Load 4264(f16lodClamp)
+            4976:  7(f16vec4) ImageSampleExplicitLod 4971 4972 Grad MinLod 4973 4974 4975
+            4977:  7(f16vec4) Load 4962(texel)
+            4978:  7(f16vec4) FAdd 4977 4976
                               Store 4962(texel) 4978
             4979:         143 Load 145(s2D)
             4980:   53(fvec2) Load 148(c2)
             4981:   53(fvec2) Load 1409(dPdxy2)
             4982:   53(fvec2) Load 1409(dPdxy2)
             4983:   52(float) Load 4257(lodClamp)
-            4984:    7(fvec4) ImageSampleExplicitLod 4979 4980 Grad MinLod 4981 4982 4983
-            4985:    7(fvec4) Load 4962(texel)
-            4986:    7(fvec4) FAdd 4985 4984
+            4984:  7(f16vec4) ImageSampleExplicitLod 4979 4980 Grad MinLod 4981 4982 4983
+            4985:  7(f16vec4) Load 4962(texel)
+            4986:  7(f16vec4) FAdd 4985 4984
                               Store 4962(texel) 4986
             4987:         143 Load 145(s2D)
-            4988:  154(fvec2) Load 156(f16c2)
-            4989:  154(fvec2) Load 1417(f16dPdxy2)
-            4990:  154(fvec2) Load 1417(f16dPdxy2)
-            4991:    6(float) Load 4264(f16lodClamp)
-            4992:    7(fvec4) ImageSampleExplicitLod 4987 4988 Grad MinLod 4989 4990 4991
-            4993:    7(fvec4) Load 4962(texel)
-            4994:    7(fvec4) FAdd 4993 4992
+            4988:154(f16vec2) Load 156(f16c2)
+            4989:154(f16vec2) Load 1417(f16dPdxy2)
+            4990:154(f16vec2) Load 1417(f16dPdxy2)
+            4991:6(float16_t) Load 4264(f16lodClamp)
+            4992:  7(f16vec4) ImageSampleExplicitLod 4987 4988 Grad MinLod 4989 4990 4991
+            4993:  7(f16vec4) Load 4962(texel)
+            4994:  7(f16vec4) FAdd 4993 4992
                               Store 4962(texel) 4994
             4995:         163 Load 165(s3D)
             4996:  167(fvec3) Load 169(c3)
             4997:  167(fvec3) Load 1425(dPdxy3)
             4998:  167(fvec3) Load 1425(dPdxy3)
             4999:   52(float) Load 4257(lodClamp)
-            5000:    7(fvec4) ImageSampleExplicitLod 4995 4996 Grad MinLod 4997 4998 4999
-            5001:    7(fvec4) Load 4962(texel)
-            5002:    7(fvec4) FAdd 5001 5000
+            5000:  7(f16vec4) ImageSampleExplicitLod 4995 4996 Grad MinLod 4997 4998 4999
+            5001:  7(f16vec4) Load 4962(texel)
+            5002:  7(f16vec4) FAdd 5001 5000
                               Store 4962(texel) 5002
             5003:         163 Load 165(s3D)
-            5004:  175(fvec3) Load 177(f16c3)
-            5005:  175(fvec3) Load 1433(f16dPdxy3)
-            5006:  175(fvec3) Load 1433(f16dPdxy3)
-            5007:    6(float) Load 4264(f16lodClamp)
-            5008:    7(fvec4) ImageSampleExplicitLod 5003 5004 Grad MinLod 5005 5006 5007
-            5009:    7(fvec4) Load 4962(texel)
-            5010:    7(fvec4) FAdd 5009 5008
+            5004:175(f16vec3) Load 177(f16c3)
+            5005:175(f16vec3) Load 1433(f16dPdxy3)
+            5006:175(f16vec3) Load 1433(f16dPdxy3)
+            5007:6(float16_t) Load 4264(f16lodClamp)
+            5008:  7(f16vec4) ImageSampleExplicitLod 5003 5004 Grad MinLod 5005 5006 5007
+            5009:  7(f16vec4) Load 4962(texel)
+            5010:  7(f16vec4) FAdd 5009 5008
                               Store 4962(texel) 5010
             5011:         184 Load 186(sCube)
             5012:  167(fvec3) Load 169(c3)
             5013:  167(fvec3) Load 1425(dPdxy3)
             5014:  167(fvec3) Load 1425(dPdxy3)
             5015:   52(float) Load 4257(lodClamp)
-            5016:    7(fvec4) ImageSampleExplicitLod 5011 5012 Grad MinLod 5013 5014 5015
-            5017:    7(fvec4) Load 4962(texel)
-            5018:    7(fvec4) FAdd 5017 5016
+            5016:  7(f16vec4) ImageSampleExplicitLod 5011 5012 Grad MinLod 5013 5014 5015
+            5017:  7(f16vec4) Load 4962(texel)
+            5018:  7(f16vec4) FAdd 5017 5016
                               Store 4962(texel) 5018
             5019:         184 Load 186(sCube)
-            5020:  175(fvec3) Load 177(f16c3)
-            5021:  175(fvec3) Load 1433(f16dPdxy3)
-            5022:  175(fvec3) Load 1433(f16dPdxy3)
-            5023:    6(float) Load 4264(f16lodClamp)
-            5024:    7(fvec4) ImageSampleExplicitLod 5019 5020 Grad MinLod 5021 5022 5023
-            5025:    7(fvec4) Load 4962(texel)
-            5026:    7(fvec4) FAdd 5025 5024
+            5020:175(f16vec3) Load 177(f16c3)
+            5021:175(f16vec3) Load 1433(f16dPdxy3)
+            5022:175(f16vec3) Load 1433(f16dPdxy3)
+            5023:6(float16_t) Load 4264(f16lodClamp)
+            5024:  7(f16vec4) ImageSampleExplicitLod 5019 5020 Grad MinLod 5021 5022 5023
+            5025:  7(f16vec4) Load 4962(texel)
+            5026:  7(f16vec4) FAdd 5025 5024
                               Store 4962(texel) 5026
             5027:         199 Load 201(s1DShadow)
             5028:  167(fvec3) Load 169(c3)
@@ -6290,22 +6290,22 @@ spv.float16Fetch.frag
             5030:   52(float) Load 1393(dPdxy1)
             5031:   52(float) Load 4257(lodClamp)
             5032:   52(float) CompositeExtract 5028 2
-            5033:    6(float) ImageSampleDrefExplicitLod 5027 5028 5032 Grad MinLod 5029 5030 5031
+            5033:6(float16_t) ImageSampleDrefExplicitLod 5027 5028 5032 Grad MinLod 5029 5030 5031
             5034:    208(ptr) AccessChain 4962(texel) 207
-            5035:    6(float) Load 5034
-            5036:    6(float) FAdd 5035 5033
+            5035:6(float16_t) Load 5034
+            5036:6(float16_t) FAdd 5035 5033
             5037:    208(ptr) AccessChain 4962(texel) 207
                               Store 5037 5036
             5038:         199 Load 201(s1DShadow)
-            5039:  154(fvec2) Load 156(f16c2)
+            5039:154(f16vec2) Load 156(f16c2)
             5040:   52(float) Load 215(compare)
-            5041:    6(float) Load 1401(f16dPdxy1)
-            5042:    6(float) Load 1401(f16dPdxy1)
-            5043:    6(float) Load 4264(f16lodClamp)
-            5044:    6(float) ImageSampleDrefExplicitLod 5038 5039 5040 Grad MinLod 5041 5042 5043
+            5041:6(float16_t) Load 1401(f16dPdxy1)
+            5042:6(float16_t) Load 1401(f16dPdxy1)
+            5043:6(float16_t) Load 4264(f16lodClamp)
+            5044:6(float16_t) ImageSampleDrefExplicitLod 5038 5039 5040 Grad MinLod 5041 5042 5043
             5045:    208(ptr) AccessChain 4962(texel) 207
-            5046:    6(float) Load 5045
-            5047:    6(float) FAdd 5046 5044
+            5046:6(float16_t) Load 5045
+            5047:6(float16_t) FAdd 5046 5044
             5048:    208(ptr) AccessChain 4962(texel) 207
                               Store 5048 5047
             5049:         224 Load 226(s2DShadow)
@@ -6314,22 +6314,22 @@ spv.float16Fetch.frag
             5052:   53(fvec2) Load 1409(dPdxy2)
             5053:   52(float) Load 4257(lodClamp)
             5054:   52(float) CompositeExtract 5050 2
-            5055:    6(float) ImageSampleDrefExplicitLod 5049 5050 5054 Grad MinLod 5051 5052 5053
+            5055:6(float16_t) ImageSampleDrefExplicitLod 5049 5050 5054 Grad MinLod 5051 5052 5053
             5056:    208(ptr) AccessChain 4962(texel) 207
-            5057:    6(float) Load 5056
-            5058:    6(float) FAdd 5057 5055
+            5057:6(float16_t) Load 5056
+            5058:6(float16_t) FAdd 5057 5055
             5059:    208(ptr) AccessChain 4962(texel) 207
                               Store 5059 5058
             5060:         224 Load 226(s2DShadow)
-            5061:  154(fvec2) Load 156(f16c2)
+            5061:154(f16vec2) Load 156(f16c2)
             5062:   52(float) Load 215(compare)
-            5063:  154(fvec2) Load 1417(f16dPdxy2)
-            5064:  154(fvec2) Load 1417(f16dPdxy2)
-            5065:    6(float) Load 4264(f16lodClamp)
-            5066:    6(float) ImageSampleDrefExplicitLod 5060 5061 5062 Grad MinLod 5063 5064 5065
+            5063:154(f16vec2) Load 1417(f16dPdxy2)
+            5064:154(f16vec2) Load 1417(f16dPdxy2)
+            5065:6(float16_t) Load 4264(f16lodClamp)
+            5066:6(float16_t) ImageSampleDrefExplicitLod 5060 5061 5062 Grad MinLod 5063 5064 5065
             5067:    208(ptr) AccessChain 4962(texel) 207
-            5068:    6(float) Load 5067
-            5069:    6(float) FAdd 5068 5066
+            5068:6(float16_t) Load 5067
+            5069:6(float16_t) FAdd 5068 5066
             5070:    208(ptr) AccessChain 4962(texel) 207
                               Store 5070 5069
             5071:         245 Load 247(sCubeShadow)
@@ -6338,22 +6338,22 @@ spv.float16Fetch.frag
             5074:  167(fvec3) Load 1425(dPdxy3)
             5075:   52(float) Load 4257(lodClamp)
             5076:   52(float) CompositeExtract 5072 3
-            5077:    6(float) ImageSampleDrefExplicitLod 5071 5072 5076 Grad MinLod 5073 5074 5075
+            5077:6(float16_t) ImageSampleDrefExplicitLod 5071 5072 5076 Grad MinLod 5073 5074 5075
             5078:    208(ptr) AccessChain 4962(texel) 207
-            5079:    6(float) Load 5078
-            5080:    6(float) FAdd 5079 5077
+            5079:6(float16_t) Load 5078
+            5080:6(float16_t) FAdd 5079 5077
             5081:    208(ptr) AccessChain 4962(texel) 207
                               Store 5081 5080
             5082:         245 Load 247(sCubeShadow)
-            5083:  175(fvec3) Load 177(f16c3)
+            5083:175(f16vec3) Load 177(f16c3)
             5084:   52(float) Load 215(compare)
-            5085:  175(fvec3) Load 1433(f16dPdxy3)
-            5086:  175(fvec3) Load 1433(f16dPdxy3)
-            5087:    6(float) Load 4264(f16lodClamp)
-            5088:    6(float) ImageSampleDrefExplicitLod 5082 5083 5084 Grad MinLod 5085 5086 5087
+            5085:175(f16vec3) Load 1433(f16dPdxy3)
+            5086:175(f16vec3) Load 1433(f16dPdxy3)
+            5087:6(float16_t) Load 4264(f16lodClamp)
+            5088:6(float16_t) ImageSampleDrefExplicitLod 5082 5083 5084 Grad MinLod 5085 5086 5087
             5089:    208(ptr) AccessChain 4962(texel) 207
-            5090:    6(float) Load 5089
-            5091:    6(float) FAdd 5090 5088
+            5090:6(float16_t) Load 5089
+            5091:6(float16_t) FAdd 5090 5088
             5092:    208(ptr) AccessChain 4962(texel) 207
                               Store 5092 5091
             5093:         269 Load 271(s1DArray)
@@ -6361,36 +6361,36 @@ spv.float16Fetch.frag
             5095:   52(float) Load 1393(dPdxy1)
             5096:   52(float) Load 1393(dPdxy1)
             5097:   52(float) Load 4257(lodClamp)
-            5098:    7(fvec4) ImageSampleExplicitLod 5093 5094 Grad MinLod 5095 5096 5097
-            5099:    7(fvec4) Load 4962(texel)
-            5100:    7(fvec4) FAdd 5099 5098
+            5098:  7(f16vec4) ImageSampleExplicitLod 5093 5094 Grad MinLod 5095 5096 5097
+            5099:  7(f16vec4) Load 4962(texel)
+            5100:  7(f16vec4) FAdd 5099 5098
                               Store 4962(texel) 5100
             5101:         269 Load 271(s1DArray)
-            5102:  154(fvec2) Load 156(f16c2)
-            5103:    6(float) Load 1401(f16dPdxy1)
-            5104:    6(float) Load 1401(f16dPdxy1)
-            5105:    6(float) Load 4264(f16lodClamp)
-            5106:    7(fvec4) ImageSampleExplicitLod 5101 5102 Grad MinLod 5103 5104 5105
-            5107:    7(fvec4) Load 4962(texel)
-            5108:    7(fvec4) FAdd 5107 5106
+            5102:154(f16vec2) Load 156(f16c2)
+            5103:6(float16_t) Load 1401(f16dPdxy1)
+            5104:6(float16_t) Load 1401(f16dPdxy1)
+            5105:6(float16_t) Load 4264(f16lodClamp)
+            5106:  7(f16vec4) ImageSampleExplicitLod 5101 5102 Grad MinLod 5103 5104 5105
+            5107:  7(f16vec4) Load 4962(texel)
+            5108:  7(f16vec4) FAdd 5107 5106
                               Store 4962(texel) 5108
             5109:         284 Load 286(s2DArray)
             5110:  167(fvec3) Load 169(c3)
             5111:   53(fvec2) Load 1409(dPdxy2)
             5112:   53(fvec2) Load 1409(dPdxy2)
             5113:   52(float) Load 4257(lodClamp)
-            5114:    7(fvec4) ImageSampleExplicitLod 5109 5110 Grad MinLod 5111 5112 5113
-            5115:    7(fvec4) Load 4962(texel)
-            5116:    7(fvec4) FAdd 5115 5114
+            5114:  7(f16vec4) ImageSampleExplicitLod 5109 5110 Grad MinLod 5111 5112 5113
+            5115:  7(f16vec4) Load 4962(texel)
+            5116:  7(f16vec4) FAdd 5115 5114
                               Store 4962(texel) 5116
             5117:         284 Load 286(s2DArray)
-            5118:  175(fvec3) Load 177(f16c3)
-            5119:  154(fvec2) Load 1417(f16dPdxy2)
-            5120:  154(fvec2) Load 1417(f16dPdxy2)
-            5121:    6(float) Load 4264(f16lodClamp)
-            5122:    7(fvec4) ImageSampleExplicitLod 5117 5118 Grad MinLod 5119 5120 5121
-            5123:    7(fvec4) Load 4962(texel)
-            5124:    7(fvec4) FAdd 5123 5122
+            5118:175(f16vec3) Load 177(f16c3)
+            5119:154(f16vec2) Load 1417(f16dPdxy2)
+            5120:154(f16vec2) Load 1417(f16dPdxy2)
+            5121:6(float16_t) Load 4264(f16lodClamp)
+            5122:  7(f16vec4) ImageSampleExplicitLod 5117 5118 Grad MinLod 5119 5120 5121
+            5123:  7(f16vec4) Load 4962(texel)
+            5124:  7(f16vec4) FAdd 5123 5122
                               Store 4962(texel) 5124
             5125:         316 Load 318(s1DArrayShadow)
             5126:  167(fvec3) Load 169(c3)
@@ -6398,22 +6398,22 @@ spv.float16Fetch.frag
             5128:   52(float) Load 1393(dPdxy1)
             5129:   52(float) Load 4257(lodClamp)
             5130:   52(float) CompositeExtract 5126 2
-            5131:    6(float) ImageSampleDrefExplicitLod 5125 5126 5130 Grad MinLod 5127 5128 5129
+            5131:6(float16_t) ImageSampleDrefExplicitLod 5125 5126 5130 Grad MinLod 5127 5128 5129
             5132:    208(ptr) AccessChain 4962(texel) 207
-            5133:    6(float) Load 5132
-            5134:    6(float) FAdd 5133 5131
+            5133:6(float16_t) Load 5132
+            5134:6(float16_t) FAdd 5133 5131
             5135:    208(ptr) AccessChain 4962(texel) 207
                               Store 5135 5134
             5136:         316 Load 318(s1DArrayShadow)
-            5137:  154(fvec2) Load 156(f16c2)
+            5137:154(f16vec2) Load 156(f16c2)
             5138:   52(float) Load 215(compare)
-            5139:    6(float) Load 1401(f16dPdxy1)
-            5140:    6(float) Load 1401(f16dPdxy1)
-            5141:    6(float) Load 4264(f16lodClamp)
-            5142:    6(float) ImageSampleDrefExplicitLod 5136 5137 5138 Grad MinLod 5139 5140 5141
+            5139:6(float16_t) Load 1401(f16dPdxy1)
+            5140:6(float16_t) Load 1401(f16dPdxy1)
+            5141:6(float16_t) Load 4264(f16lodClamp)
+            5142:6(float16_t) ImageSampleDrefExplicitLod 5136 5137 5138 Grad MinLod 5139 5140 5141
             5143:    208(ptr) AccessChain 4962(texel) 207
-            5144:    6(float) Load 5143
-            5145:    6(float) FAdd 5144 5142
+            5144:6(float16_t) Load 5143
+            5145:6(float16_t) FAdd 5144 5142
             5146:    208(ptr) AccessChain 4962(texel) 207
                               Store 5146 5145
             5147:         337 Load 339(s2DArrayShadow)
@@ -6422,22 +6422,22 @@ spv.float16Fetch.frag
             5150:   53(fvec2) Load 1409(dPdxy2)
             5151:   52(float) Load 4257(lodClamp)
             5152:   52(float) CompositeExtract 5148 3
-            5153:    6(float) ImageSampleDrefExplicitLod 5147 5148 5152 Grad MinLod 5149 5150 5151
+            5153:6(float16_t) ImageSampleDrefExplicitLod 5147 5148 5152 Grad MinLod 5149 5150 5151
             5154:    208(ptr) AccessChain 4962(texel) 207
-            5155:    6(float) Load 5154
-            5156:    6(float) FAdd 5155 5153
+            5155:6(float16_t) Load 5154
+            5156:6(float16_t) FAdd 5155 5153
             5157:    208(ptr) AccessChain 4962(texel) 207
                               Store 5157 5156
             5158:         337 Load 339(s2DArrayShadow)
-            5159:  175(fvec3) Load 177(f16c3)
+            5159:175(f16vec3) Load 177(f16c3)
             5160:   52(float) Load 215(compare)
-            5161:  154(fvec2) Load 1417(f16dPdxy2)
-            5162:  154(fvec2) Load 1417(f16dPdxy2)
-            5163:    6(float) Load 4264(f16lodClamp)
-            5164:    6(float) ImageSampleDrefExplicitLod 5158 5159 5160 Grad MinLod 5161 5162 5163
+            5161:154(f16vec2) Load 1417(f16dPdxy2)
+            5162:154(f16vec2) Load 1417(f16dPdxy2)
+            5163:6(float16_t) Load 4264(f16lodClamp)
+            5164:6(float16_t) ImageSampleDrefExplicitLod 5158 5159 5160 Grad MinLod 5161 5162 5163
             5165:    208(ptr) AccessChain 4962(texel) 207
-            5166:    6(float) Load 5165
-            5167:    6(float) FAdd 5166 5164
+            5166:6(float16_t) Load 5165
+            5167:6(float16_t) FAdd 5166 5164
             5168:    208(ptr) AccessChain 4962(texel) 207
                               Store 5168 5167
             5169:         299 Load 301(sCubeArray)
@@ -6445,23 +6445,23 @@ spv.float16Fetch.frag
             5171:  167(fvec3) Load 1425(dPdxy3)
             5172:  167(fvec3) Load 1425(dPdxy3)
             5173:   52(float) Load 4257(lodClamp)
-            5174:    7(fvec4) ImageSampleExplicitLod 5169 5170 Grad MinLod 5171 5172 5173
-            5175:    7(fvec4) Load 4962(texel)
-            5176:    7(fvec4) FAdd 5175 5174
+            5174:  7(f16vec4) ImageSampleExplicitLod 5169 5170 Grad MinLod 5171 5172 5173
+            5175:  7(f16vec4) Load 4962(texel)
+            5176:  7(f16vec4) FAdd 5175 5174
                               Store 4962(texel) 5176
             5177:         299 Load 301(sCubeArray)
-            5178:    7(fvec4) Load 309(f16c4)
-            5179:  175(fvec3) Load 1433(f16dPdxy3)
-            5180:  175(fvec3) Load 1433(f16dPdxy3)
-            5181:    6(float) Load 4264(f16lodClamp)
-            5182:    7(fvec4) ImageSampleExplicitLod 5177 5178 Grad MinLod 5179 5180 5181
-            5183:    7(fvec4) Load 4962(texel)
-            5184:    7(fvec4) FAdd 5183 5182
+            5178:  7(f16vec4) Load 309(f16c4)
+            5179:175(f16vec3) Load 1433(f16dPdxy3)
+            5180:175(f16vec3) Load 1433(f16dPdxy3)
+            5181:6(float16_t) Load 4264(f16lodClamp)
+            5182:  7(f16vec4) ImageSampleExplicitLod 5177 5178 Grad MinLod 5179 5180 5181
+            5183:  7(f16vec4) Load 4962(texel)
+            5184:  7(f16vec4) FAdd 5183 5182
                               Store 4962(texel) 5184
-            5185:    7(fvec4) Load 4962(texel)
+            5185:  7(f16vec4) Load 4962(texel)
                               ReturnValue 5185
                               FunctionEnd
-111(testSparseTextureGradOffsetClamp():    7(fvec4) Function None 8
+111(testSparseTextureGradOffsetClamp():  7(f16vec4) Function None 8
              112:             Label
      5188(texel):     64(ptr) Variable Function
                               Store 5188(texel) 121
@@ -6471,16 +6471,16 @@ spv.float16Fetch.frag
             5192:   53(fvec2) Load 1409(dPdxy2)
             5193:   52(float) Load 4257(lodClamp)
             5194:3102(ResType) ImageSparseSampleExplicitLod 5189 5190 Grad ConstOffset MinLod 5191 5192 722 5193
-            5195:    7(fvec4) CompositeExtract 5194 1
+            5195:  7(f16vec4) CompositeExtract 5194 1
                               Store 5188(texel) 5195
             5196:     47(int) CompositeExtract 5194 0
             5197:         143 Load 145(s2D)
-            5198:  154(fvec2) Load 156(f16c2)
-            5199:  154(fvec2) Load 1417(f16dPdxy2)
-            5200:  154(fvec2) Load 1417(f16dPdxy2)
-            5201:    6(float) Load 4264(f16lodClamp)
+            5198:154(f16vec2) Load 156(f16c2)
+            5199:154(f16vec2) Load 1417(f16dPdxy2)
+            5200:154(f16vec2) Load 1417(f16dPdxy2)
+            5201:6(float16_t) Load 4264(f16lodClamp)
             5202:3102(ResType) ImageSparseSampleExplicitLod 5197 5198 Grad ConstOffset MinLod 5199 5200 722 5201
-            5203:    7(fvec4) CompositeExtract 5202 1
+            5203:  7(f16vec4) CompositeExtract 5202 1
                               Store 5188(texel) 5203
             5204:     47(int) CompositeExtract 5202 0
             5205:         163 Load 165(s3D)
@@ -6489,16 +6489,16 @@ spv.float16Fetch.frag
             5208:  167(fvec3) Load 1425(dPdxy3)
             5209:   52(float) Load 4257(lodClamp)
             5210:3102(ResType) ImageSparseSampleExplicitLod 5205 5206 Grad ConstOffset MinLod 5207 5208 735 5209
-            5211:    7(fvec4) CompositeExtract 5210 1
+            5211:  7(f16vec4) CompositeExtract 5210 1
                               Store 5188(texel) 5211
             5212:     47(int) CompositeExtract 5210 0
             5213:         163 Load 165(s3D)
-            5214:  175(fvec3) Load 177(f16c3)
-            5215:  175(fvec3) Load 1433(f16dPdxy3)
-            5216:  175(fvec3) Load 1433(f16dPdxy3)
-            5217:    6(float) Load 4264(f16lodClamp)
+            5214:175(f16vec3) Load 177(f16c3)
+            5215:175(f16vec3) Load 1433(f16dPdxy3)
+            5216:175(f16vec3) Load 1433(f16dPdxy3)
+            5217:6(float16_t) Load 4264(f16lodClamp)
             5218:3102(ResType) ImageSparseSampleExplicitLod 5213 5214 Grad ConstOffset MinLod 5215 5216 735 5217
-            5219:    7(fvec4) CompositeExtract 5218 1
+            5219:  7(f16vec4) CompositeExtract 5218 1
                               Store 5188(texel) 5219
             5220:     47(int) CompositeExtract 5218 0
             5221:         224 Load 226(s2DShadow)
@@ -6509,18 +6509,18 @@ spv.float16Fetch.frag
             5226:    208(ptr) AccessChain 5188(texel) 207
             5227:   52(float) CompositeExtract 5222 2
             5228:3138(ResType) ImageSparseSampleDrefExplicitLod 5221 5222 5227 Grad ConstOffset MinLod 5223 5224 722 5225
-            5229:    6(float) CompositeExtract 5228 1
+            5229:6(float16_t) CompositeExtract 5228 1
                               Store 5226 5229
             5230:     47(int) CompositeExtract 5228 0
             5231:         224 Load 226(s2DShadow)
-            5232:  154(fvec2) Load 156(f16c2)
+            5232:154(f16vec2) Load 156(f16c2)
             5233:   52(float) Load 215(compare)
-            5234:  154(fvec2) Load 1417(f16dPdxy2)
-            5235:  154(fvec2) Load 1417(f16dPdxy2)
-            5236:    6(float) Load 4264(f16lodClamp)
+            5234:154(f16vec2) Load 1417(f16dPdxy2)
+            5235:154(f16vec2) Load 1417(f16dPdxy2)
+            5236:6(float16_t) Load 4264(f16lodClamp)
             5237:    208(ptr) AccessChain 5188(texel) 207
             5238:3138(ResType) ImageSparseSampleDrefExplicitLod 5231 5232 5233 Grad ConstOffset MinLod 5234 5235 722 5236
-            5239:    6(float) CompositeExtract 5238 1
+            5239:6(float16_t) CompositeExtract 5238 1
                               Store 5237 5239
             5240:     47(int) CompositeExtract 5238 0
             5241:         284 Load 286(s2DArray)
@@ -6529,16 +6529,16 @@ spv.float16Fetch.frag
             5244:   53(fvec2) Load 1409(dPdxy2)
             5245:   52(float) Load 4257(lodClamp)
             5246:3102(ResType) ImageSparseSampleExplicitLod 5241 5242 Grad ConstOffset MinLod 5243 5244 722 5245
-            5247:    7(fvec4) CompositeExtract 5246 1
+            5247:  7(f16vec4) CompositeExtract 5246 1
                               Store 5188(texel) 5247
             5248:     47(int) CompositeExtract 5246 0
             5249:         284 Load 286(s2DArray)
-            5250:  175(fvec3) Load 177(f16c3)
-            5251:  154(fvec2) Load 1417(f16dPdxy2)
-            5252:  154(fvec2) Load 1417(f16dPdxy2)
-            5253:    6(float) Load 4264(f16lodClamp)
+            5250:175(f16vec3) Load 177(f16c3)
+            5251:154(f16vec2) Load 1417(f16dPdxy2)
+            5252:154(f16vec2) Load 1417(f16dPdxy2)
+            5253:6(float16_t) Load 4264(f16lodClamp)
             5254:3102(ResType) ImageSparseSampleExplicitLod 5249 5250 Grad ConstOffset MinLod 5251 5252 722 5253
-            5255:    7(fvec4) CompositeExtract 5254 1
+            5255:  7(f16vec4) CompositeExtract 5254 1
                               Store 5188(texel) 5255
             5256:     47(int) CompositeExtract 5254 0
             5257:         337 Load 339(s2DArrayShadow)
@@ -6549,24 +6549,24 @@ spv.float16Fetch.frag
             5262:    208(ptr) AccessChain 5188(texel) 207
             5263:   52(float) CompositeExtract 5258 3
             5264:3138(ResType) ImageSparseSampleDrefExplicitLod 5257 5258 5263 Grad ConstOffset MinLod 5259 5260 722 5261
-            5265:    6(float) CompositeExtract 5264 1
+            5265:6(float16_t) CompositeExtract 5264 1
                               Store 5262 5265
             5266:     47(int) CompositeExtract 5264 0
             5267:         337 Load 339(s2DArrayShadow)
-            5268:  175(fvec3) Load 177(f16c3)
+            5268:175(f16vec3) Load 177(f16c3)
             5269:   52(float) Load 215(compare)
-            5270:  154(fvec2) Load 1417(f16dPdxy2)
-            5271:  154(fvec2) Load 1417(f16dPdxy2)
-            5272:    6(float) Load 4264(f16lodClamp)
+            5270:154(f16vec2) Load 1417(f16dPdxy2)
+            5271:154(f16vec2) Load 1417(f16dPdxy2)
+            5272:6(float16_t) Load 4264(f16lodClamp)
             5273:    208(ptr) AccessChain 5188(texel) 207
             5274:3138(ResType) ImageSparseSampleDrefExplicitLod 5267 5268 5269 Grad ConstOffset MinLod 5270 5271 722 5272
-            5275:    6(float) CompositeExtract 5274 1
+            5275:6(float16_t) CompositeExtract 5274 1
                               Store 5273 5275
             5276:     47(int) CompositeExtract 5274 0
-            5277:    7(fvec4) Load 5188(texel)
+            5277:  7(f16vec4) Load 5188(texel)
                               ReturnValue 5277
                               FunctionEnd
-113(testTextureGradOffsetClamp():    7(fvec4) Function None 8
+113(testTextureGradOffsetClamp():  7(f16vec4) Function None 8
              114:             Label
      5280(texel):     64(ptr) Variable Function
                               Store 5280(texel) 121
@@ -6575,54 +6575,54 @@ spv.float16Fetch.frag
             5283:   52(float) Load 1393(dPdxy1)
             5284:   52(float) Load 1393(dPdxy1)
             5285:   52(float) Load 4257(lodClamp)
-            5286:    7(fvec4) ImageSampleExplicitLod 5281 5282 Grad ConstOffset MinLod 5283 5284 709 5285
-            5287:    7(fvec4) Load 5280(texel)
-            5288:    7(fvec4) FAdd 5287 5286
+            5286:  7(f16vec4) ImageSampleExplicitLod 5281 5282 Grad ConstOffset MinLod 5283 5284 709 5285
+            5287:  7(f16vec4) Load 5280(texel)
+            5288:  7(f16vec4) FAdd 5287 5286
                               Store 5280(texel) 5288
             5289:         123 Load 125(s1D)
-            5290:    6(float) Load 135(f16c1)
-            5291:    6(float) Load 1401(f16dPdxy1)
-            5292:    6(float) Load 1401(f16dPdxy1)
-            5293:    6(float) Load 4264(f16lodClamp)
-            5294:    7(fvec4) ImageSampleExplicitLod 5289 5290 Grad ConstOffset MinLod 5291 5292 709 5293
-            5295:    7(fvec4) Load 5280(texel)
-            5296:    7(fvec4) FAdd 5295 5294
+            5290:6(float16_t) Load 135(f16c1)
+            5291:6(float16_t) Load 1401(f16dPdxy1)
+            5292:6(float16_t) Load 1401(f16dPdxy1)
+            5293:6(float16_t) Load 4264(f16lodClamp)
+            5294:  7(f16vec4) ImageSampleExplicitLod 5289 5290 Grad ConstOffset MinLod 5291 5292 709 5293
+            5295:  7(f16vec4) Load 5280(texel)
+            5296:  7(f16vec4) FAdd 5295 5294
                               Store 5280(texel) 5296
             5297:         143 Load 145(s2D)
             5298:   53(fvec2) Load 148(c2)
             5299:   53(fvec2) Load 1409(dPdxy2)
             5300:   53(fvec2) Load 1409(dPdxy2)
             5301:   52(float) Load 4257(lodClamp)
-            5302:    7(fvec4) ImageSampleExplicitLod 5297 5298 Grad ConstOffset MinLod 5299 5300 722 5301
-            5303:    7(fvec4) Load 5280(texel)
-            5304:    7(fvec4) FAdd 5303 5302
+            5302:  7(f16vec4) ImageSampleExplicitLod 5297 5298 Grad ConstOffset MinLod 5299 5300 722 5301
+            5303:  7(f16vec4) Load 5280(texel)
+            5304:  7(f16vec4) FAdd 5303 5302
                               Store 5280(texel) 5304
             5305:         143 Load 145(s2D)
-            5306:  154(fvec2) Load 156(f16c2)
-            5307:  154(fvec2) Load 1417(f16dPdxy2)
-            5308:  154(fvec2) Load 1417(f16dPdxy2)
-            5309:    6(float) Load 4264(f16lodClamp)
-            5310:    7(fvec4) ImageSampleExplicitLod 5305 5306 Grad ConstOffset MinLod 5307 5308 722 5309
-            5311:    7(fvec4) Load 5280(texel)
-            5312:    7(fvec4) FAdd 5311 5310
+            5306:154(f16vec2) Load 156(f16c2)
+            5307:154(f16vec2) Load 1417(f16dPdxy2)
+            5308:154(f16vec2) Load 1417(f16dPdxy2)
+            5309:6(float16_t) Load 4264(f16lodClamp)
+            5310:  7(f16vec4) ImageSampleExplicitLod 5305 5306 Grad ConstOffset MinLod 5307 5308 722 5309
+            5311:  7(f16vec4) Load 5280(texel)
+            5312:  7(f16vec4) FAdd 5311 5310
                               Store 5280(texel) 5312
             5313:         163 Load 165(s3D)
             5314:  167(fvec3) Load 169(c3)
             5315:  167(fvec3) Load 1425(dPdxy3)
             5316:  167(fvec3) Load 1425(dPdxy3)
             5317:   52(float) Load 4257(lodClamp)
-            5318:    7(fvec4) ImageSampleExplicitLod 5313 5314 Grad ConstOffset MinLod 5315 5316 735 5317
-            5319:    7(fvec4) Load 5280(texel)
-            5320:    7(fvec4) FAdd 5319 5318
+            5318:  7(f16vec4) ImageSampleExplicitLod 5313 5314 Grad ConstOffset MinLod 5315 5316 735 5317
+            5319:  7(f16vec4) Load 5280(texel)
+            5320:  7(f16vec4) FAdd 5319 5318
                               Store 5280(texel) 5320
             5321:         163 Load 165(s3D)
-            5322:  175(fvec3) Load 177(f16c3)
-            5323:  175(fvec3) Load 1433(f16dPdxy3)
-            5324:  175(fvec3) Load 1433(f16dPdxy3)
-            5325:    6(float) Load 4264(f16lodClamp)
-            5326:    7(fvec4) ImageSampleExplicitLod 5321 5322 Grad ConstOffset MinLod 5323 5324 735 5325
-            5327:    7(fvec4) Load 5280(texel)
-            5328:    7(fvec4) FAdd 5327 5326
+            5322:175(f16vec3) Load 177(f16c3)
+            5323:175(f16vec3) Load 1433(f16dPdxy3)
+            5324:175(f16vec3) Load 1433(f16dPdxy3)
+            5325:6(float16_t) Load 4264(f16lodClamp)
+            5326:  7(f16vec4) ImageSampleExplicitLod 5321 5322 Grad ConstOffset MinLod 5323 5324 735 5325
+            5327:  7(f16vec4) Load 5280(texel)
+            5328:  7(f16vec4) FAdd 5327 5326
                               Store 5280(texel) 5328
             5329:         199 Load 201(s1DShadow)
             5330:  167(fvec3) Load 169(c3)
@@ -6630,22 +6630,22 @@ spv.float16Fetch.frag
             5332:   52(float) Load 1393(dPdxy1)
             5333:   52(float) Load 4257(lodClamp)
             5334:   52(float) CompositeExtract 5330 2
-            5335:    6(float) ImageSampleDrefExplicitLod 5329 5330 5334 Grad ConstOffset MinLod 5331 5332 709 5333
+            5335:6(float16_t) ImageSampleDrefExplicitLod 5329 5330 5334 Grad ConstOffset MinLod 5331 5332 709 5333
             5336:    208(ptr) AccessChain 5280(texel) 207
-            5337:    6(float) Load 5336
-            5338:    6(float) FAdd 5337 5335
+            5337:6(float16_t) Load 5336
+            5338:6(float16_t) FAdd 5337 5335
             5339:    208(ptr) AccessChain 5280(texel) 207
                               Store 5339 5338
             5340:         199 Load 201(s1DShadow)
-            5341:  154(fvec2) Load 156(f16c2)
+            5341:154(f16vec2) Load 156(f16c2)
             5342:   52(float) Load 215(compare)
-            5343:    6(float) Load 1401(f16dPdxy1)
-            5344:    6(float) Load 1401(f16dPdxy1)
-            5345:    6(float) Load 4264(f16lodClamp)
-            5346:    6(float) ImageSampleDrefExplicitLod 5340 5341 5342 Grad ConstOffset MinLod 5343 5344 709 5345
+            5343:6(float16_t) Load 1401(f16dPdxy1)
+            5344:6(float16_t) Load 1401(f16dPdxy1)
+            5345:6(float16_t) Load 4264(f16lodClamp)
+            5346:6(float16_t) ImageSampleDrefExplicitLod 5340 5341 5342 Grad ConstOffset MinLod 5343 5344 709 5345
             5347:    208(ptr) AccessChain 5280(texel) 207
-            5348:    6(float) Load 5347
-            5349:    6(float) FAdd 5348 5346
+            5348:6(float16_t) Load 5347
+            5349:6(float16_t) FAdd 5348 5346
             5350:    208(ptr) AccessChain 5280(texel) 207
                               Store 5350 5349
             5351:         224 Load 226(s2DShadow)
@@ -6654,22 +6654,22 @@ spv.float16Fetch.frag
             5354:   53(fvec2) Load 1409(dPdxy2)
             5355:   52(float) Load 4257(lodClamp)
             5356:   52(float) CompositeExtract 5352 2
-            5357:    6(float) ImageSampleDrefExplicitLod 5351 5352 5356 Grad ConstOffset MinLod 5353 5354 722 5355
+            5357:6(float16_t) ImageSampleDrefExplicitLod 5351 5352 5356 Grad ConstOffset MinLod 5353 5354 722 5355
             5358:    208(ptr) AccessChain 5280(texel) 207
-            5359:    6(float) Load 5358
-            5360:    6(float) FAdd 5359 5357
+            5359:6(float16_t) Load 5358
+            5360:6(float16_t) FAdd 5359 5357
             5361:    208(ptr) AccessChain 5280(texel) 207
                               Store 5361 5360
             5362:         224 Load 226(s2DShadow)
-            5363:  154(fvec2) Load 156(f16c2)
+            5363:154(f16vec2) Load 156(f16c2)
             5364:   52(float) Load 215(compare)
-            5365:  154(fvec2) Load 1417(f16dPdxy2)
-            5366:  154(fvec2) Load 1417(f16dPdxy2)
-            5367:    6(float) Load 4264(f16lodClamp)
-            5368:    6(float) ImageSampleDrefExplicitLod 5362 5363 5364 Grad ConstOffset MinLod 5365 5366 722 5367
+            5365:154(f16vec2) Load 1417(f16dPdxy2)
+            5366:154(f16vec2) Load 1417(f16dPdxy2)
+            5367:6(float16_t) Load 4264(f16lodClamp)
+            5368:6(float16_t) ImageSampleDrefExplicitLod 5362 5363 5364 Grad ConstOffset MinLod 5365 5366 722 5367
             5369:    208(ptr) AccessChain 5280(texel) 207
-            5370:    6(float) Load 5369
-            5371:    6(float) FAdd 5370 5368
+            5370:6(float16_t) Load 5369
+            5371:6(float16_t) FAdd 5370 5368
             5372:    208(ptr) AccessChain 5280(texel) 207
                               Store 5372 5371
             5373:         269 Load 271(s1DArray)
@@ -6677,36 +6677,36 @@ spv.float16Fetch.frag
             5375:   52(float) Load 1393(dPdxy1)
             5376:   52(float) Load 1393(dPdxy1)
             5377:   52(float) Load 4257(lodClamp)
-            5378:    7(fvec4) ImageSampleExplicitLod 5373 5374 Grad ConstOffset MinLod 5375 5376 709 5377
-            5379:    7(fvec4) Load 5280(texel)
-            5380:    7(fvec4) FAdd 5379 5378
+            5378:  7(f16vec4) ImageSampleExplicitLod 5373 5374 Grad ConstOffset MinLod 5375 5376 709 5377
+            5379:  7(f16vec4) Load 5280(texel)
+            5380:  7(f16vec4) FAdd 5379 5378
                               Store 5280(texel) 5380
             5381:         269 Load 271(s1DArray)
-            5382:  154(fvec2) Load 156(f16c2)
-            5383:    6(float) Load 1401(f16dPdxy1)
-            5384:    6(float) Load 1401(f16dPdxy1)
-            5385:    6(float) Load 4264(f16lodClamp)
-            5386:    7(fvec4) ImageSampleExplicitLod 5381 5382 Grad ConstOffset MinLod 5383 5384 709 5385
-            5387:    7(fvec4) Load 5280(texel)
-            5388:    7(fvec4) FAdd 5387 5386
+            5382:154(f16vec2) Load 156(f16c2)
+            5383:6(float16_t) Load 1401(f16dPdxy1)
+            5384:6(float16_t) Load 1401(f16dPdxy1)
+            5385:6(float16_t) Load 4264(f16lodClamp)
+            5386:  7(f16vec4) ImageSampleExplicitLod 5381 5382 Grad ConstOffset MinLod 5383 5384 709 5385
+            5387:  7(f16vec4) Load 5280(texel)
+            5388:  7(f16vec4) FAdd 5387 5386
                               Store 5280(texel) 5388
             5389:         284 Load 286(s2DArray)
             5390:  167(fvec3) Load 169(c3)
             5391:   53(fvec2) Load 1409(dPdxy2)
             5392:   53(fvec2) Load 1409(dPdxy2)
             5393:   52(float) Load 4257(lodClamp)
-            5394:    7(fvec4) ImageSampleExplicitLod 5389 5390 Grad ConstOffset MinLod 5391 5392 722 5393
-            5395:    7(fvec4) Load 5280(texel)
-            5396:    7(fvec4) FAdd 5395 5394
+            5394:  7(f16vec4) ImageSampleExplicitLod 5389 5390 Grad ConstOffset MinLod 5391 5392 722 5393
+            5395:  7(f16vec4) Load 5280(texel)
+            5396:  7(f16vec4) FAdd 5395 5394
                               Store 5280(texel) 5396
             5397:         284 Load 286(s2DArray)
-            5398:  175(fvec3) Load 177(f16c3)
-            5399:  154(fvec2) Load 1417(f16dPdxy2)
-            5400:  154(fvec2) Load 1417(f16dPdxy2)
-            5401:    6(float) Load 4264(f16lodClamp)
-            5402:    7(fvec4) ImageSampleExplicitLod 5397 5398 Grad ConstOffset MinLod 5399 5400 722 5401
-            5403:    7(fvec4) Load 5280(texel)
-            5404:    7(fvec4) FAdd 5403 5402
+            5398:175(f16vec3) Load 177(f16c3)
+            5399:154(f16vec2) Load 1417(f16dPdxy2)
+            5400:154(f16vec2) Load 1417(f16dPdxy2)
+            5401:6(float16_t) Load 4264(f16lodClamp)
+            5402:  7(f16vec4) ImageSampleExplicitLod 5397 5398 Grad ConstOffset MinLod 5399 5400 722 5401
+            5403:  7(f16vec4) Load 5280(texel)
+            5404:  7(f16vec4) FAdd 5403 5402
                               Store 5280(texel) 5404
             5405:         316 Load 318(s1DArrayShadow)
             5406:  167(fvec3) Load 169(c3)
@@ -6714,22 +6714,22 @@ spv.float16Fetch.frag
             5408:   52(float) Load 1393(dPdxy1)
             5409:   52(float) Load 4257(lodClamp)
             5410:   52(float) CompositeExtract 5406 2
-            5411:    6(float) ImageSampleDrefExplicitLod 5405 5406 5410 Grad ConstOffset MinLod 5407 5408 709 5409
+            5411:6(float16_t) ImageSampleDrefExplicitLod 5405 5406 5410 Grad ConstOffset MinLod 5407 5408 709 5409
             5412:    208(ptr) AccessChain 5280(texel) 207
-            5413:    6(float) Load 5412
-            5414:    6(float) FAdd 5413 5411
+            5413:6(float16_t) Load 5412
+            5414:6(float16_t) FAdd 5413 5411
             5415:    208(ptr) AccessChain 5280(texel) 207
                               Store 5415 5414
             5416:         316 Load 318(s1DArrayShadow)
-            5417:  154(fvec2) Load 156(f16c2)
+            5417:154(f16vec2) Load 156(f16c2)
             5418:   52(float) Load 215(compare)
-            5419:    6(float) Load 1401(f16dPdxy1)
-            5420:    6(float) Load 1401(f16dPdxy1)
-            5421:    6(float) Load 4264(f16lodClamp)
-            5422:    6(float) ImageSampleDrefExplicitLod 5416 5417 5418 Grad ConstOffset MinLod 5419 5420 709 5421
+            5419:6(float16_t) Load 1401(f16dPdxy1)
+            5420:6(float16_t) Load 1401(f16dPdxy1)
+            5421:6(float16_t) Load 4264(f16lodClamp)
+            5422:6(float16_t) ImageSampleDrefExplicitLod 5416 5417 5418 Grad ConstOffset MinLod 5419 5420 709 5421
             5423:    208(ptr) AccessChain 5280(texel) 207
-            5424:    6(float) Load 5423
-            5425:    6(float) FAdd 5424 5422
+            5424:6(float16_t) Load 5423
+            5425:6(float16_t) FAdd 5424 5422
             5426:    208(ptr) AccessChain 5280(texel) 207
                               Store 5426 5425
             5427:         337 Load 339(s2DArrayShadow)
@@ -6738,28 +6738,28 @@ spv.float16Fetch.frag
             5430:   53(fvec2) Load 1409(dPdxy2)
             5431:   52(float) Load 4257(lodClamp)
             5432:   52(float) CompositeExtract 5428 3
-            5433:    6(float) ImageSampleDrefExplicitLod 5427 5428 5432 Grad ConstOffset MinLod 5429 5430 722 5431
+            5433:6(float16_t) ImageSampleDrefExplicitLod 5427 5428 5432 Grad ConstOffset MinLod 5429 5430 722 5431
             5434:    208(ptr) AccessChain 5280(texel) 207
-            5435:    6(float) Load 5434
-            5436:    6(float) FAdd 5435 5433
+            5435:6(float16_t) Load 5434
+            5436:6(float16_t) FAdd 5435 5433
             5437:    208(ptr) AccessChain 5280(texel) 207
                               Store 5437 5436
             5438:         337 Load 339(s2DArrayShadow)
-            5439:  175(fvec3) Load 177(f16c3)
+            5439:175(f16vec3) Load 177(f16c3)
             5440:   52(float) Load 215(compare)
-            5441:  154(fvec2) Load 1417(f16dPdxy2)
-            5442:  154(fvec2) Load 1417(f16dPdxy2)
-            5443:    6(float) Load 4264(f16lodClamp)
-            5444:    6(float) ImageSampleDrefExplicitLod 5438 5439 5440 Grad ConstOffset MinLod 5441 5442 722 5443
+            5441:154(f16vec2) Load 1417(f16dPdxy2)
+            5442:154(f16vec2) Load 1417(f16dPdxy2)
+            5443:6(float16_t) Load 4264(f16lodClamp)
+            5444:6(float16_t) ImageSampleDrefExplicitLod 5438 5439 5440 Grad ConstOffset MinLod 5441 5442 722 5443
             5445:    208(ptr) AccessChain 5280(texel) 207
-            5446:    6(float) Load 5445
-            5447:    6(float) FAdd 5446 5444
+            5446:6(float16_t) Load 5445
+            5447:6(float16_t) FAdd 5446 5444
             5448:    208(ptr) AccessChain 5280(texel) 207
                               Store 5448 5447
-            5449:    7(fvec4) Load 5280(texel)
+            5449:  7(f16vec4) Load 5280(texel)
                               ReturnValue 5449
                               FunctionEnd
-115(testCombinedTextureSampler():    7(fvec4) Function None 8
+115(testCombinedTextureSampler():  7(f16vec4) Function None 8
              116:             Label
      5452(texel):     64(ptr) Variable Function
                               Store 5452(texel) 121
@@ -6767,91 +6767,91 @@ spv.float16Fetch.frag
             5459:        5456 Load 5458(s)
             5460:         123 SampledImage 5455 5459
             5461:   52(float) Load 128(c1)
-            5462:    7(fvec4) ImageSampleImplicitLod 5460 5461
-            5463:    7(fvec4) Load 5452(texel)
-            5464:    7(fvec4) FAdd 5463 5462
+            5462:  7(f16vec4) ImageSampleImplicitLod 5460 5461
+            5463:  7(f16vec4) Load 5452(texel)
+            5464:  7(f16vec4) FAdd 5463 5462
                               Store 5452(texel) 5464
             5465:         122 Load 5454(t1D)
             5466:        5456 Load 5458(s)
             5467:         123 SampledImage 5465 5466
-            5468:    6(float) Load 135(f16c1)
-            5469:    6(float) Load 137(f16bias)
-            5470:    7(fvec4) ImageSampleImplicitLod 5467 5468 Bias 5469
-            5471:    7(fvec4) Load 5452(texel)
-            5472:    7(fvec4) FAdd 5471 5470
+            5468:6(float16_t) Load 135(f16c1)
+            5469:6(float16_t) Load 137(f16bias)
+            5470:  7(f16vec4) ImageSampleImplicitLod 5467 5468 Bias 5469
+            5471:  7(f16vec4) Load 5452(texel)
+            5472:  7(f16vec4) FAdd 5471 5470
                               Store 5452(texel) 5472
             5475:         142 Load 5474(t2D)
             5476:        5456 Load 5458(s)
             5477:         143 SampledImage 5475 5476
             5478:   53(fvec2) Load 148(c2)
-            5479:    7(fvec4) ImageSampleImplicitLod 5477 5478
-            5480:    7(fvec4) Load 5452(texel)
-            5481:    7(fvec4) FAdd 5480 5479
+            5479:  7(f16vec4) ImageSampleImplicitLod 5477 5478
+            5480:  7(f16vec4) Load 5452(texel)
+            5481:  7(f16vec4) FAdd 5480 5479
                               Store 5452(texel) 5481
             5482:         142 Load 5474(t2D)
             5483:        5456 Load 5458(s)
             5484:         143 SampledImage 5482 5483
-            5485:  154(fvec2) Load 156(f16c2)
-            5486:    6(float) Load 137(f16bias)
-            5487:    7(fvec4) ImageSampleImplicitLod 5484 5485 Bias 5486
-            5488:    7(fvec4) Load 5452(texel)
-            5489:    7(fvec4) FAdd 5488 5487
+            5485:154(f16vec2) Load 156(f16c2)
+            5486:6(float16_t) Load 137(f16bias)
+            5487:  7(f16vec4) ImageSampleImplicitLod 5484 5485 Bias 5486
+            5488:  7(f16vec4) Load 5452(texel)
+            5489:  7(f16vec4) FAdd 5488 5487
                               Store 5452(texel) 5489
             5492:         162 Load 5491(t3D)
             5493:        5456 Load 5458(s)
             5494:         163 SampledImage 5492 5493
             5495:  167(fvec3) Load 169(c3)
-            5496:    7(fvec4) ImageSampleImplicitLod 5494 5495
-            5497:    7(fvec4) Load 5452(texel)
-            5498:    7(fvec4) FAdd 5497 5496
+            5496:  7(f16vec4) ImageSampleImplicitLod 5494 5495
+            5497:  7(f16vec4) Load 5452(texel)
+            5498:  7(f16vec4) FAdd 5497 5496
                               Store 5452(texel) 5498
             5499:         162 Load 5491(t3D)
             5500:        5456 Load 5458(s)
             5501:         163 SampledImage 5499 5500
-            5502:  175(fvec3) Load 177(f16c3)
-            5503:    6(float) Load 137(f16bias)
-            5504:    7(fvec4) ImageSampleImplicitLod 5501 5502 Bias 5503
-            5505:    7(fvec4) Load 5452(texel)
-            5506:    7(fvec4) FAdd 5505 5504
+            5502:175(f16vec3) Load 177(f16c3)
+            5503:6(float16_t) Load 137(f16bias)
+            5504:  7(f16vec4) ImageSampleImplicitLod 5501 5502 Bias 5503
+            5505:  7(f16vec4) Load 5452(texel)
+            5506:  7(f16vec4) FAdd 5505 5504
                               Store 5452(texel) 5506
             5509:         183 Load 5508(tCube)
             5510:        5456 Load 5458(s)
             5511:         184 SampledImage 5509 5510
             5512:  167(fvec3) Load 169(c3)
-            5513:    7(fvec4) ImageSampleImplicitLod 5511 5512
-            5514:    7(fvec4) Load 5452(texel)
-            5515:    7(fvec4) FAdd 5514 5513
+            5513:  7(f16vec4) ImageSampleImplicitLod 5511 5512
+            5514:  7(f16vec4) Load 5452(texel)
+            5515:  7(f16vec4) FAdd 5514 5513
                               Store 5452(texel) 5515
             5516:         183 Load 5508(tCube)
             5517:        5456 Load 5458(s)
             5518:         184 SampledImage 5516 5517
-            5519:  175(fvec3) Load 177(f16c3)
-            5520:    6(float) Load 137(f16bias)
-            5521:    7(fvec4) ImageSampleImplicitLod 5518 5519 Bias 5520
-            5522:    7(fvec4) Load 5452(texel)
-            5523:    7(fvec4) FAdd 5522 5521
+            5519:175(f16vec3) Load 177(f16c3)
+            5520:6(float16_t) Load 137(f16bias)
+            5521:  7(f16vec4) ImageSampleImplicitLod 5518 5519 Bias 5520
+            5522:  7(f16vec4) Load 5452(texel)
+            5523:  7(f16vec4) FAdd 5522 5521
                               Store 5452(texel) 5523
             5524:         122 Load 5454(t1D)
             5526:        5456 Load 5525(sShadow)
             5527:         199 SampledImage 5524 5526
             5528:  167(fvec3) Load 169(c3)
             5529:   52(float) CompositeExtract 5528 2
-            5530:    6(float) ImageSampleDrefImplicitLod 5527 5528 5529
+            5530:6(float16_t) ImageSampleDrefImplicitLod 5527 5528 5529
             5531:    208(ptr) AccessChain 5452(texel) 207
-            5532:    6(float) Load 5531
-            5533:    6(float) FAdd 5532 5530
+            5532:6(float16_t) Load 5531
+            5533:6(float16_t) FAdd 5532 5530
             5534:    208(ptr) AccessChain 5452(texel) 207
                               Store 5534 5533
             5535:         122 Load 5454(t1D)
             5536:        5456 Load 5525(sShadow)
             5537:         199 SampledImage 5535 5536
-            5538:  154(fvec2) Load 156(f16c2)
+            5538:154(f16vec2) Load 156(f16c2)
             5539:   52(float) Load 215(compare)
-            5540:    6(float) Load 137(f16bias)
-            5541:    6(float) ImageSampleDrefImplicitLod 5537 5538 5539 Bias 5540
+            5540:6(float16_t) Load 137(f16bias)
+            5541:6(float16_t) ImageSampleDrefImplicitLod 5537 5538 5539 Bias 5540
             5542:    208(ptr) AccessChain 5452(texel) 207
-            5543:    6(float) Load 5542
-            5544:    6(float) FAdd 5543 5541
+            5543:6(float16_t) Load 5542
+            5544:6(float16_t) FAdd 5543 5541
             5545:    208(ptr) AccessChain 5452(texel) 207
                               Store 5545 5544
             5546:         142 Load 5474(t2D)
@@ -6859,22 +6859,22 @@ spv.float16Fetch.frag
             5548:         224 SampledImage 5546 5547
             5549:  167(fvec3) Load 169(c3)
             5550:   52(float) CompositeExtract 5549 2
-            5551:    6(float) ImageSampleDrefImplicitLod 5548 5549 5550
+            5551:6(float16_t) ImageSampleDrefImplicitLod 5548 5549 5550
             5552:    208(ptr) AccessChain 5452(texel) 207
-            5553:    6(float) Load 5552
-            5554:    6(float) FAdd 5553 5551
+            5553:6(float16_t) Load 5552
+            5554:6(float16_t) FAdd 5553 5551
             5555:    208(ptr) AccessChain 5452(texel) 207
                               Store 5555 5554
             5556:         142 Load 5474(t2D)
             5557:        5456 Load 5525(sShadow)
             5558:         224 SampledImage 5556 5557
-            5559:  154(fvec2) Load 156(f16c2)
+            5559:154(f16vec2) Load 156(f16c2)
             5560:   52(float) Load 215(compare)
-            5561:    6(float) Load 137(f16bias)
-            5562:    6(float) ImageSampleDrefImplicitLod 5558 5559 5560 Bias 5561
+            5561:6(float16_t) Load 137(f16bias)
+            5562:6(float16_t) ImageSampleDrefImplicitLod 5558 5559 5560 Bias 5561
             5563:    208(ptr) AccessChain 5452(texel) 207
-            5564:    6(float) Load 5563
-            5565:    6(float) FAdd 5564 5562
+            5564:6(float16_t) Load 5563
+            5565:6(float16_t) FAdd 5564 5562
             5566:    208(ptr) AccessChain 5452(texel) 207
                               Store 5566 5565
             5567:         183 Load 5508(tCube)
@@ -6882,96 +6882,96 @@ spv.float16Fetch.frag
             5569:         245 SampledImage 5567 5568
             5570:  249(fvec4) Load 251(c4)
             5571:   52(float) CompositeExtract 5570 3
-            5572:    6(float) ImageSampleDrefImplicitLod 5569 5570 5571
+            5572:6(float16_t) ImageSampleDrefImplicitLod 5569 5570 5571
             5573:    208(ptr) AccessChain 5452(texel) 207
-            5574:    6(float) Load 5573
-            5575:    6(float) FAdd 5574 5572
+            5574:6(float16_t) Load 5573
+            5575:6(float16_t) FAdd 5574 5572
             5576:    208(ptr) AccessChain 5452(texel) 207
                               Store 5576 5575
             5577:         183 Load 5508(tCube)
             5578:        5456 Load 5525(sShadow)
             5579:         245 SampledImage 5577 5578
-            5580:  175(fvec3) Load 177(f16c3)
+            5580:175(f16vec3) Load 177(f16c3)
             5581:   52(float) Load 215(compare)
-            5582:    6(float) Load 137(f16bias)
-            5583:    6(float) ImageSampleDrefImplicitLod 5579 5580 5581 Bias 5582
+            5582:6(float16_t) Load 137(f16bias)
+            5583:6(float16_t) ImageSampleDrefImplicitLod 5579 5580 5581 Bias 5582
             5584:    208(ptr) AccessChain 5452(texel) 207
-            5585:    6(float) Load 5584
-            5586:    6(float) FAdd 5585 5583
+            5585:6(float16_t) Load 5584
+            5586:6(float16_t) FAdd 5585 5583
             5587:    208(ptr) AccessChain 5452(texel) 207
                               Store 5587 5586
             5590:         268 Load 5589(t1DArray)
             5591:        5456 Load 5458(s)
             5592:         269 SampledImage 5590 5591
             5593:   53(fvec2) Load 148(c2)
-            5594:    7(fvec4) ImageSampleImplicitLod 5592 5593
-            5595:    7(fvec4) Load 5452(texel)
-            5596:    7(fvec4) FAdd 5595 5594
+            5594:  7(f16vec4) ImageSampleImplicitLod 5592 5593
+            5595:  7(f16vec4) Load 5452(texel)
+            5596:  7(f16vec4) FAdd 5595 5594
                               Store 5452(texel) 5596
             5597:         268 Load 5589(t1DArray)
             5598:        5456 Load 5458(s)
             5599:         269 SampledImage 5597 5598
-            5600:  154(fvec2) Load 156(f16c2)
-            5601:    6(float) Load 137(f16bias)
-            5602:    7(fvec4) ImageSampleImplicitLod 5599 5600 Bias 5601
-            5603:    7(fvec4) Load 5452(texel)
-            5604:    7(fvec4) FAdd 5603 5602
+            5600:154(f16vec2) Load 156(f16c2)
+            5601:6(float16_t) Load 137(f16bias)
+            5602:  7(f16vec4) ImageSampleImplicitLod 5599 5600 Bias 5601
+            5603:  7(f16vec4) Load 5452(texel)
+            5604:  7(f16vec4) FAdd 5603 5602
                               Store 5452(texel) 5604
             5607:         283 Load 5606(t2DArray)
             5608:        5456 Load 5458(s)
             5609:         284 SampledImage 5607 5608
             5610:  167(fvec3) Load 169(c3)
-            5611:    7(fvec4) ImageSampleImplicitLod 5609 5610
-            5612:    7(fvec4) Load 5452(texel)
-            5613:    7(fvec4) FAdd 5612 5611
+            5611:  7(f16vec4) ImageSampleImplicitLod 5609 5610
+            5612:  7(f16vec4) Load 5452(texel)
+            5613:  7(f16vec4) FAdd 5612 5611
                               Store 5452(texel) 5613
             5614:         283 Load 5606(t2DArray)
             5615:        5456 Load 5458(s)
             5616:         284 SampledImage 5614 5615
-            5617:  175(fvec3) Load 177(f16c3)
-            5618:    6(float) Load 137(f16bias)
-            5619:    7(fvec4) ImageSampleImplicitLod 5616 5617 Bias 5618
-            5620:    7(fvec4) Load 5452(texel)
-            5621:    7(fvec4) FAdd 5620 5619
+            5617:175(f16vec3) Load 177(f16c3)
+            5618:6(float16_t) Load 137(f16bias)
+            5619:  7(f16vec4) ImageSampleImplicitLod 5616 5617 Bias 5618
+            5620:  7(f16vec4) Load 5452(texel)
+            5621:  7(f16vec4) FAdd 5620 5619
                               Store 5452(texel) 5621
             5624:         298 Load 5623(tCubeArray)
             5625:        5456 Load 5458(s)
             5626:         299 SampledImage 5624 5625
             5627:  249(fvec4) Load 251(c4)
-            5628:    7(fvec4) ImageSampleImplicitLod 5626 5627
-            5629:    7(fvec4) Load 5452(texel)
-            5630:    7(fvec4) FAdd 5629 5628
+            5628:  7(f16vec4) ImageSampleImplicitLod 5626 5627
+            5629:  7(f16vec4) Load 5452(texel)
+            5630:  7(f16vec4) FAdd 5629 5628
                               Store 5452(texel) 5630
             5631:         298 Load 5623(tCubeArray)
             5632:        5456 Load 5458(s)
             5633:         299 SampledImage 5631 5632
-            5634:    7(fvec4) Load 309(f16c4)
-            5635:    6(float) Load 137(f16bias)
-            5636:    7(fvec4) ImageSampleImplicitLod 5633 5634 Bias 5635
-            5637:    7(fvec4) Load 5452(texel)
-            5638:    7(fvec4) FAdd 5637 5636
+            5634:  7(f16vec4) Load 309(f16c4)
+            5635:6(float16_t) Load 137(f16bias)
+            5636:  7(f16vec4) ImageSampleImplicitLod 5633 5634 Bias 5635
+            5637:  7(f16vec4) Load 5452(texel)
+            5638:  7(f16vec4) FAdd 5637 5636
                               Store 5452(texel) 5638
             5639:         268 Load 5589(t1DArray)
             5640:        5456 Load 5525(sShadow)
             5641:         316 SampledImage 5639 5640
             5642:  167(fvec3) Load 169(c3)
             5643:   52(float) CompositeExtract 5642 2
-            5644:    6(float) ImageSampleDrefImplicitLod 5641 5642 5643
+            5644:6(float16_t) ImageSampleDrefImplicitLod 5641 5642 5643
             5645:    208(ptr) AccessChain 5452(texel) 207
-            5646:    6(float) Load 5645
-            5647:    6(float) FAdd 5646 5644
+            5646:6(float16_t) Load 5645
+            5647:6(float16_t) FAdd 5646 5644
             5648:    208(ptr) AccessChain 5452(texel) 207
                               Store 5648 5647
             5649:         268 Load 5589(t1DArray)
             5650:        5456 Load 5525(sShadow)
             5651:         316 SampledImage 5649 5650
-            5652:  154(fvec2) Load 156(f16c2)
+            5652:154(f16vec2) Load 156(f16c2)
             5653:   52(float) Load 215(compare)
-            5654:    6(float) Load 137(f16bias)
-            5655:    6(float) ImageSampleDrefImplicitLod 5651 5652 5653 Bias 5654
+            5654:6(float16_t) Load 137(f16bias)
+            5655:6(float16_t) ImageSampleDrefImplicitLod 5651 5652 5653 Bias 5654
             5656:    208(ptr) AccessChain 5452(texel) 207
-            5657:    6(float) Load 5656
-            5658:    6(float) FAdd 5657 5655
+            5657:6(float16_t) Load 5656
+            5658:6(float16_t) FAdd 5657 5655
             5659:    208(ptr) AccessChain 5452(texel) 207
                               Store 5659 5658
             5660:         283 Load 5606(t2DArray)
@@ -6979,59 +6979,59 @@ spv.float16Fetch.frag
             5662:         337 SampledImage 5660 5661
             5663:  249(fvec4) Load 251(c4)
             5664:   52(float) CompositeExtract 5663 3
-            5665:    6(float) ImageSampleDrefImplicitLod 5662 5663 5664
+            5665:6(float16_t) ImageSampleDrefImplicitLod 5662 5663 5664
             5666:    208(ptr) AccessChain 5452(texel) 207
-            5667:    6(float) Load 5666
-            5668:    6(float) FAdd 5667 5665
+            5667:6(float16_t) Load 5666
+            5668:6(float16_t) FAdd 5667 5665
             5669:    208(ptr) AccessChain 5452(texel) 207
                               Store 5669 5668
             5670:         283 Load 5606(t2DArray)
             5671:        5456 Load 5525(sShadow)
             5672:         337 SampledImage 5670 5671
-            5673:  175(fvec3) Load 177(f16c3)
+            5673:175(f16vec3) Load 177(f16c3)
             5674:   52(float) Load 215(compare)
-            5675:    6(float) ImageSampleDrefImplicitLod 5672 5673 5674
+            5675:6(float16_t) ImageSampleDrefImplicitLod 5672 5673 5674
             5676:    208(ptr) AccessChain 5452(texel) 207
-            5677:    6(float) Load 5676
-            5678:    6(float) FAdd 5677 5675
+            5677:6(float16_t) Load 5676
+            5678:6(float16_t) FAdd 5677 5675
             5679:    208(ptr) AccessChain 5452(texel) 207
                               Store 5679 5678
             5682:         356 Load 5681(t2DRect)
             5683:        5456 Load 5458(s)
             5684:         357 SampledImage 5682 5683
             5685:   53(fvec2) Load 148(c2)
-            5686:    7(fvec4) ImageSampleImplicitLod 5684 5685
-            5687:    7(fvec4) Load 5452(texel)
-            5688:    7(fvec4) FAdd 5687 5686
+            5686:  7(f16vec4) ImageSampleImplicitLod 5684 5685
+            5687:  7(f16vec4) Load 5452(texel)
+            5688:  7(f16vec4) FAdd 5687 5686
                               Store 5452(texel) 5688
             5689:         356 Load 5681(t2DRect)
             5690:        5456 Load 5458(s)
             5691:         357 SampledImage 5689 5690
-            5692:  154(fvec2) Load 156(f16c2)
-            5693:    7(fvec4) ImageSampleImplicitLod 5691 5692
-            5694:    7(fvec4) Load 5452(texel)
-            5695:    7(fvec4) FAdd 5694 5693
+            5692:154(f16vec2) Load 156(f16c2)
+            5693:  7(f16vec4) ImageSampleImplicitLod 5691 5692
+            5694:  7(f16vec4) Load 5452(texel)
+            5695:  7(f16vec4) FAdd 5694 5693
                               Store 5452(texel) 5695
             5696:         356 Load 5681(t2DRect)
             5697:        5456 Load 5525(sShadow)
             5698:         371 SampledImage 5696 5697
             5699:  167(fvec3) Load 169(c3)
             5700:   52(float) CompositeExtract 5699 2
-            5701:    6(float) ImageSampleDrefImplicitLod 5698 5699 5700
+            5701:6(float16_t) ImageSampleDrefImplicitLod 5698 5699 5700
             5702:    208(ptr) AccessChain 5452(texel) 207
-            5703:    6(float) Load 5702
-            5704:    6(float) FAdd 5703 5701
+            5703:6(float16_t) Load 5702
+            5704:6(float16_t) FAdd 5703 5701
             5705:    208(ptr) AccessChain 5452(texel) 207
                               Store 5705 5704
             5706:         356 Load 5681(t2DRect)
             5707:        5456 Load 5525(sShadow)
             5708:         371 SampledImage 5706 5707
-            5709:  154(fvec2) Load 156(f16c2)
+            5709:154(f16vec2) Load 156(f16c2)
             5710:   52(float) Load 215(compare)
-            5711:    6(float) ImageSampleDrefImplicitLod 5708 5709 5710
+            5711:6(float16_t) ImageSampleDrefImplicitLod 5708 5709 5710
             5712:    208(ptr) AccessChain 5452(texel) 207
-            5713:    6(float) Load 5712
-            5714:    6(float) FAdd 5713 5711
+            5713:6(float16_t) Load 5712
+            5714:6(float16_t) FAdd 5713 5711
             5715:    208(ptr) AccessChain 5452(texel) 207
                               Store 5715 5714
             5716:         298 Load 5623(tCubeArray)
@@ -7039,32 +7039,32 @@ spv.float16Fetch.frag
             5718:         391 SampledImage 5716 5717
             5719:  249(fvec4) Load 251(c4)
             5720:   52(float) Load 215(compare)
-            5721:    6(float) ImageSampleDrefImplicitLod 5718 5719 5720
+            5721:6(float16_t) ImageSampleDrefImplicitLod 5718 5719 5720
             5722:    208(ptr) AccessChain 5452(texel) 207
-            5723:    6(float) Load 5722
-            5724:    6(float) FAdd 5723 5721
+            5723:6(float16_t) Load 5722
+            5724:6(float16_t) FAdd 5723 5721
             5725:    208(ptr) AccessChain 5452(texel) 207
                               Store 5725 5724
             5726:         298 Load 5623(tCubeArray)
             5727:        5456 Load 5525(sShadow)
             5728:         391 SampledImage 5726 5727
-            5729:    7(fvec4) Load 309(f16c4)
+            5729:  7(f16vec4) Load 309(f16c4)
             5730:   52(float) Load 215(compare)
-            5731:    6(float) ImageSampleDrefImplicitLod 5728 5729 5730
+            5731:6(float16_t) ImageSampleDrefImplicitLod 5728 5729 5730
             5732:    208(ptr) AccessChain 5452(texel) 207
-            5733:    6(float) Load 5732
-            5734:    6(float) FAdd 5733 5731
+            5733:6(float16_t) Load 5732
+            5734:6(float16_t) FAdd 5733 5731
             5735:    208(ptr) AccessChain 5452(texel) 207
                               Store 5735 5734
-            5736:    7(fvec4) Load 5452(texel)
+            5736:  7(f16vec4) Load 5452(texel)
                               ReturnValue 5736
                               FunctionEnd
-117(testSubpassLoad():    7(fvec4) Function None 8
+117(testSubpassLoad():  7(f16vec4) Function None 8
              118:             Label
             5742:        5739 Load 5741(subpass)
-            5744:    7(fvec4) ImageRead 5742 5743
+            5744:  7(f16vec4) ImageRead 5742 5743
             5748:        5745 Load 5747(subpassMS)
-            5749:    7(fvec4) ImageRead 5748 5743 Sample 1326
-            5750:    7(fvec4) FAdd 5744 5749
+            5749:  7(f16vec4) ImageRead 5748 5743 Sample 1326
+            5750:  7(f16vec4) FAdd 5744 5749
                               ReturnValue 5750
                               FunctionEnd

--- a/Test/baseResults/spv.float32.frag.out
+++ b/Test/baseResults/spv.float32.frag.out
@@ -142,8 +142,8 @@ spv.float32.frag
              107:             TypeBool
              108:             TypePointer Function 107(bool)
              149:             TypeFloat 64
-             150:             TypeVector 149(float) 3
-             151:             TypePointer Function 150(fvec3)
+             150:             TypeVector 149(float64_t) 3
+             151:             TypePointer Function 150(f64vec3)
              153:             TypeVector 26(float) 3
              154:             TypePointer Function 153(fvec3)
              158:             TypeVector 107(bool) 3
@@ -152,28 +152,28 @@ spv.float32.frag
              163:  153(fvec3) ConstantComposite 162 162 162
              164:  153(fvec3) ConstantComposite 54 54 54
              172:             TypeFloat 16
-             173:             TypeVector 172(float) 3
-             174:             TypePointer Function 173(fvec3)
+             173:             TypeVector 172(float16_t) 3
+             174:             TypePointer Function 173(f16vec3)
              180:             TypeInt 8 1
-             181:             TypeVector 180(int) 3
-             182:             TypePointer Function 181(ivec3)
+             181:             TypeVector 180(int8_t) 3
+             182:             TypePointer Function 181(i8vec3)
              186:             TypeInt 16 1
-             187:             TypeVector 186(int) 3
-             188:             TypePointer Function 187(ivec3)
+             187:             TypeVector 186(int16_t) 3
+             188:             TypePointer Function 187(i16vec3)
              192:             TypeInt 32 1
              193:             TypeVector 192(int) 3
              194:             TypePointer Function 193(ivec3)
              198:             TypeInt 64 1
-             199:             TypeVector 198(int) 3
-             200:             TypePointer Function 199(ivec3)
+             199:             TypeVector 198(int64_t) 3
+             200:             TypePointer Function 199(i64vec3)
              207:             TypeInt 16 0
-             208:             TypeVector 207(int) 3
-             209:             TypePointer Function 208(ivec3)
+             208:             TypeVector 207(int16_t) 3
+             209:             TypePointer Function 208(i16vec3)
              213:             TypeVector 31(int) 3
              214:             TypePointer Function 213(ivec3)
              218:             TypeInt 64 0
-             219:             TypeVector 218(int) 3
-             220:             TypePointer Function 219(ivec3)
+             219:             TypeVector 218(int64_t) 3
+             220:             TypePointer Function 219(i64vec3)
              224:             TypeVector 26(float) 4
              225:             TypePointer Function 224(fvec4)
     374(ResType):             TypeStruct 153(fvec3) 193(ivec3)
@@ -199,14 +199,14 @@ spv.float32.frag
          519(B1):             TypeStruct 26(float) 27(fvec2) 153(fvec3) 515 409 516 517(S) 518
              520:             TypePointer Uniform 519(B1)
              521:    520(ptr) Variable Uniform
-       522(sf16):  172(float) SpecConstant 12288
+       522(sf16):172(float16_t) SpecConstant 12288
          523(sf):   26(float) SpecConstant 1048576000
-         524(sd):  149(float) SpecConstant 0 1071644672
+         524(sd):149(float64_t) SpecConstant 0 1071644672
              525:   26(float) SpecConstantOp 115 522(sf16)
              526:   26(float) SpecConstantOp 115 522(sf16)
-             527:  149(float) SpecConstantOp 115 526
-             528:  172(float) SpecConstantOp 115 523(sf)
-             529:  172(float) SpecConstantOp 115 524(sd)
+             527:149(float64_t) SpecConstantOp 115 526
+             528:172(float16_t) SpecConstantOp 115 523(sf)
+             529:172(float16_t) SpecConstantOp 115 524(sd)
          4(main):           2 Function None 3
                5:             Label
                               Return
@@ -368,7 +368,7 @@ spv.float32.frag
        215(u32v):    214(ptr) Variable Function
        221(u64v):    220(ptr) Variable Function
              156:  153(fvec3) Load 155(f32v)
-             157:  150(fvec3) FConvert 156
+             157:150(f64vec3) FConvert 156
                               Store 152(f64v) 157
              161:  158(bvec3) Load 160(bv)
              165:  153(fvec3) Select 161 164 163
@@ -376,41 +376,41 @@ spv.float32.frag
              166:  153(fvec3) Load 155(f32v)
              167:  158(bvec3) FOrdNotEqual 166 163
                               Store 160(bv) 167
-             168:  150(fvec3) Load 152(f64v)
+             168:150(f64vec3) Load 152(f64v)
              169:  153(fvec3) FConvert 168
                               Store 155(f32v) 169
              170:  153(fvec3) Load 155(f32v)
-             171:  150(fvec3) FConvert 170
+             171:150(f64vec3) FConvert 170
                               Store 152(f64v) 171
-             176:  173(fvec3) Load 175(f16v)
+             176:173(f16vec3) Load 175(f16v)
              177:  153(fvec3) FConvert 176
                               Store 155(f32v) 177
              178:  153(fvec3) Load 155(f32v)
-             179:  173(fvec3) FConvert 178
+             179:173(f16vec3) FConvert 178
                               Store 175(f16v) 179
              184:  153(fvec3) Load 155(f32v)
-             185:  181(ivec3) ConvertFToS 184
+             185: 181(i8vec3) ConvertFToS 184
                               Store 183(i8v) 185
              190:  153(fvec3) Load 155(f32v)
-             191:  187(ivec3) ConvertFToS 190
+             191:187(i16vec3) ConvertFToS 190
                               Store 189(i16v) 191
              196:  153(fvec3) Load 155(f32v)
              197:  193(ivec3) ConvertFToS 196
                               Store 195(i32v) 197
              202:  153(fvec3) Load 155(f32v)
-             203:  199(ivec3) ConvertFToS 202
+             203:199(i64vec3) ConvertFToS 202
                               Store 201(i64v) 203
              205:  153(fvec3) Load 155(f32v)
-             206:  181(ivec3) ConvertFToS 205
+             206: 181(i8vec3) ConvertFToS 205
                               Store 204(u8v) 206
              211:  153(fvec3) Load 155(f32v)
-             212:  208(ivec3) ConvertFToU 211
+             212:208(i16vec3) ConvertFToU 211
                               Store 210(u16v) 212
              216:  153(fvec3) Load 155(f32v)
              217:  213(ivec3) ConvertFToU 216
                               Store 215(u32v) 217
              222:  153(fvec3) Load 155(f32v)
-             223:  219(ivec3) ConvertFToU 222
+             223:219(i64vec3) ConvertFToU 222
                               Store 221(u64v) 223
                               Return
                               FunctionEnd

--- a/Test/baseResults/spv.float64.frag.out
+++ b/Test/baseResults/spv.float64.frag.out
@@ -127,86 +127,86 @@ spv.float64.frag
                2:             TypeVoid
                3:             TypeFunction 2
               26:             TypeFloat 64
-              27:             TypeVector 26(float) 2
-              28:             TypePointer Function 27(fvec2)
-              30:   26(float) Constant 2696277389 1051772663
+              27:             TypeVector 26(float64_t) 2
+              28:             TypePointer Function 27(f64vec2)
+              30:26(float64_t) Constant 2696277389 1051772663
               31:             TypeInt 32 0
               32:     31(int) Constant 0
-              33:             TypePointer Function 26(float)
-              35:   26(float) Constant 0 3218079744
-              36:   26(float) Constant 3951369912 1067366481
-              37:   27(fvec2) ConstantComposite 35 36
-              54:   26(float) Constant 0 1072693248
-              60:             TypeMatrix 27(fvec2) 2
+              33:             TypePointer Function 26(float64_t)
+              35:26(float64_t) Constant 0 3218079744
+              36:26(float64_t) Constant 3951369912 1067366481
+              37: 27(f64vec2) ConstantComposite 35 36
+              54:26(float64_t) Constant 0 1072693248
+              60:             TypeMatrix 27(f64vec2) 2
               61:             TypePointer Function 60
               88:     31(int) Constant 1
              107:             TypeBool
              108:             TypePointer Function 107(bool)
-             149:             TypeVector 26(float) 3
-             150:             TypePointer Function 149(fvec3)
+             149:             TypeVector 26(float64_t) 3
+             150:             TypePointer Function 149(f64vec3)
              152:             TypeVector 107(bool) 3
              153:             TypePointer Function 152(bvec3)
-             156:   26(float) Constant 0 0
-             157:  149(fvec3) ConstantComposite 156 156 156
-             158:  149(fvec3) ConstantComposite 54 54 54
+             156:26(float64_t) Constant 0 0
+             157:149(f64vec3) ConstantComposite 156 156 156
+             158:149(f64vec3) ConstantComposite 54 54 54
              162:             TypeFloat 16
-             163:             TypeVector 162(float) 3
-             164:             TypePointer Function 163(fvec3)
+             163:             TypeVector 162(float16_t) 3
+             164:             TypePointer Function 163(f16vec3)
              170:             TypeInt 8 1
-             171:             TypeVector 170(int) 3
-             172:             TypePointer Function 171(ivec3)
+             171:             TypeVector 170(int8_t) 3
+             172:             TypePointer Function 171(i8vec3)
              176:             TypeInt 16 1
-             177:             TypeVector 176(int) 3
-             178:             TypePointer Function 177(ivec3)
+             177:             TypeVector 176(int16_t) 3
+             178:             TypePointer Function 177(i16vec3)
              182:             TypeInt 32 1
              183:             TypeVector 182(int) 3
              184:             TypePointer Function 183(ivec3)
              188:             TypeInt 64 1
-             189:             TypeVector 188(int) 3
-             190:             TypePointer Function 189(ivec3)
+             189:             TypeVector 188(int64_t) 3
+             190:             TypePointer Function 189(i64vec3)
              197:             TypeInt 16 0
-             198:             TypeVector 197(int) 3
-             199:             TypePointer Function 198(ivec3)
+             198:             TypeVector 197(int16_t) 3
+             199:             TypePointer Function 198(i16vec3)
              203:             TypeVector 31(int) 3
              204:             TypePointer Function 203(ivec3)
              208:             TypeInt 64 0
-             209:             TypeVector 208(int) 3
-             210:             TypePointer Function 209(ivec3)
-             214:             TypeVector 26(float) 4
-             215:             TypePointer Function 214(fvec4)
-    364(ResType):             TypeStruct 149(fvec3) 183(ivec3)
+             209:             TypeVector 208(int64_t) 3
+             210:             TypePointer Function 209(i64vec3)
+             214:             TypeVector 26(float64_t) 4
+             215:             TypePointer Function 214(f64vec4)
+    364(ResType):             TypeStruct 149(f64vec3) 183(ivec3)
              397:             TypeFloat 32
              398:             TypePointer Function 397(float)
-             402:             TypeMatrix 149(fvec3) 2
+             402:             TypeMatrix 149(f64vec3) 2
              403:             TypePointer Function 402
-             421:             TypeMatrix 27(fvec2) 3
+             421:             TypeMatrix 27(f64vec2) 3
              422:             TypePointer Function 421
-             427:             TypeMatrix 149(fvec3) 3
+             427:             TypeMatrix 149(f64vec3) 3
              428:             TypePointer Function 427
-             432:             TypeMatrix 214(fvec4) 4
+             432:             TypeMatrix 214(f64vec4) 4
              433:             TypePointer Function 432
-             460:             TypePointer Input 149(fvec3)
+             460:             TypePointer Input 149(f64vec3)
       461(if64v):    460(ptr) Variable Input
-             462:             TypePointer Input 26(float)
+             462:             TypePointer Input 26(float64_t)
              499:    182(int) Constant 1
-             504:   26(float) Constant 0 1071644672
-             505:   27(fvec2) ConstantComposite 504 504
+             504:26(float64_t) Constant 0 1071644672
+             505: 27(f64vec2) ConstantComposite 504 504
              507:     31(int) Constant 2
-             508:             TypeArray 26(float) 507
+             508:             TypeArray 26(float64_t) 507
              509:             TypeArray 402 507
-          510(S):             TypeStruct 26(float) 27(fvec2) 149(fvec3)
+          510(S):             TypeStruct 26(float64_t) 27(f64vec2) 149(f64vec3)
              511:             TypeArray 510(S) 507
-         512(B1):             TypeStruct 26(float) 27(fvec2) 149(fvec3) 508 402 509 510(S) 511
+         512(B1):             TypeStruct 26(float64_t) 27(f64vec2) 149(f64vec3) 508 402 509 510(S) 511
              513:             TypePointer Uniform 512(B1)
              514:    513(ptr) Variable Uniform
-       515(sf16):  162(float) SpecConstant 12288
+       515(sf16):162(float16_t) SpecConstant 12288
          516(sf):  397(float) SpecConstant 1048576000
-         517(sd):   26(float) SpecConstant 0 1071644672
+         517(sd):26(float64_t) SpecConstant 0 1071644672
              518:  397(float) SpecConstantOp 115 515(sf16)
              519:  397(float) SpecConstantOp 115 515(sf16)
-             520:   26(float) SpecConstantOp 115 519
-             521:  162(float) SpecConstantOp 115 516(sf)
-             522:  162(float) SpecConstantOp 115 517(sd)
+             520:26(float64_t) SpecConstantOp 115 519
+             521:162(float16_t) SpecConstantOp 115 516(sf)
+             522:162(float16_t) SpecConstantOp 115 517(sd)
          4(main):           2 Function None 3
                5:             Label
                               Return
@@ -216,8 +216,8 @@ spv.float64.frag
         29(f64v):     28(ptr) Variable Function
               34:     33(ptr) AccessChain 29(f64v) 32
                               Store 34 30
-              38:   27(fvec2) Load 29(f64v)
-              39:   27(fvec2) FAdd 38 37
+              38: 27(f64vec2) Load 29(f64v)
+              39: 27(f64vec2) FAdd 38 37
                               Store 29(f64v) 39
                               Return
                               FunctionEnd
@@ -227,125 +227,125 @@ spv.float64.frag
         62(f64m):     61(ptr) Variable Function
          85(f64):     33(ptr) Variable Function
           109(b):    108(ptr) Variable Function
-              41:   27(fvec2) Load 40(f64v)
-              42:   27(fvec2) Load 40(f64v)
-              43:   27(fvec2) FAdd 42 41
+              41: 27(f64vec2) Load 40(f64v)
+              42: 27(f64vec2) Load 40(f64v)
+              43: 27(f64vec2) FAdd 42 41
                               Store 40(f64v) 43
-              44:   27(fvec2) Load 40(f64v)
-              45:   27(fvec2) Load 40(f64v)
-              46:   27(fvec2) FSub 45 44
+              44: 27(f64vec2) Load 40(f64v)
+              45: 27(f64vec2) Load 40(f64v)
+              46: 27(f64vec2) FSub 45 44
                               Store 40(f64v) 46
-              47:   27(fvec2) Load 40(f64v)
-              48:   27(fvec2) Load 40(f64v)
-              49:   27(fvec2) FMul 48 47
+              47: 27(f64vec2) Load 40(f64v)
+              48: 27(f64vec2) Load 40(f64v)
+              49: 27(f64vec2) FMul 48 47
                               Store 40(f64v) 49
-              50:   27(fvec2) Load 40(f64v)
-              51:   27(fvec2) Load 40(f64v)
-              52:   27(fvec2) FDiv 51 50
+              50: 27(f64vec2) Load 40(f64v)
+              51: 27(f64vec2) Load 40(f64v)
+              52: 27(f64vec2) FDiv 51 50
                               Store 40(f64v) 52
-              53:   27(fvec2) Load 40(f64v)
-              55:   27(fvec2) CompositeConstruct 54 54
-              56:   27(fvec2) FAdd 53 55
+              53: 27(f64vec2) Load 40(f64v)
+              55: 27(f64vec2) CompositeConstruct 54 54
+              56: 27(f64vec2) FAdd 53 55
                               Store 40(f64v) 56
-              57:   27(fvec2) Load 40(f64v)
-              58:   27(fvec2) CompositeConstruct 54 54
-              59:   27(fvec2) FSub 57 58
+              57: 27(f64vec2) Load 40(f64v)
+              58: 27(f64vec2) CompositeConstruct 54 54
+              59: 27(f64vec2) FSub 57 58
                               Store 40(f64v) 59
               63:          60 Load 62(f64m)
-              64:   27(fvec2) CompositeConstruct 54 54
-              65:   27(fvec2) CompositeExtract 63 0
-              66:   27(fvec2) FAdd 65 64
-              67:   27(fvec2) CompositeExtract 63 1
-              68:   27(fvec2) FAdd 67 64
+              64: 27(f64vec2) CompositeConstruct 54 54
+              65: 27(f64vec2) CompositeExtract 63 0
+              66: 27(f64vec2) FAdd 65 64
+              67: 27(f64vec2) CompositeExtract 63 1
+              68: 27(f64vec2) FAdd 67 64
               69:          60 CompositeConstruct 66 68
                               Store 62(f64m) 69
               70:          60 Load 62(f64m)
-              71:   27(fvec2) CompositeConstruct 54 54
-              72:   27(fvec2) CompositeExtract 70 0
-              73:   27(fvec2) FSub 72 71
-              74:   27(fvec2) CompositeExtract 70 1
-              75:   27(fvec2) FSub 74 71
+              71: 27(f64vec2) CompositeConstruct 54 54
+              72: 27(f64vec2) CompositeExtract 70 0
+              73: 27(f64vec2) FSub 72 71
+              74: 27(f64vec2) CompositeExtract 70 1
+              75: 27(f64vec2) FSub 74 71
               76:          60 CompositeConstruct 73 75
                               Store 62(f64m) 76
-              77:   27(fvec2) Load 40(f64v)
-              78:   27(fvec2) FNegate 77
+              77: 27(f64vec2) Load 40(f64v)
+              78: 27(f64vec2) FNegate 77
                               Store 40(f64v) 78
               79:          60 Load 62(f64m)
-              80:   27(fvec2) CompositeExtract 79 0
-              81:   27(fvec2) FNegate 80
-              82:   27(fvec2) CompositeExtract 79 1
-              83:   27(fvec2) FNegate 82
+              80: 27(f64vec2) CompositeExtract 79 0
+              81: 27(f64vec2) FNegate 80
+              82: 27(f64vec2) CompositeExtract 79 1
+              83: 27(f64vec2) FNegate 82
               84:          60 CompositeConstruct 81 83
                               Store 62(f64m) 84
               86:     33(ptr) AccessChain 40(f64v) 32
-              87:   26(float) Load 86
+              87:26(float64_t) Load 86
               89:     33(ptr) AccessChain 40(f64v) 88
-              90:   26(float) Load 89
-              91:   26(float) FAdd 87 90
+              90:26(float64_t) Load 89
+              91:26(float64_t) FAdd 87 90
                               Store 85(f64) 91
               92:     33(ptr) AccessChain 40(f64v) 32
-              93:   26(float) Load 92
+              93:26(float64_t) Load 92
               94:     33(ptr) AccessChain 40(f64v) 88
-              95:   26(float) Load 94
-              96:   26(float) FSub 93 95
+              95:26(float64_t) Load 94
+              96:26(float64_t) FSub 93 95
                               Store 85(f64) 96
               97:     33(ptr) AccessChain 40(f64v) 32
-              98:   26(float) Load 97
+              98:26(float64_t) Load 97
               99:     33(ptr) AccessChain 40(f64v) 88
-             100:   26(float) Load 99
-             101:   26(float) FMul 98 100
+             100:26(float64_t) Load 99
+             101:26(float64_t) FMul 98 100
                               Store 85(f64) 101
              102:     33(ptr) AccessChain 40(f64v) 32
-             103:   26(float) Load 102
+             103:26(float64_t) Load 102
              104:     33(ptr) AccessChain 40(f64v) 88
-             105:   26(float) Load 104
-             106:   26(float) FDiv 103 105
+             105:26(float64_t) Load 104
+             106:26(float64_t) FDiv 103 105
                               Store 85(f64) 106
              110:     33(ptr) AccessChain 40(f64v) 32
-             111:   26(float) Load 110
-             112:   26(float) Load 85(f64)
+             111:26(float64_t) Load 110
+             112:26(float64_t) Load 85(f64)
              113:   107(bool) FOrdNotEqual 111 112
                               Store 109(b) 113
              114:     33(ptr) AccessChain 40(f64v) 88
-             115:   26(float) Load 114
-             116:   26(float) Load 85(f64)
+             115:26(float64_t) Load 114
+             116:26(float64_t) Load 85(f64)
              117:   107(bool) FOrdEqual 115 116
                               Store 109(b) 117
              118:     33(ptr) AccessChain 40(f64v) 32
-             119:   26(float) Load 118
-             120:   26(float) Load 85(f64)
+             119:26(float64_t) Load 118
+             120:26(float64_t) Load 85(f64)
              121:   107(bool) FOrdGreaterThan 119 120
                               Store 109(b) 121
              122:     33(ptr) AccessChain 40(f64v) 88
-             123:   26(float) Load 122
-             124:   26(float) Load 85(f64)
+             123:26(float64_t) Load 122
+             124:26(float64_t) Load 85(f64)
              125:   107(bool) FOrdLessThan 123 124
                               Store 109(b) 125
              126:     33(ptr) AccessChain 40(f64v) 32
-             127:   26(float) Load 126
-             128:   26(float) Load 85(f64)
+             127:26(float64_t) Load 126
+             128:26(float64_t) Load 85(f64)
              129:   107(bool) FOrdGreaterThanEqual 127 128
                               Store 109(b) 129
              130:     33(ptr) AccessChain 40(f64v) 88
-             131:   26(float) Load 130
-             132:   26(float) Load 85(f64)
+             131:26(float64_t) Load 130
+             132:26(float64_t) Load 85(f64)
              133:   107(bool) FOrdLessThanEqual 131 132
                               Store 109(b) 133
-             134:   27(fvec2) Load 40(f64v)
-             135:   26(float) Load 85(f64)
-             136:   27(fvec2) VectorTimesScalar 134 135
+             134: 27(f64vec2) Load 40(f64v)
+             135:26(float64_t) Load 85(f64)
+             136: 27(f64vec2) VectorTimesScalar 134 135
                               Store 40(f64v) 136
              137:          60 Load 62(f64m)
-             138:   26(float) Load 85(f64)
+             138:26(float64_t) Load 85(f64)
              139:          60 MatrixTimesScalar 137 138
                               Store 62(f64m) 139
              140:          60 Load 62(f64m)
-             141:   27(fvec2) Load 40(f64v)
-             142:   27(fvec2) MatrixTimesVector 140 141
+             141: 27(f64vec2) Load 40(f64v)
+             142: 27(f64vec2) MatrixTimesVector 140 141
                               Store 40(f64v) 142
-             143:   27(fvec2) Load 40(f64v)
+             143: 27(f64vec2) Load 40(f64v)
              144:          60 Load 62(f64m)
-             145:   27(fvec2) VectorTimesMatrix 143 144
+             145: 27(f64vec2) VectorTimesMatrix 143 144
                               Store 40(f64v) 145
              146:          60 Load 62(f64m)
              147:          60 Load 62(f64m)
@@ -367,40 +367,40 @@ spv.float64.frag
        205(u32v):    204(ptr) Variable Function
        211(u64v):    210(ptr) Variable Function
              155:  152(bvec3) Load 154(bv)
-             159:  149(fvec3) Select 155 158 157
+             159:149(f64vec3) Select 155 158 157
                               Store 151(f64v) 159
-             160:  149(fvec3) Load 151(f64v)
+             160:149(f64vec3) Load 151(f64v)
              161:  152(bvec3) FOrdNotEqual 160 157
                               Store 154(bv) 161
-             166:  163(fvec3) Load 165(f16v)
-             167:  149(fvec3) FConvert 166
+             166:163(f16vec3) Load 165(f16v)
+             167:149(f64vec3) FConvert 166
                               Store 151(f64v) 167
-             168:  149(fvec3) Load 151(f64v)
-             169:  163(fvec3) FConvert 168
+             168:149(f64vec3) Load 151(f64v)
+             169:163(f16vec3) FConvert 168
                               Store 165(f16v) 169
-             174:  149(fvec3) Load 151(f64v)
-             175:  171(ivec3) ConvertFToS 174
+             174:149(f64vec3) Load 151(f64v)
+             175: 171(i8vec3) ConvertFToS 174
                               Store 173(i8v) 175
-             180:  149(fvec3) Load 151(f64v)
-             181:  177(ivec3) ConvertFToS 180
+             180:149(f64vec3) Load 151(f64v)
+             181:177(i16vec3) ConvertFToS 180
                               Store 179(i16v) 181
-             186:  149(fvec3) Load 151(f64v)
+             186:149(f64vec3) Load 151(f64v)
              187:  183(ivec3) ConvertFToS 186
                               Store 185(i32v) 187
-             192:  149(fvec3) Load 151(f64v)
-             193:  189(ivec3) ConvertFToS 192
+             192:149(f64vec3) Load 151(f64v)
+             193:189(i64vec3) ConvertFToS 192
                               Store 191(i64v) 193
-             195:  149(fvec3) Load 151(f64v)
-             196:  171(ivec3) ConvertFToS 195
+             195:149(f64vec3) Load 151(f64v)
+             196: 171(i8vec3) ConvertFToS 195
                               Store 194(u8v) 196
-             201:  149(fvec3) Load 151(f64v)
-             202:  198(ivec3) ConvertFToU 201
+             201:149(f64vec3) Load 151(f64v)
+             202:198(i16vec3) ConvertFToU 201
                               Store 200(u16v) 202
-             206:  149(fvec3) Load 151(f64v)
+             206:149(f64vec3) Load 151(f64v)
              207:  203(ivec3) ConvertFToU 206
                               Store 205(u32v) 207
-             212:  149(fvec3) Load 151(f64v)
-             213:  209(ivec3) ConvertFToU 212
+             212:149(f64vec3) Load 151(f64v)
+             213:209(i64vec3) ConvertFToU 212
                               Store 211(u64v) 213
                               Return
                               FunctionEnd
@@ -408,51 +408,51 @@ spv.float64.frag
               13:             Label
       216(f64v2):    215(ptr) Variable Function
       217(f64v1):    215(ptr) Variable Function
-             218:  214(fvec4) Load 217(f64v1)
-             219:  214(fvec4) ExtInst 1(GLSL.std.450) 11(Radians) 218
+             218:214(f64vec4) Load 217(f64v1)
+             219:214(f64vec4) ExtInst 1(GLSL.std.450) 11(Radians) 218
                               Store 216(f64v2) 219
-             220:  214(fvec4) Load 217(f64v1)
-             221:  214(fvec4) ExtInst 1(GLSL.std.450) 12(Degrees) 220
+             220:214(f64vec4) Load 217(f64v1)
+             221:214(f64vec4) ExtInst 1(GLSL.std.450) 12(Degrees) 220
                               Store 216(f64v2) 221
-             222:  214(fvec4) Load 217(f64v1)
-             223:  214(fvec4) ExtInst 1(GLSL.std.450) 13(Sin) 222
+             222:214(f64vec4) Load 217(f64v1)
+             223:214(f64vec4) ExtInst 1(GLSL.std.450) 13(Sin) 222
                               Store 216(f64v2) 223
-             224:  214(fvec4) Load 217(f64v1)
-             225:  214(fvec4) ExtInst 1(GLSL.std.450) 14(Cos) 224
+             224:214(f64vec4) Load 217(f64v1)
+             225:214(f64vec4) ExtInst 1(GLSL.std.450) 14(Cos) 224
                               Store 216(f64v2) 225
-             226:  214(fvec4) Load 217(f64v1)
-             227:  214(fvec4) ExtInst 1(GLSL.std.450) 15(Tan) 226
+             226:214(f64vec4) Load 217(f64v1)
+             227:214(f64vec4) ExtInst 1(GLSL.std.450) 15(Tan) 226
                               Store 216(f64v2) 227
-             228:  214(fvec4) Load 217(f64v1)
-             229:  214(fvec4) ExtInst 1(GLSL.std.450) 16(Asin) 228
+             228:214(f64vec4) Load 217(f64v1)
+             229:214(f64vec4) ExtInst 1(GLSL.std.450) 16(Asin) 228
                               Store 216(f64v2) 229
-             230:  214(fvec4) Load 217(f64v1)
-             231:  214(fvec4) ExtInst 1(GLSL.std.450) 17(Acos) 230
+             230:214(f64vec4) Load 217(f64v1)
+             231:214(f64vec4) ExtInst 1(GLSL.std.450) 17(Acos) 230
                               Store 216(f64v2) 231
-             232:  214(fvec4) Load 217(f64v1)
-             233:  214(fvec4) Load 216(f64v2)
-             234:  214(fvec4) ExtInst 1(GLSL.std.450) 25(Atan2) 232 233
+             232:214(f64vec4) Load 217(f64v1)
+             233:214(f64vec4) Load 216(f64v2)
+             234:214(f64vec4) ExtInst 1(GLSL.std.450) 25(Atan2) 232 233
                               Store 216(f64v2) 234
-             235:  214(fvec4) Load 217(f64v1)
-             236:  214(fvec4) ExtInst 1(GLSL.std.450) 18(Atan) 235
+             235:214(f64vec4) Load 217(f64v1)
+             236:214(f64vec4) ExtInst 1(GLSL.std.450) 18(Atan) 235
                               Store 216(f64v2) 236
-             237:  214(fvec4) Load 217(f64v1)
-             238:  214(fvec4) ExtInst 1(GLSL.std.450) 19(Sinh) 237
+             237:214(f64vec4) Load 217(f64v1)
+             238:214(f64vec4) ExtInst 1(GLSL.std.450) 19(Sinh) 237
                               Store 216(f64v2) 238
-             239:  214(fvec4) Load 217(f64v1)
-             240:  214(fvec4) ExtInst 1(GLSL.std.450) 20(Cosh) 239
+             239:214(f64vec4) Load 217(f64v1)
+             240:214(f64vec4) ExtInst 1(GLSL.std.450) 20(Cosh) 239
                               Store 216(f64v2) 240
-             241:  214(fvec4) Load 217(f64v1)
-             242:  214(fvec4) ExtInst 1(GLSL.std.450) 21(Tanh) 241
+             241:214(f64vec4) Load 217(f64v1)
+             242:214(f64vec4) ExtInst 1(GLSL.std.450) 21(Tanh) 241
                               Store 216(f64v2) 242
-             243:  214(fvec4) Load 217(f64v1)
-             244:  214(fvec4) ExtInst 1(GLSL.std.450) 22(Asinh) 243
+             243:214(f64vec4) Load 217(f64v1)
+             244:214(f64vec4) ExtInst 1(GLSL.std.450) 22(Asinh) 243
                               Store 216(f64v2) 244
-             245:  214(fvec4) Load 217(f64v1)
-             246:  214(fvec4) ExtInst 1(GLSL.std.450) 23(Acosh) 245
+             245:214(f64vec4) Load 217(f64v1)
+             246:214(f64vec4) ExtInst 1(GLSL.std.450) 23(Acosh) 245
                               Store 216(f64v2) 246
-             247:  214(fvec4) Load 217(f64v1)
-             248:  214(fvec4) ExtInst 1(GLSL.std.450) 24(Atanh) 247
+             247:214(f64vec4) Load 217(f64v1)
+             248:214(f64vec4) ExtInst 1(GLSL.std.450) 24(Atanh) 247
                               Store 216(f64v2) 248
                               Return
                               FunctionEnd
@@ -460,27 +460,27 @@ spv.float64.frag
               15:             Label
       249(f64v2):     28(ptr) Variable Function
       250(f64v1):     28(ptr) Variable Function
-             251:   27(fvec2) Load 250(f64v1)
-             252:   27(fvec2) Load 249(f64v2)
-             253:   27(fvec2) ExtInst 1(GLSL.std.450) 26(Pow) 251 252
+             251: 27(f64vec2) Load 250(f64v1)
+             252: 27(f64vec2) Load 249(f64v2)
+             253: 27(f64vec2) ExtInst 1(GLSL.std.450) 26(Pow) 251 252
                               Store 249(f64v2) 253
-             254:   27(fvec2) Load 250(f64v1)
-             255:   27(fvec2) ExtInst 1(GLSL.std.450) 27(Exp) 254
+             254: 27(f64vec2) Load 250(f64v1)
+             255: 27(f64vec2) ExtInst 1(GLSL.std.450) 27(Exp) 254
                               Store 249(f64v2) 255
-             256:   27(fvec2) Load 250(f64v1)
-             257:   27(fvec2) ExtInst 1(GLSL.std.450) 28(Log) 256
+             256: 27(f64vec2) Load 250(f64v1)
+             257: 27(f64vec2) ExtInst 1(GLSL.std.450) 28(Log) 256
                               Store 249(f64v2) 257
-             258:   27(fvec2) Load 250(f64v1)
-             259:   27(fvec2) ExtInst 1(GLSL.std.450) 29(Exp2) 258
+             258: 27(f64vec2) Load 250(f64v1)
+             259: 27(f64vec2) ExtInst 1(GLSL.std.450) 29(Exp2) 258
                               Store 249(f64v2) 259
-             260:   27(fvec2) Load 250(f64v1)
-             261:   27(fvec2) ExtInst 1(GLSL.std.450) 30(Log2) 260
+             260: 27(f64vec2) Load 250(f64v1)
+             261: 27(f64vec2) ExtInst 1(GLSL.std.450) 30(Log2) 260
                               Store 249(f64v2) 261
-             262:   27(fvec2) Load 250(f64v1)
-             263:   27(fvec2) ExtInst 1(GLSL.std.450) 31(Sqrt) 262
+             262: 27(f64vec2) Load 250(f64v1)
+             263: 27(f64vec2) ExtInst 1(GLSL.std.450) 31(Sqrt) 262
                               Store 249(f64v2) 263
-             264:   27(fvec2) Load 250(f64v1)
-             265:   27(fvec2) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 264
+             264: 27(f64vec2) Load 250(f64v1)
+             265: 27(f64vec2) ExtInst 1(GLSL.std.450) 32(InverseSqrt) 264
                               Store 249(f64v2) 265
                               Return
                               FunctionEnd
@@ -493,132 +493,132 @@ spv.float64.frag
          332(bv):    153(ptr) Variable Function
           353(b):    108(ptr) Variable Function
          363(iv):    184(ptr) Variable Function
-             268:  149(fvec3) Load 267(f64v1)
-             269:  149(fvec3) ExtInst 1(GLSL.std.450) 4(FAbs) 268
+             268:149(f64vec3) Load 267(f64v1)
+             269:149(f64vec3) ExtInst 1(GLSL.std.450) 4(FAbs) 268
                               Store 266(f64v2) 269
-             270:  149(fvec3) Load 267(f64v1)
-             271:  149(fvec3) ExtInst 1(GLSL.std.450) 6(FSign) 270
+             270:149(f64vec3) Load 267(f64v1)
+             271:149(f64vec3) ExtInst 1(GLSL.std.450) 6(FSign) 270
                               Store 266(f64v2) 271
-             272:  149(fvec3) Load 267(f64v1)
-             273:  149(fvec3) ExtInst 1(GLSL.std.450) 8(Floor) 272
+             272:149(f64vec3) Load 267(f64v1)
+             273:149(f64vec3) ExtInst 1(GLSL.std.450) 8(Floor) 272
                               Store 266(f64v2) 273
-             274:  149(fvec3) Load 267(f64v1)
-             275:  149(fvec3) ExtInst 1(GLSL.std.450) 3(Trunc) 274
+             274:149(f64vec3) Load 267(f64v1)
+             275:149(f64vec3) ExtInst 1(GLSL.std.450) 3(Trunc) 274
                               Store 266(f64v2) 275
-             276:  149(fvec3) Load 267(f64v1)
-             277:  149(fvec3) ExtInst 1(GLSL.std.450) 1(Round) 276
+             276:149(f64vec3) Load 267(f64v1)
+             277:149(f64vec3) ExtInst 1(GLSL.std.450) 1(Round) 276
                               Store 266(f64v2) 277
-             278:  149(fvec3) Load 267(f64v1)
-             279:  149(fvec3) ExtInst 1(GLSL.std.450) 2(RoundEven) 278
+             278:149(f64vec3) Load 267(f64v1)
+             279:149(f64vec3) ExtInst 1(GLSL.std.450) 2(RoundEven) 278
                               Store 266(f64v2) 279
-             280:  149(fvec3) Load 267(f64v1)
-             281:  149(fvec3) ExtInst 1(GLSL.std.450) 9(Ceil) 280
+             280:149(f64vec3) Load 267(f64v1)
+             281:149(f64vec3) ExtInst 1(GLSL.std.450) 9(Ceil) 280
                               Store 266(f64v2) 281
-             282:  149(fvec3) Load 267(f64v1)
-             283:  149(fvec3) ExtInst 1(GLSL.std.450) 10(Fract) 282
+             282:149(f64vec3) Load 267(f64v1)
+             283:149(f64vec3) ExtInst 1(GLSL.std.450) 10(Fract) 282
                               Store 266(f64v2) 283
-             284:  149(fvec3) Load 267(f64v1)
-             285:  149(fvec3) Load 266(f64v2)
-             286:  149(fvec3) FMod 284 285
+             284:149(f64vec3) Load 267(f64v1)
+             285:149(f64vec3) Load 266(f64v2)
+             286:149(f64vec3) FMod 284 285
                               Store 266(f64v2) 286
-             287:  149(fvec3) Load 267(f64v1)
-             289:   26(float) Load 288(f64)
-             290:  149(fvec3) CompositeConstruct 289 289 289
-             291:  149(fvec3) FMod 287 290
+             287:149(f64vec3) Load 267(f64v1)
+             289:26(float64_t) Load 288(f64)
+             290:149(f64vec3) CompositeConstruct 289 289 289
+             291:149(f64vec3) FMod 287 290
                               Store 266(f64v2) 291
-             293:  149(fvec3) Load 267(f64v1)
-             294:  149(fvec3) ExtInst 1(GLSL.std.450) 35(Modf) 293 266(f64v2)
+             293:149(f64vec3) Load 267(f64v1)
+             294:149(f64vec3) ExtInst 1(GLSL.std.450) 35(Modf) 293 266(f64v2)
                               Store 292(f64v3) 294
-             295:  149(fvec3) Load 267(f64v1)
-             296:  149(fvec3) Load 266(f64v2)
-             297:  149(fvec3) ExtInst 1(GLSL.std.450) 37(FMin) 295 296
+             295:149(f64vec3) Load 267(f64v1)
+             296:149(f64vec3) Load 266(f64v2)
+             297:149(f64vec3) ExtInst 1(GLSL.std.450) 37(FMin) 295 296
                               Store 292(f64v3) 297
-             298:  149(fvec3) Load 267(f64v1)
-             299:   26(float) Load 288(f64)
-             300:  149(fvec3) CompositeConstruct 299 299 299
-             301:  149(fvec3) ExtInst 1(GLSL.std.450) 37(FMin) 298 300
+             298:149(f64vec3) Load 267(f64v1)
+             299:26(float64_t) Load 288(f64)
+             300:149(f64vec3) CompositeConstruct 299 299 299
+             301:149(f64vec3) ExtInst 1(GLSL.std.450) 37(FMin) 298 300
                               Store 292(f64v3) 301
-             302:  149(fvec3) Load 267(f64v1)
-             303:  149(fvec3) Load 266(f64v2)
-             304:  149(fvec3) ExtInst 1(GLSL.std.450) 40(FMax) 302 303
+             302:149(f64vec3) Load 267(f64v1)
+             303:149(f64vec3) Load 266(f64v2)
+             304:149(f64vec3) ExtInst 1(GLSL.std.450) 40(FMax) 302 303
                               Store 292(f64v3) 304
-             305:  149(fvec3) Load 267(f64v1)
-             306:   26(float) Load 288(f64)
-             307:  149(fvec3) CompositeConstruct 306 306 306
-             308:  149(fvec3) ExtInst 1(GLSL.std.450) 40(FMax) 305 307
+             305:149(f64vec3) Load 267(f64v1)
+             306:26(float64_t) Load 288(f64)
+             307:149(f64vec3) CompositeConstruct 306 306 306
+             308:149(f64vec3) ExtInst 1(GLSL.std.450) 40(FMax) 305 307
                               Store 292(f64v3) 308
-             309:  149(fvec3) Load 267(f64v1)
-             310:   26(float) Load 288(f64)
+             309:149(f64vec3) Load 267(f64v1)
+             310:26(float64_t) Load 288(f64)
              311:     33(ptr) AccessChain 266(f64v2) 32
-             312:   26(float) Load 311
-             313:  149(fvec3) CompositeConstruct 310 310 310
-             314:  149(fvec3) CompositeConstruct 312 312 312
-             315:  149(fvec3) ExtInst 1(GLSL.std.450) 43(FClamp) 309 313 314
+             312:26(float64_t) Load 311
+             313:149(f64vec3) CompositeConstruct 310 310 310
+             314:149(f64vec3) CompositeConstruct 312 312 312
+             315:149(f64vec3) ExtInst 1(GLSL.std.450) 43(FClamp) 309 313 314
                               Store 292(f64v3) 315
-             316:  149(fvec3) Load 267(f64v1)
-             317:  149(fvec3) Load 266(f64v2)
-             318:   26(float) Load 288(f64)
-             319:  149(fvec3) CompositeConstruct 318 318 318
-             320:  149(fvec3) ExtInst 1(GLSL.std.450) 43(FClamp) 316 317 319
+             316:149(f64vec3) Load 267(f64v1)
+             317:149(f64vec3) Load 266(f64v2)
+             318:26(float64_t) Load 288(f64)
+             319:149(f64vec3) CompositeConstruct 318 318 318
+             320:149(f64vec3) ExtInst 1(GLSL.std.450) 43(FClamp) 316 317 319
                               Store 292(f64v3) 320
-             321:  149(fvec3) Load 267(f64v1)
-             322:  149(fvec3) Load 266(f64v2)
-             323:   26(float) Load 288(f64)
-             324:  149(fvec3) CompositeConstruct 323 323 323
-             325:  149(fvec3) ExtInst 1(GLSL.std.450) 46(FMix) 321 322 324
+             321:149(f64vec3) Load 267(f64v1)
+             322:149(f64vec3) Load 266(f64v2)
+             323:26(float64_t) Load 288(f64)
+             324:149(f64vec3) CompositeConstruct 323 323 323
+             325:149(f64vec3) ExtInst 1(GLSL.std.450) 46(FMix) 321 322 324
                               Store 292(f64v3) 325
-             326:  149(fvec3) Load 267(f64v1)
-             327:  149(fvec3) Load 266(f64v2)
-             328:  149(fvec3) Load 292(f64v3)
-             329:  149(fvec3) ExtInst 1(GLSL.std.450) 46(FMix) 326 327 328
+             326:149(f64vec3) Load 267(f64v1)
+             327:149(f64vec3) Load 266(f64v2)
+             328:149(f64vec3) Load 292(f64v3)
+             329:149(f64vec3) ExtInst 1(GLSL.std.450) 46(FMix) 326 327 328
                               Store 292(f64v3) 329
-             330:  149(fvec3) Load 267(f64v1)
-             331:  149(fvec3) Load 266(f64v2)
+             330:149(f64vec3) Load 267(f64v1)
+             331:149(f64vec3) Load 266(f64v2)
              333:  152(bvec3) Load 332(bv)
-             334:  149(fvec3) Select 333 331 330
+             334:149(f64vec3) Select 333 331 330
                               Store 292(f64v3) 334
-             335:  149(fvec3) Load 267(f64v1)
-             336:  149(fvec3) Load 266(f64v2)
-             337:  149(fvec3) ExtInst 1(GLSL.std.450) 48(Step) 335 336
+             335:149(f64vec3) Load 267(f64v1)
+             336:149(f64vec3) Load 266(f64v2)
+             337:149(f64vec3) ExtInst 1(GLSL.std.450) 48(Step) 335 336
                               Store 292(f64v3) 337
-             338:   26(float) Load 288(f64)
-             339:  149(fvec3) Load 292(f64v3)
-             340:  149(fvec3) CompositeConstruct 338 338 338
-             341:  149(fvec3) ExtInst 1(GLSL.std.450) 48(Step) 340 339
+             338:26(float64_t) Load 288(f64)
+             339:149(f64vec3) Load 292(f64v3)
+             340:149(f64vec3) CompositeConstruct 338 338 338
+             341:149(f64vec3) ExtInst 1(GLSL.std.450) 48(Step) 340 339
                               Store 292(f64v3) 341
-             342:  149(fvec3) Load 267(f64v1)
-             343:  149(fvec3) Load 266(f64v2)
-             344:  149(fvec3) Load 292(f64v3)
-             345:  149(fvec3) ExtInst 1(GLSL.std.450) 49(SmoothStep) 342 343 344
+             342:149(f64vec3) Load 267(f64v1)
+             343:149(f64vec3) Load 266(f64v2)
+             344:149(f64vec3) Load 292(f64v3)
+             345:149(f64vec3) ExtInst 1(GLSL.std.450) 49(SmoothStep) 342 343 344
                               Store 292(f64v3) 345
-             346:   26(float) Load 288(f64)
+             346:26(float64_t) Load 288(f64)
              347:     33(ptr) AccessChain 267(f64v1) 32
-             348:   26(float) Load 347
-             349:  149(fvec3) Load 266(f64v2)
-             350:  149(fvec3) CompositeConstruct 346 346 346
-             351:  149(fvec3) CompositeConstruct 348 348 348
-             352:  149(fvec3) ExtInst 1(GLSL.std.450) 49(SmoothStep) 350 351 349
+             348:26(float64_t) Load 347
+             349:149(f64vec3) Load 266(f64v2)
+             350:149(f64vec3) CompositeConstruct 346 346 346
+             351:149(f64vec3) CompositeConstruct 348 348 348
+             352:149(f64vec3) ExtInst 1(GLSL.std.450) 49(SmoothStep) 350 351 349
                               Store 292(f64v3) 352
-             354:   26(float) Load 288(f64)
+             354:26(float64_t) Load 288(f64)
              355:   107(bool) IsNan 354
                               Store 353(b) 355
-             356:  149(fvec3) Load 267(f64v1)
+             356:149(f64vec3) Load 267(f64v1)
              357:  152(bvec3) IsInf 356
                               Store 332(bv) 357
-             358:  149(fvec3) Load 267(f64v1)
-             359:  149(fvec3) Load 266(f64v2)
-             360:  149(fvec3) Load 292(f64v3)
-             361:  149(fvec3) ExtInst 1(GLSL.std.450) 50(Fma) 358 359 360
+             358:149(f64vec3) Load 267(f64v1)
+             359:149(f64vec3) Load 266(f64v2)
+             360:149(f64vec3) Load 292(f64v3)
+             361:149(f64vec3) ExtInst 1(GLSL.std.450) 50(Fma) 358 359 360
                               Store 292(f64v3) 361
-             362:  149(fvec3) Load 267(f64v1)
+             362:149(f64vec3) Load 267(f64v1)
              365:364(ResType) ExtInst 1(GLSL.std.450) 52(FrexpStruct) 362
              366:  183(ivec3) CompositeExtract 365 1
                               Store 363(iv) 366
-             367:  149(fvec3) CompositeExtract 365 0
+             367:149(f64vec3) CompositeExtract 365 0
                               Store 266(f64v2) 367
-             368:  149(fvec3) Load 267(f64v1)
+             368:149(f64vec3) Load 267(f64v1)
              369:  183(ivec3) Load 363(iv)
-             370:  149(fvec3) ExtInst 1(GLSL.std.450) 53(Ldexp) 368 369
+             370:149(f64vec3) ExtInst 1(GLSL.std.450) 53(Ldexp) 368 369
                               Store 266(f64v2) 370
                               Return
                               FunctionEnd
@@ -629,37 +629,37 @@ spv.float64.frag
       376(f64v2):    150(ptr) Variable Function
       382(f64v3):    150(ptr) Variable Function
           399(f):    398(ptr) Variable Function
-             373:  149(fvec3) Load 372(f64v1)
-             374:   26(float) ExtInst 1(GLSL.std.450) 66(Length) 373
+             373:149(f64vec3) Load 372(f64v1)
+             374:26(float64_t) ExtInst 1(GLSL.std.450) 66(Length) 373
                               Store 371(f64) 374
-             375:  149(fvec3) Load 372(f64v1)
-             377:  149(fvec3) Load 376(f64v2)
-             378:   26(float) ExtInst 1(GLSL.std.450) 67(Distance) 375 377
+             375:149(f64vec3) Load 372(f64v1)
+             377:149(f64vec3) Load 376(f64v2)
+             378:26(float64_t) ExtInst 1(GLSL.std.450) 67(Distance) 375 377
                               Store 371(f64) 378
-             379:  149(fvec3) Load 372(f64v1)
-             380:  149(fvec3) Load 376(f64v2)
-             381:   26(float) Dot 379 380
+             379:149(f64vec3) Load 372(f64v1)
+             380:149(f64vec3) Load 376(f64v2)
+             381:26(float64_t) Dot 379 380
                               Store 371(f64) 381
-             383:  149(fvec3) Load 372(f64v1)
-             384:  149(fvec3) Load 376(f64v2)
-             385:  149(fvec3) ExtInst 1(GLSL.std.450) 68(Cross) 383 384
+             383:149(f64vec3) Load 372(f64v1)
+             384:149(f64vec3) Load 376(f64v2)
+             385:149(f64vec3) ExtInst 1(GLSL.std.450) 68(Cross) 383 384
                               Store 382(f64v3) 385
-             386:  149(fvec3) Load 372(f64v1)
-             387:  149(fvec3) ExtInst 1(GLSL.std.450) 69(Normalize) 386
+             386:149(f64vec3) Load 372(f64v1)
+             387:149(f64vec3) ExtInst 1(GLSL.std.450) 69(Normalize) 386
                               Store 376(f64v2) 387
-             388:  149(fvec3) Load 372(f64v1)
-             389:  149(fvec3) Load 376(f64v2)
-             390:  149(fvec3) Load 382(f64v3)
-             391:  149(fvec3) ExtInst 1(GLSL.std.450) 70(FaceForward) 388 389 390
+             388:149(f64vec3) Load 372(f64v1)
+             389:149(f64vec3) Load 376(f64v2)
+             390:149(f64vec3) Load 382(f64v3)
+             391:149(f64vec3) ExtInst 1(GLSL.std.450) 70(FaceForward) 388 389 390
                               Store 382(f64v3) 391
-             392:  149(fvec3) Load 372(f64v1)
-             393:  149(fvec3) Load 376(f64v2)
-             394:  149(fvec3) ExtInst 1(GLSL.std.450) 71(Reflect) 392 393
+             392:149(f64vec3) Load 372(f64v1)
+             393:149(f64vec3) Load 376(f64v2)
+             394:149(f64vec3) ExtInst 1(GLSL.std.450) 71(Reflect) 392 393
                               Store 382(f64v3) 394
-             395:  149(fvec3) Load 372(f64v1)
-             396:  149(fvec3) Load 376(f64v2)
+             395:149(f64vec3) Load 372(f64v1)
+             396:149(f64vec3) Load 376(f64v2)
              400:  397(float) Load 399(f)
-             401:  149(fvec3) ExtInst 1(GLSL.std.450) 72(Refract) 395 396 400
+             401:149(f64vec3) ExtInst 1(GLSL.std.450) 72(Refract) 395 396 400
                               Store 382(f64v3) 401
                               Return
                               FunctionEnd
@@ -677,23 +677,23 @@ spv.float64.frag
       435(f64m7):    433(ptr) Variable Function
              406:         402 Load 405(f64m1)
              408:         402 Load 407(f64m2)
-             409:  149(fvec3) CompositeExtract 406 0
-             410:  149(fvec3) CompositeExtract 408 0
-             411:  149(fvec3) FMul 409 410
-             412:  149(fvec3) CompositeExtract 406 1
-             413:  149(fvec3) CompositeExtract 408 1
-             414:  149(fvec3) FMul 412 413
+             409:149(f64vec3) CompositeExtract 406 0
+             410:149(f64vec3) CompositeExtract 408 0
+             411:149(f64vec3) FMul 409 410
+             412:149(f64vec3) CompositeExtract 406 1
+             413:149(f64vec3) CompositeExtract 408 1
+             414:149(f64vec3) FMul 412 413
              415:         402 CompositeConstruct 411 414
                               Store 404(f64m3) 415
-             417:  149(fvec3) Load 416(f64v1)
-             419:   27(fvec2) Load 418(f64v2)
+             417:149(f64vec3) Load 416(f64v1)
+             419: 27(f64vec2) Load 418(f64v2)
              420:         402 OuterProduct 417 419
                               Store 405(f64m1) 420
              424:         402 Load 405(f64m1)
              425:         421 Transpose 424
                               Store 423(f64m4) 425
              430:         427 Load 429(f64m5)
-             431:   26(float) ExtInst 1(GLSL.std.450) 33(Determinant) 430
+             431:26(float64_t) ExtInst 1(GLSL.std.450) 33(Determinant) 430
                               Store 426(f64) 431
              436:         432 Load 435(f64m7)
              437:         432 ExtInst 1(GLSL.std.450) 34(MatrixInverse) 436
@@ -705,28 +705,28 @@ spv.float64.frag
          438(bv):    153(ptr) Variable Function
       439(f64v1):    150(ptr) Variable Function
       441(f64v2):    150(ptr) Variable Function
-             440:  149(fvec3) Load 439(f64v1)
-             442:  149(fvec3) Load 441(f64v2)
+             440:149(f64vec3) Load 439(f64v1)
+             442:149(f64vec3) Load 441(f64v2)
              443:  152(bvec3) FOrdLessThan 440 442
                               Store 438(bv) 443
-             444:  149(fvec3) Load 439(f64v1)
-             445:  149(fvec3) Load 441(f64v2)
+             444:149(f64vec3) Load 439(f64v1)
+             445:149(f64vec3) Load 441(f64v2)
              446:  152(bvec3) FOrdLessThanEqual 444 445
                               Store 438(bv) 446
-             447:  149(fvec3) Load 439(f64v1)
-             448:  149(fvec3) Load 441(f64v2)
+             447:149(f64vec3) Load 439(f64v1)
+             448:149(f64vec3) Load 441(f64v2)
              449:  152(bvec3) FOrdGreaterThan 447 448
                               Store 438(bv) 449
-             450:  149(fvec3) Load 439(f64v1)
-             451:  149(fvec3) Load 441(f64v2)
+             450:149(f64vec3) Load 439(f64v1)
+             451:149(f64vec3) Load 441(f64v2)
              452:  152(bvec3) FOrdGreaterThanEqual 450 451
                               Store 438(bv) 452
-             453:  149(fvec3) Load 439(f64v1)
-             454:  149(fvec3) Load 441(f64v2)
+             453:149(f64vec3) Load 439(f64v1)
+             454:149(f64vec3) Load 441(f64v2)
              455:  152(bvec3) FOrdEqual 453 454
                               Store 438(bv) 455
-             456:  149(fvec3) Load 439(f64v1)
-             457:  149(fvec3) Load 441(f64v2)
+             456:149(f64vec3) Load 439(f64v1)
+             457:149(f64vec3) Load 441(f64v2)
              458:  152(bvec3) FOrdNotEqual 456 457
                               Store 438(bv) 458
                               Return
@@ -735,57 +735,57 @@ spv.float64.frag
               25:             Label
        459(f64v):    150(ptr) Variable Function
              463:    462(ptr) AccessChain 461(if64v) 32
-             464:   26(float) Load 463
-             465:   26(float) DPdx 464
+             464:26(float64_t) Load 463
+             465:26(float64_t) DPdx 464
              466:     33(ptr) AccessChain 459(f64v) 32
                               Store 466 465
              467:    462(ptr) AccessChain 461(if64v) 88
-             468:   26(float) Load 467
-             469:   26(float) DPdy 468
+             468:26(float64_t) Load 467
+             469:26(float64_t) DPdy 468
              470:     33(ptr) AccessChain 459(f64v) 88
                               Store 470 469
-             471:  149(fvec3) Load 461(if64v)
-             472:   27(fvec2) VectorShuffle 471 471 0 1
-             473:   27(fvec2) DPdxFine 472
-             474:  149(fvec3) Load 459(f64v)
-             475:  149(fvec3) VectorShuffle 474 473 3 4 2
+             471:149(f64vec3) Load 461(if64v)
+             472: 27(f64vec2) VectorShuffle 471 471 0 1
+             473: 27(f64vec2) DPdxFine 472
+             474:149(f64vec3) Load 459(f64v)
+             475:149(f64vec3) VectorShuffle 474 473 3 4 2
                               Store 459(f64v) 475
-             476:  149(fvec3) Load 461(if64v)
-             477:   27(fvec2) VectorShuffle 476 476 0 1
-             478:   27(fvec2) DPdyFine 477
-             479:  149(fvec3) Load 459(f64v)
-             480:  149(fvec3) VectorShuffle 479 478 3 4 2
+             476:149(f64vec3) Load 461(if64v)
+             477: 27(f64vec2) VectorShuffle 476 476 0 1
+             478: 27(f64vec2) DPdyFine 477
+             479:149(f64vec3) Load 459(f64v)
+             480:149(f64vec3) VectorShuffle 479 478 3 4 2
                               Store 459(f64v) 480
-             481:  149(fvec3) Load 461(if64v)
-             482:  149(fvec3) DPdxCoarse 481
+             481:149(f64vec3) Load 461(if64v)
+             482:149(f64vec3) DPdxCoarse 481
                               Store 459(f64v) 482
-             483:  149(fvec3) Load 461(if64v)
-             484:  149(fvec3) DPdxCoarse 483
+             483:149(f64vec3) Load 461(if64v)
+             484:149(f64vec3) DPdxCoarse 483
                               Store 459(f64v) 484
              485:    462(ptr) AccessChain 461(if64v) 32
-             486:   26(float) Load 485
-             487:   26(float) Fwidth 486
+             486:26(float64_t) Load 485
+             487:26(float64_t) Fwidth 486
              488:     33(ptr) AccessChain 459(f64v) 32
                               Store 488 487
-             489:  149(fvec3) Load 461(if64v)
-             490:   27(fvec2) VectorShuffle 489 489 0 1
-             491:   27(fvec2) FwidthFine 490
-             492:  149(fvec3) Load 459(f64v)
-             493:  149(fvec3) VectorShuffle 492 491 3 4 2
+             489:149(f64vec3) Load 461(if64v)
+             490: 27(f64vec2) VectorShuffle 489 489 0 1
+             491: 27(f64vec2) FwidthFine 490
+             492:149(f64vec3) Load 459(f64v)
+             493:149(f64vec3) VectorShuffle 492 491 3 4 2
                               Store 459(f64v) 493
-             494:  149(fvec3) Load 461(if64v)
-             495:  149(fvec3) FwidthCoarse 494
+             494:149(f64vec3) Load 461(if64v)
+             495:149(f64vec3) FwidthCoarse 494
                               Store 459(f64v) 495
              496:    462(ptr) AccessChain 461(if64v) 32
-             497:   26(float) ExtInst 1(GLSL.std.450) 76(InterpolateAtCentroid) 496
+             497:26(float64_t) ExtInst 1(GLSL.std.450) 76(InterpolateAtCentroid) 496
              498:     33(ptr) AccessChain 459(f64v) 32
                               Store 498 497
-             500:  149(fvec3) ExtInst 1(GLSL.std.450) 77(InterpolateAtSample) 461(if64v) 499
-             501:   27(fvec2) VectorShuffle 500 500 0 1
-             502:  149(fvec3) Load 459(f64v)
-             503:  149(fvec3) VectorShuffle 502 501 3 4 2
+             500:149(f64vec3) ExtInst 1(GLSL.std.450) 77(InterpolateAtSample) 461(if64v) 499
+             501: 27(f64vec2) VectorShuffle 500 500 0 1
+             502:149(f64vec3) Load 459(f64v)
+             503:149(f64vec3) VectorShuffle 502 501 3 4 2
                               Store 459(f64v) 503
-             506:  149(fvec3) ExtInst 1(GLSL.std.450) 78(InterpolateAtOffset) 461(if64v) 505
+             506:149(f64vec3) ExtInst 1(GLSL.std.450) 78(InterpolateAtOffset) 461(if64v) 505
                               Store 459(f64v) 506
                               Return
                               FunctionEnd

--- a/Test/baseResults/spv.hlslOffsets.vert.out
+++ b/Test/baseResults/spv.hlslOffsets.vert.out
@@ -66,8 +66,8 @@ Shader version: 450
                7:             TypeVector 6(float) 3
                8:             TypeVector 6(float) 2
                9:             TypeFloat 64
-              10:             TypeVector 9(float) 2
-       11(block):             TypeStruct 6(float) 7(fvec3) 6(float) 7(fvec3) 7(fvec3) 8(fvec2) 8(fvec2) 6(float) 8(fvec2) 6(float) 6(float) 8(fvec2) 8(fvec2) 10(fvec2)
+              10:             TypeVector 9(float64_t) 2
+       11(block):             TypeStruct 6(float) 7(fvec3) 6(float) 7(fvec3) 7(fvec3) 8(fvec2) 8(fvec2) 6(float) 8(fvec2) 6(float) 6(float) 8(fvec2) 8(fvec2) 10(f64vec2)
               12:             TypePointer Uniform 11(block)
               13:     12(ptr) Variable Uniform
          4(main):           2 Function None 3

--- a/Test/baseResults/spv.int16.amd.frag.out
+++ b/Test/baseResults/spv.int16.amd.frag.out
@@ -96,14 +96,14 @@ spv.int16.amd.frag
                2:             TypeVoid
                3:             TypeFunction 2
               14:             TypeInt 16 0
-              15:             TypePointer Function 14(int)
+              15:             TypePointer Function 14(int16_t)
               17:             TypeInt 16 1
               18:             TypeInt 32 0
               19:     18(int) Constant 3
-              20:             TypeArray 17(int) 19
-              21:     17(int) Constant 273
-              22:     17(int) Constant 4294967294
-              23:     17(int) Constant 256
+              20:             TypeArray 17(int16_t) 19
+              21: 17(int16_t) Constant 273
+              22: 17(int16_t) Constant 4294967294
+              23: 17(int16_t) Constant 256
               24:          20 ConstantComposite 21 22 23
     25(Uniforms):             TypeStruct 18(int)
               26:             TypePointer Uniform 25(Uniforms)
@@ -112,15 +112,15 @@ spv.int16.amd.frag
               29:     28(int) Constant 0
               30:             TypePointer Uniform 18(int)
               33:             TypePointer Function 20
-              35:             TypePointer Function 17(int)
-              39:             TypeArray 14(int) 19
-              40:     14(int) Constant 65535
+              35:             TypePointer Function 17(int16_t)
+              39:             TypeArray 14(int16_t) 19
+              40: 14(int16_t) Constant 65535
               41:          39 ConstantComposite 40 40 40
               44:             TypePointer Function 39
-              49:             TypeVector 14(int) 3
-              50:             TypePointer Function 49(ivec3)
-              53:     17(int) Constant 1
-              54:             TypeVector 17(int) 3
+              49:             TypeVector 14(int16_t) 3
+              50:             TypePointer Function 49(i16vec3)
+              53: 17(int16_t) Constant 1
+              54:             TypeVector 17(int16_t) 3
              111:     18(int) Constant 1
              117:     18(int) Constant 2
              125:             TypeBool
@@ -128,19 +128,19 @@ spv.int16.amd.frag
              128:     18(int) Constant 0
              147:             TypePointer Function 18(int)
              158:             TypePointer Function 28(int)
-             187:             TypeVector 17(int) 2
-             188:             TypePointer Function 187(ivec2)
+             187:             TypeVector 17(int16_t) 2
+             188:             TypePointer Function 187(i16vec2)
              190:             TypeVector 125(bool) 2
              191:             TypePointer Function 190(bvec2)
-             194:     17(int) Constant 0
-             195:  187(ivec2) ConstantComposite 194 194
-             196:  187(ivec2) ConstantComposite 53 53
-             198:             TypeVector 14(int) 2
-             199:             TypePointer Function 198(ivec2)
-             202:     14(int) Constant 0
-             203:     14(int) Constant 1
-             204:  198(ivec2) ConstantComposite 202 202
-             205:  198(ivec2) ConstantComposite 203 203
+             194: 17(int16_t) Constant 0
+             195:187(i16vec2) ConstantComposite 194 194
+             196:187(i16vec2) ConstantComposite 53 53
+             198:             TypeVector 14(int16_t) 2
+             199:             TypePointer Function 198(i16vec2)
+             202: 14(int16_t) Constant 0
+             203: 14(int16_t) Constant 1
+             204:198(i16vec2) ConstantComposite 202 202
+             205:198(i16vec2) ConstantComposite 203 203
              211:             TypeVector 28(int) 2
              212:             TypePointer Function 211(ivec2)
              224:             TypeVector 18(int) 2
@@ -149,80 +149,80 @@ spv.int16.amd.frag
              238:             TypeVector 237(float) 2
              239:             TypePointer Function 238(fvec2)
              249:             TypeFloat 64
-             250:             TypeVector 249(float) 2
-             251:             TypePointer Function 250(fvec2)
+             250:             TypeVector 249(float64_t) 2
+             251:             TypePointer Function 250(f64vec2)
              261:             TypeFloat 16
-             262:             TypeVector 261(float) 2
-             263:             TypePointer Function 262(fvec2)
+             262:             TypeVector 261(float16_t) 2
+             263:             TypePointer Function 262(f16vec2)
              273:             TypeInt 64 1
-             274:             TypeVector 273(int) 2
-             275:             TypePointer Function 274(ivec2)
+             274:             TypeVector 273(int64_t) 2
+             275:             TypePointer Function 274(i64vec2)
              287:             TypeInt 64 0
-             288:             TypeVector 287(int) 2
-             289:             TypePointer Function 288(ivec2)
-             316:     17(int) Constant 4294967295
-             317:  187(ivec2) ConstantComposite 316 316
-             326:   49(ivec3) ConstantComposite 202 202 202
+             288:             TypeVector 287(int64_t) 2
+             289:             TypePointer Function 288(i64vec2)
+             316: 17(int16_t) Constant 4294967295
+             317:187(i16vec2) ConstantComposite 316 316
+             326: 49(i16vec3) ConstantComposite 202 202 202
              368:   125(bool) ConstantTrue
              375:   125(bool) ConstantFalse
              376:  190(bvec2) ConstantComposite 375 375
              388:             TypeVector 125(bool) 3
              389:  388(bvec3) ConstantComposite 375 375 375
-             391:             TypeVector 261(float) 3
-             392:             TypePointer Function 391(fvec3)
-             395:             TypePointer Function 54(ivec3)
-    397(ResType):             TypeStruct 391(fvec3) 54(ivec3)
-             407:             TypePointer Function 261(float)
-             431:             TypePointer Function 273(int)
-             434:             TypeVector 17(int) 4
-             440:             TypePointer Function 287(int)
-             443:             TypeVector 14(int) 4
+             391:             TypeVector 261(float16_t) 3
+             392:             TypePointer Function 391(f16vec3)
+             395:             TypePointer Function 54(i16vec3)
+    397(ResType):             TypeStruct 391(f16vec3) 54(i16vec3)
+             407:             TypePointer Function 261(float16_t)
+             431:             TypePointer Function 273(int64_t)
+             434:             TypeVector 17(int16_t) 4
+             440:             TypePointer Function 287(int64_t)
+             443:             TypeVector 14(int16_t) 4
              449:             TypePointer Function 388(bvec3)
-      515(Block):             TypeStruct 54(ivec3) 14(int)
+      515(Block):             TypeStruct 54(i16vec3) 14(int16_t)
              516:             TypePointer Uniform 515(Block)
       517(block):    516(ptr) Variable Uniform
-             518:             TypePointer Input 49(ivec3)
+             518:             TypePointer Input 49(i16vec3)
       519(iu16v):    518(ptr) Variable Input
-             520:             TypePointer Input 17(int)
+             520:             TypePointer Input 17(int16_t)
        521(ii16):    520(ptr) Variable Input
-       522(si64):    273(int) SpecConstant 4294967286 4294967295
-       523(su64):    287(int) SpecConstant 20 0
+       522(si64):273(int64_t) SpecConstant 4294967286 4294967295
+       523(su64):287(int64_t) SpecConstant 20 0
          524(si):     28(int) SpecConstant 4294967291
          525(su):     18(int) SpecConstant 4
          526(sb):   125(bool) SpecConstantTrue
-       527(si16):     17(int) SpecConstant 4294967291
-       528(su16):     14(int) SpecConstant 4
+       527(si16): 17(int16_t) SpecConstant 4294967291
+       528(su16): 14(int16_t) SpecConstant 4
              529:   125(bool) SpecConstantOp 171 527(si16) 202
              530:   125(bool) SpecConstantOp 171 528(su16) 202
-             531:     17(int) SpecConstantOp 169 526(sb) 53 194
-             532:     14(int) SpecConstantOp 169 526(sb) 203 202
+             531: 17(int16_t) SpecConstantOp 169 526(sb) 53 194
+             532: 14(int16_t) SpecConstantOp 169 526(sb) 203 202
              533:     28(int) SpecConstantOp 114 527(si16)
              534:     28(int) SpecConstantOp 113 528(su16)
              535:     28(int) SpecConstantOp 128 534 128
-             536:     17(int) SpecConstantOp 114 524(si)
-             537:     17(int) SpecConstantOp 114 524(si)
-             538:     14(int) SpecConstantOp 128 537 202
+             536: 17(int16_t) SpecConstantOp 114 524(si)
+             537: 17(int16_t) SpecConstantOp 114 524(si)
+             538: 14(int16_t) SpecConstantOp 128 537 202
              539:     28(int) SpecConstantOp 114 527(si16)
              540:     18(int) SpecConstantOp 128 539 128
              541:     18(int) SpecConstantOp 113 528(su16)
-             542:     17(int) SpecConstantOp 113 525(su)
-             543:     17(int) SpecConstantOp 128 542 202
-             544:     14(int) SpecConstantOp 113 525(su)
-             545:    273(int) SpecConstantOp 114 527(si16)
-             546:    273(int) SpecConstantOp 113 528(su16)
-             547:    287(int) Constant 0 0
-             548:    273(int) SpecConstantOp 128 546 547
-             549:     17(int) SpecConstantOp 114 522(si64)
-             550:     17(int) SpecConstantOp 114 522(si64)
-             551:     14(int) SpecConstantOp 128 550 202
-             552:    273(int) SpecConstantOp 114 527(si16)
-             553:    287(int) SpecConstantOp 128 552 547
-             554:    287(int) SpecConstantOp 113 528(su16)
-             555:     17(int) SpecConstantOp 113 523(su64)
-             556:     17(int) SpecConstantOp 128 555 202
-             557:     14(int) SpecConstantOp 113 523(su64)
-             558:     14(int) SpecConstantOp 128 527(si16) 202
-             559:     17(int) SpecConstantOp 128 528(su16) 202
+             542: 17(int16_t) SpecConstantOp 113 525(su)
+             543: 17(int16_t) SpecConstantOp 128 542 202
+             544: 14(int16_t) SpecConstantOp 113 525(su)
+             545:273(int64_t) SpecConstantOp 114 527(si16)
+             546:273(int64_t) SpecConstantOp 113 528(su16)
+             547:287(int64_t) Constant 0 0
+             548:273(int64_t) SpecConstantOp 128 546 547
+             549: 17(int16_t) SpecConstantOp 114 522(si64)
+             550: 17(int16_t) SpecConstantOp 114 522(si64)
+             551: 14(int16_t) SpecConstantOp 128 550 202
+             552:273(int64_t) SpecConstantOp 114 527(si16)
+             553:287(int64_t) SpecConstantOp 128 552 547
+             554:287(int64_t) SpecConstantOp 113 528(su16)
+             555: 17(int16_t) SpecConstantOp 113 523(su64)
+             556: 17(int16_t) SpecConstantOp 128 555 202
+             557: 14(int16_t) SpecConstantOp 113 523(su64)
+             558: 14(int16_t) SpecConstantOp 128 527(si16) 202
+             559: 17(int16_t) SpecConstantOp 128 528(su16) 202
          4(main):           2 Function None 3
                5:             Label
              511:           2 FunctionCall 6(literal()
@@ -240,14 +240,14 @@ spv.int16.amd.frag
               32:     18(int) Load 31
                               Store 34(indexable) 24
               36:     35(ptr) AccessChain 34(indexable) 32
-              37:     17(int) Load 36
-              38:     14(int) Bitcast 37
+              37: 17(int16_t) Load 36
+              38: 14(int16_t) Bitcast 37
               42:     30(ptr) AccessChain 27 29
               43:     18(int) Load 42
                               Store 45(indexable) 41
               46:     15(ptr) AccessChain 45(indexable) 43
-              47:     14(int) Load 46
-              48:     14(int) IAdd 38 47
+              47: 14(int16_t) Load 46
+              48: 14(int16_t) IAdd 38 47
                               Store 16(u16) 48
                               Return
                               FunctionEnd
@@ -259,159 +259,159 @@ spv.int16.amd.frag
           127(b):    126(ptr) Variable Function
           148(u):    147(ptr) Variable Function
           159(i):    158(ptr) Variable Function
-              52:   49(ivec3) Load 51(u16v)
-              55:   54(ivec3) CompositeConstruct 53 53 53
-              56:   49(ivec3) IAdd 52 55
+              52: 49(i16vec3) Load 51(u16v)
+              55: 54(i16vec3) CompositeConstruct 53 53 53
+              56: 49(i16vec3) IAdd 52 55
                               Store 51(u16v) 56
-              58:     17(int) Load 57(i16)
-              59:     17(int) ISub 58 53
+              58: 17(int16_t) Load 57(i16)
+              59: 17(int16_t) ISub 58 53
                               Store 57(i16) 59
-              60:     17(int) Load 57(i16)
-              61:     17(int) IAdd 60 53
+              60: 17(int16_t) Load 57(i16)
+              61: 17(int16_t) IAdd 60 53
                               Store 57(i16) 61
-              62:   49(ivec3) Load 51(u16v)
-              63:   54(ivec3) CompositeConstruct 53 53 53
-              64:   49(ivec3) ISub 62 63
+              62: 49(i16vec3) Load 51(u16v)
+              63: 54(i16vec3) CompositeConstruct 53 53 53
+              64: 49(i16vec3) ISub 62 63
                               Store 51(u16v) 64
-              65:   49(ivec3) Load 51(u16v)
-              66:   49(ivec3) Not 65
+              65: 49(i16vec3) Load 51(u16v)
+              66: 49(i16vec3) Not 65
                               Store 51(u16v) 66
-              67:     17(int) Load 57(i16)
+              67: 17(int16_t) Load 57(i16)
                               Store 57(i16) 67
-              68:   49(ivec3) Load 51(u16v)
-              69:   49(ivec3) SNegate 68
+              68: 49(i16vec3) Load 51(u16v)
+              69: 49(i16vec3) SNegate 68
                               Store 51(u16v) 69
-              71:     17(int) Load 57(i16)
-              72:     14(int) Bitcast 71
-              73:     14(int) Load 70(u16)
-              74:     14(int) IAdd 73 72
+              71: 17(int16_t) Load 57(i16)
+              72: 14(int16_t) Bitcast 71
+              73: 14(int16_t) Load 70(u16)
+              74: 14(int16_t) IAdd 73 72
                               Store 70(u16) 74
-              75:   49(ivec3) Load 51(u16v)
-              76:   49(ivec3) Load 51(u16v)
-              77:   49(ivec3) ISub 76 75
+              75: 49(i16vec3) Load 51(u16v)
+              76: 49(i16vec3) Load 51(u16v)
+              77: 49(i16vec3) ISub 76 75
                               Store 51(u16v) 77
-              78:     17(int) Load 57(i16)
-              79:     17(int) Load 57(i16)
-              80:     17(int) IMul 79 78
+              78: 17(int16_t) Load 57(i16)
+              79: 17(int16_t) Load 57(i16)
+              80: 17(int16_t) IMul 79 78
                               Store 57(i16) 80
-              81:   49(ivec3) Load 51(u16v)
-              82:   49(ivec3) Load 51(u16v)
-              83:   49(ivec3) UDiv 82 81
+              81: 49(i16vec3) Load 51(u16v)
+              82: 49(i16vec3) Load 51(u16v)
+              83: 49(i16vec3) UDiv 82 81
                               Store 51(u16v) 83
-              84:     17(int) Load 57(i16)
-              85:     14(int) Bitcast 84
-              86:   49(ivec3) Load 51(u16v)
-              87:   49(ivec3) CompositeConstruct 85 85 85
-              88:   49(ivec3) UMod 86 87
+              84: 17(int16_t) Load 57(i16)
+              85: 14(int16_t) Bitcast 84
+              86: 49(i16vec3) Load 51(u16v)
+              87: 49(i16vec3) CompositeConstruct 85 85 85
+              88: 49(i16vec3) UMod 86 87
                               Store 51(u16v) 88
-              89:   49(ivec3) Load 51(u16v)
-              90:   49(ivec3) Load 51(u16v)
-              91:   49(ivec3) IAdd 89 90
+              89: 49(i16vec3) Load 51(u16v)
+              90: 49(i16vec3) Load 51(u16v)
+              91: 49(i16vec3) IAdd 89 90
                               Store 51(u16v) 91
-              92:     17(int) Load 57(i16)
-              93:     14(int) Bitcast 92
-              94:     14(int) Load 70(u16)
-              95:     14(int) ISub 93 94
+              92: 17(int16_t) Load 57(i16)
+              93: 14(int16_t) Bitcast 92
+              94: 14(int16_t) Load 70(u16)
+              95: 14(int16_t) ISub 93 94
                               Store 70(u16) 95
-              96:   49(ivec3) Load 51(u16v)
-              97:     17(int) Load 57(i16)
-              98:     14(int) Bitcast 97
-              99:   49(ivec3) CompositeConstruct 98 98 98
-             100:   49(ivec3) IMul 96 99
+              96: 49(i16vec3) Load 51(u16v)
+              97: 17(int16_t) Load 57(i16)
+              98: 14(int16_t) Bitcast 97
+              99: 49(i16vec3) CompositeConstruct 98 98 98
+             100: 49(i16vec3) IMul 96 99
                               Store 51(u16v) 100
-             101:     17(int) Load 57(i16)
-             102:     17(int) Load 57(i16)
-             103:     17(int) IMul 101 102
+             101: 17(int16_t) Load 57(i16)
+             102: 17(int16_t) Load 57(i16)
+             103: 17(int16_t) IMul 101 102
                               Store 57(i16) 103
-             104:     17(int) Load 57(i16)
-             105:     17(int) Load 57(i16)
-             106:     17(int) SMod 104 105
+             104: 17(int16_t) Load 57(i16)
+             105: 17(int16_t) Load 57(i16)
+             106: 17(int16_t) SMod 104 105
                               Store 57(i16) 106
-             107:     17(int) Load 57(i16)
-             108:   49(ivec3) Load 51(u16v)
-             109:   54(ivec3) CompositeConstruct 107 107 107
-             110:   49(ivec3) ShiftLeftLogical 108 109
+             107: 17(int16_t) Load 57(i16)
+             108: 49(i16vec3) Load 51(u16v)
+             109: 54(i16vec3) CompositeConstruct 107 107 107
+             110: 49(i16vec3) ShiftLeftLogical 108 109
                               Store 51(u16v) 110
              112:     15(ptr) AccessChain 51(u16v) 111
-             113:     14(int) Load 112
-             114:     17(int) Load 57(i16)
-             115:     17(int) ShiftRightArithmetic 114 113
+             113: 14(int16_t) Load 112
+             114: 17(int16_t) Load 57(i16)
+             115: 17(int16_t) ShiftRightArithmetic 114 113
                               Store 57(i16) 115
-             116:     17(int) Load 57(i16)
+             116: 17(int16_t) Load 57(i16)
              118:     15(ptr) AccessChain 51(u16v) 117
-             119:     14(int) Load 118
-             120:     17(int) ShiftLeftLogical 116 119
+             119: 14(int16_t) Load 118
+             120: 17(int16_t) ShiftLeftLogical 116 119
                               Store 57(i16) 120
-             121:   49(ivec3) Load 51(u16v)
-             122:     17(int) Load 57(i16)
-             123:   54(ivec3) CompositeConstruct 122 122 122
-             124:   49(ivec3) ShiftLeftLogical 121 123
+             121: 49(i16vec3) Load 51(u16v)
+             122: 17(int16_t) Load 57(i16)
+             123: 54(i16vec3) CompositeConstruct 122 122 122
+             124: 49(i16vec3) ShiftLeftLogical 121 123
                               Store 51(u16v) 124
              129:     15(ptr) AccessChain 51(u16v) 128
-             130:     14(int) Load 129
-             131:     17(int) Load 57(i16)
-             132:     14(int) Bitcast 131
+             130: 14(int16_t) Load 129
+             131: 17(int16_t) Load 57(i16)
+             132: 14(int16_t) Bitcast 131
              133:   125(bool) INotEqual 130 132
                               Store 127(b) 133
-             134:     17(int) Load 57(i16)
-             135:     14(int) Bitcast 134
+             134: 17(int16_t) Load 57(i16)
+             135: 14(int16_t) Bitcast 134
              136:     15(ptr) AccessChain 51(u16v) 128
-             137:     14(int) Load 136
+             137: 14(int16_t) Load 136
              138:   125(bool) IEqual 135 137
                               Store 127(b) 138
              139:     15(ptr) AccessChain 51(u16v) 128
-             140:     14(int) Load 139
+             140: 14(int16_t) Load 139
              141:     15(ptr) AccessChain 51(u16v) 111
-             142:     14(int) Load 141
+             142: 14(int16_t) Load 141
              143:   125(bool) UGreaterThan 140 142
                               Store 127(b) 143
-             144:     17(int) Load 57(i16)
+             144: 17(int16_t) Load 57(i16)
              145:     28(int) SConvert 144
              146:     18(int) Bitcast 145
              149:     18(int) Load 148(u)
              150:   125(bool) ULessThan 146 149
                               Store 127(b) 150
              151:     15(ptr) AccessChain 51(u16v) 111
-             152:     14(int) Load 151
+             152: 14(int16_t) Load 151
              153:     15(ptr) AccessChain 51(u16v) 128
-             154:     14(int) Load 153
+             154: 14(int16_t) Load 153
              155:   125(bool) UGreaterThanEqual 152 154
                               Store 127(b) 155
-             156:     17(int) Load 57(i16)
+             156: 17(int16_t) Load 57(i16)
              157:     28(int) SConvert 156
              160:     28(int) Load 159(i)
              161:   125(bool) SLessThanEqual 157 160
                               Store 127(b) 161
-             162:     17(int) Load 57(i16)
-             163:     14(int) Bitcast 162
-             164:   49(ivec3) Load 51(u16v)
-             165:   49(ivec3) CompositeConstruct 163 163 163
-             166:   49(ivec3) BitwiseOr 164 165
+             162: 17(int16_t) Load 57(i16)
+             163: 14(int16_t) Bitcast 162
+             164: 49(i16vec3) Load 51(u16v)
+             165: 49(i16vec3) CompositeConstruct 163 163 163
+             166: 49(i16vec3) BitwiseOr 164 165
                               Store 51(u16v) 166
-             167:     17(int) Load 57(i16)
-             168:     14(int) Bitcast 167
-             169:     14(int) Load 70(u16)
-             170:     14(int) BitwiseOr 168 169
+             167: 17(int16_t) Load 57(i16)
+             168: 14(int16_t) Bitcast 167
+             169: 14(int16_t) Load 70(u16)
+             170: 14(int16_t) BitwiseOr 168 169
                               Store 70(u16) 170
-             171:     17(int) Load 57(i16)
-             172:     17(int) Load 57(i16)
-             173:     17(int) BitwiseAnd 172 171
+             171: 17(int16_t) Load 57(i16)
+             172: 17(int16_t) Load 57(i16)
+             173: 17(int16_t) BitwiseAnd 172 171
                               Store 57(i16) 173
-             174:   49(ivec3) Load 51(u16v)
-             175:   49(ivec3) Load 51(u16v)
-             176:   49(ivec3) BitwiseAnd 174 175
+             174: 49(i16vec3) Load 51(u16v)
+             175: 49(i16vec3) Load 51(u16v)
+             176: 49(i16vec3) BitwiseAnd 174 175
                               Store 51(u16v) 176
-             177:     17(int) Load 57(i16)
-             178:     14(int) Bitcast 177
-             179:   49(ivec3) Load 51(u16v)
-             180:   49(ivec3) CompositeConstruct 178 178 178
-             181:   49(ivec3) BitwiseXor 179 180
+             177: 17(int16_t) Load 57(i16)
+             178: 14(int16_t) Bitcast 177
+             179: 49(i16vec3) Load 51(u16v)
+             180: 49(i16vec3) CompositeConstruct 178 178 178
+             181: 49(i16vec3) BitwiseXor 179 180
                               Store 51(u16v) 181
-             182:   49(ivec3) Load 51(u16v)
-             183:     17(int) Load 57(i16)
-             184:     14(int) Bitcast 183
-             185:   49(ivec3) CompositeConstruct 184 184 184
-             186:   49(ivec3) BitwiseXor 182 185
+             182: 49(i16vec3) Load 51(u16v)
+             183: 17(int16_t) Load 57(i16)
+             184: 14(int16_t) Bitcast 183
+             185: 49(i16vec3) CompositeConstruct 184 184 184
+             186: 49(i16vec3) BitwiseXor 182 185
                               Store 51(u16v) 186
                               Return
                               FunctionEnd
@@ -428,114 +428,114 @@ spv.int16.amd.frag
        276(i64v):    275(ptr) Variable Function
        290(u64v):    289(ptr) Variable Function
              193:  190(bvec2) Load 192(bv)
-             197:  187(ivec2) Select 193 196 195
+             197:187(i16vec2) Select 193 196 195
                               Store 189(i16v) 197
              201:  190(bvec2) Load 192(bv)
-             206:  198(ivec2) Select 201 205 204
+             206:198(i16vec2) Select 201 205 204
                               Store 200(u16v) 206
-             207:  187(ivec2) Load 189(i16v)
+             207:187(i16vec2) Load 189(i16v)
              208:  190(bvec2) INotEqual 207 204
                               Store 192(bv) 208
-             209:  198(ivec2) Load 200(u16v)
+             209:198(i16vec2) Load 200(u16v)
              210:  190(bvec2) INotEqual 209 204
                               Store 192(bv) 210
              214:  211(ivec2) Load 213(iv)
-             215:  187(ivec2) SConvert 214
+             215:187(i16vec2) SConvert 214
                               Store 189(i16v) 215
              216:  211(ivec2) Load 213(iv)
-             217:  187(ivec2) SConvert 216
-             218:  198(ivec2) Bitcast 217
+             217:187(i16vec2) SConvert 216
+             218:198(i16vec2) Bitcast 217
                               Store 200(u16v) 218
-             219:  187(ivec2) Load 189(i16v)
+             219:187(i16vec2) Load 189(i16v)
              220:  211(ivec2) SConvert 219
                               Store 213(iv) 220
-             221:  198(ivec2) Load 200(u16v)
+             221:198(i16vec2) Load 200(u16v)
              222:  211(ivec2) UConvert 221
              223:  211(ivec2) Bitcast 222
                               Store 213(iv) 223
              227:  224(ivec2) Load 226(uv)
-             228:  187(ivec2) UConvert 227
-             229:  187(ivec2) Bitcast 228
+             228:187(i16vec2) UConvert 227
+             229:187(i16vec2) Bitcast 228
                               Store 189(i16v) 229
              230:  224(ivec2) Load 226(uv)
-             231:  198(ivec2) UConvert 230
+             231:198(i16vec2) UConvert 230
                               Store 200(u16v) 231
-             232:  187(ivec2) Load 189(i16v)
+             232:187(i16vec2) Load 189(i16v)
              233:  211(ivec2) SConvert 232
              234:  224(ivec2) Bitcast 233
                               Store 226(uv) 234
-             235:  198(ivec2) Load 200(u16v)
+             235:198(i16vec2) Load 200(u16v)
              236:  224(ivec2) UConvert 235
                               Store 226(uv) 236
              241:  238(fvec2) Load 240(fv)
-             242:  187(ivec2) ConvertFToS 241
+             242:187(i16vec2) ConvertFToS 241
                               Store 189(i16v) 242
              243:  238(fvec2) Load 240(fv)
-             244:  198(ivec2) ConvertFToU 243
+             244:198(i16vec2) ConvertFToU 243
                               Store 200(u16v) 244
-             245:  187(ivec2) Load 189(i16v)
+             245:187(i16vec2) Load 189(i16v)
              246:  238(fvec2) ConvertSToF 245
                               Store 240(fv) 246
-             247:  198(ivec2) Load 200(u16v)
+             247:198(i16vec2) Load 200(u16v)
              248:  238(fvec2) ConvertUToF 247
                               Store 240(fv) 248
-             253:  250(fvec2) Load 252(dv)
-             254:  187(ivec2) ConvertFToS 253
+             253:250(f64vec2) Load 252(dv)
+             254:187(i16vec2) ConvertFToS 253
                               Store 189(i16v) 254
-             255:  250(fvec2) Load 252(dv)
-             256:  198(ivec2) ConvertFToU 255
+             255:250(f64vec2) Load 252(dv)
+             256:198(i16vec2) ConvertFToU 255
                               Store 200(u16v) 256
-             257:  187(ivec2) Load 189(i16v)
-             258:  250(fvec2) ConvertSToF 257
+             257:187(i16vec2) Load 189(i16v)
+             258:250(f64vec2) ConvertSToF 257
                               Store 252(dv) 258
-             259:  198(ivec2) Load 200(u16v)
-             260:  250(fvec2) ConvertUToF 259
+             259:198(i16vec2) Load 200(u16v)
+             260:250(f64vec2) ConvertUToF 259
                               Store 252(dv) 260
-             265:  262(fvec2) Load 264(f16v)
-             266:  187(ivec2) ConvertFToS 265
+             265:262(f16vec2) Load 264(f16v)
+             266:187(i16vec2) ConvertFToS 265
                               Store 189(i16v) 266
-             267:  262(fvec2) Load 264(f16v)
-             268:  198(ivec2) ConvertFToU 267
+             267:262(f16vec2) Load 264(f16v)
+             268:198(i16vec2) ConvertFToU 267
                               Store 200(u16v) 268
-             269:  187(ivec2) Load 189(i16v)
-             270:  262(fvec2) ConvertSToF 269
+             269:187(i16vec2) Load 189(i16v)
+             270:262(f16vec2) ConvertSToF 269
                               Store 264(f16v) 270
-             271:  198(ivec2) Load 200(u16v)
-             272:  262(fvec2) ConvertUToF 271
+             271:198(i16vec2) Load 200(u16v)
+             272:262(f16vec2) ConvertUToF 271
                               Store 264(f16v) 272
-             277:  274(ivec2) Load 276(i64v)
-             278:  187(ivec2) SConvert 277
+             277:274(i64vec2) Load 276(i64v)
+             278:187(i16vec2) SConvert 277
                               Store 189(i16v) 278
-             279:  274(ivec2) Load 276(i64v)
-             280:  187(ivec2) SConvert 279
-             281:  198(ivec2) Bitcast 280
+             279:274(i64vec2) Load 276(i64v)
+             280:187(i16vec2) SConvert 279
+             281:198(i16vec2) Bitcast 280
                               Store 200(u16v) 281
-             282:  187(ivec2) Load 189(i16v)
-             283:  274(ivec2) SConvert 282
+             282:187(i16vec2) Load 189(i16v)
+             283:274(i64vec2) SConvert 282
                               Store 276(i64v) 283
-             284:  198(ivec2) Load 200(u16v)
-             285:  274(ivec2) UConvert 284
-             286:  274(ivec2) Bitcast 285
+             284:198(i16vec2) Load 200(u16v)
+             285:274(i64vec2) UConvert 284
+             286:274(i64vec2) Bitcast 285
                               Store 276(i64v) 286
-             291:  288(ivec2) Load 290(u64v)
-             292:  187(ivec2) UConvert 291
-             293:  187(ivec2) Bitcast 292
+             291:288(i64vec2) Load 290(u64v)
+             292:187(i16vec2) UConvert 291
+             293:187(i16vec2) Bitcast 292
                               Store 189(i16v) 293
-             294:  288(ivec2) Load 290(u64v)
-             295:  198(ivec2) UConvert 294
+             294:288(i64vec2) Load 290(u64v)
+             295:198(i16vec2) UConvert 294
                               Store 200(u16v) 295
-             296:  187(ivec2) Load 189(i16v)
-             297:  274(ivec2) SConvert 296
-             298:  288(ivec2) Bitcast 297
+             296:187(i16vec2) Load 189(i16v)
+             297:274(i64vec2) SConvert 296
+             298:288(i64vec2) Bitcast 297
                               Store 290(u64v) 298
-             299:  198(ivec2) Load 200(u16v)
-             300:  288(ivec2) UConvert 299
+             299:198(i16vec2) Load 200(u16v)
+             300:288(i64vec2) UConvert 299
                               Store 290(u64v) 300
-             301:  198(ivec2) Load 200(u16v)
-             302:  187(ivec2) Bitcast 301
+             301:198(i16vec2) Load 200(u16v)
+             302:187(i16vec2) Bitcast 301
                               Store 189(i16v) 302
-             303:  187(ivec2) Load 189(i16v)
-             304:  198(ivec2) Bitcast 303
+             303:187(i16vec2) Load 189(i16v)
+             304:198(i16vec2) Bitcast 303
                               Store 200(u16v) 304
                               Return
                               FunctionEnd
@@ -552,224 +552,224 @@ spv.int16.amd.frag
     432(packi64):    431(ptr) Variable Function
     441(packu64):    440(ptr) Variable Function
          450(bv):    449(ptr) Variable Function
-             306:  187(ivec2) Load 305(i16v)
-             307:  187(ivec2) ExtInst 1(GLSL.std.450) 5(SAbs) 306
+             306:187(i16vec2) Load 305(i16v)
+             307:187(i16vec2) ExtInst 1(GLSL.std.450) 5(SAbs) 306
                               Store 305(i16v) 307
-             308:  187(ivec2) Load 305(i16v)
-             309:  187(ivec2) ExtInst 1(GLSL.std.450) 7(SSign) 308
+             308:187(i16vec2) Load 305(i16v)
+             309:187(i16vec2) ExtInst 1(GLSL.std.450) 7(SSign) 308
                               Store 305(i16v) 309
-             310:  187(ivec2) Load 305(i16v)
-             312:     17(int) Load 311(i16)
-             313:  187(ivec2) CompositeConstruct 312 312
-             314:  187(ivec2) ExtInst 1(GLSL.std.450) 39(SMin) 310 313
+             310:187(i16vec2) Load 305(i16v)
+             312: 17(int16_t) Load 311(i16)
+             313:187(i16vec2) CompositeConstruct 312 312
+             314:187(i16vec2) ExtInst 1(GLSL.std.450) 39(SMin) 310 313
                               Store 305(i16v) 314
-             315:  187(ivec2) Load 305(i16v)
-             318:  187(ivec2) ExtInst 1(GLSL.std.450) 39(SMin) 315 317
+             315:187(i16vec2) Load 305(i16v)
+             318:187(i16vec2) ExtInst 1(GLSL.std.450) 39(SMin) 315 317
                               Store 305(i16v) 318
-             320:   49(ivec3) Load 319(u16v)
-             322:     14(int) Load 321(u16)
-             323:   49(ivec3) CompositeConstruct 322 322 322
-             324:   49(ivec3) ExtInst 1(GLSL.std.450) 38(UMin) 320 323
+             320: 49(i16vec3) Load 319(u16v)
+             322: 14(int16_t) Load 321(u16)
+             323: 49(i16vec3) CompositeConstruct 322 322 322
+             324: 49(i16vec3) ExtInst 1(GLSL.std.450) 38(UMin) 320 323
                               Store 319(u16v) 324
-             325:   49(ivec3) Load 319(u16v)
-             327:   49(ivec3) ExtInst 1(GLSL.std.450) 38(UMin) 325 326
+             325: 49(i16vec3) Load 319(u16v)
+             327: 49(i16vec3) ExtInst 1(GLSL.std.450) 38(UMin) 325 326
                               Store 319(u16v) 327
-             328:  187(ivec2) Load 305(i16v)
-             329:     17(int) Load 311(i16)
-             330:  187(ivec2) CompositeConstruct 329 329
-             331:  187(ivec2) ExtInst 1(GLSL.std.450) 42(SMax) 328 330
+             328:187(i16vec2) Load 305(i16v)
+             329: 17(int16_t) Load 311(i16)
+             330:187(i16vec2) CompositeConstruct 329 329
+             331:187(i16vec2) ExtInst 1(GLSL.std.450) 42(SMax) 328 330
                               Store 305(i16v) 331
-             332:  187(ivec2) Load 305(i16v)
-             333:  187(ivec2) ExtInst 1(GLSL.std.450) 42(SMax) 332 317
+             332:187(i16vec2) Load 305(i16v)
+             333:187(i16vec2) ExtInst 1(GLSL.std.450) 42(SMax) 332 317
                               Store 305(i16v) 333
-             334:   49(ivec3) Load 319(u16v)
-             335:     14(int) Load 321(u16)
-             336:   49(ivec3) CompositeConstruct 335 335 335
-             337:   49(ivec3) ExtInst 1(GLSL.std.450) 41(UMax) 334 336
+             334: 49(i16vec3) Load 319(u16v)
+             335: 14(int16_t) Load 321(u16)
+             336: 49(i16vec3) CompositeConstruct 335 335 335
+             337: 49(i16vec3) ExtInst 1(GLSL.std.450) 41(UMax) 334 336
                               Store 319(u16v) 337
-             338:   49(ivec3) Load 319(u16v)
-             339:   49(ivec3) ExtInst 1(GLSL.std.450) 41(UMax) 338 326
+             338: 49(i16vec3) Load 319(u16v)
+             339: 49(i16vec3) ExtInst 1(GLSL.std.450) 41(UMax) 338 326
                               Store 319(u16v) 339
-             340:  187(ivec2) Load 305(i16v)
-             341:     17(int) Load 311(i16)
-             342:     17(int) SNegate 341
-             343:     17(int) Load 311(i16)
-             344:  187(ivec2) CompositeConstruct 342 342
-             345:  187(ivec2) CompositeConstruct 343 343
-             346:  187(ivec2) ExtInst 1(GLSL.std.450) 45(SClamp) 340 344 345
+             340:187(i16vec2) Load 305(i16v)
+             341: 17(int16_t) Load 311(i16)
+             342: 17(int16_t) SNegate 341
+             343: 17(int16_t) Load 311(i16)
+             344:187(i16vec2) CompositeConstruct 342 342
+             345:187(i16vec2) CompositeConstruct 343 343
+             346:187(i16vec2) ExtInst 1(GLSL.std.450) 45(SClamp) 340 344 345
                               Store 305(i16v) 346
-             347:  187(ivec2) Load 305(i16v)
-             348:  187(ivec2) Load 305(i16v)
-             349:  187(ivec2) SNegate 348
-             350:  187(ivec2) Load 305(i16v)
-             351:  187(ivec2) ExtInst 1(GLSL.std.450) 45(SClamp) 347 349 350
+             347:187(i16vec2) Load 305(i16v)
+             348:187(i16vec2) Load 305(i16v)
+             349:187(i16vec2) SNegate 348
+             350:187(i16vec2) Load 305(i16v)
+             351:187(i16vec2) ExtInst 1(GLSL.std.450) 45(SClamp) 347 349 350
                               Store 305(i16v) 351
-             352:   49(ivec3) Load 319(u16v)
-             353:     14(int) Load 321(u16)
-             354:     14(int) SNegate 353
-             355:     14(int) Load 321(u16)
-             356:   49(ivec3) CompositeConstruct 354 354 354
-             357:   49(ivec3) CompositeConstruct 355 355 355
-             358:   49(ivec3) ExtInst 1(GLSL.std.450) 44(UClamp) 352 356 357
+             352: 49(i16vec3) Load 319(u16v)
+             353: 14(int16_t) Load 321(u16)
+             354: 14(int16_t) SNegate 353
+             355: 14(int16_t) Load 321(u16)
+             356: 49(i16vec3) CompositeConstruct 354 354 354
+             357: 49(i16vec3) CompositeConstruct 355 355 355
+             358: 49(i16vec3) ExtInst 1(GLSL.std.450) 44(UClamp) 352 356 357
                               Store 319(u16v) 358
-             359:   49(ivec3) Load 319(u16v)
-             360:   49(ivec3) Load 319(u16v)
-             361:   49(ivec3) SNegate 360
-             362:   49(ivec3) Load 319(u16v)
-             363:   49(ivec3) ExtInst 1(GLSL.std.450) 44(UClamp) 359 361 362
+             359: 49(i16vec3) Load 319(u16v)
+             360: 49(i16vec3) Load 319(u16v)
+             361: 49(i16vec3) SNegate 360
+             362: 49(i16vec3) Load 319(u16v)
+             363: 49(i16vec3) ExtInst 1(GLSL.std.450) 44(UClamp) 359 361 362
                               Store 319(u16v) 363
              364:     35(ptr) AccessChain 305(i16v) 128
-             365:     17(int) Load 364
+             365: 17(int16_t) Load 364
              366:     35(ptr) AccessChain 305(i16v) 111
-             367:     17(int) Load 366
-             369:     17(int) Select 368 367 365
+             367: 17(int16_t) Load 366
+             369: 17(int16_t) Select 368 367 365
                               Store 311(i16) 369
-             370:     17(int) Load 311(i16)
-             371:  187(ivec2) CompositeConstruct 370 370
-             372:     17(int) Load 311(i16)
-             373:     17(int) SNegate 372
-             374:  187(ivec2) CompositeConstruct 373 373
-             377:  187(ivec2) Select 376 374 371
+             370: 17(int16_t) Load 311(i16)
+             371:187(i16vec2) CompositeConstruct 370 370
+             372: 17(int16_t) Load 311(i16)
+             373: 17(int16_t) SNegate 372
+             374:187(i16vec2) CompositeConstruct 373 373
+             377:187(i16vec2) Select 376 374 371
                               Store 305(i16v) 377
              378:     15(ptr) AccessChain 319(u16v) 128
-             379:     14(int) Load 378
+             379: 14(int16_t) Load 378
              380:     15(ptr) AccessChain 319(u16v) 111
-             381:     14(int) Load 380
-             382:     14(int) Select 368 381 379
+             381: 14(int16_t) Load 380
+             382: 14(int16_t) Select 368 381 379
                               Store 321(u16) 382
-             383:     14(int) Load 321(u16)
-             384:   49(ivec3) CompositeConstruct 383 383 383
-             385:     14(int) Load 321(u16)
-             386:     14(int) SNegate 385
-             387:   49(ivec3) CompositeConstruct 386 386 386
-             390:   49(ivec3) Select 389 387 384
+             383: 14(int16_t) Load 321(u16)
+             384: 49(i16vec3) CompositeConstruct 383 383 383
+             385: 14(int16_t) Load 321(u16)
+             386: 14(int16_t) SNegate 385
+             387: 49(i16vec3) CompositeConstruct 386 386 386
+             390: 49(i16vec3) Select 389 387 384
                               Store 319(u16v) 390
-             394:  391(fvec3) Load 393(f16v)
+             394:391(f16vec3) Load 393(f16v)
              398:397(ResType) ExtInst 1(GLSL.std.450) 52(FrexpStruct) 394
-             399:   54(ivec3) CompositeExtract 398 1
+             399: 54(i16vec3) CompositeExtract 398 1
                               Store 396(exp) 399
-             400:  391(fvec3) CompositeExtract 398 0
+             400:391(f16vec3) CompositeExtract 398 0
                               Store 393(f16v) 400
-             401:  391(fvec3) Load 393(f16v)
-             402:   54(ivec3) Load 396(exp)
-             403:  391(fvec3) ExtInst 1(GLSL.std.450) 53(Ldexp) 401 402
+             401:391(f16vec3) Load 393(f16v)
+             402: 54(i16vec3) Load 396(exp)
+             403:391(f16vec3) ExtInst 1(GLSL.std.450) 53(Ldexp) 401 402
                               Store 393(f16v) 403
-             404:  391(fvec3) Load 393(f16v)
-             405:  262(fvec2) VectorShuffle 404 404 0 1
-             406:  187(ivec2) Bitcast 405
+             404:391(f16vec3) Load 393(f16v)
+             405:262(f16vec2) VectorShuffle 404 404 0 1
+             406:187(i16vec2) Bitcast 405
                               Store 305(i16v) 406
              408:    407(ptr) AccessChain 393(f16v) 117
-             409:  261(float) Load 408
-             410:     14(int) Bitcast 409
+             409:261(float16_t) Load 408
+             410: 14(int16_t) Bitcast 409
              411:     15(ptr) AccessChain 319(u16v) 128
                               Store 411 410
-             412:  187(ivec2) Load 305(i16v)
-             413:  262(fvec2) Bitcast 412
-             414:  391(fvec3) Load 393(f16v)
-             415:  391(fvec3) VectorShuffle 414 413 3 4 2
+             412:187(i16vec2) Load 305(i16v)
+             413:262(f16vec2) Bitcast 412
+             414:391(f16vec3) Load 393(f16v)
+             415:391(f16vec3) VectorShuffle 414 413 3 4 2
                               Store 393(f16v) 415
-             416:   49(ivec3) Load 319(u16v)
-             417:  391(fvec3) Bitcast 416
+             416: 49(i16vec3) Load 319(u16v)
+             417:391(f16vec3) Bitcast 416
                               Store 393(f16v) 417
-             419:  187(ivec2) Load 305(i16v)
+             419:187(i16vec2) Load 305(i16v)
              420:     28(int) Bitcast 419
                               Store 418(packi) 420
              421:     28(int) Load 418(packi)
-             422:  187(ivec2) Bitcast 421
+             422:187(i16vec2) Bitcast 421
                               Store 305(i16v) 422
-             424:   49(ivec3) Load 319(u16v)
-             425:  198(ivec2) VectorShuffle 424 424 0 1
+             424: 49(i16vec3) Load 319(u16v)
+             425:198(i16vec2) VectorShuffle 424 424 0 1
              426:     18(int) Bitcast 425
                               Store 423(packu) 426
              427:     18(int) Load 423(packu)
-             428:  198(ivec2) Bitcast 427
-             429:   49(ivec3) Load 319(u16v)
-             430:   49(ivec3) VectorShuffle 429 428 3 4 2
+             428:198(i16vec2) Bitcast 427
+             429: 49(i16vec3) Load 319(u16v)
+             430: 49(i16vec3) VectorShuffle 429 428 3 4 2
                               Store 319(u16v) 430
-             433:     17(int) Load 311(i16)
-             435:  434(ivec4) CompositeConstruct 433 433 433 433
-             436:    273(int) Bitcast 435
+             433: 17(int16_t) Load 311(i16)
+             435:434(i16vec4) CompositeConstruct 433 433 433 433
+             436:273(int64_t) Bitcast 435
                               Store 432(packi64) 436
-             437:    273(int) Load 432(packi64)
-             438:  434(ivec4) Bitcast 437
-             439:  187(ivec2) VectorShuffle 438 438 0 1
+             437:273(int64_t) Load 432(packi64)
+             438:434(i16vec4) Bitcast 437
+             439:187(i16vec2) VectorShuffle 438 438 0 1
                               Store 305(i16v) 439
-             442:     14(int) Load 321(u16)
-             444:  443(ivec4) CompositeConstruct 442 442 442 442
-             445:    287(int) Bitcast 444
+             442: 14(int16_t) Load 321(u16)
+             444:443(i16vec4) CompositeConstruct 442 442 442 442
+             445:287(int64_t) Bitcast 444
                               Store 441(packu64) 445
-             446:    287(int) Load 441(packu64)
-             447:  443(ivec4) Bitcast 446
-             448:   49(ivec3) VectorShuffle 447 447 0 1 2
+             446:287(int64_t) Load 441(packu64)
+             447:443(i16vec4) Bitcast 446
+             448: 49(i16vec3) VectorShuffle 447 447 0 1 2
                               Store 319(u16v) 448
-             451:   49(ivec3) Load 319(u16v)
-             452:     14(int) Load 321(u16)
-             453:   49(ivec3) CompositeConstruct 452 452 452
+             451: 49(i16vec3) Load 319(u16v)
+             452: 14(int16_t) Load 321(u16)
+             453: 49(i16vec3) CompositeConstruct 452 452 452
              454:  388(bvec3) ULessThan 451 453
                               Store 450(bv) 454
-             455:  187(ivec2) Load 305(i16v)
-             456:     17(int) Load 311(i16)
-             457:  187(ivec2) CompositeConstruct 456 456
+             455:187(i16vec2) Load 305(i16v)
+             456: 17(int16_t) Load 311(i16)
+             457:187(i16vec2) CompositeConstruct 456 456
              458:  190(bvec2) SLessThan 455 457
              459:  388(bvec3) Load 450(bv)
              460:  388(bvec3) VectorShuffle 459 458 3 4 2
                               Store 450(bv) 460
-             461:   49(ivec3) Load 319(u16v)
-             462:     14(int) Load 321(u16)
-             463:   49(ivec3) CompositeConstruct 462 462 462
+             461: 49(i16vec3) Load 319(u16v)
+             462: 14(int16_t) Load 321(u16)
+             463: 49(i16vec3) CompositeConstruct 462 462 462
              464:  388(bvec3) ULessThanEqual 461 463
                               Store 450(bv) 464
-             465:  187(ivec2) Load 305(i16v)
-             466:     17(int) Load 311(i16)
-             467:  187(ivec2) CompositeConstruct 466 466
+             465:187(i16vec2) Load 305(i16v)
+             466: 17(int16_t) Load 311(i16)
+             467:187(i16vec2) CompositeConstruct 466 466
              468:  190(bvec2) SLessThanEqual 465 467
              469:  388(bvec3) Load 450(bv)
              470:  388(bvec3) VectorShuffle 469 468 3 4 2
                               Store 450(bv) 470
-             471:   49(ivec3) Load 319(u16v)
-             472:     14(int) Load 321(u16)
-             473:   49(ivec3) CompositeConstruct 472 472 472
+             471: 49(i16vec3) Load 319(u16v)
+             472: 14(int16_t) Load 321(u16)
+             473: 49(i16vec3) CompositeConstruct 472 472 472
              474:  388(bvec3) UGreaterThan 471 473
                               Store 450(bv) 474
-             475:  187(ivec2) Load 305(i16v)
-             476:     17(int) Load 311(i16)
-             477:  187(ivec2) CompositeConstruct 476 476
+             475:187(i16vec2) Load 305(i16v)
+             476: 17(int16_t) Load 311(i16)
+             477:187(i16vec2) CompositeConstruct 476 476
              478:  190(bvec2) SGreaterThan 475 477
              479:  388(bvec3) Load 450(bv)
              480:  388(bvec3) VectorShuffle 479 478 3 4 2
                               Store 450(bv) 480
-             481:   49(ivec3) Load 319(u16v)
-             482:     14(int) Load 321(u16)
-             483:   49(ivec3) CompositeConstruct 482 482 482
+             481: 49(i16vec3) Load 319(u16v)
+             482: 14(int16_t) Load 321(u16)
+             483: 49(i16vec3) CompositeConstruct 482 482 482
              484:  388(bvec3) UGreaterThanEqual 481 483
                               Store 450(bv) 484
-             485:  187(ivec2) Load 305(i16v)
-             486:     17(int) Load 311(i16)
-             487:  187(ivec2) CompositeConstruct 486 486
+             485:187(i16vec2) Load 305(i16v)
+             486: 17(int16_t) Load 311(i16)
+             487:187(i16vec2) CompositeConstruct 486 486
              488:  190(bvec2) SGreaterThanEqual 485 487
              489:  388(bvec3) Load 450(bv)
              490:  388(bvec3) VectorShuffle 489 488 3 4 2
                               Store 450(bv) 490
-             491:   49(ivec3) Load 319(u16v)
-             492:     14(int) Load 321(u16)
-             493:   49(ivec3) CompositeConstruct 492 492 492
+             491: 49(i16vec3) Load 319(u16v)
+             492: 14(int16_t) Load 321(u16)
+             493: 49(i16vec3) CompositeConstruct 492 492 492
              494:  388(bvec3) IEqual 491 493
                               Store 450(bv) 494
-             495:  187(ivec2) Load 305(i16v)
-             496:     17(int) Load 311(i16)
-             497:  187(ivec2) CompositeConstruct 496 496
+             495:187(i16vec2) Load 305(i16v)
+             496: 17(int16_t) Load 311(i16)
+             497:187(i16vec2) CompositeConstruct 496 496
              498:  190(bvec2) IEqual 495 497
              499:  388(bvec3) Load 450(bv)
              500:  388(bvec3) VectorShuffle 499 498 3 4 2
                               Store 450(bv) 500
-             501:   49(ivec3) Load 319(u16v)
-             502:     14(int) Load 321(u16)
-             503:   49(ivec3) CompositeConstruct 502 502 502
+             501: 49(i16vec3) Load 319(u16v)
+             502: 14(int16_t) Load 321(u16)
+             503: 49(i16vec3) CompositeConstruct 502 502 502
              504:  388(bvec3) INotEqual 501 503
                               Store 450(bv) 504
-             505:  187(ivec2) Load 305(i16v)
-             506:     17(int) Load 311(i16)
-             507:  187(ivec2) CompositeConstruct 506 506
+             505:187(i16vec2) Load 305(i16v)
+             506: 17(int16_t) Load 311(i16)
+             507:187(i16vec2) CompositeConstruct 506 506
              508:  190(bvec2) INotEqual 505 507
              509:  388(bvec3) Load 450(bv)
              510:  388(bvec3) VectorShuffle 509 508 3 4 2

--- a/Test/baseResults/spv.int16.frag.out
+++ b/Test/baseResults/spv.int16.frag.out
@@ -100,13 +100,13 @@ spv.int16.frag
                2:             TypeVoid
                3:             TypeFunction 2
               14:             TypeInt 16 1
-              15:             TypePointer Function 14(int)
+              15:             TypePointer Function 14(int16_t)
               17:             TypeInt 32 0
               18:     17(int) Constant 3
-              19:             TypeArray 14(int) 18
-              20:     14(int) Constant 4294962927
-              21:     14(int) Constant 4294967295
-              22:     14(int) Constant 16384
+              19:             TypeArray 14(int16_t) 18
+              20: 14(int16_t) Constant 4294962927
+              21: 14(int16_t) Constant 4294967295
+              22: 14(int16_t) Constant 16384
               23:          19 ConstantComposite 20 21 22
     24(Uniforms):             TypeStruct 17(int)
               25:             TypePointer Uniform 24(Uniforms)
@@ -116,83 +116,83 @@ spv.int16.frag
               29:             TypePointer Uniform 17(int)
               32:             TypePointer Function 19
               36:             TypeInt 16 0
-              37:             TypePointer Function 36(int)
-              39:             TypeArray 36(int) 18
-              40:     36(int) Constant 65535
-              41:     36(int) Constant 32767
+              37:             TypePointer Function 36(int16_t)
+              39:             TypeArray 36(int16_t) 18
+              40: 36(int16_t) Constant 65535
+              41: 36(int16_t) Constant 32767
               42:          39 ConstantComposite 40 40 41
               45:             TypePointer Function 39
               49:             TypeVector 27(int) 2
               50:             TypePointer Function 49(ivec2)
-              52:             TypeVector 14(int) 2
-              53:             TypePointer Function 52(ivec2)
-              57:             TypeVector 36(int) 2
-              58:             TypePointer Function 57(ivec2)
+              52:             TypeVector 14(int16_t) 2
+              53:             TypePointer Function 52(i16vec2)
+              57:             TypeVector 36(int16_t) 2
+              58:             TypePointer Function 57(i16vec2)
               65:             TypeVector 17(int) 2
               66:             TypePointer Function 65(ivec2)
               71:             TypeInt 64 1
-              72:             TypeVector 71(int) 2
-              73:             TypePointer Function 72(ivec2)
+              72:             TypeVector 71(int64_t) 2
+              73:             TypePointer Function 72(i64vec2)
               77:             TypeInt 64 0
-              78:             TypeVector 77(int) 2
-              79:             TypePointer Function 78(ivec2)
+              78:             TypeVector 77(int64_t) 2
+              79:             TypePointer Function 78(i64vec2)
               91:             TypeFloat 16
-              92:             TypeVector 91(float) 2
-              93:             TypePointer Function 92(fvec2)
+              92:             TypeVector 91(float16_t) 2
+              93:             TypePointer Function 92(f16vec2)
               97:             TypeFloat 32
               98:             TypeVector 97(float) 2
               99:             TypePointer Function 98(fvec2)
              103:             TypeFloat 64
-             104:             TypeVector 103(float) 2
-             105:             TypePointer Function 104(fvec2)
+             104:             TypeVector 103(float64_t) 2
+             105:             TypePointer Function 104(f64vec2)
              151:             TypeInt 8 1
-             152:             TypeVector 151(int) 2
-             153:             TypePointer Function 152(ivec2)
+             152:             TypeVector 151(int8_t) 2
+             153:             TypePointer Function 152(i8vec2)
              160:             TypeInt 8 0
-             161:             TypeVector 160(int) 2
-             162:             TypePointer Function 161(ivec2)
+             161:             TypeVector 160(int8_t) 2
+             162:             TypePointer Function 161(i8vec2)
              173:             TypeBool
              174:             TypeVector 173(bool) 2
              175:             TypePointer Function 174(bvec2)
-             178:     14(int) Constant 0
-             179:     14(int) Constant 1
-             180:   52(ivec2) ConstantComposite 178 178
-             181:   52(ivec2) ConstantComposite 179 179
-             184:     36(int) Constant 0
-             185:     36(int) Constant 1
-             186:   57(ivec2) ConstantComposite 184 184
-             187:   57(ivec2) ConstantComposite 185 185
-             193:             TypeVector 36(int) 3
-             194:             TypePointer Function 193(ivec3)
-             197:             TypeVector 14(int) 3
+             178: 14(int16_t) Constant 0
+             179: 14(int16_t) Constant 1
+             180: 52(i16vec2) ConstantComposite 178 178
+             181: 52(i16vec2) ConstantComposite 179 179
+             184: 36(int16_t) Constant 0
+             185: 36(int16_t) Constant 1
+             186: 57(i16vec2) ConstantComposite 184 184
+             187: 57(i16vec2) ConstantComposite 185 185
+             193:             TypeVector 36(int16_t) 3
+             194:             TypePointer Function 193(i16vec3)
+             197:             TypeVector 14(int16_t) 3
              219:             TypePointer Function 27(int)
              225:             TypeVector 17(int) 3
              226:             TypePointer Function 225(ivec3)
-             242:             TypePointer Function 71(int)
+             242:             TypePointer Function 71(int64_t)
              264:     17(int) Constant 1
              270:     17(int) Constant 2
              276:             TypeVector 27(int) 3
              280:             TypePointer Function 173(bool)
              282:     17(int) Constant 0
              296:             TypePointer Function 17(int)
-             354:   52(ivec2) ConstantComposite 21 21
-             363:  193(ivec3) ConstantComposite 184 184 184
+             354: 52(i16vec2) ConstantComposite 21 21
+             363:193(i16vec3) ConstantComposite 184 184 184
              405:   173(bool) ConstantTrue
              412:   173(bool) ConstantFalse
              413:  174(bvec2) ConstantComposite 412 412
              425:             TypeVector 173(bool) 3
              426:  425(bvec3) ConstantComposite 412 412 412
-             432:             TypeVector 14(int) 4
-             433:             TypePointer Function 432(ivec4)
-             441:             TypePointer Function 77(int)
-             443:             TypeVector 36(int) 4
-             444:             TypePointer Function 443(ivec4)
+             432:             TypeVector 14(int16_t) 4
+             433:             TypePointer Function 432(i16vec4)
+             441:             TypePointer Function 77(int64_t)
+             443:             TypeVector 36(int16_t) 4
+             444:             TypePointer Function 443(i16vec4)
              456:             TypePointer Function 425(bvec3)
-      518(Block):             TypeStruct 14(int) 52(ivec2) 197(ivec3) 432(ivec4) 36(int) 57(ivec2) 193(ivec3) 443(ivec4)
+      518(Block):             TypeStruct 14(int16_t) 52(i16vec2) 197(i16vec3) 432(i16vec4) 36(int16_t) 57(i16vec2) 193(i16vec3) 443(i16vec4)
              519:             TypePointer Uniform 518(Block)
       520(block):    519(ptr) Variable Uniform
-       521(si16):     14(int) SpecConstant 4294967286
-       522(su16):     36(int) SpecConstant 20
+       521(si16): 14(int16_t) SpecConstant 4294967286
+       522(su16): 36(int16_t) SpecConstant 20
          4(main):           2 Function None 3
                5:             Label
                               Return
@@ -207,13 +207,13 @@ spv.int16.frag
               31:     17(int) Load 30
                               Store 33(indexable) 23
               34:     15(ptr) AccessChain 33(indexable) 31
-              35:     14(int) Load 34
+              35: 14(int16_t) Load 34
                               Store 16(i16) 35
               43:     29(ptr) AccessChain 26 28
               44:     17(int) Load 43
                               Store 46(indexable) 42
               47:     37(ptr) AccessChain 46(indexable) 44
-              48:     36(int) Load 47
+              48: 36(int16_t) Load 47
                               Store 38(u16) 48
                               Return
                               FunctionEnd
@@ -231,135 +231,135 @@ spv.int16.frag
         154(i8v):    153(ptr) Variable Function
         163(u8v):    162(ptr) Variable Function
          176(bv):    175(ptr) Variable Function
-              55:   52(ivec2) Load 54(i16v)
+              55: 52(i16vec2) Load 54(i16v)
               56:   49(ivec2) SConvert 55
                               Store 51(i32v) 56
-              60:   57(ivec2) Load 59(u16v)
+              60: 57(i16vec2) Load 59(u16v)
               61:   49(ivec2) UConvert 60
               62:   49(ivec2) Bitcast 61
                               Store 51(i32v) 62
-              63:   52(ivec2) Load 54(i16v)
-              64:   57(ivec2) Bitcast 63
+              63: 52(i16vec2) Load 54(i16v)
+              64: 57(i16vec2) Bitcast 63
                               Store 59(u16v) 64
-              68:   52(ivec2) Load 54(i16v)
+              68: 52(i16vec2) Load 54(i16v)
               69:   49(ivec2) SConvert 68
               70:   65(ivec2) Bitcast 69
                               Store 67(u32v) 70
-              75:   52(ivec2) Load 54(i16v)
-              76:   72(ivec2) SConvert 75
+              75: 52(i16vec2) Load 54(i16v)
+              76: 72(i64vec2) SConvert 75
                               Store 74(i64v) 76
-              81:   52(ivec2) Load 54(i16v)
-              82:   72(ivec2) SConvert 81
-              83:   78(ivec2) Bitcast 82
+              81: 52(i16vec2) Load 54(i16v)
+              82: 72(i64vec2) SConvert 81
+              83: 78(i64vec2) Bitcast 82
                               Store 80(u64v) 83
-              84:   57(ivec2) Load 59(u16v)
+              84: 57(i16vec2) Load 59(u16v)
               85:   65(ivec2) UConvert 84
                               Store 67(u32v) 85
-              86:   57(ivec2) Load 59(u16v)
-              87:   72(ivec2) UConvert 86
-              88:   72(ivec2) Bitcast 87
+              86: 57(i16vec2) Load 59(u16v)
+              87: 72(i64vec2) UConvert 86
+              88: 72(i64vec2) Bitcast 87
                               Store 74(i64v) 88
-              89:   57(ivec2) Load 59(u16v)
-              90:   78(ivec2) UConvert 89
+              89: 57(i16vec2) Load 59(u16v)
+              90: 78(i64vec2) UConvert 89
                               Store 80(u64v) 90
-              95:   52(ivec2) Load 54(i16v)
-              96:   92(fvec2) ConvertSToF 95
+              95: 52(i16vec2) Load 54(i16v)
+              96: 92(f16vec2) ConvertSToF 95
                               Store 94(f16v) 96
-             101:   52(ivec2) Load 54(i16v)
+             101: 52(i16vec2) Load 54(i16v)
              102:   98(fvec2) ConvertSToF 101
                               Store 100(f32v) 102
-             107:   52(ivec2) Load 54(i16v)
-             108:  104(fvec2) ConvertSToF 107
+             107: 52(i16vec2) Load 54(i16v)
+             108:104(f64vec2) ConvertSToF 107
                               Store 106(f64v) 108
-             109:   57(ivec2) Load 59(u16v)
-             110:   92(fvec2) ConvertUToF 109
+             109: 57(i16vec2) Load 59(u16v)
+             110: 92(f16vec2) ConvertUToF 109
                               Store 94(f16v) 110
-             111:   57(ivec2) Load 59(u16v)
+             111: 57(i16vec2) Load 59(u16v)
              112:   98(fvec2) ConvertUToF 111
                               Store 100(f32v) 112
-             113:   57(ivec2) Load 59(u16v)
-             114:  104(fvec2) ConvertUToF 113
+             113: 57(i16vec2) Load 59(u16v)
+             114:104(f64vec2) ConvertUToF 113
                               Store 106(f64v) 114
-             115:   52(ivec2) Load 54(i16v)
+             115: 52(i16vec2) Load 54(i16v)
              116:   49(ivec2) SConvert 115
                               Store 51(i32v) 116
-             117:   57(ivec2) Load 59(u16v)
+             117: 57(i16vec2) Load 59(u16v)
              118:   49(ivec2) UConvert 117
              119:   49(ivec2) Bitcast 118
                               Store 51(i32v) 119
-             120:   52(ivec2) Load 54(i16v)
-             121:   57(ivec2) Bitcast 120
+             120: 52(i16vec2) Load 54(i16v)
+             121: 57(i16vec2) Bitcast 120
                               Store 59(u16v) 121
-             122:   52(ivec2) Load 54(i16v)
+             122: 52(i16vec2) Load 54(i16v)
              123:   49(ivec2) SConvert 122
              124:   65(ivec2) Bitcast 123
                               Store 67(u32v) 124
-             125:   52(ivec2) Load 54(i16v)
-             126:   72(ivec2) SConvert 125
+             125: 52(i16vec2) Load 54(i16v)
+             126: 72(i64vec2) SConvert 125
                               Store 74(i64v) 126
-             127:   52(ivec2) Load 54(i16v)
-             128:   72(ivec2) SConvert 127
-             129:   78(ivec2) Bitcast 128
+             127: 52(i16vec2) Load 54(i16v)
+             128: 72(i64vec2) SConvert 127
+             129: 78(i64vec2) Bitcast 128
                               Store 80(u64v) 129
-             130:   57(ivec2) Load 59(u16v)
+             130: 57(i16vec2) Load 59(u16v)
              131:   65(ivec2) UConvert 130
                               Store 67(u32v) 131
-             132:   57(ivec2) Load 59(u16v)
-             133:   72(ivec2) UConvert 132
-             134:   72(ivec2) Bitcast 133
+             132: 57(i16vec2) Load 59(u16v)
+             133: 72(i64vec2) UConvert 132
+             134: 72(i64vec2) Bitcast 133
                               Store 74(i64v) 134
-             135:   57(ivec2) Load 59(u16v)
-             136:   72(ivec2) UConvert 135
-             137:   72(ivec2) Bitcast 136
-             138:   78(ivec2) Bitcast 137
+             135: 57(i16vec2) Load 59(u16v)
+             136: 72(i64vec2) UConvert 135
+             137: 72(i64vec2) Bitcast 136
+             138: 78(i64vec2) Bitcast 137
                               Store 80(u64v) 138
-             139:   52(ivec2) Load 54(i16v)
-             140:   92(fvec2) ConvertSToF 139
+             139: 52(i16vec2) Load 54(i16v)
+             140: 92(f16vec2) ConvertSToF 139
                               Store 94(f16v) 140
-             141:   52(ivec2) Load 54(i16v)
+             141: 52(i16vec2) Load 54(i16v)
              142:   98(fvec2) ConvertSToF 141
                               Store 100(f32v) 142
-             143:   52(ivec2) Load 54(i16v)
-             144:  104(fvec2) ConvertSToF 143
+             143: 52(i16vec2) Load 54(i16v)
+             144:104(f64vec2) ConvertSToF 143
                               Store 106(f64v) 144
-             145:   57(ivec2) Load 59(u16v)
-             146:   92(fvec2) ConvertUToF 145
+             145: 57(i16vec2) Load 59(u16v)
+             146: 92(f16vec2) ConvertUToF 145
                               Store 94(f16v) 146
-             147:   57(ivec2) Load 59(u16v)
+             147: 57(i16vec2) Load 59(u16v)
              148:   98(fvec2) ConvertUToF 147
                               Store 100(f32v) 148
-             149:   57(ivec2) Load 59(u16v)
-             150:  104(fvec2) ConvertUToF 149
+             149: 57(i16vec2) Load 59(u16v)
+             150:104(f64vec2) ConvertUToF 149
                               Store 106(f64v) 150
-             155:   52(ivec2) Load 54(i16v)
-             156:  152(ivec2) SConvert 155
+             155: 52(i16vec2) Load 54(i16v)
+             156: 152(i8vec2) SConvert 155
                               Store 154(i8v) 156
-             157:   57(ivec2) Load 59(u16v)
-             158:  152(ivec2) UConvert 157
-             159:  152(ivec2) Bitcast 158
+             157: 57(i16vec2) Load 59(u16v)
+             158: 152(i8vec2) UConvert 157
+             159: 152(i8vec2) Bitcast 158
                               Store 154(i8v) 159
-             164:   52(ivec2) Load 54(i16v)
-             165:  152(ivec2) SConvert 164
-             166:  161(ivec2) Bitcast 165
+             164: 52(i16vec2) Load 54(i16v)
+             165: 152(i8vec2) SConvert 164
+             166: 161(i8vec2) Bitcast 165
                               Store 163(u8v) 166
-             167:   57(ivec2) Load 59(u16v)
-             168:  161(ivec2) UConvert 167
+             167: 57(i16vec2) Load 59(u16v)
+             168: 161(i8vec2) UConvert 167
                               Store 163(u8v) 168
-             169:   57(ivec2) Load 59(u16v)
-             170:  161(ivec2) UConvert 169
-             171:   52(ivec2) UConvert 170
-             172:   52(ivec2) Bitcast 171
+             169: 57(i16vec2) Load 59(u16v)
+             170: 161(i8vec2) UConvert 169
+             171: 52(i16vec2) UConvert 170
+             172: 52(i16vec2) Bitcast 171
                               Store 54(i16v) 172
              177:  174(bvec2) Load 176(bv)
-             182:   52(ivec2) Select 177 181 180
+             182: 52(i16vec2) Select 177 181 180
                               Store 54(i16v) 182
              183:  174(bvec2) Load 176(bv)
-             188:   57(ivec2) Select 183 187 186
+             188: 57(i16vec2) Select 183 187 186
                               Store 59(u16v) 188
-             189:   52(ivec2) Load 54(i16v)
+             189: 52(i16vec2) Load 54(i16v)
              190:  174(bvec2) INotEqual 189 186
                               Store 176(bv) 190
-             191:   57(ivec2) Load 59(u16v)
+             191: 57(i16vec2) Load 59(u16v)
              192:  174(bvec2) INotEqual 191 186
                               Store 176(bv) 192
                               Return
@@ -372,169 +372,169 @@ spv.int16.frag
          227(uv):    226(ptr) Variable Function
         243(i64):    242(ptr) Variable Function
           281(b):    280(ptr) Variable Function
-             196:  193(ivec3) Load 195(u16v)
-             198:  197(ivec3) CompositeConstruct 179 179 179
-             199:  193(ivec3) IAdd 196 198
+             196:193(i16vec3) Load 195(u16v)
+             198:197(i16vec3) CompositeConstruct 179 179 179
+             199:193(i16vec3) IAdd 196 198
                               Store 195(u16v) 199
-             201:     14(int) Load 200(i16)
-             202:     14(int) ISub 201 179
+             201: 14(int16_t) Load 200(i16)
+             202: 14(int16_t) ISub 201 179
                               Store 200(i16) 202
-             203:     14(int) Load 200(i16)
-             204:     14(int) IAdd 203 179
+             203: 14(int16_t) Load 200(i16)
+             204: 14(int16_t) IAdd 203 179
                               Store 200(i16) 204
-             205:  193(ivec3) Load 195(u16v)
-             206:  197(ivec3) CompositeConstruct 179 179 179
-             207:  193(ivec3) ISub 205 206
+             205:193(i16vec3) Load 195(u16v)
+             206:197(i16vec3) CompositeConstruct 179 179 179
+             207:193(i16vec3) ISub 205 206
                               Store 195(u16v) 207
-             208:  193(ivec3) Load 195(u16v)
-             209:  193(ivec3) Not 208
+             208:193(i16vec3) Load 195(u16v)
+             209:193(i16vec3) Not 208
                               Store 195(u16v) 209
-             210:     14(int) Load 200(i16)
+             210: 14(int16_t) Load 200(i16)
                               Store 200(i16) 210
-             211:  193(ivec3) Load 195(u16v)
-             212:  193(ivec3) SNegate 211
+             211:193(i16vec3) Load 195(u16v)
+             212:193(i16vec3) SNegate 211
                               Store 195(u16v) 212
-             213:     14(int) Load 200(i16)
-             214:     14(int) Load 200(i16)
-             215:     14(int) IAdd 214 213
+             213: 14(int16_t) Load 200(i16)
+             214: 14(int16_t) Load 200(i16)
+             215: 14(int16_t) IAdd 214 213
                               Store 200(i16) 215
-             216:  193(ivec3) Load 195(u16v)
-             217:  193(ivec3) Load 195(u16v)
-             218:  193(ivec3) ISub 217 216
+             216:193(i16vec3) Load 195(u16v)
+             217:193(i16vec3) Load 195(u16v)
+             218:193(i16vec3) ISub 217 216
                               Store 195(u16v) 218
-             221:     14(int) Load 200(i16)
+             221: 14(int16_t) Load 200(i16)
              222:     27(int) SConvert 221
              223:     27(int) Load 220(i)
              224:     27(int) IMul 223 222
                               Store 220(i) 224
-             228:  193(ivec3) Load 195(u16v)
+             228:193(i16vec3) Load 195(u16v)
              229:  225(ivec3) UConvert 228
              230:  225(ivec3) Load 227(uv)
              231:  225(ivec3) UDiv 230 229
                               Store 227(uv) 231
-             232:     14(int) Load 200(i16)
+             232: 14(int16_t) Load 200(i16)
              233:     27(int) SConvert 232
              234:     17(int) Bitcast 233
              235:  225(ivec3) Load 227(uv)
              236:  225(ivec3) CompositeConstruct 234 234 234
              237:  225(ivec3) UMod 235 236
                               Store 227(uv) 237
-             238:  193(ivec3) Load 195(u16v)
+             238:193(i16vec3) Load 195(u16v)
              239:  225(ivec3) UConvert 238
              240:  225(ivec3) Load 227(uv)
              241:  225(ivec3) IAdd 239 240
                               Store 227(uv) 241
-             244:     14(int) Load 200(i16)
-             245:     71(int) SConvert 244
-             246:     71(int) Load 243(i64)
-             247:     71(int) ISub 245 246
+             244: 14(int16_t) Load 200(i16)
+             245: 71(int64_t) SConvert 244
+             246: 71(int64_t) Load 243(i64)
+             247: 71(int64_t) ISub 245 246
                               Store 243(i64) 247
-             248:  193(ivec3) Load 195(u16v)
+             248:193(i16vec3) Load 195(u16v)
              249:  225(ivec3) UConvert 248
              250:  225(ivec3) Load 227(uv)
              251:  225(ivec3) IMul 249 250
                               Store 227(uv) 251
-             252:     14(int) Load 200(i16)
-             253:     71(int) SConvert 252
-             254:     71(int) Load 243(i64)
-             255:     71(int) IMul 253 254
+             252: 14(int16_t) Load 200(i16)
+             253: 71(int64_t) SConvert 252
+             254: 71(int64_t) Load 243(i64)
+             255: 71(int64_t) IMul 253 254
                               Store 243(i64) 255
-             256:     14(int) Load 200(i16)
+             256: 14(int16_t) Load 200(i16)
              257:     27(int) SConvert 256
              258:     27(int) Load 220(i)
              259:     27(int) SMod 257 258
                               Store 220(i) 259
-             260:     14(int) Load 200(i16)
-             261:  193(ivec3) Load 195(u16v)
-             262:  197(ivec3) CompositeConstruct 260 260 260
-             263:  193(ivec3) ShiftLeftLogical 261 262
+             260: 14(int16_t) Load 200(i16)
+             261:193(i16vec3) Load 195(u16v)
+             262:197(i16vec3) CompositeConstruct 260 260 260
+             263:193(i16vec3) ShiftLeftLogical 261 262
                               Store 195(u16v) 263
              265:     37(ptr) AccessChain 195(u16v) 264
-             266:     36(int) Load 265
-             267:     14(int) Load 200(i16)
-             268:     14(int) ShiftRightArithmetic 267 266
+             266: 36(int16_t) Load 265
+             267: 14(int16_t) Load 200(i16)
+             268: 14(int16_t) ShiftRightArithmetic 267 266
                               Store 200(i16) 268
-             269:     14(int) Load 200(i16)
+             269: 14(int16_t) Load 200(i16)
              271:     37(ptr) AccessChain 195(u16v) 270
-             272:     36(int) Load 271
-             273:     14(int) ShiftLeftLogical 269 272
+             272: 36(int16_t) Load 271
+             273: 14(int16_t) ShiftLeftLogical 269 272
                               Store 200(i16) 273
-             274:  193(ivec3) Load 195(u16v)
+             274:193(i16vec3) Load 195(u16v)
              275:     27(int) Load 220(i)
              277:  276(ivec3) CompositeConstruct 275 275 275
-             278:  193(ivec3) ShiftLeftLogical 274 277
+             278:193(i16vec3) ShiftLeftLogical 274 277
              279:  225(ivec3) UConvert 278
                               Store 227(uv) 279
              283:     37(ptr) AccessChain 195(u16v) 282
-             284:     36(int) Load 283
-             285:     14(int) Load 200(i16)
-             286:     36(int) Bitcast 285
+             284: 36(int16_t) Load 283
+             285: 14(int16_t) Load 200(i16)
+             286: 36(int16_t) Bitcast 285
              287:   173(bool) INotEqual 284 286
                               Store 281(b) 287
-             288:     14(int) Load 200(i16)
-             289:     36(int) Bitcast 288
+             288: 14(int16_t) Load 200(i16)
+             289: 36(int16_t) Bitcast 288
              290:     37(ptr) AccessChain 195(u16v) 282
-             291:     36(int) Load 290
+             291: 36(int16_t) Load 290
              292:   173(bool) IEqual 289 291
                               Store 281(b) 292
              293:     37(ptr) AccessChain 195(u16v) 282
-             294:     36(int) Load 293
+             294: 36(int16_t) Load 293
              295:     17(int) UConvert 294
              297:    296(ptr) AccessChain 227(uv) 264
              298:     17(int) Load 297
              299:   173(bool) UGreaterThan 295 298
                               Store 281(b) 299
-             300:     14(int) Load 200(i16)
+             300: 14(int16_t) Load 200(i16)
              301:     27(int) SConvert 300
              302:     27(int) Load 220(i)
              303:   173(bool) SLessThan 301 302
                               Store 281(b) 303
              304:     37(ptr) AccessChain 195(u16v) 264
-             305:     36(int) Load 304
+             305: 36(int16_t) Load 304
              306:     17(int) UConvert 305
              307:    296(ptr) AccessChain 227(uv) 282
              308:     17(int) Load 307
              309:   173(bool) UGreaterThanEqual 306 308
                               Store 281(b) 309
-             310:     14(int) Load 200(i16)
+             310: 14(int16_t) Load 200(i16)
              311:     27(int) SConvert 310
              312:     27(int) Load 220(i)
              313:   173(bool) SLessThanEqual 311 312
                               Store 281(b) 313
-             314:     14(int) Load 200(i16)
+             314: 14(int16_t) Load 200(i16)
              315:     27(int) SConvert 314
              316:     17(int) Bitcast 315
              317:  225(ivec3) Load 227(uv)
              318:  225(ivec3) CompositeConstruct 316 316 316
              319:  225(ivec3) BitwiseOr 317 318
                               Store 227(uv) 319
-             320:     14(int) Load 200(i16)
+             320: 14(int16_t) Load 200(i16)
              321:     27(int) SConvert 320
              322:     27(int) Load 220(i)
              323:     27(int) BitwiseOr 321 322
                               Store 220(i) 323
-             324:     14(int) Load 200(i16)
-             325:     71(int) SConvert 324
-             326:     71(int) Load 243(i64)
-             327:     71(int) BitwiseAnd 326 325
+             324: 14(int16_t) Load 200(i16)
+             325: 71(int64_t) SConvert 324
+             326: 71(int64_t) Load 243(i64)
+             327: 71(int64_t) BitwiseAnd 326 325
                               Store 243(i64) 327
-             328:  193(ivec3) Load 195(u16v)
+             328:193(i16vec3) Load 195(u16v)
              329:  225(ivec3) UConvert 328
              330:  225(ivec3) Load 227(uv)
              331:  225(ivec3) BitwiseAnd 329 330
                               Store 227(uv) 331
-             332:     14(int) Load 200(i16)
+             332: 14(int16_t) Load 200(i16)
              333:     27(int) SConvert 332
              334:     17(int) Bitcast 333
              335:  225(ivec3) Load 227(uv)
              336:  225(ivec3) CompositeConstruct 334 334 334
              337:  225(ivec3) BitwiseXor 335 336
                               Store 227(uv) 337
-             338:  193(ivec3) Load 195(u16v)
-             339:     14(int) Load 200(i16)
-             340:     36(int) Bitcast 339
-             341:  193(ivec3) CompositeConstruct 340 340 340
-             342:  193(ivec3) BitwiseXor 338 341
+             338:193(i16vec3) Load 195(u16v)
+             339: 14(int16_t) Load 200(i16)
+             340: 36(int16_t) Bitcast 339
+             341:193(i16vec3) CompositeConstruct 340 340 340
+             342:193(i16vec3) BitwiseXor 338 341
                               Store 195(u16v) 342
                               Return
                               FunctionEnd
@@ -552,190 +552,190 @@ spv.int16.frag
         442(u64):    441(ptr) Variable Function
       445(u16v4):    444(ptr) Variable Function
          457(bv):    456(ptr) Variable Function
-             344:   52(ivec2) Load 343(i16v)
-             345:   52(ivec2) ExtInst 1(GLSL.std.450) 5(SAbs) 344
+             344: 52(i16vec2) Load 343(i16v)
+             345: 52(i16vec2) ExtInst 1(GLSL.std.450) 5(SAbs) 344
                               Store 343(i16v) 345
-             347:     14(int) Load 346(i16)
-             348:     14(int) ExtInst 1(GLSL.std.450) 7(SSign) 347
+             347: 14(int16_t) Load 346(i16)
+             348: 14(int16_t) ExtInst 1(GLSL.std.450) 7(SSign) 347
                               Store 346(i16) 348
-             349:   52(ivec2) Load 343(i16v)
-             350:     14(int) Load 346(i16)
-             351:   52(ivec2) CompositeConstruct 350 350
-             352:   52(ivec2) ExtInst 1(GLSL.std.450) 39(SMin) 349 351
+             349: 52(i16vec2) Load 343(i16v)
+             350: 14(int16_t) Load 346(i16)
+             351: 52(i16vec2) CompositeConstruct 350 350
+             352: 52(i16vec2) ExtInst 1(GLSL.std.450) 39(SMin) 349 351
                               Store 343(i16v) 352
-             353:   52(ivec2) Load 343(i16v)
-             355:   52(ivec2) ExtInst 1(GLSL.std.450) 39(SMin) 353 354
+             353: 52(i16vec2) Load 343(i16v)
+             355: 52(i16vec2) ExtInst 1(GLSL.std.450) 39(SMin) 353 354
                               Store 343(i16v) 355
-             357:  193(ivec3) Load 356(u16v)
-             359:     36(int) Load 358(u16)
-             360:  193(ivec3) CompositeConstruct 359 359 359
-             361:  193(ivec3) ExtInst 1(GLSL.std.450) 38(UMin) 357 360
+             357:193(i16vec3) Load 356(u16v)
+             359: 36(int16_t) Load 358(u16)
+             360:193(i16vec3) CompositeConstruct 359 359 359
+             361:193(i16vec3) ExtInst 1(GLSL.std.450) 38(UMin) 357 360
                               Store 356(u16v) 361
-             362:  193(ivec3) Load 356(u16v)
-             364:  193(ivec3) ExtInst 1(GLSL.std.450) 38(UMin) 362 363
+             362:193(i16vec3) Load 356(u16v)
+             364:193(i16vec3) ExtInst 1(GLSL.std.450) 38(UMin) 362 363
                               Store 356(u16v) 364
-             365:   52(ivec2) Load 343(i16v)
-             366:     14(int) Load 346(i16)
-             367:   52(ivec2) CompositeConstruct 366 366
-             368:   52(ivec2) ExtInst 1(GLSL.std.450) 42(SMax) 365 367
+             365: 52(i16vec2) Load 343(i16v)
+             366: 14(int16_t) Load 346(i16)
+             367: 52(i16vec2) CompositeConstruct 366 366
+             368: 52(i16vec2) ExtInst 1(GLSL.std.450) 42(SMax) 365 367
                               Store 343(i16v) 368
-             369:   52(ivec2) Load 343(i16v)
-             370:   52(ivec2) ExtInst 1(GLSL.std.450) 42(SMax) 369 354
+             369: 52(i16vec2) Load 343(i16v)
+             370: 52(i16vec2) ExtInst 1(GLSL.std.450) 42(SMax) 369 354
                               Store 343(i16v) 370
-             371:  193(ivec3) Load 356(u16v)
-             372:     36(int) Load 358(u16)
-             373:  193(ivec3) CompositeConstruct 372 372 372
-             374:  193(ivec3) ExtInst 1(GLSL.std.450) 41(UMax) 371 373
+             371:193(i16vec3) Load 356(u16v)
+             372: 36(int16_t) Load 358(u16)
+             373:193(i16vec3) CompositeConstruct 372 372 372
+             374:193(i16vec3) ExtInst 1(GLSL.std.450) 41(UMax) 371 373
                               Store 356(u16v) 374
-             375:  193(ivec3) Load 356(u16v)
-             376:  193(ivec3) ExtInst 1(GLSL.std.450) 41(UMax) 375 363
+             375:193(i16vec3) Load 356(u16v)
+             376:193(i16vec3) ExtInst 1(GLSL.std.450) 41(UMax) 375 363
                               Store 356(u16v) 376
-             377:   52(ivec2) Load 343(i16v)
-             378:     14(int) Load 346(i16)
-             379:     14(int) SNegate 378
-             380:     14(int) Load 346(i16)
-             381:   52(ivec2) CompositeConstruct 379 379
-             382:   52(ivec2) CompositeConstruct 380 380
-             383:   52(ivec2) ExtInst 1(GLSL.std.450) 45(SClamp) 377 381 382
+             377: 52(i16vec2) Load 343(i16v)
+             378: 14(int16_t) Load 346(i16)
+             379: 14(int16_t) SNegate 378
+             380: 14(int16_t) Load 346(i16)
+             381: 52(i16vec2) CompositeConstruct 379 379
+             382: 52(i16vec2) CompositeConstruct 380 380
+             383: 52(i16vec2) ExtInst 1(GLSL.std.450) 45(SClamp) 377 381 382
                               Store 343(i16v) 383
-             384:   52(ivec2) Load 343(i16v)
-             385:   52(ivec2) Load 343(i16v)
-             386:   52(ivec2) SNegate 385
-             387:   52(ivec2) Load 343(i16v)
-             388:   52(ivec2) ExtInst 1(GLSL.std.450) 45(SClamp) 384 386 387
+             384: 52(i16vec2) Load 343(i16v)
+             385: 52(i16vec2) Load 343(i16v)
+             386: 52(i16vec2) SNegate 385
+             387: 52(i16vec2) Load 343(i16v)
+             388: 52(i16vec2) ExtInst 1(GLSL.std.450) 45(SClamp) 384 386 387
                               Store 343(i16v) 388
-             389:  193(ivec3) Load 356(u16v)
-             390:     36(int) Load 358(u16)
-             391:     36(int) SNegate 390
-             392:     36(int) Load 358(u16)
-             393:  193(ivec3) CompositeConstruct 391 391 391
-             394:  193(ivec3) CompositeConstruct 392 392 392
-             395:  193(ivec3) ExtInst 1(GLSL.std.450) 44(UClamp) 389 393 394
+             389:193(i16vec3) Load 356(u16v)
+             390: 36(int16_t) Load 358(u16)
+             391: 36(int16_t) SNegate 390
+             392: 36(int16_t) Load 358(u16)
+             393:193(i16vec3) CompositeConstruct 391 391 391
+             394:193(i16vec3) CompositeConstruct 392 392 392
+             395:193(i16vec3) ExtInst 1(GLSL.std.450) 44(UClamp) 389 393 394
                               Store 356(u16v) 395
-             396:  193(ivec3) Load 356(u16v)
-             397:  193(ivec3) Load 356(u16v)
-             398:  193(ivec3) SNegate 397
-             399:  193(ivec3) Load 356(u16v)
-             400:  193(ivec3) ExtInst 1(GLSL.std.450) 44(UClamp) 396 398 399
+             396:193(i16vec3) Load 356(u16v)
+             397:193(i16vec3) Load 356(u16v)
+             398:193(i16vec3) SNegate 397
+             399:193(i16vec3) Load 356(u16v)
+             400:193(i16vec3) ExtInst 1(GLSL.std.450) 44(UClamp) 396 398 399
                               Store 356(u16v) 400
              401:     15(ptr) AccessChain 343(i16v) 282
-             402:     14(int) Load 401
+             402: 14(int16_t) Load 401
              403:     15(ptr) AccessChain 343(i16v) 264
-             404:     14(int) Load 403
-             406:     14(int) Select 405 404 402
+             404: 14(int16_t) Load 403
+             406: 14(int16_t) Select 405 404 402
                               Store 346(i16) 406
-             407:     14(int) Load 346(i16)
-             408:   52(ivec2) CompositeConstruct 407 407
-             409:     14(int) Load 346(i16)
-             410:     14(int) SNegate 409
-             411:   52(ivec2) CompositeConstruct 410 410
-             414:   52(ivec2) Select 413 411 408
+             407: 14(int16_t) Load 346(i16)
+             408: 52(i16vec2) CompositeConstruct 407 407
+             409: 14(int16_t) Load 346(i16)
+             410: 14(int16_t) SNegate 409
+             411: 52(i16vec2) CompositeConstruct 410 410
+             414: 52(i16vec2) Select 413 411 408
                               Store 343(i16v) 414
              415:     37(ptr) AccessChain 356(u16v) 282
-             416:     36(int) Load 415
+             416: 36(int16_t) Load 415
              417:     37(ptr) AccessChain 356(u16v) 264
-             418:     36(int) Load 417
-             419:     36(int) Select 405 418 416
+             418: 36(int16_t) Load 417
+             419: 36(int16_t) Select 405 418 416
                               Store 358(u16) 419
-             420:     36(int) Load 358(u16)
-             421:  193(ivec3) CompositeConstruct 420 420 420
-             422:     36(int) Load 358(u16)
-             423:     36(int) SNegate 422
-             424:  193(ivec3) CompositeConstruct 423 423 423
-             427:  193(ivec3) Select 426 424 421
+             420: 36(int16_t) Load 358(u16)
+             421:193(i16vec3) CompositeConstruct 420 420 420
+             422: 36(int16_t) Load 358(u16)
+             423: 36(int16_t) SNegate 422
+             424:193(i16vec3) CompositeConstruct 423 423 423
+             427:193(i16vec3) Select 426 424 421
                               Store 356(u16v) 427
-             429:   52(ivec2) Load 343(i16v)
+             429: 52(i16vec2) Load 343(i16v)
              430:     27(int) Bitcast 429
                               Store 428(i32) 430
-             435:  432(ivec4) Load 434(i16v4)
-             436:     71(int) Bitcast 435
+             435:432(i16vec4) Load 434(i16v4)
+             436: 71(int64_t) Bitcast 435
                               Store 431(i64) 436
-             439:   57(ivec2) Load 438(u16v2)
+             439: 57(i16vec2) Load 438(u16v2)
              440:     17(int) Bitcast 439
                               Store 437(u32) 440
-             446:  443(ivec4) Load 445(u16v4)
-             447:     77(int) Bitcast 446
+             446:443(i16vec4) Load 445(u16v4)
+             447: 77(int64_t) Bitcast 446
                               Store 442(u64) 447
              448:     27(int) Load 428(i32)
-             449:   52(ivec2) Bitcast 448
+             449: 52(i16vec2) Bitcast 448
                               Store 343(i16v) 449
-             450:     71(int) Load 431(i64)
-             451:  432(ivec4) Bitcast 450
+             450: 71(int64_t) Load 431(i64)
+             451:432(i16vec4) Bitcast 450
                               Store 434(i16v4) 451
              452:     17(int) Load 437(u32)
-             453:   57(ivec2) Bitcast 452
+             453: 57(i16vec2) Bitcast 452
                               Store 438(u16v2) 453
-             454:     77(int) Load 442(u64)
-             455:  443(ivec4) Bitcast 454
+             454: 77(int64_t) Load 442(u64)
+             455:443(i16vec4) Bitcast 454
                               Store 445(u16v4) 455
-             458:  193(ivec3) Load 356(u16v)
-             459:     36(int) Load 358(u16)
-             460:  193(ivec3) CompositeConstruct 459 459 459
+             458:193(i16vec3) Load 356(u16v)
+             459: 36(int16_t) Load 358(u16)
+             460:193(i16vec3) CompositeConstruct 459 459 459
              461:  425(bvec3) ULessThan 458 460
                               Store 457(bv) 461
-             462:   52(ivec2) Load 343(i16v)
-             463:     14(int) Load 346(i16)
-             464:   52(ivec2) CompositeConstruct 463 463
+             462: 52(i16vec2) Load 343(i16v)
+             463: 14(int16_t) Load 346(i16)
+             464: 52(i16vec2) CompositeConstruct 463 463
              465:  174(bvec2) SLessThan 462 464
              466:  425(bvec3) Load 457(bv)
              467:  425(bvec3) VectorShuffle 466 465 3 4 2
                               Store 457(bv) 467
-             468:  193(ivec3) Load 356(u16v)
-             469:     36(int) Load 358(u16)
-             470:  193(ivec3) CompositeConstruct 469 469 469
+             468:193(i16vec3) Load 356(u16v)
+             469: 36(int16_t) Load 358(u16)
+             470:193(i16vec3) CompositeConstruct 469 469 469
              471:  425(bvec3) ULessThanEqual 468 470
                               Store 457(bv) 471
-             472:   52(ivec2) Load 343(i16v)
-             473:     14(int) Load 346(i16)
-             474:   52(ivec2) CompositeConstruct 473 473
+             472: 52(i16vec2) Load 343(i16v)
+             473: 14(int16_t) Load 346(i16)
+             474: 52(i16vec2) CompositeConstruct 473 473
              475:  174(bvec2) SLessThanEqual 472 474
              476:  425(bvec3) Load 457(bv)
              477:  425(bvec3) VectorShuffle 476 475 3 4 2
                               Store 457(bv) 477
-             478:  193(ivec3) Load 356(u16v)
-             479:     36(int) Load 358(u16)
-             480:  193(ivec3) CompositeConstruct 479 479 479
+             478:193(i16vec3) Load 356(u16v)
+             479: 36(int16_t) Load 358(u16)
+             480:193(i16vec3) CompositeConstruct 479 479 479
              481:  425(bvec3) UGreaterThan 478 480
                               Store 457(bv) 481
-             482:   52(ivec2) Load 343(i16v)
-             483:     14(int) Load 346(i16)
-             484:   52(ivec2) CompositeConstruct 483 483
+             482: 52(i16vec2) Load 343(i16v)
+             483: 14(int16_t) Load 346(i16)
+             484: 52(i16vec2) CompositeConstruct 483 483
              485:  174(bvec2) SGreaterThan 482 484
              486:  425(bvec3) Load 457(bv)
              487:  425(bvec3) VectorShuffle 486 485 3 4 2
                               Store 457(bv) 487
-             488:  193(ivec3) Load 356(u16v)
-             489:     36(int) Load 358(u16)
-             490:  193(ivec3) CompositeConstruct 489 489 489
+             488:193(i16vec3) Load 356(u16v)
+             489: 36(int16_t) Load 358(u16)
+             490:193(i16vec3) CompositeConstruct 489 489 489
              491:  425(bvec3) UGreaterThanEqual 488 490
                               Store 457(bv) 491
-             492:   52(ivec2) Load 343(i16v)
-             493:     14(int) Load 346(i16)
-             494:   52(ivec2) CompositeConstruct 493 493
+             492: 52(i16vec2) Load 343(i16v)
+             493: 14(int16_t) Load 346(i16)
+             494: 52(i16vec2) CompositeConstruct 493 493
              495:  174(bvec2) SGreaterThanEqual 492 494
              496:  425(bvec3) Load 457(bv)
              497:  425(bvec3) VectorShuffle 496 495 3 4 2
                               Store 457(bv) 497
-             498:  193(ivec3) Load 356(u16v)
-             499:     36(int) Load 358(u16)
-             500:  193(ivec3) CompositeConstruct 499 499 499
+             498:193(i16vec3) Load 356(u16v)
+             499: 36(int16_t) Load 358(u16)
+             500:193(i16vec3) CompositeConstruct 499 499 499
              501:  425(bvec3) IEqual 498 500
                               Store 457(bv) 501
-             502:   52(ivec2) Load 343(i16v)
-             503:     14(int) Load 346(i16)
-             504:   52(ivec2) CompositeConstruct 503 503
+             502: 52(i16vec2) Load 343(i16v)
+             503: 14(int16_t) Load 346(i16)
+             504: 52(i16vec2) CompositeConstruct 503 503
              505:  174(bvec2) IEqual 502 504
              506:  425(bvec3) Load 457(bv)
              507:  425(bvec3) VectorShuffle 506 505 3 4 2
                               Store 457(bv) 507
-             508:  193(ivec3) Load 356(u16v)
-             509:     36(int) Load 358(u16)
-             510:  193(ivec3) CompositeConstruct 509 509 509
+             508:193(i16vec3) Load 356(u16v)
+             509: 36(int16_t) Load 358(u16)
+             510:193(i16vec3) CompositeConstruct 509 509 509
              511:  425(bvec3) INotEqual 508 510
                               Store 457(bv) 511
-             512:   52(ivec2) Load 343(i16v)
-             513:     14(int) Load 346(i16)
-             514:   52(ivec2) CompositeConstruct 513 513
+             512: 52(i16vec2) Load 343(i16v)
+             513: 14(int16_t) Load 346(i16)
+             514: 52(i16vec2) CompositeConstruct 513 513
              515:  174(bvec2) INotEqual 512 514
              516:  425(bvec3) Load 457(bv)
              517:  425(bvec3) VectorShuffle 516 515 3 4 2

--- a/Test/baseResults/spv.int32.frag.out
+++ b/Test/baseResults/spv.int32.frag.out
@@ -130,32 +130,32 @@ spv.int32.frag
               52:             TypeVector 18(int) 2
               53:             TypePointer Function 52(ivec2)
               57:             TypeInt 64 1
-              58:             TypeVector 57(int) 2
-              59:             TypePointer Function 58(ivec2)
+              58:             TypeVector 57(int64_t) 2
+              59:             TypePointer Function 58(i64vec2)
               63:             TypeInt 64 0
-              64:             TypeVector 63(int) 2
-              65:             TypePointer Function 64(ivec2)
+              64:             TypeVector 63(int64_t) 2
+              65:             TypePointer Function 64(i64vec2)
               75:             TypeFloat 32
               76:             TypeVector 75(float) 2
               77:             TypePointer Function 76(fvec2)
               81:             TypeFloat 64
-              82:             TypeVector 81(float) 2
-              83:             TypePointer Function 82(fvec2)
+              82:             TypeVector 81(float64_t) 2
+              83:             TypePointer Function 82(f64vec2)
               91:             TypeInt 8 1
-              92:             TypeVector 91(int) 2
-              93:             TypePointer Function 92(ivec2)
+              92:             TypeVector 91(int8_t) 2
+              93:             TypePointer Function 92(i8vec2)
              100:             TypeInt 16 1
-             101:             TypeVector 100(int) 2
-             102:             TypePointer Function 101(ivec2)
+             101:             TypeVector 100(int16_t) 2
+             102:             TypePointer Function 101(i16vec2)
              120:             TypeInt 8 0
-             121:             TypeVector 120(int) 2
-             122:             TypePointer Function 121(ivec2)
+             121:             TypeVector 120(int8_t) 2
+             122:             TypePointer Function 121(i8vec2)
              129:             TypeInt 16 0
-             130:             TypeVector 129(int) 2
-             131:             TypePointer Function 130(ivec2)
+             130:             TypeVector 129(int16_t) 2
+             131:             TypePointer Function 130(i16vec2)
              149:             TypeFloat 16
-             150:             TypeVector 149(float) 2
-             151:             TypePointer Function 150(fvec2)
+             150:             TypeVector 149(float16_t) 2
+             151:             TypePointer Function 150(f16vec2)
              165:             TypeBool
              166:             TypeVector 165(bool) 2
              167:             TypePointer Function 166(bvec2)
@@ -169,7 +169,7 @@ spv.int32.frag
              184:             TypeVector 14(int) 3
              185:             TypePointer Function 184(ivec3)
              188:             TypeVector 18(int) 3
-             226:             TypePointer Function 57(int)
+             226:             TypePointer Function 57(int64_t)
              251:     14(int) Constant 2
              259:             TypePointer Function 165(bool)
              323:   52(ivec2) ConstantComposite 24 24
@@ -179,11 +179,11 @@ spv.int32.frag
              382:  166(bvec2) ConstantComposite 381 381
              394:             TypeVector 165(bool) 3
              395:  394(bvec3) ConstantComposite 381 381 381
-             397:             TypeVector 91(int) 4
-             398:             TypePointer Function 397(ivec4)
-             405:             TypeVector 120(int) 4
-             406:             TypePointer Function 405(ivec4)
-             417:             TypePointer Function 63(int)
+             397:             TypeVector 91(int8_t) 4
+             398:             TypePointer Function 397(i8vec4)
+             405:             TypeVector 120(int8_t) 4
+             406:             TypePointer Function 405(i8vec4)
+             417:             TypePointer Function 63(int64_t)
              421:             TypePointer Function 394(bvec3)
              483:             TypeVector 18(int) 4
              484:             TypeVector 14(int) 4
@@ -238,44 +238,44 @@ spv.int32.frag
               56:   49(ivec2) Bitcast 55
                               Store 51(u32v) 56
               61:   52(ivec2) Load 54(i32v)
-              62:   58(ivec2) SConvert 61
+              62: 58(i64vec2) SConvert 61
                               Store 60(i64v) 62
               67:   52(ivec2) Load 54(i32v)
-              68:   58(ivec2) SConvert 67
-              69:   64(ivec2) Bitcast 68
+              68: 58(i64vec2) SConvert 67
+              69: 64(i64vec2) Bitcast 68
                               Store 66(u64v) 69
               70:   49(ivec2) Load 51(u32v)
-              71:   58(ivec2) UConvert 70
-              72:   58(ivec2) Bitcast 71
+              71: 58(i64vec2) UConvert 70
+              72: 58(i64vec2) Bitcast 71
                               Store 60(i64v) 72
               73:   49(ivec2) Load 51(u32v)
-              74:   64(ivec2) UConvert 73
+              74: 64(i64vec2) UConvert 73
                               Store 66(u64v) 74
               79:   52(ivec2) Load 54(i32v)
               80:   76(fvec2) ConvertSToF 79
                               Store 78(f32v) 80
               85:   52(ivec2) Load 54(i32v)
-              86:   82(fvec2) ConvertSToF 85
+              86: 82(f64vec2) ConvertSToF 85
                               Store 84(f64v) 86
               87:   49(ivec2) Load 51(u32v)
               88:   76(fvec2) ConvertUToF 87
                               Store 78(f32v) 88
               89:   49(ivec2) Load 51(u32v)
-              90:   82(fvec2) ConvertUToF 89
+              90: 82(f64vec2) ConvertUToF 89
                               Store 84(f64v) 90
               95:   52(ivec2) Load 54(i32v)
-              96:   92(ivec2) SConvert 95
+              96:  92(i8vec2) SConvert 95
                               Store 94(i8v) 96
               97:   49(ivec2) Load 51(u32v)
-              98:   92(ivec2) UConvert 97
-              99:   92(ivec2) Bitcast 98
+              98:  92(i8vec2) UConvert 97
+              99:  92(i8vec2) Bitcast 98
                               Store 94(i8v) 99
              104:   52(ivec2) Load 54(i32v)
-             105:  101(ivec2) SConvert 104
+             105:101(i16vec2) SConvert 104
                               Store 103(i16v) 105
              106:   49(ivec2) Load 51(u32v)
-             107:  101(ivec2) UConvert 106
-             108:  101(ivec2) Bitcast 107
+             107:101(i16vec2) UConvert 106
+             108:101(i16vec2) Bitcast 107
                               Store 103(i16v) 108
              109:   52(ivec2) Load 54(i32v)
              110:     18(int) CompositeExtract 109 0
@@ -286,25 +286,25 @@ spv.int32.frag
              114:   52(ivec2) Bitcast 113
                               Store 54(i32v) 114
              115:   52(ivec2) Load 54(i32v)
-             116:   58(ivec2) SConvert 115
+             116: 58(i64vec2) SConvert 115
                               Store 60(i64v) 116
              117:   49(ivec2) Load 51(u32v)
-             118:   58(ivec2) UConvert 117
-             119:   58(ivec2) Bitcast 118
+             118: 58(i64vec2) UConvert 117
+             119: 58(i64vec2) Bitcast 118
                               Store 60(i64v) 119
              124:   52(ivec2) Load 54(i32v)
-             125:   92(ivec2) SConvert 124
-             126:  121(ivec2) Bitcast 125
+             125:  92(i8vec2) SConvert 124
+             126: 121(i8vec2) Bitcast 125
                               Store 123(u8v) 126
              127:   49(ivec2) Load 51(u32v)
-             128:  121(ivec2) UConvert 127
+             128: 121(i8vec2) UConvert 127
                               Store 123(u8v) 128
              133:   52(ivec2) Load 54(i32v)
-             134:  101(ivec2) SConvert 133
-             135:  130(ivec2) Bitcast 134
+             134:101(i16vec2) SConvert 133
+             135:130(i16vec2) Bitcast 134
                               Store 132(u16v) 135
              136:   49(ivec2) Load 51(u32v)
-             137:  130(ivec2) UConvert 136
+             137:130(i16vec2) UConvert 136
                               Store 132(u16v) 137
              138:   52(ivec2) Load 54(i32v)
              139:   49(ivec2) Bitcast 138
@@ -315,29 +315,29 @@ spv.int32.frag
              143:   49(ivec2) CompositeConstruct 141 142
                               Store 51(u32v) 143
              144:   52(ivec2) Load 54(i32v)
-             145:   58(ivec2) SConvert 144
-             146:   64(ivec2) Bitcast 145
+             145: 58(i64vec2) SConvert 144
+             146: 64(i64vec2) Bitcast 145
                               Store 66(u64v) 146
              147:   49(ivec2) Load 51(u32v)
-             148:   64(ivec2) UConvert 147
+             148: 64(i64vec2) UConvert 147
                               Store 66(u64v) 148
              153:   52(ivec2) Load 54(i32v)
-             154:  150(fvec2) ConvertSToF 153
+             154:150(f16vec2) ConvertSToF 153
                               Store 152(f16v) 154
              155:   52(ivec2) Load 54(i32v)
              156:   76(fvec2) ConvertSToF 155
                               Store 78(f32v) 156
              157:   52(ivec2) Load 54(i32v)
-             158:   82(fvec2) ConvertSToF 157
+             158: 82(f64vec2) ConvertSToF 157
                               Store 84(f64v) 158
              159:   49(ivec2) Load 51(u32v)
-             160:  150(fvec2) ConvertUToF 159
+             160:150(f16vec2) ConvertUToF 159
                               Store 152(f16v) 160
              161:   49(ivec2) Load 51(u32v)
              162:   76(fvec2) ConvertUToF 161
                               Store 78(f32v) 162
              163:   49(ivec2) Load 51(u32v)
-             164:   82(fvec2) ConvertUToF 163
+             164: 82(f64vec2) ConvertUToF 163
                               Store 84(f64v) 164
              169:  166(bvec2) Load 168(bv)
              173:   52(ivec2) Select 169 172 171
@@ -410,18 +410,18 @@ spv.int32.frag
              225:  184(ivec3) IAdd 223 224
                               Store 214(uv) 225
              228:     18(int) Load 191(i32)
-             229:     57(int) SConvert 228
-             230:     57(int) Load 227(i64)
-             231:     57(int) ISub 229 230
+             229: 57(int64_t) SConvert 228
+             230: 57(int64_t) Load 227(i64)
+             231: 57(int64_t) ISub 229 230
                               Store 227(i64) 231
              232:  184(ivec3) Load 186(u32v)
              233:  184(ivec3) Load 214(uv)
              234:  184(ivec3) IMul 232 233
                               Store 214(uv) 234
              235:     18(int) Load 191(i32)
-             236:     57(int) SConvert 235
-             237:     57(int) Load 227(i64)
-             238:     57(int) IMul 236 237
+             236: 57(int64_t) SConvert 235
+             237: 57(int64_t) Load 227(i64)
+             238: 57(int64_t) IMul 236 237
                               Store 227(i64) 238
              239:     18(int) Load 191(i32)
              240:     18(int) Load 210(i)
@@ -437,10 +437,10 @@ spv.int32.frag
              248:     18(int) Load 191(i32)
              249:     18(int) ShiftRightArithmetic 248 247
                               Store 191(i32) 249
-             250:     57(int) Load 227(i64)
+             250: 57(int64_t) Load 227(i64)
              252:     38(ptr) AccessChain 186(u32v) 251
              253:     14(int) Load 252
-             254:     57(int) ShiftLeftLogical 250 253
+             254: 57(int64_t) ShiftLeftLogical 250 253
                               Store 227(i64) 254
              255:  184(ivec3) Load 186(u32v)
              256:     18(int) Load 210(i)
@@ -490,9 +490,9 @@ spv.int32.frag
              294:     18(int) BitwiseOr 292 293
                               Store 210(i) 294
              295:     18(int) Load 191(i32)
-             296:     57(int) SConvert 295
-             297:     57(int) Load 227(i64)
-             298:     57(int) BitwiseAnd 297 296
+             296: 57(int64_t) SConvert 295
+             297: 57(int64_t) Load 227(i64)
+             298: 57(int64_t) BitwiseAnd 297 296
                               Store 227(i64) 298
              299:  184(ivec3) Load 186(u32v)
              300:  184(ivec3) Load 214(uv)
@@ -618,22 +618,22 @@ spv.int32.frag
              393:  184(ivec3) CompositeConstruct 392 392 392
              396:  184(ivec3) Select 395 393 390
                               Store 325(u32v) 396
-             400:  397(ivec4) Load 399(i8v4)
+             400: 397(i8vec4) Load 399(i8v4)
              401:     18(int) Bitcast 400
                               Store 315(i32) 401
-             403:  101(ivec2) Load 402(i16v2)
+             403:101(i16vec2) Load 402(i16v2)
              404:     18(int) Bitcast 403
                               Store 315(i32) 404
-             408:  405(ivec4) Load 407(u8v4)
+             408: 405(i8vec4) Load 407(u8v4)
              409:     14(int) Bitcast 408
                               Store 327(u32) 409
-             411:  130(ivec2) Load 410(u16v2)
+             411:130(i16vec2) Load 410(u16v2)
              412:     14(int) Bitcast 411
                               Store 327(u32) 412
-             414:     57(int) Load 413(i64)
+             414: 57(int64_t) Load 413(i64)
              415:   52(ivec2) Bitcast 414
                               Store 312(i32v) 415
-             419:     63(int) Load 418(u64)
+             419: 63(int64_t) Load 418(u64)
              420:   49(ivec2) Bitcast 419
                               Store 416(u32v2) 420
              423:  184(ivec3) Load 325(u32v)

--- a/Test/baseResults/spv.int64.frag.out
+++ b/Test/baseResults/spv.int64.frag.out
@@ -72,17 +72,17 @@ spv.int64.frag
                2:             TypeVoid
                3:             TypeFunction 2
               14:             TypeInt 64 0
-              15:             TypePointer Private 14(int)
+              15:             TypePointer Private 14(int64_t)
       16(u64Max):     15(ptr) Variable Private
-              17:     14(int) Constant 4294967295 4294967295
+              17: 14(int64_t) Constant 4294967295 4294967295
               18:             TypeInt 64 1
-              19:             TypePointer Function 18(int)
+              19:             TypePointer Function 18(int64_t)
               21:             TypeInt 32 0
               22:     21(int) Constant 3
-              23:             TypeArray 18(int) 22
-              24:     18(int) Constant 4008636143 4008636142
-              25:     18(int) Constant 4294967295 4294967295
-              26:     18(int) Constant 0 1
+              23:             TypeArray 18(int64_t) 22
+              24: 18(int64_t) Constant 4008636143 4008636142
+              25: 18(int64_t) Constant 4294967295 4294967295
+              26: 18(int64_t) Constant 0 1
               27:          23 ConstantComposite 24 25 26
     28(Uniforms):             TypeStruct 21(int)
               29:             TypePointer Uniform 28(Uniforms)
@@ -91,27 +91,27 @@ spv.int64.frag
               32:     31(int) Constant 0
               33:             TypePointer Uniform 21(int)
               36:             TypePointer Function 23
-              40:             TypePointer Function 14(int)
-              42:             TypeArray 14(int) 22
-              43:     14(int) Constant 0 1
-              44:     14(int) Constant 4294967295 1
+              40:             TypePointer Function 14(int64_t)
+              42:             TypeArray 14(int64_t) 22
+              43: 14(int64_t) Constant 0 1
+              44: 14(int64_t) Constant 4294967295 1
               45:          42 ConstantComposite 17 43 44
               48:             TypePointer Function 42
-              52:             TypeVector 18(int) 2
-              53:             TypePointer Function 52(ivec2)
+              52:             TypeVector 18(int64_t) 2
+              53:             TypePointer Function 52(i64vec2)
               55:             TypeBool
               56:             TypeVector 55(bool) 2
               57:             TypePointer Function 56(bvec2)
-              60:     18(int) Constant 0 0
-              61:     18(int) Constant 1 0
-              62:   52(ivec2) ConstantComposite 60 60
-              63:   52(ivec2) ConstantComposite 61 61
-              65:             TypeVector 14(int) 2
-              66:             TypePointer Function 65(ivec2)
-              69:     14(int) Constant 0 0
-              70:     14(int) Constant 1 0
-              71:   65(ivec2) ConstantComposite 69 69
-              72:   65(ivec2) ConstantComposite 70 70
+              60: 18(int64_t) Constant 0 0
+              61: 18(int64_t) Constant 1 0
+              62: 52(i64vec2) ConstantComposite 60 60
+              63: 52(i64vec2) ConstantComposite 61 61
+              65:             TypeVector 14(int64_t) 2
+              66:             TypePointer Function 65(i64vec2)
+              69: 14(int64_t) Constant 0 0
+              70: 14(int64_t) Constant 1 0
+              71: 65(i64vec2) ConstantComposite 69 69
+              72: 65(i64vec2) ConstantComposite 70 70
               74:             TypeVector 31(int) 2
               75:             TypePointer Function 74(ivec2)
               81:             TypeVector 21(int) 2
@@ -120,11 +120,11 @@ spv.int64.frag
               89:             TypeVector 88(float) 2
               90:             TypePointer Function 89(fvec2)
               94:             TypeFloat 64
-              95:             TypeVector 94(float) 2
-              96:             TypePointer Function 95(fvec2)
-             132:             TypeVector 14(int) 3
-             133:             TypePointer Function 132(ivec3)
-             136:             TypeVector 18(int) 3
+              95:             TypeVector 94(float64_t) 2
+              96:             TypePointer Function 95(f64vec2)
+             132:             TypeVector 14(int64_t) 3
+             133:             TypePointer Function 132(i64vec3)
+             136:             TypeVector 18(int64_t) 3
              158:             TypePointer Function 31(int)
              164:             TypeVector 21(int) 3
              165:             TypePointer Function 164(ivec3)
@@ -134,47 +134,47 @@ spv.int64.frag
              217:     21(int) Constant 2
              225:             TypePointer Function 55(bool)
              227:     21(int) Constant 0
-             297:   52(ivec2) ConstantComposite 25 25
-             306:  132(ivec3) ConstantComposite 69 69 69
+             297: 52(i64vec2) ConstantComposite 25 25
+             306:132(i64vec3) ConstantComposite 69 69 69
              348:    55(bool) ConstantTrue
              355:    55(bool) ConstantFalse
              356:   56(bvec2) ConstantComposite 355 355
              368:             TypeVector 55(bool) 3
              369:  368(bvec3) ConstantComposite 355 355 355
-             371:             TypeVector 94(float) 3
-             372:             TypePointer Function 371(fvec3)
-             377:             TypePointer Function 94(float)
+             371:             TypeVector 94(float64_t) 3
+             372:             TypePointer Function 371(f64vec3)
+             377:             TypePointer Function 94(float64_t)
              388:     31(int) Constant 1
              389:     31(int) Constant 2
              390:   74(ivec2) ConstantComposite 388 389
              395:   81(ivec2) ConstantComposite 217 22
              400:             TypePointer Function 368(bvec3)
-      462(Block):             TypeStruct 136(ivec3) 14(int)
+      462(Block):             TypeStruct 136(i64vec3) 14(int64_t)
              463:             TypePointer Uniform 462(Block)
       464(block):    463(ptr) Variable Uniform
-       465(si64):     18(int) SpecConstant 4294967286 4294967295
-       466(su64):     14(int) SpecConstant 20 0
+       465(si64): 18(int64_t) SpecConstant 4294967286 4294967295
+       466(su64): 14(int64_t) SpecConstant 20 0
          467(si):     31(int) SpecConstant 4294967291
          468(su):     21(int) SpecConstant 4
          469(sb):    55(bool) SpecConstantTrue
              470:    55(bool) SpecConstantOp 171 465(si64) 69
              471:    55(bool) SpecConstantOp 171 466(su64) 69
-             472:     18(int) SpecConstantOp 169 469(sb) 61 60
-             473:     14(int) SpecConstantOp 169 469(sb) 70 69
+             472: 18(int64_t) SpecConstantOp 169 469(sb) 61 60
+             473: 14(int64_t) SpecConstantOp 169 469(sb) 70 69
              474:     31(int) SpecConstantOp 114 465(si64)
-             475:     18(int) SpecConstantOp 114 467(si)
+             475: 18(int64_t) SpecConstantOp 114 467(si)
              476:     21(int) SpecConstantOp 113 466(su64)
-             477:     14(int) SpecConstantOp 113 468(su)
-             478:     18(int) SpecConstantOp 128 466(su64) 69
-             479:     14(int) SpecConstantOp 128 465(si64) 69
+             477: 14(int64_t) SpecConstantOp 113 468(su)
+             478: 18(int64_t) SpecConstantOp 128 466(su64) 69
+             479: 14(int64_t) SpecConstantOp 128 465(si64) 69
              480:     31(int) SpecConstantOp 113 466(su64)
              481:     31(int) SpecConstantOp 128 480 227
-             482:     18(int) SpecConstantOp 114 467(si)
-             483:     14(int) SpecConstantOp 128 482 69
+             482: 18(int64_t) SpecConstantOp 114 467(si)
+             483: 14(int64_t) SpecConstantOp 128 482 69
              484:     31(int) SpecConstantOp 114 465(si64)
              485:     21(int) SpecConstantOp 128 484 227
-             486:     18(int) SpecConstantOp 113 468(su)
-             487:     18(int) SpecConstantOp 128 486 69
+             486: 18(int64_t) SpecConstantOp 113 468(su)
+             487: 18(int64_t) SpecConstantOp 128 486 69
          4(main):           2 Function None 3
                5:             Label
                               Store 16(u64Max) 17
@@ -190,13 +190,13 @@ spv.int64.frag
               35:     21(int) Load 34
                               Store 37(indexable) 27
               38:     19(ptr) AccessChain 37(indexable) 35
-              39:     18(int) Load 38
+              39: 18(int64_t) Load 38
                               Store 20(i64) 39
               46:     33(ptr) AccessChain 30 32
               47:     21(int) Load 46
                               Store 49(indexable) 45
               50:     40(ptr) AccessChain 49(indexable) 47
-              51:     14(int) Load 50
+              51: 14(int64_t) Load 50
                               Store 41(u64) 51
                               Return
                               FunctionEnd
@@ -210,74 +210,74 @@ spv.int64.frag
           91(fv):     90(ptr) Variable Function
           97(dv):     96(ptr) Variable Function
               59:   56(bvec2) Load 58(bv)
-              64:   52(ivec2) Select 59 63 62
+              64: 52(i64vec2) Select 59 63 62
                               Store 54(i64v) 64
               68:   56(bvec2) Load 58(bv)
-              73:   65(ivec2) Select 68 72 71
+              73: 65(i64vec2) Select 68 72 71
                               Store 67(u64v) 73
               77:   74(ivec2) Load 76(iv)
-              78:   52(ivec2) SConvert 77
+              78: 52(i64vec2) SConvert 77
                               Store 54(i64v) 78
-              79:   52(ivec2) Load 54(i64v)
+              79: 52(i64vec2) Load 54(i64v)
               80:   74(ivec2) SConvert 79
                               Store 76(iv) 80
               84:   81(ivec2) Load 83(uv)
-              85:   65(ivec2) UConvert 84
+              85: 65(i64vec2) UConvert 84
                               Store 67(u64v) 85
-              86:   65(ivec2) Load 67(u64v)
+              86: 65(i64vec2) Load 67(u64v)
               87:   81(ivec2) UConvert 86
                               Store 83(uv) 87
-              92:   52(ivec2) Load 54(i64v)
+              92: 52(i64vec2) Load 54(i64v)
               93:   89(fvec2) ConvertSToF 92
                               Store 91(fv) 93
-              98:   52(ivec2) Load 54(i64v)
-              99:   95(fvec2) ConvertSToF 98
+              98: 52(i64vec2) Load 54(i64v)
+              99: 95(f64vec2) ConvertSToF 98
                               Store 97(dv) 99
-             100:   65(ivec2) Load 67(u64v)
+             100: 65(i64vec2) Load 67(u64v)
              101:   89(fvec2) ConvertUToF 100
                               Store 91(fv) 101
-             102:   65(ivec2) Load 67(u64v)
-             103:   95(fvec2) ConvertUToF 102
+             102: 65(i64vec2) Load 67(u64v)
+             103: 95(f64vec2) ConvertUToF 102
                               Store 97(dv) 103
              104:   89(fvec2) Load 91(fv)
-             105:   52(ivec2) ConvertFToS 104
+             105: 52(i64vec2) ConvertFToS 104
                               Store 54(i64v) 105
-             106:   95(fvec2) Load 97(dv)
-             107:   52(ivec2) ConvertFToS 106
+             106: 95(f64vec2) Load 97(dv)
+             107: 52(i64vec2) ConvertFToS 106
                               Store 54(i64v) 107
              108:   89(fvec2) Load 91(fv)
-             109:   65(ivec2) ConvertFToU 108
+             109: 65(i64vec2) ConvertFToU 108
                               Store 67(u64v) 109
-             110:   95(fvec2) Load 97(dv)
-             111:   65(ivec2) ConvertFToU 110
+             110: 95(f64vec2) Load 97(dv)
+             111: 65(i64vec2) ConvertFToU 110
                               Store 67(u64v) 111
-             112:   52(ivec2) Load 54(i64v)
+             112: 52(i64vec2) Load 54(i64v)
              113:   56(bvec2) INotEqual 112 71
                               Store 58(bv) 113
-             114:   65(ivec2) Load 67(u64v)
+             114: 65(i64vec2) Load 67(u64v)
              115:   56(bvec2) INotEqual 114 71
                               Store 58(bv) 115
-             116:   52(ivec2) Load 54(i64v)
-             117:   65(ivec2) Bitcast 116
+             116: 52(i64vec2) Load 54(i64v)
+             117: 65(i64vec2) Bitcast 116
                               Store 67(u64v) 117
-             118:   65(ivec2) Load 67(u64v)
-             119:   52(ivec2) Bitcast 118
+             118: 65(i64vec2) Load 67(u64v)
+             119: 52(i64vec2) Bitcast 118
                               Store 54(i64v) 119
-             120:   52(ivec2) Load 54(i64v)
+             120: 52(i64vec2) Load 54(i64v)
              121:   74(ivec2) SConvert 120
              122:   81(ivec2) Bitcast 121
                               Store 83(uv) 122
              123:   81(ivec2) Load 83(uv)
-             124:   52(ivec2) UConvert 123
-             125:   52(ivec2) Bitcast 124
+             124: 52(i64vec2) UConvert 123
+             125: 52(i64vec2) Bitcast 124
                               Store 54(i64v) 125
-             126:   65(ivec2) Load 67(u64v)
+             126: 65(i64vec2) Load 67(u64v)
              127:   74(ivec2) UConvert 126
              128:   74(ivec2) Bitcast 127
                               Store 76(iv) 128
              129:   74(ivec2) Load 76(iv)
-             130:   52(ivec2) SConvert 129
-             131:   65(ivec2) Bitcast 130
+             130: 52(i64vec2) SConvert 129
+             131: 65(i64vec2) Bitcast 130
                               Store 67(u64v) 131
                               Return
                               FunctionEnd
@@ -288,177 +288,177 @@ spv.int64.frag
           159(i):    158(ptr) Variable Function
          166(uv):    165(ptr) Variable Function
           226(b):    225(ptr) Variable Function
-             135:  132(ivec3) Load 134(u64v)
-             137:  136(ivec3) CompositeConstruct 61 61 61
-             138:  132(ivec3) IAdd 135 137
+             135:132(i64vec3) Load 134(u64v)
+             137:136(i64vec3) CompositeConstruct 61 61 61
+             138:132(i64vec3) IAdd 135 137
                               Store 134(u64v) 138
-             140:     18(int) Load 139(i64)
-             141:     18(int) ISub 140 61
+             140: 18(int64_t) Load 139(i64)
+             141: 18(int64_t) ISub 140 61
                               Store 139(i64) 141
-             142:     18(int) Load 139(i64)
-             143:     18(int) IAdd 142 61
+             142: 18(int64_t) Load 139(i64)
+             143: 18(int64_t) IAdd 142 61
                               Store 139(i64) 143
-             144:  132(ivec3) Load 134(u64v)
-             145:  136(ivec3) CompositeConstruct 61 61 61
-             146:  132(ivec3) ISub 144 145
+             144:132(i64vec3) Load 134(u64v)
+             145:136(i64vec3) CompositeConstruct 61 61 61
+             146:132(i64vec3) ISub 144 145
                               Store 134(u64v) 146
-             147:  132(ivec3) Load 134(u64v)
-             148:  132(ivec3) Not 147
+             147:132(i64vec3) Load 134(u64v)
+             148:132(i64vec3) Not 147
                               Store 134(u64v) 148
-             149:     18(int) Load 139(i64)
+             149: 18(int64_t) Load 139(i64)
                               Store 139(i64) 149
-             150:  132(ivec3) Load 134(u64v)
-             151:  132(ivec3) SNegate 150
+             150:132(i64vec3) Load 134(u64v)
+             151:132(i64vec3) SNegate 150
                               Store 134(u64v) 151
-             152:     18(int) Load 139(i64)
-             153:     18(int) Load 139(i64)
-             154:     18(int) IAdd 153 152
+             152: 18(int64_t) Load 139(i64)
+             153: 18(int64_t) Load 139(i64)
+             154: 18(int64_t) IAdd 153 152
                               Store 139(i64) 154
-             155:  132(ivec3) Load 134(u64v)
-             156:  132(ivec3) Load 134(u64v)
-             157:  132(ivec3) ISub 156 155
+             155:132(i64vec3) Load 134(u64v)
+             156:132(i64vec3) Load 134(u64v)
+             157:132(i64vec3) ISub 156 155
                               Store 134(u64v) 157
              160:     31(int) Load 159(i)
-             161:     18(int) SConvert 160
-             162:     18(int) Load 139(i64)
-             163:     18(int) IMul 162 161
+             161: 18(int64_t) SConvert 160
+             162: 18(int64_t) Load 139(i64)
+             163: 18(int64_t) IMul 162 161
                               Store 139(i64) 163
              167:  164(ivec3) Load 166(uv)
-             168:  132(ivec3) UConvert 167
-             169:  132(ivec3) Load 134(u64v)
-             170:  132(ivec3) UDiv 169 168
+             168:132(i64vec3) UConvert 167
+             169:132(i64vec3) Load 134(u64v)
+             170:132(i64vec3) UDiv 169 168
                               Store 134(u64v) 170
              171:     31(int) Load 159(i)
-             172:     18(int) SConvert 171
-             173:     14(int) Bitcast 172
-             174:  132(ivec3) Load 134(u64v)
-             175:  132(ivec3) CompositeConstruct 173 173 173
-             176:  132(ivec3) UMod 174 175
+             172: 18(int64_t) SConvert 171
+             173: 14(int64_t) Bitcast 172
+             174:132(i64vec3) Load 134(u64v)
+             175:132(i64vec3) CompositeConstruct 173 173 173
+             176:132(i64vec3) UMod 174 175
                               Store 134(u64v) 176
-             177:  132(ivec3) Load 134(u64v)
+             177:132(i64vec3) Load 134(u64v)
              178:  164(ivec3) Load 166(uv)
-             179:  132(ivec3) UConvert 178
-             180:  132(ivec3) IAdd 177 179
+             179:132(i64vec3) UConvert 178
+             180:132(i64vec3) IAdd 177 179
                               Store 134(u64v) 180
-             181:     18(int) Load 139(i64)
+             181: 18(int64_t) Load 139(i64)
              182:     31(int) Load 159(i)
-             183:     18(int) SConvert 182
-             184:     18(int) ISub 181 183
+             183: 18(int64_t) SConvert 182
+             184: 18(int64_t) ISub 181 183
                               Store 139(i64) 184
-             185:  132(ivec3) Load 134(u64v)
+             185:132(i64vec3) Load 134(u64v)
              186:  164(ivec3) Load 166(uv)
-             187:  132(ivec3) UConvert 186
-             188:  132(ivec3) IMul 185 187
+             187:132(i64vec3) UConvert 186
+             188:132(i64vec3) IMul 185 187
                               Store 134(u64v) 188
-             189:     18(int) Load 139(i64)
+             189: 18(int64_t) Load 139(i64)
              190:     31(int) Load 159(i)
-             191:     18(int) SConvert 190
-             192:     18(int) IMul 189 191
+             191: 18(int64_t) SConvert 190
+             192: 18(int64_t) IMul 189 191
                               Store 139(i64) 192
-             193:     18(int) Load 139(i64)
+             193: 18(int64_t) Load 139(i64)
              194:     31(int) Load 159(i)
-             195:     18(int) SConvert 194
-             196:     18(int) SMod 193 195
+             195: 18(int64_t) SConvert 194
+             196: 18(int64_t) SMod 193 195
                               Store 139(i64) 196
-             197:  132(ivec3) Load 134(u64v)
+             197:132(i64vec3) Load 134(u64v)
              198:     31(int) Load 159(i)
              200:  199(ivec3) CompositeConstruct 198 198 198
-             201:  132(ivec3) ShiftLeftLogical 197 200
+             201:132(i64vec3) ShiftLeftLogical 197 200
                               Store 134(u64v) 201
-             202:     18(int) Load 139(i64)
+             202: 18(int64_t) Load 139(i64)
              205:    204(ptr) AccessChain 166(uv) 203
              206:     21(int) Load 205
-             207:     18(int) ShiftRightArithmetic 202 206
+             207: 18(int64_t) ShiftRightArithmetic 202 206
                               Store 139(i64) 207
              208:     31(int) Load 159(i)
-             209:  132(ivec3) Load 134(u64v)
+             209:132(i64vec3) Load 134(u64v)
              210:  199(ivec3) CompositeConstruct 208 208 208
-             211:  132(ivec3) ShiftLeftLogical 209 210
+             211:132(i64vec3) ShiftLeftLogical 209 210
                               Store 134(u64v) 211
              212:    204(ptr) AccessChain 166(uv) 203
              213:     21(int) Load 212
-             214:     18(int) Load 139(i64)
-             215:     18(int) ShiftRightArithmetic 214 213
+             214: 18(int64_t) Load 139(i64)
+             215: 18(int64_t) ShiftRightArithmetic 214 213
                               Store 139(i64) 215
-             216:     18(int) Load 139(i64)
+             216: 18(int64_t) Load 139(i64)
              218:     40(ptr) AccessChain 134(u64v) 217
-             219:     14(int) Load 218
-             220:     18(int) ShiftLeftLogical 216 219
+             219: 14(int64_t) Load 218
+             220: 18(int64_t) ShiftLeftLogical 216 219
                               Store 139(i64) 220
-             221:  132(ivec3) Load 134(u64v)
-             222:     18(int) Load 139(i64)
-             223:  136(ivec3) CompositeConstruct 222 222 222
-             224:  132(ivec3) ShiftLeftLogical 221 223
+             221:132(i64vec3) Load 134(u64v)
+             222: 18(int64_t) Load 139(i64)
+             223:136(i64vec3) CompositeConstruct 222 222 222
+             224:132(i64vec3) ShiftLeftLogical 221 223
                               Store 134(u64v) 224
              228:     40(ptr) AccessChain 134(u64v) 227
-             229:     14(int) Load 228
-             230:     18(int) Load 139(i64)
-             231:     14(int) Bitcast 230
+             229: 14(int64_t) Load 228
+             230: 18(int64_t) Load 139(i64)
+             231: 14(int64_t) Bitcast 230
              232:    55(bool) INotEqual 229 231
                               Store 226(b) 232
-             233:     18(int) Load 139(i64)
-             234:     14(int) Bitcast 233
+             233: 18(int64_t) Load 139(i64)
+             234: 14(int64_t) Bitcast 233
              235:     40(ptr) AccessChain 134(u64v) 227
-             236:     14(int) Load 235
+             236: 14(int64_t) Load 235
              237:    55(bool) IEqual 234 236
                               Store 226(b) 237
              238:     40(ptr) AccessChain 134(u64v) 227
-             239:     14(int) Load 238
+             239: 14(int64_t) Load 238
              240:    204(ptr) AccessChain 166(uv) 203
              241:     21(int) Load 240
-             242:     14(int) UConvert 241
+             242: 14(int64_t) UConvert 241
              243:    55(bool) UGreaterThan 239 242
                               Store 226(b) 243
-             244:     18(int) Load 139(i64)
+             244: 18(int64_t) Load 139(i64)
              245:     31(int) Load 159(i)
-             246:     18(int) SConvert 245
+             246: 18(int64_t) SConvert 245
              247:    55(bool) SLessThan 244 246
                               Store 226(b) 247
              248:     40(ptr) AccessChain 134(u64v) 203
-             249:     14(int) Load 248
+             249: 14(int64_t) Load 248
              250:    204(ptr) AccessChain 166(uv) 227
              251:     21(int) Load 250
-             252:     14(int) UConvert 251
+             252: 14(int64_t) UConvert 251
              253:    55(bool) UGreaterThanEqual 249 252
                               Store 226(b) 253
-             254:     18(int) Load 139(i64)
+             254: 18(int64_t) Load 139(i64)
              255:     31(int) Load 159(i)
-             256:     18(int) SConvert 255
+             256: 18(int64_t) SConvert 255
              257:    55(bool) SLessThanEqual 254 256
                               Store 226(b) 257
              258:     31(int) Load 159(i)
-             259:     18(int) SConvert 258
-             260:     14(int) Bitcast 259
-             261:  132(ivec3) Load 134(u64v)
-             262:  132(ivec3) CompositeConstruct 260 260 260
-             263:  132(ivec3) BitwiseOr 261 262
+             259: 18(int64_t) SConvert 258
+             260: 14(int64_t) Bitcast 259
+             261:132(i64vec3) Load 134(u64v)
+             262:132(i64vec3) CompositeConstruct 260 260 260
+             263:132(i64vec3) BitwiseOr 261 262
                               Store 134(u64v) 263
-             264:     18(int) Load 139(i64)
+             264: 18(int64_t) Load 139(i64)
              265:     31(int) Load 159(i)
-             266:     18(int) SConvert 265
-             267:     18(int) BitwiseOr 264 266
+             266: 18(int64_t) SConvert 265
+             267: 18(int64_t) BitwiseOr 264 266
                               Store 139(i64) 267
              268:     31(int) Load 159(i)
-             269:     18(int) SConvert 268
-             270:     18(int) Load 139(i64)
-             271:     18(int) BitwiseAnd 270 269
+             269: 18(int64_t) SConvert 268
+             270: 18(int64_t) Load 139(i64)
+             271: 18(int64_t) BitwiseAnd 270 269
                               Store 139(i64) 271
-             272:  132(ivec3) Load 134(u64v)
+             272:132(i64vec3) Load 134(u64v)
              273:  164(ivec3) Load 166(uv)
-             274:  132(ivec3) UConvert 273
-             275:  132(ivec3) BitwiseAnd 272 274
+             274:132(i64vec3) UConvert 273
+             275:132(i64vec3) BitwiseAnd 272 274
                               Store 134(u64v) 275
-             276:     18(int) Load 139(i64)
-             277:     14(int) Bitcast 276
-             278:  132(ivec3) Load 134(u64v)
-             279:  132(ivec3) CompositeConstruct 277 277 277
-             280:  132(ivec3) BitwiseXor 278 279
+             276: 18(int64_t) Load 139(i64)
+             277: 14(int64_t) Bitcast 276
+             278:132(i64vec3) Load 134(u64v)
+             279:132(i64vec3) CompositeConstruct 277 277 277
+             280:132(i64vec3) BitwiseXor 278 279
                               Store 134(u64v) 280
-             281:  132(ivec3) Load 134(u64v)
-             282:     18(int) Load 139(i64)
-             283:     14(int) Bitcast 282
-             284:  132(ivec3) CompositeConstruct 283 283 283
-             285:  132(ivec3) BitwiseXor 281 284
+             281:132(i64vec3) Load 134(u64v)
+             282: 18(int64_t) Load 139(i64)
+             283: 14(int64_t) Bitcast 282
+             284:132(i64vec3) CompositeConstruct 283 283 283
+             285:132(i64vec3) BitwiseXor 281 284
                               Store 134(u64v) 285
                               Return
                               FunctionEnd
@@ -472,193 +472,193 @@ spv.int64.frag
          392(iv):     75(ptr) Variable Function
          397(uv):     82(ptr) Variable Function
          401(bv):    400(ptr) Variable Function
-             287:   52(ivec2) Load 286(i64v)
-             288:   52(ivec2) ExtInst 1(GLSL.std.450) 5(SAbs) 287
+             287: 52(i64vec2) Load 286(i64v)
+             288: 52(i64vec2) ExtInst 1(GLSL.std.450) 5(SAbs) 287
                               Store 286(i64v) 288
-             290:     18(int) Load 289(i64)
-             291:     18(int) ExtInst 1(GLSL.std.450) 7(SSign) 290
+             290: 18(int64_t) Load 289(i64)
+             291: 18(int64_t) ExtInst 1(GLSL.std.450) 7(SSign) 290
                               Store 289(i64) 291
-             292:   52(ivec2) Load 286(i64v)
-             293:     18(int) Load 289(i64)
-             294:   52(ivec2) CompositeConstruct 293 293
-             295:   52(ivec2) ExtInst 1(GLSL.std.450) 39(SMin) 292 294
+             292: 52(i64vec2) Load 286(i64v)
+             293: 18(int64_t) Load 289(i64)
+             294: 52(i64vec2) CompositeConstruct 293 293
+             295: 52(i64vec2) ExtInst 1(GLSL.std.450) 39(SMin) 292 294
                               Store 286(i64v) 295
-             296:   52(ivec2) Load 286(i64v)
-             298:   52(ivec2) ExtInst 1(GLSL.std.450) 39(SMin) 296 297
+             296: 52(i64vec2) Load 286(i64v)
+             298: 52(i64vec2) ExtInst 1(GLSL.std.450) 39(SMin) 296 297
                               Store 286(i64v) 298
-             300:  132(ivec3) Load 299(u64v)
-             302:     14(int) Load 301(u64)
-             303:  132(ivec3) CompositeConstruct 302 302 302
-             304:  132(ivec3) ExtInst 1(GLSL.std.450) 38(UMin) 300 303
+             300:132(i64vec3) Load 299(u64v)
+             302: 14(int64_t) Load 301(u64)
+             303:132(i64vec3) CompositeConstruct 302 302 302
+             304:132(i64vec3) ExtInst 1(GLSL.std.450) 38(UMin) 300 303
                               Store 299(u64v) 304
-             305:  132(ivec3) Load 299(u64v)
-             307:  132(ivec3) ExtInst 1(GLSL.std.450) 38(UMin) 305 306
+             305:132(i64vec3) Load 299(u64v)
+             307:132(i64vec3) ExtInst 1(GLSL.std.450) 38(UMin) 305 306
                               Store 299(u64v) 307
-             308:   52(ivec2) Load 286(i64v)
-             309:     18(int) Load 289(i64)
-             310:   52(ivec2) CompositeConstruct 309 309
-             311:   52(ivec2) ExtInst 1(GLSL.std.450) 42(SMax) 308 310
+             308: 52(i64vec2) Load 286(i64v)
+             309: 18(int64_t) Load 289(i64)
+             310: 52(i64vec2) CompositeConstruct 309 309
+             311: 52(i64vec2) ExtInst 1(GLSL.std.450) 42(SMax) 308 310
                               Store 286(i64v) 311
-             312:   52(ivec2) Load 286(i64v)
-             313:   52(ivec2) ExtInst 1(GLSL.std.450) 42(SMax) 312 297
+             312: 52(i64vec2) Load 286(i64v)
+             313: 52(i64vec2) ExtInst 1(GLSL.std.450) 42(SMax) 312 297
                               Store 286(i64v) 313
-             314:  132(ivec3) Load 299(u64v)
-             315:     14(int) Load 301(u64)
-             316:  132(ivec3) CompositeConstruct 315 315 315
-             317:  132(ivec3) ExtInst 1(GLSL.std.450) 41(UMax) 314 316
+             314:132(i64vec3) Load 299(u64v)
+             315: 14(int64_t) Load 301(u64)
+             316:132(i64vec3) CompositeConstruct 315 315 315
+             317:132(i64vec3) ExtInst 1(GLSL.std.450) 41(UMax) 314 316
                               Store 299(u64v) 317
-             318:  132(ivec3) Load 299(u64v)
-             319:  132(ivec3) ExtInst 1(GLSL.std.450) 41(UMax) 318 306
+             318:132(i64vec3) Load 299(u64v)
+             319:132(i64vec3) ExtInst 1(GLSL.std.450) 41(UMax) 318 306
                               Store 299(u64v) 319
-             320:   52(ivec2) Load 286(i64v)
-             321:     18(int) Load 289(i64)
-             322:     18(int) SNegate 321
-             323:     18(int) Load 289(i64)
-             324:   52(ivec2) CompositeConstruct 322 322
-             325:   52(ivec2) CompositeConstruct 323 323
-             326:   52(ivec2) ExtInst 1(GLSL.std.450) 45(SClamp) 320 324 325
+             320: 52(i64vec2) Load 286(i64v)
+             321: 18(int64_t) Load 289(i64)
+             322: 18(int64_t) SNegate 321
+             323: 18(int64_t) Load 289(i64)
+             324: 52(i64vec2) CompositeConstruct 322 322
+             325: 52(i64vec2) CompositeConstruct 323 323
+             326: 52(i64vec2) ExtInst 1(GLSL.std.450) 45(SClamp) 320 324 325
                               Store 286(i64v) 326
-             327:   52(ivec2) Load 286(i64v)
-             328:   52(ivec2) Load 286(i64v)
-             329:   52(ivec2) SNegate 328
-             330:   52(ivec2) Load 286(i64v)
-             331:   52(ivec2) ExtInst 1(GLSL.std.450) 45(SClamp) 327 329 330
+             327: 52(i64vec2) Load 286(i64v)
+             328: 52(i64vec2) Load 286(i64v)
+             329: 52(i64vec2) SNegate 328
+             330: 52(i64vec2) Load 286(i64v)
+             331: 52(i64vec2) ExtInst 1(GLSL.std.450) 45(SClamp) 327 329 330
                               Store 286(i64v) 331
-             332:  132(ivec3) Load 299(u64v)
-             333:     14(int) Load 301(u64)
-             334:     14(int) SNegate 333
-             335:     14(int) Load 301(u64)
-             336:  132(ivec3) CompositeConstruct 334 334 334
-             337:  132(ivec3) CompositeConstruct 335 335 335
-             338:  132(ivec3) ExtInst 1(GLSL.std.450) 44(UClamp) 332 336 337
+             332:132(i64vec3) Load 299(u64v)
+             333: 14(int64_t) Load 301(u64)
+             334: 14(int64_t) SNegate 333
+             335: 14(int64_t) Load 301(u64)
+             336:132(i64vec3) CompositeConstruct 334 334 334
+             337:132(i64vec3) CompositeConstruct 335 335 335
+             338:132(i64vec3) ExtInst 1(GLSL.std.450) 44(UClamp) 332 336 337
                               Store 299(u64v) 338
-             339:  132(ivec3) Load 299(u64v)
-             340:  132(ivec3) Load 299(u64v)
-             341:  132(ivec3) SNegate 340
-             342:  132(ivec3) Load 299(u64v)
-             343:  132(ivec3) ExtInst 1(GLSL.std.450) 44(UClamp) 339 341 342
+             339:132(i64vec3) Load 299(u64v)
+             340:132(i64vec3) Load 299(u64v)
+             341:132(i64vec3) SNegate 340
+             342:132(i64vec3) Load 299(u64v)
+             343:132(i64vec3) ExtInst 1(GLSL.std.450) 44(UClamp) 339 341 342
                               Store 299(u64v) 343
              344:     19(ptr) AccessChain 286(i64v) 227
-             345:     18(int) Load 344
+             345: 18(int64_t) Load 344
              346:     19(ptr) AccessChain 286(i64v) 203
-             347:     18(int) Load 346
-             349:     18(int) Select 348 347 345
+             347: 18(int64_t) Load 346
+             349: 18(int64_t) Select 348 347 345
                               Store 289(i64) 349
-             350:     18(int) Load 289(i64)
-             351:   52(ivec2) CompositeConstruct 350 350
-             352:     18(int) Load 289(i64)
-             353:     18(int) SNegate 352
-             354:   52(ivec2) CompositeConstruct 353 353
-             357:   52(ivec2) Select 356 354 351
+             350: 18(int64_t) Load 289(i64)
+             351: 52(i64vec2) CompositeConstruct 350 350
+             352: 18(int64_t) Load 289(i64)
+             353: 18(int64_t) SNegate 352
+             354: 52(i64vec2) CompositeConstruct 353 353
+             357: 52(i64vec2) Select 356 354 351
                               Store 286(i64v) 357
              358:     40(ptr) AccessChain 299(u64v) 227
-             359:     14(int) Load 358
+             359: 14(int64_t) Load 358
              360:     40(ptr) AccessChain 299(u64v) 203
-             361:     14(int) Load 360
-             362:     14(int) Select 348 361 359
+             361: 14(int64_t) Load 360
+             362: 14(int64_t) Select 348 361 359
                               Store 301(u64) 362
-             363:     14(int) Load 301(u64)
-             364:  132(ivec3) CompositeConstruct 363 363 363
-             365:     14(int) Load 301(u64)
-             366:     14(int) SNegate 365
-             367:  132(ivec3) CompositeConstruct 366 366 366
-             370:  132(ivec3) Select 369 367 364
+             363: 14(int64_t) Load 301(u64)
+             364:132(i64vec3) CompositeConstruct 363 363 363
+             365: 14(int64_t) Load 301(u64)
+             366: 14(int64_t) SNegate 365
+             367:132(i64vec3) CompositeConstruct 366 366 366
+             370:132(i64vec3) Select 369 367 364
                               Store 299(u64v) 370
-             374:  371(fvec3) Load 373(dv)
-             375:   95(fvec2) VectorShuffle 374 374 0 1
-             376:   52(ivec2) Bitcast 375
+             374:371(f64vec3) Load 373(dv)
+             375: 95(f64vec2) VectorShuffle 374 374 0 1
+             376: 52(i64vec2) Bitcast 375
                               Store 286(i64v) 376
              378:    377(ptr) AccessChain 373(dv) 217
-             379:   94(float) Load 378
-             380:     14(int) Bitcast 379
+             379:94(float64_t) Load 378
+             380: 14(int64_t) Bitcast 379
              381:     40(ptr) AccessChain 299(u64v) 227
                               Store 381 380
-             382:   52(ivec2) Load 286(i64v)
-             383:   95(fvec2) Bitcast 382
-             384:  371(fvec3) Load 373(dv)
-             385:  371(fvec3) VectorShuffle 384 383 3 4 2
+             382: 52(i64vec2) Load 286(i64v)
+             383: 95(f64vec2) Bitcast 382
+             384:371(f64vec3) Load 373(dv)
+             385:371(f64vec3) VectorShuffle 384 383 3 4 2
                               Store 373(dv) 385
-             386:  132(ivec3) Load 299(u64v)
-             387:  371(fvec3) Bitcast 386
+             386:132(i64vec3) Load 299(u64v)
+             387:371(f64vec3) Bitcast 386
                               Store 373(dv) 387
-             391:     18(int) Bitcast 390
+             391: 18(int64_t) Bitcast 390
                               Store 289(i64) 391
-             393:     18(int) Load 289(i64)
+             393: 18(int64_t) Load 289(i64)
              394:   74(ivec2) Bitcast 393
                               Store 392(iv) 394
-             396:     14(int) Bitcast 395
+             396: 14(int64_t) Bitcast 395
                               Store 301(u64) 396
-             398:     14(int) Load 301(u64)
+             398: 14(int64_t) Load 301(u64)
              399:   81(ivec2) Bitcast 398
                               Store 397(uv) 399
-             402:  132(ivec3) Load 299(u64v)
-             403:     14(int) Load 301(u64)
-             404:  132(ivec3) CompositeConstruct 403 403 403
+             402:132(i64vec3) Load 299(u64v)
+             403: 14(int64_t) Load 301(u64)
+             404:132(i64vec3) CompositeConstruct 403 403 403
              405:  368(bvec3) ULessThan 402 404
                               Store 401(bv) 405
-             406:   52(ivec2) Load 286(i64v)
-             407:     18(int) Load 289(i64)
-             408:   52(ivec2) CompositeConstruct 407 407
+             406: 52(i64vec2) Load 286(i64v)
+             407: 18(int64_t) Load 289(i64)
+             408: 52(i64vec2) CompositeConstruct 407 407
              409:   56(bvec2) SLessThan 406 408
              410:  368(bvec3) Load 401(bv)
              411:  368(bvec3) VectorShuffle 410 409 3 4 2
                               Store 401(bv) 411
-             412:  132(ivec3) Load 299(u64v)
-             413:     14(int) Load 301(u64)
-             414:  132(ivec3) CompositeConstruct 413 413 413
+             412:132(i64vec3) Load 299(u64v)
+             413: 14(int64_t) Load 301(u64)
+             414:132(i64vec3) CompositeConstruct 413 413 413
              415:  368(bvec3) ULessThanEqual 412 414
                               Store 401(bv) 415
-             416:   52(ivec2) Load 286(i64v)
-             417:     18(int) Load 289(i64)
-             418:   52(ivec2) CompositeConstruct 417 417
+             416: 52(i64vec2) Load 286(i64v)
+             417: 18(int64_t) Load 289(i64)
+             418: 52(i64vec2) CompositeConstruct 417 417
              419:   56(bvec2) SLessThanEqual 416 418
              420:  368(bvec3) Load 401(bv)
              421:  368(bvec3) VectorShuffle 420 419 3 4 2
                               Store 401(bv) 421
-             422:  132(ivec3) Load 299(u64v)
-             423:     14(int) Load 301(u64)
-             424:  132(ivec3) CompositeConstruct 423 423 423
+             422:132(i64vec3) Load 299(u64v)
+             423: 14(int64_t) Load 301(u64)
+             424:132(i64vec3) CompositeConstruct 423 423 423
              425:  368(bvec3) UGreaterThan 422 424
                               Store 401(bv) 425
-             426:   52(ivec2) Load 286(i64v)
-             427:     18(int) Load 289(i64)
-             428:   52(ivec2) CompositeConstruct 427 427
+             426: 52(i64vec2) Load 286(i64v)
+             427: 18(int64_t) Load 289(i64)
+             428: 52(i64vec2) CompositeConstruct 427 427
              429:   56(bvec2) SGreaterThan 426 428
              430:  368(bvec3) Load 401(bv)
              431:  368(bvec3) VectorShuffle 430 429 3 4 2
                               Store 401(bv) 431
-             432:  132(ivec3) Load 299(u64v)
-             433:     14(int) Load 301(u64)
-             434:  132(ivec3) CompositeConstruct 433 433 433
+             432:132(i64vec3) Load 299(u64v)
+             433: 14(int64_t) Load 301(u64)
+             434:132(i64vec3) CompositeConstruct 433 433 433
              435:  368(bvec3) UGreaterThanEqual 432 434
                               Store 401(bv) 435
-             436:   52(ivec2) Load 286(i64v)
-             437:     18(int) Load 289(i64)
-             438:   52(ivec2) CompositeConstruct 437 437
+             436: 52(i64vec2) Load 286(i64v)
+             437: 18(int64_t) Load 289(i64)
+             438: 52(i64vec2) CompositeConstruct 437 437
              439:   56(bvec2) SGreaterThanEqual 436 438
              440:  368(bvec3) Load 401(bv)
              441:  368(bvec3) VectorShuffle 440 439 3 4 2
                               Store 401(bv) 441
-             442:  132(ivec3) Load 299(u64v)
-             443:     14(int) Load 301(u64)
-             444:  132(ivec3) CompositeConstruct 443 443 443
+             442:132(i64vec3) Load 299(u64v)
+             443: 14(int64_t) Load 301(u64)
+             444:132(i64vec3) CompositeConstruct 443 443 443
              445:  368(bvec3) IEqual 442 444
                               Store 401(bv) 445
-             446:   52(ivec2) Load 286(i64v)
-             447:     18(int) Load 289(i64)
-             448:   52(ivec2) CompositeConstruct 447 447
+             446: 52(i64vec2) Load 286(i64v)
+             447: 18(int64_t) Load 289(i64)
+             448: 52(i64vec2) CompositeConstruct 447 447
              449:   56(bvec2) IEqual 446 448
              450:  368(bvec3) Load 401(bv)
              451:  368(bvec3) VectorShuffle 450 449 3 4 2
                               Store 401(bv) 451
-             452:  132(ivec3) Load 299(u64v)
-             453:     14(int) Load 301(u64)
-             454:  132(ivec3) CompositeConstruct 453 453 453
+             452:132(i64vec3) Load 299(u64v)
+             453: 14(int64_t) Load 301(u64)
+             454:132(i64vec3) CompositeConstruct 453 453 453
              455:  368(bvec3) INotEqual 452 454
                               Store 401(bv) 455
-             456:   52(ivec2) Load 286(i64v)
-             457:     18(int) Load 289(i64)
-             458:   52(ivec2) CompositeConstruct 457 457
+             456: 52(i64vec2) Load 286(i64v)
+             457: 18(int64_t) Load 289(i64)
+             458: 52(i64vec2) CompositeConstruct 457 457
              459:   56(bvec2) INotEqual 456 458
              460:  368(bvec3) Load 401(bv)
              461:  368(bvec3) VectorShuffle 460 459 3 4 2

--- a/Test/baseResults/spv.int8.frag.out
+++ b/Test/baseResults/spv.int8.frag.out
@@ -96,13 +96,13 @@ spv.int8.frag
                2:             TypeVoid
                3:             TypeFunction 2
               14:             TypeInt 8 1
-              15:             TypePointer Function 14(int)
+              15:             TypePointer Function 14(int8_t)
               17:             TypeInt 32 0
               18:     17(int) Constant 3
-              19:             TypeArray 14(int) 18
-              20:     14(int) Constant 4294967279
-              21:     14(int) Constant 4294967295
-              22:     14(int) Constant 0
+              19:             TypeArray 14(int8_t) 18
+              20:  14(int8_t) Constant 4294967279
+              21:  14(int8_t) Constant 4294967295
+              22:  14(int8_t) Constant 0
               23:          19 ConstantComposite 20 21 22
     24(Uniforms):             TypeStruct 17(int)
               25:             TypePointer Uniform 24(Uniforms)
@@ -112,82 +112,82 @@ spv.int8.frag
               29:             TypePointer Uniform 17(int)
               32:             TypePointer Function 19
               36:             TypeInt 8 0
-              37:             TypePointer Function 36(int)
-              39:             TypeArray 36(int) 18
-              40:     36(int) Constant 255
-              41:     36(int) Constant 127
+              37:             TypePointer Function 36(int8_t)
+              39:             TypeArray 36(int8_t) 18
+              40:  36(int8_t) Constant 255
+              41:  36(int8_t) Constant 127
               42:          39 ConstantComposite 40 40 41
               45:             TypePointer Function 39
-              49:             TypeVector 36(int) 2
-              50:             TypePointer Function 49(ivec2)
-              52:             TypeVector 14(int) 2
-              53:             TypePointer Function 52(ivec2)
+              49:             TypeVector 36(int8_t) 2
+              50:             TypePointer Function 49(i8vec2)
+              52:             TypeVector 14(int8_t) 2
+              53:             TypePointer Function 52(i8vec2)
               57:             TypeInt 16 1
-              58:             TypeVector 57(int) 2
-              59:             TypePointer Function 58(ivec2)
+              58:             TypeVector 57(int16_t) 2
+              59:             TypePointer Function 58(i16vec2)
               66:             TypeVector 27(int) 2
               67:             TypePointer Function 66(ivec2)
               74:             TypeVector 17(int) 2
               75:             TypePointer Function 74(ivec2)
               80:             TypeInt 64 1
-              81:             TypeVector 80(int) 2
-              82:             TypePointer Function 81(ivec2)
+              81:             TypeVector 80(int64_t) 2
+              82:             TypePointer Function 81(i64vec2)
               86:             TypeInt 64 0
-              87:             TypeVector 86(int) 2
-              88:             TypePointer Function 87(ivec2)
+              87:             TypeVector 86(int64_t) 2
+              88:             TypePointer Function 87(i64vec2)
              100:             TypeFloat 16
-             101:             TypeVector 100(float) 2
-             102:             TypePointer Function 101(fvec2)
+             101:             TypeVector 100(float16_t) 2
+             102:             TypePointer Function 101(f16vec2)
              106:             TypeFloat 32
              107:             TypeVector 106(float) 2
              108:             TypePointer Function 107(fvec2)
              112:             TypeFloat 64
-             113:             TypeVector 112(float) 2
-             114:             TypePointer Function 113(fvec2)
+             113:             TypeVector 112(float64_t) 2
+             114:             TypePointer Function 113(f64vec2)
              141:             TypeInt 16 0
-             142:             TypeVector 141(int) 2
-             143:             TypePointer Function 142(ivec2)
+             142:             TypeVector 141(int16_t) 2
+             143:             TypePointer Function 142(i16vec2)
              171:             TypeBool
              172:             TypeVector 171(bool) 2
              173:             TypePointer Function 172(bvec2)
-             176:     14(int) Constant 1
-             177:   52(ivec2) ConstantComposite 22 22
-             178:   52(ivec2) ConstantComposite 176 176
-             181:     36(int) Constant 0
-             182:     36(int) Constant 1
-             183:   49(ivec2) ConstantComposite 181 181
-             184:   49(ivec2) ConstantComposite 182 182
-             190:             TypeVector 14(int) 3
-             191:             TypePointer Function 190(ivec3)
+             176:  14(int8_t) Constant 1
+             177:  52(i8vec2) ConstantComposite 22 22
+             178:  52(i8vec2) ConstantComposite 176 176
+             181:  36(int8_t) Constant 0
+             182:  36(int8_t) Constant 1
+             183:  49(i8vec2) ConstantComposite 181 181
+             184:  49(i8vec2) ConstantComposite 182 182
+             190:             TypeVector 14(int8_t) 3
+             191:             TypePointer Function 190(i8vec3)
              215:             TypePointer Function 27(int)
              221:             TypeVector 17(int) 3
              222:             TypePointer Function 221(ivec3)
              225:             TypeVector 27(int) 3
-             241:             TypePointer Function 57(int)
+             241:             TypePointer Function 57(int16_t)
              264:     17(int) Constant 1
              270:     17(int) Constant 2
              278:             TypePointer Function 171(bool)
              280:     17(int) Constant 0
              293:             TypePointer Function 17(int)
-             352:   52(ivec2) ConstantComposite 21 21
-             358:             TypeVector 36(int) 3
-             362:  190(ivec3) ConstantComposite 22 22 22
+             352:  52(i8vec2) ConstantComposite 21 21
+             358:             TypeVector 36(int8_t) 3
+             362: 190(i8vec3) ConstantComposite 22 22 22
              404:   171(bool) ConstantTrue
              411:   171(bool) ConstantFalse
              412:  172(bvec2) ConstantComposite 411 411
              427:             TypeVector 171(bool) 3
              428:  427(bvec3) ConstantComposite 411 411 411
-             434:             TypeVector 14(int) 4
-             435:             TypePointer Function 434(ivec4)
-             439:             TypePointer Function 141(int)
-             445:             TypeVector 36(int) 4
-             446:             TypePointer Function 445(ivec4)
+             434:             TypeVector 14(int8_t) 4
+             435:             TypePointer Function 434(i8vec4)
+             439:             TypePointer Function 141(int16_t)
+             445:             TypeVector 36(int8_t) 4
+             446:             TypePointer Function 445(i8vec4)
              458:             TypePointer Function 427(bvec3)
-      526(Block):             TypeStruct 14(int) 52(ivec2) 190(ivec3) 434(ivec4) 36(int) 49(ivec2) 190(ivec3) 445(ivec4)
+      526(Block):             TypeStruct 14(int8_t) 52(i8vec2) 190(i8vec3) 434(i8vec4) 36(int8_t) 49(i8vec2) 190(i8vec3) 445(i8vec4)
              527:             TypePointer Uniform 526(Block)
       528(block):    527(ptr) Variable Uniform
-        529(si8):     14(int) SpecConstant 4294967286
-        530(su8):     36(int) SpecConstant 20
+        529(si8):  14(int8_t) SpecConstant 4294967286
+        530(su8):  36(int8_t) SpecConstant 20
          4(main):           2 Function None 3
                5:             Label
                               Return
@@ -202,13 +202,13 @@ spv.int8.frag
               31:     17(int) Load 30
                               Store 33(indexable) 23
               34:     15(ptr) AccessChain 33(indexable) 31
-              35:     14(int) Load 34
+              35:  14(int8_t) Load 34
                               Store 16(i8) 35
               43:     29(ptr) AccessChain 26 28
               44:     17(int) Load 43
                               Store 46(indexable) 42
               47:     37(ptr) AccessChain 46(indexable) 44
-              48:     36(int) Load 47
+              48:  36(int8_t) Load 47
                               Store 38(u8) 48
                               Return
                               FunctionEnd
@@ -226,133 +226,133 @@ spv.int8.frag
        115(f64v):    114(ptr) Variable Function
        144(u16v):    143(ptr) Variable Function
          174(bv):    173(ptr) Variable Function
-              55:   52(ivec2) Load 54(i8v)
-              56:   49(ivec2) Bitcast 55
+              55:  52(i8vec2) Load 54(i8v)
+              56:  49(i8vec2) Bitcast 55
                               Store 51(u8v) 56
-              61:   52(ivec2) Load 54(i8v)
-              62:   58(ivec2) SConvert 61
+              61:  52(i8vec2) Load 54(i8v)
+              62: 58(i16vec2) SConvert 61
                               Store 60(i16v) 62
-              63:   49(ivec2) Load 51(u8v)
-              64:   58(ivec2) UConvert 63
-              65:   58(ivec2) Bitcast 64
+              63:  49(i8vec2) Load 51(u8v)
+              64: 58(i16vec2) UConvert 63
+              65: 58(i16vec2) Bitcast 64
                               Store 60(i16v) 65
-              69:   52(ivec2) Load 54(i8v)
+              69:  52(i8vec2) Load 54(i8v)
               70:   66(ivec2) SConvert 69
                               Store 68(i32v) 70
-              71:   49(ivec2) Load 51(u8v)
+              71:  49(i8vec2) Load 51(u8v)
               72:   66(ivec2) UConvert 71
               73:   66(ivec2) Bitcast 72
                               Store 68(i32v) 73
-              77:   52(ivec2) Load 54(i8v)
+              77:  52(i8vec2) Load 54(i8v)
               78:   66(ivec2) SConvert 77
               79:   74(ivec2) Bitcast 78
                               Store 76(u32v) 79
-              84:   52(ivec2) Load 54(i8v)
-              85:   81(ivec2) SConvert 84
+              84:  52(i8vec2) Load 54(i8v)
+              85: 81(i64vec2) SConvert 84
                               Store 83(i64v) 85
-              90:   52(ivec2) Load 54(i8v)
-              91:   81(ivec2) SConvert 90
-              92:   87(ivec2) Bitcast 91
+              90:  52(i8vec2) Load 54(i8v)
+              91: 81(i64vec2) SConvert 90
+              92: 87(i64vec2) Bitcast 91
                               Store 89(u64v) 92
-              93:   49(ivec2) Load 51(u8v)
+              93:  49(i8vec2) Load 51(u8v)
               94:   74(ivec2) UConvert 93
                               Store 76(u32v) 94
-              95:   49(ivec2) Load 51(u8v)
-              96:   81(ivec2) UConvert 95
-              97:   81(ivec2) Bitcast 96
+              95:  49(i8vec2) Load 51(u8v)
+              96: 81(i64vec2) UConvert 95
+              97: 81(i64vec2) Bitcast 96
                               Store 83(i64v) 97
-              98:   49(ivec2) Load 51(u8v)
-              99:   87(ivec2) UConvert 98
+              98:  49(i8vec2) Load 51(u8v)
+              99: 87(i64vec2) UConvert 98
                               Store 89(u64v) 99
-             104:   52(ivec2) Load 54(i8v)
-             105:  101(fvec2) ConvertSToF 104
+             104:  52(i8vec2) Load 54(i8v)
+             105:101(f16vec2) ConvertSToF 104
                               Store 103(f16v) 105
-             110:   52(ivec2) Load 54(i8v)
+             110:  52(i8vec2) Load 54(i8v)
              111:  107(fvec2) ConvertSToF 110
                               Store 109(f32v) 111
-             116:   52(ivec2) Load 54(i8v)
-             117:  113(fvec2) ConvertSToF 116
+             116:  52(i8vec2) Load 54(i8v)
+             117:113(f64vec2) ConvertSToF 116
                               Store 115(f64v) 117
-             118:   49(ivec2) Load 51(u8v)
-             119:  101(fvec2) ConvertUToF 118
+             118:  49(i8vec2) Load 51(u8v)
+             119:101(f16vec2) ConvertUToF 118
                               Store 103(f16v) 119
-             120:   49(ivec2) Load 51(u8v)
+             120:  49(i8vec2) Load 51(u8v)
              121:  107(fvec2) ConvertUToF 120
                               Store 109(f32v) 121
-             122:   49(ivec2) Load 51(u8v)
-             123:  113(fvec2) ConvertUToF 122
+             122:  49(i8vec2) Load 51(u8v)
+             123:113(f64vec2) ConvertUToF 122
                               Store 115(f64v) 123
-             124:   49(ivec2) Load 51(u8v)
-             125:   52(ivec2) Bitcast 124
+             124:  49(i8vec2) Load 51(u8v)
+             125:  52(i8vec2) Bitcast 124
                               Store 54(i8v) 125
-             126:   52(ivec2) Load 54(i8v)
-             127:   58(ivec2) SConvert 126
+             126:  52(i8vec2) Load 54(i8v)
+             127: 58(i16vec2) SConvert 126
                               Store 60(i16v) 127
-             128:   49(ivec2) Load 51(u8v)
-             129:   58(ivec2) UConvert 128
-             130:   58(ivec2) Bitcast 129
+             128:  49(i8vec2) Load 51(u8v)
+             129: 58(i16vec2) UConvert 128
+             130: 58(i16vec2) Bitcast 129
                               Store 60(i16v) 130
-             131:   52(ivec2) Load 54(i8v)
+             131:  52(i8vec2) Load 54(i8v)
              132:   66(ivec2) SConvert 131
                               Store 68(i32v) 132
-             133:   49(ivec2) Load 51(u8v)
+             133:  49(i8vec2) Load 51(u8v)
              134:   66(ivec2) UConvert 133
              135:   66(ivec2) Bitcast 134
                               Store 68(i32v) 135
-             136:   52(ivec2) Load 54(i8v)
-             137:   81(ivec2) SConvert 136
+             136:  52(i8vec2) Load 54(i8v)
+             137: 81(i64vec2) SConvert 136
                               Store 83(i64v) 137
-             138:   52(ivec2) Load 54(i8v)
-             139:   81(ivec2) SConvert 138
-             140:   87(ivec2) Bitcast 139
+             138:  52(i8vec2) Load 54(i8v)
+             139: 81(i64vec2) SConvert 138
+             140: 87(i64vec2) Bitcast 139
                               Store 89(u64v) 140
-             145:   52(ivec2) Load 54(i8v)
-             146:   58(ivec2) SConvert 145
-             147:  142(ivec2) Bitcast 146
+             145:  52(i8vec2) Load 54(i8v)
+             146: 58(i16vec2) SConvert 145
+             147:142(i16vec2) Bitcast 146
                               Store 144(u16v) 147
-             148:   49(ivec2) Load 51(u8v)
-             149:  142(ivec2) UConvert 148
+             148:  49(i8vec2) Load 51(u8v)
+             149:142(i16vec2) UConvert 148
                               Store 144(u16v) 149
-             150:   49(ivec2) Load 51(u8v)
+             150:  49(i8vec2) Load 51(u8v)
              151:   74(ivec2) UConvert 150
                               Store 76(u32v) 151
-             152:   49(ivec2) Load 51(u8v)
-             153:   81(ivec2) UConvert 152
-             154:   81(ivec2) Bitcast 153
+             152:  49(i8vec2) Load 51(u8v)
+             153: 81(i64vec2) UConvert 152
+             154: 81(i64vec2) Bitcast 153
                               Store 83(i64v) 154
-             155:   49(ivec2) Load 51(u8v)
-             156:   81(ivec2) UConvert 155
-             157:   81(ivec2) Bitcast 156
-             158:   87(ivec2) Bitcast 157
+             155:  49(i8vec2) Load 51(u8v)
+             156: 81(i64vec2) UConvert 155
+             157: 81(i64vec2) Bitcast 156
+             158: 87(i64vec2) Bitcast 157
                               Store 89(u64v) 158
-             159:   52(ivec2) Load 54(i8v)
-             160:  101(fvec2) ConvertSToF 159
+             159:  52(i8vec2) Load 54(i8v)
+             160:101(f16vec2) ConvertSToF 159
                               Store 103(f16v) 160
-             161:   52(ivec2) Load 54(i8v)
+             161:  52(i8vec2) Load 54(i8v)
              162:  107(fvec2) ConvertSToF 161
                               Store 109(f32v) 162
-             163:   52(ivec2) Load 54(i8v)
-             164:  113(fvec2) ConvertSToF 163
+             163:  52(i8vec2) Load 54(i8v)
+             164:113(f64vec2) ConvertSToF 163
                               Store 115(f64v) 164
-             165:   49(ivec2) Load 51(u8v)
-             166:  101(fvec2) ConvertUToF 165
+             165:  49(i8vec2) Load 51(u8v)
+             166:101(f16vec2) ConvertUToF 165
                               Store 103(f16v) 166
-             167:   49(ivec2) Load 51(u8v)
+             167:  49(i8vec2) Load 51(u8v)
              168:  107(fvec2) ConvertUToF 167
                               Store 109(f32v) 168
-             169:   49(ivec2) Load 51(u8v)
-             170:  113(fvec2) ConvertUToF 169
+             169:  49(i8vec2) Load 51(u8v)
+             170:113(f64vec2) ConvertUToF 169
                               Store 115(f64v) 170
              175:  172(bvec2) Load 174(bv)
-             179:   52(ivec2) Select 175 178 177
+             179:  52(i8vec2) Select 175 178 177
                               Store 54(i8v) 179
              180:  172(bvec2) Load 174(bv)
-             185:   49(ivec2) Select 180 184 183
+             185:  49(i8vec2) Select 180 184 183
                               Store 51(u8v) 185
-             186:   52(ivec2) Load 54(i8v)
+             186:  52(i8vec2) Load 54(i8v)
              187:  172(bvec2) INotEqual 186 183
                               Store 174(bv) 187
-             188:   49(ivec2) Load 51(u8v)
+             188:  49(i8vec2) Load 51(u8v)
              189:  172(bvec2) INotEqual 188 183
                               Store 174(bv) 189
                               Return
@@ -365,171 +365,171 @@ spv.int8.frag
          223(uv):    222(ptr) Variable Function
         242(i16):    241(ptr) Variable Function
           279(b):    278(ptr) Variable Function
-             193:  190(ivec3) Load 192(u8v)
-             194:  190(ivec3) CompositeConstruct 176 176 176
-             195:  190(ivec3) IAdd 193 194
+             193: 190(i8vec3) Load 192(u8v)
+             194: 190(i8vec3) CompositeConstruct 176 176 176
+             195: 190(i8vec3) IAdd 193 194
                               Store 192(u8v) 195
-             197:     14(int) Load 196(i8)
-             198:     14(int) ISub 197 176
+             197:  14(int8_t) Load 196(i8)
+             198:  14(int8_t) ISub 197 176
                               Store 196(i8) 198
-             199:     14(int) Load 196(i8)
-             200:     14(int) IAdd 199 176
+             199:  14(int8_t) Load 196(i8)
+             200:  14(int8_t) IAdd 199 176
                               Store 196(i8) 200
-             201:  190(ivec3) Load 192(u8v)
-             202:  190(ivec3) CompositeConstruct 176 176 176
-             203:  190(ivec3) ISub 201 202
+             201: 190(i8vec3) Load 192(u8v)
+             202: 190(i8vec3) CompositeConstruct 176 176 176
+             203: 190(i8vec3) ISub 201 202
                               Store 192(u8v) 203
-             204:  190(ivec3) Load 192(u8v)
-             205:  190(ivec3) Not 204
+             204: 190(i8vec3) Load 192(u8v)
+             205: 190(i8vec3) Not 204
                               Store 192(u8v) 205
-             206:     14(int) Load 196(i8)
+             206:  14(int8_t) Load 196(i8)
                               Store 196(i8) 206
-             207:  190(ivec3) Load 192(u8v)
-             208:  190(ivec3) SNegate 207
+             207: 190(i8vec3) Load 192(u8v)
+             208: 190(i8vec3) SNegate 207
                               Store 192(u8v) 208
-             209:     14(int) Load 196(i8)
-             210:     14(int) Load 196(i8)
-             211:     14(int) IAdd 210 209
+             209:  14(int8_t) Load 196(i8)
+             210:  14(int8_t) Load 196(i8)
+             211:  14(int8_t) IAdd 210 209
                               Store 196(i8) 211
-             212:  190(ivec3) Load 192(u8v)
-             213:  190(ivec3) Load 192(u8v)
-             214:  190(ivec3) ISub 213 212
+             212: 190(i8vec3) Load 192(u8v)
+             213: 190(i8vec3) Load 192(u8v)
+             214: 190(i8vec3) ISub 213 212
                               Store 192(u8v) 214
-             217:     14(int) Load 196(i8)
+             217:  14(int8_t) Load 196(i8)
              218:     27(int) SConvert 217
              219:     27(int) Load 216(i)
              220:     27(int) IMul 219 218
                               Store 216(i) 220
-             224:  190(ivec3) Load 192(u8v)
+             224: 190(i8vec3) Load 192(u8v)
              226:  225(ivec3) SConvert 224
              227:  221(ivec3) Bitcast 226
              228:  221(ivec3) Load 223(uv)
              229:  221(ivec3) UDiv 228 227
                               Store 223(uv) 229
-             230:     14(int) Load 196(i8)
+             230:  14(int8_t) Load 196(i8)
              231:     27(int) SConvert 230
              232:     17(int) Bitcast 231
              233:  221(ivec3) Load 223(uv)
              234:  221(ivec3) CompositeConstruct 232 232 232
              235:  221(ivec3) UMod 233 234
                               Store 223(uv) 235
-             236:  190(ivec3) Load 192(u8v)
+             236: 190(i8vec3) Load 192(u8v)
              237:  225(ivec3) SConvert 236
              238:  221(ivec3) Bitcast 237
              239:  221(ivec3) Load 223(uv)
              240:  221(ivec3) IAdd 238 239
                               Store 223(uv) 240
-             243:     14(int) Load 196(i8)
-             244:     57(int) SConvert 243
-             245:     57(int) Load 242(i16)
-             246:     57(int) ISub 244 245
+             243:  14(int8_t) Load 196(i8)
+             244: 57(int16_t) SConvert 243
+             245: 57(int16_t) Load 242(i16)
+             246: 57(int16_t) ISub 244 245
                               Store 242(i16) 246
-             247:  190(ivec3) Load 192(u8v)
+             247: 190(i8vec3) Load 192(u8v)
              248:  225(ivec3) SConvert 247
              249:  221(ivec3) Bitcast 248
              250:  221(ivec3) Load 223(uv)
              251:  221(ivec3) IMul 249 250
                               Store 223(uv) 251
-             252:     14(int) Load 196(i8)
-             253:     57(int) SConvert 252
-             254:     57(int) Load 242(i16)
-             255:     57(int) IMul 253 254
+             252:  14(int8_t) Load 196(i8)
+             253: 57(int16_t) SConvert 252
+             254: 57(int16_t) Load 242(i16)
+             255: 57(int16_t) IMul 253 254
                               Store 242(i16) 255
-             256:     14(int) Load 196(i8)
+             256:  14(int8_t) Load 196(i8)
              257:     27(int) SConvert 256
              258:     27(int) Load 216(i)
              259:     27(int) SMod 257 258
                               Store 216(i) 259
-             260:     14(int) Load 196(i8)
-             261:  190(ivec3) Load 192(u8v)
-             262:  190(ivec3) CompositeConstruct 260 260 260
-             263:  190(ivec3) ShiftLeftLogical 261 262
+             260:  14(int8_t) Load 196(i8)
+             261: 190(i8vec3) Load 192(u8v)
+             262: 190(i8vec3) CompositeConstruct 260 260 260
+             263: 190(i8vec3) ShiftLeftLogical 261 262
                               Store 192(u8v) 263
              265:     15(ptr) AccessChain 192(u8v) 264
-             266:     14(int) Load 265
-             267:     14(int) Load 196(i8)
-             268:     14(int) ShiftRightArithmetic 267 266
+             266:  14(int8_t) Load 265
+             267:  14(int8_t) Load 196(i8)
+             268:  14(int8_t) ShiftRightArithmetic 267 266
                               Store 196(i8) 268
-             269:     14(int) Load 196(i8)
+             269:  14(int8_t) Load 196(i8)
              271:     15(ptr) AccessChain 192(u8v) 270
-             272:     14(int) Load 271
-             273:     14(int) ShiftLeftLogical 269 272
+             272:  14(int8_t) Load 271
+             273:  14(int8_t) ShiftLeftLogical 269 272
                               Store 196(i8) 273
-             274:  190(ivec3) Load 192(u8v)
-             275:     14(int) Load 196(i8)
-             276:  190(ivec3) CompositeConstruct 275 275 275
-             277:  190(ivec3) ShiftLeftLogical 274 276
+             274: 190(i8vec3) Load 192(u8v)
+             275:  14(int8_t) Load 196(i8)
+             276: 190(i8vec3) CompositeConstruct 275 275 275
+             277: 190(i8vec3) ShiftLeftLogical 274 276
                               Store 192(u8v) 277
              281:     15(ptr) AccessChain 192(u8v) 280
-             282:     14(int) Load 281
-             283:     14(int) Load 196(i8)
+             282:  14(int8_t) Load 281
+             283:  14(int8_t) Load 196(i8)
              284:   171(bool) INotEqual 282 283
                               Store 279(b) 284
-             285:     14(int) Load 196(i8)
+             285:  14(int8_t) Load 196(i8)
              286:     15(ptr) AccessChain 192(u8v) 280
-             287:     14(int) Load 286
+             287:  14(int8_t) Load 286
              288:   171(bool) IEqual 285 287
                               Store 279(b) 288
              289:     15(ptr) AccessChain 192(u8v) 280
-             290:     14(int) Load 289
+             290:  14(int8_t) Load 289
              291:     27(int) SConvert 290
              292:     17(int) Bitcast 291
              294:    293(ptr) AccessChain 223(uv) 264
              295:     17(int) Load 294
              296:   171(bool) UGreaterThan 292 295
                               Store 279(b) 296
-             297:     14(int) Load 196(i8)
+             297:  14(int8_t) Load 196(i8)
              298:     27(int) SConvert 297
              299:     27(int) Load 216(i)
              300:   171(bool) SLessThan 298 299
                               Store 279(b) 300
              301:     15(ptr) AccessChain 192(u8v) 264
-             302:     14(int) Load 301
+             302:  14(int8_t) Load 301
              303:     27(int) SConvert 302
              304:     17(int) Bitcast 303
              305:    293(ptr) AccessChain 223(uv) 280
              306:     17(int) Load 305
              307:   171(bool) UGreaterThanEqual 304 306
                               Store 279(b) 307
-             308:     14(int) Load 196(i8)
+             308:  14(int8_t) Load 196(i8)
              309:     27(int) SConvert 308
              310:     27(int) Load 216(i)
              311:   171(bool) SLessThanEqual 309 310
                               Store 279(b) 311
-             312:     14(int) Load 196(i8)
+             312:  14(int8_t) Load 196(i8)
              313:     27(int) SConvert 312
              314:     17(int) Bitcast 313
              315:  221(ivec3) Load 223(uv)
              316:  221(ivec3) CompositeConstruct 314 314 314
              317:  221(ivec3) BitwiseOr 315 316
                               Store 223(uv) 317
-             318:     14(int) Load 196(i8)
+             318:  14(int8_t) Load 196(i8)
              319:     27(int) SConvert 318
              320:     27(int) Load 216(i)
              321:     27(int) BitwiseOr 319 320
                               Store 216(i) 321
-             322:     14(int) Load 196(i8)
-             323:     57(int) SConvert 322
-             324:     57(int) Load 242(i16)
-             325:     57(int) BitwiseAnd 324 323
+             322:  14(int8_t) Load 196(i8)
+             323: 57(int16_t) SConvert 322
+             324: 57(int16_t) Load 242(i16)
+             325: 57(int16_t) BitwiseAnd 324 323
                               Store 242(i16) 325
-             326:  190(ivec3) Load 192(u8v)
+             326: 190(i8vec3) Load 192(u8v)
              327:  225(ivec3) SConvert 326
              328:  221(ivec3) Bitcast 327
              329:  221(ivec3) Load 223(uv)
              330:  221(ivec3) BitwiseAnd 328 329
                               Store 223(uv) 330
-             331:     14(int) Load 196(i8)
+             331:  14(int8_t) Load 196(i8)
              332:     27(int) SConvert 331
              333:     17(int) Bitcast 332
              334:  221(ivec3) Load 223(uv)
              335:  221(ivec3) CompositeConstruct 333 333 333
              336:  221(ivec3) BitwiseXor 334 335
                               Store 223(uv) 336
-             337:  190(ivec3) Load 192(u8v)
-             338:     14(int) Load 196(i8)
-             339:  190(ivec3) CompositeConstruct 338 338 338
-             340:  190(ivec3) BitwiseXor 337 339
+             337: 190(i8vec3) Load 192(u8v)
+             338:  14(int8_t) Load 196(i8)
+             339: 190(i8vec3) CompositeConstruct 338 338 338
+             340: 190(i8vec3) BitwiseXor 337 339
                               Store 192(u8v) 340
                               Return
                               FunctionEnd
@@ -547,199 +547,199 @@ spv.int8.frag
         444(u32):    293(ptr) Variable Function
        447(u8v4):    446(ptr) Variable Function
          459(bv):    458(ptr) Variable Function
-             342:   52(ivec2) Load 341(i8v)
-             343:   52(ivec2) ExtInst 1(GLSL.std.450) 5(SAbs) 342
+             342:  52(i8vec2) Load 341(i8v)
+             343:  52(i8vec2) ExtInst 1(GLSL.std.450) 5(SAbs) 342
                               Store 341(i8v) 343
-             345:     14(int) Load 344(i8)
-             346:     14(int) ExtInst 1(GLSL.std.450) 7(SSign) 345
+             345:  14(int8_t) Load 344(i8)
+             346:  14(int8_t) ExtInst 1(GLSL.std.450) 7(SSign) 345
                               Store 344(i8) 346
-             347:   52(ivec2) Load 341(i8v)
-             348:     14(int) Load 344(i8)
-             349:   52(ivec2) CompositeConstruct 348 348
-             350:   52(ivec2) ExtInst 1(GLSL.std.450) 39(SMin) 347 349
+             347:  52(i8vec2) Load 341(i8v)
+             348:  14(int8_t) Load 344(i8)
+             349:  52(i8vec2) CompositeConstruct 348 348
+             350:  52(i8vec2) ExtInst 1(GLSL.std.450) 39(SMin) 347 349
                               Store 341(i8v) 350
-             351:   52(ivec2) Load 341(i8v)
-             353:   52(ivec2) ExtInst 1(GLSL.std.450) 39(SMin) 351 352
+             351:  52(i8vec2) Load 341(i8v)
+             353:  52(i8vec2) ExtInst 1(GLSL.std.450) 39(SMin) 351 352
                               Store 341(i8v) 353
-             355:  190(ivec3) Load 354(u8v)
-             357:     36(int) Load 356(u8)
-             359:  358(ivec3) CompositeConstruct 357 357 357
-             360:  190(ivec3) ExtInst 1(GLSL.std.450) 39(SMin) 355 359
+             355: 190(i8vec3) Load 354(u8v)
+             357:  36(int8_t) Load 356(u8)
+             359: 358(i8vec3) CompositeConstruct 357 357 357
+             360: 190(i8vec3) ExtInst 1(GLSL.std.450) 39(SMin) 355 359
                               Store 354(u8v) 360
-             361:  190(ivec3) Load 354(u8v)
-             363:  190(ivec3) ExtInst 1(GLSL.std.450) 39(SMin) 361 362
+             361: 190(i8vec3) Load 354(u8v)
+             363: 190(i8vec3) ExtInst 1(GLSL.std.450) 39(SMin) 361 362
                               Store 354(u8v) 363
-             364:   52(ivec2) Load 341(i8v)
-             365:     14(int) Load 344(i8)
-             366:   52(ivec2) CompositeConstruct 365 365
-             367:   52(ivec2) ExtInst 1(GLSL.std.450) 42(SMax) 364 366
+             364:  52(i8vec2) Load 341(i8v)
+             365:  14(int8_t) Load 344(i8)
+             366:  52(i8vec2) CompositeConstruct 365 365
+             367:  52(i8vec2) ExtInst 1(GLSL.std.450) 42(SMax) 364 366
                               Store 341(i8v) 367
-             368:   52(ivec2) Load 341(i8v)
-             369:   52(ivec2) ExtInst 1(GLSL.std.450) 42(SMax) 368 352
+             368:  52(i8vec2) Load 341(i8v)
+             369:  52(i8vec2) ExtInst 1(GLSL.std.450) 42(SMax) 368 352
                               Store 341(i8v) 369
-             370:  190(ivec3) Load 354(u8v)
-             371:     36(int) Load 356(u8)
-             372:  358(ivec3) CompositeConstruct 371 371 371
-             373:  190(ivec3) ExtInst 1(GLSL.std.450) 42(SMax) 370 372
+             370: 190(i8vec3) Load 354(u8v)
+             371:  36(int8_t) Load 356(u8)
+             372: 358(i8vec3) CompositeConstruct 371 371 371
+             373: 190(i8vec3) ExtInst 1(GLSL.std.450) 42(SMax) 370 372
                               Store 354(u8v) 373
-             374:  190(ivec3) Load 354(u8v)
-             375:  190(ivec3) ExtInst 1(GLSL.std.450) 42(SMax) 374 362
+             374: 190(i8vec3) Load 354(u8v)
+             375: 190(i8vec3) ExtInst 1(GLSL.std.450) 42(SMax) 374 362
                               Store 354(u8v) 375
-             376:   52(ivec2) Load 341(i8v)
-             377:     14(int) Load 344(i8)
-             378:     14(int) SNegate 377
-             379:     14(int) Load 344(i8)
-             380:   52(ivec2) CompositeConstruct 378 378
-             381:   52(ivec2) CompositeConstruct 379 379
-             382:   52(ivec2) ExtInst 1(GLSL.std.450) 45(SClamp) 376 380 381
+             376:  52(i8vec2) Load 341(i8v)
+             377:  14(int8_t) Load 344(i8)
+             378:  14(int8_t) SNegate 377
+             379:  14(int8_t) Load 344(i8)
+             380:  52(i8vec2) CompositeConstruct 378 378
+             381:  52(i8vec2) CompositeConstruct 379 379
+             382:  52(i8vec2) ExtInst 1(GLSL.std.450) 45(SClamp) 376 380 381
                               Store 341(i8v) 382
-             383:   52(ivec2) Load 341(i8v)
-             384:   52(ivec2) Load 341(i8v)
-             385:   52(ivec2) SNegate 384
-             386:   52(ivec2) Load 341(i8v)
-             387:   52(ivec2) ExtInst 1(GLSL.std.450) 45(SClamp) 383 385 386
+             383:  52(i8vec2) Load 341(i8v)
+             384:  52(i8vec2) Load 341(i8v)
+             385:  52(i8vec2) SNegate 384
+             386:  52(i8vec2) Load 341(i8v)
+             387:  52(i8vec2) ExtInst 1(GLSL.std.450) 45(SClamp) 383 385 386
                               Store 341(i8v) 387
-             388:  190(ivec3) Load 354(u8v)
-             389:     36(int) Load 356(u8)
-             390:     36(int) SNegate 389
-             391:     36(int) Load 356(u8)
-             392:  358(ivec3) CompositeConstruct 390 390 390
-             393:  358(ivec3) CompositeConstruct 391 391 391
-             394:  190(ivec3) ExtInst 1(GLSL.std.450) 45(SClamp) 388 392 393
+             388: 190(i8vec3) Load 354(u8v)
+             389:  36(int8_t) Load 356(u8)
+             390:  36(int8_t) SNegate 389
+             391:  36(int8_t) Load 356(u8)
+             392: 358(i8vec3) CompositeConstruct 390 390 390
+             393: 358(i8vec3) CompositeConstruct 391 391 391
+             394: 190(i8vec3) ExtInst 1(GLSL.std.450) 45(SClamp) 388 392 393
                               Store 354(u8v) 394
-             395:  190(ivec3) Load 354(u8v)
-             396:  190(ivec3) Load 354(u8v)
-             397:  190(ivec3) SNegate 396
-             398:  190(ivec3) Load 354(u8v)
-             399:  190(ivec3) ExtInst 1(GLSL.std.450) 45(SClamp) 395 397 398
+             395: 190(i8vec3) Load 354(u8v)
+             396: 190(i8vec3) Load 354(u8v)
+             397: 190(i8vec3) SNegate 396
+             398: 190(i8vec3) Load 354(u8v)
+             399: 190(i8vec3) ExtInst 1(GLSL.std.450) 45(SClamp) 395 397 398
                               Store 354(u8v) 399
              400:     15(ptr) AccessChain 341(i8v) 280
-             401:     14(int) Load 400
+             401:  14(int8_t) Load 400
              402:     15(ptr) AccessChain 341(i8v) 264
-             403:     14(int) Load 402
-             405:     14(int) Select 404 403 401
+             403:  14(int8_t) Load 402
+             405:  14(int8_t) Select 404 403 401
                               Store 344(i8) 405
-             406:     14(int) Load 344(i8)
-             407:   52(ivec2) CompositeConstruct 406 406
-             408:     14(int) Load 344(i8)
-             409:     14(int) SNegate 408
-             410:   52(ivec2) CompositeConstruct 409 409
-             413:   52(ivec2) Select 412 410 407
+             406:  14(int8_t) Load 344(i8)
+             407:  52(i8vec2) CompositeConstruct 406 406
+             408:  14(int8_t) Load 344(i8)
+             409:  14(int8_t) SNegate 408
+             410:  52(i8vec2) CompositeConstruct 409 409
+             413:  52(i8vec2) Select 412 410 407
                               Store 341(i8v) 413
              414:     15(ptr) AccessChain 354(u8v) 280
-             415:     14(int) Load 414
+             415:  14(int8_t) Load 414
              416:     15(ptr) AccessChain 354(u8v) 264
-             417:     14(int) Load 416
-             418:     14(int) Select 404 417 415
-             419:     36(int) Bitcast 418
+             417:  14(int8_t) Load 416
+             418:  14(int8_t) Select 404 417 415
+             419:  36(int8_t) Bitcast 418
                               Store 356(u8) 419
-             420:     36(int) Load 356(u8)
-             421:     14(int) Bitcast 420
-             422:  190(ivec3) CompositeConstruct 421 421 421
-             423:     36(int) Load 356(u8)
-             424:     36(int) SNegate 423
-             425:     14(int) Bitcast 424
-             426:  190(ivec3) CompositeConstruct 425 425 425
-             429:  190(ivec3) Select 428 426 422
+             420:  36(int8_t) Load 356(u8)
+             421:  14(int8_t) Bitcast 420
+             422: 190(i8vec3) CompositeConstruct 421 421 421
+             423:  36(int8_t) Load 356(u8)
+             424:  36(int8_t) SNegate 423
+             425:  14(int8_t) Bitcast 424
+             426: 190(i8vec3) CompositeConstruct 425 425 425
+             429: 190(i8vec3) Select 428 426 422
                               Store 354(u8v) 429
-             431:   52(ivec2) Load 341(i8v)
-             432:     57(int) Bitcast 431
+             431:  52(i8vec2) Load 341(i8v)
+             432: 57(int16_t) Bitcast 431
                               Store 430(i16) 432
-             437:  434(ivec4) Load 436(i8v4)
+             437: 434(i8vec4) Load 436(i8v4)
              438:     27(int) Bitcast 437
                               Store 433(i32) 438
-             442:   49(ivec2) Load 441(u8v2)
-             443:    141(int) Bitcast 442
+             442:  49(i8vec2) Load 441(u8v2)
+             443:141(int16_t) Bitcast 442
                               Store 440(u16) 443
-             448:  445(ivec4) Load 447(u8v4)
+             448: 445(i8vec4) Load 447(u8v4)
              449:     17(int) Bitcast 448
                               Store 444(u32) 449
-             450:     57(int) Load 430(i16)
-             451:   52(ivec2) Bitcast 450
+             450: 57(int16_t) Load 430(i16)
+             451:  52(i8vec2) Bitcast 450
                               Store 341(i8v) 451
              452:     27(int) Load 433(i32)
-             453:  434(ivec4) Bitcast 452
+             453: 434(i8vec4) Bitcast 452
                               Store 436(i8v4) 453
-             454:    141(int) Load 440(u16)
-             455:   49(ivec2) Bitcast 454
+             454:141(int16_t) Load 440(u16)
+             455:  49(i8vec2) Bitcast 454
                               Store 441(u8v2) 455
              456:     17(int) Load 444(u32)
-             457:  445(ivec4) Bitcast 456
+             457: 445(i8vec4) Bitcast 456
                               Store 447(u8v4) 457
-             460:  190(ivec3) Load 354(u8v)
-             461:     36(int) Load 356(u8)
-             462:     14(int) Bitcast 461
-             463:  190(ivec3) CompositeConstruct 462 462 462
+             460: 190(i8vec3) Load 354(u8v)
+             461:  36(int8_t) Load 356(u8)
+             462:  14(int8_t) Bitcast 461
+             463: 190(i8vec3) CompositeConstruct 462 462 462
              464:  427(bvec3) SLessThan 460 463
                               Store 459(bv) 464
-             465:   52(ivec2) Load 341(i8v)
-             466:     14(int) Load 344(i8)
-             467:   52(ivec2) CompositeConstruct 466 466
+             465:  52(i8vec2) Load 341(i8v)
+             466:  14(int8_t) Load 344(i8)
+             467:  52(i8vec2) CompositeConstruct 466 466
              468:  172(bvec2) SLessThan 465 467
              469:  427(bvec3) Load 459(bv)
              470:  427(bvec3) VectorShuffle 469 468 3 4 2
                               Store 459(bv) 470
-             471:  190(ivec3) Load 354(u8v)
-             472:     36(int) Load 356(u8)
-             473:     14(int) Bitcast 472
-             474:  190(ivec3) CompositeConstruct 473 473 473
+             471: 190(i8vec3) Load 354(u8v)
+             472:  36(int8_t) Load 356(u8)
+             473:  14(int8_t) Bitcast 472
+             474: 190(i8vec3) CompositeConstruct 473 473 473
              475:  427(bvec3) SLessThanEqual 471 474
                               Store 459(bv) 475
-             476:   52(ivec2) Load 341(i8v)
-             477:     14(int) Load 344(i8)
-             478:   52(ivec2) CompositeConstruct 477 477
+             476:  52(i8vec2) Load 341(i8v)
+             477:  14(int8_t) Load 344(i8)
+             478:  52(i8vec2) CompositeConstruct 477 477
              479:  172(bvec2) SLessThanEqual 476 478
              480:  427(bvec3) Load 459(bv)
              481:  427(bvec3) VectorShuffle 480 479 3 4 2
                               Store 459(bv) 481
-             482:  190(ivec3) Load 354(u8v)
-             483:     36(int) Load 356(u8)
-             484:     14(int) Bitcast 483
-             485:  190(ivec3) CompositeConstruct 484 484 484
+             482: 190(i8vec3) Load 354(u8v)
+             483:  36(int8_t) Load 356(u8)
+             484:  14(int8_t) Bitcast 483
+             485: 190(i8vec3) CompositeConstruct 484 484 484
              486:  427(bvec3) SGreaterThan 482 485
                               Store 459(bv) 486
-             487:   52(ivec2) Load 341(i8v)
-             488:     14(int) Load 344(i8)
-             489:   52(ivec2) CompositeConstruct 488 488
+             487:  52(i8vec2) Load 341(i8v)
+             488:  14(int8_t) Load 344(i8)
+             489:  52(i8vec2) CompositeConstruct 488 488
              490:  172(bvec2) SGreaterThan 487 489
              491:  427(bvec3) Load 459(bv)
              492:  427(bvec3) VectorShuffle 491 490 3 4 2
                               Store 459(bv) 492
-             493:  190(ivec3) Load 354(u8v)
-             494:     36(int) Load 356(u8)
-             495:     14(int) Bitcast 494
-             496:  190(ivec3) CompositeConstruct 495 495 495
+             493: 190(i8vec3) Load 354(u8v)
+             494:  36(int8_t) Load 356(u8)
+             495:  14(int8_t) Bitcast 494
+             496: 190(i8vec3) CompositeConstruct 495 495 495
              497:  427(bvec3) SGreaterThanEqual 493 496
                               Store 459(bv) 497
-             498:   52(ivec2) Load 341(i8v)
-             499:     14(int) Load 344(i8)
-             500:   52(ivec2) CompositeConstruct 499 499
+             498:  52(i8vec2) Load 341(i8v)
+             499:  14(int8_t) Load 344(i8)
+             500:  52(i8vec2) CompositeConstruct 499 499
              501:  172(bvec2) SGreaterThanEqual 498 500
              502:  427(bvec3) Load 459(bv)
              503:  427(bvec3) VectorShuffle 502 501 3 4 2
                               Store 459(bv) 503
-             504:  190(ivec3) Load 354(u8v)
-             505:     36(int) Load 356(u8)
-             506:     14(int) Bitcast 505
-             507:  190(ivec3) CompositeConstruct 506 506 506
+             504: 190(i8vec3) Load 354(u8v)
+             505:  36(int8_t) Load 356(u8)
+             506:  14(int8_t) Bitcast 505
+             507: 190(i8vec3) CompositeConstruct 506 506 506
              508:  427(bvec3) IEqual 504 507
                               Store 459(bv) 508
-             509:   52(ivec2) Load 341(i8v)
-             510:     14(int) Load 344(i8)
-             511:   52(ivec2) CompositeConstruct 510 510
+             509:  52(i8vec2) Load 341(i8v)
+             510:  14(int8_t) Load 344(i8)
+             511:  52(i8vec2) CompositeConstruct 510 510
              512:  172(bvec2) IEqual 509 511
              513:  427(bvec3) Load 459(bv)
              514:  427(bvec3) VectorShuffle 513 512 3 4 2
                               Store 459(bv) 514
-             515:  190(ivec3) Load 354(u8v)
-             516:     36(int) Load 356(u8)
-             517:     14(int) Bitcast 516
-             518:  190(ivec3) CompositeConstruct 517 517 517
+             515: 190(i8vec3) Load 354(u8v)
+             516:  36(int8_t) Load 356(u8)
+             517:  14(int8_t) Bitcast 516
+             518: 190(i8vec3) CompositeConstruct 517 517 517
              519:  427(bvec3) INotEqual 515 518
                               Store 459(bv) 519
-             520:   52(ivec2) Load 341(i8v)
-             521:     14(int) Load 344(i8)
-             522:   52(ivec2) CompositeConstruct 521 521
+             520:  52(i8vec2) Load 341(i8v)
+             521:  14(int8_t) Load 344(i8)
+             522:  52(i8vec2) CompositeConstruct 521 521
              523:  172(bvec2) INotEqual 520 522
              524:  427(bvec3) Load 459(bv)
              525:  427(bvec3) VectorShuffle 524 523 3 4 2

--- a/Test/baseResults/spv.matrix.frag.out
+++ b/Test/baseResults/spv.matrix.frag.out
@@ -36,8 +36,8 @@ spv.matrix.frag
            28(f):     27(ptr) Variable Input
               81:    6(float) Constant 1065353216
              136:             TypeFloat 64
-             137:             TypeVector 136(float) 4
-             138:             TypeMatrix 137(fvec4) 3
+             137:             TypeVector 136(float64_t) 4
+             138:             TypeMatrix 137(f64vec4) 3
              139:             TypePointer Function 138
              157:             TypeVector 6(float) 3
              158:             TypePointer Function 157(fvec3)
@@ -193,19 +193,19 @@ spv.matrix.frag
                               Store 10(sum34) 135
              141:           8 Load 10(sum34)
              142:    7(fvec4) CompositeExtract 141 0
-             143:  137(fvec4) FConvert 142
+             143:137(f64vec4) FConvert 142
              144:    7(fvec4) CompositeExtract 141 1
-             145:  137(fvec4) FConvert 144
+             145:137(f64vec4) FConvert 144
              146:    7(fvec4) CompositeExtract 141 2
-             147:  137(fvec4) FConvert 146
+             147:137(f64vec4) FConvert 146
              148:         138 CompositeConstruct 143 145 147
                               Store 140(dm) 148
              149:         138 Load 140(dm)
-             150:  137(fvec4) CompositeExtract 149 0
+             150:137(f64vec4) CompositeExtract 149 0
              151:    7(fvec4) FConvert 150
-             152:  137(fvec4) CompositeExtract 149 1
+             152:137(f64vec4) CompositeExtract 149 1
              153:    7(fvec4) FConvert 152
-             154:  137(fvec4) CompositeExtract 149 2
+             154:137(f64vec4) CompositeExtract 149 2
              155:    7(fvec4) FConvert 154
              156:           8 CompositeConstruct 151 153 155
                               Store 10(sum34) 156

--- a/Test/baseResults/spv.rankShift.comp.out
+++ b/Test/baseResults/spv.rankShift.comp.out
@@ -21,9 +21,9 @@ spv.rankShift.comp
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeInt 64 0
-               7:             TypePointer Function 6(int)
+               7:             TypePointer Function 6(int64_t)
                9:             TypeInt 64 1
-              10:             TypePointer UniformConstant 9(int)
+              10:             TypePointer UniformConstant 9(int64_t)
         11(arg0):     10(ptr) Variable UniformConstant
               13:             TypeInt 32 0
               14:             TypePointer UniformConstant 13(int)
@@ -35,23 +35,23 @@ spv.rankShift.comp
          4(main):           2 Function None 3
                5:             Label
        8(result):      7(ptr) Variable Function
-              12:      9(int) Load 11(arg0)
+              12:  9(int64_t) Load 11(arg0)
               16:     13(int) Load 15(arg1)
-              17:      9(int) ShiftLeftLogical 12 16
-              18:      6(int) Bitcast 17
+              17:  9(int64_t) ShiftLeftLogical 12 16
+              18:  6(int64_t) Bitcast 17
                               Store 8(result) 18
-              19:      9(int) Load 11(arg0)
+              19:  9(int64_t) Load 11(arg0)
               20:     13(int) Load 15(arg1)
-              21:      9(int) ShiftRightArithmetic 19 20
-              22:      6(int) Bitcast 21
+              21:  9(int64_t) ShiftRightArithmetic 19 20
+              22:  6(int64_t) Bitcast 21
                               Store 8(result) 22
               23:     13(int) Load 15(arg1)
-              24:      6(int) Load 8(result)
-              25:      6(int) ShiftLeftLogical 24 23
+              24:  6(int64_t) Load 8(result)
+              25:  6(int64_t) ShiftLeftLogical 24 23
                               Store 8(result) 25
               26:     13(int) Load 15(arg1)
-              27:      6(int) Load 8(result)
-              28:      6(int) ShiftRightLogical 27 26
+              27:  6(int64_t) Load 8(result)
+              28:  6(int64_t) ShiftRightLogical 27 26
                               Store 8(result) 28
                               Return
                               FunctionEnd

--- a/Test/baseResults/spv.shaderBallot.comp.out
+++ b/Test/baseResults/spv.shaderBallot.comp.out
@@ -52,8 +52,8 @@ spv.shaderBallot.comp
 12(gl_SubGroupSizeARB):      9(ptr) Variable Input
               15:      6(int) Constant 4
               17:             TypeInt 64 0
-              18:             TypePointer Function 17(int)
-              20:             TypePointer Input 17(int)
+              18:             TypePointer Function 17(int64_t)
+              20:             TypePointer Input 17(int64_t)
 21(gl_SubGroupEqMaskARB):     20(ptr) Variable Input
 23(gl_SubGroupGeMaskARB):     20(ptr) Variable Input
 26(gl_SubGroupGtMaskARB):     20(ptr) Variable Input
@@ -99,22 +99,22 @@ spv.shaderBallot.comp
               14:      6(int) IAdd 11 13
               16:      6(int) UMod 14 15
                               Store 8(invocation) 16
-              22:     17(int) Load 21(gl_SubGroupEqMaskARB)
-              24:     17(int) Load 23(gl_SubGroupGeMaskARB)
-              25:     17(int) IAdd 22 24
-              27:     17(int) Load 26(gl_SubGroupGtMaskARB)
-              28:     17(int) IAdd 25 27
-              30:     17(int) Load 29(gl_SubGroupLeMaskARB)
-              31:     17(int) IAdd 28 30
-              33:     17(int) Load 32(gl_SubGroupLtMaskARB)
-              34:     17(int) IAdd 31 33
+              22: 17(int64_t) Load 21(gl_SubGroupEqMaskARB)
+              24: 17(int64_t) Load 23(gl_SubGroupGeMaskARB)
+              25: 17(int64_t) IAdd 22 24
+              27: 17(int64_t) Load 26(gl_SubGroupGtMaskARB)
+              28: 17(int64_t) IAdd 25 27
+              30: 17(int64_t) Load 29(gl_SubGroupLeMaskARB)
+              31: 17(int64_t) IAdd 28 30
+              33: 17(int64_t) Load 32(gl_SubGroupLtMaskARB)
+              34: 17(int64_t) IAdd 31 33
                               Store 19(relMask) 34
-              35:     17(int) Load 19(relMask)
+              35: 17(int64_t) Load 19(relMask)
               39:   38(ivec4) SubgroupBallotKHR 37
               40:      6(int) CompositeExtract 39 0
               41:      6(int) CompositeExtract 39 1
               43:   42(ivec2) CompositeConstruct 40 41
-              44:     17(int) Bitcast 43
+              44: 17(int64_t) Bitcast 43
               45:    36(bool) IEqual 35 44
                               SelectionMerge 47 None
                               BranchConditional 45 46 216

--- a/Test/baseResults/spv.shaderBallotAMD.comp.out
+++ b/Test/baseResults/spv.shaderBallotAMD.comp.out
@@ -56,16 +56,16 @@ spv.shaderBallotAMD.comp
                9:             TypeFloat 32
               10:             TypeVector 9(float) 3
               11:             TypeFloat 64
-              12:             TypeVector 11(float) 4
+              12:             TypeVector 11(float64_t) 4
               13:             TypeInt 64 1
               14:             TypeInt 64 0
-              15:             TypeVector 14(int) 2
+              15:             TypeVector 14(int64_t) 2
               16:             TypeFloat 16
-              17:             TypeVector 16(float) 3
+              17:             TypeVector 16(float16_t) 3
               18:             TypeInt 16 1
-              19:             TypeVector 18(int) 4
+              19:             TypeVector 18(int16_t) 4
               20:             TypeInt 16 0
-     21(Buffers):             TypeStruct 6(int) 8(ivec2) 10(fvec3) 12(fvec4) 13(int) 15(ivec2) 17(fvec3) 19(ivec4) 20(int)
+     21(Buffers):             TypeStruct 6(int) 8(ivec2) 10(fvec3) 12(f64vec4) 13(int64_t) 15(i64vec2) 17(f16vec3) 19(i16vec4) 20(int16_t)
               22:             TypePointer Uniform 21(Buffers)
               23:     22(ptr) Variable Uniform
               24:      6(int) Constant 0
@@ -76,17 +76,17 @@ spv.shaderBallotAMD.comp
               41:      6(int) Constant 2
               42:             TypePointer Uniform 10(fvec3)
               53:      6(int) Constant 3
-              54:             TypePointer Uniform 12(fvec4)
+              54:             TypePointer Uniform 12(f64vec4)
               67:      6(int) Constant 4
-              68:             TypePointer Uniform 13(int)
+              68:             TypePointer Uniform 13(int64_t)
               73:      6(int) Constant 5
-              74:             TypePointer Uniform 15(ivec2)
+              74:             TypePointer Uniform 15(i64vec2)
               83:      6(int) Constant 6
-              84:             TypePointer Uniform 17(fvec3)
+              84:             TypePointer Uniform 17(f16vec3)
               95:      6(int) Constant 7
-              96:             TypePointer Uniform 19(ivec4)
+              96:             TypePointer Uniform 19(i16vec4)
              109:      6(int) Constant 8
-             110:             TypePointer Uniform 20(int)
+             110:             TypePointer Uniform 20(int16_t)
             1339:             TypeVector 7(int) 3
             1340:      7(int) Constant 8
             1341:      7(int) Constant 1
@@ -119,59 +119,59 @@ spv.shaderBallotAMD.comp
               52:     42(ptr) AccessChain 23 41
                               Store 52 51
               55:     54(ptr) AccessChain 23 53
-              56:   12(fvec4) Load 55
-              57:   11(float) CompositeExtract 56 0
-              58:   11(float) GroupFMin 28 Reduce 57
-              59:   11(float) CompositeExtract 56 1
-              60:   11(float) GroupFMin 28 Reduce 59
-              61:   11(float) CompositeExtract 56 2
-              62:   11(float) GroupFMin 28 Reduce 61
-              63:   11(float) CompositeExtract 56 3
-              64:   11(float) GroupFMin 28 Reduce 63
-              65:   12(fvec4) CompositeConstruct 58 60 62 64
+              56: 12(f64vec4) Load 55
+              57:11(float64_t) CompositeExtract 56 0
+              58:11(float64_t) GroupFMin 28 Reduce 57
+              59:11(float64_t) CompositeExtract 56 1
+              60:11(float64_t) GroupFMin 28 Reduce 59
+              61:11(float64_t) CompositeExtract 56 2
+              62:11(float64_t) GroupFMin 28 Reduce 61
+              63:11(float64_t) CompositeExtract 56 3
+              64:11(float64_t) GroupFMin 28 Reduce 63
+              65: 12(f64vec4) CompositeConstruct 58 60 62 64
               66:     54(ptr) AccessChain 23 53
                               Store 66 65
               69:     68(ptr) AccessChain 23 67
-              70:     13(int) Load 69
-              71:     13(int) GroupSMin 28 Reduce 70
+              70: 13(int64_t) Load 69
+              71: 13(int64_t) GroupSMin 28 Reduce 70
               72:     68(ptr) AccessChain 23 67
                               Store 72 71
               75:     74(ptr) AccessChain 23 73
-              76:   15(ivec2) Load 75
-              77:     14(int) CompositeExtract 76 0
-              78:     14(int) GroupUMin 28 Reduce 77
-              79:     14(int) CompositeExtract 76 1
-              80:     14(int) GroupUMin 28 Reduce 79
-              81:   15(ivec2) CompositeConstruct 78 80
+              76: 15(i64vec2) Load 75
+              77: 14(int64_t) CompositeExtract 76 0
+              78: 14(int64_t) GroupUMin 28 Reduce 77
+              79: 14(int64_t) CompositeExtract 76 1
+              80: 14(int64_t) GroupUMin 28 Reduce 79
+              81: 15(i64vec2) CompositeConstruct 78 80
               82:     74(ptr) AccessChain 23 73
                               Store 82 81
               85:     84(ptr) AccessChain 23 83
-              86:   17(fvec3) Load 85
-              87:   16(float) CompositeExtract 86 0
-              88:   16(float) GroupFMin 28 Reduce 87
-              89:   16(float) CompositeExtract 86 1
-              90:   16(float) GroupFMin 28 Reduce 89
-              91:   16(float) CompositeExtract 86 2
-              92:   16(float) GroupFMin 28 Reduce 91
-              93:   17(fvec3) CompositeConstruct 88 90 92
+              86: 17(f16vec3) Load 85
+              87:16(float16_t) CompositeExtract 86 0
+              88:16(float16_t) GroupFMin 28 Reduce 87
+              89:16(float16_t) CompositeExtract 86 1
+              90:16(float16_t) GroupFMin 28 Reduce 89
+              91:16(float16_t) CompositeExtract 86 2
+              92:16(float16_t) GroupFMin 28 Reduce 91
+              93: 17(f16vec3) CompositeConstruct 88 90 92
               94:     84(ptr) AccessChain 23 83
                               Store 94 93
               97:     96(ptr) AccessChain 23 95
-              98:   19(ivec4) Load 97
-              99:     18(int) CompositeExtract 98 0
-             100:     18(int) GroupSMin 28 Reduce 99
-             101:     18(int) CompositeExtract 98 1
-             102:     18(int) GroupSMin 28 Reduce 101
-             103:     18(int) CompositeExtract 98 2
-             104:     18(int) GroupSMin 28 Reduce 103
-             105:     18(int) CompositeExtract 98 3
-             106:     18(int) GroupSMin 28 Reduce 105
-             107:   19(ivec4) CompositeConstruct 100 102 104 106
+              98: 19(i16vec4) Load 97
+              99: 18(int16_t) CompositeExtract 98 0
+             100: 18(int16_t) GroupSMin 28 Reduce 99
+             101: 18(int16_t) CompositeExtract 98 1
+             102: 18(int16_t) GroupSMin 28 Reduce 101
+             103: 18(int16_t) CompositeExtract 98 2
+             104: 18(int16_t) GroupSMin 28 Reduce 103
+             105: 18(int16_t) CompositeExtract 98 3
+             106: 18(int16_t) GroupSMin 28 Reduce 105
+             107: 19(i16vec4) CompositeConstruct 100 102 104 106
              108:     96(ptr) AccessChain 23 95
                               Store 108 107
              111:    110(ptr) AccessChain 23 109
-             112:     20(int) Load 111
-             113:     20(int) GroupUMin 28 Reduce 112
+             112: 20(int16_t) Load 111
+             113: 20(int16_t) GroupUMin 28 Reduce 112
              114:    110(ptr) AccessChain 23 109
                               Store 114 113
              115:     25(ptr) AccessChain 23 24
@@ -200,59 +200,59 @@ spv.shaderBallotAMD.comp
              136:     42(ptr) AccessChain 23 41
                               Store 136 135
              137:     54(ptr) AccessChain 23 53
-             138:   12(fvec4) Load 137
-             139:   11(float) CompositeExtract 138 0
-             140:   11(float) GroupFMax 28 Reduce 139
-             141:   11(float) CompositeExtract 138 1
-             142:   11(float) GroupFMax 28 Reduce 141
-             143:   11(float) CompositeExtract 138 2
-             144:   11(float) GroupFMax 28 Reduce 143
-             145:   11(float) CompositeExtract 138 3
-             146:   11(float) GroupFMax 28 Reduce 145
-             147:   12(fvec4) CompositeConstruct 140 142 144 146
+             138: 12(f64vec4) Load 137
+             139:11(float64_t) CompositeExtract 138 0
+             140:11(float64_t) GroupFMax 28 Reduce 139
+             141:11(float64_t) CompositeExtract 138 1
+             142:11(float64_t) GroupFMax 28 Reduce 141
+             143:11(float64_t) CompositeExtract 138 2
+             144:11(float64_t) GroupFMax 28 Reduce 143
+             145:11(float64_t) CompositeExtract 138 3
+             146:11(float64_t) GroupFMax 28 Reduce 145
+             147: 12(f64vec4) CompositeConstruct 140 142 144 146
              148:     54(ptr) AccessChain 23 53
                               Store 148 147
              149:     68(ptr) AccessChain 23 67
-             150:     13(int) Load 149
-             151:     13(int) GroupSMax 28 Reduce 150
+             150: 13(int64_t) Load 149
+             151: 13(int64_t) GroupSMax 28 Reduce 150
              152:     68(ptr) AccessChain 23 67
                               Store 152 151
              153:     74(ptr) AccessChain 23 73
-             154:   15(ivec2) Load 153
-             155:     14(int) CompositeExtract 154 0
-             156:     14(int) GroupUMax 28 Reduce 155
-             157:     14(int) CompositeExtract 154 1
-             158:     14(int) GroupUMax 28 Reduce 157
-             159:   15(ivec2) CompositeConstruct 156 158
+             154: 15(i64vec2) Load 153
+             155: 14(int64_t) CompositeExtract 154 0
+             156: 14(int64_t) GroupUMax 28 Reduce 155
+             157: 14(int64_t) CompositeExtract 154 1
+             158: 14(int64_t) GroupUMax 28 Reduce 157
+             159: 15(i64vec2) CompositeConstruct 156 158
              160:     74(ptr) AccessChain 23 73
                               Store 160 159
              161:     84(ptr) AccessChain 23 83
-             162:   17(fvec3) Load 161
-             163:   16(float) CompositeExtract 162 0
-             164:   16(float) GroupFMax 28 Reduce 163
-             165:   16(float) CompositeExtract 162 1
-             166:   16(float) GroupFMax 28 Reduce 165
-             167:   16(float) CompositeExtract 162 2
-             168:   16(float) GroupFMax 28 Reduce 167
-             169:   17(fvec3) CompositeConstruct 164 166 168
+             162: 17(f16vec3) Load 161
+             163:16(float16_t) CompositeExtract 162 0
+             164:16(float16_t) GroupFMax 28 Reduce 163
+             165:16(float16_t) CompositeExtract 162 1
+             166:16(float16_t) GroupFMax 28 Reduce 165
+             167:16(float16_t) CompositeExtract 162 2
+             168:16(float16_t) GroupFMax 28 Reduce 167
+             169: 17(f16vec3) CompositeConstruct 164 166 168
              170:     84(ptr) AccessChain 23 83
                               Store 170 169
              171:     96(ptr) AccessChain 23 95
-             172:   19(ivec4) Load 171
-             173:     18(int) CompositeExtract 172 0
-             174:     18(int) GroupSMax 28 Reduce 173
-             175:     18(int) CompositeExtract 172 1
-             176:     18(int) GroupSMax 28 Reduce 175
-             177:     18(int) CompositeExtract 172 2
-             178:     18(int) GroupSMax 28 Reduce 177
-             179:     18(int) CompositeExtract 172 3
-             180:     18(int) GroupSMax 28 Reduce 179
-             181:   19(ivec4) CompositeConstruct 174 176 178 180
+             172: 19(i16vec4) Load 171
+             173: 18(int16_t) CompositeExtract 172 0
+             174: 18(int16_t) GroupSMax 28 Reduce 173
+             175: 18(int16_t) CompositeExtract 172 1
+             176: 18(int16_t) GroupSMax 28 Reduce 175
+             177: 18(int16_t) CompositeExtract 172 2
+             178: 18(int16_t) GroupSMax 28 Reduce 177
+             179: 18(int16_t) CompositeExtract 172 3
+             180: 18(int16_t) GroupSMax 28 Reduce 179
+             181: 19(i16vec4) CompositeConstruct 174 176 178 180
              182:     96(ptr) AccessChain 23 95
                               Store 182 181
              183:    110(ptr) AccessChain 23 109
-             184:     20(int) Load 183
-             185:     20(int) GroupUMax 28 Reduce 184
+             184: 20(int16_t) Load 183
+             185: 20(int16_t) GroupUMax 28 Reduce 184
              186:    110(ptr) AccessChain 23 109
                               Store 186 185
              187:     25(ptr) AccessChain 23 24
@@ -281,59 +281,59 @@ spv.shaderBallotAMD.comp
              208:     42(ptr) AccessChain 23 41
                               Store 208 207
              209:     54(ptr) AccessChain 23 53
-             210:   12(fvec4) Load 209
-             211:   11(float) CompositeExtract 210 0
-             212:   11(float) GroupFAdd 28 Reduce 211
-             213:   11(float) CompositeExtract 210 1
-             214:   11(float) GroupFAdd 28 Reduce 213
-             215:   11(float) CompositeExtract 210 2
-             216:   11(float) GroupFAdd 28 Reduce 215
-             217:   11(float) CompositeExtract 210 3
-             218:   11(float) GroupFAdd 28 Reduce 217
-             219:   12(fvec4) CompositeConstruct 212 214 216 218
+             210: 12(f64vec4) Load 209
+             211:11(float64_t) CompositeExtract 210 0
+             212:11(float64_t) GroupFAdd 28 Reduce 211
+             213:11(float64_t) CompositeExtract 210 1
+             214:11(float64_t) GroupFAdd 28 Reduce 213
+             215:11(float64_t) CompositeExtract 210 2
+             216:11(float64_t) GroupFAdd 28 Reduce 215
+             217:11(float64_t) CompositeExtract 210 3
+             218:11(float64_t) GroupFAdd 28 Reduce 217
+             219: 12(f64vec4) CompositeConstruct 212 214 216 218
              220:     54(ptr) AccessChain 23 53
                               Store 220 219
              221:     68(ptr) AccessChain 23 67
-             222:     13(int) Load 221
-             223:     13(int) GroupIAdd 28 Reduce 222
+             222: 13(int64_t) Load 221
+             223: 13(int64_t) GroupIAdd 28 Reduce 222
              224:     68(ptr) AccessChain 23 67
                               Store 224 223
              225:     74(ptr) AccessChain 23 73
-             226:   15(ivec2) Load 225
-             227:     14(int) CompositeExtract 226 0
-             228:     14(int) GroupIAdd 28 Reduce 227
-             229:     14(int) CompositeExtract 226 1
-             230:     14(int) GroupIAdd 28 Reduce 229
-             231:   15(ivec2) CompositeConstruct 228 230
+             226: 15(i64vec2) Load 225
+             227: 14(int64_t) CompositeExtract 226 0
+             228: 14(int64_t) GroupIAdd 28 Reduce 227
+             229: 14(int64_t) CompositeExtract 226 1
+             230: 14(int64_t) GroupIAdd 28 Reduce 229
+             231: 15(i64vec2) CompositeConstruct 228 230
              232:     74(ptr) AccessChain 23 73
                               Store 232 231
              233:     84(ptr) AccessChain 23 83
-             234:   17(fvec3) Load 233
-             235:   16(float) CompositeExtract 234 0
-             236:   16(float) GroupFAdd 28 Reduce 235
-             237:   16(float) CompositeExtract 234 1
-             238:   16(float) GroupFAdd 28 Reduce 237
-             239:   16(float) CompositeExtract 234 2
-             240:   16(float) GroupFAdd 28 Reduce 239
-             241:   17(fvec3) CompositeConstruct 236 238 240
+             234: 17(f16vec3) Load 233
+             235:16(float16_t) CompositeExtract 234 0
+             236:16(float16_t) GroupFAdd 28 Reduce 235
+             237:16(float16_t) CompositeExtract 234 1
+             238:16(float16_t) GroupFAdd 28 Reduce 237
+             239:16(float16_t) CompositeExtract 234 2
+             240:16(float16_t) GroupFAdd 28 Reduce 239
+             241: 17(f16vec3) CompositeConstruct 236 238 240
              242:     84(ptr) AccessChain 23 83
                               Store 242 241
              243:     96(ptr) AccessChain 23 95
-             244:   19(ivec4) Load 243
-             245:     18(int) CompositeExtract 244 0
-             246:     18(int) GroupIAdd 28 Reduce 245
-             247:     18(int) CompositeExtract 244 1
-             248:     18(int) GroupIAdd 28 Reduce 247
-             249:     18(int) CompositeExtract 244 2
-             250:     18(int) GroupIAdd 28 Reduce 249
-             251:     18(int) CompositeExtract 244 3
-             252:     18(int) GroupIAdd 28 Reduce 251
-             253:   19(ivec4) CompositeConstruct 246 248 250 252
+             244: 19(i16vec4) Load 243
+             245: 18(int16_t) CompositeExtract 244 0
+             246: 18(int16_t) GroupIAdd 28 Reduce 245
+             247: 18(int16_t) CompositeExtract 244 1
+             248: 18(int16_t) GroupIAdd 28 Reduce 247
+             249: 18(int16_t) CompositeExtract 244 2
+             250: 18(int16_t) GroupIAdd 28 Reduce 249
+             251: 18(int16_t) CompositeExtract 244 3
+             252: 18(int16_t) GroupIAdd 28 Reduce 251
+             253: 19(i16vec4) CompositeConstruct 246 248 250 252
              254:     96(ptr) AccessChain 23 95
                               Store 254 253
              255:    110(ptr) AccessChain 23 109
-             256:     20(int) Load 255
-             257:     20(int) GroupIAdd 28 Reduce 256
+             256: 20(int16_t) Load 255
+             257: 20(int16_t) GroupIAdd 28 Reduce 256
              258:    110(ptr) AccessChain 23 109
                               Store 258 257
              259:     25(ptr) AccessChain 23 24
@@ -362,59 +362,59 @@ spv.shaderBallotAMD.comp
              280:     42(ptr) AccessChain 23 41
                               Store 280 279
              281:     54(ptr) AccessChain 23 53
-             282:   12(fvec4) Load 281
-             283:   11(float) CompositeExtract 282 0
-             284:   11(float) GroupFMinNonUniformAMD 28 Reduce 283
-             285:   11(float) CompositeExtract 282 1
-             286:   11(float) GroupFMinNonUniformAMD 28 Reduce 285
-             287:   11(float) CompositeExtract 282 2
-             288:   11(float) GroupFMinNonUniformAMD 28 Reduce 287
-             289:   11(float) CompositeExtract 282 3
-             290:   11(float) GroupFMinNonUniformAMD 28 Reduce 289
-             291:   12(fvec4) CompositeConstruct 284 286 288 290
+             282: 12(f64vec4) Load 281
+             283:11(float64_t) CompositeExtract 282 0
+             284:11(float64_t) GroupFMinNonUniformAMD 28 Reduce 283
+             285:11(float64_t) CompositeExtract 282 1
+             286:11(float64_t) GroupFMinNonUniformAMD 28 Reduce 285
+             287:11(float64_t) CompositeExtract 282 2
+             288:11(float64_t) GroupFMinNonUniformAMD 28 Reduce 287
+             289:11(float64_t) CompositeExtract 282 3
+             290:11(float64_t) GroupFMinNonUniformAMD 28 Reduce 289
+             291: 12(f64vec4) CompositeConstruct 284 286 288 290
              292:     54(ptr) AccessChain 23 53
                               Store 292 291
              293:     68(ptr) AccessChain 23 67
-             294:     13(int) Load 293
-             295:     13(int) GroupSMinNonUniformAMD 28 Reduce 294
+             294: 13(int64_t) Load 293
+             295: 13(int64_t) GroupSMinNonUniformAMD 28 Reduce 294
              296:     68(ptr) AccessChain 23 67
                               Store 296 295
              297:     74(ptr) AccessChain 23 73
-             298:   15(ivec2) Load 297
-             299:     14(int) CompositeExtract 298 0
-             300:     14(int) GroupUMinNonUniformAMD 28 Reduce 299
-             301:     14(int) CompositeExtract 298 1
-             302:     14(int) GroupUMinNonUniformAMD 28 Reduce 301
-             303:   15(ivec2) CompositeConstruct 300 302
+             298: 15(i64vec2) Load 297
+             299: 14(int64_t) CompositeExtract 298 0
+             300: 14(int64_t) GroupUMinNonUniformAMD 28 Reduce 299
+             301: 14(int64_t) CompositeExtract 298 1
+             302: 14(int64_t) GroupUMinNonUniformAMD 28 Reduce 301
+             303: 15(i64vec2) CompositeConstruct 300 302
              304:     74(ptr) AccessChain 23 73
                               Store 304 303
              305:     84(ptr) AccessChain 23 83
-             306:   17(fvec3) Load 305
-             307:   16(float) CompositeExtract 306 0
-             308:   16(float) GroupFMinNonUniformAMD 28 Reduce 307
-             309:   16(float) CompositeExtract 306 1
-             310:   16(float) GroupFMinNonUniformAMD 28 Reduce 309
-             311:   16(float) CompositeExtract 306 2
-             312:   16(float) GroupFMinNonUniformAMD 28 Reduce 311
-             313:   17(fvec3) CompositeConstruct 308 310 312
+             306: 17(f16vec3) Load 305
+             307:16(float16_t) CompositeExtract 306 0
+             308:16(float16_t) GroupFMinNonUniformAMD 28 Reduce 307
+             309:16(float16_t) CompositeExtract 306 1
+             310:16(float16_t) GroupFMinNonUniformAMD 28 Reduce 309
+             311:16(float16_t) CompositeExtract 306 2
+             312:16(float16_t) GroupFMinNonUniformAMD 28 Reduce 311
+             313: 17(f16vec3) CompositeConstruct 308 310 312
              314:     84(ptr) AccessChain 23 83
                               Store 314 313
              315:     96(ptr) AccessChain 23 95
-             316:   19(ivec4) Load 315
-             317:     18(int) CompositeExtract 316 0
-             318:     18(int) GroupSMinNonUniformAMD 28 Reduce 317
-             319:     18(int) CompositeExtract 316 1
-             320:     18(int) GroupSMinNonUniformAMD 28 Reduce 319
-             321:     18(int) CompositeExtract 316 2
-             322:     18(int) GroupSMinNonUniformAMD 28 Reduce 321
-             323:     18(int) CompositeExtract 316 3
-             324:     18(int) GroupSMinNonUniformAMD 28 Reduce 323
-             325:   19(ivec4) CompositeConstruct 318 320 322 324
+             316: 19(i16vec4) Load 315
+             317: 18(int16_t) CompositeExtract 316 0
+             318: 18(int16_t) GroupSMinNonUniformAMD 28 Reduce 317
+             319: 18(int16_t) CompositeExtract 316 1
+             320: 18(int16_t) GroupSMinNonUniformAMD 28 Reduce 319
+             321: 18(int16_t) CompositeExtract 316 2
+             322: 18(int16_t) GroupSMinNonUniformAMD 28 Reduce 321
+             323: 18(int16_t) CompositeExtract 316 3
+             324: 18(int16_t) GroupSMinNonUniformAMD 28 Reduce 323
+             325: 19(i16vec4) CompositeConstruct 318 320 322 324
              326:     96(ptr) AccessChain 23 95
                               Store 326 325
              327:    110(ptr) AccessChain 23 109
-             328:     20(int) Load 327
-             329:     20(int) GroupUMinNonUniformAMD 28 Reduce 328
+             328: 20(int16_t) Load 327
+             329: 20(int16_t) GroupUMinNonUniformAMD 28 Reduce 328
              330:    110(ptr) AccessChain 23 109
                               Store 330 329
              331:     25(ptr) AccessChain 23 24
@@ -443,59 +443,59 @@ spv.shaderBallotAMD.comp
              352:     42(ptr) AccessChain 23 41
                               Store 352 351
              353:     54(ptr) AccessChain 23 53
-             354:   12(fvec4) Load 353
-             355:   11(float) CompositeExtract 354 0
-             356:   11(float) GroupFMaxNonUniformAMD 28 Reduce 355
-             357:   11(float) CompositeExtract 354 1
-             358:   11(float) GroupFMaxNonUniformAMD 28 Reduce 357
-             359:   11(float) CompositeExtract 354 2
-             360:   11(float) GroupFMaxNonUniformAMD 28 Reduce 359
-             361:   11(float) CompositeExtract 354 3
-             362:   11(float) GroupFMaxNonUniformAMD 28 Reduce 361
-             363:   12(fvec4) CompositeConstruct 356 358 360 362
+             354: 12(f64vec4) Load 353
+             355:11(float64_t) CompositeExtract 354 0
+             356:11(float64_t) GroupFMaxNonUniformAMD 28 Reduce 355
+             357:11(float64_t) CompositeExtract 354 1
+             358:11(float64_t) GroupFMaxNonUniformAMD 28 Reduce 357
+             359:11(float64_t) CompositeExtract 354 2
+             360:11(float64_t) GroupFMaxNonUniformAMD 28 Reduce 359
+             361:11(float64_t) CompositeExtract 354 3
+             362:11(float64_t) GroupFMaxNonUniformAMD 28 Reduce 361
+             363: 12(f64vec4) CompositeConstruct 356 358 360 362
              364:     54(ptr) AccessChain 23 53
                               Store 364 363
              365:     68(ptr) AccessChain 23 67
-             366:     13(int) Load 365
-             367:     13(int) GroupSMaxNonUniformAMD 28 Reduce 366
+             366: 13(int64_t) Load 365
+             367: 13(int64_t) GroupSMaxNonUniformAMD 28 Reduce 366
              368:     68(ptr) AccessChain 23 67
                               Store 368 367
              369:     74(ptr) AccessChain 23 73
-             370:   15(ivec2) Load 369
-             371:     14(int) CompositeExtract 370 0
-             372:     14(int) GroupUMaxNonUniformAMD 28 Reduce 371
-             373:     14(int) CompositeExtract 370 1
-             374:     14(int) GroupUMaxNonUniformAMD 28 Reduce 373
-             375:   15(ivec2) CompositeConstruct 372 374
+             370: 15(i64vec2) Load 369
+             371: 14(int64_t) CompositeExtract 370 0
+             372: 14(int64_t) GroupUMaxNonUniformAMD 28 Reduce 371
+             373: 14(int64_t) CompositeExtract 370 1
+             374: 14(int64_t) GroupUMaxNonUniformAMD 28 Reduce 373
+             375: 15(i64vec2) CompositeConstruct 372 374
              376:     74(ptr) AccessChain 23 73
                               Store 376 375
              377:     84(ptr) AccessChain 23 83
-             378:   17(fvec3) Load 377
-             379:   16(float) CompositeExtract 378 0
-             380:   16(float) GroupFMaxNonUniformAMD 28 Reduce 379
-             381:   16(float) CompositeExtract 378 1
-             382:   16(float) GroupFMaxNonUniformAMD 28 Reduce 381
-             383:   16(float) CompositeExtract 378 2
-             384:   16(float) GroupFMaxNonUniformAMD 28 Reduce 383
-             385:   17(fvec3) CompositeConstruct 380 382 384
+             378: 17(f16vec3) Load 377
+             379:16(float16_t) CompositeExtract 378 0
+             380:16(float16_t) GroupFMaxNonUniformAMD 28 Reduce 379
+             381:16(float16_t) CompositeExtract 378 1
+             382:16(float16_t) GroupFMaxNonUniformAMD 28 Reduce 381
+             383:16(float16_t) CompositeExtract 378 2
+             384:16(float16_t) GroupFMaxNonUniformAMD 28 Reduce 383
+             385: 17(f16vec3) CompositeConstruct 380 382 384
              386:     84(ptr) AccessChain 23 83
                               Store 386 385
              387:     96(ptr) AccessChain 23 95
-             388:   19(ivec4) Load 387
-             389:     18(int) CompositeExtract 388 0
-             390:     18(int) GroupSMaxNonUniformAMD 28 Reduce 389
-             391:     18(int) CompositeExtract 388 1
-             392:     18(int) GroupSMaxNonUniformAMD 28 Reduce 391
-             393:     18(int) CompositeExtract 388 2
-             394:     18(int) GroupSMaxNonUniformAMD 28 Reduce 393
-             395:     18(int) CompositeExtract 388 3
-             396:     18(int) GroupSMaxNonUniformAMD 28 Reduce 395
-             397:   19(ivec4) CompositeConstruct 390 392 394 396
+             388: 19(i16vec4) Load 387
+             389: 18(int16_t) CompositeExtract 388 0
+             390: 18(int16_t) GroupSMaxNonUniformAMD 28 Reduce 389
+             391: 18(int16_t) CompositeExtract 388 1
+             392: 18(int16_t) GroupSMaxNonUniformAMD 28 Reduce 391
+             393: 18(int16_t) CompositeExtract 388 2
+             394: 18(int16_t) GroupSMaxNonUniformAMD 28 Reduce 393
+             395: 18(int16_t) CompositeExtract 388 3
+             396: 18(int16_t) GroupSMaxNonUniformAMD 28 Reduce 395
+             397: 19(i16vec4) CompositeConstruct 390 392 394 396
              398:     96(ptr) AccessChain 23 95
                               Store 398 397
              399:    110(ptr) AccessChain 23 109
-             400:     20(int) Load 399
-             401:     20(int) GroupUMaxNonUniformAMD 28 Reduce 400
+             400: 20(int16_t) Load 399
+             401: 20(int16_t) GroupUMaxNonUniformAMD 28 Reduce 400
              402:    110(ptr) AccessChain 23 109
                               Store 402 401
              403:     25(ptr) AccessChain 23 24
@@ -524,59 +524,59 @@ spv.shaderBallotAMD.comp
              424:     42(ptr) AccessChain 23 41
                               Store 424 423
              425:     54(ptr) AccessChain 23 53
-             426:   12(fvec4) Load 425
-             427:   11(float) CompositeExtract 426 0
-             428:   11(float) GroupFAddNonUniformAMD 28 Reduce 427
-             429:   11(float) CompositeExtract 426 1
-             430:   11(float) GroupFAddNonUniformAMD 28 Reduce 429
-             431:   11(float) CompositeExtract 426 2
-             432:   11(float) GroupFAddNonUniformAMD 28 Reduce 431
-             433:   11(float) CompositeExtract 426 3
-             434:   11(float) GroupFAddNonUniformAMD 28 Reduce 433
-             435:   12(fvec4) CompositeConstruct 428 430 432 434
+             426: 12(f64vec4) Load 425
+             427:11(float64_t) CompositeExtract 426 0
+             428:11(float64_t) GroupFAddNonUniformAMD 28 Reduce 427
+             429:11(float64_t) CompositeExtract 426 1
+             430:11(float64_t) GroupFAddNonUniformAMD 28 Reduce 429
+             431:11(float64_t) CompositeExtract 426 2
+             432:11(float64_t) GroupFAddNonUniformAMD 28 Reduce 431
+             433:11(float64_t) CompositeExtract 426 3
+             434:11(float64_t) GroupFAddNonUniformAMD 28 Reduce 433
+             435: 12(f64vec4) CompositeConstruct 428 430 432 434
              436:     54(ptr) AccessChain 23 53
                               Store 436 435
              437:     68(ptr) AccessChain 23 67
-             438:     13(int) Load 437
-             439:     13(int) GroupIAddNonUniformAMD 28 Reduce 438
+             438: 13(int64_t) Load 437
+             439: 13(int64_t) GroupIAddNonUniformAMD 28 Reduce 438
              440:     68(ptr) AccessChain 23 67
                               Store 440 439
              441:     74(ptr) AccessChain 23 73
-             442:   15(ivec2) Load 441
-             443:     14(int) CompositeExtract 442 0
-             444:     14(int) GroupIAddNonUniformAMD 28 Reduce 443
-             445:     14(int) CompositeExtract 442 1
-             446:     14(int) GroupIAddNonUniformAMD 28 Reduce 445
-             447:   15(ivec2) CompositeConstruct 444 446
+             442: 15(i64vec2) Load 441
+             443: 14(int64_t) CompositeExtract 442 0
+             444: 14(int64_t) GroupIAddNonUniformAMD 28 Reduce 443
+             445: 14(int64_t) CompositeExtract 442 1
+             446: 14(int64_t) GroupIAddNonUniformAMD 28 Reduce 445
+             447: 15(i64vec2) CompositeConstruct 444 446
              448:     74(ptr) AccessChain 23 73
                               Store 448 447
              449:     84(ptr) AccessChain 23 83
-             450:   17(fvec3) Load 449
-             451:   16(float) CompositeExtract 450 0
-             452:   16(float) GroupFAddNonUniformAMD 28 Reduce 451
-             453:   16(float) CompositeExtract 450 1
-             454:   16(float) GroupFAddNonUniformAMD 28 Reduce 453
-             455:   16(float) CompositeExtract 450 2
-             456:   16(float) GroupFAddNonUniformAMD 28 Reduce 455
-             457:   17(fvec3) CompositeConstruct 452 454 456
+             450: 17(f16vec3) Load 449
+             451:16(float16_t) CompositeExtract 450 0
+             452:16(float16_t) GroupFAddNonUniformAMD 28 Reduce 451
+             453:16(float16_t) CompositeExtract 450 1
+             454:16(float16_t) GroupFAddNonUniformAMD 28 Reduce 453
+             455:16(float16_t) CompositeExtract 450 2
+             456:16(float16_t) GroupFAddNonUniformAMD 28 Reduce 455
+             457: 17(f16vec3) CompositeConstruct 452 454 456
              458:     84(ptr) AccessChain 23 83
                               Store 458 457
              459:     96(ptr) AccessChain 23 95
-             460:   19(ivec4) Load 459
-             461:     18(int) CompositeExtract 460 0
-             462:     18(int) GroupIAddNonUniformAMD 28 Reduce 461
-             463:     18(int) CompositeExtract 460 1
-             464:     18(int) GroupIAddNonUniformAMD 28 Reduce 463
-             465:     18(int) CompositeExtract 460 2
-             466:     18(int) GroupIAddNonUniformAMD 28 Reduce 465
-             467:     18(int) CompositeExtract 460 3
-             468:     18(int) GroupIAddNonUniformAMD 28 Reduce 467
-             469:   19(ivec4) CompositeConstruct 462 464 466 468
+             460: 19(i16vec4) Load 459
+             461: 18(int16_t) CompositeExtract 460 0
+             462: 18(int16_t) GroupIAddNonUniformAMD 28 Reduce 461
+             463: 18(int16_t) CompositeExtract 460 1
+             464: 18(int16_t) GroupIAddNonUniformAMD 28 Reduce 463
+             465: 18(int16_t) CompositeExtract 460 2
+             466: 18(int16_t) GroupIAddNonUniformAMD 28 Reduce 465
+             467: 18(int16_t) CompositeExtract 460 3
+             468: 18(int16_t) GroupIAddNonUniformAMD 28 Reduce 467
+             469: 19(i16vec4) CompositeConstruct 462 464 466 468
              470:     96(ptr) AccessChain 23 95
                               Store 470 469
              471:    110(ptr) AccessChain 23 109
-             472:     20(int) Load 471
-             473:     20(int) GroupIAddNonUniformAMD 28 Reduce 472
+             472: 20(int16_t) Load 471
+             473: 20(int16_t) GroupIAddNonUniformAMD 28 Reduce 472
              474:    110(ptr) AccessChain 23 109
                               Store 474 473
              475:     25(ptr) AccessChain 23 24
@@ -605,59 +605,59 @@ spv.shaderBallotAMD.comp
              496:     42(ptr) AccessChain 23 41
                               Store 496 495
              497:     54(ptr) AccessChain 23 53
-             498:   12(fvec4) Load 497
-             499:   11(float) CompositeExtract 498 0
-             500:   11(float) GroupFMin 28 InclusiveScan 499
-             501:   11(float) CompositeExtract 498 1
-             502:   11(float) GroupFMin 28 InclusiveScan 501
-             503:   11(float) CompositeExtract 498 2
-             504:   11(float) GroupFMin 28 InclusiveScan 503
-             505:   11(float) CompositeExtract 498 3
-             506:   11(float) GroupFMin 28 InclusiveScan 505
-             507:   12(fvec4) CompositeConstruct 500 502 504 506
+             498: 12(f64vec4) Load 497
+             499:11(float64_t) CompositeExtract 498 0
+             500:11(float64_t) GroupFMin 28 InclusiveScan 499
+             501:11(float64_t) CompositeExtract 498 1
+             502:11(float64_t) GroupFMin 28 InclusiveScan 501
+             503:11(float64_t) CompositeExtract 498 2
+             504:11(float64_t) GroupFMin 28 InclusiveScan 503
+             505:11(float64_t) CompositeExtract 498 3
+             506:11(float64_t) GroupFMin 28 InclusiveScan 505
+             507: 12(f64vec4) CompositeConstruct 500 502 504 506
              508:     54(ptr) AccessChain 23 53
                               Store 508 507
              509:     68(ptr) AccessChain 23 67
-             510:     13(int) Load 509
-             511:     13(int) GroupSMin 28 InclusiveScan 510
+             510: 13(int64_t) Load 509
+             511: 13(int64_t) GroupSMin 28 InclusiveScan 510
              512:     68(ptr) AccessChain 23 67
                               Store 512 511
              513:     74(ptr) AccessChain 23 73
-             514:   15(ivec2) Load 513
-             515:     14(int) CompositeExtract 514 0
-             516:     14(int) GroupUMin 28 InclusiveScan 515
-             517:     14(int) CompositeExtract 514 1
-             518:     14(int) GroupUMin 28 InclusiveScan 517
-             519:   15(ivec2) CompositeConstruct 516 518
+             514: 15(i64vec2) Load 513
+             515: 14(int64_t) CompositeExtract 514 0
+             516: 14(int64_t) GroupUMin 28 InclusiveScan 515
+             517: 14(int64_t) CompositeExtract 514 1
+             518: 14(int64_t) GroupUMin 28 InclusiveScan 517
+             519: 15(i64vec2) CompositeConstruct 516 518
              520:     74(ptr) AccessChain 23 73
                               Store 520 519
              521:     84(ptr) AccessChain 23 83
-             522:   17(fvec3) Load 521
-             523:   16(float) CompositeExtract 522 0
-             524:   16(float) GroupFMin 28 InclusiveScan 523
-             525:   16(float) CompositeExtract 522 1
-             526:   16(float) GroupFMin 28 InclusiveScan 525
-             527:   16(float) CompositeExtract 522 2
-             528:   16(float) GroupFMin 28 InclusiveScan 527
-             529:   17(fvec3) CompositeConstruct 524 526 528
+             522: 17(f16vec3) Load 521
+             523:16(float16_t) CompositeExtract 522 0
+             524:16(float16_t) GroupFMin 28 InclusiveScan 523
+             525:16(float16_t) CompositeExtract 522 1
+             526:16(float16_t) GroupFMin 28 InclusiveScan 525
+             527:16(float16_t) CompositeExtract 522 2
+             528:16(float16_t) GroupFMin 28 InclusiveScan 527
+             529: 17(f16vec3) CompositeConstruct 524 526 528
              530:     84(ptr) AccessChain 23 83
                               Store 530 529
              531:     96(ptr) AccessChain 23 95
-             532:   19(ivec4) Load 531
-             533:     18(int) CompositeExtract 532 0
-             534:     18(int) GroupSMin 28 InclusiveScan 533
-             535:     18(int) CompositeExtract 532 1
-             536:     18(int) GroupSMin 28 InclusiveScan 535
-             537:     18(int) CompositeExtract 532 2
-             538:     18(int) GroupSMin 28 InclusiveScan 537
-             539:     18(int) CompositeExtract 532 3
-             540:     18(int) GroupSMin 28 InclusiveScan 539
-             541:   19(ivec4) CompositeConstruct 534 536 538 540
+             532: 19(i16vec4) Load 531
+             533: 18(int16_t) CompositeExtract 532 0
+             534: 18(int16_t) GroupSMin 28 InclusiveScan 533
+             535: 18(int16_t) CompositeExtract 532 1
+             536: 18(int16_t) GroupSMin 28 InclusiveScan 535
+             537: 18(int16_t) CompositeExtract 532 2
+             538: 18(int16_t) GroupSMin 28 InclusiveScan 537
+             539: 18(int16_t) CompositeExtract 532 3
+             540: 18(int16_t) GroupSMin 28 InclusiveScan 539
+             541: 19(i16vec4) CompositeConstruct 534 536 538 540
              542:     96(ptr) AccessChain 23 95
                               Store 542 541
              543:    110(ptr) AccessChain 23 109
-             544:     20(int) Load 543
-             545:     20(int) GroupUMin 28 InclusiveScan 544
+             544: 20(int16_t) Load 543
+             545: 20(int16_t) GroupUMin 28 InclusiveScan 544
              546:    110(ptr) AccessChain 23 109
                               Store 546 545
              547:     25(ptr) AccessChain 23 24
@@ -686,59 +686,59 @@ spv.shaderBallotAMD.comp
              568:     42(ptr) AccessChain 23 41
                               Store 568 567
              569:     54(ptr) AccessChain 23 53
-             570:   12(fvec4) Load 569
-             571:   11(float) CompositeExtract 570 0
-             572:   11(float) GroupFMax 28 InclusiveScan 571
-             573:   11(float) CompositeExtract 570 1
-             574:   11(float) GroupFMax 28 InclusiveScan 573
-             575:   11(float) CompositeExtract 570 2
-             576:   11(float) GroupFMax 28 InclusiveScan 575
-             577:   11(float) CompositeExtract 570 3
-             578:   11(float) GroupFMax 28 InclusiveScan 577
-             579:   12(fvec4) CompositeConstruct 572 574 576 578
+             570: 12(f64vec4) Load 569
+             571:11(float64_t) CompositeExtract 570 0
+             572:11(float64_t) GroupFMax 28 InclusiveScan 571
+             573:11(float64_t) CompositeExtract 570 1
+             574:11(float64_t) GroupFMax 28 InclusiveScan 573
+             575:11(float64_t) CompositeExtract 570 2
+             576:11(float64_t) GroupFMax 28 InclusiveScan 575
+             577:11(float64_t) CompositeExtract 570 3
+             578:11(float64_t) GroupFMax 28 InclusiveScan 577
+             579: 12(f64vec4) CompositeConstruct 572 574 576 578
              580:     54(ptr) AccessChain 23 53
                               Store 580 579
              581:     68(ptr) AccessChain 23 67
-             582:     13(int) Load 581
-             583:     13(int) GroupSMax 28 InclusiveScan 582
+             582: 13(int64_t) Load 581
+             583: 13(int64_t) GroupSMax 28 InclusiveScan 582
              584:     68(ptr) AccessChain 23 67
                               Store 584 583
              585:     74(ptr) AccessChain 23 73
-             586:   15(ivec2) Load 585
-             587:     14(int) CompositeExtract 586 0
-             588:     14(int) GroupUMax 28 InclusiveScan 587
-             589:     14(int) CompositeExtract 586 1
-             590:     14(int) GroupUMax 28 InclusiveScan 589
-             591:   15(ivec2) CompositeConstruct 588 590
+             586: 15(i64vec2) Load 585
+             587: 14(int64_t) CompositeExtract 586 0
+             588: 14(int64_t) GroupUMax 28 InclusiveScan 587
+             589: 14(int64_t) CompositeExtract 586 1
+             590: 14(int64_t) GroupUMax 28 InclusiveScan 589
+             591: 15(i64vec2) CompositeConstruct 588 590
              592:     74(ptr) AccessChain 23 73
                               Store 592 591
              593:     84(ptr) AccessChain 23 83
-             594:   17(fvec3) Load 593
-             595:   16(float) CompositeExtract 594 0
-             596:   16(float) GroupFMax 28 InclusiveScan 595
-             597:   16(float) CompositeExtract 594 1
-             598:   16(float) GroupFMax 28 InclusiveScan 597
-             599:   16(float) CompositeExtract 594 2
-             600:   16(float) GroupFMax 28 InclusiveScan 599
-             601:   17(fvec3) CompositeConstruct 596 598 600
+             594: 17(f16vec3) Load 593
+             595:16(float16_t) CompositeExtract 594 0
+             596:16(float16_t) GroupFMax 28 InclusiveScan 595
+             597:16(float16_t) CompositeExtract 594 1
+             598:16(float16_t) GroupFMax 28 InclusiveScan 597
+             599:16(float16_t) CompositeExtract 594 2
+             600:16(float16_t) GroupFMax 28 InclusiveScan 599
+             601: 17(f16vec3) CompositeConstruct 596 598 600
              602:     84(ptr) AccessChain 23 83
                               Store 602 601
              603:     96(ptr) AccessChain 23 95
-             604:   19(ivec4) Load 603
-             605:     18(int) CompositeExtract 604 0
-             606:     18(int) GroupSMax 28 InclusiveScan 605
-             607:     18(int) CompositeExtract 604 1
-             608:     18(int) GroupSMax 28 InclusiveScan 607
-             609:     18(int) CompositeExtract 604 2
-             610:     18(int) GroupSMax 28 InclusiveScan 609
-             611:     18(int) CompositeExtract 604 3
-             612:     18(int) GroupSMax 28 InclusiveScan 611
-             613:   19(ivec4) CompositeConstruct 606 608 610 612
+             604: 19(i16vec4) Load 603
+             605: 18(int16_t) CompositeExtract 604 0
+             606: 18(int16_t) GroupSMax 28 InclusiveScan 605
+             607: 18(int16_t) CompositeExtract 604 1
+             608: 18(int16_t) GroupSMax 28 InclusiveScan 607
+             609: 18(int16_t) CompositeExtract 604 2
+             610: 18(int16_t) GroupSMax 28 InclusiveScan 609
+             611: 18(int16_t) CompositeExtract 604 3
+             612: 18(int16_t) GroupSMax 28 InclusiveScan 611
+             613: 19(i16vec4) CompositeConstruct 606 608 610 612
              614:     96(ptr) AccessChain 23 95
                               Store 614 613
              615:    110(ptr) AccessChain 23 109
-             616:     20(int) Load 615
-             617:     20(int) GroupUMax 28 InclusiveScan 616
+             616: 20(int16_t) Load 615
+             617: 20(int16_t) GroupUMax 28 InclusiveScan 616
              618:    110(ptr) AccessChain 23 109
                               Store 618 617
              619:     25(ptr) AccessChain 23 24
@@ -767,59 +767,59 @@ spv.shaderBallotAMD.comp
              640:     42(ptr) AccessChain 23 41
                               Store 640 639
              641:     54(ptr) AccessChain 23 53
-             642:   12(fvec4) Load 641
-             643:   11(float) CompositeExtract 642 0
-             644:   11(float) GroupFAdd 28 InclusiveScan 643
-             645:   11(float) CompositeExtract 642 1
-             646:   11(float) GroupFAdd 28 InclusiveScan 645
-             647:   11(float) CompositeExtract 642 2
-             648:   11(float) GroupFAdd 28 InclusiveScan 647
-             649:   11(float) CompositeExtract 642 3
-             650:   11(float) GroupFAdd 28 InclusiveScan 649
-             651:   12(fvec4) CompositeConstruct 644 646 648 650
+             642: 12(f64vec4) Load 641
+             643:11(float64_t) CompositeExtract 642 0
+             644:11(float64_t) GroupFAdd 28 InclusiveScan 643
+             645:11(float64_t) CompositeExtract 642 1
+             646:11(float64_t) GroupFAdd 28 InclusiveScan 645
+             647:11(float64_t) CompositeExtract 642 2
+             648:11(float64_t) GroupFAdd 28 InclusiveScan 647
+             649:11(float64_t) CompositeExtract 642 3
+             650:11(float64_t) GroupFAdd 28 InclusiveScan 649
+             651: 12(f64vec4) CompositeConstruct 644 646 648 650
              652:     54(ptr) AccessChain 23 53
                               Store 652 651
              653:     68(ptr) AccessChain 23 67
-             654:     13(int) Load 653
-             655:     13(int) GroupIAdd 28 InclusiveScan 654
+             654: 13(int64_t) Load 653
+             655: 13(int64_t) GroupIAdd 28 InclusiveScan 654
              656:     68(ptr) AccessChain 23 67
                               Store 656 655
              657:     74(ptr) AccessChain 23 73
-             658:   15(ivec2) Load 657
-             659:     14(int) CompositeExtract 658 0
-             660:     14(int) GroupIAdd 28 InclusiveScan 659
-             661:     14(int) CompositeExtract 658 1
-             662:     14(int) GroupIAdd 28 InclusiveScan 661
-             663:   15(ivec2) CompositeConstruct 660 662
+             658: 15(i64vec2) Load 657
+             659: 14(int64_t) CompositeExtract 658 0
+             660: 14(int64_t) GroupIAdd 28 InclusiveScan 659
+             661: 14(int64_t) CompositeExtract 658 1
+             662: 14(int64_t) GroupIAdd 28 InclusiveScan 661
+             663: 15(i64vec2) CompositeConstruct 660 662
              664:     74(ptr) AccessChain 23 73
                               Store 664 663
              665:     84(ptr) AccessChain 23 83
-             666:   17(fvec3) Load 665
-             667:   16(float) CompositeExtract 666 0
-             668:   16(float) GroupFAdd 28 InclusiveScan 667
-             669:   16(float) CompositeExtract 666 1
-             670:   16(float) GroupFAdd 28 InclusiveScan 669
-             671:   16(float) CompositeExtract 666 2
-             672:   16(float) GroupFAdd 28 InclusiveScan 671
-             673:   17(fvec3) CompositeConstruct 668 670 672
+             666: 17(f16vec3) Load 665
+             667:16(float16_t) CompositeExtract 666 0
+             668:16(float16_t) GroupFAdd 28 InclusiveScan 667
+             669:16(float16_t) CompositeExtract 666 1
+             670:16(float16_t) GroupFAdd 28 InclusiveScan 669
+             671:16(float16_t) CompositeExtract 666 2
+             672:16(float16_t) GroupFAdd 28 InclusiveScan 671
+             673: 17(f16vec3) CompositeConstruct 668 670 672
              674:     84(ptr) AccessChain 23 83
                               Store 674 673
              675:     96(ptr) AccessChain 23 95
-             676:   19(ivec4) Load 675
-             677:     18(int) CompositeExtract 676 0
-             678:     18(int) GroupIAdd 28 InclusiveScan 677
-             679:     18(int) CompositeExtract 676 1
-             680:     18(int) GroupIAdd 28 InclusiveScan 679
-             681:     18(int) CompositeExtract 676 2
-             682:     18(int) GroupIAdd 28 InclusiveScan 681
-             683:     18(int) CompositeExtract 676 3
-             684:     18(int) GroupIAdd 28 InclusiveScan 683
-             685:   19(ivec4) CompositeConstruct 678 680 682 684
+             676: 19(i16vec4) Load 675
+             677: 18(int16_t) CompositeExtract 676 0
+             678: 18(int16_t) GroupIAdd 28 InclusiveScan 677
+             679: 18(int16_t) CompositeExtract 676 1
+             680: 18(int16_t) GroupIAdd 28 InclusiveScan 679
+             681: 18(int16_t) CompositeExtract 676 2
+             682: 18(int16_t) GroupIAdd 28 InclusiveScan 681
+             683: 18(int16_t) CompositeExtract 676 3
+             684: 18(int16_t) GroupIAdd 28 InclusiveScan 683
+             685: 19(i16vec4) CompositeConstruct 678 680 682 684
              686:     96(ptr) AccessChain 23 95
                               Store 686 685
              687:    110(ptr) AccessChain 23 109
-             688:     20(int) Load 687
-             689:     20(int) GroupIAdd 28 InclusiveScan 688
+             688: 20(int16_t) Load 687
+             689: 20(int16_t) GroupIAdd 28 InclusiveScan 688
              690:    110(ptr) AccessChain 23 109
                               Store 690 689
              691:     25(ptr) AccessChain 23 24
@@ -848,59 +848,59 @@ spv.shaderBallotAMD.comp
              712:     42(ptr) AccessChain 23 41
                               Store 712 711
              713:     54(ptr) AccessChain 23 53
-             714:   12(fvec4) Load 713
-             715:   11(float) CompositeExtract 714 0
-             716:   11(float) GroupFMin 28 ExclusiveScan 715
-             717:   11(float) CompositeExtract 714 1
-             718:   11(float) GroupFMin 28 ExclusiveScan 717
-             719:   11(float) CompositeExtract 714 2
-             720:   11(float) GroupFMin 28 ExclusiveScan 719
-             721:   11(float) CompositeExtract 714 3
-             722:   11(float) GroupFMin 28 ExclusiveScan 721
-             723:   12(fvec4) CompositeConstruct 716 718 720 722
+             714: 12(f64vec4) Load 713
+             715:11(float64_t) CompositeExtract 714 0
+             716:11(float64_t) GroupFMin 28 ExclusiveScan 715
+             717:11(float64_t) CompositeExtract 714 1
+             718:11(float64_t) GroupFMin 28 ExclusiveScan 717
+             719:11(float64_t) CompositeExtract 714 2
+             720:11(float64_t) GroupFMin 28 ExclusiveScan 719
+             721:11(float64_t) CompositeExtract 714 3
+             722:11(float64_t) GroupFMin 28 ExclusiveScan 721
+             723: 12(f64vec4) CompositeConstruct 716 718 720 722
              724:     54(ptr) AccessChain 23 53
                               Store 724 723
              725:     68(ptr) AccessChain 23 67
-             726:     13(int) Load 725
-             727:     13(int) GroupSMin 28 ExclusiveScan 726
+             726: 13(int64_t) Load 725
+             727: 13(int64_t) GroupSMin 28 ExclusiveScan 726
              728:     68(ptr) AccessChain 23 67
                               Store 728 727
              729:     74(ptr) AccessChain 23 73
-             730:   15(ivec2) Load 729
-             731:     14(int) CompositeExtract 730 0
-             732:     14(int) GroupUMin 28 ExclusiveScan 731
-             733:     14(int) CompositeExtract 730 1
-             734:     14(int) GroupUMin 28 ExclusiveScan 733
-             735:   15(ivec2) CompositeConstruct 732 734
+             730: 15(i64vec2) Load 729
+             731: 14(int64_t) CompositeExtract 730 0
+             732: 14(int64_t) GroupUMin 28 ExclusiveScan 731
+             733: 14(int64_t) CompositeExtract 730 1
+             734: 14(int64_t) GroupUMin 28 ExclusiveScan 733
+             735: 15(i64vec2) CompositeConstruct 732 734
              736:     74(ptr) AccessChain 23 73
                               Store 736 735
              737:     84(ptr) AccessChain 23 83
-             738:   17(fvec3) Load 737
-             739:   16(float) CompositeExtract 738 0
-             740:   16(float) GroupFMin 28 ExclusiveScan 739
-             741:   16(float) CompositeExtract 738 1
-             742:   16(float) GroupFMin 28 ExclusiveScan 741
-             743:   16(float) CompositeExtract 738 2
-             744:   16(float) GroupFMin 28 ExclusiveScan 743
-             745:   17(fvec3) CompositeConstruct 740 742 744
+             738: 17(f16vec3) Load 737
+             739:16(float16_t) CompositeExtract 738 0
+             740:16(float16_t) GroupFMin 28 ExclusiveScan 739
+             741:16(float16_t) CompositeExtract 738 1
+             742:16(float16_t) GroupFMin 28 ExclusiveScan 741
+             743:16(float16_t) CompositeExtract 738 2
+             744:16(float16_t) GroupFMin 28 ExclusiveScan 743
+             745: 17(f16vec3) CompositeConstruct 740 742 744
              746:     84(ptr) AccessChain 23 83
                               Store 746 745
              747:     96(ptr) AccessChain 23 95
-             748:   19(ivec4) Load 747
-             749:     18(int) CompositeExtract 748 0
-             750:     18(int) GroupSMin 28 ExclusiveScan 749
-             751:     18(int) CompositeExtract 748 1
-             752:     18(int) GroupSMin 28 ExclusiveScan 751
-             753:     18(int) CompositeExtract 748 2
-             754:     18(int) GroupSMin 28 ExclusiveScan 753
-             755:     18(int) CompositeExtract 748 3
-             756:     18(int) GroupSMin 28 ExclusiveScan 755
-             757:   19(ivec4) CompositeConstruct 750 752 754 756
+             748: 19(i16vec4) Load 747
+             749: 18(int16_t) CompositeExtract 748 0
+             750: 18(int16_t) GroupSMin 28 ExclusiveScan 749
+             751: 18(int16_t) CompositeExtract 748 1
+             752: 18(int16_t) GroupSMin 28 ExclusiveScan 751
+             753: 18(int16_t) CompositeExtract 748 2
+             754: 18(int16_t) GroupSMin 28 ExclusiveScan 753
+             755: 18(int16_t) CompositeExtract 748 3
+             756: 18(int16_t) GroupSMin 28 ExclusiveScan 755
+             757: 19(i16vec4) CompositeConstruct 750 752 754 756
              758:     96(ptr) AccessChain 23 95
                               Store 758 757
              759:    110(ptr) AccessChain 23 109
-             760:     20(int) Load 759
-             761:     20(int) GroupUMin 28 ExclusiveScan 760
+             760: 20(int16_t) Load 759
+             761: 20(int16_t) GroupUMin 28 ExclusiveScan 760
              762:    110(ptr) AccessChain 23 109
                               Store 762 761
              763:     25(ptr) AccessChain 23 24
@@ -929,59 +929,59 @@ spv.shaderBallotAMD.comp
              784:     42(ptr) AccessChain 23 41
                               Store 784 783
              785:     54(ptr) AccessChain 23 53
-             786:   12(fvec4) Load 785
-             787:   11(float) CompositeExtract 786 0
-             788:   11(float) GroupFMax 28 ExclusiveScan 787
-             789:   11(float) CompositeExtract 786 1
-             790:   11(float) GroupFMax 28 ExclusiveScan 789
-             791:   11(float) CompositeExtract 786 2
-             792:   11(float) GroupFMax 28 ExclusiveScan 791
-             793:   11(float) CompositeExtract 786 3
-             794:   11(float) GroupFMax 28 ExclusiveScan 793
-             795:   12(fvec4) CompositeConstruct 788 790 792 794
+             786: 12(f64vec4) Load 785
+             787:11(float64_t) CompositeExtract 786 0
+             788:11(float64_t) GroupFMax 28 ExclusiveScan 787
+             789:11(float64_t) CompositeExtract 786 1
+             790:11(float64_t) GroupFMax 28 ExclusiveScan 789
+             791:11(float64_t) CompositeExtract 786 2
+             792:11(float64_t) GroupFMax 28 ExclusiveScan 791
+             793:11(float64_t) CompositeExtract 786 3
+             794:11(float64_t) GroupFMax 28 ExclusiveScan 793
+             795: 12(f64vec4) CompositeConstruct 788 790 792 794
              796:     54(ptr) AccessChain 23 53
                               Store 796 795
              797:     68(ptr) AccessChain 23 67
-             798:     13(int) Load 797
-             799:     13(int) GroupSMax 28 ExclusiveScan 798
+             798: 13(int64_t) Load 797
+             799: 13(int64_t) GroupSMax 28 ExclusiveScan 798
              800:     68(ptr) AccessChain 23 67
                               Store 800 799
              801:     74(ptr) AccessChain 23 73
-             802:   15(ivec2) Load 801
-             803:     14(int) CompositeExtract 802 0
-             804:     14(int) GroupUMax 28 ExclusiveScan 803
-             805:     14(int) CompositeExtract 802 1
-             806:     14(int) GroupUMax 28 ExclusiveScan 805
-             807:   15(ivec2) CompositeConstruct 804 806
+             802: 15(i64vec2) Load 801
+             803: 14(int64_t) CompositeExtract 802 0
+             804: 14(int64_t) GroupUMax 28 ExclusiveScan 803
+             805: 14(int64_t) CompositeExtract 802 1
+             806: 14(int64_t) GroupUMax 28 ExclusiveScan 805
+             807: 15(i64vec2) CompositeConstruct 804 806
              808:     74(ptr) AccessChain 23 73
                               Store 808 807
              809:     84(ptr) AccessChain 23 83
-             810:   17(fvec3) Load 809
-             811:   16(float) CompositeExtract 810 0
-             812:   16(float) GroupFMax 28 ExclusiveScan 811
-             813:   16(float) CompositeExtract 810 1
-             814:   16(float) GroupFMax 28 ExclusiveScan 813
-             815:   16(float) CompositeExtract 810 2
-             816:   16(float) GroupFMax 28 ExclusiveScan 815
-             817:   17(fvec3) CompositeConstruct 812 814 816
+             810: 17(f16vec3) Load 809
+             811:16(float16_t) CompositeExtract 810 0
+             812:16(float16_t) GroupFMax 28 ExclusiveScan 811
+             813:16(float16_t) CompositeExtract 810 1
+             814:16(float16_t) GroupFMax 28 ExclusiveScan 813
+             815:16(float16_t) CompositeExtract 810 2
+             816:16(float16_t) GroupFMax 28 ExclusiveScan 815
+             817: 17(f16vec3) CompositeConstruct 812 814 816
              818:     84(ptr) AccessChain 23 83
                               Store 818 817
              819:     96(ptr) AccessChain 23 95
-             820:   19(ivec4) Load 819
-             821:     18(int) CompositeExtract 820 0
-             822:     18(int) GroupSMax 28 ExclusiveScan 821
-             823:     18(int) CompositeExtract 820 1
-             824:     18(int) GroupSMax 28 ExclusiveScan 823
-             825:     18(int) CompositeExtract 820 2
-             826:     18(int) GroupSMax 28 ExclusiveScan 825
-             827:     18(int) CompositeExtract 820 3
-             828:     18(int) GroupSMax 28 ExclusiveScan 827
-             829:   19(ivec4) CompositeConstruct 822 824 826 828
+             820: 19(i16vec4) Load 819
+             821: 18(int16_t) CompositeExtract 820 0
+             822: 18(int16_t) GroupSMax 28 ExclusiveScan 821
+             823: 18(int16_t) CompositeExtract 820 1
+             824: 18(int16_t) GroupSMax 28 ExclusiveScan 823
+             825: 18(int16_t) CompositeExtract 820 2
+             826: 18(int16_t) GroupSMax 28 ExclusiveScan 825
+             827: 18(int16_t) CompositeExtract 820 3
+             828: 18(int16_t) GroupSMax 28 ExclusiveScan 827
+             829: 19(i16vec4) CompositeConstruct 822 824 826 828
              830:     96(ptr) AccessChain 23 95
                               Store 830 829
              831:    110(ptr) AccessChain 23 109
-             832:     20(int) Load 831
-             833:     20(int) GroupUMax 28 ExclusiveScan 832
+             832: 20(int16_t) Load 831
+             833: 20(int16_t) GroupUMax 28 ExclusiveScan 832
              834:    110(ptr) AccessChain 23 109
                               Store 834 833
              835:     25(ptr) AccessChain 23 24
@@ -1010,59 +1010,59 @@ spv.shaderBallotAMD.comp
              856:     42(ptr) AccessChain 23 41
                               Store 856 855
              857:     54(ptr) AccessChain 23 53
-             858:   12(fvec4) Load 857
-             859:   11(float) CompositeExtract 858 0
-             860:   11(float) GroupFAdd 28 ExclusiveScan 859
-             861:   11(float) CompositeExtract 858 1
-             862:   11(float) GroupFAdd 28 ExclusiveScan 861
-             863:   11(float) CompositeExtract 858 2
-             864:   11(float) GroupFAdd 28 ExclusiveScan 863
-             865:   11(float) CompositeExtract 858 3
-             866:   11(float) GroupFAdd 28 ExclusiveScan 865
-             867:   12(fvec4) CompositeConstruct 860 862 864 866
+             858: 12(f64vec4) Load 857
+             859:11(float64_t) CompositeExtract 858 0
+             860:11(float64_t) GroupFAdd 28 ExclusiveScan 859
+             861:11(float64_t) CompositeExtract 858 1
+             862:11(float64_t) GroupFAdd 28 ExclusiveScan 861
+             863:11(float64_t) CompositeExtract 858 2
+             864:11(float64_t) GroupFAdd 28 ExclusiveScan 863
+             865:11(float64_t) CompositeExtract 858 3
+             866:11(float64_t) GroupFAdd 28 ExclusiveScan 865
+             867: 12(f64vec4) CompositeConstruct 860 862 864 866
              868:     54(ptr) AccessChain 23 53
                               Store 868 867
              869:     68(ptr) AccessChain 23 67
-             870:     13(int) Load 869
-             871:     13(int) GroupIAdd 28 ExclusiveScan 870
+             870: 13(int64_t) Load 869
+             871: 13(int64_t) GroupIAdd 28 ExclusiveScan 870
              872:     68(ptr) AccessChain 23 67
                               Store 872 871
              873:     74(ptr) AccessChain 23 73
-             874:   15(ivec2) Load 873
-             875:     14(int) CompositeExtract 874 0
-             876:     14(int) GroupIAdd 28 ExclusiveScan 875
-             877:     14(int) CompositeExtract 874 1
-             878:     14(int) GroupIAdd 28 ExclusiveScan 877
-             879:   15(ivec2) CompositeConstruct 876 878
+             874: 15(i64vec2) Load 873
+             875: 14(int64_t) CompositeExtract 874 0
+             876: 14(int64_t) GroupIAdd 28 ExclusiveScan 875
+             877: 14(int64_t) CompositeExtract 874 1
+             878: 14(int64_t) GroupIAdd 28 ExclusiveScan 877
+             879: 15(i64vec2) CompositeConstruct 876 878
              880:     74(ptr) AccessChain 23 73
                               Store 880 879
              881:     84(ptr) AccessChain 23 83
-             882:   17(fvec3) Load 881
-             883:   16(float) CompositeExtract 882 0
-             884:   16(float) GroupFAdd 28 ExclusiveScan 883
-             885:   16(float) CompositeExtract 882 1
-             886:   16(float) GroupFAdd 28 ExclusiveScan 885
-             887:   16(float) CompositeExtract 882 2
-             888:   16(float) GroupFAdd 28 ExclusiveScan 887
-             889:   17(fvec3) CompositeConstruct 884 886 888
+             882: 17(f16vec3) Load 881
+             883:16(float16_t) CompositeExtract 882 0
+             884:16(float16_t) GroupFAdd 28 ExclusiveScan 883
+             885:16(float16_t) CompositeExtract 882 1
+             886:16(float16_t) GroupFAdd 28 ExclusiveScan 885
+             887:16(float16_t) CompositeExtract 882 2
+             888:16(float16_t) GroupFAdd 28 ExclusiveScan 887
+             889: 17(f16vec3) CompositeConstruct 884 886 888
              890:     84(ptr) AccessChain 23 83
                               Store 890 889
              891:     96(ptr) AccessChain 23 95
-             892:   19(ivec4) Load 891
-             893:     18(int) CompositeExtract 892 0
-             894:     18(int) GroupIAdd 28 ExclusiveScan 893
-             895:     18(int) CompositeExtract 892 1
-             896:     18(int) GroupIAdd 28 ExclusiveScan 895
-             897:     18(int) CompositeExtract 892 2
-             898:     18(int) GroupIAdd 28 ExclusiveScan 897
-             899:     18(int) CompositeExtract 892 3
-             900:     18(int) GroupIAdd 28 ExclusiveScan 899
-             901:   19(ivec4) CompositeConstruct 894 896 898 900
+             892: 19(i16vec4) Load 891
+             893: 18(int16_t) CompositeExtract 892 0
+             894: 18(int16_t) GroupIAdd 28 ExclusiveScan 893
+             895: 18(int16_t) CompositeExtract 892 1
+             896: 18(int16_t) GroupIAdd 28 ExclusiveScan 895
+             897: 18(int16_t) CompositeExtract 892 2
+             898: 18(int16_t) GroupIAdd 28 ExclusiveScan 897
+             899: 18(int16_t) CompositeExtract 892 3
+             900: 18(int16_t) GroupIAdd 28 ExclusiveScan 899
+             901: 19(i16vec4) CompositeConstruct 894 896 898 900
              902:     96(ptr) AccessChain 23 95
                               Store 902 901
              903:    110(ptr) AccessChain 23 109
-             904:     20(int) Load 903
-             905:     20(int) GroupIAdd 28 ExclusiveScan 904
+             904: 20(int16_t) Load 903
+             905: 20(int16_t) GroupIAdd 28 ExclusiveScan 904
              906:    110(ptr) AccessChain 23 109
                               Store 906 905
              907:     25(ptr) AccessChain 23 24
@@ -1091,59 +1091,59 @@ spv.shaderBallotAMD.comp
              928:     42(ptr) AccessChain 23 41
                               Store 928 927
              929:     54(ptr) AccessChain 23 53
-             930:   12(fvec4) Load 929
-             931:   11(float) CompositeExtract 930 0
-             932:   11(float) GroupFMinNonUniformAMD 28 InclusiveScan 931
-             933:   11(float) CompositeExtract 930 1
-             934:   11(float) GroupFMinNonUniformAMD 28 InclusiveScan 933
-             935:   11(float) CompositeExtract 930 2
-             936:   11(float) GroupFMinNonUniformAMD 28 InclusiveScan 935
-             937:   11(float) CompositeExtract 930 3
-             938:   11(float) GroupFMinNonUniformAMD 28 InclusiveScan 937
-             939:   12(fvec4) CompositeConstruct 932 934 936 938
+             930: 12(f64vec4) Load 929
+             931:11(float64_t) CompositeExtract 930 0
+             932:11(float64_t) GroupFMinNonUniformAMD 28 InclusiveScan 931
+             933:11(float64_t) CompositeExtract 930 1
+             934:11(float64_t) GroupFMinNonUniformAMD 28 InclusiveScan 933
+             935:11(float64_t) CompositeExtract 930 2
+             936:11(float64_t) GroupFMinNonUniformAMD 28 InclusiveScan 935
+             937:11(float64_t) CompositeExtract 930 3
+             938:11(float64_t) GroupFMinNonUniformAMD 28 InclusiveScan 937
+             939: 12(f64vec4) CompositeConstruct 932 934 936 938
              940:     54(ptr) AccessChain 23 53
                               Store 940 939
              941:     68(ptr) AccessChain 23 67
-             942:     13(int) Load 941
-             943:     13(int) GroupSMinNonUniformAMD 28 InclusiveScan 942
+             942: 13(int64_t) Load 941
+             943: 13(int64_t) GroupSMinNonUniformAMD 28 InclusiveScan 942
              944:     68(ptr) AccessChain 23 67
                               Store 944 943
              945:     74(ptr) AccessChain 23 73
-             946:   15(ivec2) Load 945
-             947:     14(int) CompositeExtract 946 0
-             948:     14(int) GroupUMinNonUniformAMD 28 InclusiveScan 947
-             949:     14(int) CompositeExtract 946 1
-             950:     14(int) GroupUMinNonUniformAMD 28 InclusiveScan 949
-             951:   15(ivec2) CompositeConstruct 948 950
+             946: 15(i64vec2) Load 945
+             947: 14(int64_t) CompositeExtract 946 0
+             948: 14(int64_t) GroupUMinNonUniformAMD 28 InclusiveScan 947
+             949: 14(int64_t) CompositeExtract 946 1
+             950: 14(int64_t) GroupUMinNonUniformAMD 28 InclusiveScan 949
+             951: 15(i64vec2) CompositeConstruct 948 950
              952:     74(ptr) AccessChain 23 73
                               Store 952 951
              953:     84(ptr) AccessChain 23 83
-             954:   17(fvec3) Load 953
-             955:   16(float) CompositeExtract 954 0
-             956:   16(float) GroupFMinNonUniformAMD 28 InclusiveScan 955
-             957:   16(float) CompositeExtract 954 1
-             958:   16(float) GroupFMinNonUniformAMD 28 InclusiveScan 957
-             959:   16(float) CompositeExtract 954 2
-             960:   16(float) GroupFMinNonUniformAMD 28 InclusiveScan 959
-             961:   17(fvec3) CompositeConstruct 956 958 960
+             954: 17(f16vec3) Load 953
+             955:16(float16_t) CompositeExtract 954 0
+             956:16(float16_t) GroupFMinNonUniformAMD 28 InclusiveScan 955
+             957:16(float16_t) CompositeExtract 954 1
+             958:16(float16_t) GroupFMinNonUniformAMD 28 InclusiveScan 957
+             959:16(float16_t) CompositeExtract 954 2
+             960:16(float16_t) GroupFMinNonUniformAMD 28 InclusiveScan 959
+             961: 17(f16vec3) CompositeConstruct 956 958 960
              962:     84(ptr) AccessChain 23 83
                               Store 962 961
              963:     96(ptr) AccessChain 23 95
-             964:   19(ivec4) Load 963
-             965:     18(int) CompositeExtract 964 0
-             966:     18(int) GroupSMinNonUniformAMD 28 InclusiveScan 965
-             967:     18(int) CompositeExtract 964 1
-             968:     18(int) GroupSMinNonUniformAMD 28 InclusiveScan 967
-             969:     18(int) CompositeExtract 964 2
-             970:     18(int) GroupSMinNonUniformAMD 28 InclusiveScan 969
-             971:     18(int) CompositeExtract 964 3
-             972:     18(int) GroupSMinNonUniformAMD 28 InclusiveScan 971
-             973:   19(ivec4) CompositeConstruct 966 968 970 972
+             964: 19(i16vec4) Load 963
+             965: 18(int16_t) CompositeExtract 964 0
+             966: 18(int16_t) GroupSMinNonUniformAMD 28 InclusiveScan 965
+             967: 18(int16_t) CompositeExtract 964 1
+             968: 18(int16_t) GroupSMinNonUniformAMD 28 InclusiveScan 967
+             969: 18(int16_t) CompositeExtract 964 2
+             970: 18(int16_t) GroupSMinNonUniformAMD 28 InclusiveScan 969
+             971: 18(int16_t) CompositeExtract 964 3
+             972: 18(int16_t) GroupSMinNonUniformAMD 28 InclusiveScan 971
+             973: 19(i16vec4) CompositeConstruct 966 968 970 972
              974:     96(ptr) AccessChain 23 95
                               Store 974 973
              975:    110(ptr) AccessChain 23 109
-             976:     20(int) Load 975
-             977:     20(int) GroupUMinNonUniformAMD 28 InclusiveScan 976
+             976: 20(int16_t) Load 975
+             977: 20(int16_t) GroupUMinNonUniformAMD 28 InclusiveScan 976
              978:    110(ptr) AccessChain 23 109
                               Store 978 977
              979:     25(ptr) AccessChain 23 24
@@ -1172,59 +1172,59 @@ spv.shaderBallotAMD.comp
             1000:     42(ptr) AccessChain 23 41
                               Store 1000 999
             1001:     54(ptr) AccessChain 23 53
-            1002:   12(fvec4) Load 1001
-            1003:   11(float) CompositeExtract 1002 0
-            1004:   11(float) GroupFMaxNonUniformAMD 28 InclusiveScan 1003
-            1005:   11(float) CompositeExtract 1002 1
-            1006:   11(float) GroupFMaxNonUniformAMD 28 InclusiveScan 1005
-            1007:   11(float) CompositeExtract 1002 2
-            1008:   11(float) GroupFMaxNonUniformAMD 28 InclusiveScan 1007
-            1009:   11(float) CompositeExtract 1002 3
-            1010:   11(float) GroupFMaxNonUniformAMD 28 InclusiveScan 1009
-            1011:   12(fvec4) CompositeConstruct 1004 1006 1008 1010
+            1002: 12(f64vec4) Load 1001
+            1003:11(float64_t) CompositeExtract 1002 0
+            1004:11(float64_t) GroupFMaxNonUniformAMD 28 InclusiveScan 1003
+            1005:11(float64_t) CompositeExtract 1002 1
+            1006:11(float64_t) GroupFMaxNonUniformAMD 28 InclusiveScan 1005
+            1007:11(float64_t) CompositeExtract 1002 2
+            1008:11(float64_t) GroupFMaxNonUniformAMD 28 InclusiveScan 1007
+            1009:11(float64_t) CompositeExtract 1002 3
+            1010:11(float64_t) GroupFMaxNonUniformAMD 28 InclusiveScan 1009
+            1011: 12(f64vec4) CompositeConstruct 1004 1006 1008 1010
             1012:     54(ptr) AccessChain 23 53
                               Store 1012 1011
             1013:     68(ptr) AccessChain 23 67
-            1014:     13(int) Load 1013
-            1015:     13(int) GroupSMaxNonUniformAMD 28 InclusiveScan 1014
+            1014: 13(int64_t) Load 1013
+            1015: 13(int64_t) GroupSMaxNonUniformAMD 28 InclusiveScan 1014
             1016:     68(ptr) AccessChain 23 67
                               Store 1016 1015
             1017:     74(ptr) AccessChain 23 73
-            1018:   15(ivec2) Load 1017
-            1019:     14(int) CompositeExtract 1018 0
-            1020:     14(int) GroupUMaxNonUniformAMD 28 InclusiveScan 1019
-            1021:     14(int) CompositeExtract 1018 1
-            1022:     14(int) GroupUMaxNonUniformAMD 28 InclusiveScan 1021
-            1023:   15(ivec2) CompositeConstruct 1020 1022
+            1018: 15(i64vec2) Load 1017
+            1019: 14(int64_t) CompositeExtract 1018 0
+            1020: 14(int64_t) GroupUMaxNonUniformAMD 28 InclusiveScan 1019
+            1021: 14(int64_t) CompositeExtract 1018 1
+            1022: 14(int64_t) GroupUMaxNonUniformAMD 28 InclusiveScan 1021
+            1023: 15(i64vec2) CompositeConstruct 1020 1022
             1024:     74(ptr) AccessChain 23 73
                               Store 1024 1023
             1025:     84(ptr) AccessChain 23 83
-            1026:   17(fvec3) Load 1025
-            1027:   16(float) CompositeExtract 1026 0
-            1028:   16(float) GroupFMaxNonUniformAMD 28 InclusiveScan 1027
-            1029:   16(float) CompositeExtract 1026 1
-            1030:   16(float) GroupFMaxNonUniformAMD 28 InclusiveScan 1029
-            1031:   16(float) CompositeExtract 1026 2
-            1032:   16(float) GroupFMaxNonUniformAMD 28 InclusiveScan 1031
-            1033:   17(fvec3) CompositeConstruct 1028 1030 1032
+            1026: 17(f16vec3) Load 1025
+            1027:16(float16_t) CompositeExtract 1026 0
+            1028:16(float16_t) GroupFMaxNonUniformAMD 28 InclusiveScan 1027
+            1029:16(float16_t) CompositeExtract 1026 1
+            1030:16(float16_t) GroupFMaxNonUniformAMD 28 InclusiveScan 1029
+            1031:16(float16_t) CompositeExtract 1026 2
+            1032:16(float16_t) GroupFMaxNonUniformAMD 28 InclusiveScan 1031
+            1033: 17(f16vec3) CompositeConstruct 1028 1030 1032
             1034:     84(ptr) AccessChain 23 83
                               Store 1034 1033
             1035:     96(ptr) AccessChain 23 95
-            1036:   19(ivec4) Load 1035
-            1037:     18(int) CompositeExtract 1036 0
-            1038:     18(int) GroupSMaxNonUniformAMD 28 InclusiveScan 1037
-            1039:     18(int) CompositeExtract 1036 1
-            1040:     18(int) GroupSMaxNonUniformAMD 28 InclusiveScan 1039
-            1041:     18(int) CompositeExtract 1036 2
-            1042:     18(int) GroupSMaxNonUniformAMD 28 InclusiveScan 1041
-            1043:     18(int) CompositeExtract 1036 3
-            1044:     18(int) GroupSMaxNonUniformAMD 28 InclusiveScan 1043
-            1045:   19(ivec4) CompositeConstruct 1038 1040 1042 1044
+            1036: 19(i16vec4) Load 1035
+            1037: 18(int16_t) CompositeExtract 1036 0
+            1038: 18(int16_t) GroupSMaxNonUniformAMD 28 InclusiveScan 1037
+            1039: 18(int16_t) CompositeExtract 1036 1
+            1040: 18(int16_t) GroupSMaxNonUniformAMD 28 InclusiveScan 1039
+            1041: 18(int16_t) CompositeExtract 1036 2
+            1042: 18(int16_t) GroupSMaxNonUniformAMD 28 InclusiveScan 1041
+            1043: 18(int16_t) CompositeExtract 1036 3
+            1044: 18(int16_t) GroupSMaxNonUniformAMD 28 InclusiveScan 1043
+            1045: 19(i16vec4) CompositeConstruct 1038 1040 1042 1044
             1046:     96(ptr) AccessChain 23 95
                               Store 1046 1045
             1047:    110(ptr) AccessChain 23 109
-            1048:     20(int) Load 1047
-            1049:     20(int) GroupUMaxNonUniformAMD 28 InclusiveScan 1048
+            1048: 20(int16_t) Load 1047
+            1049: 20(int16_t) GroupUMaxNonUniformAMD 28 InclusiveScan 1048
             1050:    110(ptr) AccessChain 23 109
                               Store 1050 1049
             1051:     25(ptr) AccessChain 23 24
@@ -1253,59 +1253,59 @@ spv.shaderBallotAMD.comp
             1072:     42(ptr) AccessChain 23 41
                               Store 1072 1071
             1073:     54(ptr) AccessChain 23 53
-            1074:   12(fvec4) Load 1073
-            1075:   11(float) CompositeExtract 1074 0
-            1076:   11(float) GroupFAddNonUniformAMD 28 InclusiveScan 1075
-            1077:   11(float) CompositeExtract 1074 1
-            1078:   11(float) GroupFAddNonUniformAMD 28 InclusiveScan 1077
-            1079:   11(float) CompositeExtract 1074 2
-            1080:   11(float) GroupFAddNonUniformAMD 28 InclusiveScan 1079
-            1081:   11(float) CompositeExtract 1074 3
-            1082:   11(float) GroupFAddNonUniformAMD 28 InclusiveScan 1081
-            1083:   12(fvec4) CompositeConstruct 1076 1078 1080 1082
+            1074: 12(f64vec4) Load 1073
+            1075:11(float64_t) CompositeExtract 1074 0
+            1076:11(float64_t) GroupFAddNonUniformAMD 28 InclusiveScan 1075
+            1077:11(float64_t) CompositeExtract 1074 1
+            1078:11(float64_t) GroupFAddNonUniformAMD 28 InclusiveScan 1077
+            1079:11(float64_t) CompositeExtract 1074 2
+            1080:11(float64_t) GroupFAddNonUniformAMD 28 InclusiveScan 1079
+            1081:11(float64_t) CompositeExtract 1074 3
+            1082:11(float64_t) GroupFAddNonUniformAMD 28 InclusiveScan 1081
+            1083: 12(f64vec4) CompositeConstruct 1076 1078 1080 1082
             1084:     54(ptr) AccessChain 23 53
                               Store 1084 1083
             1085:     68(ptr) AccessChain 23 67
-            1086:     13(int) Load 1085
-            1087:     13(int) GroupIAddNonUniformAMD 28 InclusiveScan 1086
+            1086: 13(int64_t) Load 1085
+            1087: 13(int64_t) GroupIAddNonUniformAMD 28 InclusiveScan 1086
             1088:     68(ptr) AccessChain 23 67
                               Store 1088 1087
             1089:     74(ptr) AccessChain 23 73
-            1090:   15(ivec2) Load 1089
-            1091:     14(int) CompositeExtract 1090 0
-            1092:     14(int) GroupIAddNonUniformAMD 28 InclusiveScan 1091
-            1093:     14(int) CompositeExtract 1090 1
-            1094:     14(int) GroupIAddNonUniformAMD 28 InclusiveScan 1093
-            1095:   15(ivec2) CompositeConstruct 1092 1094
+            1090: 15(i64vec2) Load 1089
+            1091: 14(int64_t) CompositeExtract 1090 0
+            1092: 14(int64_t) GroupIAddNonUniformAMD 28 InclusiveScan 1091
+            1093: 14(int64_t) CompositeExtract 1090 1
+            1094: 14(int64_t) GroupIAddNonUniformAMD 28 InclusiveScan 1093
+            1095: 15(i64vec2) CompositeConstruct 1092 1094
             1096:     74(ptr) AccessChain 23 73
                               Store 1096 1095
             1097:     84(ptr) AccessChain 23 83
-            1098:   17(fvec3) Load 1097
-            1099:   16(float) CompositeExtract 1098 0
-            1100:   16(float) GroupFAddNonUniformAMD 28 InclusiveScan 1099
-            1101:   16(float) CompositeExtract 1098 1
-            1102:   16(float) GroupFAddNonUniformAMD 28 InclusiveScan 1101
-            1103:   16(float) CompositeExtract 1098 2
-            1104:   16(float) GroupFAddNonUniformAMD 28 InclusiveScan 1103
-            1105:   17(fvec3) CompositeConstruct 1100 1102 1104
+            1098: 17(f16vec3) Load 1097
+            1099:16(float16_t) CompositeExtract 1098 0
+            1100:16(float16_t) GroupFAddNonUniformAMD 28 InclusiveScan 1099
+            1101:16(float16_t) CompositeExtract 1098 1
+            1102:16(float16_t) GroupFAddNonUniformAMD 28 InclusiveScan 1101
+            1103:16(float16_t) CompositeExtract 1098 2
+            1104:16(float16_t) GroupFAddNonUniformAMD 28 InclusiveScan 1103
+            1105: 17(f16vec3) CompositeConstruct 1100 1102 1104
             1106:     84(ptr) AccessChain 23 83
                               Store 1106 1105
             1107:     96(ptr) AccessChain 23 95
-            1108:   19(ivec4) Load 1107
-            1109:     18(int) CompositeExtract 1108 0
-            1110:     18(int) GroupIAddNonUniformAMD 28 InclusiveScan 1109
-            1111:     18(int) CompositeExtract 1108 1
-            1112:     18(int) GroupIAddNonUniformAMD 28 InclusiveScan 1111
-            1113:     18(int) CompositeExtract 1108 2
-            1114:     18(int) GroupIAddNonUniformAMD 28 InclusiveScan 1113
-            1115:     18(int) CompositeExtract 1108 3
-            1116:     18(int) GroupIAddNonUniformAMD 28 InclusiveScan 1115
-            1117:   19(ivec4) CompositeConstruct 1110 1112 1114 1116
+            1108: 19(i16vec4) Load 1107
+            1109: 18(int16_t) CompositeExtract 1108 0
+            1110: 18(int16_t) GroupIAddNonUniformAMD 28 InclusiveScan 1109
+            1111: 18(int16_t) CompositeExtract 1108 1
+            1112: 18(int16_t) GroupIAddNonUniformAMD 28 InclusiveScan 1111
+            1113: 18(int16_t) CompositeExtract 1108 2
+            1114: 18(int16_t) GroupIAddNonUniformAMD 28 InclusiveScan 1113
+            1115: 18(int16_t) CompositeExtract 1108 3
+            1116: 18(int16_t) GroupIAddNonUniformAMD 28 InclusiveScan 1115
+            1117: 19(i16vec4) CompositeConstruct 1110 1112 1114 1116
             1118:     96(ptr) AccessChain 23 95
                               Store 1118 1117
             1119:    110(ptr) AccessChain 23 109
-            1120:     20(int) Load 1119
-            1121:     20(int) GroupIAddNonUniformAMD 28 InclusiveScan 1120
+            1120: 20(int16_t) Load 1119
+            1121: 20(int16_t) GroupIAddNonUniformAMD 28 InclusiveScan 1120
             1122:    110(ptr) AccessChain 23 109
                               Store 1122 1121
             1123:     25(ptr) AccessChain 23 24
@@ -1334,59 +1334,59 @@ spv.shaderBallotAMD.comp
             1144:     42(ptr) AccessChain 23 41
                               Store 1144 1143
             1145:     54(ptr) AccessChain 23 53
-            1146:   12(fvec4) Load 1145
-            1147:   11(float) CompositeExtract 1146 0
-            1148:   11(float) GroupFMinNonUniformAMD 28 ExclusiveScan 1147
-            1149:   11(float) CompositeExtract 1146 1
-            1150:   11(float) GroupFMinNonUniformAMD 28 ExclusiveScan 1149
-            1151:   11(float) CompositeExtract 1146 2
-            1152:   11(float) GroupFMinNonUniformAMD 28 ExclusiveScan 1151
-            1153:   11(float) CompositeExtract 1146 3
-            1154:   11(float) GroupFMinNonUniformAMD 28 ExclusiveScan 1153
-            1155:   12(fvec4) CompositeConstruct 1148 1150 1152 1154
+            1146: 12(f64vec4) Load 1145
+            1147:11(float64_t) CompositeExtract 1146 0
+            1148:11(float64_t) GroupFMinNonUniformAMD 28 ExclusiveScan 1147
+            1149:11(float64_t) CompositeExtract 1146 1
+            1150:11(float64_t) GroupFMinNonUniformAMD 28 ExclusiveScan 1149
+            1151:11(float64_t) CompositeExtract 1146 2
+            1152:11(float64_t) GroupFMinNonUniformAMD 28 ExclusiveScan 1151
+            1153:11(float64_t) CompositeExtract 1146 3
+            1154:11(float64_t) GroupFMinNonUniformAMD 28 ExclusiveScan 1153
+            1155: 12(f64vec4) CompositeConstruct 1148 1150 1152 1154
             1156:     54(ptr) AccessChain 23 53
                               Store 1156 1155
             1157:     68(ptr) AccessChain 23 67
-            1158:     13(int) Load 1157
-            1159:     13(int) GroupSMinNonUniformAMD 28 ExclusiveScan 1158
+            1158: 13(int64_t) Load 1157
+            1159: 13(int64_t) GroupSMinNonUniformAMD 28 ExclusiveScan 1158
             1160:     68(ptr) AccessChain 23 67
                               Store 1160 1159
             1161:     74(ptr) AccessChain 23 73
-            1162:   15(ivec2) Load 1161
-            1163:     14(int) CompositeExtract 1162 0
-            1164:     14(int) GroupUMinNonUniformAMD 28 ExclusiveScan 1163
-            1165:     14(int) CompositeExtract 1162 1
-            1166:     14(int) GroupUMinNonUniformAMD 28 ExclusiveScan 1165
-            1167:   15(ivec2) CompositeConstruct 1164 1166
+            1162: 15(i64vec2) Load 1161
+            1163: 14(int64_t) CompositeExtract 1162 0
+            1164: 14(int64_t) GroupUMinNonUniformAMD 28 ExclusiveScan 1163
+            1165: 14(int64_t) CompositeExtract 1162 1
+            1166: 14(int64_t) GroupUMinNonUniformAMD 28 ExclusiveScan 1165
+            1167: 15(i64vec2) CompositeConstruct 1164 1166
             1168:     74(ptr) AccessChain 23 73
                               Store 1168 1167
             1169:     84(ptr) AccessChain 23 83
-            1170:   17(fvec3) Load 1169
-            1171:   16(float) CompositeExtract 1170 0
-            1172:   16(float) GroupFMinNonUniformAMD 28 ExclusiveScan 1171
-            1173:   16(float) CompositeExtract 1170 1
-            1174:   16(float) GroupFMinNonUniformAMD 28 ExclusiveScan 1173
-            1175:   16(float) CompositeExtract 1170 2
-            1176:   16(float) GroupFMinNonUniformAMD 28 ExclusiveScan 1175
-            1177:   17(fvec3) CompositeConstruct 1172 1174 1176
+            1170: 17(f16vec3) Load 1169
+            1171:16(float16_t) CompositeExtract 1170 0
+            1172:16(float16_t) GroupFMinNonUniformAMD 28 ExclusiveScan 1171
+            1173:16(float16_t) CompositeExtract 1170 1
+            1174:16(float16_t) GroupFMinNonUniformAMD 28 ExclusiveScan 1173
+            1175:16(float16_t) CompositeExtract 1170 2
+            1176:16(float16_t) GroupFMinNonUniformAMD 28 ExclusiveScan 1175
+            1177: 17(f16vec3) CompositeConstruct 1172 1174 1176
             1178:     84(ptr) AccessChain 23 83
                               Store 1178 1177
             1179:     96(ptr) AccessChain 23 95
-            1180:   19(ivec4) Load 1179
-            1181:     18(int) CompositeExtract 1180 0
-            1182:     18(int) GroupSMinNonUniformAMD 28 ExclusiveScan 1181
-            1183:     18(int) CompositeExtract 1180 1
-            1184:     18(int) GroupSMinNonUniformAMD 28 ExclusiveScan 1183
-            1185:     18(int) CompositeExtract 1180 2
-            1186:     18(int) GroupSMinNonUniformAMD 28 ExclusiveScan 1185
-            1187:     18(int) CompositeExtract 1180 3
-            1188:     18(int) GroupSMinNonUniformAMD 28 ExclusiveScan 1187
-            1189:   19(ivec4) CompositeConstruct 1182 1184 1186 1188
+            1180: 19(i16vec4) Load 1179
+            1181: 18(int16_t) CompositeExtract 1180 0
+            1182: 18(int16_t) GroupSMinNonUniformAMD 28 ExclusiveScan 1181
+            1183: 18(int16_t) CompositeExtract 1180 1
+            1184: 18(int16_t) GroupSMinNonUniformAMD 28 ExclusiveScan 1183
+            1185: 18(int16_t) CompositeExtract 1180 2
+            1186: 18(int16_t) GroupSMinNonUniformAMD 28 ExclusiveScan 1185
+            1187: 18(int16_t) CompositeExtract 1180 3
+            1188: 18(int16_t) GroupSMinNonUniformAMD 28 ExclusiveScan 1187
+            1189: 19(i16vec4) CompositeConstruct 1182 1184 1186 1188
             1190:     96(ptr) AccessChain 23 95
                               Store 1190 1189
             1191:    110(ptr) AccessChain 23 109
-            1192:     20(int) Load 1191
-            1193:     20(int) GroupUMinNonUniformAMD 28 ExclusiveScan 1192
+            1192: 20(int16_t) Load 1191
+            1193: 20(int16_t) GroupUMinNonUniformAMD 28 ExclusiveScan 1192
             1194:    110(ptr) AccessChain 23 109
                               Store 1194 1193
             1195:     25(ptr) AccessChain 23 24
@@ -1415,59 +1415,59 @@ spv.shaderBallotAMD.comp
             1216:     42(ptr) AccessChain 23 41
                               Store 1216 1215
             1217:     54(ptr) AccessChain 23 53
-            1218:   12(fvec4) Load 1217
-            1219:   11(float) CompositeExtract 1218 0
-            1220:   11(float) GroupFMaxNonUniformAMD 28 ExclusiveScan 1219
-            1221:   11(float) CompositeExtract 1218 1
-            1222:   11(float) GroupFMaxNonUniformAMD 28 ExclusiveScan 1221
-            1223:   11(float) CompositeExtract 1218 2
-            1224:   11(float) GroupFMaxNonUniformAMD 28 ExclusiveScan 1223
-            1225:   11(float) CompositeExtract 1218 3
-            1226:   11(float) GroupFMaxNonUniformAMD 28 ExclusiveScan 1225
-            1227:   12(fvec4) CompositeConstruct 1220 1222 1224 1226
+            1218: 12(f64vec4) Load 1217
+            1219:11(float64_t) CompositeExtract 1218 0
+            1220:11(float64_t) GroupFMaxNonUniformAMD 28 ExclusiveScan 1219
+            1221:11(float64_t) CompositeExtract 1218 1
+            1222:11(float64_t) GroupFMaxNonUniformAMD 28 ExclusiveScan 1221
+            1223:11(float64_t) CompositeExtract 1218 2
+            1224:11(float64_t) GroupFMaxNonUniformAMD 28 ExclusiveScan 1223
+            1225:11(float64_t) CompositeExtract 1218 3
+            1226:11(float64_t) GroupFMaxNonUniformAMD 28 ExclusiveScan 1225
+            1227: 12(f64vec4) CompositeConstruct 1220 1222 1224 1226
             1228:     54(ptr) AccessChain 23 53
                               Store 1228 1227
             1229:     68(ptr) AccessChain 23 67
-            1230:     13(int) Load 1229
-            1231:     13(int) GroupSMaxNonUniformAMD 28 ExclusiveScan 1230
+            1230: 13(int64_t) Load 1229
+            1231: 13(int64_t) GroupSMaxNonUniformAMD 28 ExclusiveScan 1230
             1232:     68(ptr) AccessChain 23 67
                               Store 1232 1231
             1233:     74(ptr) AccessChain 23 73
-            1234:   15(ivec2) Load 1233
-            1235:     14(int) CompositeExtract 1234 0
-            1236:     14(int) GroupUMaxNonUniformAMD 28 ExclusiveScan 1235
-            1237:     14(int) CompositeExtract 1234 1
-            1238:     14(int) GroupUMaxNonUniformAMD 28 ExclusiveScan 1237
-            1239:   15(ivec2) CompositeConstruct 1236 1238
+            1234: 15(i64vec2) Load 1233
+            1235: 14(int64_t) CompositeExtract 1234 0
+            1236: 14(int64_t) GroupUMaxNonUniformAMD 28 ExclusiveScan 1235
+            1237: 14(int64_t) CompositeExtract 1234 1
+            1238: 14(int64_t) GroupUMaxNonUniformAMD 28 ExclusiveScan 1237
+            1239: 15(i64vec2) CompositeConstruct 1236 1238
             1240:     74(ptr) AccessChain 23 73
                               Store 1240 1239
             1241:     84(ptr) AccessChain 23 83
-            1242:   17(fvec3) Load 1241
-            1243:   16(float) CompositeExtract 1242 0
-            1244:   16(float) GroupFMaxNonUniformAMD 28 ExclusiveScan 1243
-            1245:   16(float) CompositeExtract 1242 1
-            1246:   16(float) GroupFMaxNonUniformAMD 28 ExclusiveScan 1245
-            1247:   16(float) CompositeExtract 1242 2
-            1248:   16(float) GroupFMaxNonUniformAMD 28 ExclusiveScan 1247
-            1249:   17(fvec3) CompositeConstruct 1244 1246 1248
+            1242: 17(f16vec3) Load 1241
+            1243:16(float16_t) CompositeExtract 1242 0
+            1244:16(float16_t) GroupFMaxNonUniformAMD 28 ExclusiveScan 1243
+            1245:16(float16_t) CompositeExtract 1242 1
+            1246:16(float16_t) GroupFMaxNonUniformAMD 28 ExclusiveScan 1245
+            1247:16(float16_t) CompositeExtract 1242 2
+            1248:16(float16_t) GroupFMaxNonUniformAMD 28 ExclusiveScan 1247
+            1249: 17(f16vec3) CompositeConstruct 1244 1246 1248
             1250:     84(ptr) AccessChain 23 83
                               Store 1250 1249
             1251:     96(ptr) AccessChain 23 95
-            1252:   19(ivec4) Load 1251
-            1253:     18(int) CompositeExtract 1252 0
-            1254:     18(int) GroupSMaxNonUniformAMD 28 ExclusiveScan 1253
-            1255:     18(int) CompositeExtract 1252 1
-            1256:     18(int) GroupSMaxNonUniformAMD 28 ExclusiveScan 1255
-            1257:     18(int) CompositeExtract 1252 2
-            1258:     18(int) GroupSMaxNonUniformAMD 28 ExclusiveScan 1257
-            1259:     18(int) CompositeExtract 1252 3
-            1260:     18(int) GroupSMaxNonUniformAMD 28 ExclusiveScan 1259
-            1261:   19(ivec4) CompositeConstruct 1254 1256 1258 1260
+            1252: 19(i16vec4) Load 1251
+            1253: 18(int16_t) CompositeExtract 1252 0
+            1254: 18(int16_t) GroupSMaxNonUniformAMD 28 ExclusiveScan 1253
+            1255: 18(int16_t) CompositeExtract 1252 1
+            1256: 18(int16_t) GroupSMaxNonUniformAMD 28 ExclusiveScan 1255
+            1257: 18(int16_t) CompositeExtract 1252 2
+            1258: 18(int16_t) GroupSMaxNonUniformAMD 28 ExclusiveScan 1257
+            1259: 18(int16_t) CompositeExtract 1252 3
+            1260: 18(int16_t) GroupSMaxNonUniformAMD 28 ExclusiveScan 1259
+            1261: 19(i16vec4) CompositeConstruct 1254 1256 1258 1260
             1262:     96(ptr) AccessChain 23 95
                               Store 1262 1261
             1263:    110(ptr) AccessChain 23 109
-            1264:     20(int) Load 1263
-            1265:     20(int) GroupUMaxNonUniformAMD 28 ExclusiveScan 1264
+            1264: 20(int16_t) Load 1263
+            1265: 20(int16_t) GroupUMaxNonUniformAMD 28 ExclusiveScan 1264
             1266:    110(ptr) AccessChain 23 109
                               Store 1266 1265
             1267:     25(ptr) AccessChain 23 24
@@ -1496,59 +1496,59 @@ spv.shaderBallotAMD.comp
             1288:     42(ptr) AccessChain 23 41
                               Store 1288 1287
             1289:     54(ptr) AccessChain 23 53
-            1290:   12(fvec4) Load 1289
-            1291:   11(float) CompositeExtract 1290 0
-            1292:   11(float) GroupFAddNonUniformAMD 28 ExclusiveScan 1291
-            1293:   11(float) CompositeExtract 1290 1
-            1294:   11(float) GroupFAddNonUniformAMD 28 ExclusiveScan 1293
-            1295:   11(float) CompositeExtract 1290 2
-            1296:   11(float) GroupFAddNonUniformAMD 28 ExclusiveScan 1295
-            1297:   11(float) CompositeExtract 1290 3
-            1298:   11(float) GroupFAddNonUniformAMD 28 ExclusiveScan 1297
-            1299:   12(fvec4) CompositeConstruct 1292 1294 1296 1298
+            1290: 12(f64vec4) Load 1289
+            1291:11(float64_t) CompositeExtract 1290 0
+            1292:11(float64_t) GroupFAddNonUniformAMD 28 ExclusiveScan 1291
+            1293:11(float64_t) CompositeExtract 1290 1
+            1294:11(float64_t) GroupFAddNonUniformAMD 28 ExclusiveScan 1293
+            1295:11(float64_t) CompositeExtract 1290 2
+            1296:11(float64_t) GroupFAddNonUniformAMD 28 ExclusiveScan 1295
+            1297:11(float64_t) CompositeExtract 1290 3
+            1298:11(float64_t) GroupFAddNonUniformAMD 28 ExclusiveScan 1297
+            1299: 12(f64vec4) CompositeConstruct 1292 1294 1296 1298
             1300:     54(ptr) AccessChain 23 53
                               Store 1300 1299
             1301:     68(ptr) AccessChain 23 67
-            1302:     13(int) Load 1301
-            1303:     13(int) GroupIAddNonUniformAMD 28 ExclusiveScan 1302
+            1302: 13(int64_t) Load 1301
+            1303: 13(int64_t) GroupIAddNonUniformAMD 28 ExclusiveScan 1302
             1304:     68(ptr) AccessChain 23 67
                               Store 1304 1303
             1305:     74(ptr) AccessChain 23 73
-            1306:   15(ivec2) Load 1305
-            1307:     14(int) CompositeExtract 1306 0
-            1308:     14(int) GroupIAddNonUniformAMD 28 ExclusiveScan 1307
-            1309:     14(int) CompositeExtract 1306 1
-            1310:     14(int) GroupIAddNonUniformAMD 28 ExclusiveScan 1309
-            1311:   15(ivec2) CompositeConstruct 1308 1310
+            1306: 15(i64vec2) Load 1305
+            1307: 14(int64_t) CompositeExtract 1306 0
+            1308: 14(int64_t) GroupIAddNonUniformAMD 28 ExclusiveScan 1307
+            1309: 14(int64_t) CompositeExtract 1306 1
+            1310: 14(int64_t) GroupIAddNonUniformAMD 28 ExclusiveScan 1309
+            1311: 15(i64vec2) CompositeConstruct 1308 1310
             1312:     74(ptr) AccessChain 23 73
                               Store 1312 1311
             1313:     84(ptr) AccessChain 23 83
-            1314:   17(fvec3) Load 1313
-            1315:   16(float) CompositeExtract 1314 0
-            1316:   16(float) GroupFAddNonUniformAMD 28 ExclusiveScan 1315
-            1317:   16(float) CompositeExtract 1314 1
-            1318:   16(float) GroupFAddNonUniformAMD 28 ExclusiveScan 1317
-            1319:   16(float) CompositeExtract 1314 2
-            1320:   16(float) GroupFAddNonUniformAMD 28 ExclusiveScan 1319
-            1321:   17(fvec3) CompositeConstruct 1316 1318 1320
+            1314: 17(f16vec3) Load 1313
+            1315:16(float16_t) CompositeExtract 1314 0
+            1316:16(float16_t) GroupFAddNonUniformAMD 28 ExclusiveScan 1315
+            1317:16(float16_t) CompositeExtract 1314 1
+            1318:16(float16_t) GroupFAddNonUniformAMD 28 ExclusiveScan 1317
+            1319:16(float16_t) CompositeExtract 1314 2
+            1320:16(float16_t) GroupFAddNonUniformAMD 28 ExclusiveScan 1319
+            1321: 17(f16vec3) CompositeConstruct 1316 1318 1320
             1322:     84(ptr) AccessChain 23 83
                               Store 1322 1321
             1323:     96(ptr) AccessChain 23 95
-            1324:   19(ivec4) Load 1323
-            1325:     18(int) CompositeExtract 1324 0
-            1326:     18(int) GroupIAddNonUniformAMD 28 ExclusiveScan 1325
-            1327:     18(int) CompositeExtract 1324 1
-            1328:     18(int) GroupIAddNonUniformAMD 28 ExclusiveScan 1327
-            1329:     18(int) CompositeExtract 1324 2
-            1330:     18(int) GroupIAddNonUniformAMD 28 ExclusiveScan 1329
-            1331:     18(int) CompositeExtract 1324 3
-            1332:     18(int) GroupIAddNonUniformAMD 28 ExclusiveScan 1331
-            1333:   19(ivec4) CompositeConstruct 1326 1328 1330 1332
+            1324: 19(i16vec4) Load 1323
+            1325: 18(int16_t) CompositeExtract 1324 0
+            1326: 18(int16_t) GroupIAddNonUniformAMD 28 ExclusiveScan 1325
+            1327: 18(int16_t) CompositeExtract 1324 1
+            1328: 18(int16_t) GroupIAddNonUniformAMD 28 ExclusiveScan 1327
+            1329: 18(int16_t) CompositeExtract 1324 2
+            1330: 18(int16_t) GroupIAddNonUniformAMD 28 ExclusiveScan 1329
+            1331: 18(int16_t) CompositeExtract 1324 3
+            1332: 18(int16_t) GroupIAddNonUniformAMD 28 ExclusiveScan 1331
+            1333: 19(i16vec4) CompositeConstruct 1326 1328 1330 1332
             1334:     96(ptr) AccessChain 23 95
                               Store 1334 1333
             1335:    110(ptr) AccessChain 23 109
-            1336:     20(int) Load 1335
-            1337:     20(int) GroupIAddNonUniformAMD 28 ExclusiveScan 1336
+            1336: 20(int16_t) Load 1335
+            1337: 20(int16_t) GroupIAddNonUniformAMD 28 ExclusiveScan 1336
             1338:    110(ptr) AccessChain 23 109
                               Store 1338 1337
                               Return

--- a/Test/baseResults/spv.specConstant.vert.out
+++ b/Test/baseResults/spv.specConstant.vert.out
@@ -64,18 +64,18 @@ spv.specConstant.vert
               33:             TypeInt 32 0
        34(scale):     33(int) SpecConstant 2
               38:             TypeFloat 64
-    39(spDouble):   38(float) SpecConstant 1413754136 1074340347
+    39(spDouble):38(float64_t) SpecConstant 1413754136 1074340347
      40(spFloat):    6(float) SpecConstant 1078523331
-              41:   38(float) SpecConstantOp 115 40(spFloat)
+              41:38(float64_t) SpecConstantOp 115 40(spFloat)
 50(dupArraySize):      8(int) SpecConstant 12
               51:             TypeArray 7(fvec4) 50(dupArraySize)
               52:             TypePointer Input 51
      53(dupUcol):     52(ptr) Variable Input
    60(spDupBool):    29(bool) SpecConstantTrue
     63(dupScale):     33(int) SpecConstant 2
- 67(spDupDouble):   38(float) SpecConstant 1413754136 1074340347
+ 67(spDupDouble):38(float64_t) SpecConstant 1413754136 1074340347
   68(spDupFloat):    6(float) SpecConstant 1078523331
-              69:   38(float) SpecConstantOp 115 68(spDupFloat)
+              69:38(float64_t) SpecConstantOp 115 68(spDupFloat)
               75:             TypePointer Function 8(int)
 77(gl_MaxImageUnits):      8(int) SpecConstant 8
          4(main):           2 Function None 3
@@ -94,7 +94,7 @@ spv.specConstant.vert
                                 Store 20(color) 37
                                 Branch 32
               32:             Label
-              42:   38(float) FDiv 39(spDouble) 41
+              42:38(float64_t) FDiv 39(spDouble) 41
               43:    6(float) FConvert 42
               44:    7(fvec4) Load 20(color)
               45:    7(fvec4) CompositeConstruct 43 43 43 43
@@ -125,7 +125,7 @@ spv.specConstant.vert
                                 Store 20(color) 66
                                 Branch 62
               62:             Label
-              70:   38(float) FDiv 67(spDupDouble) 69
+              70:38(float64_t) FDiv 67(spDupDouble) 69
               71:    6(float) FConvert 70
               72:    7(fvec4) Load 20(color)
               73:    7(fvec4) CompositeConstruct 71 71 71 71

--- a/Test/baseResults/spv.specConstantComposite.vert.out
+++ b/Test/baseResults/spv.specConstantComposite.vert.out
@@ -41,7 +41,7 @@ spv.specConstantComposite.vert
               32:             TypePointer Function 14(int)
   37(spec_float):   24(float) SpecConstant 1078523331
               38:             TypeFloat 64
- 39(spec_double):   38(float) SpecConstant 1413754136 1074340347
+ 39(spec_double):38(float64_t) SpecConstant 1413754136 1074340347
               40:             TypeArray 25(fvec4) 28(spec_int)
               41:             TypePointer Input 40
 42(global_vec4_array_with_spec_length):     41(ptr) Variable Input

--- a/Test/baseResults/spv.specConstantOperations.vert.out
+++ b/Test/baseResults/spv.specConstantOperations.vert.out
@@ -52,9 +52,9 @@ spv.specConstantOperations.vert
      42(sp_uint):     41(int) SpecConstant 100
      43(sp_sint):      6(int) SpecConstant 4294967286
               44:             TypeFloat 64
-   45(sp_double):   44(float) SpecConstant 2333366019 1074118410
+   45(sp_double):44(float64_t) SpecConstant 2333366019 1074118410
               46:   39(float) SpecConstantOp 115 45(sp_double)
-              47:   44(float) SpecConstantOp 115 40(sp_float)
+              47:44(float64_t) SpecConstantOp 115 40(sp_float)
               48:     41(int) Constant 0
               49:    22(bool) SpecConstantOp 171 19(sp_int) 48
               50:    22(bool) SpecConstantOp 171 42(sp_uint) 48

--- a/Test/baseResults/spv.subgroupArithmetic.comp.out
+++ b/Test/baseResults/spv.subgroupArithmetic.comp.out
@@ -54,8 +54,8 @@ spv.subgroupArithmetic.comp
               20:             TypeVector 19(int) 4
               21:             TypeVector 6(int) 4
               22:             TypeFloat 64
-              23:             TypeVector 22(float) 4
-     24(Buffers):             TypeStruct 18(fvec4) 20(ivec4) 21(ivec4) 23(fvec4)
+              23:             TypeVector 22(float64_t) 4
+     24(Buffers):             TypeStruct 18(fvec4) 20(ivec4) 21(ivec4) 23(f64vec4)
               25:             TypeArray 24(Buffers) 15
               26:             TypePointer Uniform 25
         27(data):     26(ptr) Variable Uniform
@@ -77,10 +77,10 @@ spv.subgroupArithmetic.comp
              101:             TypeVector 6(int) 2
              102:             TypePointer Uniform 21(ivec4)
              111:             TypeVector 6(int) 3
-             125:             TypePointer Uniform 22(float)
-             131:             TypeVector 22(float) 2
-             132:             TypePointer Uniform 23(fvec4)
-             141:             TypeVector 22(float) 3
+             125:             TypePointer Uniform 22(float64_t)
+             131:             TypeVector 22(float64_t) 2
+             132:             TypePointer Uniform 23(f64vec4)
+             141:             TypeVector 22(float64_t) 3
              521:             TypeBool
              530:   71(ivec2) ConstantComposite 29 29
              531:             TypeVector 521(bool) 2
@@ -194,32 +194,32 @@ spv.subgroupArithmetic.comp
                               Store 123 122
              124:      6(int) Load 8(invocation)
              126:    125(ptr) AccessChain 27(data) 29 59 30
-             127:   22(float) Load 126
-             128:   22(float) GroupNonUniformFAdd 34 Reduce 127
+             127:22(float64_t) Load 126
+             128:22(float64_t) GroupNonUniformFAdd 34 Reduce 127
              129:    125(ptr) AccessChain 27(data) 124 59 30
                               Store 129 128
              130:      6(int) Load 8(invocation)
              133:    132(ptr) AccessChain 27(data) 38 59
-             134:   23(fvec4) Load 133
-             135:  131(fvec2) VectorShuffle 134 134 0 1
-             136:  131(fvec2) GroupNonUniformFAdd 34 Reduce 135
+             134: 23(f64vec4) Load 133
+             135:131(f64vec2) VectorShuffle 134 134 0 1
+             136:131(f64vec2) GroupNonUniformFAdd 34 Reduce 135
              137:    132(ptr) AccessChain 27(data) 130 59
-             138:   23(fvec4) Load 137
-             139:   23(fvec4) VectorShuffle 138 136 4 5 2 3
+             138: 23(f64vec4) Load 137
+             139: 23(f64vec4) VectorShuffle 138 136 4 5 2 3
                               Store 137 139
              140:      6(int) Load 8(invocation)
              142:    132(ptr) AccessChain 27(data) 49 59
-             143:   23(fvec4) Load 142
-             144:  141(fvec3) VectorShuffle 143 143 0 1 2
-             145:  141(fvec3) GroupNonUniformFAdd 34 Reduce 144
+             143: 23(f64vec4) Load 142
+             144:141(f64vec3) VectorShuffle 143 143 0 1 2
+             145:141(f64vec3) GroupNonUniformFAdd 34 Reduce 144
              146:    132(ptr) AccessChain 27(data) 140 59
-             147:   23(fvec4) Load 146
-             148:   23(fvec4) VectorShuffle 147 145 4 5 6 3
+             147: 23(f64vec4) Load 146
+             148: 23(f64vec4) VectorShuffle 147 145 4 5 6 3
                               Store 146 148
              149:      6(int) Load 8(invocation)
              150:    132(ptr) AccessChain 27(data) 59 59
-             151:   23(fvec4) Load 150
-             152:   23(fvec4) GroupNonUniformFAdd 34 Reduce 151
+             151: 23(f64vec4) Load 150
+             152: 23(f64vec4) GroupNonUniformFAdd 34 Reduce 151
              153:    132(ptr) AccessChain 27(data) 149 59
                               Store 153 152
              154:      6(int) Load 8(invocation)
@@ -314,32 +314,32 @@ spv.subgroupArithmetic.comp
                               Store 231 230
              232:      6(int) Load 8(invocation)
              233:    125(ptr) AccessChain 27(data) 29 59 30
-             234:   22(float) Load 233
-             235:   22(float) GroupNonUniformFMul 34 Reduce 234
+             234:22(float64_t) Load 233
+             235:22(float64_t) GroupNonUniformFMul 34 Reduce 234
              236:    125(ptr) AccessChain 27(data) 232 59 30
                               Store 236 235
              237:      6(int) Load 8(invocation)
              238:    132(ptr) AccessChain 27(data) 38 59
-             239:   23(fvec4) Load 238
-             240:  131(fvec2) VectorShuffle 239 239 0 1
-             241:  131(fvec2) GroupNonUniformFMul 34 Reduce 240
+             239: 23(f64vec4) Load 238
+             240:131(f64vec2) VectorShuffle 239 239 0 1
+             241:131(f64vec2) GroupNonUniformFMul 34 Reduce 240
              242:    132(ptr) AccessChain 27(data) 237 59
-             243:   23(fvec4) Load 242
-             244:   23(fvec4) VectorShuffle 243 241 4 5 2 3
+             243: 23(f64vec4) Load 242
+             244: 23(f64vec4) VectorShuffle 243 241 4 5 2 3
                               Store 242 244
              245:      6(int) Load 8(invocation)
              246:    132(ptr) AccessChain 27(data) 49 59
-             247:   23(fvec4) Load 246
-             248:  141(fvec3) VectorShuffle 247 247 0 1 2
-             249:  141(fvec3) GroupNonUniformFMul 34 Reduce 248
+             247: 23(f64vec4) Load 246
+             248:141(f64vec3) VectorShuffle 247 247 0 1 2
+             249:141(f64vec3) GroupNonUniformFMul 34 Reduce 248
              250:    132(ptr) AccessChain 27(data) 245 59
-             251:   23(fvec4) Load 250
-             252:   23(fvec4) VectorShuffle 251 249 4 5 6 3
+             251: 23(f64vec4) Load 250
+             252: 23(f64vec4) VectorShuffle 251 249 4 5 6 3
                               Store 250 252
              253:      6(int) Load 8(invocation)
              254:    132(ptr) AccessChain 27(data) 59 59
-             255:   23(fvec4) Load 254
-             256:   23(fvec4) GroupNonUniformFMul 34 Reduce 255
+             255: 23(f64vec4) Load 254
+             256: 23(f64vec4) GroupNonUniformFMul 34 Reduce 255
              257:    132(ptr) AccessChain 27(data) 253 59
                               Store 257 256
              258:      6(int) Load 8(invocation)
@@ -434,32 +434,32 @@ spv.subgroupArithmetic.comp
                               Store 335 334
              336:      6(int) Load 8(invocation)
              337:    125(ptr) AccessChain 27(data) 29 59 30
-             338:   22(float) Load 337
-             339:   22(float) GroupNonUniformFMin 34 Reduce 338
+             338:22(float64_t) Load 337
+             339:22(float64_t) GroupNonUniformFMin 34 Reduce 338
              340:    125(ptr) AccessChain 27(data) 336 59 30
                               Store 340 339
              341:      6(int) Load 8(invocation)
              342:    132(ptr) AccessChain 27(data) 38 59
-             343:   23(fvec4) Load 342
-             344:  131(fvec2) VectorShuffle 343 343 0 1
-             345:  131(fvec2) GroupNonUniformFMin 34 Reduce 344
+             343: 23(f64vec4) Load 342
+             344:131(f64vec2) VectorShuffle 343 343 0 1
+             345:131(f64vec2) GroupNonUniformFMin 34 Reduce 344
              346:    132(ptr) AccessChain 27(data) 341 59
-             347:   23(fvec4) Load 346
-             348:   23(fvec4) VectorShuffle 347 345 4 5 2 3
+             347: 23(f64vec4) Load 346
+             348: 23(f64vec4) VectorShuffle 347 345 4 5 2 3
                               Store 346 348
              349:      6(int) Load 8(invocation)
              350:    132(ptr) AccessChain 27(data) 49 59
-             351:   23(fvec4) Load 350
-             352:  141(fvec3) VectorShuffle 351 351 0 1 2
-             353:  141(fvec3) GroupNonUniformFMin 34 Reduce 352
+             351: 23(f64vec4) Load 350
+             352:141(f64vec3) VectorShuffle 351 351 0 1 2
+             353:141(f64vec3) GroupNonUniformFMin 34 Reduce 352
              354:    132(ptr) AccessChain 27(data) 349 59
-             355:   23(fvec4) Load 354
-             356:   23(fvec4) VectorShuffle 355 353 4 5 6 3
+             355: 23(f64vec4) Load 354
+             356: 23(f64vec4) VectorShuffle 355 353 4 5 6 3
                               Store 354 356
              357:      6(int) Load 8(invocation)
              358:    132(ptr) AccessChain 27(data) 59 59
-             359:   23(fvec4) Load 358
-             360:   23(fvec4) GroupNonUniformFMin 34 Reduce 359
+             359: 23(f64vec4) Load 358
+             360: 23(f64vec4) GroupNonUniformFMin 34 Reduce 359
              361:    132(ptr) AccessChain 27(data) 357 59
                               Store 361 360
              362:      6(int) Load 8(invocation)
@@ -554,32 +554,32 @@ spv.subgroupArithmetic.comp
                               Store 439 438
              440:      6(int) Load 8(invocation)
              441:    125(ptr) AccessChain 27(data) 29 59 30
-             442:   22(float) Load 441
-             443:   22(float) GroupNonUniformFMax 34 Reduce 442
+             442:22(float64_t) Load 441
+             443:22(float64_t) GroupNonUniformFMax 34 Reduce 442
              444:    125(ptr) AccessChain 27(data) 440 59 30
                               Store 444 443
              445:      6(int) Load 8(invocation)
              446:    132(ptr) AccessChain 27(data) 38 59
-             447:   23(fvec4) Load 446
-             448:  131(fvec2) VectorShuffle 447 447 0 1
-             449:  131(fvec2) GroupNonUniformFMax 34 Reduce 448
+             447: 23(f64vec4) Load 446
+             448:131(f64vec2) VectorShuffle 447 447 0 1
+             449:131(f64vec2) GroupNonUniformFMax 34 Reduce 448
              450:    132(ptr) AccessChain 27(data) 445 59
-             451:   23(fvec4) Load 450
-             452:   23(fvec4) VectorShuffle 451 449 4 5 2 3
+             451: 23(f64vec4) Load 450
+             452: 23(f64vec4) VectorShuffle 451 449 4 5 2 3
                               Store 450 452
              453:      6(int) Load 8(invocation)
              454:    132(ptr) AccessChain 27(data) 49 59
-             455:   23(fvec4) Load 454
-             456:  141(fvec3) VectorShuffle 455 455 0 1 2
-             457:  141(fvec3) GroupNonUniformFMax 34 Reduce 456
+             455: 23(f64vec4) Load 454
+             456:141(f64vec3) VectorShuffle 455 455 0 1 2
+             457:141(f64vec3) GroupNonUniformFMax 34 Reduce 456
              458:    132(ptr) AccessChain 27(data) 453 59
-             459:   23(fvec4) Load 458
-             460:   23(fvec4) VectorShuffle 459 457 4 5 6 3
+             459: 23(f64vec4) Load 458
+             460: 23(f64vec4) VectorShuffle 459 457 4 5 6 3
                               Store 458 460
              461:      6(int) Load 8(invocation)
              462:    132(ptr) AccessChain 27(data) 59 59
-             463:   23(fvec4) Load 462
-             464:   23(fvec4) GroupNonUniformFMax 34 Reduce 463
+             463: 23(f64vec4) Load 462
+             464: 23(f64vec4) GroupNonUniformFMax 34 Reduce 463
              465:    132(ptr) AccessChain 27(data) 461 59
                               Store 465 464
              466:      6(int) Load 8(invocation)
@@ -968,32 +968,32 @@ spv.subgroupArithmetic.comp
                               Store 811 810
              812:      6(int) Load 8(invocation)
              813:    125(ptr) AccessChain 27(data) 29 59 30
-             814:   22(float) Load 813
-             815:   22(float) GroupNonUniformFAdd 34 InclusiveScan 814
+             814:22(float64_t) Load 813
+             815:22(float64_t) GroupNonUniformFAdd 34 InclusiveScan 814
              816:    125(ptr) AccessChain 27(data) 812 59 30
                               Store 816 815
              817:      6(int) Load 8(invocation)
              818:    132(ptr) AccessChain 27(data) 38 59
-             819:   23(fvec4) Load 818
-             820:  131(fvec2) VectorShuffle 819 819 0 1
-             821:  131(fvec2) GroupNonUniformFAdd 34 InclusiveScan 820
+             819: 23(f64vec4) Load 818
+             820:131(f64vec2) VectorShuffle 819 819 0 1
+             821:131(f64vec2) GroupNonUniformFAdd 34 InclusiveScan 820
              822:    132(ptr) AccessChain 27(data) 817 59
-             823:   23(fvec4) Load 822
-             824:   23(fvec4) VectorShuffle 823 821 4 5 2 3
+             823: 23(f64vec4) Load 822
+             824: 23(f64vec4) VectorShuffle 823 821 4 5 2 3
                               Store 822 824
              825:      6(int) Load 8(invocation)
              826:    132(ptr) AccessChain 27(data) 49 59
-             827:   23(fvec4) Load 826
-             828:  141(fvec3) VectorShuffle 827 827 0 1 2
-             829:  141(fvec3) GroupNonUniformFAdd 34 InclusiveScan 828
+             827: 23(f64vec4) Load 826
+             828:141(f64vec3) VectorShuffle 827 827 0 1 2
+             829:141(f64vec3) GroupNonUniformFAdd 34 InclusiveScan 828
              830:    132(ptr) AccessChain 27(data) 825 59
-             831:   23(fvec4) Load 830
-             832:   23(fvec4) VectorShuffle 831 829 4 5 6 3
+             831: 23(f64vec4) Load 830
+             832: 23(f64vec4) VectorShuffle 831 829 4 5 6 3
                               Store 830 832
              833:      6(int) Load 8(invocation)
              834:    132(ptr) AccessChain 27(data) 59 59
-             835:   23(fvec4) Load 834
-             836:   23(fvec4) GroupNonUniformFAdd 34 InclusiveScan 835
+             835: 23(f64vec4) Load 834
+             836: 23(f64vec4) GroupNonUniformFAdd 34 InclusiveScan 835
              837:    132(ptr) AccessChain 27(data) 833 59
                               Store 837 836
              838:      6(int) Load 8(invocation)
@@ -1088,32 +1088,32 @@ spv.subgroupArithmetic.comp
                               Store 915 914
              916:      6(int) Load 8(invocation)
              917:    125(ptr) AccessChain 27(data) 29 59 30
-             918:   22(float) Load 917
-             919:   22(float) GroupNonUniformFMul 34 InclusiveScan 918
+             918:22(float64_t) Load 917
+             919:22(float64_t) GroupNonUniformFMul 34 InclusiveScan 918
              920:    125(ptr) AccessChain 27(data) 916 59 30
                               Store 920 919
              921:      6(int) Load 8(invocation)
              922:    132(ptr) AccessChain 27(data) 38 59
-             923:   23(fvec4) Load 922
-             924:  131(fvec2) VectorShuffle 923 923 0 1
-             925:  131(fvec2) GroupNonUniformFMul 34 InclusiveScan 924
+             923: 23(f64vec4) Load 922
+             924:131(f64vec2) VectorShuffle 923 923 0 1
+             925:131(f64vec2) GroupNonUniformFMul 34 InclusiveScan 924
              926:    132(ptr) AccessChain 27(data) 921 59
-             927:   23(fvec4) Load 926
-             928:   23(fvec4) VectorShuffle 927 925 4 5 2 3
+             927: 23(f64vec4) Load 926
+             928: 23(f64vec4) VectorShuffle 927 925 4 5 2 3
                               Store 926 928
              929:      6(int) Load 8(invocation)
              930:    132(ptr) AccessChain 27(data) 49 59
-             931:   23(fvec4) Load 930
-             932:  141(fvec3) VectorShuffle 931 931 0 1 2
-             933:  141(fvec3) GroupNonUniformFMul 34 InclusiveScan 932
+             931: 23(f64vec4) Load 930
+             932:141(f64vec3) VectorShuffle 931 931 0 1 2
+             933:141(f64vec3) GroupNonUniformFMul 34 InclusiveScan 932
              934:    132(ptr) AccessChain 27(data) 929 59
-             935:   23(fvec4) Load 934
-             936:   23(fvec4) VectorShuffle 935 933 4 5 6 3
+             935: 23(f64vec4) Load 934
+             936: 23(f64vec4) VectorShuffle 935 933 4 5 6 3
                               Store 934 936
              937:      6(int) Load 8(invocation)
              938:    132(ptr) AccessChain 27(data) 59 59
-             939:   23(fvec4) Load 938
-             940:   23(fvec4) GroupNonUniformFMul 34 InclusiveScan 939
+             939: 23(f64vec4) Load 938
+             940: 23(f64vec4) GroupNonUniformFMul 34 InclusiveScan 939
              941:    132(ptr) AccessChain 27(data) 937 59
                               Store 941 940
              942:      6(int) Load 8(invocation)
@@ -1208,32 +1208,32 @@ spv.subgroupArithmetic.comp
                               Store 1019 1018
             1020:      6(int) Load 8(invocation)
             1021:    125(ptr) AccessChain 27(data) 29 59 30
-            1022:   22(float) Load 1021
-            1023:   22(float) GroupNonUniformFMin 34 InclusiveScan 1022
+            1022:22(float64_t) Load 1021
+            1023:22(float64_t) GroupNonUniformFMin 34 InclusiveScan 1022
             1024:    125(ptr) AccessChain 27(data) 1020 59 30
                               Store 1024 1023
             1025:      6(int) Load 8(invocation)
             1026:    132(ptr) AccessChain 27(data) 38 59
-            1027:   23(fvec4) Load 1026
-            1028:  131(fvec2) VectorShuffle 1027 1027 0 1
-            1029:  131(fvec2) GroupNonUniformFMin 34 InclusiveScan 1028
+            1027: 23(f64vec4) Load 1026
+            1028:131(f64vec2) VectorShuffle 1027 1027 0 1
+            1029:131(f64vec2) GroupNonUniformFMin 34 InclusiveScan 1028
             1030:    132(ptr) AccessChain 27(data) 1025 59
-            1031:   23(fvec4) Load 1030
-            1032:   23(fvec4) VectorShuffle 1031 1029 4 5 2 3
+            1031: 23(f64vec4) Load 1030
+            1032: 23(f64vec4) VectorShuffle 1031 1029 4 5 2 3
                               Store 1030 1032
             1033:      6(int) Load 8(invocation)
             1034:    132(ptr) AccessChain 27(data) 49 59
-            1035:   23(fvec4) Load 1034
-            1036:  141(fvec3) VectorShuffle 1035 1035 0 1 2
-            1037:  141(fvec3) GroupNonUniformFMin 34 InclusiveScan 1036
+            1035: 23(f64vec4) Load 1034
+            1036:141(f64vec3) VectorShuffle 1035 1035 0 1 2
+            1037:141(f64vec3) GroupNonUniformFMin 34 InclusiveScan 1036
             1038:    132(ptr) AccessChain 27(data) 1033 59
-            1039:   23(fvec4) Load 1038
-            1040:   23(fvec4) VectorShuffle 1039 1037 4 5 6 3
+            1039: 23(f64vec4) Load 1038
+            1040: 23(f64vec4) VectorShuffle 1039 1037 4 5 6 3
                               Store 1038 1040
             1041:      6(int) Load 8(invocation)
             1042:    132(ptr) AccessChain 27(data) 59 59
-            1043:   23(fvec4) Load 1042
-            1044:   23(fvec4) GroupNonUniformFMin 34 InclusiveScan 1043
+            1043: 23(f64vec4) Load 1042
+            1044: 23(f64vec4) GroupNonUniformFMin 34 InclusiveScan 1043
             1045:    132(ptr) AccessChain 27(data) 1041 59
                               Store 1045 1044
             1046:      6(int) Load 8(invocation)
@@ -1328,32 +1328,32 @@ spv.subgroupArithmetic.comp
                               Store 1123 1122
             1124:      6(int) Load 8(invocation)
             1125:    125(ptr) AccessChain 27(data) 29 59 30
-            1126:   22(float) Load 1125
-            1127:   22(float) GroupNonUniformFMax 34 InclusiveScan 1126
+            1126:22(float64_t) Load 1125
+            1127:22(float64_t) GroupNonUniformFMax 34 InclusiveScan 1126
             1128:    125(ptr) AccessChain 27(data) 1124 59 30
                               Store 1128 1127
             1129:      6(int) Load 8(invocation)
             1130:    132(ptr) AccessChain 27(data) 38 59
-            1131:   23(fvec4) Load 1130
-            1132:  131(fvec2) VectorShuffle 1131 1131 0 1
-            1133:  131(fvec2) GroupNonUniformFMax 34 InclusiveScan 1132
+            1131: 23(f64vec4) Load 1130
+            1132:131(f64vec2) VectorShuffle 1131 1131 0 1
+            1133:131(f64vec2) GroupNonUniformFMax 34 InclusiveScan 1132
             1134:    132(ptr) AccessChain 27(data) 1129 59
-            1135:   23(fvec4) Load 1134
-            1136:   23(fvec4) VectorShuffle 1135 1133 4 5 2 3
+            1135: 23(f64vec4) Load 1134
+            1136: 23(f64vec4) VectorShuffle 1135 1133 4 5 2 3
                               Store 1134 1136
             1137:      6(int) Load 8(invocation)
             1138:    132(ptr) AccessChain 27(data) 49 59
-            1139:   23(fvec4) Load 1138
-            1140:  141(fvec3) VectorShuffle 1139 1139 0 1 2
-            1141:  141(fvec3) GroupNonUniformFMax 34 InclusiveScan 1140
+            1139: 23(f64vec4) Load 1138
+            1140:141(f64vec3) VectorShuffle 1139 1139 0 1 2
+            1141:141(f64vec3) GroupNonUniformFMax 34 InclusiveScan 1140
             1142:    132(ptr) AccessChain 27(data) 1137 59
-            1143:   23(fvec4) Load 1142
-            1144:   23(fvec4) VectorShuffle 1143 1141 4 5 6 3
+            1143: 23(f64vec4) Load 1142
+            1144: 23(f64vec4) VectorShuffle 1143 1141 4 5 6 3
                               Store 1142 1144
             1145:      6(int) Load 8(invocation)
             1146:    132(ptr) AccessChain 27(data) 59 59
-            1147:   23(fvec4) Load 1146
-            1148:   23(fvec4) GroupNonUniformFMax 34 InclusiveScan 1147
+            1147: 23(f64vec4) Load 1146
+            1148: 23(f64vec4) GroupNonUniformFMax 34 InclusiveScan 1147
             1149:    132(ptr) AccessChain 27(data) 1145 59
                               Store 1149 1148
             1150:      6(int) Load 8(invocation)
@@ -1742,32 +1742,32 @@ spv.subgroupArithmetic.comp
                               Store 1485 1484
             1486:      6(int) Load 8(invocation)
             1487:    125(ptr) AccessChain 27(data) 29 59 30
-            1488:   22(float) Load 1487
-            1489:   22(float) GroupNonUniformFAdd 34 ExclusiveScan 1488
+            1488:22(float64_t) Load 1487
+            1489:22(float64_t) GroupNonUniformFAdd 34 ExclusiveScan 1488
             1490:    125(ptr) AccessChain 27(data) 1486 59 30
                               Store 1490 1489
             1491:      6(int) Load 8(invocation)
             1492:    132(ptr) AccessChain 27(data) 38 59
-            1493:   23(fvec4) Load 1492
-            1494:  131(fvec2) VectorShuffle 1493 1493 0 1
-            1495:  131(fvec2) GroupNonUniformFAdd 34 ExclusiveScan 1494
+            1493: 23(f64vec4) Load 1492
+            1494:131(f64vec2) VectorShuffle 1493 1493 0 1
+            1495:131(f64vec2) GroupNonUniformFAdd 34 ExclusiveScan 1494
             1496:    132(ptr) AccessChain 27(data) 1491 59
-            1497:   23(fvec4) Load 1496
-            1498:   23(fvec4) VectorShuffle 1497 1495 4 5 2 3
+            1497: 23(f64vec4) Load 1496
+            1498: 23(f64vec4) VectorShuffle 1497 1495 4 5 2 3
                               Store 1496 1498
             1499:      6(int) Load 8(invocation)
             1500:    132(ptr) AccessChain 27(data) 49 59
-            1501:   23(fvec4) Load 1500
-            1502:  141(fvec3) VectorShuffle 1501 1501 0 1 2
-            1503:  141(fvec3) GroupNonUniformFAdd 34 ExclusiveScan 1502
+            1501: 23(f64vec4) Load 1500
+            1502:141(f64vec3) VectorShuffle 1501 1501 0 1 2
+            1503:141(f64vec3) GroupNonUniformFAdd 34 ExclusiveScan 1502
             1504:    132(ptr) AccessChain 27(data) 1499 59
-            1505:   23(fvec4) Load 1504
-            1506:   23(fvec4) VectorShuffle 1505 1503 4 5 6 3
+            1505: 23(f64vec4) Load 1504
+            1506: 23(f64vec4) VectorShuffle 1505 1503 4 5 6 3
                               Store 1504 1506
             1507:      6(int) Load 8(invocation)
             1508:    132(ptr) AccessChain 27(data) 59 59
-            1509:   23(fvec4) Load 1508
-            1510:   23(fvec4) GroupNonUniformFAdd 34 ExclusiveScan 1509
+            1509: 23(f64vec4) Load 1508
+            1510: 23(f64vec4) GroupNonUniformFAdd 34 ExclusiveScan 1509
             1511:    132(ptr) AccessChain 27(data) 1507 59
                               Store 1511 1510
             1512:      6(int) Load 8(invocation)
@@ -1862,32 +1862,32 @@ spv.subgroupArithmetic.comp
                               Store 1589 1588
             1590:      6(int) Load 8(invocation)
             1591:    125(ptr) AccessChain 27(data) 29 59 30
-            1592:   22(float) Load 1591
-            1593:   22(float) GroupNonUniformFMul 34 ExclusiveScan 1592
+            1592:22(float64_t) Load 1591
+            1593:22(float64_t) GroupNonUniformFMul 34 ExclusiveScan 1592
             1594:    125(ptr) AccessChain 27(data) 1590 59 30
                               Store 1594 1593
             1595:      6(int) Load 8(invocation)
             1596:    132(ptr) AccessChain 27(data) 38 59
-            1597:   23(fvec4) Load 1596
-            1598:  131(fvec2) VectorShuffle 1597 1597 0 1
-            1599:  131(fvec2) GroupNonUniformFMul 34 ExclusiveScan 1598
+            1597: 23(f64vec4) Load 1596
+            1598:131(f64vec2) VectorShuffle 1597 1597 0 1
+            1599:131(f64vec2) GroupNonUniformFMul 34 ExclusiveScan 1598
             1600:    132(ptr) AccessChain 27(data) 1595 59
-            1601:   23(fvec4) Load 1600
-            1602:   23(fvec4) VectorShuffle 1601 1599 4 5 2 3
+            1601: 23(f64vec4) Load 1600
+            1602: 23(f64vec4) VectorShuffle 1601 1599 4 5 2 3
                               Store 1600 1602
             1603:      6(int) Load 8(invocation)
             1604:    132(ptr) AccessChain 27(data) 49 59
-            1605:   23(fvec4) Load 1604
-            1606:  141(fvec3) VectorShuffle 1605 1605 0 1 2
-            1607:  141(fvec3) GroupNonUniformFMul 34 ExclusiveScan 1606
+            1605: 23(f64vec4) Load 1604
+            1606:141(f64vec3) VectorShuffle 1605 1605 0 1 2
+            1607:141(f64vec3) GroupNonUniformFMul 34 ExclusiveScan 1606
             1608:    132(ptr) AccessChain 27(data) 1603 59
-            1609:   23(fvec4) Load 1608
-            1610:   23(fvec4) VectorShuffle 1609 1607 4 5 6 3
+            1609: 23(f64vec4) Load 1608
+            1610: 23(f64vec4) VectorShuffle 1609 1607 4 5 6 3
                               Store 1608 1610
             1611:      6(int) Load 8(invocation)
             1612:    132(ptr) AccessChain 27(data) 59 59
-            1613:   23(fvec4) Load 1612
-            1614:   23(fvec4) GroupNonUniformFMul 34 ExclusiveScan 1613
+            1613: 23(f64vec4) Load 1612
+            1614: 23(f64vec4) GroupNonUniformFMul 34 ExclusiveScan 1613
             1615:    132(ptr) AccessChain 27(data) 1611 59
                               Store 1615 1614
             1616:      6(int) Load 8(invocation)
@@ -1982,32 +1982,32 @@ spv.subgroupArithmetic.comp
                               Store 1693 1692
             1694:      6(int) Load 8(invocation)
             1695:    125(ptr) AccessChain 27(data) 29 59 30
-            1696:   22(float) Load 1695
-            1697:   22(float) GroupNonUniformFMin 34 ExclusiveScan 1696
+            1696:22(float64_t) Load 1695
+            1697:22(float64_t) GroupNonUniformFMin 34 ExclusiveScan 1696
             1698:    125(ptr) AccessChain 27(data) 1694 59 30
                               Store 1698 1697
             1699:      6(int) Load 8(invocation)
             1700:    132(ptr) AccessChain 27(data) 38 59
-            1701:   23(fvec4) Load 1700
-            1702:  131(fvec2) VectorShuffle 1701 1701 0 1
-            1703:  131(fvec2) GroupNonUniformFMin 34 ExclusiveScan 1702
+            1701: 23(f64vec4) Load 1700
+            1702:131(f64vec2) VectorShuffle 1701 1701 0 1
+            1703:131(f64vec2) GroupNonUniformFMin 34 ExclusiveScan 1702
             1704:    132(ptr) AccessChain 27(data) 1699 59
-            1705:   23(fvec4) Load 1704
-            1706:   23(fvec4) VectorShuffle 1705 1703 4 5 2 3
+            1705: 23(f64vec4) Load 1704
+            1706: 23(f64vec4) VectorShuffle 1705 1703 4 5 2 3
                               Store 1704 1706
             1707:      6(int) Load 8(invocation)
             1708:    132(ptr) AccessChain 27(data) 49 59
-            1709:   23(fvec4) Load 1708
-            1710:  141(fvec3) VectorShuffle 1709 1709 0 1 2
-            1711:  141(fvec3) GroupNonUniformFMin 34 ExclusiveScan 1710
+            1709: 23(f64vec4) Load 1708
+            1710:141(f64vec3) VectorShuffle 1709 1709 0 1 2
+            1711:141(f64vec3) GroupNonUniformFMin 34 ExclusiveScan 1710
             1712:    132(ptr) AccessChain 27(data) 1707 59
-            1713:   23(fvec4) Load 1712
-            1714:   23(fvec4) VectorShuffle 1713 1711 4 5 6 3
+            1713: 23(f64vec4) Load 1712
+            1714: 23(f64vec4) VectorShuffle 1713 1711 4 5 6 3
                               Store 1712 1714
             1715:      6(int) Load 8(invocation)
             1716:    132(ptr) AccessChain 27(data) 59 59
-            1717:   23(fvec4) Load 1716
-            1718:   23(fvec4) GroupNonUniformFMin 34 ExclusiveScan 1717
+            1717: 23(f64vec4) Load 1716
+            1718: 23(f64vec4) GroupNonUniformFMin 34 ExclusiveScan 1717
             1719:    132(ptr) AccessChain 27(data) 1715 59
                               Store 1719 1718
             1720:      6(int) Load 8(invocation)
@@ -2102,32 +2102,32 @@ spv.subgroupArithmetic.comp
                               Store 1797 1796
             1798:      6(int) Load 8(invocation)
             1799:    125(ptr) AccessChain 27(data) 29 59 30
-            1800:   22(float) Load 1799
-            1801:   22(float) GroupNonUniformFMax 34 ExclusiveScan 1800
+            1800:22(float64_t) Load 1799
+            1801:22(float64_t) GroupNonUniformFMax 34 ExclusiveScan 1800
             1802:    125(ptr) AccessChain 27(data) 1798 59 30
                               Store 1802 1801
             1803:      6(int) Load 8(invocation)
             1804:    132(ptr) AccessChain 27(data) 38 59
-            1805:   23(fvec4) Load 1804
-            1806:  131(fvec2) VectorShuffle 1805 1805 0 1
-            1807:  131(fvec2) GroupNonUniformFMax 34 ExclusiveScan 1806
+            1805: 23(f64vec4) Load 1804
+            1806:131(f64vec2) VectorShuffle 1805 1805 0 1
+            1807:131(f64vec2) GroupNonUniformFMax 34 ExclusiveScan 1806
             1808:    132(ptr) AccessChain 27(data) 1803 59
-            1809:   23(fvec4) Load 1808
-            1810:   23(fvec4) VectorShuffle 1809 1807 4 5 2 3
+            1809: 23(f64vec4) Load 1808
+            1810: 23(f64vec4) VectorShuffle 1809 1807 4 5 2 3
                               Store 1808 1810
             1811:      6(int) Load 8(invocation)
             1812:    132(ptr) AccessChain 27(data) 49 59
-            1813:   23(fvec4) Load 1812
-            1814:  141(fvec3) VectorShuffle 1813 1813 0 1 2
-            1815:  141(fvec3) GroupNonUniformFMax 34 ExclusiveScan 1814
+            1813: 23(f64vec4) Load 1812
+            1814:141(f64vec3) VectorShuffle 1813 1813 0 1 2
+            1815:141(f64vec3) GroupNonUniformFMax 34 ExclusiveScan 1814
             1816:    132(ptr) AccessChain 27(data) 1811 59
-            1817:   23(fvec4) Load 1816
-            1818:   23(fvec4) VectorShuffle 1817 1815 4 5 6 3
+            1817: 23(f64vec4) Load 1816
+            1818: 23(f64vec4) VectorShuffle 1817 1815 4 5 6 3
                               Store 1816 1818
             1819:      6(int) Load 8(invocation)
             1820:    132(ptr) AccessChain 27(data) 59 59
-            1821:   23(fvec4) Load 1820
-            1822:   23(fvec4) GroupNonUniformFMax 34 ExclusiveScan 1821
+            1821: 23(f64vec4) Load 1820
+            1822: 23(f64vec4) GroupNonUniformFMax 34 ExclusiveScan 1821
             1823:    132(ptr) AccessChain 27(data) 1819 59
                               Store 1823 1822
             1824:      6(int) Load 8(invocation)

--- a/Test/baseResults/spv.subgroupBallot.comp.out
+++ b/Test/baseResults/spv.subgroupBallot.comp.out
@@ -76,8 +76,8 @@ spv.subgroupBallot.comp
               42:             TypeInt 32 1
               43:             TypeVector 42(int) 4
               44:             TypeFloat 64
-              45:             TypeVector 44(float) 4
-     46(Buffers):             TypeStruct 41(fvec4) 43(ivec4) 17(ivec4) 45(fvec4)
+              45:             TypeVector 44(float64_t) 4
+     46(Buffers):             TypeStruct 41(fvec4) 43(ivec4) 17(ivec4) 45(f64vec4)
               47:             TypeArray 46(Buffers) 15
               48:             TypePointer Uniform 47
         49(data):     48(ptr) Variable Uniform
@@ -101,10 +101,10 @@ spv.subgroupBallot.comp
              149:             TypeVector 42(int) 3
              171:             TypeVector 6(int) 2
              181:             TypeVector 6(int) 3
-             197:             TypePointer Uniform 44(float)
-             204:             TypeVector 44(float) 2
-             205:             TypePointer Uniform 45(fvec4)
-             215:             TypeVector 44(float) 3
+             197:             TypePointer Uniform 44(float64_t)
+             204:             TypeVector 44(float64_t) 2
+             205:             TypePointer Uniform 45(f64vec4)
+             215:             TypeVector 44(float64_t) 3
              242:  138(ivec2) ConstantComposite 61 61
              243:             TypeVector 36(bool) 2
              247:  138(ivec2) ConstantComposite 60 60
@@ -285,36 +285,36 @@ spv.subgroupBallot.comp
                                 Store 195 194
              196:      6(int)   Load 8(invocation)
              198:    197(ptr)   AccessChain 49(data) 61 124 54
-             199:   44(float)   Load 198
+             199:44(float64_t)   Load 198
              200:      6(int)   Load 8(invocation)
-             201:   44(float)   GroupNonUniformBroadcast 38 199 200
+             201:44(float64_t)   GroupNonUniformBroadcast 38 199 200
              202:    197(ptr)   AccessChain 49(data) 196 124 54
                                 Store 202 201
              203:      6(int)   Load 8(invocation)
              206:    205(ptr)   AccessChain 49(data) 60 124
-             207:   45(fvec4)   Load 206
-             208:  204(fvec2)   VectorShuffle 207 207 0 1
+             207: 45(f64vec4)   Load 206
+             208:204(f64vec2)   VectorShuffle 207 207 0 1
              209:      6(int)   Load 8(invocation)
-             210:  204(fvec2)   GroupNonUniformBroadcast 38 208 209
+             210:204(f64vec2)   GroupNonUniformBroadcast 38 208 209
              211:    205(ptr)   AccessChain 49(data) 203 124
-             212:   45(fvec4)   Load 211
-             213:   45(fvec4)   VectorShuffle 212 210 4 5 2 3
+             212: 45(f64vec4)   Load 211
+             213: 45(f64vec4)   VectorShuffle 212 210 4 5 2 3
                                 Store 211 213
              214:      6(int)   Load 8(invocation)
              216:    205(ptr)   AccessChain 49(data) 51 124
-             217:   45(fvec4)   Load 216
-             218:  215(fvec3)   VectorShuffle 217 217 0 1 2
+             217: 45(f64vec4)   Load 216
+             218:215(f64vec3)   VectorShuffle 217 217 0 1 2
              219:      6(int)   Load 8(invocation)
-             220:  215(fvec3)   GroupNonUniformBroadcast 38 218 219
+             220:215(f64vec3)   GroupNonUniformBroadcast 38 218 219
              221:    205(ptr)   AccessChain 49(data) 214 124
-             222:   45(fvec4)   Load 221
-             223:   45(fvec4)   VectorShuffle 222 220 4 5 6 3
+             222: 45(f64vec4)   Load 221
+             223: 45(f64vec4)   VectorShuffle 222 220 4 5 6 3
                                 Store 221 223
              224:      6(int)   Load 8(invocation)
              225:    205(ptr)   AccessChain 49(data) 124 124
-             226:   45(fvec4)   Load 225
+             226: 45(f64vec4)   Load 225
              227:      6(int)   Load 8(invocation)
-             228:   45(fvec4)   GroupNonUniformBroadcast 38 226 227
+             228: 45(f64vec4)   GroupNonUniformBroadcast 38 226 227
              229:    205(ptr)   AccessChain 49(data) 224 124
                                 Store 229 228
              230:      6(int)   Load 8(invocation)
@@ -453,32 +453,32 @@ spv.subgroupBallot.comp
                                 Store 354 353
              355:      6(int)   Load 8(invocation)
              356:    197(ptr)   AccessChain 49(data) 61 124 54
-             357:   44(float)   Load 356
-             358:   44(float)   GroupNonUniformBroadcastFirst 38 357
+             357:44(float64_t)   Load 356
+             358:44(float64_t)   GroupNonUniformBroadcastFirst 38 357
              359:    197(ptr)   AccessChain 49(data) 355 124 54
                                 Store 359 358
              360:      6(int)   Load 8(invocation)
              361:    205(ptr)   AccessChain 49(data) 60 124
-             362:   45(fvec4)   Load 361
-             363:  204(fvec2)   VectorShuffle 362 362 0 1
-             364:  204(fvec2)   GroupNonUniformBroadcastFirst 38 363
+             362: 45(f64vec4)   Load 361
+             363:204(f64vec2)   VectorShuffle 362 362 0 1
+             364:204(f64vec2)   GroupNonUniformBroadcastFirst 38 363
              365:    205(ptr)   AccessChain 49(data) 360 124
-             366:   45(fvec4)   Load 365
-             367:   45(fvec4)   VectorShuffle 366 364 4 5 2 3
+             366: 45(f64vec4)   Load 365
+             367: 45(f64vec4)   VectorShuffle 366 364 4 5 2 3
                                 Store 365 367
              368:      6(int)   Load 8(invocation)
              369:    205(ptr)   AccessChain 49(data) 51 124
-             370:   45(fvec4)   Load 369
-             371:  215(fvec3)   VectorShuffle 370 370 0 1 2
-             372:  215(fvec3)   GroupNonUniformBroadcastFirst 38 371
+             370: 45(f64vec4)   Load 369
+             371:215(f64vec3)   VectorShuffle 370 370 0 1 2
+             372:215(f64vec3)   GroupNonUniformBroadcastFirst 38 371
              373:    205(ptr)   AccessChain 49(data) 368 124
-             374:   45(fvec4)   Load 373
-             375:   45(fvec4)   VectorShuffle 374 372 4 5 6 3
+             374: 45(f64vec4)   Load 373
+             375: 45(f64vec4)   VectorShuffle 374 372 4 5 6 3
                                 Store 373 375
              376:      6(int)   Load 8(invocation)
              377:    205(ptr)   AccessChain 49(data) 124 124
-             378:   45(fvec4)   Load 377
-             379:   45(fvec4)   GroupNonUniformBroadcastFirst 38 378
+             378: 45(f64vec4)   Load 377
+             379: 45(f64vec4)   GroupNonUniformBroadcastFirst 38 378
              380:    205(ptr)   AccessChain 49(data) 376 124
                                 Store 380 379
              381:      6(int)   Load 8(invocation)

--- a/Test/baseResults/spv.subgroupClustered.comp.out
+++ b/Test/baseResults/spv.subgroupClustered.comp.out
@@ -54,8 +54,8 @@ spv.subgroupClustered.comp
               20:             TypeVector 19(int) 4
               21:             TypeVector 6(int) 4
               22:             TypeFloat 64
-              23:             TypeVector 22(float) 4
-     24(Buffers):             TypeStruct 18(fvec4) 20(ivec4) 21(ivec4) 23(fvec4)
+              23:             TypeVector 22(float64_t) 4
+     24(Buffers):             TypeStruct 18(fvec4) 20(ivec4) 21(ivec4) 23(f64vec4)
               25:             TypeArray 24(Buffers) 15
               26:             TypePointer Uniform 25
         27(data):     26(ptr) Variable Uniform
@@ -78,10 +78,10 @@ spv.subgroupClustered.comp
              102:             TypeVector 6(int) 2
              103:             TypePointer Uniform 21(ivec4)
              112:             TypeVector 6(int) 3
-             126:             TypePointer Uniform 22(float)
-             132:             TypeVector 22(float) 2
-             133:             TypePointer Uniform 23(fvec4)
-             142:             TypeVector 22(float) 3
+             126:             TypePointer Uniform 22(float64_t)
+             132:             TypeVector 22(float64_t) 2
+             133:             TypePointer Uniform 23(f64vec4)
+             142:             TypeVector 22(float64_t) 3
              522:             TypeBool
              531:   72(ivec2) ConstantComposite 29 29
              532:             TypeVector 522(bool) 2
@@ -194,32 +194,32 @@ spv.subgroupClustered.comp
                               Store 124 123
              125:      6(int) Load 8(invocation)
              127:    126(ptr) AccessChain 27(data) 29 60 30
-             128:   22(float) Load 127
-             129:   22(float) GroupNonUniformFAdd 35 ClusteredReduce 128 34
+             128:22(float64_t) Load 127
+             129:22(float64_t) GroupNonUniformFAdd 35 ClusteredReduce 128 34
              130:    126(ptr) AccessChain 27(data) 125 60 30
                               Store 130 129
              131:      6(int) Load 8(invocation)
              134:    133(ptr) AccessChain 27(data) 39 60
-             135:   23(fvec4) Load 134
-             136:  132(fvec2) VectorShuffle 135 135 0 1
-             137:  132(fvec2) GroupNonUniformFAdd 35 ClusteredReduce 136 34
+             135: 23(f64vec4) Load 134
+             136:132(f64vec2) VectorShuffle 135 135 0 1
+             137:132(f64vec2) GroupNonUniformFAdd 35 ClusteredReduce 136 34
              138:    133(ptr) AccessChain 27(data) 131 60
-             139:   23(fvec4) Load 138
-             140:   23(fvec4) VectorShuffle 139 137 4 5 2 3
+             139: 23(f64vec4) Load 138
+             140: 23(f64vec4) VectorShuffle 139 137 4 5 2 3
                               Store 138 140
              141:      6(int) Load 8(invocation)
              143:    133(ptr) AccessChain 27(data) 50 60
-             144:   23(fvec4) Load 143
-             145:  142(fvec3) VectorShuffle 144 144 0 1 2
-             146:  142(fvec3) GroupNonUniformFAdd 35 ClusteredReduce 145 34
+             144: 23(f64vec4) Load 143
+             145:142(f64vec3) VectorShuffle 144 144 0 1 2
+             146:142(f64vec3) GroupNonUniformFAdd 35 ClusteredReduce 145 34
              147:    133(ptr) AccessChain 27(data) 141 60
-             148:   23(fvec4) Load 147
-             149:   23(fvec4) VectorShuffle 148 146 4 5 6 3
+             148: 23(f64vec4) Load 147
+             149: 23(f64vec4) VectorShuffle 148 146 4 5 6 3
                               Store 147 149
              150:      6(int) Load 8(invocation)
              151:    133(ptr) AccessChain 27(data) 60 60
-             152:   23(fvec4) Load 151
-             153:   23(fvec4) GroupNonUniformFAdd 35 ClusteredReduce 152 34
+             152: 23(f64vec4) Load 151
+             153: 23(f64vec4) GroupNonUniformFAdd 35 ClusteredReduce 152 34
              154:    133(ptr) AccessChain 27(data) 150 60
                               Store 154 153
              155:      6(int) Load 8(invocation)
@@ -314,32 +314,32 @@ spv.subgroupClustered.comp
                               Store 232 231
              233:      6(int) Load 8(invocation)
              234:    126(ptr) AccessChain 27(data) 29 60 30
-             235:   22(float) Load 234
-             236:   22(float) GroupNonUniformFMul 35 ClusteredReduce 235 34
+             235:22(float64_t) Load 234
+             236:22(float64_t) GroupNonUniformFMul 35 ClusteredReduce 235 34
              237:    126(ptr) AccessChain 27(data) 233 60 30
                               Store 237 236
              238:      6(int) Load 8(invocation)
              239:    133(ptr) AccessChain 27(data) 39 60
-             240:   23(fvec4) Load 239
-             241:  132(fvec2) VectorShuffle 240 240 0 1
-             242:  132(fvec2) GroupNonUniformFMul 35 ClusteredReduce 241 34
+             240: 23(f64vec4) Load 239
+             241:132(f64vec2) VectorShuffle 240 240 0 1
+             242:132(f64vec2) GroupNonUniformFMul 35 ClusteredReduce 241 34
              243:    133(ptr) AccessChain 27(data) 238 60
-             244:   23(fvec4) Load 243
-             245:   23(fvec4) VectorShuffle 244 242 4 5 2 3
+             244: 23(f64vec4) Load 243
+             245: 23(f64vec4) VectorShuffle 244 242 4 5 2 3
                               Store 243 245
              246:      6(int) Load 8(invocation)
              247:    133(ptr) AccessChain 27(data) 50 60
-             248:   23(fvec4) Load 247
-             249:  142(fvec3) VectorShuffle 248 248 0 1 2
-             250:  142(fvec3) GroupNonUniformFMul 35 ClusteredReduce 249 34
+             248: 23(f64vec4) Load 247
+             249:142(f64vec3) VectorShuffle 248 248 0 1 2
+             250:142(f64vec3) GroupNonUniformFMul 35 ClusteredReduce 249 34
              251:    133(ptr) AccessChain 27(data) 246 60
-             252:   23(fvec4) Load 251
-             253:   23(fvec4) VectorShuffle 252 250 4 5 6 3
+             252: 23(f64vec4) Load 251
+             253: 23(f64vec4) VectorShuffle 252 250 4 5 6 3
                               Store 251 253
              254:      6(int) Load 8(invocation)
              255:    133(ptr) AccessChain 27(data) 60 60
-             256:   23(fvec4) Load 255
-             257:   23(fvec4) GroupNonUniformFMul 35 ClusteredReduce 256 34
+             256: 23(f64vec4) Load 255
+             257: 23(f64vec4) GroupNonUniformFMul 35 ClusteredReduce 256 34
              258:    133(ptr) AccessChain 27(data) 254 60
                               Store 258 257
              259:      6(int) Load 8(invocation)
@@ -434,32 +434,32 @@ spv.subgroupClustered.comp
                               Store 336 335
              337:      6(int) Load 8(invocation)
              338:    126(ptr) AccessChain 27(data) 29 60 30
-             339:   22(float) Load 338
-             340:   22(float) GroupNonUniformFMin 35 ClusteredReduce 339 34
+             339:22(float64_t) Load 338
+             340:22(float64_t) GroupNonUniformFMin 35 ClusteredReduce 339 34
              341:    126(ptr) AccessChain 27(data) 337 60 30
                               Store 341 340
              342:      6(int) Load 8(invocation)
              343:    133(ptr) AccessChain 27(data) 39 60
-             344:   23(fvec4) Load 343
-             345:  132(fvec2) VectorShuffle 344 344 0 1
-             346:  132(fvec2) GroupNonUniformFMin 35 ClusteredReduce 345 34
+             344: 23(f64vec4) Load 343
+             345:132(f64vec2) VectorShuffle 344 344 0 1
+             346:132(f64vec2) GroupNonUniformFMin 35 ClusteredReduce 345 34
              347:    133(ptr) AccessChain 27(data) 342 60
-             348:   23(fvec4) Load 347
-             349:   23(fvec4) VectorShuffle 348 346 4 5 2 3
+             348: 23(f64vec4) Load 347
+             349: 23(f64vec4) VectorShuffle 348 346 4 5 2 3
                               Store 347 349
              350:      6(int) Load 8(invocation)
              351:    133(ptr) AccessChain 27(data) 50 60
-             352:   23(fvec4) Load 351
-             353:  142(fvec3) VectorShuffle 352 352 0 1 2
-             354:  142(fvec3) GroupNonUniformFMin 35 ClusteredReduce 353 34
+             352: 23(f64vec4) Load 351
+             353:142(f64vec3) VectorShuffle 352 352 0 1 2
+             354:142(f64vec3) GroupNonUniformFMin 35 ClusteredReduce 353 34
              355:    133(ptr) AccessChain 27(data) 350 60
-             356:   23(fvec4) Load 355
-             357:   23(fvec4) VectorShuffle 356 354 4 5 6 3
+             356: 23(f64vec4) Load 355
+             357: 23(f64vec4) VectorShuffle 356 354 4 5 6 3
                               Store 355 357
              358:      6(int) Load 8(invocation)
              359:    133(ptr) AccessChain 27(data) 60 60
-             360:   23(fvec4) Load 359
-             361:   23(fvec4) GroupNonUniformFMin 35 ClusteredReduce 360 34
+             360: 23(f64vec4) Load 359
+             361: 23(f64vec4) GroupNonUniformFMin 35 ClusteredReduce 360 34
              362:    133(ptr) AccessChain 27(data) 358 60
                               Store 362 361
              363:      6(int) Load 8(invocation)
@@ -554,32 +554,32 @@ spv.subgroupClustered.comp
                               Store 440 439
              441:      6(int) Load 8(invocation)
              442:    126(ptr) AccessChain 27(data) 29 60 30
-             443:   22(float) Load 442
-             444:   22(float) GroupNonUniformFMax 35 ClusteredReduce 443 34
+             443:22(float64_t) Load 442
+             444:22(float64_t) GroupNonUniformFMax 35 ClusteredReduce 443 34
              445:    126(ptr) AccessChain 27(data) 441 60 30
                               Store 445 444
              446:      6(int) Load 8(invocation)
              447:    133(ptr) AccessChain 27(data) 39 60
-             448:   23(fvec4) Load 447
-             449:  132(fvec2) VectorShuffle 448 448 0 1
-             450:  132(fvec2) GroupNonUniformFMax 35 ClusteredReduce 449 34
+             448: 23(f64vec4) Load 447
+             449:132(f64vec2) VectorShuffle 448 448 0 1
+             450:132(f64vec2) GroupNonUniformFMax 35 ClusteredReduce 449 34
              451:    133(ptr) AccessChain 27(data) 446 60
-             452:   23(fvec4) Load 451
-             453:   23(fvec4) VectorShuffle 452 450 4 5 2 3
+             452: 23(f64vec4) Load 451
+             453: 23(f64vec4) VectorShuffle 452 450 4 5 2 3
                               Store 451 453
              454:      6(int) Load 8(invocation)
              455:    133(ptr) AccessChain 27(data) 50 60
-             456:   23(fvec4) Load 455
-             457:  142(fvec3) VectorShuffle 456 456 0 1 2
-             458:  142(fvec3) GroupNonUniformFMax 35 ClusteredReduce 457 34
+             456: 23(f64vec4) Load 455
+             457:142(f64vec3) VectorShuffle 456 456 0 1 2
+             458:142(f64vec3) GroupNonUniformFMax 35 ClusteredReduce 457 34
              459:    133(ptr) AccessChain 27(data) 454 60
-             460:   23(fvec4) Load 459
-             461:   23(fvec4) VectorShuffle 460 458 4 5 6 3
+             460: 23(f64vec4) Load 459
+             461: 23(f64vec4) VectorShuffle 460 458 4 5 6 3
                               Store 459 461
              462:      6(int) Load 8(invocation)
              463:    133(ptr) AccessChain 27(data) 60 60
-             464:   23(fvec4) Load 463
-             465:   23(fvec4) GroupNonUniformFMax 35 ClusteredReduce 464 34
+             464: 23(f64vec4) Load 463
+             465: 23(f64vec4) GroupNonUniformFMax 35 ClusteredReduce 464 34
              466:    133(ptr) AccessChain 27(data) 462 60
                               Store 466 465
              467:      6(int) Load 8(invocation)

--- a/Test/baseResults/spv.subgroupPartitioned.comp.out
+++ b/Test/baseResults/spv.subgroupPartitioned.comp.out
@@ -57,8 +57,8 @@ spv.subgroupPartitioned.comp
               24:             TypeInt 32 1
               25:             TypeVector 24(int) 4
               26:             TypeFloat 64
-              27:             TypeVector 26(float) 4
-     28(Buffers):             TypeStruct 23(fvec4) 25(ivec4) 17(ivec4) 27(fvec4)
+              27:             TypeVector 26(float64_t) 4
+     28(Buffers):             TypeStruct 23(fvec4) 25(ivec4) 17(ivec4) 27(f64vec4)
               29:             TypeArray 28(Buffers) 15
               30:             TypePointer Uniform 29
         31(data):     30(ptr) Variable Uniform
@@ -79,10 +79,10 @@ spv.subgroupPartitioned.comp
               96:             TypeVector 6(int) 2
              103:             TypeVector 6(int) 3
              115:     24(int) Constant 3
-             116:             TypePointer Uniform 26(float)
-             122:             TypeVector 26(float) 2
-             123:             TypePointer Uniform 27(fvec4)
-             130:             TypeVector 26(float) 3
+             116:             TypePointer Uniform 26(float64_t)
+             122:             TypeVector 26(float64_t) 2
+             123:             TypePointer Uniform 27(f64vec4)
+             130:             TypeVector 26(float64_t) 3
              144:             TypeBool
              152:             TypeVector 144(bool) 2
              153:   96(ivec2) ConstantComposite 35 35
@@ -192,27 +192,27 @@ spv.subgroupPartitioned.comp
                               Store 113 112
              114:      6(int) Load 8(invocation)
              117:    116(ptr) AccessChain 31(data) 34 115 35
-             118:   26(float) Load 117
+             118:26(float64_t) Load 117
              119:   17(ivec4) GroupNonUniformPartitionNV 118
              120:     40(ptr) AccessChain 31(data) 114 33
                               Store 120 119
              121:      6(int) Load 8(invocation)
              124:    123(ptr) AccessChain 31(data) 34 115
-             125:   27(fvec4) Load 124
-             126:  122(fvec2) VectorShuffle 125 125 0 1
+             125: 27(f64vec4) Load 124
+             126:122(f64vec2) VectorShuffle 125 125 0 1
              127:   17(ivec4) GroupNonUniformPartitionNV 126
              128:     40(ptr) AccessChain 31(data) 121 33
                               Store 128 127
              129:      6(int) Load 8(invocation)
              131:    123(ptr) AccessChain 31(data) 34 115
-             132:   27(fvec4) Load 131
-             133:  130(fvec3) VectorShuffle 132 132 0 1 2
+             132: 27(f64vec4) Load 131
+             133:130(f64vec3) VectorShuffle 132 132 0 1 2
              134:   17(ivec4) GroupNonUniformPartitionNV 133
              135:     40(ptr) AccessChain 31(data) 129 33
                               Store 135 134
              136:      6(int) Load 8(invocation)
              137:    123(ptr) AccessChain 31(data) 34 115
-             138:   27(fvec4) Load 137
+             138: 27(f64vec4) Load 137
              139:   17(ivec4) GroupNonUniformPartitionNV 138
              140:     40(ptr) AccessChain 31(data) 136 33
                               Store 140 139
@@ -350,36 +350,36 @@ spv.subgroupPartitioned.comp
                               Store 264 263
              265:      6(int) Load 8(invocation)
              266:    116(ptr) AccessChain 31(data) 34 115 35
-             267:   26(float) Load 266
+             267:26(float64_t) Load 266
              268:   17(ivec4) Load 19(ballot)
-             269:   26(float) GroupNonUniformFAdd 178 PartitionedReduceNV 267 268
+             269:26(float64_t) GroupNonUniformFAdd 178 PartitionedReduceNV 267 268
              270:    116(ptr) AccessChain 31(data) 265 115 35
                               Store 270 269
              271:      6(int) Load 8(invocation)
              272:    123(ptr) AccessChain 31(data) 63 115
-             273:   27(fvec4) Load 272
-             274:  122(fvec2) VectorShuffle 273 273 0 1
+             273: 27(f64vec4) Load 272
+             274:122(f64vec2) VectorShuffle 273 273 0 1
              275:   17(ivec4) Load 19(ballot)
-             276:  122(fvec2) GroupNonUniformFAdd 178 PartitionedReduceNV 274 275
+             276:122(f64vec2) GroupNonUniformFAdd 178 PartitionedReduceNV 274 275
              277:    123(ptr) AccessChain 31(data) 271 115
-             278:   27(fvec4) Load 277
-             279:   27(fvec4) VectorShuffle 278 276 4 5 2 3
+             278: 27(f64vec4) Load 277
+             279: 27(f64vec4) VectorShuffle 278 276 4 5 2 3
                               Store 277 279
              280:      6(int) Load 8(invocation)
              281:    123(ptr) AccessChain 31(data) 33 115
-             282:   27(fvec4) Load 281
-             283:  130(fvec3) VectorShuffle 282 282 0 1 2
+             282: 27(f64vec4) Load 281
+             283:130(f64vec3) VectorShuffle 282 282 0 1 2
              284:   17(ivec4) Load 19(ballot)
-             285:  130(fvec3) GroupNonUniformFAdd 178 PartitionedReduceNV 283 284
+             285:130(f64vec3) GroupNonUniformFAdd 178 PartitionedReduceNV 283 284
              286:    123(ptr) AccessChain 31(data) 280 115
-             287:   27(fvec4) Load 286
-             288:   27(fvec4) VectorShuffle 287 285 4 5 6 3
+             287: 27(f64vec4) Load 286
+             288: 27(f64vec4) VectorShuffle 287 285 4 5 6 3
                               Store 286 288
              289:      6(int) Load 8(invocation)
              290:    123(ptr) AccessChain 31(data) 115 115
-             291:   27(fvec4) Load 290
+             291: 27(f64vec4) Load 290
              292:   17(ivec4) Load 19(ballot)
-             293:   27(fvec4) GroupNonUniformFAdd 178 PartitionedReduceNV 291 292
+             293: 27(f64vec4) GroupNonUniformFAdd 178 PartitionedReduceNV 291 292
              294:    123(ptr) AccessChain 31(data) 289 115
                               Store 294 293
              295:      6(int) Load 8(invocation)
@@ -486,36 +486,36 @@ spv.subgroupPartitioned.comp
                               Store 384 383
              385:      6(int) Load 8(invocation)
              386:    116(ptr) AccessChain 31(data) 34 115 35
-             387:   26(float) Load 386
+             387:26(float64_t) Load 386
              388:   17(ivec4) Load 19(ballot)
-             389:   26(float) GroupNonUniformFMul 178 PartitionedReduceNV 387 388
+             389:26(float64_t) GroupNonUniformFMul 178 PartitionedReduceNV 387 388
              390:    116(ptr) AccessChain 31(data) 385 115 35
                               Store 390 389
              391:      6(int) Load 8(invocation)
              392:    123(ptr) AccessChain 31(data) 63 115
-             393:   27(fvec4) Load 392
-             394:  122(fvec2) VectorShuffle 393 393 0 1
+             393: 27(f64vec4) Load 392
+             394:122(f64vec2) VectorShuffle 393 393 0 1
              395:   17(ivec4) Load 19(ballot)
-             396:  122(fvec2) GroupNonUniformFMul 178 PartitionedReduceNV 394 395
+             396:122(f64vec2) GroupNonUniformFMul 178 PartitionedReduceNV 394 395
              397:    123(ptr) AccessChain 31(data) 391 115
-             398:   27(fvec4) Load 397
-             399:   27(fvec4) VectorShuffle 398 396 4 5 2 3
+             398: 27(f64vec4) Load 397
+             399: 27(f64vec4) VectorShuffle 398 396 4 5 2 3
                               Store 397 399
              400:      6(int) Load 8(invocation)
              401:    123(ptr) AccessChain 31(data) 33 115
-             402:   27(fvec4) Load 401
-             403:  130(fvec3) VectorShuffle 402 402 0 1 2
+             402: 27(f64vec4) Load 401
+             403:130(f64vec3) VectorShuffle 402 402 0 1 2
              404:   17(ivec4) Load 19(ballot)
-             405:  130(fvec3) GroupNonUniformFMul 178 PartitionedReduceNV 403 404
+             405:130(f64vec3) GroupNonUniformFMul 178 PartitionedReduceNV 403 404
              406:    123(ptr) AccessChain 31(data) 400 115
-             407:   27(fvec4) Load 406
-             408:   27(fvec4) VectorShuffle 407 405 4 5 6 3
+             407: 27(f64vec4) Load 406
+             408: 27(f64vec4) VectorShuffle 407 405 4 5 6 3
                               Store 406 408
              409:      6(int) Load 8(invocation)
              410:    123(ptr) AccessChain 31(data) 115 115
-             411:   27(fvec4) Load 410
+             411: 27(f64vec4) Load 410
              412:   17(ivec4) Load 19(ballot)
-             413:   27(fvec4) GroupNonUniformFMul 178 PartitionedReduceNV 411 412
+             413: 27(f64vec4) GroupNonUniformFMul 178 PartitionedReduceNV 411 412
              414:    123(ptr) AccessChain 31(data) 409 115
                               Store 414 413
              415:      6(int) Load 8(invocation)
@@ -622,36 +622,36 @@ spv.subgroupPartitioned.comp
                               Store 504 503
              505:      6(int) Load 8(invocation)
              506:    116(ptr) AccessChain 31(data) 34 115 35
-             507:   26(float) Load 506
+             507:26(float64_t) Load 506
              508:   17(ivec4) Load 19(ballot)
-             509:   26(float) GroupNonUniformFMin 178 PartitionedReduceNV 507 508
+             509:26(float64_t) GroupNonUniformFMin 178 PartitionedReduceNV 507 508
              510:    116(ptr) AccessChain 31(data) 505 115 35
                               Store 510 509
              511:      6(int) Load 8(invocation)
              512:    123(ptr) AccessChain 31(data) 63 115
-             513:   27(fvec4) Load 512
-             514:  122(fvec2) VectorShuffle 513 513 0 1
+             513: 27(f64vec4) Load 512
+             514:122(f64vec2) VectorShuffle 513 513 0 1
              515:   17(ivec4) Load 19(ballot)
-             516:  122(fvec2) GroupNonUniformFMin 178 PartitionedReduceNV 514 515
+             516:122(f64vec2) GroupNonUniformFMin 178 PartitionedReduceNV 514 515
              517:    123(ptr) AccessChain 31(data) 511 115
-             518:   27(fvec4) Load 517
-             519:   27(fvec4) VectorShuffle 518 516 4 5 2 3
+             518: 27(f64vec4) Load 517
+             519: 27(f64vec4) VectorShuffle 518 516 4 5 2 3
                               Store 517 519
              520:      6(int) Load 8(invocation)
              521:    123(ptr) AccessChain 31(data) 33 115
-             522:   27(fvec4) Load 521
-             523:  130(fvec3) VectorShuffle 522 522 0 1 2
+             522: 27(f64vec4) Load 521
+             523:130(f64vec3) VectorShuffle 522 522 0 1 2
              524:   17(ivec4) Load 19(ballot)
-             525:  130(fvec3) GroupNonUniformFMin 178 PartitionedReduceNV 523 524
+             525:130(f64vec3) GroupNonUniformFMin 178 PartitionedReduceNV 523 524
              526:    123(ptr) AccessChain 31(data) 520 115
-             527:   27(fvec4) Load 526
-             528:   27(fvec4) VectorShuffle 527 525 4 5 6 3
+             527: 27(f64vec4) Load 526
+             528: 27(f64vec4) VectorShuffle 527 525 4 5 6 3
                               Store 526 528
              529:      6(int) Load 8(invocation)
              530:    123(ptr) AccessChain 31(data) 115 115
-             531:   27(fvec4) Load 530
+             531: 27(f64vec4) Load 530
              532:   17(ivec4) Load 19(ballot)
-             533:   27(fvec4) GroupNonUniformFMin 178 PartitionedReduceNV 531 532
+             533: 27(f64vec4) GroupNonUniformFMin 178 PartitionedReduceNV 531 532
              534:    123(ptr) AccessChain 31(data) 529 115
                               Store 534 533
              535:      6(int) Load 8(invocation)
@@ -758,36 +758,36 @@ spv.subgroupPartitioned.comp
                               Store 624 623
              625:      6(int) Load 8(invocation)
              626:    116(ptr) AccessChain 31(data) 34 115 35
-             627:   26(float) Load 626
+             627:26(float64_t) Load 626
              628:   17(ivec4) Load 19(ballot)
-             629:   26(float) GroupNonUniformFMax 178 PartitionedReduceNV 627 628
+             629:26(float64_t) GroupNonUniformFMax 178 PartitionedReduceNV 627 628
              630:    116(ptr) AccessChain 31(data) 625 115 35
                               Store 630 629
              631:      6(int) Load 8(invocation)
              632:    123(ptr) AccessChain 31(data) 63 115
-             633:   27(fvec4) Load 632
-             634:  122(fvec2) VectorShuffle 633 633 0 1
+             633: 27(f64vec4) Load 632
+             634:122(f64vec2) VectorShuffle 633 633 0 1
              635:   17(ivec4) Load 19(ballot)
-             636:  122(fvec2) GroupNonUniformFMax 178 PartitionedReduceNV 634 635
+             636:122(f64vec2) GroupNonUniformFMax 178 PartitionedReduceNV 634 635
              637:    123(ptr) AccessChain 31(data) 631 115
-             638:   27(fvec4) Load 637
-             639:   27(fvec4) VectorShuffle 638 636 4 5 2 3
+             638: 27(f64vec4) Load 637
+             639: 27(f64vec4) VectorShuffle 638 636 4 5 2 3
                               Store 637 639
              640:      6(int) Load 8(invocation)
              641:    123(ptr) AccessChain 31(data) 33 115
-             642:   27(fvec4) Load 641
-             643:  130(fvec3) VectorShuffle 642 642 0 1 2
+             642: 27(f64vec4) Load 641
+             643:130(f64vec3) VectorShuffle 642 642 0 1 2
              644:   17(ivec4) Load 19(ballot)
-             645:  130(fvec3) GroupNonUniformFMax 178 PartitionedReduceNV 643 644
+             645:130(f64vec3) GroupNonUniformFMax 178 PartitionedReduceNV 643 644
              646:    123(ptr) AccessChain 31(data) 640 115
-             647:   27(fvec4) Load 646
-             648:   27(fvec4) VectorShuffle 647 645 4 5 6 3
+             647: 27(f64vec4) Load 646
+             648: 27(f64vec4) VectorShuffle 647 645 4 5 6 3
                               Store 646 648
              649:      6(int) Load 8(invocation)
              650:    123(ptr) AccessChain 31(data) 115 115
-             651:   27(fvec4) Load 650
+             651: 27(f64vec4) Load 650
              652:   17(ivec4) Load 19(ballot)
-             653:   27(fvec4) GroupNonUniformFMax 178 PartitionedReduceNV 651 652
+             653: 27(f64vec4) GroupNonUniformFMax 178 PartitionedReduceNV 651 652
              654:    123(ptr) AccessChain 31(data) 649 115
                               Store 654 653
              655:      6(int) Load 8(invocation)
@@ -1224,36 +1224,36 @@ spv.subgroupPartitioned.comp
                               Store 1044 1043
             1045:      6(int) Load 8(invocation)
             1046:    116(ptr) AccessChain 31(data) 34 115 35
-            1047:   26(float) Load 1046
+            1047:26(float64_t) Load 1046
             1048:   17(ivec4) Load 19(ballot)
-            1049:   26(float) GroupNonUniformFAdd 178 PartitionedInclusiveScanNV 1047 1048
+            1049:26(float64_t) GroupNonUniformFAdd 178 PartitionedInclusiveScanNV 1047 1048
             1050:    116(ptr) AccessChain 31(data) 1045 115 35
                               Store 1050 1049
             1051:      6(int) Load 8(invocation)
             1052:    123(ptr) AccessChain 31(data) 63 115
-            1053:   27(fvec4) Load 1052
-            1054:  122(fvec2) VectorShuffle 1053 1053 0 1
+            1053: 27(f64vec4) Load 1052
+            1054:122(f64vec2) VectorShuffle 1053 1053 0 1
             1055:   17(ivec4) Load 19(ballot)
-            1056:  122(fvec2) GroupNonUniformFAdd 178 PartitionedInclusiveScanNV 1054 1055
+            1056:122(f64vec2) GroupNonUniformFAdd 178 PartitionedInclusiveScanNV 1054 1055
             1057:    123(ptr) AccessChain 31(data) 1051 115
-            1058:   27(fvec4) Load 1057
-            1059:   27(fvec4) VectorShuffle 1058 1056 4 5 2 3
+            1058: 27(f64vec4) Load 1057
+            1059: 27(f64vec4) VectorShuffle 1058 1056 4 5 2 3
                               Store 1057 1059
             1060:      6(int) Load 8(invocation)
             1061:    123(ptr) AccessChain 31(data) 33 115
-            1062:   27(fvec4) Load 1061
-            1063:  130(fvec3) VectorShuffle 1062 1062 0 1 2
+            1062: 27(f64vec4) Load 1061
+            1063:130(f64vec3) VectorShuffle 1062 1062 0 1 2
             1064:   17(ivec4) Load 19(ballot)
-            1065:  130(fvec3) GroupNonUniformFAdd 178 PartitionedInclusiveScanNV 1063 1064
+            1065:130(f64vec3) GroupNonUniformFAdd 178 PartitionedInclusiveScanNV 1063 1064
             1066:    123(ptr) AccessChain 31(data) 1060 115
-            1067:   27(fvec4) Load 1066
-            1068:   27(fvec4) VectorShuffle 1067 1065 4 5 6 3
+            1067: 27(f64vec4) Load 1066
+            1068: 27(f64vec4) VectorShuffle 1067 1065 4 5 6 3
                               Store 1066 1068
             1069:      6(int) Load 8(invocation)
             1070:    123(ptr) AccessChain 31(data) 115 115
-            1071:   27(fvec4) Load 1070
+            1071: 27(f64vec4) Load 1070
             1072:   17(ivec4) Load 19(ballot)
-            1073:   27(fvec4) GroupNonUniformFAdd 178 PartitionedInclusiveScanNV 1071 1072
+            1073: 27(f64vec4) GroupNonUniformFAdd 178 PartitionedInclusiveScanNV 1071 1072
             1074:    123(ptr) AccessChain 31(data) 1069 115
                               Store 1074 1073
             1075:      6(int) Load 8(invocation)
@@ -1360,36 +1360,36 @@ spv.subgroupPartitioned.comp
                               Store 1164 1163
             1165:      6(int) Load 8(invocation)
             1166:    116(ptr) AccessChain 31(data) 34 115 35
-            1167:   26(float) Load 1166
+            1167:26(float64_t) Load 1166
             1168:   17(ivec4) Load 19(ballot)
-            1169:   26(float) GroupNonUniformFMul 178 PartitionedInclusiveScanNV 1167 1168
+            1169:26(float64_t) GroupNonUniformFMul 178 PartitionedInclusiveScanNV 1167 1168
             1170:    116(ptr) AccessChain 31(data) 1165 115 35
                               Store 1170 1169
             1171:      6(int) Load 8(invocation)
             1172:    123(ptr) AccessChain 31(data) 63 115
-            1173:   27(fvec4) Load 1172
-            1174:  122(fvec2) VectorShuffle 1173 1173 0 1
+            1173: 27(f64vec4) Load 1172
+            1174:122(f64vec2) VectorShuffle 1173 1173 0 1
             1175:   17(ivec4) Load 19(ballot)
-            1176:  122(fvec2) GroupNonUniformFMul 178 PartitionedInclusiveScanNV 1174 1175
+            1176:122(f64vec2) GroupNonUniformFMul 178 PartitionedInclusiveScanNV 1174 1175
             1177:    123(ptr) AccessChain 31(data) 1171 115
-            1178:   27(fvec4) Load 1177
-            1179:   27(fvec4) VectorShuffle 1178 1176 4 5 2 3
+            1178: 27(f64vec4) Load 1177
+            1179: 27(f64vec4) VectorShuffle 1178 1176 4 5 2 3
                               Store 1177 1179
             1180:      6(int) Load 8(invocation)
             1181:    123(ptr) AccessChain 31(data) 33 115
-            1182:   27(fvec4) Load 1181
-            1183:  130(fvec3) VectorShuffle 1182 1182 0 1 2
+            1182: 27(f64vec4) Load 1181
+            1183:130(f64vec3) VectorShuffle 1182 1182 0 1 2
             1184:   17(ivec4) Load 19(ballot)
-            1185:  130(fvec3) GroupNonUniformFMul 178 PartitionedInclusiveScanNV 1183 1184
+            1185:130(f64vec3) GroupNonUniformFMul 178 PartitionedInclusiveScanNV 1183 1184
             1186:    123(ptr) AccessChain 31(data) 1180 115
-            1187:   27(fvec4) Load 1186
-            1188:   27(fvec4) VectorShuffle 1187 1185 4 5 6 3
+            1187: 27(f64vec4) Load 1186
+            1188: 27(f64vec4) VectorShuffle 1187 1185 4 5 6 3
                               Store 1186 1188
             1189:      6(int) Load 8(invocation)
             1190:    123(ptr) AccessChain 31(data) 115 115
-            1191:   27(fvec4) Load 1190
+            1191: 27(f64vec4) Load 1190
             1192:   17(ivec4) Load 19(ballot)
-            1193:   27(fvec4) GroupNonUniformFMul 178 PartitionedInclusiveScanNV 1191 1192
+            1193: 27(f64vec4) GroupNonUniformFMul 178 PartitionedInclusiveScanNV 1191 1192
             1194:    123(ptr) AccessChain 31(data) 1189 115
                               Store 1194 1193
             1195:      6(int) Load 8(invocation)
@@ -1496,36 +1496,36 @@ spv.subgroupPartitioned.comp
                               Store 1284 1283
             1285:      6(int) Load 8(invocation)
             1286:    116(ptr) AccessChain 31(data) 34 115 35
-            1287:   26(float) Load 1286
+            1287:26(float64_t) Load 1286
             1288:   17(ivec4) Load 19(ballot)
-            1289:   26(float) GroupNonUniformFMin 178 PartitionedInclusiveScanNV 1287 1288
+            1289:26(float64_t) GroupNonUniformFMin 178 PartitionedInclusiveScanNV 1287 1288
             1290:    116(ptr) AccessChain 31(data) 1285 115 35
                               Store 1290 1289
             1291:      6(int) Load 8(invocation)
             1292:    123(ptr) AccessChain 31(data) 63 115
-            1293:   27(fvec4) Load 1292
-            1294:  122(fvec2) VectorShuffle 1293 1293 0 1
+            1293: 27(f64vec4) Load 1292
+            1294:122(f64vec2) VectorShuffle 1293 1293 0 1
             1295:   17(ivec4) Load 19(ballot)
-            1296:  122(fvec2) GroupNonUniformFMin 178 PartitionedInclusiveScanNV 1294 1295
+            1296:122(f64vec2) GroupNonUniformFMin 178 PartitionedInclusiveScanNV 1294 1295
             1297:    123(ptr) AccessChain 31(data) 1291 115
-            1298:   27(fvec4) Load 1297
-            1299:   27(fvec4) VectorShuffle 1298 1296 4 5 2 3
+            1298: 27(f64vec4) Load 1297
+            1299: 27(f64vec4) VectorShuffle 1298 1296 4 5 2 3
                               Store 1297 1299
             1300:      6(int) Load 8(invocation)
             1301:    123(ptr) AccessChain 31(data) 33 115
-            1302:   27(fvec4) Load 1301
-            1303:  130(fvec3) VectorShuffle 1302 1302 0 1 2
+            1302: 27(f64vec4) Load 1301
+            1303:130(f64vec3) VectorShuffle 1302 1302 0 1 2
             1304:   17(ivec4) Load 19(ballot)
-            1305:  130(fvec3) GroupNonUniformFMin 178 PartitionedInclusiveScanNV 1303 1304
+            1305:130(f64vec3) GroupNonUniformFMin 178 PartitionedInclusiveScanNV 1303 1304
             1306:    123(ptr) AccessChain 31(data) 1300 115
-            1307:   27(fvec4) Load 1306
-            1308:   27(fvec4) VectorShuffle 1307 1305 4 5 6 3
+            1307: 27(f64vec4) Load 1306
+            1308: 27(f64vec4) VectorShuffle 1307 1305 4 5 6 3
                               Store 1306 1308
             1309:      6(int) Load 8(invocation)
             1310:    123(ptr) AccessChain 31(data) 115 115
-            1311:   27(fvec4) Load 1310
+            1311: 27(f64vec4) Load 1310
             1312:   17(ivec4) Load 19(ballot)
-            1313:   27(fvec4) GroupNonUniformFMin 178 PartitionedInclusiveScanNV 1311 1312
+            1313: 27(f64vec4) GroupNonUniformFMin 178 PartitionedInclusiveScanNV 1311 1312
             1314:    123(ptr) AccessChain 31(data) 1309 115
                               Store 1314 1313
             1315:      6(int) Load 8(invocation)
@@ -1632,36 +1632,36 @@ spv.subgroupPartitioned.comp
                               Store 1404 1403
             1405:      6(int) Load 8(invocation)
             1406:    116(ptr) AccessChain 31(data) 34 115 35
-            1407:   26(float) Load 1406
+            1407:26(float64_t) Load 1406
             1408:   17(ivec4) Load 19(ballot)
-            1409:   26(float) GroupNonUniformFMax 178 PartitionedInclusiveScanNV 1407 1408
+            1409:26(float64_t) GroupNonUniformFMax 178 PartitionedInclusiveScanNV 1407 1408
             1410:    116(ptr) AccessChain 31(data) 1405 115 35
                               Store 1410 1409
             1411:      6(int) Load 8(invocation)
             1412:    123(ptr) AccessChain 31(data) 63 115
-            1413:   27(fvec4) Load 1412
-            1414:  122(fvec2) VectorShuffle 1413 1413 0 1
+            1413: 27(f64vec4) Load 1412
+            1414:122(f64vec2) VectorShuffle 1413 1413 0 1
             1415:   17(ivec4) Load 19(ballot)
-            1416:  122(fvec2) GroupNonUniformFMax 178 PartitionedInclusiveScanNV 1414 1415
+            1416:122(f64vec2) GroupNonUniformFMax 178 PartitionedInclusiveScanNV 1414 1415
             1417:    123(ptr) AccessChain 31(data) 1411 115
-            1418:   27(fvec4) Load 1417
-            1419:   27(fvec4) VectorShuffle 1418 1416 4 5 2 3
+            1418: 27(f64vec4) Load 1417
+            1419: 27(f64vec4) VectorShuffle 1418 1416 4 5 2 3
                               Store 1417 1419
             1420:      6(int) Load 8(invocation)
             1421:    123(ptr) AccessChain 31(data) 33 115
-            1422:   27(fvec4) Load 1421
-            1423:  130(fvec3) VectorShuffle 1422 1422 0 1 2
+            1422: 27(f64vec4) Load 1421
+            1423:130(f64vec3) VectorShuffle 1422 1422 0 1 2
             1424:   17(ivec4) Load 19(ballot)
-            1425:  130(fvec3) GroupNonUniformFMax 178 PartitionedInclusiveScanNV 1423 1424
+            1425:130(f64vec3) GroupNonUniformFMax 178 PartitionedInclusiveScanNV 1423 1424
             1426:    123(ptr) AccessChain 31(data) 1420 115
-            1427:   27(fvec4) Load 1426
-            1428:   27(fvec4) VectorShuffle 1427 1425 4 5 6 3
+            1427: 27(f64vec4) Load 1426
+            1428: 27(f64vec4) VectorShuffle 1427 1425 4 5 6 3
                               Store 1426 1428
             1429:      6(int) Load 8(invocation)
             1430:    123(ptr) AccessChain 31(data) 115 115
-            1431:   27(fvec4) Load 1430
+            1431: 27(f64vec4) Load 1430
             1432:   17(ivec4) Load 19(ballot)
-            1433:   27(fvec4) GroupNonUniformFMax 178 PartitionedInclusiveScanNV 1431 1432
+            1433: 27(f64vec4) GroupNonUniformFMax 178 PartitionedInclusiveScanNV 1431 1432
             1434:    123(ptr) AccessChain 31(data) 1429 115
                               Store 1434 1433
             1435:      6(int) Load 8(invocation)
@@ -2098,36 +2098,36 @@ spv.subgroupPartitioned.comp
                               Store 1818 1817
             1819:      6(int) Load 8(invocation)
             1820:    116(ptr) AccessChain 31(data) 34 115 35
-            1821:   26(float) Load 1820
+            1821:26(float64_t) Load 1820
             1822:   17(ivec4) Load 19(ballot)
-            1823:   26(float) GroupNonUniformFAdd 178 PartitionedExclusiveScanNV 1821 1822
+            1823:26(float64_t) GroupNonUniformFAdd 178 PartitionedExclusiveScanNV 1821 1822
             1824:    116(ptr) AccessChain 31(data) 1819 115 35
                               Store 1824 1823
             1825:      6(int) Load 8(invocation)
             1826:    123(ptr) AccessChain 31(data) 63 115
-            1827:   27(fvec4) Load 1826
-            1828:  122(fvec2) VectorShuffle 1827 1827 0 1
+            1827: 27(f64vec4) Load 1826
+            1828:122(f64vec2) VectorShuffle 1827 1827 0 1
             1829:   17(ivec4) Load 19(ballot)
-            1830:  122(fvec2) GroupNonUniformFAdd 178 PartitionedExclusiveScanNV 1828 1829
+            1830:122(f64vec2) GroupNonUniformFAdd 178 PartitionedExclusiveScanNV 1828 1829
             1831:    123(ptr) AccessChain 31(data) 1825 115
-            1832:   27(fvec4) Load 1831
-            1833:   27(fvec4) VectorShuffle 1832 1830 4 5 2 3
+            1832: 27(f64vec4) Load 1831
+            1833: 27(f64vec4) VectorShuffle 1832 1830 4 5 2 3
                               Store 1831 1833
             1834:      6(int) Load 8(invocation)
             1835:    123(ptr) AccessChain 31(data) 33 115
-            1836:   27(fvec4) Load 1835
-            1837:  130(fvec3) VectorShuffle 1836 1836 0 1 2
+            1836: 27(f64vec4) Load 1835
+            1837:130(f64vec3) VectorShuffle 1836 1836 0 1 2
             1838:   17(ivec4) Load 19(ballot)
-            1839:  130(fvec3) GroupNonUniformFAdd 178 PartitionedExclusiveScanNV 1837 1838
+            1839:130(f64vec3) GroupNonUniformFAdd 178 PartitionedExclusiveScanNV 1837 1838
             1840:    123(ptr) AccessChain 31(data) 1834 115
-            1841:   27(fvec4) Load 1840
-            1842:   27(fvec4) VectorShuffle 1841 1839 4 5 6 3
+            1841: 27(f64vec4) Load 1840
+            1842: 27(f64vec4) VectorShuffle 1841 1839 4 5 6 3
                               Store 1840 1842
             1843:      6(int) Load 8(invocation)
             1844:    123(ptr) AccessChain 31(data) 115 115
-            1845:   27(fvec4) Load 1844
+            1845: 27(f64vec4) Load 1844
             1846:   17(ivec4) Load 19(ballot)
-            1847:   27(fvec4) GroupNonUniformFAdd 178 PartitionedExclusiveScanNV 1845 1846
+            1847: 27(f64vec4) GroupNonUniformFAdd 178 PartitionedExclusiveScanNV 1845 1846
             1848:    123(ptr) AccessChain 31(data) 1843 115
                               Store 1848 1847
             1849:      6(int) Load 8(invocation)
@@ -2234,36 +2234,36 @@ spv.subgroupPartitioned.comp
                               Store 1938 1937
             1939:      6(int) Load 8(invocation)
             1940:    116(ptr) AccessChain 31(data) 34 115 35
-            1941:   26(float) Load 1940
+            1941:26(float64_t) Load 1940
             1942:   17(ivec4) Load 19(ballot)
-            1943:   26(float) GroupNonUniformFMul 178 PartitionedExclusiveScanNV 1941 1942
+            1943:26(float64_t) GroupNonUniformFMul 178 PartitionedExclusiveScanNV 1941 1942
             1944:    116(ptr) AccessChain 31(data) 1939 115 35
                               Store 1944 1943
             1945:      6(int) Load 8(invocation)
             1946:    123(ptr) AccessChain 31(data) 63 115
-            1947:   27(fvec4) Load 1946
-            1948:  122(fvec2) VectorShuffle 1947 1947 0 1
+            1947: 27(f64vec4) Load 1946
+            1948:122(f64vec2) VectorShuffle 1947 1947 0 1
             1949:   17(ivec4) Load 19(ballot)
-            1950:  122(fvec2) GroupNonUniformFMul 178 PartitionedExclusiveScanNV 1948 1949
+            1950:122(f64vec2) GroupNonUniformFMul 178 PartitionedExclusiveScanNV 1948 1949
             1951:    123(ptr) AccessChain 31(data) 1945 115
-            1952:   27(fvec4) Load 1951
-            1953:   27(fvec4) VectorShuffle 1952 1950 4 5 2 3
+            1952: 27(f64vec4) Load 1951
+            1953: 27(f64vec4) VectorShuffle 1952 1950 4 5 2 3
                               Store 1951 1953
             1954:      6(int) Load 8(invocation)
             1955:    123(ptr) AccessChain 31(data) 33 115
-            1956:   27(fvec4) Load 1955
-            1957:  130(fvec3) VectorShuffle 1956 1956 0 1 2
+            1956: 27(f64vec4) Load 1955
+            1957:130(f64vec3) VectorShuffle 1956 1956 0 1 2
             1958:   17(ivec4) Load 19(ballot)
-            1959:  130(fvec3) GroupNonUniformFMul 178 PartitionedExclusiveScanNV 1957 1958
+            1959:130(f64vec3) GroupNonUniformFMul 178 PartitionedExclusiveScanNV 1957 1958
             1960:    123(ptr) AccessChain 31(data) 1954 115
-            1961:   27(fvec4) Load 1960
-            1962:   27(fvec4) VectorShuffle 1961 1959 4 5 6 3
+            1961: 27(f64vec4) Load 1960
+            1962: 27(f64vec4) VectorShuffle 1961 1959 4 5 6 3
                               Store 1960 1962
             1963:      6(int) Load 8(invocation)
             1964:    123(ptr) AccessChain 31(data) 115 115
-            1965:   27(fvec4) Load 1964
+            1965: 27(f64vec4) Load 1964
             1966:   17(ivec4) Load 19(ballot)
-            1967:   27(fvec4) GroupNonUniformFMul 178 PartitionedExclusiveScanNV 1965 1966
+            1967: 27(f64vec4) GroupNonUniformFMul 178 PartitionedExclusiveScanNV 1965 1966
             1968:    123(ptr) AccessChain 31(data) 1963 115
                               Store 1968 1967
             1969:      6(int) Load 8(invocation)
@@ -2370,36 +2370,36 @@ spv.subgroupPartitioned.comp
                               Store 2058 2057
             2059:      6(int) Load 8(invocation)
             2060:    116(ptr) AccessChain 31(data) 34 115 35
-            2061:   26(float) Load 2060
+            2061:26(float64_t) Load 2060
             2062:   17(ivec4) Load 19(ballot)
-            2063:   26(float) GroupNonUniformFMin 178 PartitionedExclusiveScanNV 2061 2062
+            2063:26(float64_t) GroupNonUniformFMin 178 PartitionedExclusiveScanNV 2061 2062
             2064:    116(ptr) AccessChain 31(data) 2059 115 35
                               Store 2064 2063
             2065:      6(int) Load 8(invocation)
             2066:    123(ptr) AccessChain 31(data) 63 115
-            2067:   27(fvec4) Load 2066
-            2068:  122(fvec2) VectorShuffle 2067 2067 0 1
+            2067: 27(f64vec4) Load 2066
+            2068:122(f64vec2) VectorShuffle 2067 2067 0 1
             2069:   17(ivec4) Load 19(ballot)
-            2070:  122(fvec2) GroupNonUniformFMin 178 PartitionedExclusiveScanNV 2068 2069
+            2070:122(f64vec2) GroupNonUniformFMin 178 PartitionedExclusiveScanNV 2068 2069
             2071:    123(ptr) AccessChain 31(data) 2065 115
-            2072:   27(fvec4) Load 2071
-            2073:   27(fvec4) VectorShuffle 2072 2070 4 5 2 3
+            2072: 27(f64vec4) Load 2071
+            2073: 27(f64vec4) VectorShuffle 2072 2070 4 5 2 3
                               Store 2071 2073
             2074:      6(int) Load 8(invocation)
             2075:    123(ptr) AccessChain 31(data) 33 115
-            2076:   27(fvec4) Load 2075
-            2077:  130(fvec3) VectorShuffle 2076 2076 0 1 2
+            2076: 27(f64vec4) Load 2075
+            2077:130(f64vec3) VectorShuffle 2076 2076 0 1 2
             2078:   17(ivec4) Load 19(ballot)
-            2079:  130(fvec3) GroupNonUniformFMin 178 PartitionedExclusiveScanNV 2077 2078
+            2079:130(f64vec3) GroupNonUniformFMin 178 PartitionedExclusiveScanNV 2077 2078
             2080:    123(ptr) AccessChain 31(data) 2074 115
-            2081:   27(fvec4) Load 2080
-            2082:   27(fvec4) VectorShuffle 2081 2079 4 5 6 3
+            2081: 27(f64vec4) Load 2080
+            2082: 27(f64vec4) VectorShuffle 2081 2079 4 5 6 3
                               Store 2080 2082
             2083:      6(int) Load 8(invocation)
             2084:    123(ptr) AccessChain 31(data) 115 115
-            2085:   27(fvec4) Load 2084
+            2085: 27(f64vec4) Load 2084
             2086:   17(ivec4) Load 19(ballot)
-            2087:   27(fvec4) GroupNonUniformFMin 178 PartitionedExclusiveScanNV 2085 2086
+            2087: 27(f64vec4) GroupNonUniformFMin 178 PartitionedExclusiveScanNV 2085 2086
             2088:    123(ptr) AccessChain 31(data) 2083 115
                               Store 2088 2087
             2089:      6(int) Load 8(invocation)
@@ -2506,36 +2506,36 @@ spv.subgroupPartitioned.comp
                               Store 2178 2177
             2179:      6(int) Load 8(invocation)
             2180:    116(ptr) AccessChain 31(data) 34 115 35
-            2181:   26(float) Load 2180
+            2181:26(float64_t) Load 2180
             2182:   17(ivec4) Load 19(ballot)
-            2183:   26(float) GroupNonUniformFMax 178 PartitionedExclusiveScanNV 2181 2182
+            2183:26(float64_t) GroupNonUniformFMax 178 PartitionedExclusiveScanNV 2181 2182
             2184:    116(ptr) AccessChain 31(data) 2179 115 35
                               Store 2184 2183
             2185:      6(int) Load 8(invocation)
             2186:    123(ptr) AccessChain 31(data) 63 115
-            2187:   27(fvec4) Load 2186
-            2188:  122(fvec2) VectorShuffle 2187 2187 0 1
+            2187: 27(f64vec4) Load 2186
+            2188:122(f64vec2) VectorShuffle 2187 2187 0 1
             2189:   17(ivec4) Load 19(ballot)
-            2190:  122(fvec2) GroupNonUniformFMax 178 PartitionedExclusiveScanNV 2188 2189
+            2190:122(f64vec2) GroupNonUniformFMax 178 PartitionedExclusiveScanNV 2188 2189
             2191:    123(ptr) AccessChain 31(data) 2185 115
-            2192:   27(fvec4) Load 2191
-            2193:   27(fvec4) VectorShuffle 2192 2190 4 5 2 3
+            2192: 27(f64vec4) Load 2191
+            2193: 27(f64vec4) VectorShuffle 2192 2190 4 5 2 3
                               Store 2191 2193
             2194:      6(int) Load 8(invocation)
             2195:    123(ptr) AccessChain 31(data) 33 115
-            2196:   27(fvec4) Load 2195
-            2197:  130(fvec3) VectorShuffle 2196 2196 0 1 2
+            2196: 27(f64vec4) Load 2195
+            2197:130(f64vec3) VectorShuffle 2196 2196 0 1 2
             2198:   17(ivec4) Load 19(ballot)
-            2199:  130(fvec3) GroupNonUniformFMax 178 PartitionedExclusiveScanNV 2197 2198
+            2199:130(f64vec3) GroupNonUniformFMax 178 PartitionedExclusiveScanNV 2197 2198
             2200:    123(ptr) AccessChain 31(data) 2194 115
-            2201:   27(fvec4) Load 2200
-            2202:   27(fvec4) VectorShuffle 2201 2199 4 5 6 3
+            2201: 27(f64vec4) Load 2200
+            2202: 27(f64vec4) VectorShuffle 2201 2199 4 5 6 3
                               Store 2200 2202
             2203:      6(int) Load 8(invocation)
             2204:    123(ptr) AccessChain 31(data) 115 115
-            2205:   27(fvec4) Load 2204
+            2205: 27(f64vec4) Load 2204
             2206:   17(ivec4) Load 19(ballot)
-            2207:   27(fvec4) GroupNonUniformFMax 178 PartitionedExclusiveScanNV 2205 2206
+            2207: 27(f64vec4) GroupNonUniformFMax 178 PartitionedExclusiveScanNV 2205 2206
             2208:    123(ptr) AccessChain 31(data) 2203 115
                               Store 2208 2207
             2209:      6(int) Load 8(invocation)

--- a/Test/baseResults/spv.subgroupQuad.comp.out
+++ b/Test/baseResults/spv.subgroupQuad.comp.out
@@ -54,8 +54,8 @@ spv.subgroupQuad.comp
               20:             TypeVector 19(int) 4
               21:             TypeVector 6(int) 4
               22:             TypeFloat 64
-              23:             TypeVector 22(float) 4
-     24(Buffers):             TypeStruct 18(fvec4) 20(ivec4) 21(ivec4) 23(fvec4)
+              23:             TypeVector 22(float64_t) 4
+     24(Buffers):             TypeStruct 18(fvec4) 20(ivec4) 21(ivec4) 23(f64vec4)
               25:             TypeArray 24(Buffers) 15
               26:             TypePointer Uniform 25
         27(data):     26(ptr) Variable Uniform
@@ -78,10 +78,10 @@ spv.subgroupQuad.comp
              102:             TypeVector 6(int) 2
              103:             TypePointer Uniform 21(ivec4)
              112:             TypeVector 6(int) 3
-             126:             TypePointer Uniform 22(float)
-             132:             TypeVector 22(float) 2
-             133:             TypePointer Uniform 23(fvec4)
-             142:             TypeVector 22(float) 3
+             126:             TypePointer Uniform 22(float64_t)
+             132:             TypeVector 22(float64_t) 2
+             133:             TypePointer Uniform 23(f64vec4)
+             142:             TypeVector 22(float64_t) 3
              158:             TypeBool
              167:   72(ivec2) ConstantComposite 29 29
              168:             TypeVector 158(bool) 2
@@ -195,32 +195,32 @@ spv.subgroupQuad.comp
                               Store 124 123
              125:      6(int) Load 8(invocation)
              127:    126(ptr) AccessChain 27(data) 29 60 30
-             128:   22(float) Load 127
-             129:   22(float) GroupNonUniformQuadBroadcast 35 128 34
+             128:22(float64_t) Load 127
+             129:22(float64_t) GroupNonUniformQuadBroadcast 35 128 34
              130:    126(ptr) AccessChain 27(data) 125 60 30
                               Store 130 129
              131:      6(int) Load 8(invocation)
              134:    133(ptr) AccessChain 27(data) 39 60
-             135:   23(fvec4) Load 134
-             136:  132(fvec2) VectorShuffle 135 135 0 1
-             137:  132(fvec2) GroupNonUniformQuadBroadcast 35 136 34
+             135: 23(f64vec4) Load 134
+             136:132(f64vec2) VectorShuffle 135 135 0 1
+             137:132(f64vec2) GroupNonUniformQuadBroadcast 35 136 34
              138:    133(ptr) AccessChain 27(data) 131 60
-             139:   23(fvec4) Load 138
-             140:   23(fvec4) VectorShuffle 139 137 4 5 2 3
+             139: 23(f64vec4) Load 138
+             140: 23(f64vec4) VectorShuffle 139 137 4 5 2 3
                               Store 138 140
              141:      6(int) Load 8(invocation)
              143:    133(ptr) AccessChain 27(data) 50 60
-             144:   23(fvec4) Load 143
-             145:  142(fvec3) VectorShuffle 144 144 0 1 2
-             146:  142(fvec3) GroupNonUniformQuadBroadcast 35 145 34
+             144: 23(f64vec4) Load 143
+             145:142(f64vec3) VectorShuffle 144 144 0 1 2
+             146:142(f64vec3) GroupNonUniformQuadBroadcast 35 145 34
              147:    133(ptr) AccessChain 27(data) 141 60
-             148:   23(fvec4) Load 147
-             149:   23(fvec4) VectorShuffle 148 146 4 5 6 3
+             148: 23(f64vec4) Load 147
+             149: 23(f64vec4) VectorShuffle 148 146 4 5 6 3
                               Store 147 149
              150:      6(int) Load 8(invocation)
              151:    133(ptr) AccessChain 27(data) 60 60
-             152:   23(fvec4) Load 151
-             153:   23(fvec4) GroupNonUniformQuadBroadcast 35 152 34
+             152: 23(f64vec4) Load 151
+             153: 23(f64vec4) GroupNonUniformQuadBroadcast 35 152 34
              154:    133(ptr) AccessChain 27(data) 150 60
                               Store 154 153
              155:      6(int) Load 8(invocation)
@@ -353,32 +353,32 @@ spv.subgroupQuad.comp
                               Store 276 275
              277:      6(int) Load 8(invocation)
              278:    126(ptr) AccessChain 27(data) 29 60 30
-             279:   22(float) Load 278
-             280:   22(float) GroupNonUniformQuadSwap 35 279 30
+             279:22(float64_t) Load 278
+             280:22(float64_t) GroupNonUniformQuadSwap 35 279 30
              281:    126(ptr) AccessChain 27(data) 277 60 30
                               Store 281 280
              282:      6(int) Load 8(invocation)
              283:    133(ptr) AccessChain 27(data) 39 60
-             284:   23(fvec4) Load 283
-             285:  132(fvec2) VectorShuffle 284 284 0 1
-             286:  132(fvec2) GroupNonUniformQuadSwap 35 285 30
+             284: 23(f64vec4) Load 283
+             285:132(f64vec2) VectorShuffle 284 284 0 1
+             286:132(f64vec2) GroupNonUniformQuadSwap 35 285 30
              287:    133(ptr) AccessChain 27(data) 282 60
-             288:   23(fvec4) Load 287
-             289:   23(fvec4) VectorShuffle 288 286 4 5 2 3
+             288: 23(f64vec4) Load 287
+             289: 23(f64vec4) VectorShuffle 288 286 4 5 2 3
                               Store 287 289
              290:      6(int) Load 8(invocation)
              291:    133(ptr) AccessChain 27(data) 50 60
-             292:   23(fvec4) Load 291
-             293:  142(fvec3) VectorShuffle 292 292 0 1 2
-             294:  142(fvec3) GroupNonUniformQuadSwap 35 293 30
+             292: 23(f64vec4) Load 291
+             293:142(f64vec3) VectorShuffle 292 292 0 1 2
+             294:142(f64vec3) GroupNonUniformQuadSwap 35 293 30
              295:    133(ptr) AccessChain 27(data) 290 60
-             296:   23(fvec4) Load 295
-             297:   23(fvec4) VectorShuffle 296 294 4 5 6 3
+             296: 23(f64vec4) Load 295
+             297: 23(f64vec4) VectorShuffle 296 294 4 5 6 3
                               Store 295 297
              298:      6(int) Load 8(invocation)
              299:    133(ptr) AccessChain 27(data) 60 60
-             300:   23(fvec4) Load 299
-             301:   23(fvec4) GroupNonUniformQuadSwap 35 300 30
+             300: 23(f64vec4) Load 299
+             301: 23(f64vec4) GroupNonUniformQuadSwap 35 300 30
              302:    133(ptr) AccessChain 27(data) 298 60
                               Store 302 301
              303:      6(int) Load 8(invocation)
@@ -511,32 +511,32 @@ spv.subgroupQuad.comp
                               Store 414 413
              415:      6(int) Load 8(invocation)
              416:    126(ptr) AccessChain 27(data) 29 60 30
-             417:   22(float) Load 416
-             418:   22(float) GroupNonUniformQuadSwap 35 417 34
+             417:22(float64_t) Load 416
+             418:22(float64_t) GroupNonUniformQuadSwap 35 417 34
              419:    126(ptr) AccessChain 27(data) 415 60 30
                               Store 419 418
              420:      6(int) Load 8(invocation)
              421:    133(ptr) AccessChain 27(data) 39 60
-             422:   23(fvec4) Load 421
-             423:  132(fvec2) VectorShuffle 422 422 0 1
-             424:  132(fvec2) GroupNonUniformQuadSwap 35 423 34
+             422: 23(f64vec4) Load 421
+             423:132(f64vec2) VectorShuffle 422 422 0 1
+             424:132(f64vec2) GroupNonUniformQuadSwap 35 423 34
              425:    133(ptr) AccessChain 27(data) 420 60
-             426:   23(fvec4) Load 425
-             427:   23(fvec4) VectorShuffle 426 424 4 5 2 3
+             426: 23(f64vec4) Load 425
+             427: 23(f64vec4) VectorShuffle 426 424 4 5 2 3
                               Store 425 427
              428:      6(int) Load 8(invocation)
              429:    133(ptr) AccessChain 27(data) 50 60
-             430:   23(fvec4) Load 429
-             431:  142(fvec3) VectorShuffle 430 430 0 1 2
-             432:  142(fvec3) GroupNonUniformQuadSwap 35 431 34
+             430: 23(f64vec4) Load 429
+             431:142(f64vec3) VectorShuffle 430 430 0 1 2
+             432:142(f64vec3) GroupNonUniformQuadSwap 35 431 34
              433:    133(ptr) AccessChain 27(data) 428 60
-             434:   23(fvec4) Load 433
-             435:   23(fvec4) VectorShuffle 434 432 4 5 6 3
+             434: 23(f64vec4) Load 433
+             435: 23(f64vec4) VectorShuffle 434 432 4 5 6 3
                               Store 433 435
              436:      6(int) Load 8(invocation)
              437:    133(ptr) AccessChain 27(data) 60 60
-             438:   23(fvec4) Load 437
-             439:   23(fvec4) GroupNonUniformQuadSwap 35 438 34
+             438: 23(f64vec4) Load 437
+             439: 23(f64vec4) GroupNonUniformQuadSwap 35 438 34
              440:    133(ptr) AccessChain 27(data) 436 60
                               Store 440 439
              441:      6(int) Load 8(invocation)
@@ -669,32 +669,32 @@ spv.subgroupQuad.comp
                               Store 553 552
              554:      6(int) Load 8(invocation)
              555:    126(ptr) AccessChain 27(data) 29 60 30
-             556:   22(float) Load 555
-             557:   22(float) GroupNonUniformQuadSwap 35 556 478
+             556:22(float64_t) Load 555
+             557:22(float64_t) GroupNonUniformQuadSwap 35 556 478
              558:    126(ptr) AccessChain 27(data) 554 60 30
                               Store 558 557
              559:      6(int) Load 8(invocation)
              560:    133(ptr) AccessChain 27(data) 39 60
-             561:   23(fvec4) Load 560
-             562:  132(fvec2) VectorShuffle 561 561 0 1
-             563:  132(fvec2) GroupNonUniformQuadSwap 35 562 478
+             561: 23(f64vec4) Load 560
+             562:132(f64vec2) VectorShuffle 561 561 0 1
+             563:132(f64vec2) GroupNonUniformQuadSwap 35 562 478
              564:    133(ptr) AccessChain 27(data) 559 60
-             565:   23(fvec4) Load 564
-             566:   23(fvec4) VectorShuffle 565 563 4 5 2 3
+             565: 23(f64vec4) Load 564
+             566: 23(f64vec4) VectorShuffle 565 563 4 5 2 3
                               Store 564 566
              567:      6(int) Load 8(invocation)
              568:    133(ptr) AccessChain 27(data) 50 60
-             569:   23(fvec4) Load 568
-             570:  142(fvec3) VectorShuffle 569 569 0 1 2
-             571:  142(fvec3) GroupNonUniformQuadSwap 35 570 478
+             569: 23(f64vec4) Load 568
+             570:142(f64vec3) VectorShuffle 569 569 0 1 2
+             571:142(f64vec3) GroupNonUniformQuadSwap 35 570 478
              572:    133(ptr) AccessChain 27(data) 567 60
-             573:   23(fvec4) Load 572
-             574:   23(fvec4) VectorShuffle 573 571 4 5 6 3
+             573: 23(f64vec4) Load 572
+             574: 23(f64vec4) VectorShuffle 573 571 4 5 6 3
                               Store 572 574
              575:      6(int) Load 8(invocation)
              576:    133(ptr) AccessChain 27(data) 60 60
-             577:   23(fvec4) Load 576
-             578:   23(fvec4) GroupNonUniformQuadSwap 35 577 478
+             577: 23(f64vec4) Load 576
+             578: 23(f64vec4) GroupNonUniformQuadSwap 35 577 478
              579:    133(ptr) AccessChain 27(data) 575 60
                               Store 579 578
              580:      6(int) Load 8(invocation)

--- a/Test/baseResults/spv.subgroupShuffle.comp.out
+++ b/Test/baseResults/spv.subgroupShuffle.comp.out
@@ -54,8 +54,8 @@ spv.subgroupShuffle.comp
               20:             TypeVector 19(int) 4
               21:             TypeVector 6(int) 4
               22:             TypeFloat 64
-              23:             TypeVector 22(float) 4
-     24(Buffers):             TypeStruct 18(fvec4) 20(ivec4) 21(ivec4) 23(fvec4)
+              23:             TypeVector 22(float64_t) 4
+     24(Buffers):             TypeStruct 18(fvec4) 20(ivec4) 21(ivec4) 23(f64vec4)
               25:             TypeArray 24(Buffers) 15
               26:             TypePointer Uniform 25
         27(data):     26(ptr) Variable Uniform
@@ -77,10 +77,10 @@ spv.subgroupShuffle.comp
              110:             TypeVector 6(int) 2
              111:             TypePointer Uniform 21(ivec4)
              121:             TypeVector 6(int) 3
-             137:             TypePointer Uniform 22(float)
-             144:             TypeVector 22(float) 2
-             145:             TypePointer Uniform 23(fvec4)
-             155:             TypeVector 22(float) 3
+             137:             TypePointer Uniform 22(float64_t)
+             144:             TypeVector 22(float64_t) 2
+             145:             TypePointer Uniform 23(f64vec4)
+             155:             TypeVector 22(float64_t) 3
              173:             TypeBool
              183:   76(ivec2) ConstantComposite 29 29
              184:             TypeVector 173(bool) 2
@@ -206,36 +206,36 @@ spv.subgroupShuffle.comp
                               Store 135 134
              136:      6(int) Load 8(invocation)
              138:    137(ptr) AccessChain 27(data) 29 62 30
-             139:   22(float) Load 138
+             139:22(float64_t) Load 138
              140:      6(int) Load 8(invocation)
-             141:   22(float) GroupNonUniformShuffle 35 139 140
+             141:22(float64_t) GroupNonUniformShuffle 35 139 140
              142:    137(ptr) AccessChain 27(data) 136 62 30
                               Store 142 141
              143:      6(int) Load 8(invocation)
              146:    145(ptr) AccessChain 27(data) 39 62
-             147:   23(fvec4) Load 146
-             148:  144(fvec2) VectorShuffle 147 147 0 1
+             147: 23(f64vec4) Load 146
+             148:144(f64vec2) VectorShuffle 147 147 0 1
              149:      6(int) Load 8(invocation)
-             150:  144(fvec2) GroupNonUniformShuffle 35 148 149
+             150:144(f64vec2) GroupNonUniformShuffle 35 148 149
              151:    145(ptr) AccessChain 27(data) 143 62
-             152:   23(fvec4) Load 151
-             153:   23(fvec4) VectorShuffle 152 150 4 5 2 3
+             152: 23(f64vec4) Load 151
+             153: 23(f64vec4) VectorShuffle 152 150 4 5 2 3
                               Store 151 153
              154:      6(int) Load 8(invocation)
              156:    145(ptr) AccessChain 27(data) 51 62
-             157:   23(fvec4) Load 156
-             158:  155(fvec3) VectorShuffle 157 157 0 1 2
+             157: 23(f64vec4) Load 156
+             158:155(f64vec3) VectorShuffle 157 157 0 1 2
              159:      6(int) Load 8(invocation)
-             160:  155(fvec3) GroupNonUniformShuffle 35 158 159
+             160:155(f64vec3) GroupNonUniformShuffle 35 158 159
              161:    145(ptr) AccessChain 27(data) 154 62
-             162:   23(fvec4) Load 161
-             163:   23(fvec4) VectorShuffle 162 160 4 5 6 3
+             162: 23(f64vec4) Load 161
+             163: 23(f64vec4) VectorShuffle 162 160 4 5 6 3
                               Store 161 163
              164:      6(int) Load 8(invocation)
              165:    145(ptr) AccessChain 27(data) 62 62
-             166:   23(fvec4) Load 165
+             166: 23(f64vec4) Load 165
              167:      6(int) Load 8(invocation)
-             168:   23(fvec4) GroupNonUniformShuffle 35 166 167
+             168: 23(f64vec4) GroupNonUniformShuffle 35 166 167
              169:    145(ptr) AccessChain 27(data) 164 62
                               Store 169 168
              170:      6(int) Load 8(invocation)
@@ -384,36 +384,36 @@ spv.subgroupShuffle.comp
                               Store 307 306
              308:      6(int) Load 8(invocation)
              309:    137(ptr) AccessChain 27(data) 29 62 30
-             310:   22(float) Load 309
+             310:22(float64_t) Load 309
              311:      6(int) Load 8(invocation)
-             312:   22(float) GroupNonUniformShuffleXor 35 310 311
+             312:22(float64_t) GroupNonUniformShuffleXor 35 310 311
              313:    137(ptr) AccessChain 27(data) 308 62 30
                               Store 313 312
              314:      6(int) Load 8(invocation)
              315:    145(ptr) AccessChain 27(data) 39 62
-             316:   23(fvec4) Load 315
-             317:  144(fvec2) VectorShuffle 316 316 0 1
+             316: 23(f64vec4) Load 315
+             317:144(f64vec2) VectorShuffle 316 316 0 1
              318:      6(int) Load 8(invocation)
-             319:  144(fvec2) GroupNonUniformShuffleXor 35 317 318
+             319:144(f64vec2) GroupNonUniformShuffleXor 35 317 318
              320:    145(ptr) AccessChain 27(data) 314 62
-             321:   23(fvec4) Load 320
-             322:   23(fvec4) VectorShuffle 321 319 4 5 2 3
+             321: 23(f64vec4) Load 320
+             322: 23(f64vec4) VectorShuffle 321 319 4 5 2 3
                               Store 320 322
              323:      6(int) Load 8(invocation)
              324:    145(ptr) AccessChain 27(data) 51 62
-             325:   23(fvec4) Load 324
-             326:  155(fvec3) VectorShuffle 325 325 0 1 2
+             325: 23(f64vec4) Load 324
+             326:155(f64vec3) VectorShuffle 325 325 0 1 2
              327:      6(int) Load 8(invocation)
-             328:  155(fvec3) GroupNonUniformShuffleXor 35 326 327
+             328:155(f64vec3) GroupNonUniformShuffleXor 35 326 327
              329:    145(ptr) AccessChain 27(data) 323 62
-             330:   23(fvec4) Load 329
-             331:   23(fvec4) VectorShuffle 330 328 4 5 6 3
+             330: 23(f64vec4) Load 329
+             331: 23(f64vec4) VectorShuffle 330 328 4 5 6 3
                               Store 329 331
              332:      6(int) Load 8(invocation)
              333:    145(ptr) AccessChain 27(data) 62 62
-             334:   23(fvec4) Load 333
+             334: 23(f64vec4) Load 333
              335:      6(int) Load 8(invocation)
-             336:   23(fvec4) GroupNonUniformShuffleXor 35 334 335
+             336: 23(f64vec4) GroupNonUniformShuffleXor 35 334 335
              337:    145(ptr) AccessChain 27(data) 332 62
                               Store 337 336
              338:      6(int) Load 8(invocation)

--- a/Test/baseResults/spv.subgroupShuffleRelative.comp.out
+++ b/Test/baseResults/spv.subgroupShuffleRelative.comp.out
@@ -54,8 +54,8 @@ spv.subgroupShuffleRelative.comp
               20:             TypeVector 19(int) 4
               21:             TypeVector 6(int) 4
               22:             TypeFloat 64
-              23:             TypeVector 22(float) 4
-     24(Buffers):             TypeStruct 18(fvec4) 20(ivec4) 21(ivec4) 23(fvec4)
+              23:             TypeVector 22(float64_t) 4
+     24(Buffers):             TypeStruct 18(fvec4) 20(ivec4) 21(ivec4) 23(f64vec4)
               25:             TypeArray 24(Buffers) 15
               26:             TypePointer Uniform 25
         27(data):     26(ptr) Variable Uniform
@@ -77,10 +77,10 @@ spv.subgroupShuffleRelative.comp
              110:             TypeVector 6(int) 2
              111:             TypePointer Uniform 21(ivec4)
              121:             TypeVector 6(int) 3
-             137:             TypePointer Uniform 22(float)
-             144:             TypeVector 22(float) 2
-             145:             TypePointer Uniform 23(fvec4)
-             155:             TypeVector 22(float) 3
+             137:             TypePointer Uniform 22(float64_t)
+             144:             TypeVector 22(float64_t) 2
+             145:             TypePointer Uniform 23(f64vec4)
+             155:             TypeVector 22(float64_t) 3
              173:             TypeBool
              183:   76(ivec2) ConstantComposite 29 29
              184:             TypeVector 173(bool) 2
@@ -206,36 +206,36 @@ spv.subgroupShuffleRelative.comp
                               Store 135 134
              136:      6(int) Load 8(invocation)
              138:    137(ptr) AccessChain 27(data) 29 62 30
-             139:   22(float) Load 138
+             139:22(float64_t) Load 138
              140:      6(int) Load 8(invocation)
-             141:   22(float) GroupNonUniformShuffleUp 35 139 140
+             141:22(float64_t) GroupNonUniformShuffleUp 35 139 140
              142:    137(ptr) AccessChain 27(data) 136 62 30
                               Store 142 141
              143:      6(int) Load 8(invocation)
              146:    145(ptr) AccessChain 27(data) 39 62
-             147:   23(fvec4) Load 146
-             148:  144(fvec2) VectorShuffle 147 147 0 1
+             147: 23(f64vec4) Load 146
+             148:144(f64vec2) VectorShuffle 147 147 0 1
              149:      6(int) Load 8(invocation)
-             150:  144(fvec2) GroupNonUniformShuffleUp 35 148 149
+             150:144(f64vec2) GroupNonUniformShuffleUp 35 148 149
              151:    145(ptr) AccessChain 27(data) 143 62
-             152:   23(fvec4) Load 151
-             153:   23(fvec4) VectorShuffle 152 150 4 5 2 3
+             152: 23(f64vec4) Load 151
+             153: 23(f64vec4) VectorShuffle 152 150 4 5 2 3
                               Store 151 153
              154:      6(int) Load 8(invocation)
              156:    145(ptr) AccessChain 27(data) 51 62
-             157:   23(fvec4) Load 156
-             158:  155(fvec3) VectorShuffle 157 157 0 1 2
+             157: 23(f64vec4) Load 156
+             158:155(f64vec3) VectorShuffle 157 157 0 1 2
              159:      6(int) Load 8(invocation)
-             160:  155(fvec3) GroupNonUniformShuffleUp 35 158 159
+             160:155(f64vec3) GroupNonUniformShuffleUp 35 158 159
              161:    145(ptr) AccessChain 27(data) 154 62
-             162:   23(fvec4) Load 161
-             163:   23(fvec4) VectorShuffle 162 160 4 5 6 3
+             162: 23(f64vec4) Load 161
+             163: 23(f64vec4) VectorShuffle 162 160 4 5 6 3
                               Store 161 163
              164:      6(int) Load 8(invocation)
              165:    145(ptr) AccessChain 27(data) 62 62
-             166:   23(fvec4) Load 165
+             166: 23(f64vec4) Load 165
              167:      6(int) Load 8(invocation)
-             168:   23(fvec4) GroupNonUniformShuffleUp 35 166 167
+             168: 23(f64vec4) GroupNonUniformShuffleUp 35 166 167
              169:    145(ptr) AccessChain 27(data) 164 62
                               Store 169 168
              170:      6(int) Load 8(invocation)
@@ -384,36 +384,36 @@ spv.subgroupShuffleRelative.comp
                               Store 307 306
              308:      6(int) Load 8(invocation)
              309:    137(ptr) AccessChain 27(data) 29 62 30
-             310:   22(float) Load 309
+             310:22(float64_t) Load 309
              311:      6(int) Load 8(invocation)
-             312:   22(float) GroupNonUniformShuffleDown 35 310 311
+             312:22(float64_t) GroupNonUniformShuffleDown 35 310 311
              313:    137(ptr) AccessChain 27(data) 308 62 30
                               Store 313 312
              314:      6(int) Load 8(invocation)
              315:    145(ptr) AccessChain 27(data) 39 62
-             316:   23(fvec4) Load 315
-             317:  144(fvec2) VectorShuffle 316 316 0 1
+             316: 23(f64vec4) Load 315
+             317:144(f64vec2) VectorShuffle 316 316 0 1
              318:      6(int) Load 8(invocation)
-             319:  144(fvec2) GroupNonUniformShuffleDown 35 317 318
+             319:144(f64vec2) GroupNonUniformShuffleDown 35 317 318
              320:    145(ptr) AccessChain 27(data) 314 62
-             321:   23(fvec4) Load 320
-             322:   23(fvec4) VectorShuffle 321 319 4 5 2 3
+             321: 23(f64vec4) Load 320
+             322: 23(f64vec4) VectorShuffle 321 319 4 5 2 3
                               Store 320 322
              323:      6(int) Load 8(invocation)
              324:    145(ptr) AccessChain 27(data) 51 62
-             325:   23(fvec4) Load 324
-             326:  155(fvec3) VectorShuffle 325 325 0 1 2
+             325: 23(f64vec4) Load 324
+             326:155(f64vec3) VectorShuffle 325 325 0 1 2
              327:      6(int) Load 8(invocation)
-             328:  155(fvec3) GroupNonUniformShuffleDown 35 326 327
+             328:155(f64vec3) GroupNonUniformShuffleDown 35 326 327
              329:    145(ptr) AccessChain 27(data) 323 62
-             330:   23(fvec4) Load 329
-             331:   23(fvec4) VectorShuffle 330 328 4 5 6 3
+             330: 23(f64vec4) Load 329
+             331: 23(f64vec4) VectorShuffle 330 328 4 5 6 3
                               Store 329 331
              332:      6(int) Load 8(invocation)
              333:    145(ptr) AccessChain 27(data) 62 62
-             334:   23(fvec4) Load 333
+             334: 23(f64vec4) Load 333
              335:      6(int) Load 8(invocation)
-             336:   23(fvec4) GroupNonUniformShuffleDown 35 334 335
+             336: 23(f64vec4) GroupNonUniformShuffleDown 35 334 335
              337:    145(ptr) AccessChain 27(data) 332 62
                               Store 337 336
              338:      6(int) Load 8(invocation)

--- a/Test/baseResults/spv.subgroupVote.comp.out
+++ b/Test/baseResults/spv.subgroupVote.comp.out
@@ -56,8 +56,8 @@ spv.subgroupVote.comp
               20:             TypeVector 19(int) 4
               21:             TypeVector 6(int) 4
               22:             TypeFloat 64
-              23:             TypeVector 22(float) 4
-     24(Buffers):             TypeStruct 18(fvec4) 20(ivec4) 21(ivec4) 23(fvec4) 19(int)
+              23:             TypeVector 22(float64_t) 4
+     24(Buffers):             TypeStruct 18(fvec4) 20(ivec4) 21(ivec4) 23(f64vec4) 19(int)
               25:             TypeArray 24(Buffers) 15
               26:             TypePointer Uniform 25
         27(data):     26(ptr) Variable Uniform
@@ -81,10 +81,10 @@ spv.subgroupVote.comp
              111:             TypeVector 6(int) 2
              112:             TypePointer Uniform 21(ivec4)
              120:             TypeVector 6(int) 3
-             142:             TypePointer Uniform 22(float)
-             149:             TypeVector 22(float) 2
-             150:             TypePointer Uniform 23(fvec4)
-             158:             TypeVector 22(float) 3
+             142:             TypePointer Uniform 22(float64_t)
+             149:             TypeVector 22(float64_t) 2
+             150:             TypePointer Uniform 23(f64vec4)
+             158:             TypeVector 22(float64_t) 3
              182:   81(ivec2) ConstantComposite 33 33
              183:             TypeVector 34(bool) 2
              194:   90(ivec3) ConstantComposite 33 33 33
@@ -212,30 +212,30 @@ spv.subgroupVote.comp
              139:                 Label
              141:      6(int)     Load 8(invocation)
              143:    142(ptr)     AccessChain 27(data) 33 68 41
-             144:   22(float)     Load 143
+             144:22(float64_t)     Load 143
              145:    34(bool)     GroupNonUniformAllEqual 36 144
              146:     19(int)     Select 145 46 33
              147:     30(ptr)     AccessChain 27(data) 141 29
                                   Store 147 146
              148:      6(int)     Load 8(invocation)
              151:    150(ptr)     AccessChain 27(data) 46 68
-             152:   23(fvec4)     Load 151
-             153:  149(fvec2)     VectorShuffle 152 152 0 1
+             152: 23(f64vec4)     Load 151
+             153:149(f64vec2)     VectorShuffle 152 152 0 1
              154:    34(bool)     GroupNonUniformAllEqual 36 153
              155:     19(int)     Select 154 46 33
              156:     30(ptr)     AccessChain 27(data) 148 29
                                   Store 156 155
              157:      6(int)     Load 8(invocation)
              159:    150(ptr)     AccessChain 27(data) 59 68
-             160:   23(fvec4)     Load 159
-             161:  158(fvec3)     VectorShuffle 160 160 0 1 2
+             160: 23(f64vec4)     Load 159
+             161:158(f64vec3)     VectorShuffle 160 160 0 1 2
              162:    34(bool)     GroupNonUniformAllEqual 36 161
              163:     19(int)     Select 162 46 33
              164:     30(ptr)     AccessChain 27(data) 157 29
                                   Store 164 163
              165:      6(int)     Load 8(invocation)
              166:    150(ptr)     AccessChain 27(data) 68 68
-             167:   23(fvec4)     Load 166
+             167: 23(f64vec4)     Load 166
              168:    34(bool)     GroupNonUniformAllEqual 36 167
              169:     19(int)     Select 168 46 33
              170:     30(ptr)     AccessChain 27(data) 165 29

--- a/Test/baseResults/spv.vulkan110.int16.frag.out
+++ b/Test/baseResults/spv.vulkan110.int16.frag.out
@@ -97,13 +97,13 @@ spv.vulkan110.int16.frag
                2:             TypeVoid
                3:             TypeFunction 2
               14:             TypeInt 16 1
-              15:             TypePointer Function 14(int)
+              15:             TypePointer Function 14(int16_t)
               17:             TypeInt 32 0
               18:     17(int) Constant 3
-              19:             TypeArray 14(int) 18
-              20:     14(int) Constant 4294962927
-              21:     14(int) Constant 4294967295
-              22:     14(int) Constant 16384
+              19:             TypeArray 14(int16_t) 18
+              20: 14(int16_t) Constant 4294962927
+              21: 14(int16_t) Constant 4294967295
+              22: 14(int16_t) Constant 16384
               23:          19 ConstantComposite 20 21 22
     24(Uniforms):             TypeStruct 17(int)
               25:             TypePointer Uniform 24(Uniforms)
@@ -113,83 +113,83 @@ spv.vulkan110.int16.frag
               29:             TypePointer Uniform 17(int)
               32:             TypePointer Function 19
               36:             TypeInt 16 0
-              37:             TypePointer Function 36(int)
-              39:             TypeArray 36(int) 18
-              40:     36(int) Constant 65535
-              41:     36(int) Constant 32767
+              37:             TypePointer Function 36(int16_t)
+              39:             TypeArray 36(int16_t) 18
+              40: 36(int16_t) Constant 65535
+              41: 36(int16_t) Constant 32767
               42:          39 ConstantComposite 40 40 41
               45:             TypePointer Function 39
               49:             TypeVector 27(int) 2
               50:             TypePointer Function 49(ivec2)
-              52:             TypeVector 14(int) 2
-              53:             TypePointer Function 52(ivec2)
-              57:             TypeVector 36(int) 2
-              58:             TypePointer Function 57(ivec2)
+              52:             TypeVector 14(int16_t) 2
+              53:             TypePointer Function 52(i16vec2)
+              57:             TypeVector 36(int16_t) 2
+              58:             TypePointer Function 57(i16vec2)
               65:             TypeVector 17(int) 2
               66:             TypePointer Function 65(ivec2)
               71:             TypeInt 64 1
-              72:             TypeVector 71(int) 2
-              73:             TypePointer Function 72(ivec2)
+              72:             TypeVector 71(int64_t) 2
+              73:             TypePointer Function 72(i64vec2)
               77:             TypeInt 64 0
-              78:             TypeVector 77(int) 2
-              79:             TypePointer Function 78(ivec2)
+              78:             TypeVector 77(int64_t) 2
+              79:             TypePointer Function 78(i64vec2)
               91:             TypeFloat 16
-              92:             TypeVector 91(float) 2
-              93:             TypePointer Function 92(fvec2)
+              92:             TypeVector 91(float16_t) 2
+              93:             TypePointer Function 92(f16vec2)
               97:             TypeFloat 32
               98:             TypeVector 97(float) 2
               99:             TypePointer Function 98(fvec2)
              103:             TypeFloat 64
-             104:             TypeVector 103(float) 2
-             105:             TypePointer Function 104(fvec2)
+             104:             TypeVector 103(float64_t) 2
+             105:             TypePointer Function 104(f64vec2)
              151:             TypeInt 8 1
-             152:             TypeVector 151(int) 2
-             153:             TypePointer Function 152(ivec2)
+             152:             TypeVector 151(int8_t) 2
+             153:             TypePointer Function 152(i8vec2)
              160:             TypeInt 8 0
-             161:             TypeVector 160(int) 2
-             162:             TypePointer Function 161(ivec2)
+             161:             TypeVector 160(int8_t) 2
+             162:             TypePointer Function 161(i8vec2)
              173:             TypeBool
              174:             TypeVector 173(bool) 2
              175:             TypePointer Function 174(bvec2)
-             178:     14(int) Constant 0
-             179:     14(int) Constant 1
-             180:   52(ivec2) ConstantComposite 178 178
-             181:   52(ivec2) ConstantComposite 179 179
-             184:     36(int) Constant 0
-             185:     36(int) Constant 1
-             186:   57(ivec2) ConstantComposite 184 184
-             187:   57(ivec2) ConstantComposite 185 185
-             193:             TypeVector 36(int) 3
-             194:             TypePointer Function 193(ivec3)
-             197:             TypeVector 14(int) 3
+             178: 14(int16_t) Constant 0
+             179: 14(int16_t) Constant 1
+             180: 52(i16vec2) ConstantComposite 178 178
+             181: 52(i16vec2) ConstantComposite 179 179
+             184: 36(int16_t) Constant 0
+             185: 36(int16_t) Constant 1
+             186: 57(i16vec2) ConstantComposite 184 184
+             187: 57(i16vec2) ConstantComposite 185 185
+             193:             TypeVector 36(int16_t) 3
+             194:             TypePointer Function 193(i16vec3)
+             197:             TypeVector 14(int16_t) 3
              219:             TypePointer Function 27(int)
              225:             TypeVector 17(int) 3
              226:             TypePointer Function 225(ivec3)
-             242:             TypePointer Function 71(int)
+             242:             TypePointer Function 71(int64_t)
              264:     17(int) Constant 1
              270:     17(int) Constant 2
              276:             TypeVector 27(int) 3
              280:             TypePointer Function 173(bool)
              282:     17(int) Constant 0
              296:             TypePointer Function 17(int)
-             354:   52(ivec2) ConstantComposite 21 21
-             363:  193(ivec3) ConstantComposite 184 184 184
+             354: 52(i16vec2) ConstantComposite 21 21
+             363:193(i16vec3) ConstantComposite 184 184 184
              405:   173(bool) ConstantTrue
              412:   173(bool) ConstantFalse
              413:  174(bvec2) ConstantComposite 412 412
              425:             TypeVector 173(bool) 3
              426:  425(bvec3) ConstantComposite 412 412 412
-             432:             TypeVector 14(int) 4
-             433:             TypePointer Function 432(ivec4)
-             441:             TypePointer Function 77(int)
-             443:             TypeVector 36(int) 4
-             444:             TypePointer Function 443(ivec4)
+             432:             TypeVector 14(int16_t) 4
+             433:             TypePointer Function 432(i16vec4)
+             441:             TypePointer Function 77(int64_t)
+             443:             TypeVector 36(int16_t) 4
+             444:             TypePointer Function 443(i16vec4)
              456:             TypePointer Function 425(bvec3)
-      518(Block):             TypeStruct 14(int) 52(ivec2) 197(ivec3) 432(ivec4) 36(int) 57(ivec2) 193(ivec3) 443(ivec4)
+      518(Block):             TypeStruct 14(int16_t) 52(i16vec2) 197(i16vec3) 432(i16vec4) 36(int16_t) 57(i16vec2) 193(i16vec3) 443(i16vec4)
              519:             TypePointer Uniform 518(Block)
       520(block):    519(ptr) Variable Uniform
-       521(si16):     14(int) SpecConstant 4294967286
-       522(su16):     36(int) SpecConstant 20
+       521(si16): 14(int16_t) SpecConstant 4294967286
+       522(su16): 36(int16_t) SpecConstant 20
          4(main):           2 Function None 3
                5:             Label
                               Return
@@ -204,13 +204,13 @@ spv.vulkan110.int16.frag
               31:     17(int) Load 30
                               Store 33(indexable) 23
               34:     15(ptr) AccessChain 33(indexable) 31
-              35:     14(int) Load 34
+              35: 14(int16_t) Load 34
                               Store 16(i16) 35
               43:     29(ptr) AccessChain 26 28
               44:     17(int) Load 43
                               Store 46(indexable) 42
               47:     37(ptr) AccessChain 46(indexable) 44
-              48:     36(int) Load 47
+              48: 36(int16_t) Load 47
                               Store 38(u16) 48
                               Return
                               FunctionEnd
@@ -228,135 +228,135 @@ spv.vulkan110.int16.frag
         154(i8v):    153(ptr) Variable Function
         163(u8v):    162(ptr) Variable Function
          176(bv):    175(ptr) Variable Function
-              55:   52(ivec2) Load 54(i16v)
+              55: 52(i16vec2) Load 54(i16v)
               56:   49(ivec2) SConvert 55
                               Store 51(i32v) 56
-              60:   57(ivec2) Load 59(u16v)
+              60: 57(i16vec2) Load 59(u16v)
               61:   49(ivec2) UConvert 60
               62:   49(ivec2) Bitcast 61
                               Store 51(i32v) 62
-              63:   52(ivec2) Load 54(i16v)
-              64:   57(ivec2) Bitcast 63
+              63: 52(i16vec2) Load 54(i16v)
+              64: 57(i16vec2) Bitcast 63
                               Store 59(u16v) 64
-              68:   52(ivec2) Load 54(i16v)
+              68: 52(i16vec2) Load 54(i16v)
               69:   49(ivec2) SConvert 68
               70:   65(ivec2) Bitcast 69
                               Store 67(u32v) 70
-              75:   52(ivec2) Load 54(i16v)
-              76:   72(ivec2) SConvert 75
+              75: 52(i16vec2) Load 54(i16v)
+              76: 72(i64vec2) SConvert 75
                               Store 74(i64v) 76
-              81:   52(ivec2) Load 54(i16v)
-              82:   72(ivec2) SConvert 81
-              83:   78(ivec2) Bitcast 82
+              81: 52(i16vec2) Load 54(i16v)
+              82: 72(i64vec2) SConvert 81
+              83: 78(i64vec2) Bitcast 82
                               Store 80(u64v) 83
-              84:   57(ivec2) Load 59(u16v)
+              84: 57(i16vec2) Load 59(u16v)
               85:   65(ivec2) UConvert 84
                               Store 67(u32v) 85
-              86:   57(ivec2) Load 59(u16v)
-              87:   72(ivec2) UConvert 86
-              88:   72(ivec2) Bitcast 87
+              86: 57(i16vec2) Load 59(u16v)
+              87: 72(i64vec2) UConvert 86
+              88: 72(i64vec2) Bitcast 87
                               Store 74(i64v) 88
-              89:   57(ivec2) Load 59(u16v)
-              90:   78(ivec2) UConvert 89
+              89: 57(i16vec2) Load 59(u16v)
+              90: 78(i64vec2) UConvert 89
                               Store 80(u64v) 90
-              95:   52(ivec2) Load 54(i16v)
-              96:   92(fvec2) ConvertSToF 95
+              95: 52(i16vec2) Load 54(i16v)
+              96: 92(f16vec2) ConvertSToF 95
                               Store 94(f16v) 96
-             101:   52(ivec2) Load 54(i16v)
+             101: 52(i16vec2) Load 54(i16v)
              102:   98(fvec2) ConvertSToF 101
                               Store 100(f32v) 102
-             107:   52(ivec2) Load 54(i16v)
-             108:  104(fvec2) ConvertSToF 107
+             107: 52(i16vec2) Load 54(i16v)
+             108:104(f64vec2) ConvertSToF 107
                               Store 106(f64v) 108
-             109:   57(ivec2) Load 59(u16v)
-             110:   92(fvec2) ConvertUToF 109
+             109: 57(i16vec2) Load 59(u16v)
+             110: 92(f16vec2) ConvertUToF 109
                               Store 94(f16v) 110
-             111:   57(ivec2) Load 59(u16v)
+             111: 57(i16vec2) Load 59(u16v)
              112:   98(fvec2) ConvertUToF 111
                               Store 100(f32v) 112
-             113:   57(ivec2) Load 59(u16v)
-             114:  104(fvec2) ConvertUToF 113
+             113: 57(i16vec2) Load 59(u16v)
+             114:104(f64vec2) ConvertUToF 113
                               Store 106(f64v) 114
-             115:   52(ivec2) Load 54(i16v)
+             115: 52(i16vec2) Load 54(i16v)
              116:   49(ivec2) SConvert 115
                               Store 51(i32v) 116
-             117:   57(ivec2) Load 59(u16v)
+             117: 57(i16vec2) Load 59(u16v)
              118:   49(ivec2) UConvert 117
              119:   49(ivec2) Bitcast 118
                               Store 51(i32v) 119
-             120:   52(ivec2) Load 54(i16v)
-             121:   57(ivec2) Bitcast 120
+             120: 52(i16vec2) Load 54(i16v)
+             121: 57(i16vec2) Bitcast 120
                               Store 59(u16v) 121
-             122:   52(ivec2) Load 54(i16v)
+             122: 52(i16vec2) Load 54(i16v)
              123:   49(ivec2) SConvert 122
              124:   65(ivec2) Bitcast 123
                               Store 67(u32v) 124
-             125:   52(ivec2) Load 54(i16v)
-             126:   72(ivec2) SConvert 125
+             125: 52(i16vec2) Load 54(i16v)
+             126: 72(i64vec2) SConvert 125
                               Store 74(i64v) 126
-             127:   52(ivec2) Load 54(i16v)
-             128:   72(ivec2) SConvert 127
-             129:   78(ivec2) Bitcast 128
+             127: 52(i16vec2) Load 54(i16v)
+             128: 72(i64vec2) SConvert 127
+             129: 78(i64vec2) Bitcast 128
                               Store 80(u64v) 129
-             130:   57(ivec2) Load 59(u16v)
+             130: 57(i16vec2) Load 59(u16v)
              131:   65(ivec2) UConvert 130
                               Store 67(u32v) 131
-             132:   57(ivec2) Load 59(u16v)
-             133:   72(ivec2) UConvert 132
-             134:   72(ivec2) Bitcast 133
+             132: 57(i16vec2) Load 59(u16v)
+             133: 72(i64vec2) UConvert 132
+             134: 72(i64vec2) Bitcast 133
                               Store 74(i64v) 134
-             135:   57(ivec2) Load 59(u16v)
-             136:   72(ivec2) UConvert 135
-             137:   72(ivec2) Bitcast 136
-             138:   78(ivec2) Bitcast 137
+             135: 57(i16vec2) Load 59(u16v)
+             136: 72(i64vec2) UConvert 135
+             137: 72(i64vec2) Bitcast 136
+             138: 78(i64vec2) Bitcast 137
                               Store 80(u64v) 138
-             139:   52(ivec2) Load 54(i16v)
-             140:   92(fvec2) ConvertSToF 139
+             139: 52(i16vec2) Load 54(i16v)
+             140: 92(f16vec2) ConvertSToF 139
                               Store 94(f16v) 140
-             141:   52(ivec2) Load 54(i16v)
+             141: 52(i16vec2) Load 54(i16v)
              142:   98(fvec2) ConvertSToF 141
                               Store 100(f32v) 142
-             143:   52(ivec2) Load 54(i16v)
-             144:  104(fvec2) ConvertSToF 143
+             143: 52(i16vec2) Load 54(i16v)
+             144:104(f64vec2) ConvertSToF 143
                               Store 106(f64v) 144
-             145:   57(ivec2) Load 59(u16v)
-             146:   92(fvec2) ConvertUToF 145
+             145: 57(i16vec2) Load 59(u16v)
+             146: 92(f16vec2) ConvertUToF 145
                               Store 94(f16v) 146
-             147:   57(ivec2) Load 59(u16v)
+             147: 57(i16vec2) Load 59(u16v)
              148:   98(fvec2) ConvertUToF 147
                               Store 100(f32v) 148
-             149:   57(ivec2) Load 59(u16v)
-             150:  104(fvec2) ConvertUToF 149
+             149: 57(i16vec2) Load 59(u16v)
+             150:104(f64vec2) ConvertUToF 149
                               Store 106(f64v) 150
-             155:   52(ivec2) Load 54(i16v)
-             156:  152(ivec2) SConvert 155
+             155: 52(i16vec2) Load 54(i16v)
+             156: 152(i8vec2) SConvert 155
                               Store 154(i8v) 156
-             157:   57(ivec2) Load 59(u16v)
-             158:  152(ivec2) UConvert 157
-             159:  152(ivec2) Bitcast 158
+             157: 57(i16vec2) Load 59(u16v)
+             158: 152(i8vec2) UConvert 157
+             159: 152(i8vec2) Bitcast 158
                               Store 154(i8v) 159
-             164:   52(ivec2) Load 54(i16v)
-             165:  152(ivec2) SConvert 164
-             166:  161(ivec2) Bitcast 165
+             164: 52(i16vec2) Load 54(i16v)
+             165: 152(i8vec2) SConvert 164
+             166: 161(i8vec2) Bitcast 165
                               Store 163(u8v) 166
-             167:   57(ivec2) Load 59(u16v)
-             168:  161(ivec2) UConvert 167
+             167: 57(i16vec2) Load 59(u16v)
+             168: 161(i8vec2) UConvert 167
                               Store 163(u8v) 168
-             169:   57(ivec2) Load 59(u16v)
-             170:  161(ivec2) UConvert 169
-             171:   52(ivec2) UConvert 170
-             172:   52(ivec2) Bitcast 171
+             169: 57(i16vec2) Load 59(u16v)
+             170: 161(i8vec2) UConvert 169
+             171: 52(i16vec2) UConvert 170
+             172: 52(i16vec2) Bitcast 171
                               Store 54(i16v) 172
              177:  174(bvec2) Load 176(bv)
-             182:   52(ivec2) Select 177 181 180
+             182: 52(i16vec2) Select 177 181 180
                               Store 54(i16v) 182
              183:  174(bvec2) Load 176(bv)
-             188:   57(ivec2) Select 183 187 186
+             188: 57(i16vec2) Select 183 187 186
                               Store 59(u16v) 188
-             189:   52(ivec2) Load 54(i16v)
+             189: 52(i16vec2) Load 54(i16v)
              190:  174(bvec2) INotEqual 189 186
                               Store 176(bv) 190
-             191:   57(ivec2) Load 59(u16v)
+             191: 57(i16vec2) Load 59(u16v)
              192:  174(bvec2) INotEqual 191 186
                               Store 176(bv) 192
                               Return
@@ -369,169 +369,169 @@ spv.vulkan110.int16.frag
          227(uv):    226(ptr) Variable Function
         243(i64):    242(ptr) Variable Function
           281(b):    280(ptr) Variable Function
-             196:  193(ivec3) Load 195(u16v)
-             198:  197(ivec3) CompositeConstruct 179 179 179
-             199:  193(ivec3) IAdd 196 198
+             196:193(i16vec3) Load 195(u16v)
+             198:197(i16vec3) CompositeConstruct 179 179 179
+             199:193(i16vec3) IAdd 196 198
                               Store 195(u16v) 199
-             201:     14(int) Load 200(i16)
-             202:     14(int) ISub 201 179
+             201: 14(int16_t) Load 200(i16)
+             202: 14(int16_t) ISub 201 179
                               Store 200(i16) 202
-             203:     14(int) Load 200(i16)
-             204:     14(int) IAdd 203 179
+             203: 14(int16_t) Load 200(i16)
+             204: 14(int16_t) IAdd 203 179
                               Store 200(i16) 204
-             205:  193(ivec3) Load 195(u16v)
-             206:  197(ivec3) CompositeConstruct 179 179 179
-             207:  193(ivec3) ISub 205 206
+             205:193(i16vec3) Load 195(u16v)
+             206:197(i16vec3) CompositeConstruct 179 179 179
+             207:193(i16vec3) ISub 205 206
                               Store 195(u16v) 207
-             208:  193(ivec3) Load 195(u16v)
-             209:  193(ivec3) Not 208
+             208:193(i16vec3) Load 195(u16v)
+             209:193(i16vec3) Not 208
                               Store 195(u16v) 209
-             210:     14(int) Load 200(i16)
+             210: 14(int16_t) Load 200(i16)
                               Store 200(i16) 210
-             211:  193(ivec3) Load 195(u16v)
-             212:  193(ivec3) SNegate 211
+             211:193(i16vec3) Load 195(u16v)
+             212:193(i16vec3) SNegate 211
                               Store 195(u16v) 212
-             213:     14(int) Load 200(i16)
-             214:     14(int) Load 200(i16)
-             215:     14(int) IAdd 214 213
+             213: 14(int16_t) Load 200(i16)
+             214: 14(int16_t) Load 200(i16)
+             215: 14(int16_t) IAdd 214 213
                               Store 200(i16) 215
-             216:  193(ivec3) Load 195(u16v)
-             217:  193(ivec3) Load 195(u16v)
-             218:  193(ivec3) ISub 217 216
+             216:193(i16vec3) Load 195(u16v)
+             217:193(i16vec3) Load 195(u16v)
+             218:193(i16vec3) ISub 217 216
                               Store 195(u16v) 218
-             221:     14(int) Load 200(i16)
+             221: 14(int16_t) Load 200(i16)
              222:     27(int) SConvert 221
              223:     27(int) Load 220(i)
              224:     27(int) IMul 223 222
                               Store 220(i) 224
-             228:  193(ivec3) Load 195(u16v)
+             228:193(i16vec3) Load 195(u16v)
              229:  225(ivec3) UConvert 228
              230:  225(ivec3) Load 227(uv)
              231:  225(ivec3) UDiv 230 229
                               Store 227(uv) 231
-             232:     14(int) Load 200(i16)
+             232: 14(int16_t) Load 200(i16)
              233:     27(int) SConvert 232
              234:     17(int) Bitcast 233
              235:  225(ivec3) Load 227(uv)
              236:  225(ivec3) CompositeConstruct 234 234 234
              237:  225(ivec3) UMod 235 236
                               Store 227(uv) 237
-             238:  193(ivec3) Load 195(u16v)
+             238:193(i16vec3) Load 195(u16v)
              239:  225(ivec3) UConvert 238
              240:  225(ivec3) Load 227(uv)
              241:  225(ivec3) IAdd 239 240
                               Store 227(uv) 241
-             244:     14(int) Load 200(i16)
-             245:     71(int) SConvert 244
-             246:     71(int) Load 243(i64)
-             247:     71(int) ISub 245 246
+             244: 14(int16_t) Load 200(i16)
+             245: 71(int64_t) SConvert 244
+             246: 71(int64_t) Load 243(i64)
+             247: 71(int64_t) ISub 245 246
                               Store 243(i64) 247
-             248:  193(ivec3) Load 195(u16v)
+             248:193(i16vec3) Load 195(u16v)
              249:  225(ivec3) UConvert 248
              250:  225(ivec3) Load 227(uv)
              251:  225(ivec3) IMul 249 250
                               Store 227(uv) 251
-             252:     14(int) Load 200(i16)
-             253:     71(int) SConvert 252
-             254:     71(int) Load 243(i64)
-             255:     71(int) IMul 253 254
+             252: 14(int16_t) Load 200(i16)
+             253: 71(int64_t) SConvert 252
+             254: 71(int64_t) Load 243(i64)
+             255: 71(int64_t) IMul 253 254
                               Store 243(i64) 255
-             256:     14(int) Load 200(i16)
+             256: 14(int16_t) Load 200(i16)
              257:     27(int) SConvert 256
              258:     27(int) Load 220(i)
              259:     27(int) SMod 257 258
                               Store 220(i) 259
-             260:     14(int) Load 200(i16)
-             261:  193(ivec3) Load 195(u16v)
-             262:  197(ivec3) CompositeConstruct 260 260 260
-             263:  193(ivec3) ShiftLeftLogical 261 262
+             260: 14(int16_t) Load 200(i16)
+             261:193(i16vec3) Load 195(u16v)
+             262:197(i16vec3) CompositeConstruct 260 260 260
+             263:193(i16vec3) ShiftLeftLogical 261 262
                               Store 195(u16v) 263
              265:     37(ptr) AccessChain 195(u16v) 264
-             266:     36(int) Load 265
-             267:     14(int) Load 200(i16)
-             268:     14(int) ShiftRightArithmetic 267 266
+             266: 36(int16_t) Load 265
+             267: 14(int16_t) Load 200(i16)
+             268: 14(int16_t) ShiftRightArithmetic 267 266
                               Store 200(i16) 268
-             269:     14(int) Load 200(i16)
+             269: 14(int16_t) Load 200(i16)
              271:     37(ptr) AccessChain 195(u16v) 270
-             272:     36(int) Load 271
-             273:     14(int) ShiftLeftLogical 269 272
+             272: 36(int16_t) Load 271
+             273: 14(int16_t) ShiftLeftLogical 269 272
                               Store 200(i16) 273
-             274:  193(ivec3) Load 195(u16v)
+             274:193(i16vec3) Load 195(u16v)
              275:     27(int) Load 220(i)
              277:  276(ivec3) CompositeConstruct 275 275 275
-             278:  193(ivec3) ShiftLeftLogical 274 277
+             278:193(i16vec3) ShiftLeftLogical 274 277
              279:  225(ivec3) UConvert 278
                               Store 227(uv) 279
              283:     37(ptr) AccessChain 195(u16v) 282
-             284:     36(int) Load 283
-             285:     14(int) Load 200(i16)
-             286:     36(int) Bitcast 285
+             284: 36(int16_t) Load 283
+             285: 14(int16_t) Load 200(i16)
+             286: 36(int16_t) Bitcast 285
              287:   173(bool) INotEqual 284 286
                               Store 281(b) 287
-             288:     14(int) Load 200(i16)
-             289:     36(int) Bitcast 288
+             288: 14(int16_t) Load 200(i16)
+             289: 36(int16_t) Bitcast 288
              290:     37(ptr) AccessChain 195(u16v) 282
-             291:     36(int) Load 290
+             291: 36(int16_t) Load 290
              292:   173(bool) IEqual 289 291
                               Store 281(b) 292
              293:     37(ptr) AccessChain 195(u16v) 282
-             294:     36(int) Load 293
+             294: 36(int16_t) Load 293
              295:     17(int) UConvert 294
              297:    296(ptr) AccessChain 227(uv) 264
              298:     17(int) Load 297
              299:   173(bool) UGreaterThan 295 298
                               Store 281(b) 299
-             300:     14(int) Load 200(i16)
+             300: 14(int16_t) Load 200(i16)
              301:     27(int) SConvert 300
              302:     27(int) Load 220(i)
              303:   173(bool) SLessThan 301 302
                               Store 281(b) 303
              304:     37(ptr) AccessChain 195(u16v) 264
-             305:     36(int) Load 304
+             305: 36(int16_t) Load 304
              306:     17(int) UConvert 305
              307:    296(ptr) AccessChain 227(uv) 282
              308:     17(int) Load 307
              309:   173(bool) UGreaterThanEqual 306 308
                               Store 281(b) 309
-             310:     14(int) Load 200(i16)
+             310: 14(int16_t) Load 200(i16)
              311:     27(int) SConvert 310
              312:     27(int) Load 220(i)
              313:   173(bool) SLessThanEqual 311 312
                               Store 281(b) 313
-             314:     14(int) Load 200(i16)
+             314: 14(int16_t) Load 200(i16)
              315:     27(int) SConvert 314
              316:     17(int) Bitcast 315
              317:  225(ivec3) Load 227(uv)
              318:  225(ivec3) CompositeConstruct 316 316 316
              319:  225(ivec3) BitwiseOr 317 318
                               Store 227(uv) 319
-             320:     14(int) Load 200(i16)
+             320: 14(int16_t) Load 200(i16)
              321:     27(int) SConvert 320
              322:     27(int) Load 220(i)
              323:     27(int) BitwiseOr 321 322
                               Store 220(i) 323
-             324:     14(int) Load 200(i16)
-             325:     71(int) SConvert 324
-             326:     71(int) Load 243(i64)
-             327:     71(int) BitwiseAnd 326 325
+             324: 14(int16_t) Load 200(i16)
+             325: 71(int64_t) SConvert 324
+             326: 71(int64_t) Load 243(i64)
+             327: 71(int64_t) BitwiseAnd 326 325
                               Store 243(i64) 327
-             328:  193(ivec3) Load 195(u16v)
+             328:193(i16vec3) Load 195(u16v)
              329:  225(ivec3) UConvert 328
              330:  225(ivec3) Load 227(uv)
              331:  225(ivec3) BitwiseAnd 329 330
                               Store 227(uv) 331
-             332:     14(int) Load 200(i16)
+             332: 14(int16_t) Load 200(i16)
              333:     27(int) SConvert 332
              334:     17(int) Bitcast 333
              335:  225(ivec3) Load 227(uv)
              336:  225(ivec3) CompositeConstruct 334 334 334
              337:  225(ivec3) BitwiseXor 335 336
                               Store 227(uv) 337
-             338:  193(ivec3) Load 195(u16v)
-             339:     14(int) Load 200(i16)
-             340:     36(int) Bitcast 339
-             341:  193(ivec3) CompositeConstruct 340 340 340
-             342:  193(ivec3) BitwiseXor 338 341
+             338:193(i16vec3) Load 195(u16v)
+             339: 14(int16_t) Load 200(i16)
+             340: 36(int16_t) Bitcast 339
+             341:193(i16vec3) CompositeConstruct 340 340 340
+             342:193(i16vec3) BitwiseXor 338 341
                               Store 195(u16v) 342
                               Return
                               FunctionEnd
@@ -549,190 +549,190 @@ spv.vulkan110.int16.frag
         442(u64):    441(ptr) Variable Function
       445(u16v4):    444(ptr) Variable Function
          457(bv):    456(ptr) Variable Function
-             344:   52(ivec2) Load 343(i16v)
-             345:   52(ivec2) ExtInst 1(GLSL.std.450) 5(SAbs) 344
+             344: 52(i16vec2) Load 343(i16v)
+             345: 52(i16vec2) ExtInst 1(GLSL.std.450) 5(SAbs) 344
                               Store 343(i16v) 345
-             347:     14(int) Load 346(i16)
-             348:     14(int) ExtInst 1(GLSL.std.450) 7(SSign) 347
+             347: 14(int16_t) Load 346(i16)
+             348: 14(int16_t) ExtInst 1(GLSL.std.450) 7(SSign) 347
                               Store 346(i16) 348
-             349:   52(ivec2) Load 343(i16v)
-             350:     14(int) Load 346(i16)
-             351:   52(ivec2) CompositeConstruct 350 350
-             352:   52(ivec2) ExtInst 1(GLSL.std.450) 39(SMin) 349 351
+             349: 52(i16vec2) Load 343(i16v)
+             350: 14(int16_t) Load 346(i16)
+             351: 52(i16vec2) CompositeConstruct 350 350
+             352: 52(i16vec2) ExtInst 1(GLSL.std.450) 39(SMin) 349 351
                               Store 343(i16v) 352
-             353:   52(ivec2) Load 343(i16v)
-             355:   52(ivec2) ExtInst 1(GLSL.std.450) 39(SMin) 353 354
+             353: 52(i16vec2) Load 343(i16v)
+             355: 52(i16vec2) ExtInst 1(GLSL.std.450) 39(SMin) 353 354
                               Store 343(i16v) 355
-             357:  193(ivec3) Load 356(u16v)
-             359:     36(int) Load 358(u16)
-             360:  193(ivec3) CompositeConstruct 359 359 359
-             361:  193(ivec3) ExtInst 1(GLSL.std.450) 38(UMin) 357 360
+             357:193(i16vec3) Load 356(u16v)
+             359: 36(int16_t) Load 358(u16)
+             360:193(i16vec3) CompositeConstruct 359 359 359
+             361:193(i16vec3) ExtInst 1(GLSL.std.450) 38(UMin) 357 360
                               Store 356(u16v) 361
-             362:  193(ivec3) Load 356(u16v)
-             364:  193(ivec3) ExtInst 1(GLSL.std.450) 38(UMin) 362 363
+             362:193(i16vec3) Load 356(u16v)
+             364:193(i16vec3) ExtInst 1(GLSL.std.450) 38(UMin) 362 363
                               Store 356(u16v) 364
-             365:   52(ivec2) Load 343(i16v)
-             366:     14(int) Load 346(i16)
-             367:   52(ivec2) CompositeConstruct 366 366
-             368:   52(ivec2) ExtInst 1(GLSL.std.450) 42(SMax) 365 367
+             365: 52(i16vec2) Load 343(i16v)
+             366: 14(int16_t) Load 346(i16)
+             367: 52(i16vec2) CompositeConstruct 366 366
+             368: 52(i16vec2) ExtInst 1(GLSL.std.450) 42(SMax) 365 367
                               Store 343(i16v) 368
-             369:   52(ivec2) Load 343(i16v)
-             370:   52(ivec2) ExtInst 1(GLSL.std.450) 42(SMax) 369 354
+             369: 52(i16vec2) Load 343(i16v)
+             370: 52(i16vec2) ExtInst 1(GLSL.std.450) 42(SMax) 369 354
                               Store 343(i16v) 370
-             371:  193(ivec3) Load 356(u16v)
-             372:     36(int) Load 358(u16)
-             373:  193(ivec3) CompositeConstruct 372 372 372
-             374:  193(ivec3) ExtInst 1(GLSL.std.450) 41(UMax) 371 373
+             371:193(i16vec3) Load 356(u16v)
+             372: 36(int16_t) Load 358(u16)
+             373:193(i16vec3) CompositeConstruct 372 372 372
+             374:193(i16vec3) ExtInst 1(GLSL.std.450) 41(UMax) 371 373
                               Store 356(u16v) 374
-             375:  193(ivec3) Load 356(u16v)
-             376:  193(ivec3) ExtInst 1(GLSL.std.450) 41(UMax) 375 363
+             375:193(i16vec3) Load 356(u16v)
+             376:193(i16vec3) ExtInst 1(GLSL.std.450) 41(UMax) 375 363
                               Store 356(u16v) 376
-             377:   52(ivec2) Load 343(i16v)
-             378:     14(int) Load 346(i16)
-             379:     14(int) SNegate 378
-             380:     14(int) Load 346(i16)
-             381:   52(ivec2) CompositeConstruct 379 379
-             382:   52(ivec2) CompositeConstruct 380 380
-             383:   52(ivec2) ExtInst 1(GLSL.std.450) 45(SClamp) 377 381 382
+             377: 52(i16vec2) Load 343(i16v)
+             378: 14(int16_t) Load 346(i16)
+             379: 14(int16_t) SNegate 378
+             380: 14(int16_t) Load 346(i16)
+             381: 52(i16vec2) CompositeConstruct 379 379
+             382: 52(i16vec2) CompositeConstruct 380 380
+             383: 52(i16vec2) ExtInst 1(GLSL.std.450) 45(SClamp) 377 381 382
                               Store 343(i16v) 383
-             384:   52(ivec2) Load 343(i16v)
-             385:   52(ivec2) Load 343(i16v)
-             386:   52(ivec2) SNegate 385
-             387:   52(ivec2) Load 343(i16v)
-             388:   52(ivec2) ExtInst 1(GLSL.std.450) 45(SClamp) 384 386 387
+             384: 52(i16vec2) Load 343(i16v)
+             385: 52(i16vec2) Load 343(i16v)
+             386: 52(i16vec2) SNegate 385
+             387: 52(i16vec2) Load 343(i16v)
+             388: 52(i16vec2) ExtInst 1(GLSL.std.450) 45(SClamp) 384 386 387
                               Store 343(i16v) 388
-             389:  193(ivec3) Load 356(u16v)
-             390:     36(int) Load 358(u16)
-             391:     36(int) SNegate 390
-             392:     36(int) Load 358(u16)
-             393:  193(ivec3) CompositeConstruct 391 391 391
-             394:  193(ivec3) CompositeConstruct 392 392 392
-             395:  193(ivec3) ExtInst 1(GLSL.std.450) 44(UClamp) 389 393 394
+             389:193(i16vec3) Load 356(u16v)
+             390: 36(int16_t) Load 358(u16)
+             391: 36(int16_t) SNegate 390
+             392: 36(int16_t) Load 358(u16)
+             393:193(i16vec3) CompositeConstruct 391 391 391
+             394:193(i16vec3) CompositeConstruct 392 392 392
+             395:193(i16vec3) ExtInst 1(GLSL.std.450) 44(UClamp) 389 393 394
                               Store 356(u16v) 395
-             396:  193(ivec3) Load 356(u16v)
-             397:  193(ivec3) Load 356(u16v)
-             398:  193(ivec3) SNegate 397
-             399:  193(ivec3) Load 356(u16v)
-             400:  193(ivec3) ExtInst 1(GLSL.std.450) 44(UClamp) 396 398 399
+             396:193(i16vec3) Load 356(u16v)
+             397:193(i16vec3) Load 356(u16v)
+             398:193(i16vec3) SNegate 397
+             399:193(i16vec3) Load 356(u16v)
+             400:193(i16vec3) ExtInst 1(GLSL.std.450) 44(UClamp) 396 398 399
                               Store 356(u16v) 400
              401:     15(ptr) AccessChain 343(i16v) 282
-             402:     14(int) Load 401
+             402: 14(int16_t) Load 401
              403:     15(ptr) AccessChain 343(i16v) 264
-             404:     14(int) Load 403
-             406:     14(int) Select 405 404 402
+             404: 14(int16_t) Load 403
+             406: 14(int16_t) Select 405 404 402
                               Store 346(i16) 406
-             407:     14(int) Load 346(i16)
-             408:   52(ivec2) CompositeConstruct 407 407
-             409:     14(int) Load 346(i16)
-             410:     14(int) SNegate 409
-             411:   52(ivec2) CompositeConstruct 410 410
-             414:   52(ivec2) Select 413 411 408
+             407: 14(int16_t) Load 346(i16)
+             408: 52(i16vec2) CompositeConstruct 407 407
+             409: 14(int16_t) Load 346(i16)
+             410: 14(int16_t) SNegate 409
+             411: 52(i16vec2) CompositeConstruct 410 410
+             414: 52(i16vec2) Select 413 411 408
                               Store 343(i16v) 414
              415:     37(ptr) AccessChain 356(u16v) 282
-             416:     36(int) Load 415
+             416: 36(int16_t) Load 415
              417:     37(ptr) AccessChain 356(u16v) 264
-             418:     36(int) Load 417
-             419:     36(int) Select 405 418 416
+             418: 36(int16_t) Load 417
+             419: 36(int16_t) Select 405 418 416
                               Store 358(u16) 419
-             420:     36(int) Load 358(u16)
-             421:  193(ivec3) CompositeConstruct 420 420 420
-             422:     36(int) Load 358(u16)
-             423:     36(int) SNegate 422
-             424:  193(ivec3) CompositeConstruct 423 423 423
-             427:  193(ivec3) Select 426 424 421
+             420: 36(int16_t) Load 358(u16)
+             421:193(i16vec3) CompositeConstruct 420 420 420
+             422: 36(int16_t) Load 358(u16)
+             423: 36(int16_t) SNegate 422
+             424:193(i16vec3) CompositeConstruct 423 423 423
+             427:193(i16vec3) Select 426 424 421
                               Store 356(u16v) 427
-             429:   52(ivec2) Load 343(i16v)
+             429: 52(i16vec2) Load 343(i16v)
              430:     27(int) Bitcast 429
                               Store 428(i32) 430
-             435:  432(ivec4) Load 434(i16v4)
-             436:     71(int) Bitcast 435
+             435:432(i16vec4) Load 434(i16v4)
+             436: 71(int64_t) Bitcast 435
                               Store 431(i64) 436
-             439:   57(ivec2) Load 438(u16v2)
+             439: 57(i16vec2) Load 438(u16v2)
              440:     17(int) Bitcast 439
                               Store 437(u32) 440
-             446:  443(ivec4) Load 445(u16v4)
-             447:     77(int) Bitcast 446
+             446:443(i16vec4) Load 445(u16v4)
+             447: 77(int64_t) Bitcast 446
                               Store 442(u64) 447
              448:     27(int) Load 428(i32)
-             449:   52(ivec2) Bitcast 448
+             449: 52(i16vec2) Bitcast 448
                               Store 343(i16v) 449
-             450:     71(int) Load 431(i64)
-             451:  432(ivec4) Bitcast 450
+             450: 71(int64_t) Load 431(i64)
+             451:432(i16vec4) Bitcast 450
                               Store 434(i16v4) 451
              452:     17(int) Load 437(u32)
-             453:   57(ivec2) Bitcast 452
+             453: 57(i16vec2) Bitcast 452
                               Store 438(u16v2) 453
-             454:     77(int) Load 442(u64)
-             455:  443(ivec4) Bitcast 454
+             454: 77(int64_t) Load 442(u64)
+             455:443(i16vec4) Bitcast 454
                               Store 445(u16v4) 455
-             458:  193(ivec3) Load 356(u16v)
-             459:     36(int) Load 358(u16)
-             460:  193(ivec3) CompositeConstruct 459 459 459
+             458:193(i16vec3) Load 356(u16v)
+             459: 36(int16_t) Load 358(u16)
+             460:193(i16vec3) CompositeConstruct 459 459 459
              461:  425(bvec3) ULessThan 458 460
                               Store 457(bv) 461
-             462:   52(ivec2) Load 343(i16v)
-             463:     14(int) Load 346(i16)
-             464:   52(ivec2) CompositeConstruct 463 463
+             462: 52(i16vec2) Load 343(i16v)
+             463: 14(int16_t) Load 346(i16)
+             464: 52(i16vec2) CompositeConstruct 463 463
              465:  174(bvec2) SLessThan 462 464
              466:  425(bvec3) Load 457(bv)
              467:  425(bvec3) VectorShuffle 466 465 3 4 2
                               Store 457(bv) 467
-             468:  193(ivec3) Load 356(u16v)
-             469:     36(int) Load 358(u16)
-             470:  193(ivec3) CompositeConstruct 469 469 469
+             468:193(i16vec3) Load 356(u16v)
+             469: 36(int16_t) Load 358(u16)
+             470:193(i16vec3) CompositeConstruct 469 469 469
              471:  425(bvec3) ULessThanEqual 468 470
                               Store 457(bv) 471
-             472:   52(ivec2) Load 343(i16v)
-             473:     14(int) Load 346(i16)
-             474:   52(ivec2) CompositeConstruct 473 473
+             472: 52(i16vec2) Load 343(i16v)
+             473: 14(int16_t) Load 346(i16)
+             474: 52(i16vec2) CompositeConstruct 473 473
              475:  174(bvec2) SLessThanEqual 472 474
              476:  425(bvec3) Load 457(bv)
              477:  425(bvec3) VectorShuffle 476 475 3 4 2
                               Store 457(bv) 477
-             478:  193(ivec3) Load 356(u16v)
-             479:     36(int) Load 358(u16)
-             480:  193(ivec3) CompositeConstruct 479 479 479
+             478:193(i16vec3) Load 356(u16v)
+             479: 36(int16_t) Load 358(u16)
+             480:193(i16vec3) CompositeConstruct 479 479 479
              481:  425(bvec3) UGreaterThan 478 480
                               Store 457(bv) 481
-             482:   52(ivec2) Load 343(i16v)
-             483:     14(int) Load 346(i16)
-             484:   52(ivec2) CompositeConstruct 483 483
+             482: 52(i16vec2) Load 343(i16v)
+             483: 14(int16_t) Load 346(i16)
+             484: 52(i16vec2) CompositeConstruct 483 483
              485:  174(bvec2) SGreaterThan 482 484
              486:  425(bvec3) Load 457(bv)
              487:  425(bvec3) VectorShuffle 486 485 3 4 2
                               Store 457(bv) 487
-             488:  193(ivec3) Load 356(u16v)
-             489:     36(int) Load 358(u16)
-             490:  193(ivec3) CompositeConstruct 489 489 489
+             488:193(i16vec3) Load 356(u16v)
+             489: 36(int16_t) Load 358(u16)
+             490:193(i16vec3) CompositeConstruct 489 489 489
              491:  425(bvec3) UGreaterThanEqual 488 490
                               Store 457(bv) 491
-             492:   52(ivec2) Load 343(i16v)
-             493:     14(int) Load 346(i16)
-             494:   52(ivec2) CompositeConstruct 493 493
+             492: 52(i16vec2) Load 343(i16v)
+             493: 14(int16_t) Load 346(i16)
+             494: 52(i16vec2) CompositeConstruct 493 493
              495:  174(bvec2) SGreaterThanEqual 492 494
              496:  425(bvec3) Load 457(bv)
              497:  425(bvec3) VectorShuffle 496 495 3 4 2
                               Store 457(bv) 497
-             498:  193(ivec3) Load 356(u16v)
-             499:     36(int) Load 358(u16)
-             500:  193(ivec3) CompositeConstruct 499 499 499
+             498:193(i16vec3) Load 356(u16v)
+             499: 36(int16_t) Load 358(u16)
+             500:193(i16vec3) CompositeConstruct 499 499 499
              501:  425(bvec3) IEqual 498 500
                               Store 457(bv) 501
-             502:   52(ivec2) Load 343(i16v)
-             503:     14(int) Load 346(i16)
-             504:   52(ivec2) CompositeConstruct 503 503
+             502: 52(i16vec2) Load 343(i16v)
+             503: 14(int16_t) Load 346(i16)
+             504: 52(i16vec2) CompositeConstruct 503 503
              505:  174(bvec2) IEqual 502 504
              506:  425(bvec3) Load 457(bv)
              507:  425(bvec3) VectorShuffle 506 505 3 4 2
                               Store 457(bv) 507
-             508:  193(ivec3) Load 356(u16v)
-             509:     36(int) Load 358(u16)
-             510:  193(ivec3) CompositeConstruct 509 509 509
+             508:193(i16vec3) Load 356(u16v)
+             509: 36(int16_t) Load 358(u16)
+             510:193(i16vec3) CompositeConstruct 509 509 509
              511:  425(bvec3) INotEqual 508 510
                               Store 457(bv) 511
-             512:   52(ivec2) Load 343(i16v)
-             513:     14(int) Load 346(i16)
-             514:   52(ivec2) CompositeConstruct 513 513
+             512: 52(i16vec2) Load 343(i16v)
+             513: 14(int16_t) Load 346(i16)
+             514: 52(i16vec2) CompositeConstruct 513 513
              515:  174(bvec2) INotEqual 512 514
              516:  425(bvec3) Load 457(bv)
              517:  425(bvec3) VectorShuffle 516 515 3 4 2


### PR DESCRIPTION
Without this, it is very hard to read disassembly of shaders that use explicitly-sized types. I left int/float as-is to avoid perturbing hundreds more generated files.

disassemble.cpp is the only non-generated file that changed.
