### PR TITLE
Fix various build warnings/errors

### DIFF
--- a/glslang/MachineIndependent/Constant.cpp
+++ b/glslang/MachineIndependent/Constant.cpp
@@ -184,7 +184,7 @@ TIntermTyped* TIntermConstantUnion::fold(TOperator op, const TIntermTyped* right
                 else if (leftUnionArray[i].getDConst() > 0.0)
                     newConstArray[i].setDConst((double)INFINITY);
                 else if (leftUnionArray[i].getDConst() < 0.0)
-                    newConstArray[i].setDConst((double)-INFINITY);
+                    newConstArray[i].setDConst(-(double)INFINITY);
                 else
                     newConstArray[i].setDConst((double)NAN);
                 break;
@@ -223,8 +223,8 @@ TIntermTyped* TIntermConstantUnion::fold(TOperator op, const TIntermTyped* right
             case EbtInt:
                 if (rightUnionArray[i] == 0)
                     newConstArray[i].setIConst(0x7FFFFFFF);
-                else if (rightUnionArray[i].getIConst() == -1 && leftUnionArray[i].getIConst() == -(int)0x80000000)
-                    newConstArray[i].setIConst(-(int)0x80000000);
+                else if (rightUnionArray[i].getIConst() == -1 && leftUnionArray[i].getIConst() == (int)-0x80000000ll)
+                    newConstArray[i].setIConst((int)-0x80000000ll);
                 else
                     newConstArray[i].setIConst(leftUnionArray[i].getIConst() / rightUnionArray[i].getIConst());
                 break;
@@ -239,8 +239,8 @@ TIntermTyped* TIntermConstantUnion::fold(TOperator op, const TIntermTyped* right
             case EbtInt64:
                 if (rightUnionArray[i] == 0ll)
                     newConstArray[i].setI64Const(0x7FFFFFFFFFFFFFFFll);
-                else if (rightUnionArray[i].getI64Const() == -1 && leftUnionArray[i].getI64Const() == -0x8000000000000000ll)
-                    newConstArray[i].setI64Const(-0x8000000000000000ll);
+                else if (rightUnionArray[i].getI64Const() == -1 && leftUnionArray[i].getI64Const() == (long long)-0x8000000000000000ll)
+                    newConstArray[i].setI64Const((long long)-0x8000000000000000ll);
                 else
                     newConstArray[i].setI64Const(leftUnionArray[i].getI64Const() / rightUnionArray[i].getI64Const());
                 break;

--- a/glslang/MachineIndependent/reflection.h
+++ b/glslang/MachineIndependent/reflection.h
@@ -57,7 +57,7 @@ class TObjectReflection {
 public:
     TObjectReflection(const TString& pName, const TType& pType, int pOffset, int pGLDefineType, int pSize, int pIndex) :
         name(pName), offset(pOffset),
-        glDefineType(pGLDefineType), size(pSize), index(pIndex), counterIndex(-1), type(pType.clone()), stages(EShLanguageMask(0)) { }
+        glDefineType(pGLDefineType), size(pSize), index(pIndex), counterIndex(-1), stages(EShLanguageMask(0)), type(pType.clone()) { }
 
     const TType* const getType() const { return type; }
     int getBinding() const


### PR DESCRIPTION
1) On some old versions of MSVC:

       glslang\MachineIndependent\Constant.cpp(187): warning C4056: overflow in floating-point constant arithmetic

On this platform the definition of INFINITY is as follows:

	#ifndef _HUGE_ENUF
	   #define _HUGE_ENUF  1e+300  // _HUGE_ENUF*_HUGE_ENUF must overflow
	#endif
	#define INFINITY   ((float)(_HUGE_ENUF * _HUGE_ENUF))

Moving the negation outside the cast seems to resolve that issue.

2) Some Linux compilers were unhappy with lines 226/227

	    glslang/MachineIndependent/Constant.cpp: In member function 'virtual glslang::TIntermTyped* glslang::TIntermConstantUnion::fold(glslang::TOperator, const glslang::TIntermTyped*) const':
	    glslang/MachineIndependent/Constant.cpp:226:99: error: integer overflow in expression [-Werror=overflow]
			     else if (rightUnionArray[i].getIConst() == -1 && leftUnionArray[i].getIConst() == -(int)0x80000000)
													     ^~~~~~~~~~~~~~~~
	    glslang/MachineIndependent/Constant.cpp:227:48: error: integer overflow in expression [-Werror=overflow]
			         newConstArray[i].setIConst(-(int)0x80000000);
	                                               ^~~~~~~~~~~~~~~~

Moving the negation to the right side of the cast made those happy, but then some Windows compilers were unhappy:

	glslang\MachineIndependent\Constant.cpp(226): warning C4146: unary minus operator applied to unsigned type, result still unsigned
	glslang\MachineIndependent\Constant.cpp(227): warning C4146: unary minus operator applied to unsigned type, result still unsigned

which required adding on the "ll" suffix.

3) Android builds where unhappy with line 242:

	    glslang/MachineIndependent/Constant.cpp:242:100: error: comparison of integers of different signs: 'long long' and 'unsigned long long' [-Werror,-Wsign-compare]
        	              else if (rightUnionArray[i].getI64Const() == -1 && leftUnionArray[i].getI64Const() == -0x8000000000000000ll)
                	                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~
	    1 error generated.

Adding an explicit (long long) cast resolved this.
And the negation needs to be on the right side of the cast otherwise linux builds are unhappy as in (2).

4) Android builds are unhappy with out of order initializers:

	    glslang/MachineIndependent/reflection.h:60:84: error: field 'type' will be initialized after field 'stages' [-Werror,-Wreorder]
		    glDefineType(pGLDefineType), size(pSize), index(pIndex), counterIndex(-1), type(pType.clone()), stages(EShLanguageMask(0)) { }
											       ^
	    1 error generated.


Change-Id: Ic9a05fa7912498284885113d8b051f93f822f62b