### PR TITLE
CMake options for postfix and SPVRemapper.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(SKIP_GLSLANG_INSTALL "Skip installation" ${SKIP_GLSLANG_INSTALL})
 if(NOT ${SKIP_GLSLANG_INSTALL})
   set(ENABLE_GLSLANG_INSTALL ON)
 endif()
+option(ENABLE_SPVREMAPPER "Enables building of SPVRemapper" ON)
 
 option(ENABLE_AMD_EXTENSIONS "Enables support of AMD-specific extensions" ON)
 option(ENABLE_GLSLANG_BINARIES "Builds glslangValidator and spirv-remap" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ if(ENABLE_HLSL)
 endif(ENABLE_HLSL)
 
 if(WIN32)
-    set(CMAKE_DEBUG_POSTFIX "d")
+    set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Adds a postfix for debug-built libraries.")
     if(MSVC)
         include(ChooseMSVCCRT.cmake)
     endif(MSVC)

--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -45,13 +45,17 @@ set_property(TARGET SPIRV PROPERTY FOLDER glslang)
 set_property(TARGET SPIRV PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_include_directories(SPIRV PUBLIC ..)
 
-add_library(SPVRemapper ${LIB_TYPE} ${SPVREMAP_SOURCES} ${SPVREMAP_HEADERS})
-set_property(TARGET SPVRemapper PROPERTY FOLDER glslang)
-set_property(TARGET SPVRemapper PROPERTY POSITION_INDEPENDENT_CODE ON)
+if (ENABLE_SPVREMAPPER)
+    add_library(SPVRemapper ${LIB_TYPE} ${SPVREMAP_SOURCES} ${SPVREMAP_HEADERS})
+    set_property(TARGET SPVRemapper PROPERTY FOLDER glslang)
+    set_property(TARGET SPVRemapper PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
 
 if(WIN32 AND BUILD_SHARED_LIBS)
     set_target_properties(SPIRV PROPERTIES PREFIX "")
-    set_target_properties(SPVRemapper PROPERTIES PREFIX "")
+    if (ENABLE_SPVREMAPPER)
+        set_target_properties(SPVRemapper PROPERTIES PREFIX "")
+    endif()
 endif()
 
 if(ENABLE_OPT)
@@ -72,11 +76,20 @@ endif(WIN32)
 
 if(ENABLE_GLSLANG_INSTALL)
     if(BUILD_SHARED_LIBS)
-        install(TARGETS SPIRV SPVRemapper
+        if (ENABLE_SPVREMAPPER)
+            install(TARGETS SPVRemapper
+                    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        endif()
+        install(TARGETS SPIRV
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
     else()
-        install(TARGETS SPIRV SPVRemapper
+        if (ENABLE_SPVREMAPPER)
+            install(TARGETS SPVRemapper
+                    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        endif()
+        install(TARGETS SPIRV
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endif()
 


### PR DESCRIPTION
These changes allow for SPVRemapper to not be build (builds by default), and allows for higher up projects to override the default output postfix.