### PR TITLE
SPV: Add option to print disassembly in standard form using SPIRV-Tools.

### DIFF
--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -60,6 +60,7 @@ if(ENABLE_OPT)
         PRIVATE ${spirv-tools_SOURCE_DIR}/source
     )
     target_link_libraries(SPIRV glslang SPIRV-Tools-opt)
+    target_include_directories(SPIRV PUBLIC ../External)
 else()
     target_link_libraries(SPIRV glslang)
 endif(ENABLE_OPT)

--- a/SPIRV/disassemble.cpp
+++ b/SPIRV/disassemble.cpp
@@ -716,4 +716,25 @@ void Disassemble(std::ostream& out, const std::vector<unsigned int>& stream)
     SpirvStream.processInstructions();
 }
 
+#if ENABLE_OPT
+
+#include "spirv-tools/source/disassemble.h"
+
+// Use the SPIRV-Tools disassembler to print SPIR-V.
+void SpirvToolsDisassemble(std::ostream& out, const std::vector<unsigned int>& spirv)
+{
+    spv_context context = spvContextCreate(SPV_ENV_UNIVERSAL_1_3);
+    spv_text text;
+    spv_diagnostic diagnostic = nullptr;
+    spvBinaryToText(context, &spirv.front(), spirv.size(),
+        SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES | SPV_BINARY_TO_TEXT_OPTION_INDENT,
+        &text, &diagnostic);
+    if (diagnostic == nullptr)
+        out << text->str;
+    else
+        spvDiagnosticPrint(diagnostic);
+}
+
+#endif
+
 }; // end namespace spv

--- a/SPIRV/disassemble.h
+++ b/SPIRV/disassemble.h
@@ -45,7 +45,11 @@
 
 namespace spv {
 
+    // disassemble with glslang custom disassembler
     void Disassemble(std::ostream& out, const std::vector<unsigned int>&);
+
+    // disassemble with SPIRV-Tools disassembler
+    void SpirvToolsDisassemble(std::ostream& out, const std::vector<unsigned int>& stream);
 
 };  // end namespace spv
 

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -33,6 +33,7 @@ endif(WIN32)
 
 target_link_libraries(glslangValidator ${LIBRARIES})
 target_link_libraries(spirv-remap ${LIBRARIES})
+target_include_directories(glslangValidator PUBLIC ../External)
 
 if(WIN32)
     source_group("Source" FILES ${SOURCES})

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -102,6 +102,7 @@ enum TOptions {
     EOptionDumpBareVersion      = (1 << 31),
 };
 bool targetHlslFunctionality1 = false;
+bool SpvToolsDisassembler = false;
 
 //
 // Return codes from main/exit().
@@ -506,6 +507,8 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
                         sourceEntryPointName = argv[1];
                         bumpArg();
                         break;
+                    } else if (lowerword == "spirv-dis") {
+                        SpvToolsDisassembler = true;
                     } else if (lowerword == "stdin") {
                         Options |= EOptionStdin;
                         shaderStageName = argv[1];
@@ -982,9 +985,15 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
                         } else {
                             glslang::OutputSpvBin(spirv, GetBinaryName((EShLanguage)stage));
                         }
-                        if (Options & EOptionHumanReadableSpv) {
+#if ENABLE_OPT
+                        if (SpvToolsDisassembler)
+                            spv::SpirvToolsDisassemble(std::cout, spirv);
+#else
+                        if (SpvToolsDisassembler)
+                            printf("SPIRV-Tools is not enabled; use -H for human readable SPIR-V\n");
+#endif
+                        if (!SpvToolsDisassembler && (Options & EOptionHumanReadableSpv))
                             spv::Disassemble(std::cout, spirv);
-                        }
                     }
                 }
             }
@@ -1405,6 +1414,8 @@ void usage()
            "  --shift-UBO-binding [stage] [num set]... per-descriptor-set shift values\n"
            "  --shift-cbuffer-binding [stage] num  synonym for --shift-UBO-binding\n"
            "  --shift-cbuffer-binding [stage] [num set]... per-descriptor-set shift values\n"
+           "  --spirv-dis                          output standard form disassembly; works only\n"
+           "                                       when a SPIR-V generation option is also used\n"
            "  --sub [stage] num                    synonym for --shift-UBO-binding\n"
            "  --source-entrypoint <name>           the given shader source function is\n"
            "                                       renamed to be the <name> given in -e\n"


### PR DESCRIPTION
This allows printing SPIR-V in the standard form, as per SPIR-V tools.  Can be used, for example, like:

```
glslangValidator -V --spirv-dis t.frag  # compile for Vulkan, print SPIR-V assembly via SPIRV-Tools
```

The existing and default uses of glslang are all still as they were.

@dneto0 and @greg-lunarg, or anyone, a few design questions:

- Recommendations for the  option spelling and interactions? Note, I am not yet intending to switch how the regression suites work.
- I reused ENABLE_OPT to know if SPIRV-Tools was present or not, and it seems it had some use like that already. Should we change the name to generalize, or have a two-level hierarchy? Seems the hard part of this change will be managing CMake options and compiler flags. Simple is to just keep using ENABLE_OPT for this, despite being misnamed. I did not have to include an extra library to get the functionality.
- Opened related issue https://github.com/KhronosGroup/SPIRV-Tools/issues/1652 to request standalone disassembly.
- Should I do anything with the SPIRV-Tools `spv_diagnostic`?