### PR TITLE
build: Do not cache debug library suffix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ if(ENABLE_HLSL)
 endif(ENABLE_HLSL)
 
 if(WIN32)
-    set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Adds a postfix for debug-built libraries.")
+    set(CMAKE_DEBUG_POSTFIX "d")
     if(MSVC)
         include(ChooseMSVCCRT.cmake)
     endif(MSVC)


### PR DESCRIPTION
For nested project builds, writing CMAKE_DEBUG_POSTFIX into the cache
ends up affecting other projects. Caching this value doesn't seem to be
required in practice, so this change removes the cache tag.