### PR TITLE
build: Add ccache option to CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,14 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND WIN32)
     set(CMAKE_INSTALL_PREFIX "install" CACHE STRING "..." FORCE)
 endif()
 
+option(USE_CCACHE "Use ccache" OFF)
+if(USE_CCACHE)
+    find_program(CCACHE_FOUND ccache)
+    if(CCACHE_FOUND)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    endif(CCACHE_FOUND)
+endif()
+
 project(glslang)
 # make testing optional
 include(CTest)


### PR DESCRIPTION
This is totally optional, but lets people build this repo with
ccache to improve rebuild speeds.  It also can help a great deal
on ccache-enabled CI systems like Travis-CI.  We build fixed
revisions of glslang a lot on Travis, so this will be a big help
with CI machine loading.