### PR TITLE
Fix more warnings in glslang

### DIFF
--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -640,7 +640,7 @@ bool Builder::containsType(Id typeId, spv::Op typeOp, int width) const
     {
     case OpTypeInt:
     case OpTypeFloat:
-        return typeClass == typeOp && instr.getImmediateOperand(0) == width;
+        return typeClass == typeOp && instr.getImmediateOperand(0) == (unsigned int)width;
     case OpTypeStruct:
         for (int m = 0; m < instr.getNumOperands(); ++m) {
             if (containsType(instr.getIdOperand(m), typeOp, width))

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -1508,6 +1508,8 @@ void TParseContext::memorySemanticsCheck(const TSourceLoc& loc, const TFunction&
 
     // Grab the semantics and storage class semantics from the operands, based on opcode
     switch (callNode.getOp()) {
+    default:
+        break;
     case EOpAtomicAdd:
     case EOpAtomicMin:
     case EOpAtomicMax:


### PR DESCRIPTION
```
glslang/MachineIndependent/ParseHelper.cpp:1510:13: error: 712 enumeration values not handled in switch: 'EOpNull', 'EOpSequence', 'EOpLinkerObjects'... [-Werror,-Wswitch]
    switch (callNode.getOp()) {
            ^
1 error generated.
```
```
glslang/SPIRV/SpvBuilder.cpp:643:68: error: comparison of integers of different signs: 'unsigned int' and 'int' [-Werror,-Wsign-compare]
        return typeClass == typeOp && instr.getImmediateOperand(0) == width;
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~
1 error generated.
```
Change-Id: Ib1792117f7909f2666b90230938efde75d5b6e01