### PR TITLE
Work around a CMake cross-compilation issue

### DIFF
--- a/glslang/OSDependent/Unix/CMakeLists.txt
+++ b/glslang/OSDependent/Unix/CMakeLists.txt
@@ -4,10 +4,12 @@ set_property(TARGET OSDependent PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # Link pthread
 set(CMAKE_THREAD_PREFER_PTHREAD ON)
-if(${CMAKE_VERSION} VERSION_LESS "3.1.0")
+if(${CMAKE_VERSION} VERSION_LESS "3.1.0" OR CMAKE_CROSSCOMPILING)
     # Needed as long as we support CMake 2.8 for Ubuntu 14.04,
     # which does not support the recommended Threads::Threads target.
     # https://cmake.org/cmake/help/v2.8.12/cmake.html#module:FindThreads
+    # Also needed when cross-compiling to work around
+    # https://gitlab.kitware.com/cmake/cmake/issues/16920
     find_package(Threads)
     target_link_libraries(OSDependent ${CMAKE_THREAD_LIBS_INIT})
 else()


### PR DESCRIPTION
CMake can't correctly configure the latest code because of an issue with cross-compilation of pthreads:
https://gitlab.kitware.com/cmake/cmake/issues/16920