### PR TITLE
ParseHelper: don't assign xfb_offset for struct members

### DIFF
--- a/Test/baseResults/spv.xfbOffsetOnStructMembersAssignment.vert.out
+++ b/Test/baseResults/spv.xfbOffsetOnStructMembersAssignment.vert.out
@@ -27,16 +27,14 @@ spv.xfbOffsetOnStructMembersAssignment.vert
                               Name 34  ""
                               Name 38  "gl_VertexID"
                               Name 39  "gl_InstanceID"
-                              MemberDecorate 7(S) 0 Offset 16
-                              MemberDecorate 7(S) 1 Offset 20
                               Decorate 9(s1) Location 0
                               Decorate 9(s1) XfbBuffer 2
                               Decorate 9(s1) XfbStride 24
-                              MemberDecorate 19(S2) 0 Offset 8
-                              MemberDecorate 19(S2) 1 Offset 12
+                              Decorate 9(s1) Offset 16
                               Decorate 21(s2) Location 5
                               Decorate 21(s2) XfbBuffer 1
                               Decorate 21(s2) XfbStride 28
+                              Decorate 21(s2) Offset 8
                               MemberDecorate 32(gl_PerVertex) 0 BuiltIn Position
                               MemberDecorate 32(gl_PerVertex) 1 BuiltIn PointSize
                               MemberDecorate 32(gl_PerVertex) 2 BuiltIn ClipDistance

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -6235,11 +6235,6 @@ TIntermNode* TParseContext::declareVariable(const TSourceLoc& loc, TString& iden
     // fix up
     fixOffset(loc, *symbol);
 
-    if (symbol->getType().getBasicType() == EbtStruct) {
-       fixXfbOffsets(symbol->getWritableType().getQualifier(),
-                     *(symbol->getWritableType().getWritableStruct()));
-    }
-
     return initNode;
 }
 


### PR DESCRIPTION
This commit undoes the code on the commit "ParseHelper: assign
xfb_offset for struct members too" (commit
af8c1bdb161e4b2ddf019b61bdfca61f84cb1ca8), except the method renaming,
and updates the tests.

During the review of the implementation of Vulkan extension
VK_EXT_transform_feedback for the Linux Intel driver, it was pointed
that the Vulkan environment spec for SPIR-V only ever refers to block
or block members being decorated. It would be strange to not do the
same for OpenGL (ARB_gl_spirv). That would also fit better to what
GLSL does, where setting explicit xfb offsets for struct members is
not allowed.

FWIW, the original patch was proposed based on the fact that
ARB_gl_spirv is relying on OpenGL for how xfb offsets should be
assigned to members, and it was not clear (at least to me) which is
the responsible of such.