### PR TITLE
CMake: Fix linking pthread of CMake < 3.1

### DIFF
--- a/glslang/OSDependent/Unix/CMakeLists.txt
+++ b/glslang/OSDependent/Unix/CMakeLists.txt
@@ -2,10 +2,20 @@ add_library(OSDependent STATIC ossource.cpp ../osinclude.h)
 set_property(TARGET OSDependent PROPERTY FOLDER glslang)
 set_property(TARGET OSDependent PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+# Link pthread
 set(CMAKE_THREAD_PREFER_PTHREAD ON)
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads)
-target_link_libraries(OSDependent Threads::Threads)
+if(${CMAKE_VERSION} VERSION_LESS "3.1.0")
+    # Needed as long as we support CMake 2.8 for Ubuntu 14.04,
+    # which does not support the recommended Threads::Threads target.
+    # https://cmake.org/cmake/help/v2.8.12/cmake.html#module:FindThreads
+    find_package(Threads)
+    target_link_libraries(OSDependent ${CMAKE_THREAD_LIBS_INIT})
+else()
+    # This is the recommended way, so we use it for 3.1+.
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads)
+    target_link_libraries(OSDependent Threads::Threads)
+endif()
 
 if(ENABLE_GLSLANG_INSTALL)
     install(TARGETS OSDependent


### PR DESCRIPTION
As reported in #1624, Ubuntu 14.04 LTS still uses CMake 2.8.12 which
does not support the Threads::Threads target (added in CMake 3.1).

This could be reverted once the required CMake version is bumped to 3.1+.

Not tested against CMake < 3.1, could you try it @archimedus?