### PR TITLE
Suppress a MSVC cast warning in GN.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -148,6 +148,11 @@ source_set("glslang_sources") {
       "-Wno-unused-variable",
     ]
   }
+  if (is_win && !is_clang) {
+    cflags = [
+      "/wd4018", # signed/unsigned mismatch
+    ]
+  }
 
   deps = [
     "${spirv_tools_dir}:spvtools_opt",


### PR DESCRIPTION
Also came up when using the BUILD.gn file with ANGLE.

ANGLE bug: 3088

@johnkslang PTAL