### PR TITLE
CMake: Allow linking against system-installed SPIRV-Tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,7 +314,12 @@ if(BUILD_EXTERNAL AND IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/External)
     add_subdirectory(External)
 endif()
 
-if(NOT TARGET SPIRV-Tools-opt)
+find_package(PkgConfig)
+if(PkgConfig_FOUND)
+    pkg_check_modules(SPIRV-Tools SPIRV-Tools)
+endif()
+# Former would be system-installed, later is from External
+if(NOT SPIRV-Tools_FOUND AND NOT TARGET SPIRV-Tools-opt)
     set(ENABLE_OPT OFF)
 endif()
 

--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -91,14 +91,19 @@ if(WIN32 AND BUILD_SHARED_LIBS)
 endif()
 
 if(ENABLE_OPT)
-    target_include_directories(SPIRV
-        PRIVATE ${spirv-tools_SOURCE_DIR}/include
-        PRIVATE ${spirv-tools_SOURCE_DIR}/source
-    )
-    target_link_libraries(SPIRV PRIVATE MachineIndependent SPIRV-Tools-opt)
-    target_include_directories(SPIRV PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../External>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/External>)
+    if(SPIRV-Tools_FOUND)
+        target_include_directories(SPIRV PUBLIC ${SPIRV-Tools_INCLUDEDIR})
+        target_link_libraries(SPIRV glslang ${SPIRV-Tools_LIBRARIES})
+    else()
+        target_include_directories(SPIRV
+            PRIVATE ${spirv-tools_SOURCE_DIR}/include
+            PRIVATE ${spirv-tools_SOURCE_DIR}/source
+        )
+        target_link_libraries(SPIRV PRIVATE MachineIndependent SPIRV-Tools-opt)
+        target_include_directories(SPIRV PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../External>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/External>)
+    endif()
 else()
     target_link_libraries(SPIRV PRIVATE MachineIndependent)
 endif()


### PR DESCRIPTION
Fixes #1585.

@kyrios123 Can you confirm that it works for your use case too?

Output on my system:
```
+ CFLAGS='-O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fasynchronous-unwind-tables'
+ export CFLAGS
+ CXXFLAGS='-O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fasynchronous-unwind-tables'
+ export CXXFLAGS
+ FFLAGS='-O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fasynchronous-unwind-tables'
+ export FFLAGS
+ LDFLAGS=' -Wl,--as-needed -Wl,-z,relro -Wl,-O1 -Wl,--build-id -Wl,--enable-new-dtags'
+ export LDFLAGS
+ mkdir -p build
+ cd build
+ /usr/bin/cmake .. -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_INSTALL_LIBDIR:PATH=/usr/lib64 -DCMAKE_INSTALL_LIBEXECDIR:PATH=/usr/libexec -DCMAKE_INSTALL_SYSCONFDIR:PATH=/etc -DINCLUDE_INSTALL_DIR:PATH=/usr/include -DLIB_INSTALL_DIR:PATH=/usr/lib64 -DSYSCONF_INSTALL_DIR:PATH=/etc -DSHARE_INSTALL_PREFIX:PATH=/usr/share -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING=-DNDEBUG -DCMAKE_C_FLAGS_RELWITHDEBINFO:STRING=-DNDEBUG -DLIB_SUFFIX=64 -DCMAKE_SKIP_RPATH:BOOL=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON '-DCMAKE_MODULE_LINKER_FLAGS=-Wl,--as-needed -Wl,-z,relro -Wl,-O1 -Wl,--build-id -Wl,--enable-new-dtags' -DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_STATIC_LIBS:BOOL=OFF
-- The C compiler identification is GNU 8.2.1
-- The CXX compiler identification is GNU 8.2.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Google Mock was not found - tests based on that will not build
-- Found PkgConfig: /usr/bin/pkg-config (found version "1.4.2") 
-- Checking for module 'SPIRV-Tools'
--   Found SPIRV-Tools, version 2018.6.1
-- optimizer enabled
-- Configuring done
-- Generating done
```
And tests:
```
+ pushd Test
~/Mageia/Sandbox/_rpm/BUILD/glslang-7.10.2984/Test ~/Mageia/Sandbox/_rpm/BUILD/glslang-7.10.2984
+ LD_LIBRARY_PATH=/home/akien/Mageia/Sandbox/_rpm/BUILDROOT/glslang-7.10.2984-1.mga7.x86_64/usr/lib64
+ ./runtests
Running reflection...
Comparing single thread to multithread for all tests in current directory...
Running entry-point renaming tests
Running ill-defined uncalled function
Tests Succeeded.
Running explicit stage test and compound suffix tests
Running hlsl offsets
Running hlsl offsets
Configuring HLSL descriptor set and binding number manually
Testing per-descriptor-set IO map shift
Testing SPV no location
Testing SPV Debug Information
Testing Includer
Testing -D and -U
Testing --client and --target-env
spv.targetVulkan.vert
spv.targetOpenGL.vert
spv.targetVulkan.vert
spv.targetVulkan.vert
spv.targetOpenGL.vert
spv.targetVulkan.vert
spv.targetOpenGL.vert
spv.targetVulkan.vert
Testing GLSL entry point rename
Testing remapper error handling
Testing position Y inversion
Testing hlsl_functionality1
Testing HLSL-specific PP feature expansion
Tests Succeeded.
```