### PR TITLE
build: Don't ship GTEST headers in install target

### DIFF
--- a/External/CMakeLists.txt
+++ b/External/CMakeLists.txt
@@ -10,7 +10,8 @@ if(BUILD_TESTING)
         if(WIN32)
             set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
         endif(WIN32)
-        add_subdirectory(googletest)
+        # EXCLUDE_FROM_ALL keeps the install target from installing GTEST files.
+        add_subdirectory(googletest EXCLUDE_FROM_ALL)
         set(GTEST_TARGETS
             gtest
             gtest_main


### PR DESCRIPTION
A project that uses googletest(GTEST) shouldn't include googletest
headers with its artifacts in its install target.  These headers
simply are not needed by the consumers of the install target and
can cause conflicts with other projects that use googletest
themselves and this project's install target.  And they are just not
part of the expected glslang build artifacts.

It is likely that the addition of the googletest headers to the install
target was a simple oversight that happens as a result of adding
googletest as a CMake subdirectory.

For more information on how this causes conflicts with other projects,
please see: https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/821.