### PR TITLE
Update spirv-tools known good

### DIFF
--- a/known_good.json
+++ b/known_good.json
@@ -5,14 +5,14 @@
       "site" : "github",
       "subrepo" : "KhronosGroup/SPIRV-Tools",
       "subdir" : "External/spirv-tools",
-      "commit" : "f2c93c6e124836797311facb8449f9a0b76fefc2"
+      "commit" : "9ecbcf5fc87db00d3d6275522c735b5667007647"
     },
     {
       "name" : "spirv-tools/external/spirv-headers",
       "site" : "github",
       "subrepo" : "KhronosGroup/SPIRV-Headers",
       "subdir" : "External/spirv-tools/external/spirv-headers",
-      "commit" : "12f8de9f04327336b699b1b80aa390ae7f9ddbf4"
+      "commit" : "ff684ffc6a35d2a58f0f63108877d0064ea33feb"
     }
   ]
 }


### PR DESCRIPTION
Includes the following:

Add Vulkan 1.1 capability sets
Don't merge types of resources
Remove stores of undef.
Make sure the constant folder get the correct type.