### PR TITLE
Include cstdint for int8_t and friends

### DIFF
--- a/glslang/MachineIndependent/Constant.cpp
+++ b/glslang/MachineIndependent/Constant.cpp
@@ -39,6 +39,7 @@
 #include "localintermediate.h"
 #include <cmath>
 #include <cfloat>
+#include <cstdint>
 #include <cstdlib>
 #include <climits>
 


### PR DESCRIPTION
Required for VS2013 build.

Fixes #1630