### PR TITLE
Casts to enable capabilities in spir-v output

### DIFF
--- a/SPIRV/SpvPostProcess.cpp
+++ b/SPIRV/SpvPostProcess.cpp
@@ -118,9 +118,6 @@ void Builder::postProcessType(const Instruction& inst, Id typeId)
     case OpAccessChain:
     case OpPtrAccessChain:
     case OpCopyObject:
-    case OpFConvert:
-    case OpSConvert:
-    case OpUConvert:
         break;
     case OpExtInst:
 #if AMD_EXTENSIONS

--- a/Test/baseResults/spv.1.3.8bitstorage-ssbo.vert.out
+++ b/Test/baseResults/spv.1.3.8bitstorage-ssbo.vert.out
@@ -4,6 +4,7 @@ spv.1.3.8bitstorage-ssbo.vert
 // Id's are bound by 28
 
                               Capability Shader
+                              Capability Int8
                               Capability CapabilityStorageBuffer8BitAccess
                               Extension  "SPV_KHR_8bit_storage"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.1.3.8bitstorage-ubo.vert.out
+++ b/Test/baseResults/spv.1.3.8bitstorage-ubo.vert.out
@@ -4,6 +4,7 @@ spv.1.3.8bitstorage-ubo.vert
 // Id's are bound by 29
 
                               Capability Shader
+                              Capability Int8
                               Capability CapabilityUniformAndStorageBuffer8BitAccess
                               Extension  "SPV_KHR_8bit_storage"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.16bitstorage-int.frag.out
+++ b/Test/baseResults/spv.16bitstorage-int.frag.out
@@ -4,6 +4,7 @@ spv.16bitstorage-int.frag
 // Id's are bound by 172
 
                               Capability Shader
+                              Capability Int16
                               Capability StorageUniformBufferBlock16
                               Capability StorageUniform16
                               Extension  "SPV_KHR_16bit_storage"

--- a/Test/baseResults/spv.16bitstorage-uint.frag.out
+++ b/Test/baseResults/spv.16bitstorage-uint.frag.out
@@ -4,6 +4,7 @@ spv.16bitstorage-uint.frag
 // Id's are bound by 173
 
                               Capability Shader
+                              Capability Int16
                               Capability StorageUniformBufferBlock16
                               Capability StorageUniform16
                               Extension  "SPV_KHR_16bit_storage"

--- a/Test/baseResults/spv.16bitstorage.frag.out
+++ b/Test/baseResults/spv.16bitstorage.frag.out
@@ -4,6 +4,7 @@ spv.16bitstorage.frag
 // Id's are bound by 172
 
                               Capability Shader
+                              Capability Float16
                               Capability StorageUniformBufferBlock16
                               Capability StorageUniform16
                               Extension  "SPV_KHR_16bit_storage"

--- a/Test/baseResults/spv.8bitstorage-int.frag.out
+++ b/Test/baseResults/spv.8bitstorage-int.frag.out
@@ -4,6 +4,7 @@ spv.8bitstorage-int.frag
 // Id's are bound by 172
 
                               Capability Shader
+                              Capability Int8
                               Capability CapabilityUniformAndStorageBuffer8BitAccess
                               Extension  "SPV_KHR_8bit_storage"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.8bitstorage-ssbo.vert.out
+++ b/Test/baseResults/spv.8bitstorage-ssbo.vert.out
@@ -4,6 +4,7 @@ spv.8bitstorage-ssbo.vert
 // Id's are bound by 28
 
                               Capability Shader
+                              Capability Int8
                               Capability CapabilityUniformAndStorageBuffer8BitAccess
                               Extension  "SPV_KHR_8bit_storage"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.8bitstorage-ubo.vert.out
+++ b/Test/baseResults/spv.8bitstorage-ubo.vert.out
@@ -4,6 +4,7 @@ spv.8bitstorage-ubo.vert
 // Id's are bound by 29
 
                               Capability Shader
+                              Capability Int8
                               Capability CapabilityUniformAndStorageBuffer8BitAccess
                               Extension  "SPV_KHR_8bit_storage"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.8bitstorage-uint.frag.out
+++ b/Test/baseResults/spv.8bitstorage-uint.frag.out
@@ -4,6 +4,7 @@ spv.8bitstorage-uint.frag
 // Id's are bound by 173
 
                               Capability Shader
+                              Capability Int8
                               Capability CapabilityUniformAndStorageBuffer8BitAccess
                               Extension  "SPV_KHR_8bit_storage"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.bufferhandle11.frag.out
+++ b/Test/baseResults/spv.bufferhandle11.frag.out
@@ -7,6 +7,7 @@ WARNING: 0:6: '' : all default precisions are highp; use precision statements to
 // Id's are bound by 60
 
                               Capability Shader
+                              Capability Int8
                               Capability CapabilityStorageBuffer8BitAccess
                               Capability CapabilityPhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"


### PR DESCRIPTION
First to explain the origin of the need for this fix, when compiling a particular shader the spir-v produced would produce validation errors

```
[ UNASSIGNED-CoreValidation-Shader-InconsistentSpirv ] Object: VK_NULL_HANDLE (Type = 0) | SPIR-V module not valid: Using a 16-bit floating point type requires the Float16 or Float16Buffer capability, or an extension that explicitly enables 16-bit floating point.
 %half = OpTypeFloat 16
```

An example shader that produces this would be

```#version 450
layout(row_major) uniform;
layout(row_major) buffer;
#extension GL_EXT_shader_16bit_storage : require
#extension GL_KHX_shader_explicit_arithmetic_types : require

layout(rgba16f)
layout(binding = 1, set = 7)
uniform image2D gOutput;

layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
void main()
{
    ivec2 pos = ivec2(gl_GlobalInvocationID);
    vec4 v = ivec4(pos.x, pos.y, pos.x, pos.y) * (1.0f / 16.0f);
    imageStore(gOutput, ivec2(pos), f16vec4(v));
} 
```
Other shaders that use float16_t do not have the problem. On looking into the spir-v assembler the difference is the failing shader does not have `Capability Float16` in it's spir-v code.

The only float16_t instruction is the f16vec4 cast. On looking at the glslang source the method `void spv::Builder::postProcessType(const Instruction& inst, Id typeId)` looks at types on instructions to see about adding capabilities such as with addCapability(CapabilityFloat16);

That in that code we have the sequence
```
    case OpFConvert:
    case OpSConvert:
    case OpUConvert:
        break;
```
 
Which leads to the float16_t cast being ignored from the point of view of enabling capabilities. 

The PR removes these 3 cases, such that the `default:` path is taken - and this path does notice the float16_t usage and the `Capability Float16` line appears in the spir-v for the above shader. 