### PR TITLE
BUILD.gn: glslang_sources need the public config too

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -40,6 +40,8 @@ config("glslang_public") {
 }
 
 source_set("glslang_sources") {
+  public_configs = [ ":glslang_public" ]
+
   sources = [
     "OGLCompilersDLL/InitializeDll.cpp",
     "OGLCompilersDLL/InitializeDll.h",
@@ -152,8 +154,6 @@ source_set("glslang_sources") {
 }
 
 static_library("glslang_static") {
-  public_configs = [ ":glslang_public" ]
-
   deps = [
     ":glslang_sources",
   ]


### PR DESCRIPTION
PTAL @dj2 @johnkslang this should be the last one of these PRs for now (at least to roll into Dawn, Chrome might need more)