### PR TITLE
Updated type conversion rules for HLSL frontend

### DIFF
--- a/Test/baseResults/hlsl.type.type.conversion.all.frag.out
+++ b/Test/baseResults/hlsl.type.type.conversion.all.frag.out
@@ -1,0 +1,1469 @@
+hlsl.type.type.conversion.all.frag
+ERROR: 0:88: '=' :  cannot convert from ' const 2X2 matrix of float' to ' temp 2-component vector of float'
+ERROR: 0:89: '=' :  cannot convert from ' const 2X3 matrix of float' to ' temp 2-component vector of float'
+ERROR: 0:90: '=' :  cannot convert from ' const 2X4 matrix of float' to ' temp 2-component vector of float'
+ERROR: 0:91: '=' :  cannot convert from ' const 3X2 matrix of float' to ' temp 2-component vector of float'
+ERROR: 0:92: '=' :  cannot convert from ' const 3X3 matrix of float' to ' temp 2-component vector of float'
+ERROR: 0:93: '=' :  cannot convert from ' const 3X4 matrix of float' to ' temp 2-component vector of float'
+ERROR: 0:94: '=' :  cannot convert from ' const 4X2 matrix of float' to ' temp 2-component vector of float'
+ERROR: 0:95: '=' :  cannot convert from ' const 4X3 matrix of float' to ' temp 2-component vector of float'
+ERROR: 0:96: '=' :  cannot convert from ' const 4X4 matrix of float' to ' temp 2-component vector of float'
+ERROR: 0:97: '=' :  cannot convert from ' const 2-component vector of float' to ' temp 3-component vector of float'
+ERROR: 0:98: '=' :  cannot convert from ' const 2X2 matrix of float' to ' temp 3-component vector of float'
+ERROR: 0:99: '=' :  cannot convert from ' const 2X3 matrix of float' to ' temp 3-component vector of float'
+ERROR: 0:100: '=' :  cannot convert from ' const 2X4 matrix of float' to ' temp 3-component vector of float'
+ERROR: 0:101: '=' :  cannot convert from ' const 3X2 matrix of float' to ' temp 3-component vector of float'
+ERROR: 0:102: '=' :  cannot convert from ' const 3X3 matrix of float' to ' temp 3-component vector of float'
+ERROR: 0:103: '=' :  cannot convert from ' const 3X4 matrix of float' to ' temp 3-component vector of float'
+ERROR: 0:104: '=' :  cannot convert from ' const 4X2 matrix of float' to ' temp 3-component vector of float'
+ERROR: 0:105: '=' :  cannot convert from ' const 4X3 matrix of float' to ' temp 3-component vector of float'
+ERROR: 0:106: '=' :  cannot convert from ' const 4X4 matrix of float' to ' temp 3-component vector of float'
+ERROR: 0:107: '=' :  cannot convert from ' const 2-component vector of float' to ' temp 4-component vector of float'
+ERROR: 0:108: '=' :  cannot convert from ' const 3-component vector of float' to ' temp 4-component vector of float'
+ERROR: 0:109: '=' :  cannot convert from ' const 2X3 matrix of float' to ' temp 4-component vector of float'
+ERROR: 0:110: '=' :  cannot convert from ' const 2X4 matrix of float' to ' temp 4-component vector of float'
+ERROR: 0:111: '=' :  cannot convert from ' const 3X2 matrix of float' to ' temp 4-component vector of float'
+ERROR: 0:112: '=' :  cannot convert from ' const 3X3 matrix of float' to ' temp 4-component vector of float'
+ERROR: 0:113: '=' :  cannot convert from ' const 3X4 matrix of float' to ' temp 4-component vector of float'
+ERROR: 0:114: '=' :  cannot convert from ' const 4X2 matrix of float' to ' temp 4-component vector of float'
+ERROR: 0:115: '=' :  cannot convert from ' const 4X3 matrix of float' to ' temp 4-component vector of float'
+ERROR: 0:116: '=' :  cannot convert from ' const 4X4 matrix of float' to ' temp 4-component vector of float'
+ERROR: 0:117: '=' :  cannot convert from ' const 2-component vector of float' to ' temp 2X2 matrix of float'
+ERROR: 0:118: '=' :  cannot convert from ' const 3-component vector of float' to ' temp 2X2 matrix of float'
+ERROR: 0:119: '=' :  cannot convert from ' const 2-component vector of float' to ' temp 2X3 matrix of float'
+ERROR: 0:120: '=' :  cannot convert from ' const 3-component vector of float' to ' temp 2X3 matrix of float'
+ERROR: 0:121: '=' :  cannot convert from ' const 4-component vector of float' to ' temp 2X3 matrix of float'
+ERROR: 0:122: '=' :  cannot convert from ' const 2X2 matrix of float' to ' temp 2X3 matrix of float'
+ERROR: 0:123: '=' :  cannot convert from ' const 3X2 matrix of float' to ' temp 2X3 matrix of float'
+ERROR: 0:124: '=' :  cannot convert from ' const 4X2 matrix of float' to ' temp 2X3 matrix of float'
+ERROR: 0:125: '=' :  cannot convert from ' const 2-component vector of float' to ' temp 2X4 matrix of float'
+ERROR: 0:126: '=' :  cannot convert from ' const 3-component vector of float' to ' temp 2X4 matrix of float'
+ERROR: 0:127: '=' :  cannot convert from ' const 4-component vector of float' to ' temp 2X4 matrix of float'
+ERROR: 0:128: '=' :  cannot convert from ' const 2X2 matrix of float' to ' temp 2X4 matrix of float'
+ERROR: 0:129: '=' :  cannot convert from ' const 2X3 matrix of float' to ' temp 2X4 matrix of float'
+ERROR: 0:130: '=' :  cannot convert from ' const 3X2 matrix of float' to ' temp 2X4 matrix of float'
+ERROR: 0:131: '=' :  cannot convert from ' const 3X3 matrix of float' to ' temp 2X4 matrix of float'
+ERROR: 0:132: '=' :  cannot convert from ' const 4X2 matrix of float' to ' temp 2X4 matrix of float'
+ERROR: 0:133: '=' :  cannot convert from ' const 4X3 matrix of float' to ' temp 2X4 matrix of float'
+ERROR: 0:134: '=' :  cannot convert from ' const 2-component vector of float' to ' temp 3X2 matrix of float'
+ERROR: 0:135: '=' :  cannot convert from ' const 3-component vector of float' to ' temp 3X2 matrix of float'
+ERROR: 0:136: '=' :  cannot convert from ' const 4-component vector of float' to ' temp 3X2 matrix of float'
+ERROR: 0:137: '=' :  cannot convert from ' const 2X2 matrix of float' to ' temp 3X2 matrix of float'
+ERROR: 0:138: '=' :  cannot convert from ' const 2X3 matrix of float' to ' temp 3X2 matrix of float'
+ERROR: 0:139: '=' :  cannot convert from ' const 2X4 matrix of float' to ' temp 3X2 matrix of float'
+ERROR: 0:140: '=' :  cannot convert from ' const 2-component vector of float' to ' temp 3X3 matrix of float'
+ERROR: 0:141: '=' :  cannot convert from ' const 3-component vector of float' to ' temp 3X3 matrix of float'
+ERROR: 0:142: '=' :  cannot convert from ' const 4-component vector of float' to ' temp 3X3 matrix of float'
+ERROR: 0:143: '=' :  cannot convert from ' const 2X2 matrix of float' to ' temp 3X3 matrix of float'
+ERROR: 0:144: '=' :  cannot convert from ' const 2X3 matrix of float' to ' temp 3X3 matrix of float'
+ERROR: 0:145: '=' :  cannot convert from ' const 2X4 matrix of float' to ' temp 3X3 matrix of float'
+ERROR: 0:146: '=' :  cannot convert from ' const 3X2 matrix of float' to ' temp 3X3 matrix of float'
+ERROR: 0:147: '=' :  cannot convert from ' const 4X2 matrix of float' to ' temp 3X3 matrix of float'
+ERROR: 0:148: '=' :  cannot convert from ' const 2-component vector of float' to ' temp 3X4 matrix of float'
+ERROR: 0:149: '=' :  cannot convert from ' const 3-component vector of float' to ' temp 3X4 matrix of float'
+ERROR: 0:150: '=' :  cannot convert from ' const 4-component vector of float' to ' temp 3X4 matrix of float'
+ERROR: 0:151: '=' :  cannot convert from ' const 2X2 matrix of float' to ' temp 3X4 matrix of float'
+ERROR: 0:152: '=' :  cannot convert from ' const 2X3 matrix of float' to ' temp 3X4 matrix of float'
+ERROR: 0:153: '=' :  cannot convert from ' const 2X4 matrix of float' to ' temp 3X4 matrix of float'
+ERROR: 0:154: '=' :  cannot convert from ' const 3X2 matrix of float' to ' temp 3X4 matrix of float'
+ERROR: 0:155: '=' :  cannot convert from ' const 3X3 matrix of float' to ' temp 3X4 matrix of float'
+ERROR: 0:156: '=' :  cannot convert from ' const 4X2 matrix of float' to ' temp 3X4 matrix of float'
+ERROR: 0:157: '=' :  cannot convert from ' const 4X3 matrix of float' to ' temp 3X4 matrix of float'
+ERROR: 0:158: '=' :  cannot convert from ' const 2-component vector of float' to ' temp 4X2 matrix of float'
+ERROR: 0:159: '=' :  cannot convert from ' const 3-component vector of float' to ' temp 4X2 matrix of float'
+ERROR: 0:160: '=' :  cannot convert from ' const 4-component vector of float' to ' temp 4X2 matrix of float'
+ERROR: 0:161: '=' :  cannot convert from ' const 2X2 matrix of float' to ' temp 4X2 matrix of float'
+ERROR: 0:162: '=' :  cannot convert from ' const 2X3 matrix of float' to ' temp 4X2 matrix of float'
+ERROR: 0:163: '=' :  cannot convert from ' const 2X4 matrix of float' to ' temp 4X2 matrix of float'
+ERROR: 0:164: '=' :  cannot convert from ' const 3X2 matrix of float' to ' temp 4X2 matrix of float'
+ERROR: 0:165: '=' :  cannot convert from ' const 3X3 matrix of float' to ' temp 4X2 matrix of float'
+ERROR: 0:166: '=' :  cannot convert from ' const 3X4 matrix of float' to ' temp 4X2 matrix of float'
+ERROR: 0:167: '=' :  cannot convert from ' const 2-component vector of float' to ' temp 4X3 matrix of float'
+ERROR: 0:168: '=' :  cannot convert from ' const 3-component vector of float' to ' temp 4X3 matrix of float'
+ERROR: 0:169: '=' :  cannot convert from ' const 4-component vector of float' to ' temp 4X3 matrix of float'
+ERROR: 0:170: '=' :  cannot convert from ' const 2X2 matrix of float' to ' temp 4X3 matrix of float'
+ERROR: 0:171: '=' :  cannot convert from ' const 2X3 matrix of float' to ' temp 4X3 matrix of float'
+ERROR: 0:172: '=' :  cannot convert from ' const 2X4 matrix of float' to ' temp 4X3 matrix of float'
+ERROR: 0:173: '=' :  cannot convert from ' const 3X2 matrix of float' to ' temp 4X3 matrix of float'
+ERROR: 0:174: '=' :  cannot convert from ' const 3X3 matrix of float' to ' temp 4X3 matrix of float'
+ERROR: 0:175: '=' :  cannot convert from ' const 3X4 matrix of float' to ' temp 4X3 matrix of float'
+ERROR: 0:176: '=' :  cannot convert from ' const 4X2 matrix of float' to ' temp 4X3 matrix of float'
+ERROR: 0:177: '=' :  cannot convert from ' const 2-component vector of float' to ' temp 4X4 matrix of float'
+ERROR: 0:178: '=' :  cannot convert from ' const 3-component vector of float' to ' temp 4X4 matrix of float'
+ERROR: 0:179: '=' :  cannot convert from ' const 4-component vector of float' to ' temp 4X4 matrix of float'
+ERROR: 0:180: '=' :  cannot convert from ' const 2X2 matrix of float' to ' temp 4X4 matrix of float'
+ERROR: 0:181: '=' :  cannot convert from ' const 2X3 matrix of float' to ' temp 4X4 matrix of float'
+ERROR: 0:182: '=' :  cannot convert from ' const 2X4 matrix of float' to ' temp 4X4 matrix of float'
+ERROR: 0:183: '=' :  cannot convert from ' const 3X2 matrix of float' to ' temp 4X4 matrix of float'
+ERROR: 0:184: '=' :  cannot convert from ' const 3X3 matrix of float' to ' temp 4X4 matrix of float'
+ERROR: 0:185: '=' :  cannot convert from ' const 3X4 matrix of float' to ' temp 4X4 matrix of float'
+ERROR: 0:186: '=' :  cannot convert from ' const 4X2 matrix of float' to ' temp 4X4 matrix of float'
+ERROR: 0:187: '=' :  cannot convert from ' const 4X3 matrix of float' to ' temp 4X4 matrix of float'
+ERROR: 100 compilation errors.  No code generated.
+
+
+Shader version: 500
+gl_FragCoord origin is upper left
+ERROR: node is still EOpNull!
+0:18  Function Definition: @main( ( temp 4-component vector of float)
+0:18    Function Parameters: 
+0:?     Sequence
+0:19      Sequence
+0:19        move second child to first child ( temp float)
+0:19          'var0' ( temp float)
+0:19          Constant:
+0:19            0.000000
+0:20      Sequence
+0:20        move second child to first child ( temp 2-component vector of float)
+0:20          'var13' ( temp 2-component vector of float)
+0:20          Constant:
+0:20            0.000000
+0:20            0.000000
+0:21      Sequence
+0:21        move second child to first child ( temp 2-component vector of float)
+0:21          'var14' ( temp 2-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:22      Sequence
+0:22        move second child to first child ( temp 3-component vector of float)
+0:22          'var26' ( temp 3-component vector of float)
+0:22          Constant:
+0:22            0.000000
+0:22            0.000000
+0:22            0.000000
+0:23      Sequence
+0:23        move second child to first child ( temp 3-component vector of float)
+0:23          'var28' ( temp 3-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:24      Sequence
+0:24        move second child to first child ( temp 4-component vector of float)
+0:24          'var39' ( temp 4-component vector of float)
+0:24          Constant:
+0:24            0.000000
+0:24            0.000000
+0:24            0.000000
+0:24            0.000000
+0:25      Sequence
+0:25        move second child to first child ( temp 4-component vector of float)
+0:25          'var42' ( temp 4-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:26      Sequence
+0:26        move second child to first child ( temp 4-component vector of float)
+0:26          'var43' ( temp 4-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:27      Sequence
+0:27        move second child to first child ( temp 2X2 matrix of float)
+0:27          'var52' ( temp 2X2 matrix of float)
+0:27          Constant:
+0:27            0.000000
+0:27            0.000000
+0:27            0.000000
+0:27            0.000000
+0:28      Sequence
+0:28        move second child to first child ( temp 2X2 matrix of float)
+0:28          'var55' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:29      Sequence
+0:29        move second child to first child ( temp 2X2 matrix of float)
+0:29          'var56' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:30      Sequence
+0:30        move second child to first child ( temp 2X3 matrix of float)
+0:30          'var65' ( temp 2X3 matrix of float)
+0:30          Constant:
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:31      Sequence
+0:31        move second child to first child ( temp 2X3 matrix of float)
+0:31          'var70' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:32      Sequence
+0:32        move second child to first child ( temp 2X4 matrix of float)
+0:32          'var78' ( temp 2X4 matrix of float)
+0:32          Constant:
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:33      Sequence
+0:33        move second child to first child ( temp 2X4 matrix of float)
+0:33          'var84' ( temp 2X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:34      Sequence
+0:34        move second child to first child ( temp 3X2 matrix of float)
+0:34          'var91' ( temp 3X2 matrix of float)
+0:34          Constant:
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:35      Sequence
+0:35        move second child to first child ( temp 3X2 matrix of float)
+0:35          'var98' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:36      Sequence
+0:36        move second child to first child ( temp 3X3 matrix of float)
+0:36          'var104' ( temp 3X3 matrix of float)
+0:36          Constant:
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:37      Sequence
+0:37        move second child to first child ( temp 3X3 matrix of float)
+0:37          'var112' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:38      Sequence
+0:38        move second child to first child ( temp 3X4 matrix of float)
+0:38          'var117' ( temp 3X4 matrix of float)
+0:38          Constant:
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:39      Sequence
+0:39        move second child to first child ( temp 3X4 matrix of float)
+0:39          'var126' ( temp 3X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:40      Sequence
+0:40        move second child to first child ( temp 4X2 matrix of float)
+0:40          'var130' ( temp 4X2 matrix of float)
+0:40          Constant:
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:41      Sequence
+0:41        move second child to first child ( temp 4X2 matrix of float)
+0:41          'var140' ( temp 4X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:42      Sequence
+0:42        move second child to first child ( temp 4X3 matrix of float)
+0:42          'var143' ( temp 4X3 matrix of float)
+0:42          Constant:
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:43      Sequence
+0:43        move second child to first child ( temp 4X3 matrix of float)
+0:43          'var154' ( temp 4X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:44      Sequence
+0:44        move second child to first child ( temp 4X4 matrix of float)
+0:44          'var156' ( temp 4X4 matrix of float)
+0:44          Constant:
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:45      Sequence
+0:45        move second child to first child ( temp 4X4 matrix of float)
+0:45          'var168' ( temp 4X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:46      Sequence
+0:46        move second child to first child ( temp float)
+0:46          'var1' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:47      Sequence
+0:47        move second child to first child ( temp float)
+0:47          'var2' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:48      Sequence
+0:48        move second child to first child ( temp float)
+0:48          'var3' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:49      Sequence
+0:49        move second child to first child ( temp float)
+0:49          'var4' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:50      Sequence
+0:50        move second child to first child ( temp float)
+0:50          'var5' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:51      Sequence
+0:51        move second child to first child ( temp float)
+0:51          'var6' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:52      Sequence
+0:52        move second child to first child ( temp float)
+0:52          'var7' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:53      Sequence
+0:53        move second child to first child ( temp float)
+0:53          'var8' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:54      Sequence
+0:54        move second child to first child ( temp float)
+0:54          'var9' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:55      Sequence
+0:55        move second child to first child ( temp float)
+0:55          'var10' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:56      Sequence
+0:56        move second child to first child ( temp float)
+0:56          'var11' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:57      Sequence
+0:57        move second child to first child ( temp float)
+0:57          'var12' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:58      Sequence
+0:58        move second child to first child ( temp 2-component vector of float)
+0:58          'var15' ( temp 2-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:59      Sequence
+0:59        move second child to first child ( temp 2-component vector of float)
+0:59          'var16' ( temp 2-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:60      Sequence
+0:60        move second child to first child ( temp 3-component vector of float)
+0:60          'var29' ( temp 3-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:61      Sequence
+0:61        move second child to first child ( temp 2X2 matrix of float)
+0:61          'var57' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:62      Sequence
+0:62        move second child to first child ( temp 2X2 matrix of float)
+0:62          'var58' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:63      Sequence
+0:63        move second child to first child ( temp 2X2 matrix of float)
+0:63          'var59' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:64      Sequence
+0:64        move second child to first child ( temp 2X2 matrix of float)
+0:64          'var60' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:65      Sequence
+0:65        move second child to first child ( temp 2X2 matrix of float)
+0:65          'var61' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:66      Sequence
+0:66        move second child to first child ( temp 2X2 matrix of float)
+0:66          'var62' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:67      Sequence
+0:67        move second child to first child ( temp 2X2 matrix of float)
+0:67          'var63' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:68      Sequence
+0:68        move second child to first child ( temp 2X2 matrix of float)
+0:68          'var64' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:69      Sequence
+0:69        move second child to first child ( temp 2X3 matrix of float)
+0:69          'var71' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:70      Sequence
+0:70        move second child to first child ( temp 2X3 matrix of float)
+0:70          'var73' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:71      Sequence
+0:71        move second child to first child ( temp 2X3 matrix of float)
+0:71          'var74' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:72      Sequence
+0:72        move second child to first child ( temp 2X3 matrix of float)
+0:72          'var76' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:73      Sequence
+0:73        move second child to first child ( temp 2X3 matrix of float)
+0:73          'var77' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:74      Sequence
+0:74        move second child to first child ( temp 2X4 matrix of float)
+0:74          'var87' ( temp 2X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:75      Sequence
+0:75        move second child to first child ( temp 2X4 matrix of float)
+0:75          'var90' ( temp 2X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:76      Sequence
+0:76        move second child to first child ( temp 3X2 matrix of float)
+0:76          'var99' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:77      Sequence
+0:77        move second child to first child ( temp 3X2 matrix of float)
+0:77          'var100' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:78      Sequence
+0:78        move second child to first child ( temp 3X2 matrix of float)
+0:78          'var101' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:79      Sequence
+0:79        move second child to first child ( temp 3X2 matrix of float)
+0:79          'var102' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:80      Sequence
+0:80        move second child to first child ( temp 3X2 matrix of float)
+0:80          'var103' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:81      Sequence
+0:81        move second child to first child ( temp 3X3 matrix of float)
+0:81          'var113' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:82      Sequence
+0:82        move second child to first child ( temp 3X3 matrix of float)
+0:82          'var115' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:83      Sequence
+0:83        move second child to first child ( temp 3X3 matrix of float)
+0:83          'var116' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:84      Sequence
+0:84        move second child to first child ( temp 3X4 matrix of float)
+0:84          'var129' ( temp 3X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:85      Sequence
+0:85        move second child to first child ( temp 4X2 matrix of float)
+0:85          'var141' ( temp 4X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:86      Sequence
+0:86        move second child to first child ( temp 4X2 matrix of float)
+0:86          'var142' ( temp 4X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:87      Sequence
+0:87        move second child to first child ( temp 4X3 matrix of float)
+0:87          'var155' ( temp 4X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:188      Branch: Return with expression
+0:188        Constant:
+0:188          0.000000
+0:188          0.000000
+0:188          0.000000
+0:188          0.000000
+0:18  Function Definition: main( ( temp void)
+0:18    Function Parameters: 
+0:?     Sequence
+0:18      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:18        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+
+Linked fragment stage:
+
+
+Shader version: 500
+gl_FragCoord origin is upper left
+ERROR: node is still EOpNull!
+0:18  Function Definition: @main( ( temp 4-component vector of float)
+0:18    Function Parameters: 
+0:?     Sequence
+0:19      Sequence
+0:19        move second child to first child ( temp float)
+0:19          'var0' ( temp float)
+0:19          Constant:
+0:19            0.000000
+0:20      Sequence
+0:20        move second child to first child ( temp 2-component vector of float)
+0:20          'var13' ( temp 2-component vector of float)
+0:20          Constant:
+0:20            0.000000
+0:20            0.000000
+0:21      Sequence
+0:21        move second child to first child ( temp 2-component vector of float)
+0:21          'var14' ( temp 2-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:22      Sequence
+0:22        move second child to first child ( temp 3-component vector of float)
+0:22          'var26' ( temp 3-component vector of float)
+0:22          Constant:
+0:22            0.000000
+0:22            0.000000
+0:22            0.000000
+0:23      Sequence
+0:23        move second child to first child ( temp 3-component vector of float)
+0:23          'var28' ( temp 3-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:24      Sequence
+0:24        move second child to first child ( temp 4-component vector of float)
+0:24          'var39' ( temp 4-component vector of float)
+0:24          Constant:
+0:24            0.000000
+0:24            0.000000
+0:24            0.000000
+0:24            0.000000
+0:25      Sequence
+0:25        move second child to first child ( temp 4-component vector of float)
+0:25          'var42' ( temp 4-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:26      Sequence
+0:26        move second child to first child ( temp 4-component vector of float)
+0:26          'var43' ( temp 4-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:27      Sequence
+0:27        move second child to first child ( temp 2X2 matrix of float)
+0:27          'var52' ( temp 2X2 matrix of float)
+0:27          Constant:
+0:27            0.000000
+0:27            0.000000
+0:27            0.000000
+0:27            0.000000
+0:28      Sequence
+0:28        move second child to first child ( temp 2X2 matrix of float)
+0:28          'var55' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:29      Sequence
+0:29        move second child to first child ( temp 2X2 matrix of float)
+0:29          'var56' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:30      Sequence
+0:30        move second child to first child ( temp 2X3 matrix of float)
+0:30          'var65' ( temp 2X3 matrix of float)
+0:30          Constant:
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:31      Sequence
+0:31        move second child to first child ( temp 2X3 matrix of float)
+0:31          'var70' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:32      Sequence
+0:32        move second child to first child ( temp 2X4 matrix of float)
+0:32          'var78' ( temp 2X4 matrix of float)
+0:32          Constant:
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:33      Sequence
+0:33        move second child to first child ( temp 2X4 matrix of float)
+0:33          'var84' ( temp 2X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:34      Sequence
+0:34        move second child to first child ( temp 3X2 matrix of float)
+0:34          'var91' ( temp 3X2 matrix of float)
+0:34          Constant:
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:35      Sequence
+0:35        move second child to first child ( temp 3X2 matrix of float)
+0:35          'var98' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:36      Sequence
+0:36        move second child to first child ( temp 3X3 matrix of float)
+0:36          'var104' ( temp 3X3 matrix of float)
+0:36          Constant:
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:37      Sequence
+0:37        move second child to first child ( temp 3X3 matrix of float)
+0:37          'var112' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:38      Sequence
+0:38        move second child to first child ( temp 3X4 matrix of float)
+0:38          'var117' ( temp 3X4 matrix of float)
+0:38          Constant:
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:39      Sequence
+0:39        move second child to first child ( temp 3X4 matrix of float)
+0:39          'var126' ( temp 3X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:40      Sequence
+0:40        move second child to first child ( temp 4X2 matrix of float)
+0:40          'var130' ( temp 4X2 matrix of float)
+0:40          Constant:
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:41      Sequence
+0:41        move second child to first child ( temp 4X2 matrix of float)
+0:41          'var140' ( temp 4X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:42      Sequence
+0:42        move second child to first child ( temp 4X3 matrix of float)
+0:42          'var143' ( temp 4X3 matrix of float)
+0:42          Constant:
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:43      Sequence
+0:43        move second child to first child ( temp 4X3 matrix of float)
+0:43          'var154' ( temp 4X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:44      Sequence
+0:44        move second child to first child ( temp 4X4 matrix of float)
+0:44          'var156' ( temp 4X4 matrix of float)
+0:44          Constant:
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:45      Sequence
+0:45        move second child to first child ( temp 4X4 matrix of float)
+0:45          'var168' ( temp 4X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:46      Sequence
+0:46        move second child to first child ( temp float)
+0:46          'var1' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:47      Sequence
+0:47        move second child to first child ( temp float)
+0:47          'var2' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:48      Sequence
+0:48        move second child to first child ( temp float)
+0:48          'var3' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:49      Sequence
+0:49        move second child to first child ( temp float)
+0:49          'var4' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:50      Sequence
+0:50        move second child to first child ( temp float)
+0:50          'var5' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:51      Sequence
+0:51        move second child to first child ( temp float)
+0:51          'var6' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:52      Sequence
+0:52        move second child to first child ( temp float)
+0:52          'var7' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:53      Sequence
+0:53        move second child to first child ( temp float)
+0:53          'var8' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:54      Sequence
+0:54        move second child to first child ( temp float)
+0:54          'var9' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:55      Sequence
+0:55        move second child to first child ( temp float)
+0:55          'var10' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:56      Sequence
+0:56        move second child to first child ( temp float)
+0:56          'var11' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:57      Sequence
+0:57        move second child to first child ( temp float)
+0:57          'var12' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:58      Sequence
+0:58        move second child to first child ( temp 2-component vector of float)
+0:58          'var15' ( temp 2-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:59      Sequence
+0:59        move second child to first child ( temp 2-component vector of float)
+0:59          'var16' ( temp 2-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:60      Sequence
+0:60        move second child to first child ( temp 3-component vector of float)
+0:60          'var29' ( temp 3-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:61      Sequence
+0:61        move second child to first child ( temp 2X2 matrix of float)
+0:61          'var57' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:62      Sequence
+0:62        move second child to first child ( temp 2X2 matrix of float)
+0:62          'var58' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:63      Sequence
+0:63        move second child to first child ( temp 2X2 matrix of float)
+0:63          'var59' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:64      Sequence
+0:64        move second child to first child ( temp 2X2 matrix of float)
+0:64          'var60' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:65      Sequence
+0:65        move second child to first child ( temp 2X2 matrix of float)
+0:65          'var61' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:66      Sequence
+0:66        move second child to first child ( temp 2X2 matrix of float)
+0:66          'var62' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:67      Sequence
+0:67        move second child to first child ( temp 2X2 matrix of float)
+0:67          'var63' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:68      Sequence
+0:68        move second child to first child ( temp 2X2 matrix of float)
+0:68          'var64' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:69      Sequence
+0:69        move second child to first child ( temp 2X3 matrix of float)
+0:69          'var71' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:70      Sequence
+0:70        move second child to first child ( temp 2X3 matrix of float)
+0:70          'var73' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:71      Sequence
+0:71        move second child to first child ( temp 2X3 matrix of float)
+0:71          'var74' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:72      Sequence
+0:72        move second child to first child ( temp 2X3 matrix of float)
+0:72          'var76' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:73      Sequence
+0:73        move second child to first child ( temp 2X3 matrix of float)
+0:73          'var77' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:74      Sequence
+0:74        move second child to first child ( temp 2X4 matrix of float)
+0:74          'var87' ( temp 2X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:75      Sequence
+0:75        move second child to first child ( temp 2X4 matrix of float)
+0:75          'var90' ( temp 2X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:76      Sequence
+0:76        move second child to first child ( temp 3X2 matrix of float)
+0:76          'var99' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:77      Sequence
+0:77        move second child to first child ( temp 3X2 matrix of float)
+0:77          'var100' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:78      Sequence
+0:78        move second child to first child ( temp 3X2 matrix of float)
+0:78          'var101' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:79      Sequence
+0:79        move second child to first child ( temp 3X2 matrix of float)
+0:79          'var102' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:80      Sequence
+0:80        move second child to first child ( temp 3X2 matrix of float)
+0:80          'var103' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:81      Sequence
+0:81        move second child to first child ( temp 3X3 matrix of float)
+0:81          'var113' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:82      Sequence
+0:82        move second child to first child ( temp 3X3 matrix of float)
+0:82          'var115' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:83      Sequence
+0:83        move second child to first child ( temp 3X3 matrix of float)
+0:83          'var116' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:84      Sequence
+0:84        move second child to first child ( temp 3X4 matrix of float)
+0:84          'var129' ( temp 3X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:85      Sequence
+0:85        move second child to first child ( temp 4X2 matrix of float)
+0:85          'var141' ( temp 4X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:86      Sequence
+0:86        move second child to first child ( temp 4X2 matrix of float)
+0:86          'var142' ( temp 4X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:87      Sequence
+0:87        move second child to first child ( temp 4X3 matrix of float)
+0:87          'var155' ( temp 4X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:188      Branch: Return with expression
+0:188        Constant:
+0:188          0.000000
+0:188          0.000000
+0:188          0.000000
+0:188          0.000000
+0:18  Function Definition: main( ( temp void)
+0:18    Function Parameters: 
+0:?     Sequence
+0:18      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:18        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+SPIR-V is not generated for failed compile or link

--- a/Test/baseResults/hlsl.type.type.conversion.valid.frag.out
+++ b/Test/baseResults/hlsl.type.type.conversion.valid.frag.out
@@ -1,0 +1,1640 @@
+hlsl.type.type.conversion.valid.frag
+Shader version: 500
+gl_FragCoord origin is upper left
+0:? Sequence
+0:18  Function Definition: @main( ( temp 4-component vector of float)
+0:18    Function Parameters: 
+0:?     Sequence
+0:19      Sequence
+0:19        move second child to first child ( temp float)
+0:19          'var0' ( temp float)
+0:19          Constant:
+0:19            0.000000
+0:20      Sequence
+0:20        move second child to first child ( temp 2-component vector of float)
+0:20          'var13' ( temp 2-component vector of float)
+0:20          Constant:
+0:20            0.000000
+0:20            0.000000
+0:21      Sequence
+0:21        move second child to first child ( temp 2-component vector of float)
+0:21          'var14' ( temp 2-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:22      Sequence
+0:22        move second child to first child ( temp 3-component vector of float)
+0:22          'var26' ( temp 3-component vector of float)
+0:22          Constant:
+0:22            0.000000
+0:22            0.000000
+0:22            0.000000
+0:23      Sequence
+0:23        move second child to first child ( temp 3-component vector of float)
+0:23          'var28' ( temp 3-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:24      Sequence
+0:24        move second child to first child ( temp 4-component vector of float)
+0:24          'var39' ( temp 4-component vector of float)
+0:24          Constant:
+0:24            0.000000
+0:24            0.000000
+0:24            0.000000
+0:24            0.000000
+0:25      Sequence
+0:25        move second child to first child ( temp 4-component vector of float)
+0:25          'var42' ( temp 4-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:26      Sequence
+0:26        move second child to first child ( temp 4-component vector of float)
+0:26          'var43' ( temp 4-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:27      Sequence
+0:27        move second child to first child ( temp 2X2 matrix of float)
+0:27          'var52' ( temp 2X2 matrix of float)
+0:27          Constant:
+0:27            0.000000
+0:27            0.000000
+0:27            0.000000
+0:27            0.000000
+0:28      Sequence
+0:28        move second child to first child ( temp 2X2 matrix of float)
+0:28          'var55' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:29      Sequence
+0:29        move second child to first child ( temp 2X2 matrix of float)
+0:29          'var56' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:30      Sequence
+0:30        move second child to first child ( temp 2X3 matrix of float)
+0:30          'var65' ( temp 2X3 matrix of float)
+0:30          Constant:
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:31      Sequence
+0:31        move second child to first child ( temp 2X3 matrix of float)
+0:31          'var70' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:32      Sequence
+0:32        move second child to first child ( temp 2X4 matrix of float)
+0:32          'var78' ( temp 2X4 matrix of float)
+0:32          Constant:
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:33      Sequence
+0:33        move second child to first child ( temp 2X4 matrix of float)
+0:33          'var84' ( temp 2X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:34      Sequence
+0:34        move second child to first child ( temp 3X2 matrix of float)
+0:34          'var91' ( temp 3X2 matrix of float)
+0:34          Constant:
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:35      Sequence
+0:35        move second child to first child ( temp 3X2 matrix of float)
+0:35          'var98' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:36      Sequence
+0:36        move second child to first child ( temp 3X3 matrix of float)
+0:36          'var104' ( temp 3X3 matrix of float)
+0:36          Constant:
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:37      Sequence
+0:37        move second child to first child ( temp 3X3 matrix of float)
+0:37          'var112' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:38      Sequence
+0:38        move second child to first child ( temp 3X4 matrix of float)
+0:38          'var117' ( temp 3X4 matrix of float)
+0:38          Constant:
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:39      Sequence
+0:39        move second child to first child ( temp 3X4 matrix of float)
+0:39          'var126' ( temp 3X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:40      Sequence
+0:40        move second child to first child ( temp 4X2 matrix of float)
+0:40          'var130' ( temp 4X2 matrix of float)
+0:40          Constant:
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:41      Sequence
+0:41        move second child to first child ( temp 4X2 matrix of float)
+0:41          'var140' ( temp 4X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:42      Sequence
+0:42        move second child to first child ( temp 4X3 matrix of float)
+0:42          'var143' ( temp 4X3 matrix of float)
+0:42          Constant:
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:43      Sequence
+0:43        move second child to first child ( temp 4X3 matrix of float)
+0:43          'var154' ( temp 4X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:44      Sequence
+0:44        move second child to first child ( temp 4X4 matrix of float)
+0:44          'var156' ( temp 4X4 matrix of float)
+0:44          Constant:
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:45      Sequence
+0:45        move second child to first child ( temp 4X4 matrix of float)
+0:45          'var168' ( temp 4X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:46      Sequence
+0:46        move second child to first child ( temp float)
+0:46          'var1' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:47      Sequence
+0:47        move second child to first child ( temp float)
+0:47          'var2' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:48      Sequence
+0:48        move second child to first child ( temp float)
+0:48          'var3' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:49      Sequence
+0:49        move second child to first child ( temp float)
+0:49          'var4' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:50      Sequence
+0:50        move second child to first child ( temp float)
+0:50          'var5' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:51      Sequence
+0:51        move second child to first child ( temp float)
+0:51          'var6' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:52      Sequence
+0:52        move second child to first child ( temp float)
+0:52          'var7' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:53      Sequence
+0:53        move second child to first child ( temp float)
+0:53          'var8' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:54      Sequence
+0:54        move second child to first child ( temp float)
+0:54          'var9' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:55      Sequence
+0:55        move second child to first child ( temp float)
+0:55          'var10' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:56      Sequence
+0:56        move second child to first child ( temp float)
+0:56          'var11' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:57      Sequence
+0:57        move second child to first child ( temp float)
+0:57          'var12' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:58      Sequence
+0:58        move second child to first child ( temp 2-component vector of float)
+0:58          'var15' ( temp 2-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:59      Sequence
+0:59        move second child to first child ( temp 2-component vector of float)
+0:59          'var16' ( temp 2-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:60      Sequence
+0:60        move second child to first child ( temp 3-component vector of float)
+0:60          'var29' ( temp 3-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:61      Sequence
+0:61        move second child to first child ( temp 2X2 matrix of float)
+0:61          'var57' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:62      Sequence
+0:62        move second child to first child ( temp 2X2 matrix of float)
+0:62          'var58' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:63      Sequence
+0:63        move second child to first child ( temp 2X2 matrix of float)
+0:63          'var59' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:64      Sequence
+0:64        move second child to first child ( temp 2X2 matrix of float)
+0:64          'var60' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:65      Sequence
+0:65        move second child to first child ( temp 2X2 matrix of float)
+0:65          'var61' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:66      Sequence
+0:66        move second child to first child ( temp 2X2 matrix of float)
+0:66          'var62' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:67      Sequence
+0:67        move second child to first child ( temp 2X2 matrix of float)
+0:67          'var63' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:68      Sequence
+0:68        move second child to first child ( temp 2X2 matrix of float)
+0:68          'var64' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:69      Sequence
+0:69        move second child to first child ( temp 2X3 matrix of float)
+0:69          'var71' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:70      Sequence
+0:70        move second child to first child ( temp 2X3 matrix of float)
+0:70          'var73' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:71      Sequence
+0:71        move second child to first child ( temp 2X3 matrix of float)
+0:71          'var74' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:72      Sequence
+0:72        move second child to first child ( temp 2X3 matrix of float)
+0:72          'var76' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:73      Sequence
+0:73        move second child to first child ( temp 2X3 matrix of float)
+0:73          'var77' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:74      Sequence
+0:74        move second child to first child ( temp 2X4 matrix of float)
+0:74          'var87' ( temp 2X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:75      Sequence
+0:75        move second child to first child ( temp 2X4 matrix of float)
+0:75          'var90' ( temp 2X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:76      Sequence
+0:76        move second child to first child ( temp 3X2 matrix of float)
+0:76          'var99' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:77      Sequence
+0:77        move second child to first child ( temp 3X2 matrix of float)
+0:77          'var100' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:78      Sequence
+0:78        move second child to first child ( temp 3X2 matrix of float)
+0:78          'var101' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:79      Sequence
+0:79        move second child to first child ( temp 3X2 matrix of float)
+0:79          'var102' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:80      Sequence
+0:80        move second child to first child ( temp 3X2 matrix of float)
+0:80          'var103' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:81      Sequence
+0:81        move second child to first child ( temp 3X3 matrix of float)
+0:81          'var113' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:82      Sequence
+0:82        move second child to first child ( temp 3X3 matrix of float)
+0:82          'var115' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:83      Sequence
+0:83        move second child to first child ( temp 3X3 matrix of float)
+0:83          'var116' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:84      Sequence
+0:84        move second child to first child ( temp 3X4 matrix of float)
+0:84          'var129' ( temp 3X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:85      Sequence
+0:85        move second child to first child ( temp 4X2 matrix of float)
+0:85          'var141' ( temp 4X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:86      Sequence
+0:86        move second child to first child ( temp 4X2 matrix of float)
+0:86          'var142' ( temp 4X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:87      Sequence
+0:87        move second child to first child ( temp 4X3 matrix of float)
+0:87          'var155' ( temp 4X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:88      Branch: Return with expression
+0:88        Constant:
+0:88          0.000000
+0:88          0.000000
+0:88          0.000000
+0:88          0.000000
+0:18  Function Definition: main( ( temp void)
+0:18    Function Parameters: 
+0:?     Sequence
+0:18      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:18        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+
+Linked fragment stage:
+
+
+Shader version: 500
+gl_FragCoord origin is upper left
+0:? Sequence
+0:18  Function Definition: @main( ( temp 4-component vector of float)
+0:18    Function Parameters: 
+0:?     Sequence
+0:19      Sequence
+0:19        move second child to first child ( temp float)
+0:19          'var0' ( temp float)
+0:19          Constant:
+0:19            0.000000
+0:20      Sequence
+0:20        move second child to first child ( temp 2-component vector of float)
+0:20          'var13' ( temp 2-component vector of float)
+0:20          Constant:
+0:20            0.000000
+0:20            0.000000
+0:21      Sequence
+0:21        move second child to first child ( temp 2-component vector of float)
+0:21          'var14' ( temp 2-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:22      Sequence
+0:22        move second child to first child ( temp 3-component vector of float)
+0:22          'var26' ( temp 3-component vector of float)
+0:22          Constant:
+0:22            0.000000
+0:22            0.000000
+0:22            0.000000
+0:23      Sequence
+0:23        move second child to first child ( temp 3-component vector of float)
+0:23          'var28' ( temp 3-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:24      Sequence
+0:24        move second child to first child ( temp 4-component vector of float)
+0:24          'var39' ( temp 4-component vector of float)
+0:24          Constant:
+0:24            0.000000
+0:24            0.000000
+0:24            0.000000
+0:24            0.000000
+0:25      Sequence
+0:25        move second child to first child ( temp 4-component vector of float)
+0:25          'var42' ( temp 4-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:26      Sequence
+0:26        move second child to first child ( temp 4-component vector of float)
+0:26          'var43' ( temp 4-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:27      Sequence
+0:27        move second child to first child ( temp 2X2 matrix of float)
+0:27          'var52' ( temp 2X2 matrix of float)
+0:27          Constant:
+0:27            0.000000
+0:27            0.000000
+0:27            0.000000
+0:27            0.000000
+0:28      Sequence
+0:28        move second child to first child ( temp 2X2 matrix of float)
+0:28          'var55' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:29      Sequence
+0:29        move second child to first child ( temp 2X2 matrix of float)
+0:29          'var56' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:30      Sequence
+0:30        move second child to first child ( temp 2X3 matrix of float)
+0:30          'var65' ( temp 2X3 matrix of float)
+0:30          Constant:
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:30            0.000000
+0:31      Sequence
+0:31        move second child to first child ( temp 2X3 matrix of float)
+0:31          'var70' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:32      Sequence
+0:32        move second child to first child ( temp 2X4 matrix of float)
+0:32          'var78' ( temp 2X4 matrix of float)
+0:32          Constant:
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:32            0.000000
+0:33      Sequence
+0:33        move second child to first child ( temp 2X4 matrix of float)
+0:33          'var84' ( temp 2X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:34      Sequence
+0:34        move second child to first child ( temp 3X2 matrix of float)
+0:34          'var91' ( temp 3X2 matrix of float)
+0:34          Constant:
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:34            0.000000
+0:35      Sequence
+0:35        move second child to first child ( temp 3X2 matrix of float)
+0:35          'var98' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:36      Sequence
+0:36        move second child to first child ( temp 3X3 matrix of float)
+0:36          'var104' ( temp 3X3 matrix of float)
+0:36          Constant:
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:36            0.000000
+0:37      Sequence
+0:37        move second child to first child ( temp 3X3 matrix of float)
+0:37          'var112' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:38      Sequence
+0:38        move second child to first child ( temp 3X4 matrix of float)
+0:38          'var117' ( temp 3X4 matrix of float)
+0:38          Constant:
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:38            0.000000
+0:39      Sequence
+0:39        move second child to first child ( temp 3X4 matrix of float)
+0:39          'var126' ( temp 3X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:40      Sequence
+0:40        move second child to first child ( temp 4X2 matrix of float)
+0:40          'var130' ( temp 4X2 matrix of float)
+0:40          Constant:
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:40            0.000000
+0:41      Sequence
+0:41        move second child to first child ( temp 4X2 matrix of float)
+0:41          'var140' ( temp 4X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:42      Sequence
+0:42        move second child to first child ( temp 4X3 matrix of float)
+0:42          'var143' ( temp 4X3 matrix of float)
+0:42          Constant:
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:42            0.000000
+0:43      Sequence
+0:43        move second child to first child ( temp 4X3 matrix of float)
+0:43          'var154' ( temp 4X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:44      Sequence
+0:44        move second child to first child ( temp 4X4 matrix of float)
+0:44          'var156' ( temp 4X4 matrix of float)
+0:44          Constant:
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:44            0.000000
+0:45      Sequence
+0:45        move second child to first child ( temp 4X4 matrix of float)
+0:45          'var168' ( temp 4X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:46      Sequence
+0:46        move second child to first child ( temp float)
+0:46          'var1' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:47      Sequence
+0:47        move second child to first child ( temp float)
+0:47          'var2' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:48      Sequence
+0:48        move second child to first child ( temp float)
+0:48          'var3' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:49      Sequence
+0:49        move second child to first child ( temp float)
+0:49          'var4' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:50      Sequence
+0:50        move second child to first child ( temp float)
+0:50          'var5' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:51      Sequence
+0:51        move second child to first child ( temp float)
+0:51          'var6' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:52      Sequence
+0:52        move second child to first child ( temp float)
+0:52          'var7' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:53      Sequence
+0:53        move second child to first child ( temp float)
+0:53          'var8' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:54      Sequence
+0:54        move second child to first child ( temp float)
+0:54          'var9' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:55      Sequence
+0:55        move second child to first child ( temp float)
+0:55          'var10' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:56      Sequence
+0:56        move second child to first child ( temp float)
+0:56          'var11' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:57      Sequence
+0:57        move second child to first child ( temp float)
+0:57          'var12' ( temp float)
+0:?           Constant:
+0:?             0.000000
+0:58      Sequence
+0:58        move second child to first child ( temp 2-component vector of float)
+0:58          'var15' ( temp 2-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:59      Sequence
+0:59        move second child to first child ( temp 2-component vector of float)
+0:59          'var16' ( temp 2-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:60      Sequence
+0:60        move second child to first child ( temp 3-component vector of float)
+0:60          'var29' ( temp 3-component vector of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:61      Sequence
+0:61        move second child to first child ( temp 2X2 matrix of float)
+0:61          'var57' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:62      Sequence
+0:62        move second child to first child ( temp 2X2 matrix of float)
+0:62          'var58' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:63      Sequence
+0:63        move second child to first child ( temp 2X2 matrix of float)
+0:63          'var59' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:64      Sequence
+0:64        move second child to first child ( temp 2X2 matrix of float)
+0:64          'var60' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:65      Sequence
+0:65        move second child to first child ( temp 2X2 matrix of float)
+0:65          'var61' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:66      Sequence
+0:66        move second child to first child ( temp 2X2 matrix of float)
+0:66          'var62' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:67      Sequence
+0:67        move second child to first child ( temp 2X2 matrix of float)
+0:67          'var63' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:68      Sequence
+0:68        move second child to first child ( temp 2X2 matrix of float)
+0:68          'var64' ( temp 2X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:69      Sequence
+0:69        move second child to first child ( temp 2X3 matrix of float)
+0:69          'var71' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:70      Sequence
+0:70        move second child to first child ( temp 2X3 matrix of float)
+0:70          'var73' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:71      Sequence
+0:71        move second child to first child ( temp 2X3 matrix of float)
+0:71          'var74' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:72      Sequence
+0:72        move second child to first child ( temp 2X3 matrix of float)
+0:72          'var76' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:73      Sequence
+0:73        move second child to first child ( temp 2X3 matrix of float)
+0:73          'var77' ( temp 2X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:74      Sequence
+0:74        move second child to first child ( temp 2X4 matrix of float)
+0:74          'var87' ( temp 2X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:75      Sequence
+0:75        move second child to first child ( temp 2X4 matrix of float)
+0:75          'var90' ( temp 2X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:76      Sequence
+0:76        move second child to first child ( temp 3X2 matrix of float)
+0:76          'var99' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:77      Sequence
+0:77        move second child to first child ( temp 3X2 matrix of float)
+0:77          'var100' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:78      Sequence
+0:78        move second child to first child ( temp 3X2 matrix of float)
+0:78          'var101' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:79      Sequence
+0:79        move second child to first child ( temp 3X2 matrix of float)
+0:79          'var102' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:80      Sequence
+0:80        move second child to first child ( temp 3X2 matrix of float)
+0:80          'var103' ( temp 3X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:81      Sequence
+0:81        move second child to first child ( temp 3X3 matrix of float)
+0:81          'var113' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:82      Sequence
+0:82        move second child to first child ( temp 3X3 matrix of float)
+0:82          'var115' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:83      Sequence
+0:83        move second child to first child ( temp 3X3 matrix of float)
+0:83          'var116' ( temp 3X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:84      Sequence
+0:84        move second child to first child ( temp 3X4 matrix of float)
+0:84          'var129' ( temp 3X4 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:85      Sequence
+0:85        move second child to first child ( temp 4X2 matrix of float)
+0:85          'var141' ( temp 4X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:86      Sequence
+0:86        move second child to first child ( temp 4X2 matrix of float)
+0:86          'var142' ( temp 4X2 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:87      Sequence
+0:87        move second child to first child ( temp 4X3 matrix of float)
+0:87          'var155' ( temp 4X3 matrix of float)
+0:?           Constant:
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:?             0.000000
+0:88      Branch: Return with expression
+0:88        Constant:
+0:88          0.000000
+0:88          0.000000
+0:88          0.000000
+0:88          0.000000
+0:18  Function Definition: main( ( temp void)
+0:18    Function Parameters: 
+0:?     Sequence
+0:18      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:18        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+// Module Version 10300
+// Generated by (magic number): 80007
+// Id's are bound by 122
+
+                              Capability Shader
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Fragment 4  "main" 120
+                              ExecutionMode 4 OriginUpperLeft
+                              Source HLSL 500
+                              Name 4  "main"
+                              Name 9  "@main("
+                              Name 12  "var0"
+                              Name 16  "var13"
+                              Name 18  "var14"
+                              Name 21  "var26"
+                              Name 23  "var28"
+                              Name 25  "var39"
+                              Name 27  "var42"
+                              Name 28  "var43"
+                              Name 31  "var52"
+                              Name 33  "var55"
+                              Name 34  "var56"
+                              Name 37  "var65"
+                              Name 39  "var70"
+                              Name 42  "var78"
+                              Name 44  "var84"
+                              Name 47  "var91"
+                              Name 49  "var98"
+                              Name 52  "var104"
+                              Name 54  "var112"
+                              Name 57  "var117"
+                              Name 59  "var126"
+                              Name 62  "var130"
+                              Name 64  "var140"
+                              Name 67  "var143"
+                              Name 69  "var154"
+                              Name 72  "var156"
+                              Name 74  "var168"
+                              Name 75  "var1"
+                              Name 76  "var2"
+                              Name 77  "var3"
+                              Name 78  "var4"
+                              Name 79  "var5"
+                              Name 80  "var6"
+                              Name 81  "var7"
+                              Name 82  "var8"
+                              Name 83  "var9"
+                              Name 84  "var10"
+                              Name 85  "var11"
+                              Name 86  "var12"
+                              Name 87  "var15"
+                              Name 88  "var16"
+                              Name 89  "var29"
+                              Name 90  "var57"
+                              Name 91  "var58"
+                              Name 92  "var59"
+                              Name 93  "var60"
+                              Name 94  "var61"
+                              Name 95  "var62"
+                              Name 96  "var63"
+                              Name 97  "var64"
+                              Name 98  "var71"
+                              Name 99  "var73"
+                              Name 100  "var74"
+                              Name 101  "var76"
+                              Name 102  "var77"
+                              Name 103  "var87"
+                              Name 104  "var90"
+                              Name 105  "var99"
+                              Name 106  "var100"
+                              Name 107  "var101"
+                              Name 108  "var102"
+                              Name 109  "var103"
+                              Name 110  "var113"
+                              Name 111  "var115"
+                              Name 112  "var116"
+                              Name 113  "var129"
+                              Name 114  "var141"
+                              Name 115  "var142"
+                              Name 116  "var155"
+                              Name 120  "@entryPointOutput"
+                              Decorate 120(@entryPointOutput) Location 0
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeFloat 32
+               7:             TypeVector 6(float) 4
+               8:             TypeFunction 7(fvec4)
+              11:             TypePointer Function 6(float)
+              13:    6(float) Constant 0
+              14:             TypeVector 6(float) 2
+              15:             TypePointer Function 14(fvec2)
+              17:   14(fvec2) ConstantComposite 13 13
+              19:             TypeVector 6(float) 3
+              20:             TypePointer Function 19(fvec3)
+              22:   19(fvec3) ConstantComposite 13 13 13
+              24:             TypePointer Function 7(fvec4)
+              26:    7(fvec4) ConstantComposite 13 13 13 13
+              29:             TypeMatrix 14(fvec2) 2
+              30:             TypePointer Function 29
+              32:          29 ConstantComposite 17 17
+              35:             TypeMatrix 19(fvec3) 2
+              36:             TypePointer Function 35
+              38:          35 ConstantComposite 22 22
+              40:             TypeMatrix 7(fvec4) 2
+              41:             TypePointer Function 40
+              43:          40 ConstantComposite 26 26
+              45:             TypeMatrix 14(fvec2) 3
+              46:             TypePointer Function 45
+              48:          45 ConstantComposite 17 17 17
+              50:             TypeMatrix 19(fvec3) 3
+              51:             TypePointer Function 50
+              53:          50 ConstantComposite 22 22 22
+              55:             TypeMatrix 7(fvec4) 3
+              56:             TypePointer Function 55
+              58:          55 ConstantComposite 26 26 26
+              60:             TypeMatrix 14(fvec2) 4
+              61:             TypePointer Function 60
+              63:          60 ConstantComposite 17 17 17 17
+              65:             TypeMatrix 19(fvec3) 4
+              66:             TypePointer Function 65
+              68:          65 ConstantComposite 22 22 22 22
+              70:             TypeMatrix 7(fvec4) 4
+              71:             TypePointer Function 70
+              73:          70 ConstantComposite 26 26 26 26
+             119:             TypePointer Output 7(fvec4)
+120(@entryPointOutput):    119(ptr) Variable Output
+         4(main):           2 Function None 3
+               5:             Label
+             121:    7(fvec4) FunctionCall 9(@main()
+                              Store 120(@entryPointOutput) 121
+                              Return
+                              FunctionEnd
+       9(@main():    7(fvec4) Function None 8
+              10:             Label
+        12(var0):     11(ptr) Variable Function
+       16(var13):     15(ptr) Variable Function
+       18(var14):     15(ptr) Variable Function
+       21(var26):     20(ptr) Variable Function
+       23(var28):     20(ptr) Variable Function
+       25(var39):     24(ptr) Variable Function
+       27(var42):     24(ptr) Variable Function
+       28(var43):     24(ptr) Variable Function
+       31(var52):     30(ptr) Variable Function
+       33(var55):     30(ptr) Variable Function
+       34(var56):     30(ptr) Variable Function
+       37(var65):     36(ptr) Variable Function
+       39(var70):     36(ptr) Variable Function
+       42(var78):     41(ptr) Variable Function
+       44(var84):     41(ptr) Variable Function
+       47(var91):     46(ptr) Variable Function
+       49(var98):     46(ptr) Variable Function
+      52(var104):     51(ptr) Variable Function
+      54(var112):     51(ptr) Variable Function
+      57(var117):     56(ptr) Variable Function
+      59(var126):     56(ptr) Variable Function
+      62(var130):     61(ptr) Variable Function
+      64(var140):     61(ptr) Variable Function
+      67(var143):     66(ptr) Variable Function
+      69(var154):     66(ptr) Variable Function
+      72(var156):     71(ptr) Variable Function
+      74(var168):     71(ptr) Variable Function
+        75(var1):     11(ptr) Variable Function
+        76(var2):     11(ptr) Variable Function
+        77(var3):     11(ptr) Variable Function
+        78(var4):     11(ptr) Variable Function
+        79(var5):     11(ptr) Variable Function
+        80(var6):     11(ptr) Variable Function
+        81(var7):     11(ptr) Variable Function
+        82(var8):     11(ptr) Variable Function
+        83(var9):     11(ptr) Variable Function
+       84(var10):     11(ptr) Variable Function
+       85(var11):     11(ptr) Variable Function
+       86(var12):     11(ptr) Variable Function
+       87(var15):     15(ptr) Variable Function
+       88(var16):     15(ptr) Variable Function
+       89(var29):     20(ptr) Variable Function
+       90(var57):     30(ptr) Variable Function
+       91(var58):     30(ptr) Variable Function
+       92(var59):     30(ptr) Variable Function
+       93(var60):     30(ptr) Variable Function
+       94(var61):     30(ptr) Variable Function
+       95(var62):     30(ptr) Variable Function
+       96(var63):     30(ptr) Variable Function
+       97(var64):     30(ptr) Variable Function
+       98(var71):     36(ptr) Variable Function
+       99(var73):     36(ptr) Variable Function
+      100(var74):     36(ptr) Variable Function
+      101(var76):     36(ptr) Variable Function
+      102(var77):     36(ptr) Variable Function
+      103(var87):     41(ptr) Variable Function
+      104(var90):     41(ptr) Variable Function
+      105(var99):     46(ptr) Variable Function
+     106(var100):     46(ptr) Variable Function
+     107(var101):     46(ptr) Variable Function
+     108(var102):     46(ptr) Variable Function
+     109(var103):     46(ptr) Variable Function
+     110(var113):     51(ptr) Variable Function
+     111(var115):     51(ptr) Variable Function
+     112(var116):     51(ptr) Variable Function
+     113(var129):     56(ptr) Variable Function
+     114(var141):     61(ptr) Variable Function
+     115(var142):     61(ptr) Variable Function
+     116(var155):     66(ptr) Variable Function
+                              Store 12(var0) 13
+                              Store 16(var13) 17
+                              Store 18(var14) 17
+                              Store 21(var26) 22
+                              Store 23(var28) 22
+                              Store 25(var39) 26
+                              Store 27(var42) 26
+                              Store 28(var43) 26
+                              Store 31(var52) 32
+                              Store 33(var55) 32
+                              Store 34(var56) 32
+                              Store 37(var65) 38
+                              Store 39(var70) 38
+                              Store 42(var78) 43
+                              Store 44(var84) 43
+                              Store 47(var91) 48
+                              Store 49(var98) 48
+                              Store 52(var104) 53
+                              Store 54(var112) 53
+                              Store 57(var117) 58
+                              Store 59(var126) 58
+                              Store 62(var130) 63
+                              Store 64(var140) 63
+                              Store 67(var143) 68
+                              Store 69(var154) 68
+                              Store 72(var156) 73
+                              Store 74(var168) 73
+                              Store 75(var1) 13
+                              Store 76(var2) 13
+                              Store 77(var3) 13
+                              Store 78(var4) 13
+                              Store 79(var5) 13
+                              Store 80(var6) 13
+                              Store 81(var7) 13
+                              Store 82(var8) 13
+                              Store 83(var9) 13
+                              Store 84(var10) 13
+                              Store 85(var11) 13
+                              Store 86(var12) 13
+                              Store 87(var15) 17
+                              Store 88(var16) 17
+                              Store 89(var29) 22
+                              Store 90(var57) 32
+                              Store 91(var58) 32
+                              Store 92(var59) 32
+                              Store 93(var60) 32
+                              Store 94(var61) 32
+                              Store 95(var62) 32
+                              Store 96(var63) 32
+                              Store 97(var64) 32
+                              Store 98(var71) 38
+                              Store 99(var73) 38
+                              Store 100(var74) 38
+                              Store 101(var76) 38
+                              Store 102(var77) 38
+                              Store 103(var87) 43
+                              Store 104(var90) 43
+                              Store 105(var99) 48
+                              Store 106(var100) 48
+                              Store 107(var101) 48
+                              Store 108(var102) 48
+                              Store 109(var103) 48
+                              Store 110(var113) 53
+                              Store 111(var115) 53
+                              Store 112(var116) 53
+                              Store 113(var129) 58
+                              Store 114(var141) 63
+                              Store 115(var142) 63
+                              Store 116(var155) 68
+                              ReturnValue 26
+                              FunctionEnd

--- a/Test/hlsl.type.type.conversion.all.frag
+++ b/Test/hlsl.type.type.conversion.all.frag
@@ -1,0 +1,190 @@
+#define zeros 0
+#define zeros1 0
+#define zeros2 0, 0
+#define zeros3 0, 0, 0
+#define zeros4 0, 0, 0, 0
+#define zeros5 0, 0, 0, 0, 0
+#define zeros6 0, 0, 0, 0, 0, 0
+#define zeros7 0, 0, 0, 0, 0, 0, 0
+#define zeros8 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros9 0, 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros10 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros11 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros12 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros13 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros14 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros15 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros16 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+float4 main() : SV_Target {
+  float var0 = float(zeros1);
+  float2 var13 = float(zeros1);
+  float2 var14 = float2(zeros2);
+  float3 var26 = float(zeros1);
+  float3 var28 = float3(zeros3);
+  float4 var39 = float(zeros1);
+  float4 var42 = float4(zeros4);
+  float4 var43 = float2x2(zeros4);
+  float2x2 var52 = float(zeros1);
+  float2x2 var55 = float4(zeros4);
+  float2x2 var56 = float2x2(zeros4);
+  float2x3 var65 = float(zeros1);
+  float2x3 var70 = float2x3(zeros6);
+  float2x4 var78 = float(zeros1);
+  float2x4 var84 = float2x4(zeros8);
+  float3x2 var91 = float(zeros1);
+  float3x2 var98 = float3x2(zeros6);
+  float3x3 var104 = float(zeros1);
+  float3x3 var112 = float3x3(zeros9);
+  float3x4 var117 = float(zeros1);
+  float3x4 var126 = float3x4(zeros12);
+  float4x2 var130 = float(zeros1);
+  float4x2 var140 = float4x2(zeros8);
+  float4x3 var143 = float(zeros1);
+  float4x3 var154 = float4x3(zeros12);
+  float4x4 var156 = float(zeros1);
+  float4x4 var168 = float4x4(zeros16);
+  float var1 = float2(zeros2);// warning X3206: implicit truncation of vector type
+  float var2 = float3(zeros3);// warning X3206: implicit truncation of vector type
+  float var3 = float4(zeros4);// warning X3206: implicit truncation of vector type
+  float var4 = float2x2(zeros4);// warning X3206: implicit truncation of vector type
+  float var5 = float2x3(zeros6);// warning X3206: implicit truncation of vector type
+  float var6 = float2x4(zeros8);// warning X3206: implicit truncation of vector type
+  float var7 = float3x2(zeros6);// warning X3206: implicit truncation of vector type
+  float var8 = float3x3(zeros9);// warning X3206: implicit truncation of vector type
+  float var9 = float3x4(zeros12);// warning X3206: implicit truncation of vector type
+  float var10 = float4x2(zeros8);// warning X3206: implicit truncation of vector type
+  float var11 = float4x3(zeros12);// warning X3206: implicit truncation of vector type
+  float var12 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float2 var15 = float3(zeros3);// warning X3206: implicit truncation of vector type
+  float2 var16 = float4(zeros4);// warning X3206: implicit truncation of vector type
+  float3 var29 = float4(zeros4);// warning X3206: implicit truncation of vector type
+  float2x2 var57 = float2x3(zeros6);// warning X3206: implicit truncation of vector type
+  float2x2 var58 = float2x4(zeros8);// warning X3206: implicit truncation of vector type
+  float2x2 var59 = float3x2(zeros6);// warning X3206: implicit truncation of vector type
+  float2x2 var60 = float3x3(zeros9);// warning X3206: implicit truncation of vector type
+  float2x2 var61 = float3x4(zeros12);// warning X3206: implicit truncation of vector type
+  float2x2 var62 = float4x2(zeros8);// warning X3206: implicit truncation of vector type
+  float2x2 var63 = float4x3(zeros12);// warning X3206: implicit truncation of vector type
+  float2x2 var64 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float2x3 var71 = float2x4(zeros8);// warning X3206: implicit truncation of vector type
+  float2x3 var73 = float3x3(zeros9);// warning X3206: implicit truncation of vector type
+  float2x3 var74 = float3x4(zeros12);// warning X3206: implicit truncation of vector type
+  float2x3 var76 = float4x3(zeros12);// warning X3206: implicit truncation of vector type
+  float2x3 var77 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float2x4 var87 = float3x4(zeros12);// warning X3206: implicit truncation of vector type
+  float2x4 var90 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float3x2 var99 = float3x3(zeros9);// warning X3206: implicit truncation of vector type
+  float3x2 var100 = float3x4(zeros12);// warning X3206: implicit truncation of vector type
+  float3x2 var101 = float4x2(zeros8);// warning X3206: implicit truncation of vector type
+  float3x2 var102 = float4x3(zeros12);// warning X3206: implicit truncation of vector type
+  float3x2 var103 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float3x3 var113 = float3x4(zeros12);// warning X3206: implicit truncation of vector type
+  float3x3 var115 = float4x3(zeros12);// warning X3206: implicit truncation of vector type
+  float3x3 var116 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float3x4 var129 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float4x2 var141 = float4x3(zeros12);// warning X3206: implicit truncation of vector type
+  float4x2 var142 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float4x3 var155 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float2 var17 = float2x2(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x2' to 'float2'
+  float2 var18 = float2x3(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x3' to 'float2'
+  float2 var19 = float2x4(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x4' to 'float2'
+  float2 var20 = float3x2(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x2' to 'float2'
+  float2 var21 = float3x3(zeros9);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x3' to 'float2'
+  float2 var22 = float3x4(zeros12);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x4' to 'float2'
+  float2 var23 = float4x2(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x2' to 'float2'
+  float2 var24 = float4x3(zeros12);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x3' to 'float2'
+  float2 var25 = float4x4(zeros16);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x4' to 'float2'
+  float3 var27 = float2(zeros2);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2' to 'float3'
+  float3 var30 = float2x2(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x2' to 'float3'
+  float3 var31 = float2x3(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x3' to 'float3'
+  float3 var32 = float2x4(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x4' to 'float3'
+  float3 var33 = float3x2(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x2' to 'float3'
+  float3 var34 = float3x3(zeros9);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x3' to 'float3'
+  float3 var35 = float3x4(zeros12);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x4' to 'float3'
+  float3 var36 = float4x2(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x2' to 'float3'
+  float3 var37 = float4x3(zeros12);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x3' to 'float3'
+  float3 var38 = float4x4(zeros16);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x4' to 'float3'
+  float4 var40 = float2(zeros2);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2' to 'float4'
+  float4 var41 = float3(zeros3);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3' to 'float4'
+  float4 var44 = float2x3(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x3' to 'float4'
+  float4 var45 = float2x4(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x4' to 'float4'
+  float4 var46 = float3x2(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x2' to 'float4'
+  float4 var47 = float3x3(zeros9);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x3' to 'float4'
+  float4 var48 = float3x4(zeros12);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x4' to 'float4'
+  float4 var49 = float4x2(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x2' to 'float4'
+  float4 var50 = float4x3(zeros12);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x3' to 'float4'
+  float4 var51 = float4x4(zeros16);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x4' to 'float4'
+  float2x2 var53 = float2(zeros2);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2' to 'float2x2'
+  float2x2 var54 = float3(zeros3);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3' to 'float2x2'
+  float2x3 var66 = float2(zeros2);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2' to 'float2x3'
+  float2x3 var67 = float3(zeros3);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3' to 'float2x3'
+  float2x3 var68 = float4(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4' to 'float2x3'
+  float2x3 var69 = float2x2(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x2' to 'float2x3'
+  float2x3 var72 = float3x2(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x2' to 'float2x3'
+  float2x3 var75 = float4x2(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x2' to 'float2x3'
+  float2x4 var79 = float2(zeros2);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2' to 'float2x4'
+  float2x4 var80 = float3(zeros3);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3' to 'float2x4'
+  float2x4 var81 = float4(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4' to 'float2x4'
+  float2x4 var82 = float2x2(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x2' to 'float2x4'
+  float2x4 var83 = float2x3(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x3' to 'float2x4'
+  float2x4 var85 = float3x2(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x2' to 'float2x4'
+  float2x4 var86 = float3x3(zeros9);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x3' to 'float2x4'
+  float2x4 var88 = float4x2(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x2' to 'float2x4'
+  float2x4 var89 = float4x3(zeros12);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x3' to 'float2x4'
+  float3x2 var92 = float2(zeros2);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2' to 'float3x2'
+  float3x2 var93 = float3(zeros3);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3' to 'float3x2'
+  float3x2 var94 = float4(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4' to 'float3x2'
+  float3x2 var95 = float2x2(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x2' to 'float3x2'
+  float3x2 var96 = float2x3(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x3' to 'float3x2'
+  float3x2 var97 = float2x4(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x4' to 'float3x2'
+  float3x3 var105 = float2(zeros2);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2' to 'float3x3'
+  float3x3 var106 = float3(zeros3);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3' to 'float3x3'
+  float3x3 var107 = float4(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4' to 'float3x3'
+  float3x3 var108 = float2x2(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x2' to 'float3x3'
+  float3x3 var109 = float2x3(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x3' to 'float3x3'
+  float3x3 var110 = float2x4(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x4' to 'float3x3'
+  float3x3 var111 = float3x2(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x2' to 'float3x3'
+  float3x3 var114 = float4x2(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x2' to 'float3x3'
+  float3x4 var118 = float2(zeros2);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2' to 'float3x4'
+  float3x4 var119 = float3(zeros3);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3' to 'float3x4'
+  float3x4 var120 = float4(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4' to 'float3x4'
+  float3x4 var121 = float2x2(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x2' to 'float3x4'
+  float3x4 var122 = float2x3(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x3' to 'float3x4'
+  float3x4 var123 = float2x4(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x4' to 'float3x4'
+  float3x4 var124 = float3x2(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x2' to 'float3x4'
+  float3x4 var125 = float3x3(zeros9);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x3' to 'float3x4'
+  float3x4 var127 = float4x2(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x2' to 'float3x4'
+  float3x4 var128 = float4x3(zeros12);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x3' to 'float3x4'
+  float4x2 var131 = float2(zeros2);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2' to 'float4x2'
+  float4x2 var132 = float3(zeros3);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3' to 'float4x2'
+  float4x2 var133 = float4(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4' to 'float4x2'
+  float4x2 var134 = float2x2(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x2' to 'float4x2'
+  float4x2 var135 = float2x3(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x3' to 'float4x2'
+  float4x2 var136 = float2x4(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x4' to 'float4x2'
+  float4x2 var137 = float3x2(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x2' to 'float4x2'
+  float4x2 var138 = float3x3(zeros9);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x3' to 'float4x2'
+  float4x2 var139 = float3x4(zeros12);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x4' to 'float4x2'
+  float4x3 var144 = float2(zeros2);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2' to 'float4x3'
+  float4x3 var145 = float3(zeros3);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3' to 'float4x3'
+  float4x3 var146 = float4(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4' to 'float4x3'
+  float4x3 var147 = float2x2(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x2' to 'float4x3'
+  float4x3 var148 = float2x3(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x3' to 'float4x3'
+  float4x3 var149 = float2x4(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x4' to 'float4x3'
+  float4x3 var150 = float3x2(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x2' to 'float4x3'
+  float4x3 var151 = float3x3(zeros9);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x3' to 'float4x3'
+  float4x3 var152 = float3x4(zeros12);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x4' to 'float4x3'
+  float4x3 var153 = float4x2(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x2' to 'float4x3'
+  float4x4 var157 = float2(zeros2);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2' to 'float4x4'
+  float4x4 var158 = float3(zeros3);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3' to 'float4x4'
+  float4x4 var159 = float4(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4' to 'float4x4'
+  float4x4 var160 = float2x2(zeros4);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x2' to 'float4x4'
+  float4x4 var161 = float2x3(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x3' to 'float4x4'
+  float4x4 var162 = float2x4(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float2x4' to 'float4x4'
+  float4x4 var163 = float3x2(zeros6);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x2' to 'float4x4'
+  float4x4 var164 = float3x3(zeros9);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x3' to 'float4x4'
+  float4x4 var165 = float3x4(zeros12);// Compilation failed because: error X3017: cannot implicitly convert from 'const float3x4' to 'float4x4'
+  float4x4 var166 = float4x2(zeros8);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x2' to 'float4x4'
+  float4x4 var167 = float4x3(zeros12);// Compilation failed because: error X3017: cannot implicitly convert from 'const float4x3' to 'float4x4'
+  return 0;
+}
+

--- a/Test/hlsl.type.type.conversion.valid.frag
+++ b/Test/hlsl.type.type.conversion.valid.frag
@@ -1,0 +1,90 @@
+#define zeros 0
+#define zeros1 0
+#define zeros2 0, 0
+#define zeros3 0, 0, 0
+#define zeros4 0, 0, 0, 0
+#define zeros5 0, 0, 0, 0, 0
+#define zeros6 0, 0, 0, 0, 0, 0
+#define zeros7 0, 0, 0, 0, 0, 0, 0
+#define zeros8 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros9 0, 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros10 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros11 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros12 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros13 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros14 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros15 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+#define zeros16 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+float4 main() : SV_Target {
+  float var0 = float(zeros1);
+  float2 var13 = float(zeros1);
+  float2 var14 = float2(zeros2);
+  float3 var26 = float(zeros1);
+  float3 var28 = float3(zeros3);
+  float4 var39 = float(zeros1);
+  float4 var42 = float4(zeros4);
+  float4 var43 = float2x2(zeros4);
+  float2x2 var52 = float(zeros1);
+  float2x2 var55 = float4(zeros4);
+  float2x2 var56 = float2x2(zeros4);
+  float2x3 var65 = float(zeros1);
+  float2x3 var70 = float2x3(zeros6);
+  float2x4 var78 = float(zeros1);
+  float2x4 var84 = float2x4(zeros8);
+  float3x2 var91 = float(zeros1);
+  float3x2 var98 = float3x2(zeros6);
+  float3x3 var104 = float(zeros1);
+  float3x3 var112 = float3x3(zeros9);
+  float3x4 var117 = float(zeros1);
+  float3x4 var126 = float3x4(zeros12);
+  float4x2 var130 = float(zeros1);
+  float4x2 var140 = float4x2(zeros8);
+  float4x3 var143 = float(zeros1);
+  float4x3 var154 = float4x3(zeros12);
+  float4x4 var156 = float(zeros1);
+  float4x4 var168 = float4x4(zeros16);
+  float var1 = float2(zeros2);// warning X3206: implicit truncation of vector type
+  float var2 = float3(zeros3);// warning X3206: implicit truncation of vector type
+  float var3 = float4(zeros4);// warning X3206: implicit truncation of vector type
+  float var4 = float2x2(zeros4);// warning X3206: implicit truncation of vector type
+  float var5 = float2x3(zeros6);// warning X3206: implicit truncation of vector type
+  float var6 = float2x4(zeros8);// warning X3206: implicit truncation of vector type
+  float var7 = float3x2(zeros6);// warning X3206: implicit truncation of vector type
+  float var8 = float3x3(zeros9);// warning X3206: implicit truncation of vector type
+  float var9 = float3x4(zeros12);// warning X3206: implicit truncation of vector type
+  float var10 = float4x2(zeros8);// warning X3206: implicit truncation of vector type
+  float var11 = float4x3(zeros12);// warning X3206: implicit truncation of vector type
+  float var12 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float2 var15 = float3(zeros3);// warning X3206: implicit truncation of vector type
+  float2 var16 = float4(zeros4);// warning X3206: implicit truncation of vector type
+  float3 var29 = float4(zeros4);// warning X3206: implicit truncation of vector type
+  float2x2 var57 = float2x3(zeros6);// warning X3206: implicit truncation of vector type
+  float2x2 var58 = float2x4(zeros8);// warning X3206: implicit truncation of vector type
+  float2x2 var59 = float3x2(zeros6);// warning X3206: implicit truncation of vector type
+  float2x2 var60 = float3x3(zeros9);// warning X3206: implicit truncation of vector type
+  float2x2 var61 = float3x4(zeros12);// warning X3206: implicit truncation of vector type
+  float2x2 var62 = float4x2(zeros8);// warning X3206: implicit truncation of vector type
+  float2x2 var63 = float4x3(zeros12);// warning X3206: implicit truncation of vector type
+  float2x2 var64 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float2x3 var71 = float2x4(zeros8);// warning X3206: implicit truncation of vector type
+  float2x3 var73 = float3x3(zeros9);// warning X3206: implicit truncation of vector type
+  float2x3 var74 = float3x4(zeros12);// warning X3206: implicit truncation of vector type
+  float2x3 var76 = float4x3(zeros12);// warning X3206: implicit truncation of vector type
+  float2x3 var77 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float2x4 var87 = float3x4(zeros12);// warning X3206: implicit truncation of vector type
+  float2x4 var90 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float3x2 var99 = float3x3(zeros9);// warning X3206: implicit truncation of vector type
+  float3x2 var100 = float3x4(zeros12);// warning X3206: implicit truncation of vector type
+  float3x2 var101 = float4x2(zeros8);// warning X3206: implicit truncation of vector type
+  float3x2 var102 = float4x3(zeros12);// warning X3206: implicit truncation of vector type
+  float3x2 var103 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float3x3 var113 = float3x4(zeros12);// warning X3206: implicit truncation of vector type
+  float3x3 var115 = float4x3(zeros12);// warning X3206: implicit truncation of vector type
+  float3x3 var116 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float3x4 var129 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float4x2 var141 = float4x3(zeros12);// warning X3206: implicit truncation of vector type
+  float4x2 var142 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  float4x3 var155 = float4x4(zeros16);// warning X3206: implicit truncation of vector type
+  return 0;
+}
+

--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -1119,9 +1119,12 @@ void TIntermediate::addBiShapeConversion(TOperator op, TIntermTyped*& lhsNode, T
         rhsNode = addUniShapeConversion(op, lhsNode->getType(), rhsNode);
         return;
 
+    case EOpMul:
+        // matrix multiply does not change shapes
+        if (lhsNode->isMatrix() && rhsNode->isMatrix())
+            return;
     case EOpAdd:
     case EOpSub:
-    case EOpMul:
     case EOpDiv:
         // want to support vector * scalar native ops in AST and lower, not smear, similarly for
         // matrix * vector, etc.
@@ -1194,9 +1197,19 @@ TIntermTyped* TIntermediate::addShapeConversion(const TType& type, TIntermTyped*
     // The new node that handles the conversion
     TOperator constructorOp = mapTypeToConstructorOp(type);
 
-    // HLSL has custom semantics for scalar->mat shape conversions.
     if (source == EShSourceHlsl) {
-        if (node->getType().isScalarOrVec1() && type.isMatrix()) {
+        // HLSL rules for scalar, vector and matrix conversions:
+        // 1) scalar can become anything, initializing every component with its value
+        // 2) vector and matrix can become scalar, first element is used (warning: truncation)
+        // 3) matrix can become matrix with less rows and/or columns (warning: truncation)
+        // 4) vector can become vector with less rows size (warning: truncation)
+        // 5a) vector 4 can become 2x2 matrix (special case) (same packing layout, its a reinterpret)
+        // 5b) 2x2 matrix can become vector 4 (special case) (same packing layout, its a reinterpret)
+
+        const TType &sourceType = node->getType();
+
+        // rule 1 for scalar to matrix is special
+        if (sourceType.isScalarOrVec1() && type.isMatrix()) {
 
             // HLSL semantics: the scalar (or vec1) is replicated to every component of the matrix.  Left to its
             // own devices, the constructor from a scalar would populate the diagonal.  This forces replication
@@ -1204,7 +1217,7 @@ TIntermTyped* TIntermediate::addShapeConversion(const TType& type, TIntermTyped*
 
             // Note that if the node is complex (e.g, a function call), we don't want to duplicate it here
             // repeatedly, so we copy it to a temp, then use the temp.
-            const int matSize = type.getMatrixRows() * type.getMatrixCols();
+            const int matSize = type.computeNumComponents();
             TIntermAggregate* rhsAggregate = new TIntermAggregate();
 
             const bool isSimple = (node->getAsSymbolNode() != nullptr) || (node->getAsConstantUnion() != nullptr);
@@ -1212,11 +1225,43 @@ TIntermTyped* TIntermediate::addShapeConversion(const TType& type, TIntermTyped*
             if (!isSimple) {
                 assert(0); // TODO: use node replicator service when available.
             }
-            
-            for (int x=0; x<matSize; ++x)
+
+            for (int x = 0; x < matSize; ++x)
                 rhsAggregate->getSequence().push_back(node);
 
             return setAggregateOperator(rhsAggregate, constructorOp, type, node->getLoc());
+        }
+
+        // rule 1 and 2
+        if ((sourceType.isScalar() && !type.isScalar()) || (!sourceType.isScalar() && type.isScalar()))
+            return setAggregateOperator(makeAggregate(node), constructorOp, type, node->getLoc());
+
+        // rule 3 and 5b
+        if (sourceType.isMatrix()) {
+            // rule 3
+            if (type.isMatrix()) {
+                if ((sourceType.getMatrixCols() != type.getMatrixCols() || sourceType.getMatrixRows() != type.getMatrixRows()) &&
+                    sourceType.getMatrixCols() >= type.getMatrixCols() && sourceType.getMatrixRows() >= type.getMatrixRows())
+                    return setAggregateOperator(makeAggregate(node), constructorOp, type, node->getLoc());
+            // rule 5b
+            } else if (type.isVector()) {
+                if (type.getVectorSize() == 4 && sourceType.getMatrixCols() == 2 && sourceType.getMatrixRows() == 2)
+                    return setAggregateOperator(makeAggregate(node), constructorOp, type, node->getLoc());
+            }
+        }
+
+        // rule 4 and 5a
+        if (sourceType.isVector()) {
+            // rule 4
+            if (type.isVector())
+            {
+                if (sourceType.getVectorSize() > type.getVectorSize())
+                    return setAggregateOperator(makeAggregate(node), constructorOp, type, node->getLoc());
+            // rule 5a
+            } else if (type.isMatrix()) {
+                if (sourceType.getVectorSize() == 4 && type.getMatrixCols() == 2 && type.getMatrixRows() == 2)
+                    return setAggregateOperator(makeAggregate(node), constructorOp, type, node->getLoc());
+            }
         }
     }
 

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -382,7 +382,8 @@ INSTANTIATE_TEST_CASE_P(
         {"hlsl.typeGraphCopy.vert", "main"},
         {"hlsl.typedef.frag", "PixelShaderFunction"},
         {"hlsl.whileLoop.frag", "PixelShaderFunction"},
-        {"hlsl.void.frag", "PixelShaderFunction"}
+        {"hlsl.void.frag", "PixelShaderFunction"},
+        {"hlsl.type.type.conversion.all.frag", "main"}
     }),
     FileNameAsCustomTestSuffix
 );
@@ -399,6 +400,7 @@ INSTANTIATE_TEST_CASE_P(
         {"hlsl.wavequery.frag", "PixelShaderFunction"},
         {"hlsl.wavereduction.comp", "CSMain"},
         {"hlsl.wavevote.comp", "CSMain"},
+        { "hlsl.type.type.conversion.valid.frag", "main" }
     }),
     FileNameAsCustomTestSuffix
 );


### PR DESCRIPTION
This fixes some of the type conversion gaps of scalar, vector and matrix type of the HLSL frontend.

All cases of the tests where compiled with D3dcompiler_47.dll v 10.0.17.134.1 to verify which conversions are invalid and which are not (comments after each line contain the compile log of fxc).