### PR TITLE
NDK build: Use NDK r17b and its own CMake toolchain file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,20 +48,16 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$CC" == "clang" ]]; then
       export CC=clang-3.6 CXX=clang++-3.6;
     fi
-  # Download Android NDK and Android CMake toolchain file.
-  # Unfortunately the android.toolchain.cmake file does not understand how to
-  # get the API level from Android NDK r17b.  So fall back on r13b.
-  # Get only one commit at tag r13b.
+  # Download a recent Android NDK and use its android.toolchain.cmake file.
   - if [[ "$BUILD_NDK" == "ON" ]]; then
       export ANDROID_NDK=$HOME/android-ndk;
       git init $ANDROID_NDK;
       pushd $ANDROID_NDK;
-        git remote add urho3d https://github.com/urho3d/android-ndk.git;
-        git fetch --depth=1 urho3d r13b;
+        git remote add dneto0 https://github.com/dneto0/android-ndk.git;
+        git fetch --depth=1 dneto0 r17b-strip;
         git checkout FETCH_HEAD;
       popd;
-      git clone --depth=1 https://github.com/taka-no-me/android-cmake.git $HOME/android-cmake;
-      export TOOLCHAIN_PATH=$HOME/android-cmake/android.toolchain.cmake;
+      export TOOLCHAIN_PATH=$ANDROID_NDK/build/cmake/android.toolchain.cmake;
     fi
 
 before_script:
@@ -71,10 +67,12 @@ before_script:
 script:
   - mkdir build && cd build
   # For Android, do release building using NDK without testing.
+  # Use android-14, the oldest native API level supporeted by NDK r17b.
+  # We can use newer API levels if we want.
   # For Linux and macOS, do debug/release building with testing.
   - if [[ "$BUILD_NDK" == "ON" ]]; then
       cmake -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_PATH}
-            -DANDROID_NATIVE_API_LEVEL=android-12
+            -DANDROID_NATIVE_API_LEVEL=android-14
             -DCMAKE_BUILD_TYPE=Release
             -DANDROID_ABI="armeabi-v7a with NEON"
             -DBUILD_TESTING=OFF ..;


### PR DESCRIPTION
More recent NDK releases have their own CMake toolchain file.
Use it.

Also, download the NDK from github.com:dneto0/android-ndk.
That is a fork of the repo we used to use, but we have more
control over how long it stays stable.