### PR TITLE
Update to newer SPIRV-Tools, including VK_EXT_scalar_block_layout

### DIFF
--- a/Test/baseResults/hlsl.buffer.frag.out
+++ b/Test/baseResults/hlsl.buffer.frag.out
@@ -146,7 +146,7 @@ gl_FragCoord origin is upper left
 0:?     'input' ( in 4-component vector of float FragCoord)
 
 error: SPIRV-Tools Validation Errors
-error: Structure id 50 decorated as BufferBlock for variable in Uniform storage class must follow standard storage buffer layout rules: member 7 at offset 128 overlaps previous member ending at offset 171
+error: Structure id 50 decorated as BufferBlock for variable in Uniform storage class must follow relaxed storage buffer layout rules: member 7 at offset 128 overlaps previous member ending at offset 171
   %tbufName = OpTypeStruct %v4float %int %float %float %float %float %float %float %mat3v4float %mat3v4float %mat3v4float %mat3v4float
 
 // Module Version 10000

--- a/known_good.json
+++ b/known_good.json
@@ -5,7 +5,7 @@
       "site" : "github",
       "subrepo" : "KhronosGroup/SPIRV-Tools",
       "subdir" : "External/spirv-tools",
-      "commit" : "ab76e332de7a8480c5753b1c63cc6052949df9fc"
+      "commit" : "8e9be303b00ba352ee25dbcd352769641637a853"
     },
     {
       "name" : "spirv-tools/external/spirv-headers",


### PR DESCRIPTION
Validator has more refined messages about what kind of block layout
rules have been applied.