### PR TITLE
Make sure source strings are terminated

### DIFF
--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -880,10 +880,9 @@ bool ProcessDeferred(
     if (messages & EShMsgDebugInfo) {
         intermediate.setSourceFile(names[numPre]);
         for (int s = 0; s < numStrings; ++s) {
-            // The string may be null-terminated, so make sure we create one
-            // with the given length.
-            std::string tmp(strings[numPre + s], lengths[numPre + s]);
-            intermediate.addSourceText(tmp.c_str());
+            // The string may not be null-terminated, so make sure we provide
+            // the length along with the string.
+            intermediate.addSourceText(strings[numPre + s], lengths[numPre + s]);
         }
     }
     SetupBuiltinSymbolTable(version, profile, spvVersion, source);

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -879,8 +879,12 @@ bool ProcessDeferred(
         intermediate.setHlslOffsets();
     if (messages & EShMsgDebugInfo) {
         intermediate.setSourceFile(names[numPre]);
-        for (int s = 0; s < numStrings; ++s)
-            intermediate.addSourceText(strings[numPre + s]);
+        for (int s = 0; s < numStrings; ++s) {
+            // The string may be null-terminated, so make sure we create one
+            // with the given length.
+            std::string tmp(strings[numPre + s], lengths[numPre + s]);
+            intermediate.addSourceText(tmp.c_str());
+        }
     }
     SetupBuiltinSymbolTable(version, profile, spvVersion, source);
 

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -666,7 +666,7 @@ public:
 
     void setSourceFile(const char* file) { if (file != nullptr) sourceFile = file; }
     const std::string& getSourceFile() const { return sourceFile; }
-    void addSourceText(const char* text) { sourceText = sourceText + text; }
+    void addSourceText(const char* text, size_t len) { sourceText.append(text, len); }
     const std::string& getSourceText() const { return sourceText; }
     const std::map<std::string, std::string>& getIncludeText() const { return includeText; }
     void addIncludeText(const char* name, const char* text, size_t len) { includeText[name].assign(text,len); }


### PR DESCRIPTION
The source strings may or may not have a null terminator. We need to
make sure we add one before outputting the source strings as we iterate
over the c-str looking for the null terminator.