### PR TITLE
Fixup unused parameter warnings

### DIFF
--- a/SPIRV/SpvPostProcess.cpp
+++ b/SPIRV/SpvPostProcess.cpp
@@ -208,7 +208,7 @@ void Builder::postProcess(const Instruction& inst)
 }
 
 // Called for each instruction in a reachable block.
-void Builder::postProcessReachable(const Instruction& inst)
+void Builder::postProcessReachable(const Instruction&)
 {
     // did have code here, but questionable to do so without deleting the instructions
 }

--- a/SPIRV/SpvTools.cpp
+++ b/SPIRV/SpvTools.cpp
@@ -114,8 +114,8 @@ void SpirvToolsValidate(const glslang::TIntermediate& intermediate, std::vector<
 
 // Apply the SPIRV-Tools optimizer to generated SPIR-V, for the purpose of
 // legalizing HLSL SPIR-V.
-void SpirvToolsLegalize(const glslang::TIntermediate& intermediate, std::vector<unsigned int>& spirv,
-                        spv::SpvBuildLogger* logger, const SpvOptions* options)
+void SpirvToolsLegalize(const glslang::TIntermediate&, std::vector<unsigned int>& spirv,
+                        spv::SpvBuildLogger*, const SpvOptions* options)
 {
     spv_target_env target_env = SPV_ENV_UNIVERSAL_1_2;
 


### PR DESCRIPTION
This CL removes the current parameters which are unused in order to
fixup the issued clang warnings.