### PR TITLE
Fixup leak of TString

### DIFF
--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -4607,7 +4607,7 @@ void HlslParseContext::decomposeIntrinsic(const TSourceLoc& loc, TIntermTyped*& 
         if (nullptr == symbol) {
             type.getQualifier().builtIn = builtin;
 
-            TVariable* variable = new TVariable(new TString(name), type);
+            TVariable* variable = new TVariable(NewPoolTString(name), type);
 
             symbolTable.insert(*variable);
 


### PR DESCRIPTION
In decomposeIntrinsic a new TString was being allocated and passed into
a TVariable. That string was leaking. This CL converts the new TString
to call NewPoolTString to allocate from the TString pool.