### PR TITLE
GLSL/SPV: If a texture is used with a shadow sampler, force 'shadow'.

### DIFF
--- a/Test/baseResults/spv.separate.frag.out
+++ b/Test/baseResults/spv.separate.frag.out
@@ -28,33 +28,33 @@ spv.separate.frag
                               Name 84  "itexCubeArray"
                               Name 91  "utexCubeArray"
                               Name 98  "tex1DArray"
-                              Name 106  "itex1DArray"
-                              Name 113  "utex1D"
-                              Name 120  "itex1D"
-                              Name 127  "utex1DArray"
-                              Name 134  "texBuffer"
-                              Name 146  "tex2DArray"
-                              Name 158  "itex2D"
-                              Name 165  "itex3D"
-                              Name 172  "itexCube"
-                              Name 179  "itex2DArray"
-                              Name 186  "utex2D"
-                              Name 193  "utex3D"
-                              Name 200  "utexCube"
-                              Name 207  "utex2DArray"
-                              Name 214  "itex2DRect"
-                              Name 221  "utex2DRect"
-                              Name 228  "itexBuffer"
-                              Name 235  "utexBuffer"
-                              Name 242  "tex2DMS"
-                              Name 249  "itex2DMS"
-                              Name 256  "utex2DMS"
-                              Name 263  "tex2DMSArray"
-                              Name 270  "itex2DMSArray"
-                              Name 277  "utex2DMSArray"
-                              Name 284  "tex1D"
-                              Name 294  "tex3D"
-                              Name 305  "tex2DRect"
+                              Name 105  "itex1DArray"
+                              Name 112  "utex1D"
+                              Name 119  "itex1D"
+                              Name 126  "utex1DArray"
+                              Name 133  "texBuffer"
+                              Name 145  "tex2DArray"
+                              Name 157  "itex2D"
+                              Name 164  "itex3D"
+                              Name 171  "itexCube"
+                              Name 178  "itex2DArray"
+                              Name 185  "utex2D"
+                              Name 192  "utex3D"
+                              Name 199  "utexCube"
+                              Name 206  "utex2DArray"
+                              Name 213  "itex2DRect"
+                              Name 220  "utex2DRect"
+                              Name 227  "itexBuffer"
+                              Name 234  "utexBuffer"
+                              Name 241  "tex2DMS"
+                              Name 248  "itex2DMS"
+                              Name 255  "utex2DMS"
+                              Name 262  "tex2DMSArray"
+                              Name 269  "itex2DMSArray"
+                              Name 276  "utex2DMSArray"
+                              Name 283  "tex1D"
+                              Name 293  "tex3D"
+                              Name 304  "tex2DRect"
                               Decorate 14(t2d) DescriptorSet 0
                               Decorate 18(s) DescriptorSet 0
                               Decorate 31(t3d) DescriptorSet 0
@@ -67,33 +67,33 @@ spv.separate.frag
                               Decorate 84(itexCubeArray) DescriptorSet 0
                               Decorate 91(utexCubeArray) DescriptorSet 0
                               Decorate 98(tex1DArray) DescriptorSet 0
-                              Decorate 106(itex1DArray) DescriptorSet 0
-                              Decorate 113(utex1D) DescriptorSet 0
-                              Decorate 120(itex1D) DescriptorSet 0
-                              Decorate 127(utex1DArray) DescriptorSet 0
-                              Decorate 134(texBuffer) DescriptorSet 0
-                              Decorate 146(tex2DArray) DescriptorSet 0
-                              Decorate 158(itex2D) DescriptorSet 0
-                              Decorate 165(itex3D) DescriptorSet 0
-                              Decorate 172(itexCube) DescriptorSet 0
-                              Decorate 179(itex2DArray) DescriptorSet 0
-                              Decorate 186(utex2D) DescriptorSet 0
-                              Decorate 193(utex3D) DescriptorSet 0
-                              Decorate 200(utexCube) DescriptorSet 0
-                              Decorate 207(utex2DArray) DescriptorSet 0
-                              Decorate 214(itex2DRect) DescriptorSet 0
-                              Decorate 221(utex2DRect) DescriptorSet 0
-                              Decorate 228(itexBuffer) DescriptorSet 0
-                              Decorate 235(utexBuffer) DescriptorSet 0
-                              Decorate 242(tex2DMS) DescriptorSet 0
-                              Decorate 249(itex2DMS) DescriptorSet 0
-                              Decorate 256(utex2DMS) DescriptorSet 0
-                              Decorate 263(tex2DMSArray) DescriptorSet 0
-                              Decorate 270(itex2DMSArray) DescriptorSet 0
-                              Decorate 277(utex2DMSArray) DescriptorSet 0
-                              Decorate 284(tex1D) DescriptorSet 0
-                              Decorate 294(tex3D) DescriptorSet 0
-                              Decorate 305(tex2DRect) DescriptorSet 0
+                              Decorate 105(itex1DArray) DescriptorSet 0
+                              Decorate 112(utex1D) DescriptorSet 0
+                              Decorate 119(itex1D) DescriptorSet 0
+                              Decorate 126(utex1DArray) DescriptorSet 0
+                              Decorate 133(texBuffer) DescriptorSet 0
+                              Decorate 145(tex2DArray) DescriptorSet 0
+                              Decorate 157(itex2D) DescriptorSet 0
+                              Decorate 164(itex3D) DescriptorSet 0
+                              Decorate 171(itexCube) DescriptorSet 0
+                              Decorate 178(itex2DArray) DescriptorSet 0
+                              Decorate 185(utex2D) DescriptorSet 0
+                              Decorate 192(utex3D) DescriptorSet 0
+                              Decorate 199(utexCube) DescriptorSet 0
+                              Decorate 206(utex2DArray) DescriptorSet 0
+                              Decorate 213(itex2DRect) DescriptorSet 0
+                              Decorate 220(utex2DRect) DescriptorSet 0
+                              Decorate 227(itexBuffer) DescriptorSet 0
+                              Decorate 234(utexBuffer) DescriptorSet 0
+                              Decorate 241(tex2DMS) DescriptorSet 0
+                              Decorate 248(itex2DMS) DescriptorSet 0
+                              Decorate 255(utex2DMS) DescriptorSet 0
+                              Decorate 262(tex2DMSArray) DescriptorSet 0
+                              Decorate 269(itex2DMSArray) DescriptorSet 0
+                              Decorate 276(utex2DMSArray) DescriptorSet 0
+                              Decorate 283(tex1D) DescriptorSet 0
+                              Decorate 293(tex3D) DescriptorSet 0
+                              Decorate 304(tex2DRect) DescriptorSet 0
                2:             TypeVoid
                3:             TypeFunction 2
                8:             TypeFloat 32
@@ -147,127 +147,127 @@ spv.separate.frag
               90:             TypePointer UniformConstant 89
 91(utexCubeArray):     90(ptr) Variable UniformConstant
               94:             TypeSampledImage 89
-              96:             TypeImage 8(float) 1D array sampled format:Unknown
+              96:             TypeImage 8(float) 1D depth array sampled format:Unknown
               97:             TypePointer UniformConstant 96
   98(tex1DArray):     97(ptr) Variable UniformConstant
-             101:             TypeImage 8(float) 1D depth array sampled format:Unknown
-             102:             TypeSampledImage 101
-             104:             TypeImage 32(int) 1D array sampled format:Unknown
-             105:             TypePointer UniformConstant 104
-106(itex1DArray):    105(ptr) Variable UniformConstant
-             109:             TypeSampledImage 104
-             111:             TypeImage 27(int) 1D sampled format:Unknown
-             112:             TypePointer UniformConstant 111
-     113(utex1D):    112(ptr) Variable UniformConstant
-             116:             TypeSampledImage 111
-             118:             TypeImage 32(int) 1D sampled format:Unknown
-             119:             TypePointer UniformConstant 118
-     120(itex1D):    119(ptr) Variable UniformConstant
-             123:             TypeSampledImage 118
-             125:             TypeImage 27(int) 1D array sampled format:Unknown
-             126:             TypePointer UniformConstant 125
-127(utex1DArray):    126(ptr) Variable UniformConstant
-             130:             TypeSampledImage 125
-             132:             TypeImage 8(float) Buffer sampled format:Unknown
-             133:             TypePointer UniformConstant 132
-  134(texBuffer):    133(ptr) Variable UniformConstant
-             137:             TypeSampledImage 132
-             141:             TypeImage 8(float) Cube depth sampled format:Unknown
-             142:             TypeSampledImage 141
-             144:             TypeImage 8(float) 2D array sampled format:Unknown
-             145:             TypePointer UniformConstant 144
- 146(tex2DArray):    145(ptr) Variable UniformConstant
-             149:             TypeSampledImage 144
-             153:             TypeImage 8(float) 2D depth array sampled format:Unknown
-             154:             TypeSampledImage 153
-             156:             TypeImage 32(int) 2D sampled format:Unknown
-             157:             TypePointer UniformConstant 156
-     158(itex2D):    157(ptr) Variable UniformConstant
-             161:             TypeSampledImage 156
-             163:             TypeImage 32(int) 3D sampled format:Unknown
-             164:             TypePointer UniformConstant 163
-     165(itex3D):    164(ptr) Variable UniformConstant
-             168:             TypeSampledImage 163
-             170:             TypeImage 32(int) Cube sampled format:Unknown
-             171:             TypePointer UniformConstant 170
-   172(itexCube):    171(ptr) Variable UniformConstant
-             175:             TypeSampledImage 170
-             177:             TypeImage 32(int) 2D array sampled format:Unknown
-             178:             TypePointer UniformConstant 177
-179(itex2DArray):    178(ptr) Variable UniformConstant
-             182:             TypeSampledImage 177
-             184:             TypeImage 27(int) 2D sampled format:Unknown
-             185:             TypePointer UniformConstant 184
-     186(utex2D):    185(ptr) Variable UniformConstant
-             189:             TypeSampledImage 184
-             191:             TypeImage 27(int) 3D sampled format:Unknown
-             192:             TypePointer UniformConstant 191
-     193(utex3D):    192(ptr) Variable UniformConstant
-             196:             TypeSampledImage 191
-             198:             TypeImage 27(int) Cube sampled format:Unknown
-             199:             TypePointer UniformConstant 198
-   200(utexCube):    199(ptr) Variable UniformConstant
-             203:             TypeSampledImage 198
-             205:             TypeImage 27(int) 2D array sampled format:Unknown
-             206:             TypePointer UniformConstant 205
-207(utex2DArray):    206(ptr) Variable UniformConstant
-             210:             TypeSampledImage 205
-             212:             TypeImage 32(int) Rect sampled format:Unknown
-             213:             TypePointer UniformConstant 212
- 214(itex2DRect):    213(ptr) Variable UniformConstant
-             217:             TypeSampledImage 212
-             219:             TypeImage 27(int) Rect sampled format:Unknown
-             220:             TypePointer UniformConstant 219
- 221(utex2DRect):    220(ptr) Variable UniformConstant
-             224:             TypeSampledImage 219
-             226:             TypeImage 32(int) Buffer sampled format:Unknown
-             227:             TypePointer UniformConstant 226
- 228(itexBuffer):    227(ptr) Variable UniformConstant
-             231:             TypeSampledImage 226
-             233:             TypeImage 27(int) Buffer sampled format:Unknown
-             234:             TypePointer UniformConstant 233
- 235(utexBuffer):    234(ptr) Variable UniformConstant
-             238:             TypeSampledImage 233
-             240:             TypeImage 8(float) 2D multi-sampled sampled format:Unknown
-             241:             TypePointer UniformConstant 240
-    242(tex2DMS):    241(ptr) Variable UniformConstant
-             245:             TypeSampledImage 240
-             247:             TypeImage 32(int) 2D multi-sampled sampled format:Unknown
-             248:             TypePointer UniformConstant 247
-   249(itex2DMS):    248(ptr) Variable UniformConstant
-             252:             TypeSampledImage 247
-             254:             TypeImage 27(int) 2D multi-sampled sampled format:Unknown
-             255:             TypePointer UniformConstant 254
-   256(utex2DMS):    255(ptr) Variable UniformConstant
-             259:             TypeSampledImage 254
-             261:             TypeImage 8(float) 2D array multi-sampled sampled format:Unknown
-             262:             TypePointer UniformConstant 261
-263(tex2DMSArray):    262(ptr) Variable UniformConstant
-             266:             TypeSampledImage 261
-             268:             TypeImage 32(int) 2D array multi-sampled sampled format:Unknown
-             269:             TypePointer UniformConstant 268
-270(itex2DMSArray):    269(ptr) Variable UniformConstant
-             273:             TypeSampledImage 268
-             275:             TypeImage 27(int) 2D array multi-sampled sampled format:Unknown
-             276:             TypePointer UniformConstant 275
-277(utex2DMSArray):    276(ptr) Variable UniformConstant
-             280:             TypeSampledImage 275
-             282:             TypeImage 8(float) 1D sampled format:Unknown
-             283:             TypePointer UniformConstant 282
-      284(tex1D):    283(ptr) Variable UniformConstant
-             287:             TypeSampledImage 282
-             291:             TypeImage 8(float) 1D depth sampled format:Unknown
-             292:             TypeSampledImage 291
-      294(tex3D):     36(ptr) Variable UniformConstant
-             300:             TypeImage 8(float) 2D depth sampled format:Unknown
-             301:             TypeSampledImage 300
-             303:             TypeImage 8(float) Rect sampled format:Unknown
-             304:             TypePointer UniformConstant 303
-  305(tex2DRect):    304(ptr) Variable UniformConstant
-             308:             TypeSampledImage 303
-             312:             TypeImage 8(float) Rect depth sampled format:Unknown
-             313:             TypeSampledImage 312
-             317:             TypeSampledImage 96
+             101:             TypeSampledImage 96
+             103:             TypeImage 32(int) 1D array sampled format:Unknown
+             104:             TypePointer UniformConstant 103
+105(itex1DArray):    104(ptr) Variable UniformConstant
+             108:             TypeSampledImage 103
+             110:             TypeImage 27(int) 1D sampled format:Unknown
+             111:             TypePointer UniformConstant 110
+     112(utex1D):    111(ptr) Variable UniformConstant
+             115:             TypeSampledImage 110
+             117:             TypeImage 32(int) 1D sampled format:Unknown
+             118:             TypePointer UniformConstant 117
+     119(itex1D):    118(ptr) Variable UniformConstant
+             122:             TypeSampledImage 117
+             124:             TypeImage 27(int) 1D array sampled format:Unknown
+             125:             TypePointer UniformConstant 124
+126(utex1DArray):    125(ptr) Variable UniformConstant
+             129:             TypeSampledImage 124
+             131:             TypeImage 8(float) Buffer sampled format:Unknown
+             132:             TypePointer UniformConstant 131
+  133(texBuffer):    132(ptr) Variable UniformConstant
+             136:             TypeSampledImage 131
+             140:             TypeImage 8(float) Cube depth sampled format:Unknown
+             141:             TypeSampledImage 140
+             143:             TypeImage 8(float) 2D array sampled format:Unknown
+             144:             TypePointer UniformConstant 143
+ 145(tex2DArray):    144(ptr) Variable UniformConstant
+             148:             TypeSampledImage 143
+             152:             TypeImage 8(float) 2D depth array sampled format:Unknown
+             153:             TypeSampledImage 152
+             155:             TypeImage 32(int) 2D sampled format:Unknown
+             156:             TypePointer UniformConstant 155
+     157(itex2D):    156(ptr) Variable UniformConstant
+             160:             TypeSampledImage 155
+             162:             TypeImage 32(int) 3D sampled format:Unknown
+             163:             TypePointer UniformConstant 162
+     164(itex3D):    163(ptr) Variable UniformConstant
+             167:             TypeSampledImage 162
+             169:             TypeImage 32(int) Cube sampled format:Unknown
+             170:             TypePointer UniformConstant 169
+   171(itexCube):    170(ptr) Variable UniformConstant
+             174:             TypeSampledImage 169
+             176:             TypeImage 32(int) 2D array sampled format:Unknown
+             177:             TypePointer UniformConstant 176
+178(itex2DArray):    177(ptr) Variable UniformConstant
+             181:             TypeSampledImage 176
+             183:             TypeImage 27(int) 2D sampled format:Unknown
+             184:             TypePointer UniformConstant 183
+     185(utex2D):    184(ptr) Variable UniformConstant
+             188:             TypeSampledImage 183
+             190:             TypeImage 27(int) 3D sampled format:Unknown
+             191:             TypePointer UniformConstant 190
+     192(utex3D):    191(ptr) Variable UniformConstant
+             195:             TypeSampledImage 190
+             197:             TypeImage 27(int) Cube sampled format:Unknown
+             198:             TypePointer UniformConstant 197
+   199(utexCube):    198(ptr) Variable UniformConstant
+             202:             TypeSampledImage 197
+             204:             TypeImage 27(int) 2D array sampled format:Unknown
+             205:             TypePointer UniformConstant 204
+206(utex2DArray):    205(ptr) Variable UniformConstant
+             209:             TypeSampledImage 204
+             211:             TypeImage 32(int) Rect sampled format:Unknown
+             212:             TypePointer UniformConstant 211
+ 213(itex2DRect):    212(ptr) Variable UniformConstant
+             216:             TypeSampledImage 211
+             218:             TypeImage 27(int) Rect sampled format:Unknown
+             219:             TypePointer UniformConstant 218
+ 220(utex2DRect):    219(ptr) Variable UniformConstant
+             223:             TypeSampledImage 218
+             225:             TypeImage 32(int) Buffer sampled format:Unknown
+             226:             TypePointer UniformConstant 225
+ 227(itexBuffer):    226(ptr) Variable UniformConstant
+             230:             TypeSampledImage 225
+             232:             TypeImage 27(int) Buffer sampled format:Unknown
+             233:             TypePointer UniformConstant 232
+ 234(utexBuffer):    233(ptr) Variable UniformConstant
+             237:             TypeSampledImage 232
+             239:             TypeImage 8(float) 2D multi-sampled sampled format:Unknown
+             240:             TypePointer UniformConstant 239
+    241(tex2DMS):    240(ptr) Variable UniformConstant
+             244:             TypeSampledImage 239
+             246:             TypeImage 32(int) 2D multi-sampled sampled format:Unknown
+             247:             TypePointer UniformConstant 246
+   248(itex2DMS):    247(ptr) Variable UniformConstant
+             251:             TypeSampledImage 246
+             253:             TypeImage 27(int) 2D multi-sampled sampled format:Unknown
+             254:             TypePointer UniformConstant 253
+   255(utex2DMS):    254(ptr) Variable UniformConstant
+             258:             TypeSampledImage 253
+             260:             TypeImage 8(float) 2D array multi-sampled sampled format:Unknown
+             261:             TypePointer UniformConstant 260
+262(tex2DMSArray):    261(ptr) Variable UniformConstant
+             265:             TypeSampledImage 260
+             267:             TypeImage 32(int) 2D array multi-sampled sampled format:Unknown
+             268:             TypePointer UniformConstant 267
+269(itex2DMSArray):    268(ptr) Variable UniformConstant
+             272:             TypeSampledImage 267
+             274:             TypeImage 27(int) 2D array multi-sampled sampled format:Unknown
+             275:             TypePointer UniformConstant 274
+276(utex2DMSArray):    275(ptr) Variable UniformConstant
+             279:             TypeSampledImage 274
+             281:             TypeImage 8(float) 1D sampled format:Unknown
+             282:             TypePointer UniformConstant 281
+      283(tex1D):    282(ptr) Variable UniformConstant
+             286:             TypeSampledImage 281
+             290:             TypeImage 8(float) 1D depth sampled format:Unknown
+             291:             TypeSampledImage 290
+      293(tex3D):     36(ptr) Variable UniformConstant
+             299:             TypeImage 8(float) 2D depth sampled format:Unknown
+             300:             TypeSampledImage 299
+             302:             TypeImage 8(float) Rect sampled format:Unknown
+             303:             TypePointer UniformConstant 302
+  304(tex2DRect):    303(ptr) Variable UniformConstant
+             307:             TypeSampledImage 302
+             311:             TypeImage 8(float) Rect depth sampled format:Unknown
+             312:             TypeSampledImage 311
+             316:             TypeImage 8(float) 1D array sampled format:Unknown
+             317:             TypeSampledImage 316
          4(main):           2 Function None 3
                5:             Label
               15:          12 Load 14(t2d)
@@ -316,105 +316,105 @@ spv.separate.frag
               95:          94 SampledImage 92 93
               99:          96 Load 98(tex1DArray)
              100:          16 Load 77(sShadow)
-             103:         102 SampledImage 99 100
-             107:         104 Load 106(itex1DArray)
-             108:          16 Load 18(s)
-             110:         109 SampledImage 107 108
-             114:         111 Load 113(utex1D)
-             115:          16 Load 18(s)
-             117:         116 SampledImage 114 115
-             121:         118 Load 120(itex1D)
-             122:          16 Load 18(s)
-             124:         123 SampledImage 121 122
-             128:         125 Load 127(utex1DArray)
-             129:          16 Load 18(s)
-             131:         130 SampledImage 128 129
-             135:         132 Load 134(texBuffer)
-             136:          16 Load 18(s)
-             138:         137 SampledImage 135 136
-             139:          62 Load 64(texCube)
-             140:          16 Load 77(sShadow)
-             143:         142 SampledImage 139 140
-             147:         144 Load 146(tex2DArray)
-             148:          16 Load 18(s)
-             150:         149 SampledImage 147 148
-             151:         144 Load 146(tex2DArray)
-             152:          16 Load 77(sShadow)
-             155:         154 SampledImage 151 152
-             159:         156 Load 158(itex2D)
-             160:          16 Load 18(s)
-             162:         161 SampledImage 159 160
-             166:         163 Load 165(itex3D)
-             167:          16 Load 18(s)
-             169:         168 SampledImage 166 167
-             173:         170 Load 172(itexCube)
-             174:          16 Load 18(s)
-             176:         175 SampledImage 173 174
-             180:         177 Load 179(itex2DArray)
-             181:          16 Load 18(s)
-             183:         182 SampledImage 180 181
-             187:         184 Load 186(utex2D)
-             188:          16 Load 18(s)
-             190:         189 SampledImage 187 188
-             194:         191 Load 193(utex3D)
-             195:          16 Load 18(s)
-             197:         196 SampledImage 194 195
-             201:         198 Load 200(utexCube)
-             202:          16 Load 18(s)
-             204:         203 SampledImage 201 202
-             208:         205 Load 207(utex2DArray)
-             209:          16 Load 18(s)
-             211:         210 SampledImage 208 209
-             215:         212 Load 214(itex2DRect)
-             216:          16 Load 18(s)
-             218:         217 SampledImage 215 216
-             222:         219 Load 221(utex2DRect)
-             223:          16 Load 18(s)
-             225:         224 SampledImage 222 223
-             229:         226 Load 228(itexBuffer)
-             230:          16 Load 18(s)
-             232:         231 SampledImage 229 230
-             236:         233 Load 235(utexBuffer)
-             237:          16 Load 18(s)
-             239:         238 SampledImage 236 237
-             243:         240 Load 242(tex2DMS)
-             244:          16 Load 18(s)
-             246:         245 SampledImage 243 244
-             250:         247 Load 249(itex2DMS)
-             251:          16 Load 18(s)
-             253:         252 SampledImage 250 251
-             257:         254 Load 256(utex2DMS)
-             258:          16 Load 18(s)
-             260:         259 SampledImage 257 258
-             264:         261 Load 263(tex2DMSArray)
-             265:          16 Load 18(s)
-             267:         266 SampledImage 264 265
-             271:         268 Load 270(itex2DMSArray)
-             272:          16 Load 18(s)
-             274:         273 SampledImage 271 272
-             278:         275 Load 277(utex2DMSArray)
-             279:          16 Load 18(s)
-             281:         280 SampledImage 278 279
-             285:         282 Load 284(tex1D)
-             286:          16 Load 18(s)
-             288:         287 SampledImage 285 286
-             289:         282 Load 284(tex1D)
-             290:          16 Load 77(sShadow)
-             293:         292 SampledImage 289 290
-             295:          26 Load 294(tex3D)
-             296:          16 Load 18(s)
-             297:          45 SampledImage 295 296
-             298:          12 Load 58(tex2D)
-             299:          16 Load 77(sShadow)
-             302:         301 SampledImage 298 299
-             306:         303 Load 305(tex2DRect)
-             307:          16 Load 18(s)
-             309:         308 SampledImage 306 307
-             310:         303 Load 305(tex2DRect)
-             311:          16 Load 77(sShadow)
-             314:         313 SampledImage 310 311
-             315:          96 Load 98(tex1DArray)
-             316:          16 Load 18(s)
-             318:         317 SampledImage 315 316
+             102:         101 SampledImage 99 100
+             106:         103 Load 105(itex1DArray)
+             107:          16 Load 18(s)
+             109:         108 SampledImage 106 107
+             113:         110 Load 112(utex1D)
+             114:          16 Load 18(s)
+             116:         115 SampledImage 113 114
+             120:         117 Load 119(itex1D)
+             121:          16 Load 18(s)
+             123:         122 SampledImage 120 121
+             127:         124 Load 126(utex1DArray)
+             128:          16 Load 18(s)
+             130:         129 SampledImage 127 128
+             134:         131 Load 133(texBuffer)
+             135:          16 Load 18(s)
+             137:         136 SampledImage 134 135
+             138:          62 Load 64(texCube)
+             139:          16 Load 77(sShadow)
+             142:         141 SampledImage 138 139
+             146:         143 Load 145(tex2DArray)
+             147:          16 Load 18(s)
+             149:         148 SampledImage 146 147
+             150:         143 Load 145(tex2DArray)
+             151:          16 Load 77(sShadow)
+             154:         153 SampledImage 150 151
+             158:         155 Load 157(itex2D)
+             159:          16 Load 18(s)
+             161:         160 SampledImage 158 159
+             165:         162 Load 164(itex3D)
+             166:          16 Load 18(s)
+             168:         167 SampledImage 165 166
+             172:         169 Load 171(itexCube)
+             173:          16 Load 18(s)
+             175:         174 SampledImage 172 173
+             179:         176 Load 178(itex2DArray)
+             180:          16 Load 18(s)
+             182:         181 SampledImage 179 180
+             186:         183 Load 185(utex2D)
+             187:          16 Load 18(s)
+             189:         188 SampledImage 186 187
+             193:         190 Load 192(utex3D)
+             194:          16 Load 18(s)
+             196:         195 SampledImage 193 194
+             200:         197 Load 199(utexCube)
+             201:          16 Load 18(s)
+             203:         202 SampledImage 200 201
+             207:         204 Load 206(utex2DArray)
+             208:          16 Load 18(s)
+             210:         209 SampledImage 207 208
+             214:         211 Load 213(itex2DRect)
+             215:          16 Load 18(s)
+             217:         216 SampledImage 214 215
+             221:         218 Load 220(utex2DRect)
+             222:          16 Load 18(s)
+             224:         223 SampledImage 221 222
+             228:         225 Load 227(itexBuffer)
+             229:          16 Load 18(s)
+             231:         230 SampledImage 228 229
+             235:         232 Load 234(utexBuffer)
+             236:          16 Load 18(s)
+             238:         237 SampledImage 235 236
+             242:         239 Load 241(tex2DMS)
+             243:          16 Load 18(s)
+             245:         244 SampledImage 242 243
+             249:         246 Load 248(itex2DMS)
+             250:          16 Load 18(s)
+             252:         251 SampledImage 249 250
+             256:         253 Load 255(utex2DMS)
+             257:          16 Load 18(s)
+             259:         258 SampledImage 256 257
+             263:         260 Load 262(tex2DMSArray)
+             264:          16 Load 18(s)
+             266:         265 SampledImage 263 264
+             270:         267 Load 269(itex2DMSArray)
+             271:          16 Load 18(s)
+             273:         272 SampledImage 270 271
+             277:         274 Load 276(utex2DMSArray)
+             278:          16 Load 18(s)
+             280:         279 SampledImage 277 278
+             284:         281 Load 283(tex1D)
+             285:          16 Load 18(s)
+             287:         286 SampledImage 284 285
+             288:         281 Load 283(tex1D)
+             289:          16 Load 77(sShadow)
+             292:         291 SampledImage 288 289
+             294:          26 Load 293(tex3D)
+             295:          16 Load 18(s)
+             296:          45 SampledImage 294 295
+             297:          12 Load 58(tex2D)
+             298:          16 Load 77(sShadow)
+             301:         300 SampledImage 297 298
+             305:         302 Load 304(tex2DRect)
+             306:          16 Load 18(s)
+             308:         307 SampledImage 305 306
+             309:         302 Load 304(tex2DRect)
+             310:          16 Load 77(sShadow)
+             313:         312 SampledImage 309 310
+             314:          96 Load 98(tex1DArray)
+             315:          16 Load 18(s)
+             318:         317 SampledImage 314 315
                               Return
                               FunctionEnd

--- a/Test/baseResults/vulkan.frag.out
+++ b/Test/baseResults/vulkan.frag.out
@@ -16,7 +16,6 @@ ERROR: 0:21: 'sampler3D' : sampler-constructor cannot make an array of samplers
 ERROR: 0:22: 'sampler2D' : sampler-constructor first argument must be a scalar textureXXX type 
 ERROR: 0:23: 'sampler2D' : sampler-constructor first argument must match type and dimensionality of constructor type 
 ERROR: 0:24: 'sampler2D' : sampler-constructor second argument presence of shadow must match constructor presence of shadow 
-ERROR: 0:25: 'sampler2DShadow' : sampler-constructor second argument presence of shadow must match constructor presence of shadow 
 ERROR: 0:28: 'sampler2D' : sampler/image types can only be used in uniform variables or function parameters: s2D
 ERROR: 0:29: 'sampler3D' : sampler-constructor cannot make an array of samplers 
 ERROR: 0:29: 'sampler3D' : sampler/image types can only be used in uniform variables or function parameters: s3d
@@ -56,7 +55,7 @@ ERROR: 0:101: 'noise1' : no matching overloaded function found
 ERROR: 0:102: 'noise2' : no matching overloaded function found 
 ERROR: 0:103: 'noise3' : no matching overloaded function found 
 ERROR: 0:104: 'noise4' : no matching overloaded function found 
-ERROR: 55 compilation errors.  No code generated.
+ERROR: 54 compilation errors.  No code generated.
 
 
 ERROR: Linking fragment stage: Only one push_constant block is allowed per stage

--- a/Test/vulkan.frag
+++ b/Test/vulkan.frag
@@ -22,7 +22,7 @@ void badConst()
     sampler2D(i2d, s);            // ERROR, image instead of texture
     sampler2D(t3d[1], s);         // ERROR, 3D not 2D
     sampler2D(t2d, sShadow);      // ERROR, shadow mismatch
-    sampler2DShadow(t2d, s);      // ERROR, shadow mismatch
+    sampler2DShadow(t2d, s);
 }
 
 sampler2D s2D = sampler2D(t2d, s);            // ERROR, no sampler constructor

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -2655,15 +2655,16 @@ bool TParseContext::constructorTextureSamplerError(const TSourceLoc& loc, const 
     // second argument
     //   * the constructor's second argument must be a scalar of type
     //     *sampler* or *samplerShadow*
-    //   * the presence or absence of depth comparison (Shadow) must match
-    //     between the constructed sampler type and the type of the second argument
+    //   * if the second argument is *samplerShadow* the constructor must be a
+    //     shadow constructor (however, shadow constructors are allowed to have
+    //     a second argument of *sampler*)
     if (  function[1].type->getBasicType() != EbtSampler ||
         ! function[1].type->getSampler().isPureSampler() ||
           function[1].type->isArray()) {
         error(loc, "sampler-constructor second argument must be a scalar type 'sampler'", token, "");
         return true;
     }
-    if (function.getType().getSampler().shadow != function[1].type->getSampler().shadow) {
+    if (!function.getType().getSampler().shadow && function[1].type->getSampler().shadow) {
         error(loc, "sampler-constructor second argument presence of shadow must match constructor presence of shadow", token, "");
         return true;
     }

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -5917,8 +5917,14 @@ TIntermTyped* TParseContext::addConstructor(const TSourceLoc& loc, TIntermNode* 
 
     // Combined texture-sampler constructors are completely semantic checked
     // in constructorTextureSamplerError()
-    if (op == EOpConstructTextureSampler)
+    if (op == EOpConstructTextureSampler) {
+        if (aggrNode->getSequence()[1]->getAsTyped()->getType().getSampler().shadow) {
+            // Transfer depth into the texture (SPIR-V image) type, as a hint
+            // for tools to know this texture/image is a depth image.
+            aggrNode->getSequence()[0]->getAsTyped()->getWritableType().getSampler().shadow = true;
+        }
         return intermediate.setAggregateOperator(aggrNode, op, type, loc);
+    }
 
     TTypeList::const_iterator memberTypes;
     if (op == EOpConstructStruct)

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -6246,7 +6246,8 @@ bool HlslParseContext::constructorError(const TSourceLoc& loc, TIntermNode* node
     bool constructingMatrix = false;
     switch (op) {
     case EOpConstructTextureSampler:
-        return constructorTextureSamplerError(loc, function);
+        error(loc, "unhandled texture constructor", "constructor", "");
+        return true;
     case EOpConstructMat2x2:
     case EOpConstructMat2x3:
     case EOpConstructMat2x4:
@@ -6436,67 +6437,6 @@ bool HlslParseContext::isScalarConstructor(const TIntermNode* node)
     return node->getAsTyped() != nullptr &&
            node->getAsTyped()->isScalar() &&
            (node->getAsAggregate() == nullptr || node->getAsAggregate()->getOp() != EOpNull);
-}
-
-// Verify all the correct semantics for constructing a combined texture/sampler.
-// Return true if the semantics are incorrect.
-bool HlslParseContext::constructorTextureSamplerError(const TSourceLoc& loc, const TFunction& function)
-{
-    TString constructorName = function.getType().getBasicTypeString();  // TODO: performance: should not be making copy; interface needs to change
-    const char* token = constructorName.c_str();
-
-    // exactly two arguments needed
-    if (function.getParamCount() != 2) {
-        error(loc, "sampler-constructor requires two arguments", token, "");
-        return true;
-    }
-
-    // For now, not allowing arrayed constructors, the rest of this function
-    // is set up to allow them, if this test is removed:
-    if (function.getType().isArray()) {
-        error(loc, "sampler-constructor cannot make an array of samplers", token, "");
-        return true;
-    }
-
-    // first argument
-    //  * the constructor's first argument must be a texture type
-    //  * the dimensionality (1D, 2D, 3D, Cube, Rect, Buffer, MS, and Array)
-    //    of the texture type must match that of the constructed sampler type
-    //    (that is, the suffixes of the type of the first argument and the
-    //    type of the constructor will be spelled the same way)
-    if (function[0].type->getBasicType() != EbtSampler ||
-        ! function[0].type->getSampler().isTexture() ||
-        function[0].type->isArray()) {
-        error(loc, "sampler-constructor first argument must be a scalar textureXXX type", token, "");
-        return true;
-    }
-    // simulate the first argument's impact on the result type, so it can be compared with the encapsulated operator!=()
-    TSampler texture = function.getType().getSampler();
-    texture.combined = false;
-    texture.shadow = false;
-    if (texture != function[0].type->getSampler()) {
-        error(loc, "sampler-constructor first argument must match type and dimensionality of constructor type", token, "");
-        return true;
-    }
-
-    // second argument
-    //   * the constructor's second argument must be a scalar of type
-    //     *sampler* or *samplerShadow*
-    //   * the presence or absence of depth comparison (Shadow) must match
-    //     between the constructed sampler type and the type of the second argument
-    if (function[1].type->getBasicType() != EbtSampler ||
-        ! function[1].type->getSampler().isPureSampler() ||
-        function[1].type->isArray()) {
-        error(loc, "sampler-constructor second argument must be a scalar type 'sampler'", token, "");
-        return true;
-    }
-    if (function.getType().getSampler().shadow != function[1].type->getSampler().shadow) {
-        error(loc, "sampler-constructor second argument presence of shadow must match constructor presence of shadow",
-              token, "");
-        return true;
-    }
-
-    return false;
 }
 
 // Checks to see if a void variable has been declared and raise an error message for such a case
@@ -8175,8 +8115,6 @@ TIntermTyped* HlslParseContext::addConstructor(const TSourceLoc& loc, TIntermTyp
     TIntermAggregate* aggrNode = node->getAsAggregate();
     TOperator op = intermediate.mapTypeToConstructorOp(type);
 
-    // Combined texture-sampler constructors are completely semantic checked
-    // in constructorTextureSamplerError()
     if (op == EOpConstructTextureSampler)
         return intermediate.setAggregateOperator(aggrNode, op, type, loc);
 

--- a/hlsl/hlslParseHelper.h
+++ b/hlsl/hlslParseHelper.h
@@ -122,7 +122,6 @@ public:
     void integerCheck(const TIntermTyped* node, const char* token);
     void globalCheck(const TSourceLoc&, const char* token);
     bool constructorError(const TSourceLoc&, TIntermNode*, TFunction&, TOperator, TType&);
-    bool constructorTextureSamplerError(const TSourceLoc&, const TFunction&);
     void arraySizeCheck(const TSourceLoc&, TIntermTyped* expr, TArraySize&);
     void arraySizeRequiredCheck(const TSourceLoc&, const TArraySizes&);
     void structArrayCheck(const TSourceLoc&, const TType& structure);


### PR DESCRIPTION
Fixes #854. But, only good if we are not trying to use the same texture for both shadow and non-shadow constructors.

Force the type of the texture to have 'shadow' set when it is constructed with a samplerShadow.