### PR TITLE
Suppress MSVC warning about unused variable.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -152,6 +152,7 @@ source_set("glslang_sources") {
   if (is_win && !is_clang) {
     cflags = [
       "/wd4018", # signed/unsigned mismatch
+      "/wd4189", # local variable is initialized but not referenced
     ]
   }
 

--- a/SPIRV/SpvPostProcess.cpp
+++ b/SPIRV/SpvPostProcess.cpp
@@ -258,6 +258,7 @@ void Builder::postProcess(Instruction& inst)
                 assert(inst.getNumOperands() >= 3);
                 unsigned int memoryAccess = inst.getImmediateOperand((inst.getOpCode() == OpStore) ? 2 : 1);
                 assert(memoryAccess & MemoryAccessAlignedMask);
+                static_cast<void>(memoryAccess);
                 // Compute the index of the alignment operand.
                 int alignmentIdx = 2;
                 if (inst.getOpCode() == OpStore)


### PR DESCRIPTION
One variable was only used in an 'assert' call. MSVC flagged this
as unused in Release. Suppress the warning and also add a static
cast to void so the variable becomes referenced.

@johnkslang PTAL