### PR TITLE
tooling: Fix update sources script for Python 3

### DIFF
--- a/update_glslang_sources.py
+++ b/update_glslang_sources.py
@@ -96,7 +96,7 @@ class GoodCommit(object):
     def AddRemote(self):
         """Add the remote 'known-good' if it does not exist."""
         remotes = command_output(['git', 'remote'], self.subdir).splitlines()
-        if 'known-good' not in remotes:
+        if b'known-good' not in remotes:
             command_output(['git', 'remote', 'add', 'known-good', self.GetUrl()], self.subdir)
 
     def HasCommit(self):


### PR DESCRIPTION
This one small change allows the update_glslang_sources.py script to operate correctly with Python 2 and Python 3.

Change the string literal type to "bytes" so that it matches the type returned by the subprocess calls.  Otherwise, under Python 3, the search for "known-good" in the list of remotes always fails.  This is OK for the first execution of update_glsang_sources, since the remote is not there on the first run.  But on subsequent runs, the search still fails to match and the script stops when trying to create a remote that already exists.