### PR TITLE
More precisely check for the qualifiers that enable the vulkan memory model for buffer references.

### DIFF
--- a/Test/baseResults/spv.bufferhandle13.frag.out
+++ b/Test/baseResults/spv.bufferhandle13.frag.out
@@ -4,13 +4,11 @@ spv.bufferhandle13.frag
 // Id's are bound by 58
 
                               Capability Shader
-                              Capability CapabilityVulkanMemoryModelKHR
                               Capability CapabilityPhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                               Extension  "SPV_KHR_storage_buffer_storage_class"
-                              Extension  "SPV_KHR_vulkan_memory_model"
                1:             ExtInstImport  "GLSL.std.450"
-                              MemoryModel PhysicalStorageBuffer64EXT VulkanKHR
+                              MemoryModel PhysicalStorageBuffer64EXT GLSL450
                               EntryPoint Fragment 4  "main"
                               ExecutionMode 4 OriginUpperLeft
                               Source GLSL 450

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -537,6 +537,11 @@ public:
     {
         return subgroupcoherent || workgroupcoherent || queuefamilycoherent || devicecoherent || coherent || volatil || restrict || readonly || writeonly;
     }
+    bool bufferReferenceNeedsVulkanMemoryModel() const
+    {
+        // include qualifiers that map to load/store availability/visibility/nonprivate memory access operands
+        return subgroupcoherent || workgroupcoherent || queuefamilycoherent || devicecoherent || coherent || nonprivate;
+    }
 
     bool isInterpolation() const
     {

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -355,7 +355,7 @@ TIntermTyped* TParseContext::handleVariable(const TSourceLoc& loc, TSymbol* symb
         intermediate.addIoAccessed(*string);
 
     if (variable->getType().getBasicType() == EbtReference &&
-        variable->getType().getQualifier().isMemory()) {
+        variable->getType().getQualifier().bufferReferenceNeedsVulkanMemoryModel()) {
         intermediate.setUseVulkanMemoryModel();
     }
 


### PR DESCRIPTION
Not all memory qualifiers necessarily need the vulkan memory model, e.g. volatile/restrict that correspond to core SPIR-V features do not.