### PR TITLE
HLSL: fix for overload and intrinsic rules

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -6721,6 +6721,7 @@ spv::Id TGlslangToSpvTraverser::createMiscOperation(glslang::TOperator op, spv::
         opCode = spv::OpBitFieldInsert;
         break;
 
+    case glslang::EOpFmaD:
     case glslang::EOpFma:
         libCall = spv::GLSLstd450Fma;
         break;

--- a/Test/baseResults/hlsl.intrinsics.double.frag.out
+++ b/Test/baseResults/hlsl.intrinsics.double.frag.out
@@ -16,7 +16,7 @@ gl_FragCoord origin is upper left
 0:6      Sequence
 0:6        move second child to first child ( temp double)
 0:6          'r00' ( temp double)
-0:6          fma ( temp double)
+0:6          fma (double) ( temp double)
 0:6            'inDV1a' ( in double)
 0:6            'inDV1b' ( in double)
 0:6            'inDV1c' ( in double)
@@ -100,7 +100,7 @@ gl_FragCoord origin is upper left
 0:6      Sequence
 0:6        move second child to first child ( temp double)
 0:6          'r00' ( temp double)
-0:6          fma ( temp double)
+0:6          fma (double) ( temp double)
 0:6            'inDV1a' ( in double)
 0:6            'inDV1b' ( in double)
 0:6            'inDV1c' ( in double)

--- a/Test/baseResults/hlsl.overload.2.frag.out
+++ b/Test/baseResults/hlsl.overload.2.frag.out
@@ -1,0 +1,276 @@
+hlsl.overload.2.frag
+Shader version: 500
+gl_FragCoord origin is upper left
+0:? Sequence
+0:2  Function Definition: randPos(vf3; ( temp float)
+0:2    Function Parameters: 
+0:2      'p' ( in 3-component vector of float)
+0:?     Sequence
+0:3      Branch: Return with expression
+0:3        Fraction ( temp float)
+0:3          component-wise multiply ( temp float)
+0:3            sine ( temp float)
+0:3              component-wise multiply ( temp float)
+0:3                dot-product ( temp float)
+0:3                  vector swizzle ( temp 3-component vector of float)
+0:3                    'p' ( in 3-component vector of float)
+0:3                    Sequence
+0:3                      Constant:
+0:3                        0 (const int)
+0:3                      Constant:
+0:3                        1 (const int)
+0:3                      Constant:
+0:3                        2 (const int)
+0:?                   Constant:
+0:?                     1.000000
+0:?                     -2.781300
+0:?                     3.010000
+0:3                Constant:
+0:3                  12.989800
+0:3            Constant:
+0:3              43758.545300
+0:6  Function Definition: rand(f1; ( temp float)
+0:6    Function Parameters: 
+0:6      'p' ( in float)
+0:?     Sequence
+0:7      Branch: Return with expression
+0:7        Fraction ( temp float)
+0:7          component-wise multiply ( temp float)
+0:7            sine ( temp float)
+0:7              component-wise multiply ( temp float)
+0:7                'p' ( in float)
+0:7                Constant:
+0:7                  12.989800
+0:7            Constant:
+0:7              43758.545300
+0:13  Function Definition: @main( ( temp 4-component vector of float)
+0:13    Function Parameters: 
+0:?     Sequence
+0:14      Sequence
+0:14        move second child to first child ( temp float)
+0:14          'randVal' ( temp float)
+0:14          Function Call: rand(f1; ( temp float)
+0:14            Construct float ( in float)
+0:14              add ( temp 2-component vector of float)
+0:14                Function Call: randPos(vf3; ( temp float)
+0:14                  worldPos: direct index for structure (layout( offset=0) uniform 3-component vector of float)
+0:14                    'anon@0' (layout( row_major std140) uniform block{layout( offset=0) uniform 3-component vector of float worldPos, layout( offset=16) uniform 2-component vector of float ssgi_current_frame})
+0:14                    Constant:
+0:14                      0 (const uint)
+0:14                sine ( temp 2-component vector of float)
+0:14                  vector-scale ( temp 2-component vector of float)
+0:14                    ssgi_current_frame: direct index for structure (layout( offset=16) uniform 2-component vector of float)
+0:14                      'anon@0' (layout( row_major std140) uniform block{layout( offset=0) uniform 3-component vector of float worldPos, layout( offset=16) uniform 2-component vector of float ssgi_current_frame})
+0:14                      Constant:
+0:14                        1 (const uint)
+0:14                    Constant:
+0:14                      0.131700
+0:15      Branch: Return with expression
+0:15        Constant:
+0:15          0.000000
+0:15          0.000000
+0:15          0.000000
+0:15          0.000000
+0:13  Function Definition: main( ( temp void)
+0:13    Function Parameters: 
+0:?     Sequence
+0:13      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:13        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     'anon@0' (layout( row_major std140) uniform block{layout( offset=0) uniform 3-component vector of float worldPos, layout( offset=16) uniform 2-component vector of float ssgi_current_frame})
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+
+Linked fragment stage:
+
+
+Shader version: 500
+gl_FragCoord origin is upper left
+0:? Sequence
+0:2  Function Definition: randPos(vf3; ( temp float)
+0:2    Function Parameters: 
+0:2      'p' ( in 3-component vector of float)
+0:?     Sequence
+0:3      Branch: Return with expression
+0:3        Fraction ( temp float)
+0:3          component-wise multiply ( temp float)
+0:3            sine ( temp float)
+0:3              component-wise multiply ( temp float)
+0:3                dot-product ( temp float)
+0:3                  vector swizzle ( temp 3-component vector of float)
+0:3                    'p' ( in 3-component vector of float)
+0:3                    Sequence
+0:3                      Constant:
+0:3                        0 (const int)
+0:3                      Constant:
+0:3                        1 (const int)
+0:3                      Constant:
+0:3                        2 (const int)
+0:?                   Constant:
+0:?                     1.000000
+0:?                     -2.781300
+0:?                     3.010000
+0:3                Constant:
+0:3                  12.989800
+0:3            Constant:
+0:3              43758.545300
+0:6  Function Definition: rand(f1; ( temp float)
+0:6    Function Parameters: 
+0:6      'p' ( in float)
+0:?     Sequence
+0:7      Branch: Return with expression
+0:7        Fraction ( temp float)
+0:7          component-wise multiply ( temp float)
+0:7            sine ( temp float)
+0:7              component-wise multiply ( temp float)
+0:7                'p' ( in float)
+0:7                Constant:
+0:7                  12.989800
+0:7            Constant:
+0:7              43758.545300
+0:13  Function Definition: @main( ( temp 4-component vector of float)
+0:13    Function Parameters: 
+0:?     Sequence
+0:14      Sequence
+0:14        move second child to first child ( temp float)
+0:14          'randVal' ( temp float)
+0:14          Function Call: rand(f1; ( temp float)
+0:14            Construct float ( in float)
+0:14              add ( temp 2-component vector of float)
+0:14                Function Call: randPos(vf3; ( temp float)
+0:14                  worldPos: direct index for structure (layout( offset=0) uniform 3-component vector of float)
+0:14                    'anon@0' (layout( row_major std140) uniform block{layout( offset=0) uniform 3-component vector of float worldPos, layout( offset=16) uniform 2-component vector of float ssgi_current_frame})
+0:14                    Constant:
+0:14                      0 (const uint)
+0:14                sine ( temp 2-component vector of float)
+0:14                  vector-scale ( temp 2-component vector of float)
+0:14                    ssgi_current_frame: direct index for structure (layout( offset=16) uniform 2-component vector of float)
+0:14                      'anon@0' (layout( row_major std140) uniform block{layout( offset=0) uniform 3-component vector of float worldPos, layout( offset=16) uniform 2-component vector of float ssgi_current_frame})
+0:14                      Constant:
+0:14                        1 (const uint)
+0:14                    Constant:
+0:14                      0.131700
+0:15      Branch: Return with expression
+0:15        Constant:
+0:15          0.000000
+0:15          0.000000
+0:15          0.000000
+0:15          0.000000
+0:13  Function Definition: main( ( temp void)
+0:13    Function Parameters: 
+0:?     Sequence
+0:13      move second child to first child ( temp 4-component vector of float)
+0:?         '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+0:13        Function Call: @main( ( temp 4-component vector of float)
+0:?   Linker Objects
+0:?     'anon@0' (layout( row_major std140) uniform block{layout( offset=0) uniform 3-component vector of float worldPos, layout( offset=16) uniform 2-component vector of float ssgi_current_frame})
+0:?     '@entryPointOutput' (layout( location=0) out 4-component vector of float)
+
+// Module Version 10000
+// Generated by (magic number): 80007
+// Id's are bound by 74
+
+                              Capability Shader
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Fragment 4  "main" 72
+                              ExecutionMode 4 OriginUpperLeft
+                              Source HLSL 500
+                              Name 4  "main"
+                              Name 11  "randPos(vf3;"
+                              Name 10  "p"
+                              Name 16  "rand(f1;"
+                              Name 15  "p"
+                              Name 20  "@main("
+                              Name 43  "randVal"
+                              Name 45  "$Global"
+                              MemberName 45($Global) 0  "worldPos"
+                              MemberName 45($Global) 1  "ssgi_current_frame"
+                              Name 47  ""
+                              Name 50  "param"
+                              Name 65  "param"
+                              Name 72  "@entryPointOutput"
+                              MemberDecorate 45($Global) 0 Offset 0
+                              MemberDecorate 45($Global) 1 Offset 16
+                              Decorate 45($Global) Block
+                              Decorate 47 DescriptorSet 0
+                              Decorate 72(@entryPointOutput) Location 0
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeFloat 32
+               7:             TypeVector 6(float) 3
+               8:             TypePointer Function 7(fvec3)
+               9:             TypeFunction 6(float) 8(ptr)
+              13:             TypePointer Function 6(float)
+              14:             TypeFunction 6(float) 13(ptr)
+              18:             TypeVector 6(float) 4
+              19:             TypeFunction 18(fvec4)
+              23:    6(float) Constant 1065353216
+              24:    6(float) Constant 3224502482
+              25:    6(float) Constant 1077978071
+              26:    7(fvec3) ConstantComposite 23 24 25
+              28:    6(float) Constant 1095751225
+              31:    6(float) Constant 1193995916
+              44:             TypeVector 6(float) 2
+     45($Global):             TypeStruct 7(fvec3) 44(fvec2)
+              46:             TypePointer Uniform 45($Global)
+              47:     46(ptr) Variable Uniform
+              48:             TypeInt 32 1
+              49:     48(int) Constant 0
+              51:             TypePointer Uniform 7(fvec3)
+              55:     48(int) Constant 1
+              56:             TypePointer Uniform 44(fvec2)
+              59:    6(float) Constant 1040637021
+              67:    6(float) Constant 0
+              68:   18(fvec4) ConstantComposite 67 67 67 67
+              71:             TypePointer Output 18(fvec4)
+72(@entryPointOutput):     71(ptr) Variable Output
+         4(main):           2 Function None 3
+               5:             Label
+              73:   18(fvec4) FunctionCall 20(@main()
+                              Store 72(@entryPointOutput) 73
+                              Return
+                              FunctionEnd
+11(randPos(vf3;):    6(float) Function None 9
+           10(p):      8(ptr) FunctionParameter
+              12:             Label
+              22:    7(fvec3) Load 10(p)
+              27:    6(float) Dot 22 26
+              29:    6(float) FMul 27 28
+              30:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 29
+              32:    6(float) FMul 30 31
+              33:    6(float) ExtInst 1(GLSL.std.450) 10(Fract) 32
+                              ReturnValue 33
+                              FunctionEnd
+    16(rand(f1;):    6(float) Function None 14
+           15(p):     13(ptr) FunctionParameter
+              17:             Label
+              36:    6(float) Load 15(p)
+              37:    6(float) FMul 36 28
+              38:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 37
+              39:    6(float) FMul 38 31
+              40:    6(float) ExtInst 1(GLSL.std.450) 10(Fract) 39
+                              ReturnValue 40
+                              FunctionEnd
+      20(@main():   18(fvec4) Function None 19
+              21:             Label
+     43(randVal):     13(ptr) Variable Function
+       50(param):      8(ptr) Variable Function
+       65(param):     13(ptr) Variable Function
+              52:     51(ptr) AccessChain 47 49
+              53:    7(fvec3) Load 52
+                              Store 50(param) 53
+              54:    6(float) FunctionCall 11(randPos(vf3;) 50(param)
+              57:     56(ptr) AccessChain 47 55
+              58:   44(fvec2) Load 57
+              60:   44(fvec2) VectorTimesScalar 58 59
+              61:   44(fvec2) ExtInst 1(GLSL.std.450) 13(Sin) 60
+              62:   44(fvec2) CompositeConstruct 54 54
+              63:   44(fvec2) FAdd 62 61
+              64:    6(float) CompositeExtract 63 0
+                              Store 65(param) 64
+              66:    6(float) FunctionCall 16(rand(f1;) 65(param)
+                              Store 43(randVal) 66
+                              ReturnValue 68
+                              FunctionEnd

--- a/Test/hlsl.overload.2.frag
+++ b/Test/hlsl.overload.2.frag
@@ -1,0 +1,16 @@
+float randPos(float3 p)
+{
+  return frac(sin(dot(p.xyz, float3(1, -2.7813, 3.01))*12.9898) * 43758.5453);
+}
+float rand(float p)
+{
+  return frac(sin(p*12.9898) * 43758.5453);
+}
+
+float3 v2 : register(c0);
+float2 v1 : register(c1);
+
+float4 main() : SV_Target {
+  float randVal = rand(randPos(v2)+sin(v1*0.1317));
+  return 0;
+}

--- a/glslang/Include/intermediate.h
+++ b/glslang/Include/intermediate.h
@@ -905,6 +905,7 @@ enum TOperator {
     // HLSL operations
     //
 
+    EOpFmaD,                // in HLSL fma is double only and only accepts douzble
     EOpClip,                // discard if input value < 0
     EOpIsFinite,
     EOpLog10,               // base 10 log
@@ -934,6 +935,7 @@ enum TOperator {
     EOpTextureBias,                      // HLSL texture bias: will be lowered to EOpTexture
     EOpAsDouble,                         // slightly different from EOpUint64BitsToDouble
     EOpD3DCOLORtoUBYTE4,                 // convert and swizzle 4-component color to UBYTE4 range
+    EOpCheckAccessFullyMapped,           // HLSL checks result from sparse texture lookup
 
     EOpMethodSample,                     // Texture object methods.  These are translated to existing
     EOpMethodSampleBias,                 // AST methods, and exist to represent HLSL semantics until that

--- a/glslang/MachineIndependent/ParseHelper.h
+++ b/glslang/MachineIndependent/ParseHelper.h
@@ -205,7 +205,7 @@ protected:
     // see implementation for detail
     const TFunction* selectFunction(const TVector<const TFunction*>, const TFunction&,
         std::function<bool(const TType&, const TType&, TOperator, int arg)>,
-        std::function<bool(const TType&, const TType&, const TType&)>,
+        std::function<int(const TType&, const TType&, const TType&)>,
         /* output */ bool& tie);
 
     virtual void parseSwizzleSelector(const TSourceLoc&, const TString&, int size,

--- a/glslang/MachineIndependent/intermOut.cpp
+++ b/glslang/MachineIndependent/intermOut.cpp
@@ -970,6 +970,7 @@ bool TOutputTraverser::visitAggregate(TVisit /* visit */, TIntermAggregate* node
     case EOpBitfieldExtract:            out.debug << "bitfieldExtract";       break;
     case EOpBitfieldInsert:             out.debug << "bitfieldInsert";        break;
 
+    case EOpFmaD:                       out.debug << "fma (double)";          break;
     case EOpFma:                        out.debug << "fma";                   break;
     case EOpFrexp:                      out.debug << "frexp";                 break;
     case EOpLdexp:                      out.debug << "ldexp";                 break;

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -383,7 +383,8 @@ INSTANTIATE_TEST_CASE_P(
         {"hlsl.typedef.frag", "PixelShaderFunction"},
         {"hlsl.whileLoop.frag", "PixelShaderFunction"},
         {"hlsl.void.frag", "PixelShaderFunction"},
-        {"hlsl.type.type.conversion.all.frag", "main"}
+        {"hlsl.type.type.conversion.all.frag", "main"},
+        {"hlsl.overload.2.frag", "main"}
     }),
     FileNameAsCustomTestSuffix
 );

--- a/hlsl/hlslParseables.cpp
+++ b/hlsl/hlslParseables.cpp
@@ -1102,7 +1102,7 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int /*version*/, EProfile /*profil
     symbolTable.relateToOperator("atan",                        EOpAtan);
     symbolTable.relateToOperator("atan2",                       EOpAtan);
     symbolTable.relateToOperator("ceil",                        EOpCeil);
-    // symbolTable.relateToOperator("CheckAccessFullyMapped");
+    symbolTable.relateToOperator("CheckAccessFullyMapped",      EOpCheckAccessFullyMapped);
     symbolTable.relateToOperator("clamp",                       EOpClamp);
     symbolTable.relateToOperator("clip",                        EOpClip);
     symbolTable.relateToOperator("cos",                         EOpCos);
@@ -1135,7 +1135,7 @@ void TBuiltInParseablesHlsl::identifyBuiltIns(int /*version*/, EProfile /*profil
     symbolTable.relateToOperator("firstbithigh",                EOpFindMSB);
     symbolTable.relateToOperator("firstbitlow",                 EOpFindLSB);
     symbolTable.relateToOperator("floor",                       EOpFloor);
-    symbolTable.relateToOperator("fma",                         EOpFma);
+    symbolTable.relateToOperator("fma",                         EOpFmaD);
     symbolTable.relateToOperator("fmod",                        EOpMod);
     symbolTable.relateToOperator("frac",                        EOpFract);
     symbolTable.relateToOperator("frexp",                       EOpFrexp);


### PR DESCRIPTION
- added FmaD, as 'mad' and 'fma' are not the
  same on HLSL, mad is non double, fma is
  double exclusive. Boils down to same fma
  instruction in spir-v.
- following intrinsics forbid type conversion
  of their inputs (truncation is still allowed)
  - asdouble
  - fma
  - CheckAccessFullyMapped
- added opcode for CheckAccessFullyMapped
  to support proper intrinsics handling,
  still not implemented though.
- Changed overload system to properly handle
  HLSL rules. Changes how selectFunction works.
  - better is now a function that returns the
    relative distance between two param comparisons.
  - now sums all relative distances up to decide
    if two possible overloads are equal.
- Added more complex test to validate overload
  rules.