### PR TITLE
Relax a stringToDouble test for, OSX AppleClang 9.1

### DIFF
--- a/Test/baseResults/stringToDouble.vert.out
+++ b/Test/baseResults/stringToDouble.vert.out
@@ -108,7 +108,7 @@ Shader version: 460
 0:26        move second child to first child ( temp double)
 0:26          'e11' ( temp double)
 0:26          Constant:
-0:26            9.8813129168249e-324
+0:26            1.0000000000000e-307
 0:27      Sequence
 0:27        move second child to first child ( temp double)
 0:27          'e12' ( temp double)
@@ -561,7 +561,7 @@ Shader version: 460
 0:26        move second child to first child ( temp double)
 0:26          'e11' ( temp double)
 0:26          Constant:
-0:26            9.8813129168249e-324
+0:26            1.0000000000000e-307
 0:27      Sequence
 0:27        move second child to first child ( temp double)
 0:27          'e12' ( temp double)

--- a/Test/stringToDouble.vert
+++ b/Test/stringToDouble.vert
@@ -23,7 +23,7 @@ void main()
     float e8 = 1e-16;
     double e9 = 1e100;
     double e10 = 1e+308;
-    double e11 = 1e-323;
+    double e11 = 1e-307; // Was 1e-323, but that's flushed to zero sometimes. 1e-308 can be flushed to 0.
     double e12 = 1e+309;
     double e13 = 1e-324;
     double e24 = 1e+999;


### PR DESCRIPTION
1e-323 was flushed to zero.
1e-308 is also flushed to zero.
Use 1e-307 instead, which still satisfies the test intent.

Fixes #1400