### PR TITLE
Update spirv-tools known-good.

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -7024,18 +7024,18 @@ void GlslangToSpv(const glslang::TIntermediate& intermediate, std::vector<unsign
         optimizer.RegisterPass(CreateLocalAccessChainConvertPass());
         optimizer.RegisterPass(CreateLocalSingleBlockLoadStoreElimPass());
         optimizer.RegisterPass(CreateLocalSingleStoreElimPass());
+        optimizer.RegisterPass(CreateSimplificationPass());
         optimizer.RegisterPass(CreateAggressiveDCEPass());
-        optimizer.RegisterPass(CreateInsertExtractElimPass());
+        optimizer.RegisterPass(CreateVectorDCEPass());
         optimizer.RegisterPass(CreateDeadInsertElimPass());
         optimizer.RegisterPass(CreateAggressiveDCEPass());
-        optimizer.RegisterPass(CreateCCPPass());
-        optimizer.RegisterPass(CreateSimplificationPass());
         optimizer.RegisterPass(CreateDeadBranchElimPass());
-        optimizer.RegisterPass(CreateCFGCleanupPass());
         optimizer.RegisterPass(CreateBlockMergePass());
         optimizer.RegisterPass(CreateLocalMultiStoreElimPass());
+        optimizer.RegisterPass(CreateIfConversionPass());
+        optimizer.RegisterPass(CreateSimplificationPass());
         optimizer.RegisterPass(CreateAggressiveDCEPass());
-        optimizer.RegisterPass(CreateInsertExtractElimPass());
+        optimizer.RegisterPass(CreateVectorDCEPass());
         optimizer.RegisterPass(CreateDeadInsertElimPass());
         if (options->optimizeSize) {
             optimizer.RegisterPass(CreateRedundancyEliminationPass());
@@ -7043,6 +7043,7 @@ void GlslangToSpv(const glslang::TIntermediate& intermediate, std::vector<unsign
             // optimizer.RegisterPass(CreateCommonUniformElimPass());
         }
         optimizer.RegisterPass(CreateAggressiveDCEPass());
+        optimizer.RegisterPass(CreateCFGCleanupPass());
 
         if (!optimizer.Run(spirv.data(), spirv.size(), &spirv))
             return;

--- a/known_good.json
+++ b/known_good.json
@@ -5,7 +5,7 @@
       "site" : "github",
       "subrepo" : "KhronosGroup/SPIRV-Tools",
       "subdir" : "External/spirv-tools",
-      "commit" : "a579e720a8d7805ec9ebf657a4c6fa67ec268f7e"
+      "commit" : "545d6ca26d3beddcb8dc5dc363deb1544a2eeb87"
     },
     {
       "name" : "spirv-tools/external/spirv-headers",


### PR DESCRIPTION
Includes:

Fold FMix feeding Extract, and use the simplification pass.

Also adds IfConversion and VectorDCE to spirv-opt recipes.