### PR TITLE
Enhancement: add extra command line options that modifies aml

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -174,6 +174,7 @@ std::vector<std::string> Processes;                     // what should be record
 typedef std::map<unsigned int, unsigned int> TPerSetBaseBinding;
 
 std::vector<std::pair<std::string, int>> uniformLocationOverrides;
+int uniformBase = 0;
 
 std::array<std::array<unsigned int, EShLangCount>, glslang::EResCount> baseBinding;
 std::array<std::array<TPerSetBaseBinding, EShLangCount>, glslang::EResCount> baseBindingForSet;
@@ -465,6 +466,12 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
                     } else if (lowerword == "auto-map-locations" || // synonyms
                                lowerword == "aml") {
                         Options |= EOptionAutoMapLocations;
+                    } else if (lowerword == "uniform-base") {
+                        if (argc <= 1)
+                            Error("no <base> provided for --uniform-base");
+                        uniformBase = ::strtol(argv[1], NULL, 10);
+                        bumpArg();
+                        break;
                     } else if (lowerword == "client") {
                         if (argc > 1) {
                             if (strcmp(argv[1], "vulkan100") == 0)
@@ -923,6 +930,8 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
             shader->addUniformLocationOverride(uniOverride.first.c_str(),
                                                uniOverride.second);
         }
+
+        shader->setUniformLocationBase(uniformBase);
 
         // Set up the environment, some subsettings take precedence over earlier
         // ways of setting things.
@@ -1444,6 +1453,7 @@ void usage()
            "              suppress GLSL warnings, except as required by \"#extension : warn\"\n"
            "  -x          save binary output as text-based 32-bit hexadecimal numbers\n"
            "  -u<name>:<loc> specify a uniform location override for --aml\n"
+           "  --uniform-base <base> set a base to use for generated uniform locations\n"
            "  --auto-map-bindings | --amb       automatically bind uniform variables\n"
            "                                    without explicit bindings\n"
            "  --auto-map-locations | --aml      automatically locate input/output lacking\n"

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -173,6 +173,8 @@ std::vector<std::string> Processes;                     // what should be record
 // Per descriptor-set binding base data
 typedef std::map<unsigned int, unsigned int> TPerSetBaseBinding;
 
+std::vector<std::pair<std::string, int>> uniformLocationOverrides;
+
 std::array<std::array<unsigned int, EShLangCount>, glslang::EResCount> baseBinding;
 std::array<std::array<TPerSetBaseBinding, EShLangCount>, glslang::EResCount> baseBindingForSet;
 std::array<std::vector<std::string>, EShLangCount> baseResourceSetBinding;
@@ -431,6 +433,22 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
         Options &= ~EOptionVulkanRules;
     };
 
+    const auto getUniformOverride = [getStringOperand]() {
+        const char *arg = getStringOperand("-u<name>:<location>");
+        const char *split = strchr(arg, ':');
+        if (split == NULL) {
+            printf("%s: missing location\n", arg);
+            exit(EFailUsage);
+        }
+        errno = 0;
+        int location = ::strtol(split + 1, NULL, 10);
+        if (errno) {
+            printf("%s: invalid location\n", arg);
+            exit(EFailUsage);
+        }
+        return std::make_pair(std::string(arg, split - arg), location);
+    };
+
     for (bumpArg(); argc >= 1; bumpArg()) {
         if (argv[0][0] == '-') {
             switch (argv[0][1]) {
@@ -571,6 +589,9 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
                     Options |= EOptionReadHlsl;
                 else
                     UserPreamble.addDef(getStringOperand("-D<macro> macro name"));
+                break;
+            case 'u':
+                uniformLocationOverrides.push_back(getUniformOverride());
                 break;
             case 'E':
                 Options |= EOptionOutputPreprocessed;
@@ -897,6 +918,11 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
 
         if (Options & EOptionInvertY)
             shader->setInvertY(true);
+
+        for (auto& uniOverride : uniformLocationOverrides) {
+            shader->addUniformLocationOverride(uniOverride.first.c_str(),
+                                               uniOverride.second);
+        }
 
         // Set up the environment, some subsettings take precedence over earlier
         // ways of setting things.
@@ -1417,6 +1443,7 @@ void usage()
            "  -w | --suppress-warnings\n"
            "              suppress GLSL warnings, except as required by \"#extension : warn\"\n"
            "  -x          save binary output as text-based 32-bit hexadecimal numbers\n"
+           "  -u<name>:<loc> specify a uniform location override for --aml\n"
            "  --auto-map-bindings | --amb       automatically bind uniform variables\n"
            "                                    without explicit bindings\n"
            "  --auto-map-locations | --aml      automatically locate input/output lacking\n"

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1759,6 +1759,10 @@ void TShader::setAutoMapBindings(bool map)              { intermediate->setAutoM
 void TShader::setInvertY(bool invert)                   { intermediate->setInvertY(invert); }
 // Fragile: currently within one stage: simple auto-assignment of location
 void TShader::setAutoMapLocations(bool map)             { intermediate->setAutoMapLocations(map); }
+void TShader::addUniformLocationOverride(const char* name, int loc)
+{
+    intermediate->addUniformLocationOverride(name, loc);
+}
 // See comment above TDefaultHlslIoMapper in iomapper.cpp:
 void TShader::setHlslIoMapping(bool hlslIoMap)          { intermediate->setHlslIoMapping(hlslIoMap); }
 void TShader::setFlattenUniformArrays(bool flatten)     { intermediate->setFlattenUniformArrays(flatten); }

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1763,6 +1763,10 @@ void TShader::addUniformLocationOverride(const char* name, int loc)
 {
     intermediate->addUniformLocationOverride(name, loc);
 }
+void TShader::setUniformLocationBase(int base)
+{
+    intermediate->setUniformLocationBase(base);
+}
 // See comment above TDefaultHlslIoMapper in iomapper.cpp:
 void TShader::setHlslIoMapping(bool hlslIoMap)          { intermediate->setHlslIoMapping(hlslIoMap); }
 void TShader::setFlattenUniformArrays(bool flatten)     { intermediate->setFlattenUniformArrays(flatten); }

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -359,7 +359,7 @@ struct TDefaultIoResolverBase : public glslang::TIoMapResolver
 {
     TDefaultIoResolverBase(const TIntermediate &intermediate) :
         intermediate(intermediate),
-        nextUniformLocation(0),
+        nextUniformLocation(intermediate.getUniformLocationBase()),
         nextInputLocation(0),
         nextOutputLocation(0)
     { }

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -434,7 +434,7 @@ struct TDefaultIoResolverBase : public glslang::TIoMapResolver
 
         return 0;
     }
-    int resolveUniformLocation(EShLanguage /*stage*/, const char* /*name*/, const glslang::TType& type, bool /*is_live*/) override
+    int resolveUniformLocation(EShLanguage /*stage*/, const char* name, const glslang::TType& type, bool /*is_live*/) override
     {
         // kick out of not doing this
         if (!doAutoLocationMapping())
@@ -455,7 +455,11 @@ struct TDefaultIoResolverBase : public glslang::TIoMapResolver
                 return -1;
         }
 
-        int location = nextUniformLocation;
+        int location = intermediate.getUniformLocationOverride(name);
+        if (location != -1)
+                return location;
+
+        location = nextUniformLocation;
 
         nextUniformLocation += TIntermediate::computeTypeUniformLocationSize(type);
 

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -671,6 +671,20 @@ public:
     void addProcessArgument(const std::string& arg) { processes.addArgument(arg); }
     const std::vector<std::string>& getProcesses() const { return processes.getProcesses(); }
 
+    void addUniformLocationOverride(const TString& name, int location)
+    {
+            uniformLocationOverrides[name] = location;
+    }
+
+    int getUniformLocationOverride(const TString& name) const
+    {
+            auto pos = uniformLocationOverrides.find(name);
+            if (pos == uniformLocationOverrides.end())
+                    return -1;
+            else
+                    return pos->second;
+    }
+
     void setNeedsLegalization() { needToLegalize = true; }
     bool needsLegalization() const { return needToLegalize; }
 
@@ -795,6 +809,8 @@ protected:
 
     bool needToLegalize;
     bool binaryDoubleOutput;
+
+    std::unordered_map<TString, int> uniformLocationOverrides;
 
 private:
     void operator=(TIntermediate&); // prevent assignments

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -252,7 +252,8 @@ public:
         hlslIoMapping(false),
         textureSamplerTransformMode(EShTexSampTransKeep),
         needToLegalize(false),
-        binaryDoubleOutput(false)
+        binaryDoubleOutput(false),
+        uniformLocationBase(0)
     {
         localSize[0] = 1;
         localSize[1] = 1;
@@ -685,6 +686,9 @@ public:
                     return pos->second;
     }
 
+    void setUniformLocationBase(int base) { uniformLocationBase = base; }
+    int getUniformLocationBase() const { return uniformLocationBase; }
+
     void setNeedsLegalization() { needToLegalize = true; }
     bool needsLegalization() const { return needToLegalize; }
 
@@ -811,6 +815,7 @@ protected:
     bool binaryDoubleOutput;
 
     std::unordered_map<TString, int> uniformLocationOverrides;
+    int uniformLocationBase;
 
 private:
     void operator=(TIntermediate&); // prevent assignments

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -413,6 +413,7 @@ public:
     void setResourceSetBinding(const std::vector<std::string>& base);
     void setAutoMapBindings(bool map);
     void setAutoMapLocations(bool map);
+    void addUniformLocationOverride(const char* name, int loc);
     void setInvertY(bool invert);
     void setHlslIoMapping(bool hlslIoMap);
     void setFlattenUniformArrays(bool flatten);

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -414,6 +414,7 @@ public:
     void setAutoMapBindings(bool map);
     void setAutoMapLocations(bool map);
     void addUniformLocationOverride(const char* name, int loc);
+    void setUniformLocationBase(int base);
     void setInvertY(bool invert);
     void setHlslIoMapping(bool hlslIoMap);
     void setFlattenUniformArrays(bool flatten);


### PR DESCRIPTION
Disclaimer: the patches would need some extra documentation/cleaning, but we preferred to discuss first if those features would be accepted.

Although it is planned, right now glslangValidator lacks inter-stage linking/fixing (in other words, get --aml working inter-stage).

One way to mitigate this right now would be to add two command line options:
   * -u<name>:<loc> specify a uniform location override for --aml
   * --uniform-base <base> set a base to use for generated uniform locations

It is true that this requires the glslangValidator caller to gather that info, something that goes somewhat against the idea of aml (automatic location assignment). But for our use case, we are able to automatize getting that info. We are using those command line options as part of the testing of the ongoing ARB_gl_spirv implementation for the Mesa driver. We are trying to reuse as much piglit GLSL tests as possible. In order to do that, we use glslangValidator, but we have a previous script that analyze the GLSL test, in order to fix as many of them. This script is able to do some inter-stage analysis, so it can provide that info to glslangValidator.
