### PR TITLE
Fix tessellation control shader bounding box support.

### DIFF
--- a/Test/310.tesc
+++ b/Test/310.tesc
@@ -128,6 +128,21 @@ void goodfoop()
     d = fma(d, d, d);
 }
 
+void bbextBad()
+{
+    gl_BoundingBoxEXT;  // ERROR without GL_EXT_primitive_bounding_box
+    gl_BoundingBox;  // ERROR, version < 320
+}
+
+#extension GL_EXT_primitive_bounding_box : enable
+
+void bbext()
+{
+    gl_BoundingBoxEXT[0] = vec4(0.0);
+    gl_BoundingBoxEXT[1] = vec4(1.0);
+    gl_BoundingBoxEXT[2] = vec4(2.0);  // ERROR, overflow
+}
+
 void bbBad()
 {
     gl_BoundingBoxOES;  // ERROR without GL_OES_primitive_bounding_box 

--- a/Test/320.tesc
+++ b/Test/320.tesc
@@ -118,9 +118,10 @@ void goodfoop()
 
 void bb()
 {
+    gl_BoundingBoxEXT[0] = vec4(0.0);
     gl_BoundingBoxOES[0] = vec4(0.0);
-    gl_BoundingBoxOES[1] = vec4(1.0);
-    gl_BoundingBoxOES[2] = vec4(2.0);  // ERROR, overflow
+    gl_BoundingBox[1] = vec4(1.0);
+    gl_BoundingBox[2] = vec4(2.0);  // ERROR, overflow
 }
 
 out patch badpatchBName {  // ERROR, array size required

--- a/Test/320.tesc
+++ b/Test/320.tesc
@@ -118,10 +118,20 @@ void goodfoop()
 
 void bb()
 {
-    gl_BoundingBoxEXT[0] = vec4(0.0);
-    gl_BoundingBoxOES[0] = vec4(0.0);
+    gl_BoundingBoxEXT[0] = vec4(0.0); // ERROR without GL_EXT_primitive_bounding_box 
+    gl_BoundingBoxOES[0] = vec4(0.0); // ERROR without GL_OES_primitive_bounding_box 
+    gl_BoundingBox[0] = vec4(1.0);
     gl_BoundingBox[1] = vec4(1.0);
     gl_BoundingBox[2] = vec4(2.0);  // ERROR, overflow
+}
+
+#extension GL_EXT_primitive_bounding_box : enable
+#extension GL_OES_primitive_bounding_box : enable
+
+void bbext()
+{
+    gl_BoundingBoxEXT[1] = vec4(0.0);
+    gl_BoundingBoxOES[1] = vec4(0.0);
 }
 
 out patch badpatchBName {  // ERROR, array size required

--- a/Test/baseResults/310.tesc.out
+++ b/Test/baseResults/310.tesc.out
@@ -37,19 +37,21 @@ GL_OES_gpu_shader5
 ERROR: 0:104: 'sample' : Reserved word. 
 ERROR: 0:106: 'vertices' : can only apply to a standalone qualifier 
 ERROR: 0:107: 'vertices' : inconsistent output number of vertices for array size of misSized
-ERROR: 0:133: 'gl_BoundingBoxOES' : required extension not requested: Possible extensions include:
-GL_EXT_primitive_bounding_box
-GL_OES_primitive_bounding_box
-ERROR: 0:142: '[' :  array index out of range '2'
-ERROR: 0:145: '' : array size required 
-ERROR: 0:161: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
-ERROR: 0:162: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
-ERROR: 0:165: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
-ERROR: 38 compilation errors.  No code generated.
+ERROR: 0:133: 'gl_BoundingBoxEXT' : required extension not requested: GL_EXT_primitive_bounding_box
+ERROR: 0:134: 'gl_BoundingBox' : undeclared identifier 
+ERROR: 0:143: '[' :  array index out of range '2'
+ERROR: 0:148: 'gl_BoundingBoxOES' : required extension not requested: GL_OES_primitive_bounding_box
+ERROR: 0:157: '[' :  array index out of range '2'
+ERROR: 0:160: '' : array size required 
+ERROR: 0:176: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
+ERROR: 0:177: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
+ERROR: 0:180: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
+ERROR: 41 compilation errors.  No code generated.
 
 
 Shader version: 310
 Requested GL_ARB_separate_shader_objects
+Requested GL_EXT_primitive_bounding_box
 Requested GL_OES_gpu_shader5
 Requested GL_OES_primitive_bounding_box
 Requested GL_OES_shader_io_blocks
@@ -241,113 +243,151 @@ ERROR: node is still EOpNull!
 0:128          'd' ( noContraction temp highp float)
 0:128          'd' ( noContraction temp highp float)
 0:128          'd' ( noContraction temp highp float)
-0:131  Function Definition: bbBad( ( global void)
+0:131  Function Definition: bbextBad( ( global void)
 0:131    Function Parameters: 
 0:133    Sequence
-0:133      'gl_BoundingBoxOES' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
-0:138  Function Definition: bb( ( global void)
-0:138    Function Parameters: 
-0:140    Sequence
-0:140      move second child to first child ( temp highp 4-component vector of float)
-0:140        direct index ( patch temp highp 4-component vector of float BoundingBox)
-0:140          'gl_BoundingBoxOES' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
-0:140          Constant:
-0:140            0 (const int)
-0:140        Constant:
-0:140          0.000000
-0:140          0.000000
-0:140          0.000000
-0:140          0.000000
+0:133      'gl_BoundingBoxEXT' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
+0:134      'gl_BoundingBox' ( temp float)
+0:139  Function Definition: bbext( ( global void)
+0:139    Function Parameters: 
+0:141    Sequence
 0:141      move second child to first child ( temp highp 4-component vector of float)
 0:141        direct index ( patch temp highp 4-component vector of float BoundingBox)
-0:141          'gl_BoundingBoxOES' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
+0:141          'gl_BoundingBoxEXT' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
 0:141          Constant:
-0:141            1 (const int)
+0:141            0 (const int)
 0:141        Constant:
-0:141          1.000000
-0:141          1.000000
-0:141          1.000000
-0:141          1.000000
+0:141          0.000000
+0:141          0.000000
+0:141          0.000000
+0:141          0.000000
 0:142      move second child to first child ( temp highp 4-component vector of float)
 0:142        direct index ( patch temp highp 4-component vector of float BoundingBox)
-0:142          'gl_BoundingBoxOES' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
+0:142          'gl_BoundingBoxEXT' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
 0:142          Constant:
-0:142            2 (const int)
+0:142            1 (const int)
 0:142        Constant:
-0:142          2.000000
-0:142          2.000000
-0:142          2.000000
-0:142          2.000000
-0:153  Function Definition: outputtingOutparam(i1; ( global void)
+0:142          1.000000
+0:142          1.000000
+0:142          1.000000
+0:142          1.000000
+0:143      move second child to first child ( temp highp 4-component vector of float)
+0:143        direct index ( patch temp highp 4-component vector of float BoundingBox)
+0:143          'gl_BoundingBoxEXT' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
+0:143          Constant:
+0:143            2 (const int)
+0:143        Constant:
+0:143          2.000000
+0:143          2.000000
+0:143          2.000000
+0:143          2.000000
+0:146  Function Definition: bbBad( ( global void)
+0:146    Function Parameters: 
+0:148    Sequence
+0:148      'gl_BoundingBoxOES' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
+0:153  Function Definition: bb( ( global void)
 0:153    Function Parameters: 
-0:153      'a' ( out highp int)
 0:155    Sequence
-0:155      move second child to first child ( temp highp int)
-0:155        'a' ( out highp int)
+0:155      move second child to first child ( temp highp 4-component vector of float)
+0:155        direct index ( patch temp highp 4-component vector of float BoundingBox)
+0:155          'gl_BoundingBoxOES' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
+0:155          Constant:
+0:155            0 (const int)
 0:155        Constant:
-0:155          2 (const int)
-0:158  Function Definition: outputting( ( global void)
-0:158    Function Parameters: 
-0:160    Sequence
-0:160      move second child to first child ( temp highp int)
-0:160        indirect index ( temp highp int)
-0:160          'outa' ( out 4-element array of highp int)
-0:160          'gl_InvocationID' ( in highp int InvocationID)
-0:160        Constant:
-0:160          2 (const int)
-0:161      move second child to first child ( temp highp int)
-0:161        direct index ( temp highp int)
-0:161          'outa' ( out 4-element array of highp int)
-0:161          Constant:
-0:161            1 (const int)
-0:161        Constant:
-0:161          2 (const int)
-0:162      move second child to first child ( temp highp 4-component vector of float)
-0:162        gl_Position: direct index for structure ( out highp 4-component vector of float Position)
-0:162          direct index ( temp block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
-0:162            'gl_out' ( out 4-element array of block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
-0:162            Constant:
-0:162              0 (const int)
-0:162          Constant:
-0:162            0 (const int)
-0:162        Constant:
-0:162          1.000000
-0:162          1.000000
-0:162          1.000000
-0:162          1.000000
-0:163      direct index ( temp highp int)
-0:163        'outa' ( out 4-element array of highp int)
-0:163        Constant:
-0:163          1 (const int)
-0:164      direct index ( temp block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
-0:164        'gl_out' ( out 4-element array of block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
-0:164        Constant:
-0:164          0 (const int)
-0:165      Function Call: outputtingOutparam(i1; ( global void)
-0:165        direct index ( temp highp int)
-0:165          'outa' ( out 4-element array of highp int)
-0:165          Constant:
-0:165            0 (const int)
-0:166      Function Call: outputtingOutparam(i1; ( global void)
-0:166        indirect index ( temp highp int)
-0:166          'outa' ( out 4-element array of highp int)
-0:166          'gl_InvocationID' ( in highp int InvocationID)
-0:167      move second child to first child ( temp highp float)
-0:167        f: direct index for structure ( out highp float)
-0:167          direct index ( patch temp block{ out highp float f})
-0:167            'patchIName' ( patch out 4-element array of block{ out highp float f})
-0:167            Constant:
-0:167              1 (const int)
-0:167          Constant:
-0:167            0 (const int)
-0:167        Constant:
-0:167          3.140000
-0:168      move second child to first child ( temp highp int)
-0:168        indirect index ( temp highp int)
-0:168          'outa' ( out 4-element array of highp int)
-0:168          'gl_InvocationID' ( in highp int InvocationID)
-0:168        Constant:
-0:168          2 (const int)
+0:155          0.000000
+0:155          0.000000
+0:155          0.000000
+0:155          0.000000
+0:156      move second child to first child ( temp highp 4-component vector of float)
+0:156        direct index ( patch temp highp 4-component vector of float BoundingBox)
+0:156          'gl_BoundingBoxOES' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
+0:156          Constant:
+0:156            1 (const int)
+0:156        Constant:
+0:156          1.000000
+0:156          1.000000
+0:156          1.000000
+0:156          1.000000
+0:157      move second child to first child ( temp highp 4-component vector of float)
+0:157        direct index ( patch temp highp 4-component vector of float BoundingBox)
+0:157          'gl_BoundingBoxOES' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
+0:157          Constant:
+0:157            2 (const int)
+0:157        Constant:
+0:157          2.000000
+0:157          2.000000
+0:157          2.000000
+0:157          2.000000
+0:168  Function Definition: outputtingOutparam(i1; ( global void)
+0:168    Function Parameters: 
+0:168      'a' ( out highp int)
+0:170    Sequence
+0:170      move second child to first child ( temp highp int)
+0:170        'a' ( out highp int)
+0:170        Constant:
+0:170          2 (const int)
+0:173  Function Definition: outputting( ( global void)
+0:173    Function Parameters: 
+0:175    Sequence
+0:175      move second child to first child ( temp highp int)
+0:175        indirect index ( temp highp int)
+0:175          'outa' ( out 4-element array of highp int)
+0:175          'gl_InvocationID' ( in highp int InvocationID)
+0:175        Constant:
+0:175          2 (const int)
+0:176      move second child to first child ( temp highp int)
+0:176        direct index ( temp highp int)
+0:176          'outa' ( out 4-element array of highp int)
+0:176          Constant:
+0:176            1 (const int)
+0:176        Constant:
+0:176          2 (const int)
+0:177      move second child to first child ( temp highp 4-component vector of float)
+0:177        gl_Position: direct index for structure ( out highp 4-component vector of float Position)
+0:177          direct index ( temp block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
+0:177            'gl_out' ( out 4-element array of block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
+0:177            Constant:
+0:177              0 (const int)
+0:177          Constant:
+0:177            0 (const int)
+0:177        Constant:
+0:177          1.000000
+0:177          1.000000
+0:177          1.000000
+0:177          1.000000
+0:178      direct index ( temp highp int)
+0:178        'outa' ( out 4-element array of highp int)
+0:178        Constant:
+0:178          1 (const int)
+0:179      direct index ( temp block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
+0:179        'gl_out' ( out 4-element array of block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
+0:179        Constant:
+0:179          0 (const int)
+0:180      Function Call: outputtingOutparam(i1; ( global void)
+0:180        direct index ( temp highp int)
+0:180          'outa' ( out 4-element array of highp int)
+0:180          Constant:
+0:180            0 (const int)
+0:181      Function Call: outputtingOutparam(i1; ( global void)
+0:181        indirect index ( temp highp int)
+0:181          'outa' ( out 4-element array of highp int)
+0:181          'gl_InvocationID' ( in highp int InvocationID)
+0:182      move second child to first child ( temp highp float)
+0:182        f: direct index for structure ( out highp float)
+0:182          direct index ( patch temp block{ out highp float f})
+0:182            'patchIName' ( patch out 4-element array of block{ out highp float f})
+0:182            Constant:
+0:182              1 (const int)
+0:182          Constant:
+0:182            0 (const int)
+0:182        Constant:
+0:182          3.140000
+0:183      move second child to first child ( temp highp int)
+0:183        indirect index ( temp highp int)
+0:183          'outa' ( out 4-element array of highp int)
+0:183          'gl_InvocationID' ( in highp int InvocationID)
+0:183        Constant:
+0:183          2 (const int)
 0:?   Linker Objects
 0:?     'gl_out' ( out 4-element array of block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
 0:?     'outa' ( out 4-element array of highp int)
@@ -381,6 +421,7 @@ Linked tessellation control stage:
 
 Shader version: 310
 Requested GL_ARB_separate_shader_objects
+Requested GL_EXT_primitive_bounding_box
 Requested GL_OES_gpu_shader5
 Requested GL_OES_primitive_bounding_box
 Requested GL_OES_shader_io_blocks

--- a/Test/baseResults/320.tesc.out
+++ b/Test/baseResults/320.tesc.out
@@ -37,16 +37,20 @@ GL_OES_tessellation_point_size
 ERROR: 0:105: 'gl_PointSize' : required extension not requested: Possible extensions include:
 GL_EXT_tessellation_point_size
 GL_OES_tessellation_point_size
-ERROR: 0:124: '[' :  array index out of range '2'
-ERROR: 0:127: '' : array size required 
-ERROR: 0:143: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
-ERROR: 0:144: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
-ERROR: 0:147: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
-ERROR: 35 compilation errors.  No code generated.
+ERROR: 0:121: 'gl_BoundingBoxEXT' : required extension not requested: GL_EXT_primitive_bounding_box
+ERROR: 0:122: 'gl_BoundingBoxOES' : required extension not requested: GL_OES_primitive_bounding_box
+ERROR: 0:125: '[' :  array index out of range '2'
+ERROR: 0:137: '' : array size required 
+ERROR: 0:153: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
+ERROR: 0:154: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
+ERROR: 0:157: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
+ERROR: 37 compilation errors.  No code generated.
 
 
 Shader version: 320
 Requested GL_ARB_separate_shader_objects
+Requested GL_EXT_primitive_bounding_box
+Requested GL_OES_primitive_bounding_box
 vertices = 4
 ERROR: node is still EOpNull!
 0:13  Function Definition: main( ( global void)
@@ -251,7 +255,7 @@ ERROR: node is still EOpNull!
 0:123        direct index ( patch temp highp 4-component vector of float BoundingBox)
 0:123          'gl_BoundingBox' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
 0:123          Constant:
-0:123            1 (const int)
+0:123            0 (const int)
 0:123        Constant:
 0:123          1.000000
 0:123          1.000000
@@ -261,82 +265,115 @@ ERROR: node is still EOpNull!
 0:124        direct index ( patch temp highp 4-component vector of float BoundingBox)
 0:124          'gl_BoundingBox' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
 0:124          Constant:
-0:124            2 (const int)
+0:124            1 (const int)
 0:124        Constant:
-0:124          2.000000
-0:124          2.000000
-0:124          2.000000
-0:124          2.000000
-0:135  Function Definition: outputtingOutparam(i1; ( global void)
-0:135    Function Parameters: 
-0:135      'a' ( out highp int)
-0:137    Sequence
-0:137      move second child to first child ( temp highp int)
-0:137        'a' ( out highp int)
-0:137        Constant:
-0:137          2 (const int)
-0:140  Function Definition: outputting( ( global void)
-0:140    Function Parameters: 
-0:142    Sequence
-0:142      move second child to first child ( temp highp int)
-0:142        indirect index ( temp highp int)
-0:142          'outa' ( out 4-element array of highp int)
-0:142          'gl_InvocationID' ( in highp int InvocationID)
-0:142        Constant:
-0:142          2 (const int)
-0:143      move second child to first child ( temp highp int)
-0:143        direct index ( temp highp int)
-0:143          'outa' ( out 4-element array of highp int)
-0:143          Constant:
-0:143            1 (const int)
-0:143        Constant:
-0:143          2 (const int)
-0:144      move second child to first child ( temp highp 4-component vector of float)
-0:144        gl_Position: direct index for structure ( out highp 4-component vector of float Position)
-0:144          direct index ( temp block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
-0:144            'gl_out' ( out 4-element array of block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
-0:144            Constant:
-0:144              0 (const int)
-0:144          Constant:
-0:144            0 (const int)
-0:144        Constant:
-0:144          1.000000
-0:144          1.000000
-0:144          1.000000
-0:144          1.000000
-0:145      direct index ( temp highp int)
-0:145        'outa' ( out 4-element array of highp int)
-0:145        Constant:
-0:145          1 (const int)
-0:146      direct index ( temp block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
-0:146        'gl_out' ( out 4-element array of block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
-0:146        Constant:
-0:146          0 (const int)
-0:147      Function Call: outputtingOutparam(i1; ( global void)
-0:147        direct index ( temp highp int)
-0:147          'outa' ( out 4-element array of highp int)
-0:147          Constant:
-0:147            0 (const int)
-0:148      Function Call: outputtingOutparam(i1; ( global void)
-0:148        indirect index ( temp highp int)
-0:148          'outa' ( out 4-element array of highp int)
-0:148          'gl_InvocationID' ( in highp int InvocationID)
-0:149      move second child to first child ( temp highp float)
-0:149        f: direct index for structure ( out highp float)
-0:149          direct index ( patch temp block{ out highp float f})
-0:149            'patchIName' ( patch out 4-element array of block{ out highp float f})
-0:149            Constant:
-0:149              1 (const int)
-0:149          Constant:
-0:149            0 (const int)
-0:149        Constant:
-0:149          3.140000
-0:150      move second child to first child ( temp highp int)
-0:150        indirect index ( temp highp int)
-0:150          'outa' ( out 4-element array of highp int)
-0:150          'gl_InvocationID' ( in highp int InvocationID)
-0:150        Constant:
-0:150          2 (const int)
+0:124          1.000000
+0:124          1.000000
+0:124          1.000000
+0:124          1.000000
+0:125      move second child to first child ( temp highp 4-component vector of float)
+0:125        direct index ( patch temp highp 4-component vector of float BoundingBox)
+0:125          'gl_BoundingBox' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
+0:125          Constant:
+0:125            2 (const int)
+0:125        Constant:
+0:125          2.000000
+0:125          2.000000
+0:125          2.000000
+0:125          2.000000
+0:131  Function Definition: bbext( ( global void)
+0:131    Function Parameters: 
+0:133    Sequence
+0:133      move second child to first child ( temp highp 4-component vector of float)
+0:133        direct index ( patch temp highp 4-component vector of float BoundingBox)
+0:133          'gl_BoundingBoxEXT' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
+0:133          Constant:
+0:133            1 (const int)
+0:133        Constant:
+0:133          0.000000
+0:133          0.000000
+0:133          0.000000
+0:133          0.000000
+0:134      move second child to first child ( temp highp 4-component vector of float)
+0:134        direct index ( patch temp highp 4-component vector of float BoundingBox)
+0:134          'gl_BoundingBoxOES' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
+0:134          Constant:
+0:134            1 (const int)
+0:134        Constant:
+0:134          0.000000
+0:134          0.000000
+0:134          0.000000
+0:134          0.000000
+0:145  Function Definition: outputtingOutparam(i1; ( global void)
+0:145    Function Parameters: 
+0:145      'a' ( out highp int)
+0:147    Sequence
+0:147      move second child to first child ( temp highp int)
+0:147        'a' ( out highp int)
+0:147        Constant:
+0:147          2 (const int)
+0:150  Function Definition: outputting( ( global void)
+0:150    Function Parameters: 
+0:152    Sequence
+0:152      move second child to first child ( temp highp int)
+0:152        indirect index ( temp highp int)
+0:152          'outa' ( out 4-element array of highp int)
+0:152          'gl_InvocationID' ( in highp int InvocationID)
+0:152        Constant:
+0:152          2 (const int)
+0:153      move second child to first child ( temp highp int)
+0:153        direct index ( temp highp int)
+0:153          'outa' ( out 4-element array of highp int)
+0:153          Constant:
+0:153            1 (const int)
+0:153        Constant:
+0:153          2 (const int)
+0:154      move second child to first child ( temp highp 4-component vector of float)
+0:154        gl_Position: direct index for structure ( out highp 4-component vector of float Position)
+0:154          direct index ( temp block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
+0:154            'gl_out' ( out 4-element array of block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
+0:154            Constant:
+0:154              0 (const int)
+0:154          Constant:
+0:154            0 (const int)
+0:154        Constant:
+0:154          1.000000
+0:154          1.000000
+0:154          1.000000
+0:154          1.000000
+0:155      direct index ( temp highp int)
+0:155        'outa' ( out 4-element array of highp int)
+0:155        Constant:
+0:155          1 (const int)
+0:156      direct index ( temp block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
+0:156        'gl_out' ( out 4-element array of block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
+0:156        Constant:
+0:156          0 (const int)
+0:157      Function Call: outputtingOutparam(i1; ( global void)
+0:157        direct index ( temp highp int)
+0:157          'outa' ( out 4-element array of highp int)
+0:157          Constant:
+0:157            0 (const int)
+0:158      Function Call: outputtingOutparam(i1; ( global void)
+0:158        indirect index ( temp highp int)
+0:158          'outa' ( out 4-element array of highp int)
+0:158          'gl_InvocationID' ( in highp int InvocationID)
+0:159      move second child to first child ( temp highp float)
+0:159        f: direct index for structure ( out highp float)
+0:159          direct index ( patch temp block{ out highp float f})
+0:159            'patchIName' ( patch out 4-element array of block{ out highp float f})
+0:159            Constant:
+0:159              1 (const int)
+0:159          Constant:
+0:159            0 (const int)
+0:159        Constant:
+0:159          3.140000
+0:160      move second child to first child ( temp highp int)
+0:160        indirect index ( temp highp int)
+0:160          'outa' ( out 4-element array of highp int)
+0:160          'gl_InvocationID' ( in highp int InvocationID)
+0:160        Constant:
+0:160          2 (const int)
 0:?   Linker Objects
 0:?     'gl_out' ( out 4-element array of block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
 0:?     'outa' ( out 4-element array of highp int)
@@ -370,6 +407,8 @@ Linked tessellation control stage:
 
 Shader version: 320
 Requested GL_ARB_separate_shader_objects
+Requested GL_EXT_primitive_bounding_box
+Requested GL_OES_primitive_bounding_box
 vertices = 4
 ERROR: node is still EOpNull!
 0:13  Function Definition: main( ( global void)

--- a/Test/baseResults/320.tesc.out
+++ b/Test/baseResults/320.tesc.out
@@ -37,11 +37,11 @@ GL_OES_tessellation_point_size
 ERROR: 0:105: 'gl_PointSize' : required extension not requested: Possible extensions include:
 GL_EXT_tessellation_point_size
 GL_OES_tessellation_point_size
-ERROR: 0:123: '[' :  array index out of range '2'
-ERROR: 0:126: '' : array size required 
-ERROR: 0:142: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
+ERROR: 0:124: '[' :  array index out of range '2'
+ERROR: 0:127: '' : array size required 
 ERROR: 0:143: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
-ERROR: 0:146: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
+ERROR: 0:144: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
+ERROR: 0:147: '[]' : tessellation-control per-vertex output l-value must be indexed with gl_InvocationID 
 ERROR: 35 compilation errors.  No code generated.
 
 
@@ -229,7 +229,7 @@ ERROR: node is still EOpNull!
 0:121    Sequence
 0:121      move second child to first child ( temp highp 4-component vector of float)
 0:121        direct index ( patch temp highp 4-component vector of float BoundingBox)
-0:121          'gl_BoundingBoxOES' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
+0:121          'gl_BoundingBoxEXT' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
 0:121          Constant:
 0:121            0 (const int)
 0:121        Constant:
@@ -241,92 +241,102 @@ ERROR: node is still EOpNull!
 0:122        direct index ( patch temp highp 4-component vector of float BoundingBox)
 0:122          'gl_BoundingBoxOES' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
 0:122          Constant:
-0:122            1 (const int)
+0:122            0 (const int)
 0:122        Constant:
-0:122          1.000000
-0:122          1.000000
-0:122          1.000000
-0:122          1.000000
+0:122          0.000000
+0:122          0.000000
+0:122          0.000000
+0:122          0.000000
 0:123      move second child to first child ( temp highp 4-component vector of float)
 0:123        direct index ( patch temp highp 4-component vector of float BoundingBox)
-0:123          'gl_BoundingBoxOES' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
+0:123          'gl_BoundingBox' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
 0:123          Constant:
-0:123            2 (const int)
+0:123            1 (const int)
 0:123        Constant:
-0:123          2.000000
-0:123          2.000000
-0:123          2.000000
-0:123          2.000000
-0:134  Function Definition: outputtingOutparam(i1; ( global void)
-0:134    Function Parameters: 
-0:134      'a' ( out highp int)
-0:136    Sequence
-0:136      move second child to first child ( temp highp int)
-0:136        'a' ( out highp int)
-0:136        Constant:
-0:136          2 (const int)
-0:139  Function Definition: outputting( ( global void)
-0:139    Function Parameters: 
-0:141    Sequence
-0:141      move second child to first child ( temp highp int)
-0:141        indirect index ( temp highp int)
-0:141          'outa' ( out 4-element array of highp int)
-0:141          'gl_InvocationID' ( in highp int InvocationID)
-0:141        Constant:
-0:141          2 (const int)
+0:123          1.000000
+0:123          1.000000
+0:123          1.000000
+0:123          1.000000
+0:124      move second child to first child ( temp highp 4-component vector of float)
+0:124        direct index ( patch temp highp 4-component vector of float BoundingBox)
+0:124          'gl_BoundingBox' ( patch out 2-element array of highp 4-component vector of float BoundingBox)
+0:124          Constant:
+0:124            2 (const int)
+0:124        Constant:
+0:124          2.000000
+0:124          2.000000
+0:124          2.000000
+0:124          2.000000
+0:135  Function Definition: outputtingOutparam(i1; ( global void)
+0:135    Function Parameters: 
+0:135      'a' ( out highp int)
+0:137    Sequence
+0:137      move second child to first child ( temp highp int)
+0:137        'a' ( out highp int)
+0:137        Constant:
+0:137          2 (const int)
+0:140  Function Definition: outputting( ( global void)
+0:140    Function Parameters: 
+0:142    Sequence
 0:142      move second child to first child ( temp highp int)
-0:142        direct index ( temp highp int)
+0:142        indirect index ( temp highp int)
 0:142          'outa' ( out 4-element array of highp int)
-0:142          Constant:
-0:142            1 (const int)
+0:142          'gl_InvocationID' ( in highp int InvocationID)
 0:142        Constant:
 0:142          2 (const int)
-0:143      move second child to first child ( temp highp 4-component vector of float)
-0:143        gl_Position: direct index for structure ( out highp 4-component vector of float Position)
-0:143          direct index ( temp block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
-0:143            'gl_out' ( out 4-element array of block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
-0:143            Constant:
-0:143              0 (const int)
+0:143      move second child to first child ( temp highp int)
+0:143        direct index ( temp highp int)
+0:143          'outa' ( out 4-element array of highp int)
 0:143          Constant:
-0:143            0 (const int)
+0:143            1 (const int)
 0:143        Constant:
-0:143          1.000000
-0:143          1.000000
-0:143          1.000000
-0:143          1.000000
-0:144      direct index ( temp highp int)
-0:144        'outa' ( out 4-element array of highp int)
+0:143          2 (const int)
+0:144      move second child to first child ( temp highp 4-component vector of float)
+0:144        gl_Position: direct index for structure ( out highp 4-component vector of float Position)
+0:144          direct index ( temp block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
+0:144            'gl_out' ( out 4-element array of block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
+0:144            Constant:
+0:144              0 (const int)
+0:144          Constant:
+0:144            0 (const int)
 0:144        Constant:
-0:144          1 (const int)
-0:145      direct index ( temp block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
-0:145        'gl_out' ( out 4-element array of block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
+0:144          1.000000
+0:144          1.000000
+0:144          1.000000
+0:144          1.000000
+0:145      direct index ( temp highp int)
+0:145        'outa' ( out 4-element array of highp int)
 0:145        Constant:
-0:145          0 (const int)
-0:146      Function Call: outputtingOutparam(i1; ( global void)
-0:146        direct index ( temp highp int)
-0:146          'outa' ( out 4-element array of highp int)
-0:146          Constant:
-0:146            0 (const int)
+0:145          1 (const int)
+0:146      direct index ( temp block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
+0:146        'gl_out' ( out 4-element array of block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
+0:146        Constant:
+0:146          0 (const int)
 0:147      Function Call: outputtingOutparam(i1; ( global void)
-0:147        indirect index ( temp highp int)
+0:147        direct index ( temp highp int)
 0:147          'outa' ( out 4-element array of highp int)
-0:147          'gl_InvocationID' ( in highp int InvocationID)
-0:148      move second child to first child ( temp highp float)
-0:148        f: direct index for structure ( out highp float)
-0:148          direct index ( patch temp block{ out highp float f})
-0:148            'patchIName' ( patch out 4-element array of block{ out highp float f})
-0:148            Constant:
-0:148              1 (const int)
-0:148          Constant:
-0:148            0 (const int)
-0:148        Constant:
-0:148          3.140000
-0:149      move second child to first child ( temp highp int)
-0:149        indirect index ( temp highp int)
-0:149          'outa' ( out 4-element array of highp int)
-0:149          'gl_InvocationID' ( in highp int InvocationID)
+0:147          Constant:
+0:147            0 (const int)
+0:148      Function Call: outputtingOutparam(i1; ( global void)
+0:148        indirect index ( temp highp int)
+0:148          'outa' ( out 4-element array of highp int)
+0:148          'gl_InvocationID' ( in highp int InvocationID)
+0:149      move second child to first child ( temp highp float)
+0:149        f: direct index for structure ( out highp float)
+0:149          direct index ( patch temp block{ out highp float f})
+0:149            'patchIName' ( patch out 4-element array of block{ out highp float f})
+0:149            Constant:
+0:149              1 (const int)
+0:149          Constant:
+0:149            0 (const int)
 0:149        Constant:
-0:149          2 (const int)
+0:149          3.140000
+0:150      move second child to first child ( temp highp int)
+0:150        indirect index ( temp highp int)
+0:150          'outa' ( out 4-element array of highp int)
+0:150          'gl_InvocationID' ( in highp int InvocationID)
+0:150        Constant:
+0:150          2 (const int)
 0:?   Linker Objects
 0:?     'gl_out' ( out 4-element array of block{ out highp 4-component vector of float Position gl_Position,  out highp float PointSize gl_PointSize})
 0:?     'outa' ( out 4-element array of highp int)

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -5794,7 +5794,14 @@ void TBuiltIns::initialize(int version, EProfile profile, const SpvVersion& spvV
             "patch out highp float gl_TessLevelOuter[4];"
             "patch out highp float gl_TessLevelInner[2];"
             "patch out highp vec4 gl_BoundingBoxOES[2];"
+            "patch out highp vec4 gl_BoundingBoxEXT[2];"
             "\n");
+        if (profile == EEsProfile && version >= 320) {
+            stageBuiltins[EShLangTessControl].append(
+                "patch out highp vec4 gl_BoundingBox[2];"
+                "\n"
+            );
+        }
     }
 
     if ((profile != EEsProfile && version >= 140) ||
@@ -8014,10 +8021,18 @@ void TBuiltIns::identifyBuiltIns(int version, EProfile profile, const SpvVersion
 
     case EShLangTessControl:
         if (profile == EEsProfile && version >= 310) {
+            BuiltInVariable("gl_BoundingBoxEXT", EbvBoundingBox, symbolTable);
+            if (version < 320)
+                symbolTable.setVariableExtensions("gl_BoundingBoxEXT", 1,
+                                                  &E_GL_EXT_primitive_bounding_box);
             BuiltInVariable("gl_BoundingBoxOES", EbvBoundingBox, symbolTable);
             if (version < 320)
-                symbolTable.setVariableExtensions("gl_BoundingBoxOES", Num_AEP_primitive_bounding_box,
-                                                  AEP_primitive_bounding_box);
+                symbolTable.setVariableExtensions("gl_BoundingBoxOES", 1,
+                                                  &E_GL_OES_primitive_bounding_box);
+
+            if (version >= 320) {
+                BuiltInVariable("gl_BoundingBox", EbvBoundingBox, symbolTable);
+            }
         }
 
         // Fall through

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -8022,13 +8022,11 @@ void TBuiltIns::identifyBuiltIns(int version, EProfile profile, const SpvVersion
     case EShLangTessControl:
         if (profile == EEsProfile && version >= 310) {
             BuiltInVariable("gl_BoundingBoxEXT", EbvBoundingBox, symbolTable);
-            if (version < 320)
-                symbolTable.setVariableExtensions("gl_BoundingBoxEXT", 1,
-                                                  &E_GL_EXT_primitive_bounding_box);
+            symbolTable.setVariableExtensions("gl_BoundingBoxEXT", 1,
+                                              &E_GL_EXT_primitive_bounding_box);
             BuiltInVariable("gl_BoundingBoxOES", EbvBoundingBox, symbolTable);
-            if (version < 320)
-                symbolTable.setVariableExtensions("gl_BoundingBoxOES", 1,
-                                                  &E_GL_OES_primitive_bounding_box);
+            symbolTable.setVariableExtensions("gl_BoundingBoxOES", 1,
+                                              &E_GL_OES_primitive_bounding_box);
 
             if (version >= 320) {
                 BuiltInVariable("gl_BoundingBox", EbvBoundingBox, symbolTable);


### PR DESCRIPTION
Prior to this change, OES_primitive_bounding_box and EXT_primitive_bounding_box were both recognised as extensions, but only the name gl_BoundingBoxOES could be used. However the EXT version uses the name gl_BoundingBoxEXT instead. In addition, since GLES 3.2, the extension has been included in the core standard and the name gl_BoundingBox may be used instead. This change aims to make both extensions and the 3.2 core version all work.

All my real changes are in Initialize.cpp. The rest is just updating the test framework to cover uses of all three variable names.

One thing I'd appreciate reviewing is whether my change to replace
`symbolTable.setVariableExtensions("gl_BoundingBoxOES", Num_AEP_primitive_bounding_box, AEP_primitive_bounding_box);`
with
`symbolTable.setVariableExtensions("gl_BoundingBoxOES", 1, &E_GL_OES_primitive_bounding_box);`
is correct. As far as I can see, there is nothing in the spec that suggests requesting EXT_primitive_bounding_box should allow usage of gl_BoundingBoxOES etc., but I'm not certain what the convention is about duplicate extensions like this.

The issue was first noticed trying to compile shaders from the gfxbench test gl_4, which utilises gl_BoundingBoxEXT.