### PR TITLE
Allocate empty function name in the string pool.

### DIFF
--- a/glslang/MachineIndependent/glslang.y
+++ b/glslang/MachineIndependent/glslang.y
@@ -473,8 +473,8 @@ function_identifier
 
         if ($$.function == 0) {
             // error recover
-            TString empty("");
-            $$.function = new TFunction(&empty, TType(EbtVoid), EOpNull);
+            TString* empty = NewPoolTString("");
+            $$.function = new TFunction(empty, TType(EbtVoid), EOpNull);
         }
     }
     | non_uniform_qualifier {

--- a/glslang/MachineIndependent/glslang_tab.cpp
+++ b/glslang/MachineIndependent/glslang_tab.cpp
@@ -4447,8 +4447,8 @@ yyreduce:
 
         if ((yyval.interm).function == 0) {
             // error recover
-            TString empty("");
-            (yyval.interm).function = new TFunction(&empty, TType(EbtVoid), EOpNull);
+            TString* empty = NewPoolTString("");
+            (yyval.interm).function = new TFunction(empty, TType(EbtVoid), EOpNull);
         }
     }
 #line 4455 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */


### PR DESCRIPTION
Inside the grammar for function_identifier if the .function is null an
empty function name is allocated. This is allocated on the stack and
passed into TFunction as a pointer. TFunction just stores that pointer.

Later, when we access the name we will receive an invalid usage of a
stack allocated variable. This CL switches to using NewPoolTStringn for
the empty function name.