### PR TITLE
Rename PCH macro to glslang_pch (to avoid name collision) and update to latest spirv-tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ if(USE_CCACHE)
 endif()
 
 # Precompiled header macro. Parameters are source file list and filename for pch cpp file.
-macro(PCH SRCS PCHCPP)
+macro(glslang_pch SRCS PCHCPP)
   if(MSVC)
     if (CMAKE_GENERATOR MATCHES "^Visual Studio")
       set(PCH_NAME "$(IntDir)\\pch.pch")
@@ -58,7 +58,7 @@ macro(PCH SRCS PCHCPP)
     set_source_files_properties(${PCHCPP} PROPERTIES COMPILE_FLAGS "/Ycpch.h /Fp${PCH_NAME} /Zm300" OBJECT_OUTPUTS "${PCH_NAME}")
     list(APPEND ${SRCS} "${PCHCPP}")
   endif()
-endmacro(PCH)
+endmacro(glslang_pch)
 
 project(glslang)
 # make testing optional

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -80,7 +80,7 @@ set(HEADERS
 #                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 # set(BISON_GLSLParser_OUTPUT_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/MachineIndependent/glslang_tab.cpp)
 
-PCH(SOURCES MachineIndependent/pch.cpp)
+glslang_pch(SOURCES MachineIndependent/pch.cpp)
 
 add_library(glslang ${LIB_TYPE} ${BISON_GLSLParser_OUTPUT_SOURCE} ${SOURCES} ${HEADERS})
 set_property(TARGET glslang PROPERTY FOLDER glslang)

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -25,7 +25,7 @@ if(BUILD_TESTING)
             # -- Remapper tests
             ${CMAKE_CURRENT_SOURCE_DIR}/Remap.FromFile.cpp)
 
-        PCH(TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/pch.cpp)
+        glslang_pch(TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/pch.cpp)
 
         add_executable(glslangtests ${TEST_SOURCES})
         set_property(TARGET glslangtests PROPERTY FOLDER tests)

--- a/hlsl/CMakeLists.txt
+++ b/hlsl/CMakeLists.txt
@@ -17,7 +17,7 @@ set(HEADERS
     hlslGrammar.h
     hlslParseables.h)
 
-PCH(SOURCES pch.cpp)
+glslang_pch(SOURCES pch.cpp)
 
 add_library(HLSL ${LIB_TYPE} ${SOURCES} ${HEADERS})
 set_property(TARGET HLSL PROPERTY FOLDER hlsl)

--- a/known_good.json
+++ b/known_good.json
@@ -5,7 +5,7 @@
       "site" : "github",
       "subrepo" : "KhronosGroup/SPIRV-Tools",
       "subdir" : "External/spirv-tools",
-      "commit" : "fb996dce752507132c40c255898154cce6c072c5"
+      "commit" : "9d699f6d4038f432c55310d5d0b4a6d507c1b686"
     },
     {
       "name" : "spirv-tools/external/spirv-headers",


### PR DESCRIPTION
This pulls in the latest spirv-tools which has more PCH enabled. A clean Debug glslang build on Windows now takes about a minute on my system.

When I first tried to merge in spirv-tools yesterday, I found that the PCH macros conflicted, so I'm renaming all of them to be unique per-project. I've already renamed spirv-tools.
