### PR TITLE
Removed usage of strnlen in floating-point tests

### DIFF
--- a/glslang/MachineIndependent/intermOut.cpp
+++ b/glslang/MachineIndependent/intermOut.cpp
@@ -1115,7 +1115,7 @@ static void OutputDouble(TInfoSink& out, double value, TOutputTraverser::EExtraO
 
         // remove a leading zero in the 100s slot in exponent; it is not portable
         // pattern:   XX...XXXe+0XX or XX...XXXe-0XX
-        int len = (int)strnlen(buf, maxSize);
+        int len = std::min((int)strlen(buf), maxSize);
         if (len > 5) {
             if (buf[len-5] == 'e' && (buf[len-4] == '+' || buf[len-4] == '-') && buf[len-3] == '0') {
                 buf[len-3] = buf[len-2];


### PR DESCRIPTION
`strnlen` is defined as `size_t strnlen(const char *s, size_t maxlen);` on most systems; however, it is not a standard C++ function. Some compilers like MinGW fail to compile after https://github.com/KhronosGroup/glslang/commit/1ea1b13f388a06cbfa363585657eec7f4fc189a7