### PR TITLE
Fix compiler warning emitted from GCC8

### DIFF
--- a/SPIRV/bitutils.h
+++ b/SPIRV/bitutils.h
@@ -26,7 +26,7 @@ Dest BitwiseCast(Src source) {
   Dest dest;
   static_assert(sizeof(source) == sizeof(dest),
                 "BitwiseCast: Source and destination must have the same size");
-  std::memcpy(&dest, &source, sizeof(dest));
+  std::memcpy(static_cast<void*>(&dest), &source, sizeof(dest));
   return dest;
 }
 


### PR DESCRIPTION
the following warning gets emitted:

```
In file included from ./Vulkan/glslang/SPIRV/hex_float.h:39,
                 from ./Vulkan/glslang/SPIRV/SpvBuilder.cpp:49:
./Vulkan/glslang/SPIRV/bitutils.h: In instantiation of ‘Dest spvutils::BitwiseCast(Src) [with Dest = spvutils::Float16; Src = short unsigned int]’:
./Vulkan/glslang/SPIRV/hex_float.h:138:47:   required from ‘T spvutils::FloatProxy<T>::getAsFloat() const [with T = spvutils::Float16]’
./Vulkan/glslang/SPIRV/hex_float.h:821:52:   required from here
./Vulkan/glslang/SPIRV/bitutils.h:29:14: warning: ‘void* memcpy(void*, const void*, size_t)’ writing to an object of non-trivially copyable type ‘class spvutils::Float16’; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
   std::memcpy(&dest, &source, sizeof(dest));
   ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ./Vulkan/glslang/SPIRV/SpvBuilder.cpp:49:
./Vulkan/glslang/SPIRV/hex_float.h:43:7: note: ‘class spvutils::Float16’ declared here
 class Float16 {
       ^~~~~~~
In file included from ./Vulkan/glslang/SPIRV/hex_float.h:39,
                 from ./Vulkan/glslang/SPIRV/SpvBuilder.cpp:49:
./Vulkan/glslang/SPIRV/bitutils.h: In instantiation of ‘Dest spvutils::BitwiseCast(Src) [with Dest = spvutils::FloatProxy<spvutils::Float16>; Src = short unsigned int]’:
./Vulkan/glslang/SPIRV/hex_float.h:431:28:   required from ‘void spvutils::HexFloat<T, Traits>::setFromSignUnbiasedExponentAndNormalizedSignificand(bool, spvutils::HexFloat<T, Traits>::int_type, spvutils::HexFloat<T, Traits>::uint_type, bool) [with T = spvutils::FloatProxy<spvutils::Float16>; Traits = spvutils::HexFloatTraits<spvutils::FloatProxy<spvutils::Float16> >; spvutils::HexFloat<T, Traits>::int_type = short int; spvutils::HexFloat<T, Traits>::uint_type = short unsigned int]’
./Vulkan/glslang/SPIRV/hex_float.h:633:5:   required from ‘void spvutils::HexFloat<T, Traits>::castTo(other_T&, spvutils::round_direction) [with other_T = spvutils::HexFloat<spvutils::FloatProxy<spvutils::Float16>, spvutils::HexFloatTraits<spvutils::FloatProxy<spvutils::Float16> > >; T = spvutils::FloatProxy<float>; Traits = spvutils::HexFloatTraits<spvutils::FloatProxy<float> >]’
./Vulkan/glslang/SPIRV/hex_float.h:817:39:   required from here
./Vulkan/glslang/SPIRV/bitutils.h:29:14: warning: ‘void* memcpy(void*, const void*, size_t)’ copying an object of non-trivial type ‘class spvutils::FloatProxy<spvutils::Float16>’ from an array of ‘short unsigned int’ [-Wclass-memaccess]
   std::memcpy(&dest, &source, sizeof(dest));
   ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ./Vulkan/glslang/SPIRV/SpvBuilder.cpp:49:
./Vulkan/glslang/SPIRV/hex_float.h:115:7: note: ‘class spvutils::FloatProxy<spvutils::Float16>’ declared here
 class FloatProxy {
       ^~~~~~~~~~
```