### PR TITLE
Fix type recursion with EOpIndexIndirect dereferences

### DIFF
--- a/Test/baseResults/reflection.options.vert.out
+++ b/Test/baseResults/reflection.options.vert.out
@@ -6,9 +6,33 @@ UBO.verts[1].position[0]: offset 24, type 1406, size 3, index 0, binding -1, sta
 UBO.verts[1].normal[0]: offset 36, type 1406, size 3, index 0, binding -1, stages 0, arrayStride 4, topLevelArrayStride 24
 UBO.flt[0]: offset 48, type 1406, size 8, index 0, binding -1, stages 1, arrayStride 4, topLevelArrayStride 4
 UBO.unused: offset 80, type 8dc8, size 1, index 0, binding -1, stages 0
+UBO.uniform_multi[0][0][0]: offset 96, type 1406, size 2, index 0, binding -1, stages 1, arrayStride 4, topLevelArrayStride 24
+UBO.uniform_multi[0][1][0]: offset 104, type 1406, size 2, index 0, binding -1, stages 0, arrayStride 4, topLevelArrayStride 24
+UBO.uniform_multi[0][2][0]: offset 112, type 1406, size 2, index 0, binding -1, stages 0, arrayStride 4, topLevelArrayStride 24
+UBO.uniform_multi[1][0][0]: offset 120, type 1406, size 2, index 0, binding -1, stages 0, arrayStride 4, topLevelArrayStride 24
+UBO.uniform_multi[1][1][0]: offset 128, type 1406, size 2, index 0, binding -1, stages 0, arrayStride 4, topLevelArrayStride 24
+UBO.uniform_multi[1][2][0]: offset 136, type 1406, size 2, index 0, binding -1, stages 0, arrayStride 4, topLevelArrayStride 24
+UBO.uniform_multi[2][0][0]: offset 144, type 1406, size 2, index 0, binding -1, stages 0, arrayStride 4, topLevelArrayStride 24
+UBO.uniform_multi[2][1][0]: offset 152, type 1406, size 2, index 0, binding -1, stages 0, arrayStride 4, topLevelArrayStride 24
+UBO.uniform_multi[2][2][0]: offset 160, type 1406, size 2, index 0, binding -1, stages 0, arrayStride 4, topLevelArrayStride 24
+UBO.uniform_multi[3][0][0]: offset 168, type 1406, size 2, index 0, binding -1, stages 0, arrayStride 4, topLevelArrayStride 24
+UBO.uniform_multi[3][1][0]: offset 176, type 1406, size 2, index 0, binding -1, stages 0, arrayStride 4, topLevelArrayStride 24
+UBO.uniform_multi[3][2][0]: offset 184, type 1406, size 2, index 0, binding -1, stages 0, arrayStride 4, topLevelArrayStride 24
+uniform_multi[0][0][0]: offset -1, type 1406, size 2, index -1, binding -1, stages 1, arrayStride 4, topLevelArrayStride 24
+uniform_multi[0][1][0]: offset -1, type 1406, size 2, index -1, binding -1, stages 1, arrayStride 4, topLevelArrayStride 24
+uniform_multi[0][2][0]: offset -1, type 1406, size 2, index -1, binding -1, stages 1, arrayStride 4, topLevelArrayStride 24
+uniform_multi[1][0][0]: offset -1, type 1406, size 2, index -1, binding -1, stages 1, arrayStride 4, topLevelArrayStride 24
+uniform_multi[1][1][0]: offset -1, type 1406, size 2, index -1, binding -1, stages 1, arrayStride 4, topLevelArrayStride 24
+uniform_multi[1][2][0]: offset -1, type 1406, size 2, index -1, binding -1, stages 1, arrayStride 4, topLevelArrayStride 24
+uniform_multi[2][0][0]: offset -1, type 1406, size 2, index -1, binding -1, stages 1, arrayStride 4, topLevelArrayStride 24
+uniform_multi[2][1][0]: offset -1, type 1406, size 2, index -1, binding -1, stages 1, arrayStride 4, topLevelArrayStride 24
+uniform_multi[2][2][0]: offset -1, type 1406, size 2, index -1, binding -1, stages 1, arrayStride 4, topLevelArrayStride 24
+uniform_multi[3][0][0]: offset -1, type 1406, size 2, index -1, binding -1, stages 1, arrayStride 4, topLevelArrayStride 24
+uniform_multi[3][1][0]: offset -1, type 1406, size 2, index -1, binding -1, stages 1, arrayStride 4, topLevelArrayStride 24
+uniform_multi[3][2][0]: offset -1, type 1406, size 2, index -1, binding -1, stages 1, arrayStride 4, topLevelArrayStride 24
 
 Uniform block reflection:
-UBO: offset -1, type ffffffff, size 96, index -1, binding -1, stages 1, numMembers 6
+UBO: offset -1, type ffffffff, size 192, index -1, binding -1, stages 1, numMembers 7
 
 Buffer variable reflection:
 t[0].v[0].position[0]: offset 0, type 1406, size 3, index 0, binding -1, stages 1, arrayStride 4, topLevelArrayStride 72

--- a/Test/baseResults/reflection.vert.out
+++ b/Test/baseResults/reflection.vert.out
@@ -25,8 +25,8 @@ nested.foo.n1.a: offset 0, type 1406, size 1, index 3, binding -1, stages 1
 nested.foo.n2.b: offset 16, type 1406, size 1, index 3, binding -1, stages 1
 nested.foo.n2.c: offset 20, type 1406, size 1, index 3, binding -1, stages 1
 nested.foo.n2.d: offset 24, type 1406, size 1, index 3, binding -1, stages 1
-deepA[0].d2.d1[2].va: offset -1, type 8b50, size 2, index -1, binding -1, stages 1, arrayStride 8, topLevelArrayStride 176
-deepA[1].d2.d1[2].va: offset -1, type 8b50, size 2, index -1, binding -1, stages 1, arrayStride 8, topLevelArrayStride 176
+deepA[0].d2.d1[2].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1, arrayStride 8, topLevelArrayStride 176
+deepA[1].d2.d1[2].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1, arrayStride 8, topLevelArrayStride 176
 deepB[1].d2.d1[0].va: offset -1, type 8b50, size 2, index -1, binding -1, stages 1, arrayStride 8, topLevelArrayStride 176
 deepB[1].d2.d1[1].va: offset -1, type 8b50, size 2, index -1, binding -1, stages 1, arrayStride 8, topLevelArrayStride 176
 deepB[1].d2.d1[2].va: offset -1, type 8b50, size 2, index -1, binding -1, stages 1, arrayStride 8, topLevelArrayStride 176
@@ -68,6 +68,20 @@ deepD[1].d2.d1[2].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 
 deepD[1].d2.d1[3].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1, arrayStride 8, topLevelArrayStride 8
 deepD[1].d2.d1[3].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1
 deepD[1].v3: offset -1, type 8b54, size 1, index -1, binding -1, stages 1
+deepA[0].d2.d1[0].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1, arrayStride 8, topLevelArrayStride 176
+deepA[0].d2.d1[0].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1, topLevelArrayStride 176
+deepA[0].d2.d1[1].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1, arrayStride 8, topLevelArrayStride 176
+deepA[0].d2.d1[1].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1, topLevelArrayStride 176
+deepA[0].d2.d1[2].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1, topLevelArrayStride 176
+deepA[0].d2.d1[3].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1, arrayStride 8, topLevelArrayStride 176
+deepA[0].d2.d1[3].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1, topLevelArrayStride 176
+deepA[1].d2.d1[0].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1, arrayStride 8, topLevelArrayStride 176
+deepA[1].d2.d1[0].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1, topLevelArrayStride 176
+deepA[1].d2.d1[1].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1, arrayStride 8, topLevelArrayStride 176
+deepA[1].d2.d1[1].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1, topLevelArrayStride 176
+deepA[1].d2.d1[2].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1, topLevelArrayStride 176
+deepA[1].d2.d1[3].va: offset -1, type 8b50, size 3, index -1, binding -1, stages 1, arrayStride 8, topLevelArrayStride 176
+deepA[1].d2.d1[3].b: offset -1, type 8b56, size 1, index -1, binding -1, stages 1, topLevelArrayStride 176
 abl.foo: offset 0, type 1406, size 1, index 7, binding -1, stages 1
 abl2.foo: offset 0, type 1406, size 1, index 11, binding -1, stages 1
 buf1.runtimeArray: offset 4, type 1406, size 4, index 12, binding -1, stages 1, arrayStride 4, topLevelArrayStride 4

--- a/Test/reflection.options.vert
+++ b/Test/reflection.options.vert
@@ -24,7 +24,10 @@ uniform UBO {
     VertexInfo verts[2];
     float flt[8];
     uvec4 unused;
+    float uniform_multi[4][3][2];
 } ubo;
+
+uniform float uniform_multi[4][3][2];
 
 struct OutputStruct {
     float val;
@@ -47,6 +50,8 @@ void main()
     f += multiarray.f[gl_InstanceID];
     f += ubo.verts[gl_InstanceID].position[0];
     f += ubo.flt[gl_InstanceID];
+    f += ubo.uniform_multi[0][0][0];
+    f += uniform_multi[gl_InstanceID][gl_InstanceID][gl_InstanceID];
     TriangleInfo tlocal[5] = t;
     outval.val = f;
     outarr[2] = f;

--- a/Test/reflection.vert
+++ b/Test/reflection.vert
@@ -213,6 +213,7 @@ void main()
         f += deepB[i].d2.d1[i].va[1].x;
         deep3 d = deepC[1];
         deep3 da[2] = deepD;
+        deep1 db = deepA[i].d2.d1[i];
     } else
         f = ufDead3;
 

--- a/glslang/MachineIndependent/reflection.cpp
+++ b/glslang/MachineIndependent/reflection.cpp
@@ -317,8 +317,7 @@ public:
                         newBaseName.append(TString("[") + String(i) + "]");
                     TList<TIntermBinary*>::const_iterator nextDeref = deref;
                     ++nextDeref;
-                    TType derefType(*terminalType, 0);
-                    blowUpActiveAggregate(derefType, newBaseName, derefs, nextDeref, offset, blockIndex, arraySize,
+                    blowUpActiveAggregate(*terminalType, newBaseName, derefs, nextDeref, offset, blockIndex, arraySize,
                                           topLevelArrayStride, baseStorage, active);
 
                     if (offset >= 0)
@@ -705,7 +704,7 @@ public:
     // Are we at a level in a dereference chain at which individual active uniform queries are made?
     bool isReflectionGranularity(const TType& type)
     {
-        return type.getBasicType() != EbtBlock && type.getBasicType() != EbtStruct;
+        return type.getBasicType() != EbtBlock && type.getBasicType() != EbtStruct && !type.isArrayOfArrays();
     }
 
     // For a binary operation indexing into an aggregate, chase down the base of the aggregate.


### PR DESCRIPTION
I found this because I changed `isReflectionGranularity` to correctly count arrays-of-arrays as not yet fully reflected, however it can happen in specific other cases with arrays-of-structs (as I've added a test for).

In `blowUpActiveAggregate` when walking the list of dereferences in reflection to determine what active uniforms to reflect, the `terminalType` starts at the passed in `baseType` and then is updated with `visitNode->getType()` for each index. This means the dereference from the indirection is already accounted for. For direct indexes the type doesn't change, all that happens is the `offset` and `name` are adjusted to account for the index. For an indirect indexing into an array we go wide and recurse for the remaining dereferences over each possible index that could be.

The problem is that when we do this recursion, there's an incorrect extra dereference `TType derefType(*terminalType, 0);` before recursing, even though `visitNode->getType()` has already accounted for it. On multi-dimensional arrays this means one level is skipped, for arrays-of-structs it can mean we accidentally step into the first child instead of ending up at the struct.

Most of the time this doesn't cause problems, because if we continue to walk a list of dereferences the problem is hidden/corrected by the subsequent `visitNode->getType()` getting things back on track. However if the _last_ dereference is `EOpIndexIndirect` then the recursive call will have `baseType` be wrong for the rest of the processing down to reflection granularity.

This is easiest to see with multi-dimensional arrays, but you can also reflect this shader:

```
#version 440 core
struct foo {
    float a;
    vec2 b;
};
struct bar {
    foo x[4];
};
uniform bar root;
void main() {
    foo tmp = root.x[gl_InstanceID];
}
```

And without this PR you will get reflection such as this:

```
Uniform reflection:
root.x[0]: offset -1, type 1406, size 1, index -1, binding -1, stages 1, topLevelArrayStride 16
root.x[1]: offset -1, type 1406, size 1, index -1, binding -1, stages 1, topLevelArrayStride 16
root.x[2]: offset -1, type 1406, size 1, index -1, binding -1, stages 1, topLevelArrayStride 16
root.x[3]: offset -1, type 1406, size 1, index -1, binding -1, stages 1, topLevelArrayStride 16
```

Because the extra dereference has already stepped into the first float child of the `struct foo`, before we decide to process the struct copy itself. With this change, we get more correctly:

```
Uniform reflection:
root.x[0].a: offset -1, type 1406, size 1, index -1, binding -1, stages 1, topLevelArrayStride 16
root.x[0].b: offset -1, type 8b50, size 1, index -1, binding -1, stages 1, topLevelArrayStride 16
root.x[1].a: offset -1, type 1406, size 1, index -1, binding -1, stages 1, topLevelArrayStride 16
root.x[1].b: offset -1, type 8b50, size 1, index -1, binding -1, stages 1, topLevelArrayStride 16
root.x[2].a: offset -1, type 1406, size 1, index -1, binding -1, stages 1, topLevelArrayStride 16
root.x[2].b: offset -1, type 8b50, size 1, index -1, binding -1, stages 1, topLevelArrayStride 16
root.x[3].a: offset -1, type 1406, size 1, index -1, binding -1, stages 1, topLevelArrayStride 16
root.x[3].b: offset -1, type 8b50, size 1, index -1, binding -1, stages 1, topLevelArrayStride 16
```

The test change in `reflection.vert` exercises this aspect, where the test change in `reflection.options.vert` tests the multi-dimensional array case.