### PR TITLE
Reflection exposes the Shader Stages where a Uniform is present

### DIFF
--- a/Test/baseResults/hlsl.automap.frag.out
+++ b/Test/baseResults/hlsl.automap.frag.out
@@ -1,29 +1,29 @@
 hlsl.automap.frag
 Uniform reflection:
-t1: offset -1, type 8b5d, size 1, index -1, binding 11
-t2: offset -1, type 8b5e, size 1, index -1, binding 12
-t3: offset -1, type 8b5f, size 1, index -1, binding 13
-t4.@data: offset 0, type 8b52, size 1, index 0, binding -1
-t5.@data: offset 0, type 1405, size 0, index 1, binding -1
-t6: offset -1, type 8dc2, size 1, index -1, binding 16
-s1: offset -1, type 0, size 1, index -1, binding 31
-s2: offset -1, type 0, size 1, index -1, binding 32
-u1: offset -1, type 904c, size 1, index -1, binding 41
-u2: offset -1, type 904d, size 1, index -1, binding 42
-u3: offset -1, type 904e, size 1, index -1, binding 43
-u4: offset -1, type 9051, size 1, index -1, binding 44
-u5.@data: offset 0, type 1405, size 0, index 2, binding -1
-u6.@data: offset 0, type 1406, size 1, index 3, binding -1
-cb1: offset 0, type 1404, size 1, index 4, binding -1
-tb1: offset 0, type 1404, size 1, index 5, binding -1
+t1: offset -1, type 8b5d, size 1, index -1, binding 11, stages 16
+t2: offset -1, type 8b5e, size 1, index -1, binding 12, stages 16
+t3: offset -1, type 8b5f, size 1, index -1, binding 13, stages 16
+t4.@data: offset 0, type 8b52, size 1, index 0, binding -1, stages 16
+t5.@data: offset 0, type 1405, size 0, index 1, binding -1, stages 16
+t6: offset -1, type 8dc2, size 1, index -1, binding 16, stages 16
+s1: offset -1, type 0, size 1, index -1, binding 31, stages 16
+s2: offset -1, type 0, size 1, index -1, binding 32, stages 16
+u1: offset -1, type 904c, size 1, index -1, binding 41, stages 16
+u2: offset -1, type 904d, size 1, index -1, binding 42, stages 16
+u3: offset -1, type 904e, size 1, index -1, binding 43, stages 16
+u4: offset -1, type 9051, size 1, index -1, binding 44, stages 16
+u5.@data: offset 0, type 1405, size 0, index 2, binding -1, stages 16
+u6.@data: offset 0, type 1406, size 1, index 3, binding -1, stages 16
+cb1: offset 0, type 1404, size 1, index 4, binding -1, stages 16
+tb1: offset 0, type 1404, size 1, index 5, binding -1, stages 16
 
 Uniform block reflection:
-t4: offset -1, type ffffffff, size 0, index -1, binding 14
-t5: offset -1, type ffffffff, size 0, index -1, binding 15
-u5: offset -1, type ffffffff, size 0, index -1, binding 45
-u6: offset -1, type ffffffff, size 0, index -1, binding 46
-cb: offset -1, type ffffffff, size 4, index -1, binding 51
-tb: offset -1, type ffffffff, size 4, index -1, binding 17
+t4: offset -1, type ffffffff, size 0, index -1, binding 14, stages 0
+t5: offset -1, type ffffffff, size 0, index -1, binding 15, stages 0
+u5: offset -1, type ffffffff, size 0, index -1, binding 45, stages 0
+u6: offset -1, type ffffffff, size 0, index -1, binding 46, stages 0
+cb: offset -1, type ffffffff, size 4, index -1, binding 51, stages 0
+tb: offset -1, type ffffffff, size 4, index -1, binding 17, stages 0
 
 Vertex attribute reflection:
 

--- a/Test/baseResults/hlsl.reflection.binding.frag.out
+++ b/Test/baseResults/hlsl.reflection.binding.frag.out
@@ -1,19 +1,19 @@
 hlsl.reflection.binding.frag
 Uniform reflection:
-t1: offset -1, type 8b5d, size 1, index -1, binding 15
-s1: offset -1, type 0, size 1, index -1, binding 5
-t1a: offset -1, type 8b5d, size 1, index -1, binding 16
-s1a: offset -1, type 0, size 1, index -1, binding 6
-c1_a: offset 0, type 8b52, size 1, index 0, binding -1
-c1_b: offset 16, type 1404, size 1, index 0, binding -1
-c1_c: offset 20, type 1406, size 1, index 0, binding -1
-c2_a: offset 0, type 8b52, size 1, index 1, binding -1
-c2_b: offset 16, type 1404, size 1, index 1, binding -1
-c2_c: offset 20, type 1406, size 1, index 1, binding -1
+t1: offset -1, type 8b5d, size 1, index -1, binding 15, stages 16
+s1: offset -1, type 0, size 1, index -1, binding 5, stages 16
+t1a: offset -1, type 8b5d, size 1, index -1, binding 16, stages 16
+s1a: offset -1, type 0, size 1, index -1, binding 6, stages 16
+c1_a: offset 0, type 8b52, size 1, index 0, binding -1, stages 16
+c1_b: offset 16, type 1404, size 1, index 0, binding -1, stages 16
+c1_c: offset 20, type 1406, size 1, index 0, binding -1, stages 16
+c2_a: offset 0, type 8b52, size 1, index 1, binding -1, stages 16
+c2_b: offset 16, type 1404, size 1, index 1, binding -1, stages 16
+c2_c: offset 20, type 1406, size 1, index 1, binding -1, stages 16
 
 Uniform block reflection:
-cbuff1: offset -1, type ffffffff, size 24, index -1, binding 2
-cbuff2: offset -1, type ffffffff, size 24, index -1, binding 3
+cbuff1: offset -1, type ffffffff, size 24, index -1, binding 2, stages 0
+cbuff2: offset -1, type ffffffff, size 24, index -1, binding 3, stages 0
 
 Vertex attribute reflection:
 

--- a/Test/baseResults/hlsl.reflection.vert.out
+++ b/Test/baseResults/hlsl.reflection.vert.out
@@ -1,76 +1,76 @@
 hlsl.reflection.vert
 Uniform reflection:
-anonMember3: offset 80, type 8b52, size 1, index 0, binding -1
-s.a: offset 0, type 1404, size 1, index 1, binding -1
-m23: offset 16, type 8b67, size 1, index 0, binding -1
-scalarAfterm23: offset 48, type 1404, size 1, index 0, binding -1
-c_m23: offset 16, type 8b67, size 1, index 2, binding -1
-c_scalarAfterm23: offset 48, type 1404, size 1, index 2, binding -1
-scalarBeforeArray: offset 96, type 1404, size 1, index 0, binding -1
-floatArray: offset 112, type 1406, size 5, index 0, binding -1
-scalarAfterArray: offset 192, type 1404, size 1, index 0, binding -1
-m22: offset 208, type 8b5a, size 9, index 0, binding -1
-dm22: offset 32, type 8b5a, size 4, index 1, binding -1
-foo.n1.a: offset 0, type 1406, size 1, index 3, binding -1
-foo.n2.b: offset 16, type 1406, size 1, index 3, binding -1
-foo.n2.c: offset 20, type 1406, size 1, index 3, binding -1
-foo.n2.d: offset 24, type 1406, size 1, index 3, binding -1
-deepA.d2.d1[2].va: offset 376, type 8b50, size 2, index 1, binding -1
-deepB.d2.d1.va: offset 984, type 8b50, size 2, index 1, binding -1
-deepB.d2.d1[0].va: offset 984, type 8b50, size 2, index 1, binding -1
-deepB.d2.d1[1].va: offset 984, type 8b50, size 2, index 1, binding -1
-deepB.d2.d1[2].va: offset 984, type 8b50, size 2, index 1, binding -1
-deepB.d2.d1[3].va: offset 984, type 8b50, size 2, index 1, binding -1
-deepC.iv4: offset 1568, type 8b52, size 1, index 1, binding -1
-deepC.d2.i: offset 1568, type 1404, size 1, index 1, binding -1
-deepC.d2.d1[0].va: offset 1568, type 8b50, size 3, index 1, binding -1
-deepC.d2.d1[0].b: offset 1568, type 8b56, size 1, index 1, binding -1
-deepC.d2.d1[1].va: offset 1568, type 8b50, size 3, index 1, binding -1
-deepC.d2.d1[1].b: offset 1568, type 8b56, size 1, index 1, binding -1
-deepC.d2.d1[2].va: offset 1568, type 8b50, size 3, index 1, binding -1
-deepC.d2.d1[2].b: offset 1568, type 8b56, size 1, index 1, binding -1
-deepC.d2.d1[3].va: offset 1568, type 8b50, size 3, index 1, binding -1
-deepC.d2.d1[3].b: offset 1568, type 8b56, size 1, index 1, binding -1
-deepC.v3: offset 1568, type 8b54, size 1, index 1, binding -1
-deepD[0].iv4: offset 2480, type 8b52, size 1, index 1, binding -1
-deepD[0].d2.i: offset 2480, type 1404, size 1, index 1, binding -1
-deepD[0].d2.d1[0].va: offset 2480, type 8b50, size 3, index 1, binding -1
-deepD[0].d2.d1[0].b: offset 2480, type 8b56, size 1, index 1, binding -1
-deepD[0].d2.d1[1].va: offset 2480, type 8b50, size 3, index 1, binding -1
-deepD[0].d2.d1[1].b: offset 2480, type 8b56, size 1, index 1, binding -1
-deepD[0].d2.d1[2].va: offset 2480, type 8b50, size 3, index 1, binding -1
-deepD[0].d2.d1[2].b: offset 2480, type 8b56, size 1, index 1, binding -1
-deepD[0].d2.d1[3].va: offset 2480, type 8b50, size 3, index 1, binding -1
-deepD[0].d2.d1[3].b: offset 2480, type 8b56, size 1, index 1, binding -1
-deepD[0].v3: offset 2480, type 8b54, size 1, index 1, binding -1
-deepD[1].iv4: offset 2480, type 8b52, size 1, index 1, binding -1
-deepD[1].d2.i: offset 2480, type 1404, size 1, index 1, binding -1
-deepD[1].d2.d1[0].va: offset 2480, type 8b50, size 3, index 1, binding -1
-deepD[1].d2.d1[0].b: offset 2480, type 8b56, size 1, index 1, binding -1
-deepD[1].d2.d1[1].va: offset 2480, type 8b50, size 3, index 1, binding -1
-deepD[1].d2.d1[1].b: offset 2480, type 8b56, size 1, index 1, binding -1
-deepD[1].d2.d1[2].va: offset 2480, type 8b50, size 3, index 1, binding -1
-deepD[1].d2.d1[2].b: offset 2480, type 8b56, size 1, index 1, binding -1
-deepD[1].d2.d1[3].va: offset 2480, type 8b50, size 3, index 1, binding -1
-deepD[1].d2.d1[3].b: offset 2480, type 8b56, size 1, index 1, binding -1
-deepD[1].v3: offset 2480, type 8b54, size 1, index 1, binding -1
-foo1: offset 0, type 1406, size 1, index 4, binding -1
-foo2: offset 0, type 1406, size 1, index 5, binding -1
-anonMember1: offset 0, type 8b51, size 1, index 0, binding -1
-uf1: offset 16, type 1406, size 1, index 1, binding -1
+anonMember3: offset 80, type 8b52, size 1, index 0, binding -1, stages 1
+s.a: offset 0, type 1404, size 1, index 1, binding -1, stages 1
+m23: offset 16, type 8b67, size 1, index 0, binding -1, stages 1
+scalarAfterm23: offset 48, type 1404, size 1, index 0, binding -1, stages 1
+c_m23: offset 16, type 8b67, size 1, index 2, binding -1, stages 1
+c_scalarAfterm23: offset 48, type 1404, size 1, index 2, binding -1, stages 1
+scalarBeforeArray: offset 96, type 1404, size 1, index 0, binding -1, stages 1
+floatArray: offset 112, type 1406, size 5, index 0, binding -1, stages 1
+scalarAfterArray: offset 192, type 1404, size 1, index 0, binding -1, stages 1
+m22: offset 208, type 8b5a, size 9, index 0, binding -1, stages 1
+dm22: offset 32, type 8b5a, size 4, index 1, binding -1, stages 1
+foo.n1.a: offset 0, type 1406, size 1, index 3, binding -1, stages 1
+foo.n2.b: offset 16, type 1406, size 1, index 3, binding -1, stages 1
+foo.n2.c: offset 20, type 1406, size 1, index 3, binding -1, stages 1
+foo.n2.d: offset 24, type 1406, size 1, index 3, binding -1, stages 1
+deepA.d2.d1[2].va: offset 376, type 8b50, size 2, index 1, binding -1, stages 1
+deepB.d2.d1.va: offset 984, type 8b50, size 2, index 1, binding -1, stages 1
+deepB.d2.d1[0].va: offset 984, type 8b50, size 2, index 1, binding -1, stages 1
+deepB.d2.d1[1].va: offset 984, type 8b50, size 2, index 1, binding -1, stages 1
+deepB.d2.d1[2].va: offset 984, type 8b50, size 2, index 1, binding -1, stages 1
+deepB.d2.d1[3].va: offset 984, type 8b50, size 2, index 1, binding -1, stages 1
+deepC.iv4: offset 1568, type 8b52, size 1, index 1, binding -1, stages 1
+deepC.d2.i: offset 1568, type 1404, size 1, index 1, binding -1, stages 1
+deepC.d2.d1[0].va: offset 1568, type 8b50, size 3, index 1, binding -1, stages 1
+deepC.d2.d1[0].b: offset 1568, type 8b56, size 1, index 1, binding -1, stages 1
+deepC.d2.d1[1].va: offset 1568, type 8b50, size 3, index 1, binding -1, stages 1
+deepC.d2.d1[1].b: offset 1568, type 8b56, size 1, index 1, binding -1, stages 1
+deepC.d2.d1[2].va: offset 1568, type 8b50, size 3, index 1, binding -1, stages 1
+deepC.d2.d1[2].b: offset 1568, type 8b56, size 1, index 1, binding -1, stages 1
+deepC.d2.d1[3].va: offset 1568, type 8b50, size 3, index 1, binding -1, stages 1
+deepC.d2.d1[3].b: offset 1568, type 8b56, size 1, index 1, binding -1, stages 1
+deepC.v3: offset 1568, type 8b54, size 1, index 1, binding -1, stages 1
+deepD[0].iv4: offset 2480, type 8b52, size 1, index 1, binding -1, stages 1
+deepD[0].d2.i: offset 2480, type 1404, size 1, index 1, binding -1, stages 1
+deepD[0].d2.d1[0].va: offset 2480, type 8b50, size 3, index 1, binding -1, stages 1
+deepD[0].d2.d1[0].b: offset 2480, type 8b56, size 1, index 1, binding -1, stages 1
+deepD[0].d2.d1[1].va: offset 2480, type 8b50, size 3, index 1, binding -1, stages 1
+deepD[0].d2.d1[1].b: offset 2480, type 8b56, size 1, index 1, binding -1, stages 1
+deepD[0].d2.d1[2].va: offset 2480, type 8b50, size 3, index 1, binding -1, stages 1
+deepD[0].d2.d1[2].b: offset 2480, type 8b56, size 1, index 1, binding -1, stages 1
+deepD[0].d2.d1[3].va: offset 2480, type 8b50, size 3, index 1, binding -1, stages 1
+deepD[0].d2.d1[3].b: offset 2480, type 8b56, size 1, index 1, binding -1, stages 1
+deepD[0].v3: offset 2480, type 8b54, size 1, index 1, binding -1, stages 1
+deepD[1].iv4: offset 2480, type 8b52, size 1, index 1, binding -1, stages 1
+deepD[1].d2.i: offset 2480, type 1404, size 1, index 1, binding -1, stages 1
+deepD[1].d2.d1[0].va: offset 2480, type 8b50, size 3, index 1, binding -1, stages 1
+deepD[1].d2.d1[0].b: offset 2480, type 8b56, size 1, index 1, binding -1, stages 1
+deepD[1].d2.d1[1].va: offset 2480, type 8b50, size 3, index 1, binding -1, stages 1
+deepD[1].d2.d1[1].b: offset 2480, type 8b56, size 1, index 1, binding -1, stages 1
+deepD[1].d2.d1[2].va: offset 2480, type 8b50, size 3, index 1, binding -1, stages 1
+deepD[1].d2.d1[2].b: offset 2480, type 8b56, size 1, index 1, binding -1, stages 1
+deepD[1].d2.d1[3].va: offset 2480, type 8b50, size 3, index 1, binding -1, stages 1
+deepD[1].d2.d1[3].b: offset 2480, type 8b56, size 1, index 1, binding -1, stages 1
+deepD[1].v3: offset 2480, type 8b54, size 1, index 1, binding -1, stages 1
+foo1: offset 0, type 1406, size 1, index 4, binding -1, stages 1
+foo2: offset 0, type 1406, size 1, index 5, binding -1, stages 1
+anonMember1: offset 0, type 8b51, size 1, index 0, binding -1, stages 1
+uf1: offset 16, type 1406, size 1, index 1, binding -1, stages 1
 
 Uniform block reflection:
-nameless: offset -1, type ffffffff, size 496, index -1, binding -1
-$Global: offset -1, type ffffffff, size 3088, index -1, binding -1
-c_nameless: offset -1, type ffffffff, size 96, index -1, binding -1
-nested: offset -1, type ffffffff, size 32, index -1, binding -1
-abl: offset -1, type ffffffff, size 4, index -1, binding -1
-abl2: offset -1, type ffffffff, size 4, index -1, binding -1
+nameless: offset -1, type ffffffff, size 496, index -1, binding -1, stages 0
+$Global: offset -1, type ffffffff, size 3088, index -1, binding -1, stages 0
+c_nameless: offset -1, type ffffffff, size 96, index -1, binding -1, stages 0
+nested: offset -1, type ffffffff, size 32, index -1, binding -1, stages 0
+abl: offset -1, type ffffffff, size 4, index -1, binding -1, stages 0
+abl2: offset -1, type ffffffff, size 4, index -1, binding -1, stages 0
 
 Vertex attribute reflection:
-attributeFloat: offset 0, type 1406, size 0, index 0, binding -1
-attributeFloat2: offset 0, type 8b50, size 0, index 0, binding -1
-attributeFloat3: offset 0, type 8b51, size 0, index 0, binding -1
-attributeFloat4: offset 0, type 8b52, size 0, index 0, binding -1
-attributeMat4: offset 0, type 8b5c, size 0, index 0, binding -1
+attributeFloat: offset 0, type 1406, size 0, index 0, binding -1, stages 0
+attributeFloat2: offset 0, type 8b50, size 0, index 0, binding -1, stages 0
+attributeFloat3: offset 0, type 8b51, size 0, index 0, binding -1, stages 0
+attributeFloat4: offset 0, type 8b52, size 0, index 0, binding -1, stages 0
+attributeMat4: offset 0, type 8b5c, size 0, index 0, binding -1, stages 0
 

--- a/Test/baseResults/hlsl.shift.per-set.frag.out
+++ b/Test/baseResults/hlsl.shift.per-set.frag.out
@@ -196,30 +196,30 @@ gl_FragCoord origin is upper left
 0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
 
 Uniform reflection:
-t1: offset -1, type 8b5d, size 1, index -1, binding 21
-t2: offset -1, type 8b5e, size 1, index -1, binding 22
-t3: offset -1, type 8b5f, size 1, index -1, binding 26
-t4.@data: offset 0, type 8b52, size 1, index 0, binding -1
-t5.@data: offset 0, type 1405, size 0, index 1, binding -1
-t6: offset -1, type 8dc2, size 1, index -1, binding 23
-s1: offset -1, type 0, size 1, index -1, binding 11
-s2: offset -1, type 0, size 1, index -1, binding 17
-u1: offset -1, type 904c, size 1, index -1, binding 31
-u2: offset -1, type 904d, size 1, index -1, binding 42
-u3: offset -1, type 904e, size 1, index -1, binding 43
-u4: offset -1, type 9051, size 1, index -1, binding 34
-u5.@data: offset 0, type 1405, size 0, index 2, binding -1
-u6.@data: offset 0, type 1406, size 1, index 3, binding -1
-cb1: offset 0, type 1404, size 1, index 4, binding -1
-tb1: offset 0, type 1404, size 1, index 5, binding -1
+t1: offset -1, type 8b5d, size 1, index -1, binding 21, stages 16
+t2: offset -1, type 8b5e, size 1, index -1, binding 22, stages 16
+t3: offset -1, type 8b5f, size 1, index -1, binding 26, stages 16
+t4.@data: offset 0, type 8b52, size 1, index 0, binding -1, stages 16
+t5.@data: offset 0, type 1405, size 0, index 1, binding -1, stages 16
+t6: offset -1, type 8dc2, size 1, index -1, binding 23, stages 16
+s1: offset -1, type 0, size 1, index -1, binding 11, stages 16
+s2: offset -1, type 0, size 1, index -1, binding 17, stages 16
+u1: offset -1, type 904c, size 1, index -1, binding 31, stages 16
+u2: offset -1, type 904d, size 1, index -1, binding 42, stages 16
+u3: offset -1, type 904e, size 1, index -1, binding 43, stages 16
+u4: offset -1, type 9051, size 1, index -1, binding 34, stages 16
+u5.@data: offset 0, type 1405, size 0, index 2, binding -1, stages 16
+u6.@data: offset 0, type 1406, size 1, index 3, binding -1, stages 16
+cb1: offset 0, type 1404, size 1, index 4, binding -1, stages 16
+tb1: offset 0, type 1404, size 1, index 5, binding -1, stages 16
 
 Uniform block reflection:
-t4: offset -1, type ffffffff, size 0, index -1, binding 21
-t5: offset -1, type ffffffff, size 0, index -1, binding 22
-u5: offset -1, type ffffffff, size 0, index -1, binding 44
-u6: offset -1, type ffffffff, size 0, index -1, binding 34
-cb: offset -1, type ffffffff, size 4, index -1, binding 51
-tb: offset -1, type ffffffff, size 4, index -1, binding 27
+t4: offset -1, type ffffffff, size 0, index -1, binding 21, stages 0
+t5: offset -1, type ffffffff, size 0, index -1, binding 22, stages 0
+u5: offset -1, type ffffffff, size 0, index -1, binding 44, stages 0
+u6: offset -1, type ffffffff, size 0, index -1, binding 34, stages 0
+cb: offset -1, type ffffffff, size 4, index -1, binding 51, stages 0
+tb: offset -1, type ffffffff, size 4, index -1, binding 27, stages 0
 
 Vertex attribute reflection:
 

--- a/Test/baseResults/reflection.vert.out
+++ b/Test/baseResults/reflection.vert.out
@@ -1,107 +1,107 @@
 reflection.vert
 Uniform reflection:
-image_ui2D: offset -1, type 9063, size 1, index -1, binding -1
-sampler_2D: offset -1, type 8b5e, size 1, index -1, binding -1
-sampler_2DMSArray: offset -1, type 910b, size 1, index -1, binding -1
-anonMember3: offset 80, type 8b52, size 1, index 0, binding -1
-s.a: offset -1, type 1404, size 1, index -1, binding -1
-named.scalar: offset 12, type 1404, size 1, index 1, binding -1
-m23: offset 16, type 8b67, size 1, index 0, binding -1
-scalarAfterm23: offset 48, type 1404, size 1, index 0, binding -1
-c_m23: offset 16, type 8b67, size 1, index 2, binding -1
-c_scalarAfterm23: offset 64, type 1404, size 1, index 2, binding -1
-scalarBeforeArray: offset 96, type 1404, size 1, index 0, binding -1
-floatArray: offset 112, type 1406, size 5, index 0, binding -1
-scalarAfterArray: offset 192, type 1404, size 1, index 0, binding -1
-named.memvec2: offset 48, type 8b50, size 1, index 1, binding -1
-named.memf1: offset 56, type 1406, size 1, index 1, binding -1
-named.memf2: offset 60, type 8b56, size 1, index 1, binding -1
-named.memf3: offset 64, type 1404, size 1, index 1, binding -1
-named.memvec2a: offset 72, type 8b50, size 1, index 1, binding -1
-named.m22: offset 80, type 8b5a, size 7, index 1, binding -1
-dm22: offset -1, type 8b5a, size 4, index -1, binding -1
-m22: offset 208, type 8b5a, size 3, index 0, binding -1
-nested.foo.n1.a: offset 0, type 1406, size 1, index 3, binding -1
-nested.foo.n2.b: offset 16, type 1406, size 1, index 3, binding -1
-nested.foo.n2.c: offset 20, type 1406, size 1, index 3, binding -1
-nested.foo.n2.d: offset 24, type 1406, size 1, index 3, binding -1
-deepA[0].d2.d1[2].va: offset -1, type 8b50, size 2, index -1, binding -1
-deepA[1].d2.d1[2].va: offset -1, type 8b50, size 2, index -1, binding -1
-deepB[1].d2.d1[0].va: offset -1, type 8b50, size 2, index -1, binding -1
-deepB[1].d2.d1[1].va: offset -1, type 8b50, size 2, index -1, binding -1
-deepB[1].d2.d1[2].va: offset -1, type 8b50, size 2, index -1, binding -1
-deepB[1].d2.d1[3].va: offset -1, type 8b50, size 2, index -1, binding -1
-deepB[0].d2.d1[0].va: offset -1, type 8b50, size 2, index -1, binding -1
-deepB[0].d2.d1[1].va: offset -1, type 8b50, size 2, index -1, binding -1
-deepB[0].d2.d1[2].va: offset -1, type 8b50, size 2, index -1, binding -1
-deepB[0].d2.d1[3].va: offset -1, type 8b50, size 2, index -1, binding -1
-deepC[1].iv4: offset -1, type 8b52, size 1, index -1, binding -1
-deepC[1].d2.i: offset -1, type 1404, size 1, index -1, binding -1
-deepC[1].d2.d1[0].va: offset -1, type 8b50, size 3, index -1, binding -1
-deepC[1].d2.d1[0].b: offset -1, type 8b56, size 1, index -1, binding -1
-deepC[1].d2.d1[1].va: offset -1, type 8b50, size 3, index -1, binding -1
-deepC[1].d2.d1[1].b: offset -1, type 8b56, size 1, index -1, binding -1
-deepC[1].d2.d1[2].va: offset -1, type 8b50, size 3, index -1, binding -1
-deepC[1].d2.d1[2].b: offset -1, type 8b56, size 1, index -1, binding -1
-deepC[1].d2.d1[3].va: offset -1, type 8b50, size 3, index -1, binding -1
-deepC[1].d2.d1[3].b: offset -1, type 8b56, size 1, index -1, binding -1
-deepC[1].v3: offset -1, type 8b54, size 1, index -1, binding -1
-deepD[0].iv4: offset -1, type 8b52, size 1, index -1, binding -1
-deepD[0].d2.i: offset -1, type 1404, size 1, index -1, binding -1
-deepD[0].d2.d1[0].va: offset -1, type 8b50, size 3, index -1, binding -1
-deepD[0].d2.d1[0].b: offset -1, type 8b56, size 1, index -1, binding -1
-deepD[0].d2.d1[1].va: offset -1, type 8b50, size 3, index -1, binding -1
-deepD[0].d2.d1[1].b: offset -1, type 8b56, size 1, index -1, binding -1
-deepD[0].d2.d1[2].va: offset -1, type 8b50, size 3, index -1, binding -1
-deepD[0].d2.d1[2].b: offset -1, type 8b56, size 1, index -1, binding -1
-deepD[0].d2.d1[3].va: offset -1, type 8b50, size 3, index -1, binding -1
-deepD[0].d2.d1[3].b: offset -1, type 8b56, size 1, index -1, binding -1
-deepD[0].v3: offset -1, type 8b54, size 1, index -1, binding -1
-deepD[1].iv4: offset -1, type 8b52, size 1, index -1, binding -1
-deepD[1].d2.i: offset -1, type 1404, size 1, index -1, binding -1
-deepD[1].d2.d1[0].va: offset -1, type 8b50, size 3, index -1, binding -1
-deepD[1].d2.d1[0].b: offset -1, type 8b56, size 1, index -1, binding -1
-deepD[1].d2.d1[1].va: offset -1, type 8b50, size 3, index -1, binding -1
-deepD[1].d2.d1[1].b: offset -1, type 8b56, size 1, index -1, binding -1
-deepD[1].d2.d1[2].va: offset -1, type 8b50, size 3, index -1, binding -1
-deepD[1].d2.d1[2].b: offset -1, type 8b56, size 1, index -1, binding -1
-deepD[1].d2.d1[3].va: offset -1, type 8b50, size 3, index -1, binding -1
-deepD[1].d2.d1[3].b: offset -1, type 8b56, size 1, index -1, binding -1
-deepD[1].v3: offset -1, type 8b54, size 1, index -1, binding -1
-abl.foo: offset 0, type 1406, size 1, index 7, binding -1
-abl2.foo: offset 0, type 1406, size 1, index 11, binding -1
-buf1.runtimeArray: offset 4, type 1406, size 4, index 12, binding -1
-buf2.runtimeArray.c: offset 8, type 1406, size 1, index 13, binding -1
-buf3.runtimeArray: offset 4, type 1406, size 0, index 14, binding -1
-buf4.runtimeArray.c: offset 8, type 1406, size 1, index 15, binding -1
-anonMember1: offset 0, type 8b51, size 1, index 0, binding -1
-uf1: offset -1, type 1406, size 1, index -1, binding -1
-uf2: offset -1, type 1406, size 1, index -1, binding -1
-named.member3: offset 32, type 8b52, size 1, index 1, binding -1
+image_ui2D: offset -1, type 9063, size 1, index -1, binding -1, stages 1
+sampler_2D: offset -1, type 8b5e, size 1, index -1, binding -1, stages 1
+sampler_2DMSArray: offset -1, type 910b, size 1, index -1, binding -1, stages 1
+anonMember3: offset 80, type 8b52, size 1, index 0, binding -1, stages 1
+s.a: offset -1, type 1404, size 1, index -1, binding -1, stages 1
+named.scalar: offset 12, type 1404, size 1, index 1, binding -1, stages 1
+m23: offset 16, type 8b67, size 1, index 0, binding -1, stages 1
+scalarAfterm23: offset 48, type 1404, size 1, index 0, binding -1, stages 1
+c_m23: offset 16, type 8b67, size 1, index 2, binding -1, stages 1
+c_scalarAfterm23: offset 64, type 1404, size 1, index 2, binding -1, stages 1
+scalarBeforeArray: offset 96, type 1404, size 1, index 0, binding -1, stages 1
+floatArray: offset 112, type 1406, size 5, index 0, binding -1, stages 1
+scalarAfterArray: offset 192, type 1404, size 1, index 0, binding -1, stages 1
+named.memvec2: offset 48, type 8b50, size 1, index 1, binding -1, stages 1
+named.memf1: offset 56, type 1406, size 1, index 1, binding -1, stages 1
+named.memf2: offset 60, type 8b56, size 1, index 1, binding -1, stages 1
+named.memf3: offset 64, type 1404, size 1, index 1, binding -1, stages 1
+named.memvec2a: offset 72, type 8b50, size 1, index 1, binding -1, stages 1
+named.m22: offset 80, type 8b5a, size 7, index 1, binding -1, stages 1
+dm22: offset -1, type 8b5a, size 4, index -1, binding -1, stages 1
+m22: offset 208, type 8b5a, size 3, index 0, binding -1, stages 1
+nested.foo.n1.a: offset 0, type 1406, size 1, index 3, binding -1, stages 1
+nested.foo.n2.b: offset 16, type 1406, size 1, index 3, binding -1, stages 1
+nested.foo.n2.c: offset 20, type 1406, size 1, index 3, binding -1, stages 1
+nested.foo.n2.d: offset 24, type 1406, size 1, index 3, binding -1, stages 1
+deepA[0].d2.d1[2].va: offset -1, type 8b50, size 2, index -1, binding -1, stages 1
+deepA[1].d2.d1[2].va: offset -1, type 8b50, size 2, index -1, binding -1, stages 1
+deepB[1].d2.d1[0].va: offset -1, type 8b50, size 2, index -1, binding -1, stages 1
+deepB[1].d2.d1[1].va: offset -1, type 8b50, size 2, index -1, binding -1, stages 1
+deepB[1].d2.d1[2].va: offset -1, type 8b50, size 2, index -1, binding -1, stages 1
+deepB[1].d2.d1[3].va: offset -1, type 8b50, size 2, index -1, binding -1, stages 1
+deepB[0].d2.d1[0].va: offset -1, type 8b50, size 2, index -1, binding -1, stages 1
+deepB[0].d2.d1[1].va: offset -1, type 8b50, size 2, index -1, binding -1, stages 1
+deepB[0].d2.d1[2].va: offset -1, type 8b50, size 2, index -1, binding -1, stages 1
+deepB[0].d2.d1[3].va: offset -1, type 8b50, size 2, index -1, binding -1, stages 1
+deepC[1].iv4: offset -1, type 8b52, size 1, index -1, binding -1, stages 1
+deepC[1].d2.i: offset -1, type 1404, size 1, index -1, binding -1, stages 1
+deepC[1].d2.d1[0].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1
+deepC[1].d2.d1[0].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1
+deepC[1].d2.d1[1].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1
+deepC[1].d2.d1[1].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1
+deepC[1].d2.d1[2].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1
+deepC[1].d2.d1[2].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1
+deepC[1].d2.d1[3].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1
+deepC[1].d2.d1[3].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1
+deepC[1].v3: offset -1, type 8b54, size 1, index -1, binding -1, stages 1
+deepD[0].iv4: offset -1, type 8b52, size 1, index -1, binding -1, stages 1
+deepD[0].d2.i: offset -1, type 1404, size 1, index -1, binding -1, stages 1
+deepD[0].d2.d1[0].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1
+deepD[0].d2.d1[0].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1
+deepD[0].d2.d1[1].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1
+deepD[0].d2.d1[1].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1
+deepD[0].d2.d1[2].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1
+deepD[0].d2.d1[2].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1
+deepD[0].d2.d1[3].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1
+deepD[0].d2.d1[3].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1
+deepD[0].v3: offset -1, type 8b54, size 1, index -1, binding -1, stages 1
+deepD[1].iv4: offset -1, type 8b52, size 1, index -1, binding -1, stages 1
+deepD[1].d2.i: offset -1, type 1404, size 1, index -1, binding -1, stages 1
+deepD[1].d2.d1[0].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1
+deepD[1].d2.d1[0].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1
+deepD[1].d2.d1[1].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1
+deepD[1].d2.d1[1].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1
+deepD[1].d2.d1[2].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1
+deepD[1].d2.d1[2].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1
+deepD[1].d2.d1[3].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1
+deepD[1].d2.d1[3].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1
+deepD[1].v3: offset -1, type 8b54, size 1, index -1, binding -1, stages 1
+abl.foo: offset 0, type 1406, size 1, index 7, binding -1, stages 1
+abl2.foo: offset 0, type 1406, size 1, index 11, binding -1, stages 1
+buf1.runtimeArray: offset 4, type 1406, size 4, index 12, binding -1, stages 1
+buf2.runtimeArray.c: offset 8, type 1406, size 1, index 13, binding -1, stages 1
+buf3.runtimeArray: offset 4, type 1406, size 0, index 14, binding -1, stages 1
+buf4.runtimeArray.c: offset 8, type 1406, size 1, index 15, binding -1, stages 1
+anonMember1: offset 0, type 8b51, size 1, index 0, binding -1, stages 1
+uf1: offset -1, type 1406, size 1, index -1, binding -1, stages 1
+uf2: offset -1, type 1406, size 1, index -1, binding -1, stages 1
+named.member3: offset 32, type 8b52, size 1, index 1, binding -1, stages 1
 
 Uniform block reflection:
-nameless: offset -1, type ffffffff, size 496, index -1, binding -1
-named: offset -1, type ffffffff, size 304, index -1, binding -1
-c_nameless: offset -1, type ffffffff, size 112, index -1, binding -1
-nested: offset -1, type ffffffff, size 32, index -1, binding -1
-abl[0]: offset -1, type ffffffff, size 4, index -1, binding -1
-abl[1]: offset -1, type ffffffff, size 4, index -1, binding -1
-abl[2]: offset -1, type ffffffff, size 4, index -1, binding -1
-abl[3]: offset -1, type ffffffff, size 4, index -1, binding -1
-abl2[0]: offset -1, type ffffffff, size 4, index -1, binding -1
-abl2[1]: offset -1, type ffffffff, size 4, index -1, binding -1
-abl2[2]: offset -1, type ffffffff, size 4, index -1, binding -1
-abl2[3]: offset -1, type ffffffff, size 4, index -1, binding -1
-buf1: offset -1, type ffffffff, size 4, index -1, binding -1
-buf2: offset -1, type ffffffff, size 4, index -1, binding -1
-buf3: offset -1, type ffffffff, size 4, index -1, binding -1
-buf4: offset -1, type ffffffff, size 4, index -1, binding -1
+nameless: offset -1, type ffffffff, size 496, index -1, binding -1, stages 0
+named: offset -1, type ffffffff, size 304, index -1, binding -1, stages 0
+c_nameless: offset -1, type ffffffff, size 112, index -1, binding -1, stages 0
+nested: offset -1, type ffffffff, size 32, index -1, binding -1, stages 0
+abl[0]: offset -1, type ffffffff, size 4, index -1, binding -1, stages 0
+abl[1]: offset -1, type ffffffff, size 4, index -1, binding -1, stages 0
+abl[2]: offset -1, type ffffffff, size 4, index -1, binding -1, stages 0
+abl[3]: offset -1, type ffffffff, size 4, index -1, binding -1, stages 0
+abl2[0]: offset -1, type ffffffff, size 4, index -1, binding -1, stages 0
+abl2[1]: offset -1, type ffffffff, size 4, index -1, binding -1, stages 0
+abl2[2]: offset -1, type ffffffff, size 4, index -1, binding -1, stages 0
+abl2[3]: offset -1, type ffffffff, size 4, index -1, binding -1, stages 0
+buf1: offset -1, type ffffffff, size 4, index -1, binding -1, stages 0
+buf2: offset -1, type ffffffff, size 4, index -1, binding -1, stages 0
+buf3: offset -1, type ffffffff, size 4, index -1, binding -1, stages 0
+buf4: offset -1, type ffffffff, size 4, index -1, binding -1, stages 0
 
 Vertex attribute reflection:
-attributeFloat: offset 0, type 1406, size 0, index 0, binding -1
-attributeFloat2: offset 0, type 8b50, size 0, index 0, binding -1
-attributeFloat3: offset 0, type 8b51, size 0, index 0, binding -1
-attributeFloat4: offset 0, type 8b52, size 0, index 0, binding -1
-attributeMat4: offset 0, type 8b5c, size 0, index 0, binding -1
-gl_InstanceID: offset 0, type 1404, size 0, index 0, binding -1
+attributeFloat: offset 0, type 1406, size 0, index 0, binding -1, stages 0
+attributeFloat2: offset 0, type 8b50, size 0, index 0, binding -1, stages 0
+attributeFloat3: offset 0, type 8b51, size 0, index 0, binding -1, stages 0
+attributeFloat4: offset 0, type 8b52, size 0, index 0, binding -1, stages 0
+attributeMat4: offset 0, type 8b5c, size 0, index 0, binding -1, stages 0
+gl_InstanceID: offset 0, type 1404, size 0, index 0, binding -1, stages 0
 

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1910,6 +1910,7 @@ const char* TProgram::getUniformBlockName(int index) const   { return reflection
 int TProgram::getUniformBlockSize(int index) const           { return reflection->getUniformBlock(index).size; }
 int TProgram::getUniformIndex(const char* name) const        { return reflection->getIndex(name); }
 int TProgram::getUniformBinding(int index) const             { return reflection->getUniform(index).getBinding(); }
+EShLanguageMask TProgram::getUniformStages(int index) const  { return reflection->getUniform(index).stages; }
 int TProgram::getUniformBlockBinding(int index) const        { return reflection->getUniformBlock(index).getBinding(); }
 int TProgram::getUniformBlockIndex(int index) const          { return reflection->getUniform(index).index; }
 int TProgram::getUniformBlockCounterIndex(int index) const   { return reflection->getUniformBlock(index).counterIndex; }

--- a/glslang/MachineIndependent/reflection.cpp
+++ b/glslang/MachineIndependent/reflection.cpp
@@ -778,6 +778,14 @@ void TReflection::buildCounterIndices(const TIntermediate& intermediate)
     }
 }
 
+// build Shader Stages mask for all uniforms
+void TReflection::buildUniformStageMask(const TIntermediate& intermediate)
+{
+    for (int i = 0; i < int(indexToUniform.size()); ++i) {
+        indexToUniform[i].stages = static_cast<EShLanguageMask>(indexToUniform[i].stages | 1 << intermediate.getStage());
+    }
+}
+
 // Merge live symbols from 'intermediate' into the existing reflection database.
 //
 // Returns false if the input is too malformed to do this.
@@ -803,6 +811,7 @@ bool TReflection::addStage(EShLanguage stage, const TIntermediate& intermediate)
     }
 
     buildCounterIndices(intermediate);
+    buildUniformStageMask(intermediate);
 
     return true;
 }

--- a/glslang/MachineIndependent/reflection.h
+++ b/glslang/MachineIndependent/reflection.h
@@ -57,7 +57,7 @@ class TObjectReflection {
 public:
     TObjectReflection(const TString& pName, const TType& pType, int pOffset, int pGLDefineType, int pSize, int pIndex) :
         name(pName), offset(pOffset),
-        glDefineType(pGLDefineType), size(pSize), index(pIndex), counterIndex(-1), type(pType.clone()) { }
+        glDefineType(pGLDefineType), size(pSize), index(pIndex), counterIndex(-1), type(pType.clone()), stages(EShLanguageMask(0)) { }
 
     const TType* const getType() const { return type; }
     int getBinding() const
@@ -68,8 +68,8 @@ public:
     }
     void dump() const
     {
-        printf("%s: offset %d, type %x, size %d, index %d, binding %d",
-               name.c_str(), offset, glDefineType, size, index, getBinding() );
+        printf("%s: offset %d, type %x, size %d, index %d, binding %d, stages %d",
+               name.c_str(), offset, glDefineType, size, index, getBinding(), stages );
 
         if (counterIndex != -1)
             printf(", counter %d", counterIndex);
@@ -84,6 +84,7 @@ public:
     int size;         // data size in bytes for a block, array size for a (non-block) object that's an array
     int index;
     int counterIndex;
+    EShLanguageMask stages;
 
 protected:
     TObjectReflection() : offset(-1), glDefineType(-1), size(-1), index(-1), type(nullptr) { }
@@ -157,6 +158,7 @@ protected:
     friend class glslang::TReflectionTraverser;
 
     void buildCounterIndices(const TIntermediate&);
+    void buildUniformStageMask(const TIntermediate& intermediate);
     void buildAttributeReflection(EShLanguage, const TIntermediate&);
 
     // Need a TString hash: typedef std::unordered_map<TString, int> TNameToIndex;

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -671,6 +671,7 @@ public:
     int getUniformBlockSize(int blockIndex) const;         // can be used for glGetActiveUniformBlockiv(UNIFORM_BLOCK_DATA_SIZE)
     int getUniformIndex(const char* name) const;           // can be used for glGetUniformIndices()
     int getUniformBinding(int index) const;                // returns the binding number
+    EShLanguageMask getUniformStages(int index) const;     // returns Shaders Stages where a Uniform is present
     int getUniformBlockBinding(int index) const;           // returns the block binding number
     int getUniformBlockIndex(int index) const;             // can be used for glGetActiveUniformsiv(GL_UNIFORM_BLOCK_INDEX)
     int getUniformBlockCounterIndex(int index) const;      // returns block index of associated counter.


### PR DESCRIPTION
This pull request adds the exposition of the shader stages on uniforms reflection.
This approach seems the only way to get this information.
Is there any other possible implementation?