### PR TITLE
Fix NV_EXTENSIONS-disabled build

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -49,9 +49,7 @@ namespace spv {
 #ifdef AMD_EXTENSIONS
     #include "GLSL.ext.AMD.h"
 #endif
-#ifdef NV_EXTENSIONS
     #include "GLSL.ext.NV.h"
-#endif
 }
 
 // Glslang includes


### PR DESCRIPTION
This fixes the build for #1712. I didn't want to add dozens of new ifdefs around all the cooperative matrix code, and it didn't really make sense to move the string to another file, so this seemed like the most straightforward fix (and is in the direction of eventually removing all these ifdefs).
