### PR TITLE
Fix a few GN build issues.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -141,13 +141,38 @@ source_set("glslang_sources") {
 
   if (is_clang) {
     cflags_cc = [
-      "-Wno-implicit-fallthrough",
       "-Wno-ignored-qualifiers",
+      "-Wno-implicit-fallthrough",
+      "-Wno-sign-compare",
       "-Wno-unused-variable",
     ]
   }
 
   deps = [
     "${spirv_tools_dir}:spvtools_opt",
+  ]
+}
+
+source_set("glslang_default_resource_limits_sources") {
+  sources = [
+    "StandAlone/ResourceLimits.cpp",
+    "StandAlone/ResourceLimits.h",
+  ]
+  deps = [ ":glslang_sources" ]
+  public_configs = [ ":glslang_public" ]
+}
+
+source_set("glslang_validator") {
+  sources = [
+    "StandAlone/DirStackFileIncluder.h",
+    "StandAlone/StandAlone.cpp",
+  ]
+  if (!is_win) {
+    cflags = [ "-Woverflow" ]
+  }
+  defines = [ "ENABLE_OPT=0" ]
+  deps = [
+    ":glslang_default_resource_limits_sources",
+    ":glslang_sources",
   ]
 }


### PR DESCRIPTION
 * adds a source set for default resource limits to mirror CMake
 * adds a target executable for the standalone validator
 * fixes a missing warning

Allows ANGLE to use the integrated BUILD.gn instead of a custom one.

ANGLE bug: 3088

@johnkslang PTAL