### PR TITLE
Avoid running the validator as part of the optimization pass.

### DIFF
--- a/SPIRV/SpvTools.cpp
+++ b/SPIRV/SpvTools.cpp
@@ -191,7 +191,9 @@ void SpirvToolsLegalize(const glslang::TIntermediate&, std::vector<unsigned int>
         optimizer.RegisterPass(spvtools::CreateRedundantLineInfoElimPass());
     }
 
-    optimizer.Run(spirv.data(), spirv.size(), &spirv);
+    spvtools::OptimizerOptions spvOptOptions;
+    spvOptOptions.set_run_validator(false); // The validator may run as a seperate step later on
+    optimizer.Run(spirv.data(), spirv.size(), &spirv, spvOptOptions);
 }
 
 }; // end namespace glslang


### PR DESCRIPTION
The spvtools::Optimizer::Run method glslang is using constructs a default set
of spvtools::OptimizerOptions. This default set of options instructs the
validator to run. That is not quite correct since glslang will invoke the
validator _explicitly_ after the optimization pass.

Change-Id: I30f458304c6e7f81e89fc4ebd25eabbbd8348063