### PR TITLE
GN: Make glslang_validator an executable.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -169,7 +169,7 @@ source_set("glslang_default_resource_limits_sources") {
   public_configs = [ ":glslang_public" ]
 }
 
-source_set("glslang_validator") {
+executable("glslang_validator") {
   sources = [
     "StandAlone/DirStackFileIncluder.h",
     "StandAlone/StandAlone.cpp",


### PR DESCRIPTION
The target was accidentally listed as a source_set.

@johnkslang PTAL