### PR TITLE
Disable Clang extra semicolon warning.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -141,6 +141,7 @@ source_set("glslang_sources") {
 
   if (is_clang) {
     cflags_cc = [
+      "-Wno-extra-semi",
       "-Wno-ignored-qualifiers",
       "-Wno-implicit-fallthrough",
       "-Wno-inconsistent-missing-override",


### PR DESCRIPTION
Usually this warning is disabled by default. But when turned on Clang
complains about extra semicolons in Glslang headers. Turn this off for
now. See http://crbug.com/926235

@johnkslang PTAL