### PR TITLE
CMake: Link OSDependent with Threads::Threads

### DIFF
--- a/glslang/OSDependent/Unix/CMakeLists.txt
+++ b/glslang/OSDependent/Unix/CMakeLists.txt
@@ -2,6 +2,11 @@ add_library(OSDependent STATIC ossource.cpp ../osinclude.h)
 set_property(TARGET OSDependent PROPERTY FOLDER glslang)
 set_property(TARGET OSDependent PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+set(CMAKE_THREAD_PREFER_PTHREAD ON)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads)
+target_link_libraries(OSDependent Threads::Threads)
+
 if(ENABLE_GLSLANG_INSTALL)
     install(TARGETS OSDependent
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Would typically be pthreads.
Without this, '-Wl,--no-undefined' would output these errors:
```
/usr/bin/ld: OSDependent/Unix/libOSDependent.a(ossource.cpp.o): in function `glslang::OS_CleanupThreadData()':
/home/akien/Mageia/Sandbox/_rpm/BUILD/glslang-7.10.2984/glslang/OSDependent/Unix/ossource.cpp:83: undefined reference to `__pthread_register_cancel'
/usr/bin/ld: /home/akien/Mageia/Sandbox/_rpm/BUILD/glslang-7.10.2984/glslang/OSDependent/Unix/ossource.cpp:93: undefined reference to `__pthread_unregister_cancel'
/usr/bin/ld: OSDependent/Unix/libOSDependent.a(ossource.cpp.o): in function `glslang::OS_AllocTLSIndex()':
/home/akien/Mageia/Sandbox/_rpm/BUILD/glslang-7.10.2984/glslang/OSDependent/Unix/ossource.cpp:122: undefined reference to `pthread_key_create'
/usr/bin/ld: OSDependent/Unix/libOSDependent.a(ossource.cpp.o): in function `glslang::OS_SetTLSValue(void*, void*)':
/home/akien/Mageia/Sandbox/_rpm/BUILD/glslang-7.10.2984/glslang/OSDependent/Unix/ossource.cpp:137: undefined reference to `pthread_setspecific'
/usr/bin/ld: OSDependent/Unix/libOSDependent.a(ossource.cpp.o): in function `glslang::OS_FreeTLSIndex(void*)':
/home/akien/Mageia/Sandbox/_rpm/BUILD/glslang-7.10.2984/glslang/OSDependent/Unix/ossource.cpp:162: undefined reference to `pthread_key_delete'
/usr/bin/ld: OSDependent/Unix/libOSDependent.a(ossource.cpp.o): in function `glslang::InitGlobalLock()':
/home/akien/Mageia/Sandbox/_rpm/BUILD/glslang-7.10.2984/glslang/OSDependent/Unix/ossource.cpp:175: undefined reference to `pthread_mutexattr_init'
/usr/bin/ld: /home/akien/Mageia/Sandbox/_rpm/BUILD/glslang-7.10.2984/glslang/OSDependent/Unix/ossource.cpp:176: undefined reference to `pthread_mutexattr_settype'
/usr/bin/ld: OSDependent/Unix/libOSDependent.a(ossource.cpp.o): in function `glslang::OS_GetTLSValue(void*)':
/home/akien/Mageia/Sandbox/_rpm/BUILD/glslang-7.10.2984/glslang/OSDependent/Unix/ossource.cpp:149: undefined reference to `pthread_getspecific'
```

Ref. #1484.