### PR TITLE
script: Improve update sources script

### DIFF
--- a/update_glslang_sources.py
+++ b/update_glslang_sources.py
@@ -66,7 +66,7 @@ def command_retval(cmd, directory):
     p = subprocess.Popen(cmd,
                          cwd=directory,
                          stdout=subprocess.PIPE)
-    (stdout, _) = p.communicate()
+    p.communicate()
     return p.returncode
 
 
@@ -95,8 +95,8 @@ class GoodCommit(object):
 
     def AddRemote(self):
         """Add the remote 'known-good' if it does not exist."""
-        print('Ignore "fatal" errors for missing known-good remote:')
-        if command_retval(['git', 'remote', 'show', 'known-good'], self.subdir) != 0:
+        remotes = command_output(['git', 'remote'], self.subdir).splitlines()
+        if 'known-good' not in remotes:
             command_output(['git', 'remote', 'add', 'known-good', self.GetUrl()], self.subdir)
 
     def HasCommit(self):


### PR DESCRIPTION
- remove unused variable to pass pylint
- Use another approach to detect if known-good remote is already
  present to avoid the need for "ignore following errors" message.