### PR TITLE
TProgram exposes layout manipulation functions

### DIFF
--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -687,40 +687,40 @@ public:
     int layoutOffset;
     int layoutAlign;
 
-                 unsigned int layoutLocation            :12;
-    static const unsigned int layoutLocationEnd    =  0xFFF;
+         mutable unsigned int layoutLocation              : 12;
+    static const unsigned int layoutLocationEnd       =  0xFFF;
 
-                 unsigned int layoutComponent           : 3;
-    static const unsigned int layoutComponentEnd    =     4;
+                 unsigned int layoutComponent             :  3;
+    static const unsigned int layoutComponentEnd      =    0x4;
 
-                 unsigned int layoutSet                 : 7;
-    static const unsigned int layoutSetEnd         =   0x3F;
+                 unsigned int layoutSet                   :  7;
+    static const unsigned int layoutSetEnd            =   0x3F;
 
-                 unsigned int layoutBinding            : 16;
-    static const unsigned int layoutBindingEnd    =  0xFFFF;
+         mutable unsigned int layoutBinding               : 16;
+    static const unsigned int layoutBindingEnd        = 0xFFFF;
 
-                 unsigned int layoutIndex              :  8;
-    static const unsigned int layoutIndexEnd    =      0xFF;
+                 unsigned int layoutIndex                 :  8;
+    static const unsigned int layoutIndexEnd          =   0xFF;
 
-                 unsigned int layoutStream              : 8;
-    static const unsigned int layoutStreamEnd    =     0xFF;
+                 unsigned int layoutStream                :  8;
+    static const unsigned int layoutStreamEnd         =   0xFF;
 
-                 unsigned int layoutXfbBuffer           : 4;
-    static const unsigned int layoutXfbBufferEnd    =   0xF;
+                 unsigned int layoutXfbBuffer             :  4;
+    static const unsigned int layoutXfbBufferEnd      =    0xF;
 
-                 unsigned int layoutXfbStride          : 10;
-    static const unsigned int layoutXfbStrideEnd    = 0x3FF;
+                 unsigned int layoutXfbStride             : 10;
+    static const unsigned int layoutXfbStrideEnd      =  0x3FF;
 
-                 unsigned int layoutXfbOffset          : 10;
-    static const unsigned int layoutXfbOffsetEnd    = 0x3FF;
+                 unsigned int layoutXfbOffset             : 10;
+    static const unsigned int layoutXfbOffsetEnd      =  0x3FF;
 
-                 unsigned int layoutAttachment          : 8;  // for input_attachment_index
-    static const unsigned int layoutAttachmentEnd    = 0XFF;
+                 unsigned int layoutAttachment            :  8; // for input_attachment_index
+    static const unsigned int layoutAttachmentEnd     =   0XFF;
 
-                 unsigned int layoutSpecConstantId       : 11;
-    static const unsigned int layoutSpecConstantIdEnd = 0x7FF;
+                 unsigned int layoutSpecConstantId        : 11;
+    static const unsigned int layoutSpecConstantIdEnd =  0x7FF;
 
-    TLayoutFormat layoutFormat                         :  8;
+    TLayoutFormat layoutFormat                            :  8;
 
     bool layoutPushConstant;
 
@@ -777,6 +777,10 @@ public:
     {
         return layoutLocation != layoutLocationEnd;
     }
+    void setLocation(unsigned int location) const
+    {
+        layoutLocation = location;
+    }
     bool hasComponent() const
     {
         return layoutComponent != layoutComponentEnd;
@@ -792,6 +796,10 @@ public:
     bool hasBinding() const
     {
         return layoutBinding != layoutBindingEnd;
+    }
+    void setBinding(unsigned int binding) const
+    {
+        layoutBinding = binding;
     }
     bool hasStream() const
     {

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1924,7 +1924,73 @@ const TType* TProgram::getUniformTType(int index) const      { return reflection
 const TType* TProgram::getUniformBlockTType(int index) const { return reflection->getUniformBlock(index).getType(); }
 unsigned TProgram::getLocalSize(int dim) const               { return reflection->getLocalSize(dim); }
 
-void TProgram::dumpReflection()                      { reflection->dump(); }
+// Uniforms
+EShLanguageMask TProgram::getUniformStages(int index) const  { return reflection->getUniformStages(index); }
+bool TProgram::getUniformHasLocation(int index) const        { return reflection->getUniformQualifier(index)->hasLocation(); }
+bool TProgram::getUniformHasBinding(int index) const         { return reflection->getUniformQualifier(index)->hasBinding(); }
+bool TProgram::getUniformHasSet(int index) const             { return reflection->getUniformQualifier(index)->hasSet(); }
+int TProgram::getUniformLocation(int index) const            { return reflection->getUniformQualifier(index)->hasLocation() ?
+                                                                      reflection->getUniformQualifier(index)->layoutLocation : -1; }
+int TProgram::getUniformSet(int index) const                 { return reflection->getUniformQualifier(index)->hasSet() ?
+                                                                      reflection->getUniformQualifier(index)->layoutSet : -1; }
+
+void TProgram::setUniformBinding(int index, int binding)     { reflection->getUniformQualifier(index)->setBinding(binding); }
+void TProgram::setUniformLocation(int index, int location)   { reflection->getUniformQualifier(index)->setLocation(location); }
+
+// Attributes
+bool TProgram::getAttributeHasLocation(int index) const      { return reflection->getAttributeQualifier(index)->hasLocation(); }
+int TProgram::getAttributeLocation(int index) const          { return reflection->getAttributeQualifier(index)->hasLocation() ?
+                                                                      reflection->getAttributeQualifier(index)->layoutLocation : -1;}
+int TProgram::getAttributeArraySize(int index) const         { return reflection->getAttribute(index).size; }
+
+void TProgram::setAttributeLocation(int index, int location) { reflection->setAttributeLocation(index, location); }
+
+// VaryingIns
+int TProgram::getNumLiveVaryingInVariables() const           { return reflection->getNumInVaryings(); }
+const char* TProgram::getVaryingInName(int index) const      { return reflection->getVaryingIn(index).name.c_str(); }
+int TProgram::getVaryingInIndex(const char* name) const      { return reflection->getVaryingInIndex(name); }
+int TProgram::getVaryingInType(int index) const              { return reflection->getVaryingIn(index).glDefineType; }
+int TProgram::getVaryingInArraySize(int index) const         { return reflection->getVaryingIn(index).size; }
+int TProgram::getVaryingInLocation(int index) const          { return reflection->getVaryingInQualifier(index)->hasLocation() ?
+                                                                      reflection->getVaryingInQualifier(index)->layoutLocation : -1; }
+bool TProgram::getVaryingInHasLocation(int index) const      { return reflection->getVaryingInQualifier(index)->hasLocation(); }
+
+bool TProgram::isInVaryingFlat(int index) const              { assert(reflection->getVaryingInQualifier(index)->flat == !reflection->getVaryingInQualifier(index)->smooth);
+                                                               return reflection->getVaryingInQualifier(index)->flat; }
+bool TProgram::isInVaryingNoPerspective(int index) const     { return reflection->getVaryingInQualifier(index)->nopersp; }
+
+void TProgram::setVaryingInLocation(int index, int location) { reflection->setVaryingInLocation(index, location); }
+
+// VaryingOuts
+int TProgram::getNumLiveVaryingOutVariables() const          { return reflection->getNumOutVaryings(); }
+const char* TProgram::getVaryingOutName(int index) const     { return reflection->getVaryingOut(index).name.c_str(); }
+int TProgram::getVaryingOutIndex(const char* name) const     { return reflection->getVaryingOutIndex(name); }
+int TProgram::getVaryingOutType(int index) const             { return reflection->getVaryingOut(index).glDefineType; }
+int TProgram::getVaryingOutArraySize(int index) const        { return reflection->getVaryingOut(index).size; }
+int TProgram::getVaryingOutLocation(int index) const         { return reflection->getVaryingOutQualifier(index)->hasLocation() ?
+                                                                      reflection->getVaryingOutQualifier(index)->layoutLocation : -1; }
+bool TProgram::getVaryingOutHasLocation(int index) const     { return reflection->getVaryingOutQualifier(index)->hasLocation(); }
+
+bool TProgram::isOutVaryingFlat(int index) const             { assert(reflection->getVaryingOutQualifier(index)->flat == !reflection->getVaryingOutQualifier(index)->smooth);
+                                                               return reflection->getVaryingOutQualifier(index)->flat; }
+bool TProgram::isOutVaryingNoPerspective(int index) const    { return reflection->getVaryingOutQualifier(index)->nopersp; }
+
+void TProgram::setVaryingOutLocation(int index, int location){ reflection->setVaryingOutLocation(index, location); }
+
+// Built ins
+int TProgram::getNumLiveBuiltIns(void) const                 { return reflection->getNumLiveBuiltIns(); }
+const char* TProgram::getBuiltInName(int index) const        { return reflection->getBuiltIn(index).name.c_str(); }
+int TProgram::getBuiltinType(int index) const                { return reflection->getBuiltIn(index).glDefineType; }
+int TProgram::getBuiltInIndex(const char* name) const        { return reflection->getBuiltInIndex(name); }
+int TProgram::getBuiltInHasLocation(int index) const         { return reflection->getBuiltInQualifier(index)->hasLocation(); }
+
+void TProgram::setBuiltInLocation(int index, int location)   { reflection->getBuiltInQualifier(index)->setLocation(location); }
+
+// Functions
+int TProgram::getNumLiveFunctions(void) const                { return reflection->getNumLiveFunctions(); }
+const char* TProgram::getFunctionName(int index) const       { return reflection->getFunctionName(index); }
+
+void TProgram::dumpReflection()                              { reflection->dump(); }
 
 //
 // I/O mapping implementation.

--- a/glslang/MachineIndependent/reflection.cpp
+++ b/glslang/MachineIndependent/reflection.cpp
@@ -97,19 +97,15 @@ public:
         }
     }
 
-    void addAttribute(const TIntermSymbol& base)
+    void addVarLocation(const TIntermSymbol& base)
     {
         if (processedDerefs.find(&base) == processedDerefs.end()) {
             processedDerefs.insert(&base);
 
-            const TString &name = base.getName();
-            const TType &type = base.getType();
-
-            TReflection::TNameToIndex::const_iterator it = reflection.nameToIndex.find(name);
-            if (it == reflection.nameToIndex.end()) {
-                reflection.nameToIndex[name] = (int)reflection.indexToAttribute.size();
-                reflection.indexToAttribute.push_back(TObjectReflection(name, type, 0, mapToGlType(type), 0, 0));
-            }
+            // Use a degenerate (empty) set of dereferences to immediately put as at the end of
+            // the dereference change expected by blowUpActiveAggregate.
+            TList<TIntermBinary*> derefs;
+            blowUpActiveAggregate(base.getType(), base.getName(), derefs, derefs.end(), 0, 0, 0);
         }
     }
 
@@ -245,15 +241,73 @@ public:
         if (arraySize == 0)
             arraySize = mapToGlArraySize(*terminalType);
 
-        TReflection::TNameToIndex::const_iterator it = reflection.nameToIndex.find(name);
-        if (it == reflection.nameToIndex.end()) {
-            reflection.nameToIndex[name] = (int)reflection.indexToUniform.size();
-            reflection.indexToUniform.push_back(TObjectReflection(name, *terminalType, offset,
-                                                                  mapToGlType(*terminalType),
-                                                                  arraySize, blockIndex));
-        } else if (arraySize > 1) {
-            int& reflectedArraySize = reflection.indexToUniform[it->second].size;
-            reflectedArraySize = std::max(arraySize, reflectedArraySize);
+        switch(baseType.getQualifier().storage) {
+        // Input Varyings
+        case EvqVaryingIn: {
+            TReflection::TNameToIndex::const_iterator it = reflection.varyingInNameToIndex.find(name);
+            if (it == reflection.varyingInNameToIndex.end()) {
+                reflection.varyingInNameToIndex[name] = (int)reflection.indexToVaryingIn.size();
+                reflection.indexToVaryingIn.push_back(TObjectReflection(name, baseType, offset, mapToGlType(*terminalType), arraySize, blockIndex));
+                reflection.varyingInQualifiers.push_back(&baseType.getQualifier());
+                if (intermediate.getStage() == EShLangVertex) {
+                    reflection.nameToIndex[name] = (int)reflection.indexToAttribute.size();
+                    reflection.indexToAttribute.push_back(TObjectReflection(name, baseType, offset, mapToGlType(*terminalType), 0, blockIndex));
+                }
+            } else if (arraySize > 1) {
+                int& reflectedArraySize = reflection.indexToVaryingIn[it->second].size;
+                reflectedArraySize = std::max(arraySize, reflectedArraySize);
+            }
+            break;
+            }
+        // Output Varyings
+        case EvqVaryingOut: {
+            TReflection::TNameToIndex::const_iterator it = reflection.varyingOutNameToIndex.find(name);
+            if (it == reflection.varyingOutNameToIndex.end()) {
+                reflection.varyingOutNameToIndex[name] = (int)reflection.indexToVaryingOut.size();
+                reflection.indexToVaryingOut.push_back(TObjectReflection(name, baseType, offset, mapToGlType(*terminalType), arraySize, blockIndex));
+                reflection.varyingOutQualifiers.push_back(&baseType.getQualifier());
+            } else if (arraySize > 1) {
+                int& reflectedArraySize = reflection.indexToVaryingOut[it->second].size;
+                reflectedArraySize = std::max(arraySize, reflectedArraySize);
+            }
+            break;
+            }
+        // Built ins
+        case EvqVertexId ... EvqFragDepth: {
+            TReflection::TNameToIndex::const_iterator it = reflection.builtInsNameToIndex.find(name);
+            if (it == reflection.builtInsNameToIndex.end()) {
+                reflection.builtInsNameToIndex[name] = (int)reflection.builtInsQualifiers.size();
+                reflection.indexToBuiltin.push_back(TObjectReflection(name, baseType, offset, mapToGlType(*terminalType), arraySize, blockIndex));
+                reflection.builtInsQualifiers.push_back(&baseType.getQualifier());
+                if (intermediate.getStage() == EShLangVertex && baseType.getQualifier().isPipeInput()) {
+                    reflection.nameToIndex[name] = (int)reflection.indexToAttribute.size();
+                    reflection.indexToAttribute.push_back(TObjectReflection(name, baseType, offset, mapToGlType(*terminalType), 0, blockIndex));
+                }
+            }
+            else if (arraySize > 1) {
+                int& reflectedArraySize = reflection.indexToVaryingOut[it->second].size;
+                reflectedArraySize = std::max(arraySize, reflectedArraySize);
+            }
+            break;
+            }
+        default: {
+            TReflection::TNameToIndex::const_iterator it = reflection.nameToIndex.find(name);
+            if (it == reflection.nameToIndex.end()) {
+                reflection.nameToIndex[name] = (int)reflection.indexToUniform.size();
+                reflection.indexToUniform.push_back(TObjectReflection(name, *terminalType, offset, mapToGlType(*terminalType), arraySize, blockIndex));
+                reflection.uniformQualifiers.push_back(&baseType.getQualifier());
+                reflection.uniformStages.push_back(static_cast<EShLanguageMask>(1 << intermediate.getStage()));
+            } else if (arraySize > 1) {
+                int& reflectedArraySize = reflection.indexToUniform[it->second].size;
+                reflectedArraySize = std::max(arraySize, reflectedArraySize);
+                EShLanguageMask& reflectedStages = reflection.uniformStages[it->second];
+                reflectedStages = static_cast<EShLanguageMask>(reflectedStages | (1 << intermediate.getStage()));
+            } else if (reflection.uniformStages[it->second]) {
+                EShLanguageMask& reflectedStages = reflection.uniformStages[it->second];
+                reflectedStages = static_cast<EShLanguageMask>(reflectedStages | (1 << intermediate.getStage()));
+            }
+            break;
+            }
         }
     }
 
@@ -743,11 +797,19 @@ bool TReflectionTraverser::visitBinary(TVisit /* visit */, TIntermBinary* node)
 // To reflect non-dereferenced objects.
 void TReflectionTraverser::visitSymbol(TIntermSymbol* base)
 {
-    if (base->getQualifier().storage == EvqUniform)
+    if (IsAnonymous(base->getName()))
+        return;
+
+    TStorageQualifier storage = base->getQualifier().storage;
+
+    if (storage == EvqUniform)
         addUniform(*base);
 
-    if (intermediate.getStage() == EShLangVertex && base->getQualifier().isPipeInput())
-        addAttribute(*base);
+    if ((storage == EvqVaryingOut) ||
+        (storage == EvqVaryingIn) ||
+        (intermediate.getStage() == EShLangVertex && base->getQualifier().isPipeInput()) ||
+        (storage >= EvqVertexId && storage <= EvqFragDepth))
+        addVarLocation(*base);
 }
 
 //

--- a/glslang/MachineIndependent/reflection.cpp
+++ b/glslang/MachineIndependent/reflection.cpp
@@ -273,7 +273,16 @@ public:
             break;
             }
         // Built ins
-        case EvqVertexId ... EvqFragDepth: {
+        case EvqVertexId:
+        case EvqInstanceId:
+        case EvqPosition:
+        case EvqPointSize:
+        case EvqClipVertex:
+        case EvqFace:
+        case EvqFragCoord:
+        case EvqPointCoord:
+        case EvqFragColor:
+        case EvqFragDepth: {
             TReflection::TNameToIndex::const_iterator it = reflection.builtInsNameToIndex.find(name);
             if (it == reflection.builtInsNameToIndex.end()) {
                 reflection.builtInsNameToIndex[name] = (int)reflection.builtInsQualifiers.size();

--- a/glslang/MachineIndependent/reflection.h
+++ b/glslang/MachineIndependent/reflection.h
@@ -145,11 +145,137 @@ public:
             return it->second;
     }
 
+    EShLanguageMask getUniformStages(int i) const
+    {
+        if (i >= 0 && i < (int)indexToUniform.size())
+            return uniformStages[i];
+        else
+            return EShLanguageMask(0);
+    }
+
+    const TQualifier* getUniformQualifier(int i) const
+    {
+        if (i >= 0 && i < (int)indexToUniform.size())
+            return uniformQualifiers[i];
+        else
+            return &badQualifier;
+    }
+
+    // VaryingIns
+    int getNumInVaryings() { return (int)indexToVaryingIn.size(); }
+    const TObjectReflection& getVaryingIn(int i) const
+    {
+        if (i >= 0 && i < (int)indexToVaryingIn.size())
+            return indexToVaryingIn[i];
+        else
+            return badReflection;
+    }
+
+    int getVaryingInIndex(const char* name) const
+    {
+        TNameToIndex::const_iterator it = varyingInNameToIndex.find(name);
+        if (it == varyingInNameToIndex.end())
+            return -1;
+        else
+            return it->second;
+    }
+
+    const TQualifier* getVaryingInQualifier(int i) const
+    {
+        if (i >= 0 && i < (int)indexToVaryingIn.size())
+            return varyingInQualifiers[i];
+        else
+            return &badQualifier;
+    }
+
+    void setVaryingInLocation(int i, int location)
+    {
+        if (i >= 0 && i < (int)indexToVaryingIn.size())
+            varyingInQualifiers[i]->setLocation(location);
+    }
+
+    // VaryingOuts
+    int getNumOutVaryings() { return (int)indexToVaryingOut.size(); }
+    const TObjectReflection& getVaryingOut(int i) const
+    {
+        if (i >= 0 && i < (int)indexToVaryingOut.size())
+            return indexToVaryingOut[i];
+        else
+            return badReflection;
+    }
+
+    int getVaryingOutIndex(const char* name) const
+    {
+        TNameToIndex::const_iterator it = varyingOutNameToIndex.find(name);
+        if (it == varyingOutNameToIndex.end())
+            return -1;
+        else
+            return it->second;
+    }
+
+    const TQualifier* getVaryingOutQualifier(int i) const
+    {
+        if (i >= 0 && i < (int)indexToVaryingOut.size())
+            return varyingOutQualifiers[i];
+        else
+            return &badQualifier;
+    }
+
+    void setVaryingOutLocation(int i, int location)
+    {
+        if(i >= 0 && i < (int)indexToVaryingOut.size())
+            varyingOutQualifiers[i]->setLocation(location);
+    }
+
+    const TQualifier* getAttributeQualifier(int i) const
+    {
+        if (i >= 0 && i < (int)indexToAttribute.size())
+            return varyingInQualifiers[i];
+        else
+            return &badQualifier;
+    }
+
+    void setAttributeLocation(int i, int location)
+    {
+        if (i >= 0 && i < (int)indexToAttribute.size()){
+            varyingInQualifiers[i]->setLocation(location);
+        }
+    }
+
+    int getNumLiveBuiltIns(void) const { return (int)builtInsNameToIndex.size(); }
+    int getBuiltInIndex(const char* name) const
+    {
+        TNameToIndex::const_iterator it = builtInsNameToIndex.find(name);
+        if (it == builtInsNameToIndex.end())
+            return -1;
+        else
+            return it->second;
+    }
+
+    const TQualifier* getBuiltInQualifier(int index) const
+    {
+        if (index >= 0 && index < (int)builtInsQualifiers.size())
+            return builtInsQualifiers[index];
+        else
+            return &badQualifier;
+    }
+
+    const TObjectReflection& getBuiltIn(int i) const
+    {
+        if (i >= 0 && i < (int)indexToBuiltin.size())
+            return indexToBuiltin[i];
+        else
+            return badReflection;
+    }
+
     // see getIndex(const char*)
     int getIndex(const TString& name) const { return getIndex(name.c_str()); }
 
     // Thread local size
     unsigned getLocalSize(int dim) const { return dim <= 2 ? localSize[dim] : 0; }
+
+    int getNumLiveFunctions(void) { return (int)liveFunctions.size(); }
+    const char* getFunctionName(int index) { return liveFunctions[index].c_str(); }
 
     void dump();
 
@@ -170,6 +296,27 @@ protected:
     TMapIndexToReflection indexToAttribute;
 
     unsigned int localSize[3];
+
+    TQualifier                      badQualifier;
+
+    std::vector<EShLanguageMask>    uniformStages;
+    std::vector<const TQualifier *> uniformQualifiers;
+
+    std::vector<int>                attributeIndices;
+
+    TNameToIndex                    varyingInNameToIndex;
+    TMapIndexToReflection           indexToVaryingIn;
+    std::vector<const TQualifier *> varyingInQualifiers;
+
+    TNameToIndex                    varyingOutNameToIndex;
+    TMapIndexToReflection           indexToVaryingOut;
+    std::vector<const TQualifier *> varyingOutQualifiers;
+
+    TNameToIndex                    builtInsNameToIndex;
+    TMapIndexToReflection           indexToBuiltin;
+    std::vector<const TQualifier *> builtInsQualifiers;
+
+    std::vector<TString>            liveFunctions;
 };
 
 } // end namespace glslang

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -655,6 +655,8 @@ public:
     virtual ~TProgram();
     void addShader(TShader* shader) { stages[shader->stage].push_back(shader); }
 
+    bool hasReflection(void) const { return (reflection != nullptr); }
+
     // Link Validation interface
     bool link(EShMessages);
     const char* getInfoLog();
@@ -679,11 +681,68 @@ public:
     int getUniformArraySize(int index) const;              // can be used for glGetActiveUniformsiv(GL_UNIFORM_SIZE)
     int getNumLiveAttributes() const;                      // can be used for glGetProgramiv(GL_ACTIVE_ATTRIBUTES)
     unsigned getLocalSize(int dim) const;                  // return dim'th local size
-    const char *getAttributeName(int index) const;         // can be used for glGetActiveAttrib()
+    const char* getAttributeName(int index) const;         // can be used for glGetActiveAttrib()
     int getAttributeType(int index) const;                 // can be used for glGetActiveAttrib()
     const TType* getUniformTType(int index) const;         // returns a TType*
     const TType* getUniformBlockTType(int index) const;    // returns a TType*
     const TType* getAttributeTType(int index) const;       // returns a TType*
+
+    EShLanguageMask getUniformStages(int index) const;     // returns shader stage of uniform
+    bool getUniformHasLocation(int index) const;
+    bool getUniformHasBinding(int index) const;
+    bool getUniformHasSet(int index) const;
+    int getUniformLocation(int index) const;
+    int getUniformSet(int index) const;
+
+    void setUniformBinding(int index, int binding);
+    void setUniformLocation(int index, int binding);
+
+    bool getAttributeHasLocation(int index) const;
+    int getAttributeLocation(int index) const;
+    int getAttributeArraySize(int index) const;
+
+    void setAttributeLocation(int index, int location);
+
+    // VaryingIns
+    int getNumLiveVaryingInVariables() const;
+    const char* getVaryingInName(int index) const;
+    int getVaryingInIndex(const char* name) const;
+    int getVaryingInType(int index) const;
+    int getVaryingInArraySize(int index) const;
+    int getVaryingInLocation(int index) const;
+    bool getVaryingInHasLocation(int index) const;
+
+    bool isInVaryingFlat(int index) const;
+    bool isInVaryingNoPerspective(int index) const;
+
+    void setVaryingInLocation(int index, int location);
+
+    // VaryingOuts
+    int getNumLiveVaryingOutVariables() const;
+    const char* getVaryingOutName(int index) const;
+    int getVaryingOutIndex(const char* name) const;
+    int getVaryingOutType(int index) const;
+    int getVaryingOutArraySize(int index) const;
+    int getVaryingOutLocation(int index) const;
+    bool getVaryingOutHasLocation(int index) const;
+
+    bool isOutVaryingFlat(int index) const;
+    bool isOutVaryingNoPerspective(int index) const;
+
+    void setVaryingOutLocation(int index, int location);
+
+    // Built ins
+    int getNumLiveBuiltIns(void) const;
+    const char* getBuiltInName(int index) const;
+    int getBuiltinType(int index) const;
+    int getBuiltInIndex(const char* name) const;
+    int getBuiltInHasLocation(int index) const;
+
+    void setBuiltInLocation(int index, int location);
+
+    // Functions
+    int getNumLiveFunctions(void) const;
+    const char* getFunctionName(int index) const;
 
     void dumpReflection();
 


### PR DESCRIPTION
New functions allow the manipulation of an already built reflection.
User can query and change the location/binding of the shader's uniforms,
vertex attributes and varyings.
Changes will be reflected in the generated spirv (if requested).