### PR TITLE
Fix inferred output primitive for GL_NV_geometry_shader_passthrough 

### DIFF
--- a/Test/baseResults/spv.GeometryShaderPassthrough.geom.out
+++ b/Test/baseResults/spv.GeometryShaderPassthrough.geom.out
@@ -11,6 +11,7 @@ spv.GeometryShaderPassthrough.geom
                               EntryPoint Geometry 4  "main" 10 14
                               ExecutionMode 4 Triangles
                               ExecutionMode 4 Invocations 1
+                              ExecutionMode 4 OutputTriangleStrip
                               ExecutionMode 4 OutputVertices 3
                               Source GLSL 450
                               SourceExtension  "GL_NV_geometry_shader_passthrough"

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -4487,7 +4487,7 @@ void TParseContext::finish()
             switch (intermediate.getInputPrimitive()) {
             case ElgPoints:      intermediate.setOutputPrimitive(ElgPoints);    break;
             case ElgLines:       intermediate.setOutputPrimitive(ElgLineStrip); break;
-            case ElgTriangles:   intermediate.setOutputPrimitive(ElgTriangles); break;
+            case ElgTriangles:   intermediate.setOutputPrimitive(ElgTriangleStrip); break;
             default: break;
             }
         }

--- a/glslang/MachineIndependent/linkValidate.cpp
+++ b/glslang/MachineIndependent/linkValidate.cpp
@@ -689,17 +689,9 @@ void TIntermediate::finalCheck(TInfoSink& infoSink, bool keepUncalled)
     case EShLangGeometry:
         if (inputPrimitive == ElgNone)
             error(infoSink, "At least one shader must specify an input layout primitive");
-        if (outputPrimitive == ElgNone
-#ifdef NV_EXTENSIONS
-            && !getGeoPassthroughEXT()
-#endif
-            )
+        if (outputPrimitive == ElgNone)
             error(infoSink, "At least one shader must specify an output layout primitive");
-        if (vertices == TQualifier::layoutNotSet
-#ifdef NV_EXTENSIONS
-            && !getGeoPassthroughEXT()
-#endif
-           )
+        if (vertices == TQualifier::layoutNotSet)
             error(infoSink, "At least one shader must specify a layout(max_vertices = value)");
         break;
     case EShLangFragment:


### PR DESCRIPTION
For GL_NV_geometry_shader_passthrough extension, the inferred output primitive for ElgTriangles should be ElgTriangleStrip.

Also removed unnecessary relax for GL_NV_geometry_shader_passthrough in link validate