### PR TITLE
Constant.cpp Floating point divide by zero

### DIFF
--- a/glslang/MachineIndependent/Constant.cpp
+++ b/glslang/MachineIndependent/Constant.cpp
@@ -179,7 +179,27 @@ TIntermTyped* TIntermConstantUnion::fold(TOperator op, const TIntermTyped* right
             case EbtDouble:
             case EbtFloat:
             case EbtFloat16:
-                newConstArray[i].setDConst(leftUnionArray[i].getDConst() / rightUnionArray[i].getDConst());
+                {
+                    auto right = rightUnionArray[i].getDConst();
+                    auto left = leftUnionArray[i].getDConst();
+
+                    if (right)
+                    {
+                        newConstArray[i].setDConst(left / right);
+                    }
+                    else if (left > 0)
+                    {
+                        newConstArray[i].setDConst((double)INFINITY);
+                    }
+                    else if (left < 0)
+                    {
+                        newConstArray[i].setDConst((double)-INFINITY);
+                    }
+                    else
+                    {
+                        newConstArray[i].setDConst((double)NAN);
+                    }
+                }
                 break;
             case EbtInt8:
                 if (rightUnionArray[i] == (signed char)0)


### PR DESCRIPTION
Constant.cpp will throw a floating point divide by zero if floating point exceptions are enabled in Win32 causing the program to crash. This fix manually checks the right-hand argument of the division and sets appropriate Infinity, Negative Infinity, or NAN as if the floating point exceptions were disabled.