### PR TITLE
Fix treatment of array input/output variables in reflection

### DIFF
--- a/Test/baseResults/hlsl.automap.frag.out
+++ b/Test/baseResults/hlsl.automap.frag.out
@@ -32,5 +32,5 @@ Buffer block reflection:
 Pipeline input reflection:
 
 Pipeline output reflection:
-@entryPointOutput: offset 0, type 8b52, size 0, index 0, binding -1, stages 16
+@entryPointOutput: offset 0, type 8b52, size 1, index 0, binding -1, stages 16
 

--- a/Test/baseResults/hlsl.reflection.binding.frag.out
+++ b/Test/baseResults/hlsl.reflection.binding.frag.out
@@ -22,5 +22,5 @@ Buffer block reflection:
 Pipeline input reflection:
 
 Pipeline output reflection:
-psout.Color: offset 0, type 8b52, size 0, index 0, binding -1, stages 16
+psout.Color: offset 0, type 8b52, size 1, index 0, binding -1, stages 16
 

--- a/Test/baseResults/hlsl.reflection.vert.out
+++ b/Test/baseResults/hlsl.reflection.vert.out
@@ -72,11 +72,11 @@ Buffer variable reflection:
 Buffer block reflection:
 
 Pipeline input reflection:
-attributeFloat: offset 0, type 1406, size 0, index 0, binding -1, stages 1
-attributeFloat2: offset 0, type 8b50, size 0, index 0, binding -1, stages 1
-attributeFloat3: offset 0, type 8b51, size 0, index 0, binding -1, stages 1
-attributeFloat4: offset 0, type 8b52, size 0, index 0, binding -1, stages 1
-attributeMat4: offset 0, type 8b5c, size 0, index 0, binding -1, stages 1
+attributeFloat: offset 0, type 1406, size 1, index 0, binding -1, stages 1
+attributeFloat2: offset 0, type 8b50, size 1, index 0, binding -1, stages 1
+attributeFloat3: offset 0, type 8b51, size 1, index 0, binding -1, stages 1
+attributeFloat4: offset 0, type 8b52, size 1, index 0, binding -1, stages 1
+attributeMat4: offset 0, type 8b5c, size 1, index 0, binding -1, stages 1
 
 Pipeline output reflection:
 

--- a/Test/baseResults/hlsl.shift.per-set.frag.out
+++ b/Test/baseResults/hlsl.shift.per-set.frag.out
@@ -233,5 +233,5 @@ Buffer block reflection:
 Pipeline input reflection:
 
 Pipeline output reflection:
-@entryPointOutput: offset 0, type 8b52, size 0, index 0, binding -1, stages 16
+@entryPointOutput: offset 0, type 8b52, size 1, index 0, binding -1, stages 16
 

--- a/Test/baseResults/reflection.linked.out
+++ b/Test/baseResults/reflection.linked.out
@@ -13,8 +13,8 @@ Buffer variable reflection:
 Buffer block reflection:
 
 Pipeline input reflection:
-vertin: offset 0, type 1406, size 0, index 0, binding -1, stages 1
+vertin: offset 0, type 1406, size 1, index 0, binding -1, stages 1
 
 Pipeline output reflection:
-fragout: offset 0, type 1406, size 0, index 0, binding -1, stages 16
+fragout: offset 0, type 1406, size 1, index 0, binding -1, stages 16
 

--- a/Test/baseResults/reflection.options.vert.out
+++ b/Test/baseResults/reflection.options.vert.out
@@ -40,4 +40,5 @@ outval.val: offset 0, type 1406, size 1, index 0, binding -1, stages 1
 outval.a: offset 0, type 8b51, size 1, index 0, binding -1, stages 1
 outval.b[0]: offset 0, type 8b50, size 4, index 0, binding -1, stages 1
 outval.c: offset 0, type 8b5a, size 1, index 0, binding -1, stages 1
+outarr[0]: offset 0, type 1406, size 3, index 0, binding -1, stages 1
 

--- a/Test/baseResults/reflection.vert.out
+++ b/Test/baseResults/reflection.vert.out
@@ -151,12 +151,13 @@ Buffer variable reflection:
 Buffer block reflection:
 
 Pipeline input reflection:
-attributeFloat: offset 0, type 1406, size 0, index 0, binding -1, stages 1
-attributeFloat2: offset 0, type 8b50, size 0, index 0, binding -1, stages 1
-attributeFloat3: offset 0, type 8b51, size 0, index 0, binding -1, stages 1
-attributeFloat4: offset 0, type 8b52, size 0, index 0, binding -1, stages 1
-attributeMat4: offset 0, type 8b5c, size 0, index 0, binding -1, stages 1
-gl_InstanceID: offset 0, type 1404, size 0, index 0, binding -1, stages 1
+attributeFloat: offset 0, type 1406, size 1, index 0, binding -1, stages 1
+attributeFloat2: offset 0, type 8b50, size 1, index 0, binding -1, stages 1
+attributeFloat3: offset 0, type 8b51, size 1, index 0, binding -1, stages 1
+attributeFloat4: offset 0, type 8b52, size 1, index 0, binding -1, stages 1
+attributeMat4: offset 0, type 8b5c, size 1, index 0, binding -1, stages 1
+attributeFloatArray: offset 0, type 1406, size 3, index 0, binding -1, stages 1
+gl_InstanceID: offset 0, type 1404, size 1, index 0, binding -1, stages 1
 
 Pipeline output reflection:
 

--- a/Test/reflection.options.vert
+++ b/Test/reflection.options.vert
@@ -34,6 +34,7 @@ struct OutputStruct {
 };
 
 out OutputStruct outval;
+out float outarr[3];
 
 void main()
 {
@@ -48,4 +49,5 @@ void main()
     f += ubo.flt[gl_InstanceID];
     TriangleInfo tlocal[5] = t;
     outval.val = f;
+    outarr[2] = f;
 }

--- a/Test/reflection.vert
+++ b/Test/reflection.vert
@@ -107,6 +107,7 @@ layout(location = 2) in vec2 attributeFloat2;
 in vec3 attributeFloat3;
 in vec4 attributeFloat4;
 in mat4 attributeMat4;
+in float attributeFloatArray[3];
 
 uniform deep3 deepA[2], deepB[2], deepC[3], deepD[2];
 
@@ -223,6 +224,7 @@ void main()
     f += attributeFloat3.x;
     f += attributeFloat4.x;
     f += attributeMat4[0][1];
+    f += attributeFloatArray[2];
     f += buf1i.runtimeArray[3];
     f += buf2i.runtimeArray[3].c;
     f += buf3i.runtimeArray[gl_InstanceID];

--- a/glslang/MachineIndependent/reflection.cpp
+++ b/glslang/MachineIndependent/reflection.cpp
@@ -121,7 +121,7 @@ public:
                 }
 
                 // by convention if this is an arrayed block we ignore the array in the reflection
-                if (type.isArray()) {
+                if (type.isArray() && type.getBasicType() == EbtBlock) {
                     blowUpIOAggregate(input, baseName, TType(type, 0));
                 } else {               
                     blowUpIOAggregate(input, baseName, type);
@@ -130,7 +130,8 @@ public:
                 TReflection::TNameToIndex::const_iterator it = reflection.nameToIndex.find(name.c_str());
                 if (it == reflection.nameToIndex.end()) {
                     reflection.nameToIndex[name.c_str()] = (int)ioItems.size();
-                    ioItems.push_back(TObjectReflection(name.c_str(), type, 0, mapToGlType(type), 0, 0));
+                    ioItems.push_back(
+                        TObjectReflection(name.c_str(), type, 0, mapToGlType(type), mapToGlArraySize(type), 0));
 
                     EShLanguageMask& stages = ioItems.back().stages;
                     stages = static_cast<EShLanguageMask>(stages | 1 << intermediate.getStage());


### PR DESCRIPTION
Minor fix I found while fleshing out my own tests - plain array variables should not have their root array skipped, only blocks.

I've also adjusted the output so that the array size is passed through even when we're not exploding I/O variables.