### PR TITLE
BUILD.gn: remove reference to non-existent header

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -58,7 +58,6 @@ source_set("glslang_sources") {
     "SPIRV/SpvBuilder.cpp",
     "SPIRV/SpvBuilder.h",
     "SPIRV/SpvPostProcess.cpp",
-    "SPIRV/SpvPostProcess.h",
     "SPIRV/bitutils.h",
     "SPIRV/disassemble.cpp",
     "SPIRV/disassemble.h",


### PR DESCRIPTION
PTAL @johnkslang (FYI @dj2).

Glslang was never build in Chrome so some sanity check for GN files were never run causing this to go unnoticed. After this is landed we can build glslang in chrome in the "all" target (as a dependency of Dawn)