### PR TITLE
Switched to std::string for TReflection and TObjectReflection

### DIFF
--- a/glslang/MachineIndependent/reflection.cpp
+++ b/glslang/MachineIndependent/reflection.cpp
@@ -105,10 +105,10 @@ public:
             const TString &name = base.getName();
             const TType &type = base.getType();
 
-            TReflection::TNameToIndex::const_iterator it = reflection.nameToIndex.find(name);
+            TReflection::TNameToIndex::const_iterator it = reflection.nameToIndex.find(name.c_str());
             if (it == reflection.nameToIndex.end()) {
-                reflection.nameToIndex[name] = (int)reflection.indexToAttribute.size();
-                reflection.indexToAttribute.push_back(TObjectReflection(name, type, 0, mapToGlType(type), 0, 0));
+                reflection.nameToIndex[name.c_str()] = (int)reflection.indexToAttribute.size();
+                reflection.indexToAttribute.push_back(TObjectReflection(name.c_str(), type, 0, mapToGlType(type), 0, 0));
             }
         }
     }
@@ -327,10 +327,10 @@ public:
         if (arraySize == 0)
             arraySize = mapToGlArraySize(*terminalType);
 
-        TReflection::TNameToIndex::const_iterator it = reflection.nameToIndex.find(name);
+        TReflection::TNameToIndex::const_iterator it = reflection.nameToIndex.find(name.c_str());
         if (it == reflection.nameToIndex.end()) {
-            reflection.nameToIndex[name] = (int)reflection.indexToUniform.size();
-            reflection.indexToUniform.push_back(TObjectReflection(name, *terminalType, offset,
+            reflection.nameToIndex[name.c_str()] = (int)reflection.indexToUniform.size();
+            reflection.indexToUniform.push_back(TObjectReflection(name.c_str(), *terminalType, offset,
                                                                   mapToGlType(*terminalType),
                                                                   arraySize, blockIndex));
         } else if (arraySize > 1) {
@@ -430,11 +430,11 @@ public:
     int addBlockName(const TString& name, const TType& type, int size)
     {
         int blockIndex;
-        TReflection::TNameToIndex::const_iterator it = reflection.nameToIndex.find(name);
-        if (reflection.nameToIndex.find(name) == reflection.nameToIndex.end()) {
+        TReflection::TNameToIndex::const_iterator it = reflection.nameToIndex.find(name.c_str());
+        if (reflection.nameToIndex.find(name.c_str()) == reflection.nameToIndex.end()) {
             blockIndex = (int)reflection.indexToUniformBlock.size();
-            reflection.nameToIndex[name] = blockIndex;
-            reflection.indexToUniformBlock.push_back(TObjectReflection(name, type, -1, -1, size, -1));
+            reflection.nameToIndex[name.c_str()] = blockIndex;
+            reflection.indexToUniformBlock.push_back(TObjectReflection(name.c_str(), type, -1, -1, size, -1));
         } else
             blockIndex = it->second;
 
@@ -852,7 +852,7 @@ void TReflection::buildCounterIndices(const TIntermediate& intermediate)
 {
     // search for ones that have counters
     for (int i = 0; i < int(indexToUniformBlock.size()); ++i) {
-        const TString counterName(intermediate.addCounterBufferName(indexToUniformBlock[i].name));
+        const TString counterName(intermediate.addCounterBufferName(indexToUniformBlock[i].name).c_str());
         const int index = getIndex(counterName);
 
         if (index >= 0)

--- a/glslang/MachineIndependent/reflection.h
+++ b/glslang/MachineIndependent/reflection.h
@@ -55,7 +55,7 @@ class TReflectionTraverser;
 // Data needed for just a single object at the granularity exchanged by the reflection API
 class TObjectReflection {
 public:
-    TObjectReflection(const TString& pName, const TType& pType, int pOffset, int pGLDefineType, int pSize, int pIndex) :
+    TObjectReflection(const std::string& pName, const TType& pType, int pOffset, int pGLDefineType, int pSize, int pIndex) :
         name(pName), offset(pOffset),
         glDefineType(pGLDefineType), size(pSize), index(pIndex), counterIndex(-1), stages(EShLanguageMask(0)), type(pType.clone()) { }
 
@@ -78,7 +78,7 @@ public:
     }
     static TObjectReflection badReflection() { return TObjectReflection(); }
 
-    TString name;
+    std::string name;
     int offset;
     int glDefineType;
     int size;         // data size in bytes for a block, array size for a (non-block) object that's an array
@@ -163,7 +163,7 @@ protected:
     void buildAttributeReflection(EShLanguage, const TIntermediate&);
 
     // Need a TString hash: typedef std::unordered_map<TString, int> TNameToIndex;
-    typedef std::map<TString, int> TNameToIndex;
+    typedef std::map<std::string, int> TNameToIndex;
     typedef std::vector<TObjectReflection> TMapIndexToReflection;
 
     TObjectReflection badReflection; // return for queries of -1 or generally out of range; has expected descriptions with in it for this


### PR DESCRIPTION
In MSVC 2017 (Windows 10 SDK 10.0.17763.0) Debug mode when a reflection is deleted (when a shader goes out of scope) xutility will fail to orphan all due to the TString allocator implementation. 
By switching to std::string xutility no longer throws the error in debug mode.
![image](https://user-images.githubusercontent.com/4019937/52103506-958a1280-25ab-11e9-9380-054675f0379d.png)
