### PR TITLE
Fix several signed/unsigned comparison compile warnings.

### DIFF
--- a/glslang/MachineIndependent/intermOut.cpp
+++ b/glslang/MachineIndependent/intermOut.cpp
@@ -1131,7 +1131,7 @@ static void OutputDouble(TInfoSink& out, double value, TOutputTraverser::EExtraO
         {
             out.debug << " : ";
             long long b = *reinterpret_cast<long long*>(&value);
-            for (int i = 0; i < 8 * sizeof(value); ++i, ++b) {
+            for (size_t i = 0; i < 8 * sizeof(value); ++i, ++b) {
                 out.debug << ((b & 0x8000000000000000) != 0 ? "1" : "0");
                 b <<= 1;
             }

--- a/glslang/MachineIndependent/preprocessor/PpTokens.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpTokens.cpp
@@ -188,7 +188,7 @@ void TPpContext::TokenStream::putToken(int atom, TPpToken* ppToken)
     // save the numeric value
     if (SaveValue(atom)) {
         const char* n = reinterpret_cast<const char*>(&ppToken->i64val);
-        for (int i = 0; i < sizeof(ppToken->i64val); ++i)
+        for (size_t i = 0; i < sizeof(ppToken->i64val); ++i)
             putSubtoken(*n++);
     }
 }
@@ -238,7 +238,7 @@ int TPpContext::TokenStream::getToken(TParseContextBase& parseContext, TPpToken 
     // get the numeric value
     if (SaveValue(atom)) {
         char* n = reinterpret_cast<char*>(&ppToken->i64val);
-        for (int i = 0; i < sizeof(ppToken->i64val); ++i)
+        for (size_t i = 0; i < sizeof(ppToken->i64val); ++i)
             *n++ = getSubtoken();
     }
 


### PR DESCRIPTION
Fixes a few compilation warnings.  This makes the loop variable type the same as the return type of sizeof() (which is size_t).

No functional changes or test diffs.
