### PR TITLE
Check if _MSC_VER is defined before using.

### DIFF
--- a/SPIRV/SPVRemapper.h
+++ b/SPIRV/SPVRemapper.h
@@ -45,7 +45,7 @@ namespace spv {
 
 // MSVC defines __cplusplus as an older value, even when it supports almost all of 11.
 // We handle that here by making our own symbol.
-#if __cplusplus >= 201103L || _MSC_VER >= 1700
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1700)
 #   define use_cpp11 1
 #endif
 

--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -38,7 +38,7 @@
 #define _COMMON_INCLUDED_
 
 
-#if defined(__ANDROID__) || _MSC_VER < 1700
+#if defined(__ANDROID__) || (defined(_MSC_VER) && _MSC_VER < 1700)
 #include <sstream>
 namespace std {
 template<typename T>


### PR DESCRIPTION
Fixes compilation errors on some platforms.