### PR TITLE
Fix MSVC warning C4065: 'default' but no 'case' labels

### DIFF
--- a/SPIRV/SpvPostProcess.cpp
+++ b/SPIRV/SpvPostProcess.cpp
@@ -121,8 +121,8 @@ void Builder::postProcessType(const Instruction& inst, Id typeId)
     case OpUConvert:
         break;
     case OpExtInst:
-        switch (inst.getImmediateOperand(1)) {
 #if AMD_EXTENSIONS
+        switch (inst.getImmediateOperand(1)) {
         case GLSLstd450Frexp:
         case GLSLstd450FrexpStruct:
             if (getSpvVersion() < glslang::EShTargetSpv_1_3 && containsType(typeId, OpTypeInt, 16))
@@ -134,10 +134,10 @@ void Builder::postProcessType(const Instruction& inst, Id typeId)
             if (getSpvVersion() < glslang::EShTargetSpv_1_3 && containsType(typeId, OpTypeFloat, 16))
                 addExtension(spv::E_SPV_AMD_gpu_shader_half_float);
             break;
-#endif
         default:
             break;
         }
+#endif
         break;
     default:
         if (basicTypeOp == OpTypeFloat && width == 16)


### PR DESCRIPTION
This would happen in SpvPostProcess when we don't enable AMD extensions.

PTAL @johnkslang 