### PR TITLE
Fix a couple of warnings clang found

### DIFF
--- a/SPIRV/SpvPostProcess.cpp
+++ b/SPIRV/SpvPostProcess.cpp
@@ -222,7 +222,7 @@ void Builder::postProcess(Instruction& inst)
                     Instruction *idx = module.getInstruction(accessChain->getIdOperand(i));
                     if (type->getOpCode() == OpTypeStruct) {
                         assert(idx->getOpCode() == OpConstant);
-                        int c = idx->getImmediateOperand(0);
+                        unsigned int c = idx->getImmediateOperand(0);
 
                         const auto function = [&](const std::unique_ptr<Instruction>& decoration) {
                             if (decoration.get()->getOpCode() == OpMemberDecorate &&

--- a/glslang/MachineIndependent/SymbolTable.cpp
+++ b/glslang/MachineIndependent/SymbolTable.cpp
@@ -297,7 +297,7 @@ TVariable::TVariable(const TVariable& copyOf) : TSymbol(copyOf)
     if (copyOf.getNumExtensions() > 0)
         setExtensions(copyOf.getNumExtensions(), copyOf.getExtensions());
     if (copyOf.hasMemberExtensions()) {
-        for (int m = 0; m < copyOf.type.getStruct()->size(); ++m) {
+        for (int m = 0; m < (int)copyOf.type.getStruct()->size(); ++m) {
             if (copyOf.getNumMemberExtensions(m) > 0)
                 setMemberExtensions(m, copyOf.getNumMemberExtensions(m), copyOf.getMemberExtensions(m));
         }

--- a/glslang/MachineIndependent/SymbolTable.h
+++ b/glslang/MachineIndependent/SymbolTable.h
@@ -345,20 +345,20 @@ protected:
 class TAnonMember : public TSymbol {
 public:
     TAnonMember(const TString* n, unsigned int m, TVariable& a, int an) : TSymbol(n), anonContainer(a), memberNumber(m), anonId(an) { }
-    virtual TAnonMember* clone() const;
+    virtual TAnonMember* clone() const override;
     virtual ~TAnonMember() { }
 
-    virtual const TAnonMember* getAsAnonMember() const { return this; }
+    virtual const TAnonMember* getAsAnonMember() const override { return this; }
     virtual const TVariable& getAnonContainer() const { return anonContainer; }
     virtual unsigned int getMemberNumber() const { return memberNumber; }
 
-    virtual const TType& getType() const
+    virtual const TType& getType() const override
     {
         const TTypeList& types = *anonContainer.getType().getStruct();
         return *types[memberNumber].type;
     }
 
-    virtual TType& getWritableType()
+    virtual TType& getWritableType() override
     {
         assert(writable);
         const TTypeList& types = *anonContainer.getType().getStruct();
@@ -373,7 +373,7 @@ public:
     virtual const char** getExtensions() const override { return anonContainer.getMemberExtensions(memberNumber); }
 
     virtual int getAnonId() const { return anonId; }
-    virtual void dump(TInfoSink &infoSink) const;
+    virtual void dump(TInfoSink &infoSink) const override;
 
 protected:
     explicit TAnonMember(const TAnonMember&);


### PR DESCRIPTION
Clang warns if an interface specifies override for some overridden functions, but leaves it out for others that do override:

```
glslang/MachineIndependent/SymbolTable.h:348:26: error: 'clone'
      overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
    virtual TAnonMember* clone() const;
                         ^
glslang/MachineIndependent/SymbolTable.h:88:22: note: overridden virtual
      function is here
    virtual TSymbol* clone() const = 0;
```

There are also a couple of cases of unsigned/signed integer comparisons that generate `-Wsign-compare`.