### PR TITLE
Move getBufferReferenceAlignment to be a method of TType

### DIFF
--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -2188,6 +2188,16 @@ public:
         return ! operator==(right);
     }
 
+    unsigned int getBufferReferenceAlignment() const
+    {
+        if (getBasicType() == glslang::EbtReference) {
+            return getReferentType()->getQualifier().hasBufferReferenceAlign() ?
+                        (1u << getReferentType()->getQualifier().layoutBufferReferenceAlign) : 16u;
+        } else {
+            return 0;
+        }
+    }
+
 protected:
     // Require consumer to pick between deep copy and shallow copy.
     TType(const TType& type);


### PR DESCRIPTION
This is a better place for it logically, since it is not specific to
glsl->spirv translation. And in a future change I want to use it outside
of glslangtospv.