### PR TITLE
HLSL: Fix #1655; use "" for nullptr file names. 

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -3232,7 +3232,7 @@ spv::Id TGlslangToSpvTraverser::convertGlslangStructToSpvType(const glslang::TTy
     // Decorate it
     decorateStructType(type, glslangMembers, explicitLayout, qualifier, spvType);
 
-    for (int i = 0; i < deferredForwardPointers.size(); ++i) {
+    for (int i = 0; i < (int)deferredForwardPointers.size(); ++i) {
         auto it = deferredForwardPointers[i];
         convertGlslangToSpvType(*it.first, explicitLayout, it.second, false);
     }

--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -250,7 +250,8 @@ struct TSourceLoc {
             return nullptr;
         return name->c_str();
     }
-    TString* name; // descriptive name for this string
+    const char* getFilenameStr() const { return name == nullptr ? "" : name->c_str(); }
+    TString* name; // descriptive name for this string, when a textual name is available, otherwise nullptr
     int string;
     int line;
     int column;

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -5062,7 +5062,7 @@ void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publi
         if (! IsPow2(value))
             error(loc, "must be a power of 2", "buffer_reference_align", "");
         else
-            publicType.qualifier.layoutBufferReferenceAlign = std::log2(value);
+            publicType.qualifier.layoutBufferReferenceAlign = (unsigned int)std::log2(value);
         return;
     }
 

--- a/glslang/MachineIndependent/preprocessor/PpContext.h
+++ b/glslang/MachineIndependent/preprocessor/PpContext.h
@@ -549,9 +549,9 @@ protected:
               scanner.setLine(startLoc.line);
               scanner.setString(startLoc.string);
 
-              scanner.setFile(startLoc.name->c_str(), 0);
-              scanner.setFile(startLoc.name->c_str(), 1);
-              scanner.setFile(startLoc.name->c_str(), 2);
+              scanner.setFile(startLoc.getFilenameStr(), 0);
+              scanner.setFile(startLoc.getFilenameStr(), 1);
+              scanner.setFile(startLoc.getFilenameStr(), 2);
         }
 
         // tInput methods:

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -133,7 +133,7 @@ bool HlslParseContext::parseShaderStrings(TPpContext& ppContext, TInputScanner& 
         // Print a message formated such that if you click on the message it will take you right to
         // the line through most UIs.
         const glslang::TSourceLoc& sourceLoc = input.getSourceLoc();
-        infoSink.info << sourceLoc.name->c_str() << "(" << sourceLoc.line << "): error at column " << sourceLoc.column
+        infoSink.info << sourceLoc.getFilenameStr() << "(" << sourceLoc.line << "): error at column " << sourceLoc.column
                       << ", HLSL parsing failed.\n";
         ++numErrors;
         return false;


### PR DESCRIPTION
Needs test cases, but with file-based testing that might be hard to create in the current infrastructure.

