### PR TITLE
Add NDK build files

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,100 @@
+LOCAL_PATH := $(call my-dir)
+
+GLSLANG_OS_FLAGS := -DGLSLANG_OSINCLUDE_UNIX
+# AMD and NV extensions are turned on by default in upstream Glslang.
+GLSLANG_DEFINES:= -DAMD_EXTENSIONS -DNV_EXTENSIONS -DENABLE_HLSL $(GLSLANG_OS_FLAGS)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE:=OSDependent
+LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti $(GLSLANG_DEFINES)
+LOCAL_EXPORT_C_INCLUDES:=$(LOCAL_PATH)
+LOCAL_SRC_FILES:=glslang/OSDependent/Unix/ossource.cpp
+LOCAL_C_INCLUDES:=$(LOCAL_PATH) $(LOCAL_PATH)/glslang/OSDependent/Unix/
+LOCAL_EXPORT_C_INCLUDES:=$(LOCAL_PATH)/glslang/OSDependent/Unix/
+include $(BUILD_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE:=OGLCompiler
+LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti $(GLSLANG_DEFINES)
+LOCAL_EXPORT_C_INCLUDES:=$(LOCAL_PATH)
+LOCAL_SRC_FILES:=OGLCompilersDLL/InitializeDll.cpp
+LOCAL_C_INCLUDES:=$(LOCAL_PATH)/OGLCompiler
+LOCAL_STATIC_LIBRARIES:=OSDependent
+include $(BUILD_STATIC_LIBRARY)
+
+# Build Glslang's HLSL parser library.
+include $(CLEAR_VARS)
+LOCAL_MODULE:=HLSL
+LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti $(GLSLANG_DEFINES)
+LOCAL_SRC_FILES:= \
+		hlsl/hlslAttributes.cpp \
+		hlsl/hlslGrammar.cpp \
+		hlsl/hlslOpMap.cpp \
+		hlsl/hlslParseables.cpp \
+		hlsl/hlslParseHelper.cpp \
+		hlsl/hlslScanContext.cpp \
+		hlsl/hlslTokenStream.cpp
+LOCAL_C_INCLUDES:=$(LOCAL_PATH) \
+	$(LOCAL_PATH)/hlsl
+include $(BUILD_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+GLSLANG_OUT_PATH=$(if $(call host-path-is-absolute,$(TARGET_OUT)),$(TARGET_OUT),$(abspath $(TARGET_OUT)))
+
+LOCAL_MODULE:=glslang
+LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti $(GLSLANG_DEFINES)
+LOCAL_EXPORT_C_INCLUDES:=$(LOCAL_PATH)
+LOCAL_SRC_FILES:= \
+		glslang/GenericCodeGen/CodeGen.cpp \
+		glslang/GenericCodeGen/Link.cpp \
+		glslang/MachineIndependent/attribute.cpp \
+		glslang/MachineIndependent/Constant.cpp \
+		glslang/MachineIndependent/glslang_tab.cpp \
+		glslang/MachineIndependent/InfoSink.cpp \
+		glslang/MachineIndependent/Initialize.cpp \
+		glslang/MachineIndependent/Intermediate.cpp \
+		glslang/MachineIndependent/intermOut.cpp \
+		glslang/MachineIndependent/IntermTraverse.cpp \
+		glslang/MachineIndependent/iomapper.cpp \
+		glslang/MachineIndependent/limits.cpp \
+		glslang/MachineIndependent/linkValidate.cpp \
+		glslang/MachineIndependent/parseConst.cpp \
+		glslang/MachineIndependent/ParseContextBase.cpp \
+		glslang/MachineIndependent/ParseHelper.cpp \
+		glslang/MachineIndependent/PoolAlloc.cpp \
+		glslang/MachineIndependent/propagateNoContraction.cpp \
+		glslang/MachineIndependent/reflection.cpp \
+		glslang/MachineIndependent/RemoveTree.cpp \
+		glslang/MachineIndependent/Scan.cpp \
+		glslang/MachineIndependent/ShaderLang.cpp \
+		glslang/MachineIndependent/SymbolTable.cpp \
+		glslang/MachineIndependent/Versions.cpp \
+		glslang/MachineIndependent/preprocessor/PpAtom.cpp \
+		glslang/MachineIndependent/preprocessor/PpContext.cpp \
+		glslang/MachineIndependent/preprocessor/Pp.cpp \
+		glslang/MachineIndependent/preprocessor/PpScanner.cpp \
+		glslang/MachineIndependent/preprocessor/PpTokens.cpp
+LOCAL_C_INCLUDES:=$(LOCAL_PATH) \
+	$(LOCAL_PATH)/glslang/MachineIndependent \
+	$(GLSLANG_OUT_PATH)
+LOCAL_STATIC_LIBRARIES:=OSDependent OGLCompiler HLSL
+include $(BUILD_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE:=SPIRV
+LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti -Werror $(GLSLANG_DEFINES)
+LOCAL_EXPORT_C_INCLUDES:=$(LOCAL_PATH)
+LOCAL_SRC_FILES:= \
+	SPIRV/GlslangToSpv.cpp \
+	SPIRV/InReadableOrder.cpp \
+	SPIRV/Logger.cpp \
+	SPIRV/SPVRemapper.cpp \
+	SPIRV/SpvBuilder.cpp \
+	SPIRV/SpvPostProcess.cpp \
+	SPIRV/SpvTools.cpp \
+	SPIRV/disassemble.cpp \
+	SPIRV/doc.cpp
+LOCAL_C_INCLUDES:=$(LOCAL_PATH) $(LOCAL_PATH)/glslang/SPIRV
+LOCAL_EXPORT_C_INCLUDES:=$(LOCAL_PATH)/glslang/SPIRV
+LOCAL_STATIC_LIBRARIES:=glslang
+include $(BUILD_STATIC_LIBRARY)

--- a/ndk_test/Android.mk
+++ b/ndk_test/Android.mk
@@ -1,0 +1,12 @@
+LOCAL_PATH:= $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_CPP_EXTENSION := .cc .cpp .cxx
+LOCAL_SRC_FILES:=test.cpp
+LOCAL_MODULE:=glslang_ndk_test
+LOCAL_LDLIBS:=-landroid
+LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti -Werror
+LOCAL_STATIC_LIBRARIES:=glslang SPIRV HLSL
+include $(BUILD_SHARED_LIBRARY)
+
+include $(LOCAL_PATH)/../Android.mk

--- a/ndk_test/jni/Application.mk
+++ b/ndk_test/jni/Application.mk
@@ -1,0 +1,5 @@
+APP_ABI := all
+APP_BUILD_SCRIPT := Android.mk
+APP_STL := gnustl_static
+APP_PLATFORM := android-9
+NDK_TOOLCHAIN_VERSION := 4.9

--- a/ndk_test/test.cpp
+++ b/ndk_test/test.cpp
@@ -1,0 +1,19 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "SPIRV/GlslangToSpv.h"
+
+void android_main(struct android_app* state) {
+  int version = glslang::GetSpirvGeneratorVersion();
+}


### PR DESCRIPTION
This CL adds Android.mk files to simplify NDK builds for downstream projects. The necessary
files are added so an NDK build can be done inside glslang to test it is functional.