### PR TITLE
introduce ability to dump builtin symbol table

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -162,6 +162,7 @@ const char* shaderStageName = nullptr;
 const char* variableName = nullptr;
 bool HlslEnable16BitTypes = false;
 bool HlslDX9compatible = false;
+bool DumpBuiltinSymbols = false;
 std::vector<std::string> IncludeDirectoryList;
 
 // Source environment
@@ -494,6 +495,8 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
                                 Error("--client expects vulkan100 or opengl100");
                         }
                         bumpArg();
+                    } else if (lowerword == "dump-builtin-symbols") {
+                        DumpBuiltinSymbols = true;
                     } else if (lowerword == "entry-point") {
                         entryPointName = argv[1];
                         if (argc <= 1)
@@ -833,6 +836,8 @@ void SetMessageOptions(EShMessages& messages)
         messages = (EShMessages)(messages | EShMsgHlslLegalization);
     if (HlslDX9compatible)
         messages = (EShMessages)(messages | EShMsgHlslDX9Compatible);
+    if (DumpBuiltinSymbols)
+        messages = (EShMessages)(messages | EShMsgBuiltinSymbolTable);
 }
 
 //
@@ -1520,6 +1525,7 @@ void usage()
            "  --auto-map-locations | --aml      automatically locate input/output lacking\n"
            "                                    'location' (fragile, not cross stage)\n"
            "  --client {vulkan<ver>|opengl<ver>} see -V and -G\n"
+           "  --dump-builtin-symbols            prints builint symbol table prior each stage\n"
            "  -dumpfullversion | -dumpversion   print bare major.minor.patchlevel\n"
            "  --flatten-uniform-arrays | --fua  flatten uniform texture/sampler arrays to\n"
            "                                    scalars\n"

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -1525,7 +1525,7 @@ void usage()
            "  --auto-map-locations | --aml      automatically locate input/output lacking\n"
            "                                    'location' (fragile, not cross stage)\n"
            "  --client {vulkan<ver>|opengl<ver>} see -V and -G\n"
-           "  --dump-builtin-symbols            prints builint symbol table prior each stage\n"
+           "  --dump-builtin-symbols            prints builtin symbol table prior each compile\n"
            "  -dumpfullversion | -dumpversion   print bare major.minor.patchlevel\n"
            "  --flatten-uniform-arrays | --fua  flatten uniform texture/sampler arrays to\n"
            "                                    scalars\n"

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -2018,7 +2018,7 @@ public:
         }
 
         // Add struct/block members
-        if (isStruct()) {
+        if (isStruct() && structure) {
             appendStr("{");
             for (size_t i = 0; i < structure->size(); ++i) {
                 if (! (*structure)[i].type->hiddenMember()) {

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -2019,11 +2019,6 @@ public:
 
         // Add struct/block members
         if (isStruct() && structure) {
-            if (typeName) {
-                appendStr(" ");
-                appendStr(typeName->c_str());
-                appendStr(" ");
-            }
             appendStr("{");
             for (size_t i = 0; i < structure->size(); ++i) {
                 if (! (*structure)[i].type->hiddenMember()) {

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -2019,6 +2019,11 @@ public:
 
         // Add struct/block members
         if (isStruct() && structure) {
+            if (typeName) {
+                appendStr(" ");
+                appendStr(typeName->c_str());
+                appendStr(" ");
+            }
             appendStr("{");
             for (size_t i = 0; i < structure->size(); ++i) {
                 if (! (*structure)[i].type->hiddenMember()) {

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -480,7 +480,9 @@ void SetupBuiltinSymbolTable(int version, EProfile profile, const SpvVersion& sp
 void DumpBuiltinSymbolTable(TInfoSink& infoSink, const TSymbolTable& symbolTable)
 {
     infoSink.debug << "BuiltinSymbolTable {\n";
+
     symbolTable.dump(infoSink, true);
+
     infoSink.debug << "}\n";
 }
 
@@ -915,9 +917,8 @@ bool ProcessDeferred(
         return false;
     }
 
-    if (messages & EShMsgBuiltinSymbolTable) {
+    if (messages & EShMsgBuiltinSymbolTable)
         DumpBuiltinSymbolTable(compiler->infoSink, *symbolTable);
-    }
 
     //
     // Now we can process the full shader under proper symbols and rules.

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -377,6 +377,8 @@ bool InitializeSymbolTables(TInfoSink& infoSink, TSymbolTable** commonTable,  TS
                                    infoSink, commonTable, symbolTables);
 #endif
 
+
+
     return true;
 }
 
@@ -472,6 +474,14 @@ void SetupBuiltinSymbolTable(int version, EProfile profile, const SpvVersion& sp
     SetThreadPoolAllocator(&previousAllocator);
 
     glslang::ReleaseGlobalLock();
+}
+
+// Function to Print all builtins
+void DumpBuiltinSymbolTable(TInfoSink& infoSink, const TSymbolTable& symbolTable)
+{
+    infoSink.debug << "BuiltinSymbolTable {\n";
+    symbolTable.dump(infoSink, true);
+    infoSink.debug << "}\n";
 }
 
 // Return true if the shader was correctly specified for version/profile/stage.
@@ -903,6 +913,10 @@ bool ProcessDeferred(
     if (! AddContextSpecificSymbols(resources, compiler->infoSink, *symbolTable, version, profile, spvVersion,
                                     stage, source)) {
         return false;
+    }
+
+    if (messages & EShMsgBuiltinSymbolTable) {
+        DumpBuiltinSymbolTable(compiler->infoSink, *symbolTable);
     }
 
     //

--- a/glslang/MachineIndependent/SymbolTable.cpp
+++ b/glslang/MachineIndependent/SymbolTable.cpp
@@ -176,37 +176,78 @@ void TType::buildMangledName(TString& mangledName) const
 // Dump functions.
 //
 
-void TVariable::dump(TInfoSink& infoSink) const
+void TSymbol::dumpExtensions(TInfoSink &infoSink) const
 {
-    infoSink.debug << getName().c_str() << ": " << type.getStorageQualifierString() << " " << type.getBasicTypeString();
-    if (type.isArray()) {
-        infoSink.debug << "[0]";
+    int numExtensions = getNumExtensions();
+    if (numExtensions)
+    {
+        infoSink.debug << " <";
+        for (int i = 0; i < numExtensions; i++)
+        {
+            infoSink.debug << getExtensions()[i] << ",";
+        }
+        infoSink.debug << ">";
     }
+}
+
+void TVariable::dump(TInfoSink &infoSink, bool complete) const
+{
+    if (complete)
+    {
+        infoSink.debug << getName().c_str() << ": " << type.getCompleteString();
+        dumpExtensions(infoSink);
+    }
+    else {
+        infoSink.debug << getName().c_str() << ": " << type.getStorageQualifierString() << " "
+                       << type.getBasicTypeString();
+        if (type.isArray())
+        {
+            infoSink.debug << "[0]";
+        }
+    }
+
     infoSink.debug << "\n";
 }
 
-void TFunction::dump(TInfoSink& infoSink) const
+void TFunction::dump(TInfoSink &infoSink, bool complete) const
 {
-    infoSink.debug << getName().c_str() << ": " <<  returnType.getBasicTypeString() << " " << getMangledName().c_str() << "\n";
+    if (complete)
+    {
+        infoSink.debug << getName().c_str() << ": " << returnType.getCompleteString() << " " << getName().c_str() << "(";
+        int numParams = getParamCount();
+        for (int i = 0; i < numParams; i++){
+          const TParameter& param = parameters[i];
+          infoSink.debug << param.type->getCompleteString() << " " << (param.name ? param.name->c_str() : "") << (i < numParams-1 ? "," : "");
+        }
+        infoSink.debug << ")";
+        dumpExtensions(infoSink);
+    } else
+    {
+        infoSink.debug << getName().c_str() << ": " << returnType.getBasicTypeString() << " "
+                       << getMangledName().c_str() << "n";
+    }
+
+    infoSink.debug << "\n";
 }
 
-void TAnonMember::dump(TInfoSink& TInfoSink) const
+void TAnonMember::dump(TInfoSink &TInfoSink, bool complete) const
 {
-    TInfoSink.debug << "anonymous member " << getMemberNumber() << " of " << getAnonContainer().getName().c_str() << "\n";
+    TInfoSink.debug << "anonymous member " << getMemberNumber() << " of " << getAnonContainer().getName().c_str()
+                    << "\n";
 }
 
-void TSymbolTableLevel::dump(TInfoSink &infoSink) const
+void TSymbolTableLevel::dump(TInfoSink &infoSink, bool complete) const
 {
     tLevel::const_iterator it;
     for (it = level.begin(); it != level.end(); ++it)
-        (*it).second->dump(infoSink);
+        (*it).second->dump(infoSink, complete);
 }
 
-void TSymbolTable::dump(TInfoSink &infoSink) const
+void TSymbolTable::dump(TInfoSink &infoSink, bool complete) const
 {
     for (int level = currentLevel(); level >= 0; --level) {
         infoSink.debug << "LEVEL " << level << "\n";
-        table[level]->dump(infoSink);
+        table[level]->dump(infoSink, complete);
     }
 }
 

--- a/glslang/MachineIndependent/SymbolTable.cpp
+++ b/glslang/MachineIndependent/SymbolTable.cpp
@@ -176,7 +176,7 @@ void TType::buildMangledName(TString& mangledName) const
 // Dump functions.
 //
 
-void TSymbol::dumpExtensions(TInfoSink &infoSink) const
+void TSymbol::dumpExtensions(TInfoSink& infoSink) const
 {
     int numExtensions = getNumExtensions();
     if (numExtensions) {
@@ -189,13 +189,12 @@ void TSymbol::dumpExtensions(TInfoSink &infoSink) const
     }
 }
 
-void TVariable::dump(TInfoSink &infoSink, bool complete) const
+void TVariable::dump(TInfoSink& infoSink, bool complete) const
 {
     if (complete) {
         infoSink.debug << getName().c_str() << ": " << type.getCompleteString();
         dumpExtensions(infoSink);
-    } else
-    {
+    } else {
         infoSink.debug << getName().c_str() << ": " << type.getStorageQualifierString() << " "
                        << type.getBasicTypeString();
 
@@ -206,7 +205,7 @@ void TVariable::dump(TInfoSink &infoSink, bool complete) const
     infoSink.debug << "\n";
 }
 
-void TFunction::dump(TInfoSink &infoSink, bool complete) const
+void TFunction::dump(TInfoSink& infoSink, bool complete) const
 {
     if (complete) {
         infoSink.debug << getName().c_str() << ": " << returnType.getCompleteString() << " " << getName().c_str()
@@ -222,8 +221,7 @@ void TFunction::dump(TInfoSink &infoSink, bool complete) const
 
         infoSink.debug << ")";
         dumpExtensions(infoSink);
-    } else
-    {
+    } else {
         infoSink.debug << getName().c_str() << ": " << returnType.getBasicTypeString() << " "
                        << getMangledName().c_str() << "n";
     }
@@ -231,20 +229,20 @@ void TFunction::dump(TInfoSink &infoSink, bool complete) const
     infoSink.debug << "\n";
 }
 
-void TAnonMember::dump(TInfoSink &TInfoSink, bool complete) const
+void TAnonMember::dump(TInfoSink& TInfoSink, bool complete) const
 {
     TInfoSink.debug << "anonymous member " << getMemberNumber() << " of " << getAnonContainer().getName().c_str()
                     << "\n";
 }
 
-void TSymbolTableLevel::dump(TInfoSink &infoSink, bool complete) const
+void TSymbolTableLevel::dump(TInfoSink& infoSink, bool complete) const
 {
     tLevel::const_iterator it;
     for (it = level.begin(); it != level.end(); ++it)
         (*it).second->dump(infoSink, complete);
 }
 
-void TSymbolTable::dump(TInfoSink &infoSink, bool complete) const
+void TSymbolTable::dump(TInfoSink& infoSink, bool complete) const
 {
     for (int level = currentLevel(); level >= 0; --level) {
         infoSink.debug << "LEVEL " << level << "\n";

--- a/glslang/MachineIndependent/SymbolTable.cpp
+++ b/glslang/MachineIndependent/SymbolTable.cpp
@@ -179,31 +179,28 @@ void TType::buildMangledName(TString& mangledName) const
 void TSymbol::dumpExtensions(TInfoSink &infoSink) const
 {
     int numExtensions = getNumExtensions();
-    if (numExtensions)
-    {
+    if (numExtensions) {
         infoSink.debug << " <";
+
         for (int i = 0; i < numExtensions; i++)
-        {
             infoSink.debug << getExtensions()[i] << ",";
-        }
+        
         infoSink.debug << ">";
     }
 }
 
 void TVariable::dump(TInfoSink &infoSink, bool complete) const
 {
-    if (complete)
-    {
+    if (complete) {
         infoSink.debug << getName().c_str() << ": " << type.getCompleteString();
         dumpExtensions(infoSink);
     } else
     {
         infoSink.debug << getName().c_str() << ": " << type.getStorageQualifierString() << " "
                        << type.getBasicTypeString();
+
         if (type.isArray())
-        {
             infoSink.debug << "[0]";
-        }
     }
 
     infoSink.debug << "\n";
@@ -211,17 +208,17 @@ void TVariable::dump(TInfoSink &infoSink, bool complete) const
 
 void TFunction::dump(TInfoSink &infoSink, bool complete) const
 {
-    if (complete)
-    {
+    if (complete) {
         infoSink.debug << getName().c_str() << ": " << returnType.getCompleteString() << " " << getName().c_str()
                        << "(";
+
         int numParams = getParamCount();
-        for (int i = 0; i < numParams; i++)
-        {
+        for (int i = 0; i < numParams; i++) {
             const TParameter &param = parameters[i];
             infoSink.debug << param.type->getCompleteString() << " "
                            << (param.name ? param.name->c_str() : "") << (i < numParams - 1 ? "," : "");
         }
+
         infoSink.debug << ")";
         dumpExtensions(infoSink);
     } else

--- a/glslang/MachineIndependent/SymbolTable.cpp
+++ b/glslang/MachineIndependent/SymbolTable.cpp
@@ -196,8 +196,8 @@ void TVariable::dump(TInfoSink &infoSink, bool complete) const
     {
         infoSink.debug << getName().c_str() << ": " << type.getCompleteString();
         dumpExtensions(infoSink);
-    }
-    else {
+    } else
+    {
         infoSink.debug << getName().c_str() << ": " << type.getStorageQualifierString() << " "
                        << type.getBasicTypeString();
         if (type.isArray())
@@ -213,11 +213,14 @@ void TFunction::dump(TInfoSink &infoSink, bool complete) const
 {
     if (complete)
     {
-        infoSink.debug << getName().c_str() << ": " << returnType.getCompleteString() << " " << getName().c_str() << "(";
+        infoSink.debug << getName().c_str() << ": " << returnType.getCompleteString() << " " << getName().c_str()
+                       << "(";
         int numParams = getParamCount();
-        for (int i = 0; i < numParams; i++){
-          const TParameter& param = parameters[i];
-          infoSink.debug << param.type->getCompleteString() << " " << (param.name ? param.name->c_str() : "") << (i < numParams-1 ? "," : "");
+        for (int i = 0; i < numParams; i++)
+        {
+            const TParameter &param = parameters[i];
+            infoSink.debug << param.type->getCompleteString() << " "
+                           << (param.name ? param.name->c_str() : "") << (i < numParams - 1 ? "," : "");
         }
         infoSink.debug << ")";
         dumpExtensions(infoSink);

--- a/glslang/MachineIndependent/SymbolTable.cpp
+++ b/glslang/MachineIndependent/SymbolTable.cpp
@@ -216,7 +216,8 @@ void TFunction::dump(TInfoSink &infoSink, bool complete) const
         for (int i = 0; i < numParams; i++) {
             const TParameter &param = parameters[i];
             infoSink.debug << param.type->getCompleteString() << " "
-                           << (param.name ? param.name->c_str() : "") << (i < numParams - 1 ? "," : "");
+                           << (param.type->isStruct() ? "of " + param.type->getTypeName() + " " : "")
+                           << (param.name ? *param.name : "") << (i < numParams - 1 ? "," : "");
         }
 
         infoSink.debug << ")";

--- a/glslang/MachineIndependent/SymbolTable.h
+++ b/glslang/MachineIndependent/SymbolTable.h
@@ -116,7 +116,8 @@ public:
     }
     virtual int getNumExtensions() const { return extensions == nullptr ? 0 : (int)extensions->size(); }
     virtual const char** getExtensions() const { return extensions->data(); }
-    virtual void dump(TInfoSink &infoSink) const = 0;
+    virtual void dump(TInfoSink &infoSink, bool pretty = false) const = 0;
+    void dumpExtensions(TInfoSink &infoSink) const;
 
     virtual bool isReadOnly() const { return ! writable; }
     virtual void makeReadOnly() { writable = false; }
@@ -192,7 +193,7 @@ public:
     }
     virtual const char** getMemberExtensions(int member) const { return (*memberExtensions)[member].data(); }
 
-    virtual void dump(TInfoSink &infoSink) const;
+    virtual void dump(TInfoSink &infoSink, bool complete = false) const;
 
 protected:
     explicit TVariable(const TVariable&);
@@ -313,7 +314,7 @@ public:
     virtual TParameter& operator[](int i) { assert(writable); return parameters[i]; }
     virtual const TParameter& operator[](int i) const { return parameters[i]; }
 
-    virtual void dump(TInfoSink &infoSink) const override;
+    virtual void dump(TInfoSink &infoSink, bool complete = false) const override;
 
 protected:
     explicit TFunction(const TFunction&);
@@ -373,7 +374,7 @@ public:
     virtual const char** getExtensions() const override { return anonContainer.getMemberExtensions(memberNumber); }
 
     virtual int getAnonId() const { return anonId; }
-    virtual void dump(TInfoSink &infoSink) const override;
+    virtual void dump(TInfoSink &infoSink, bool complete = false) const override;
 
 protected:
     explicit TAnonMember(const TAnonMember&);
@@ -541,7 +542,7 @@ public:
 
     void relateToOperator(const char* name, TOperator op);
     void setFunctionExtensions(const char* name, int num, const char* const extensions[]);
-    void dump(TInfoSink &infoSink) const;
+    void dump(TInfoSink &infoSink, bool complete = false) const;
     TSymbolTableLevel* clone() const;
     void readOnly();
 
@@ -842,7 +843,7 @@ public:
     }
 
     int getMaxSymbolId() { return uniqueId; }
-    void dump(TInfoSink &infoSink) const;
+    void dump(TInfoSink &infoSink, bool complete = false) const;
     void copyTable(const TSymbolTable& copyOf);
 
     void setPreviousDefaultPrecisions(TPrecisionQualifier *p) { table[currentLevel()]->setPreviousDefaultPrecisions(p); }

--- a/glslang/MachineIndependent/SymbolTable.h
+++ b/glslang/MachineIndependent/SymbolTable.h
@@ -116,7 +116,7 @@ public:
     }
     virtual int getNumExtensions() const { return extensions == nullptr ? 0 : (int)extensions->size(); }
     virtual const char** getExtensions() const { return extensions->data(); }
-    virtual void dump(TInfoSink &infoSink, bool pretty = false) const = 0;
+    virtual void dump(TInfoSink &infoSink, bool complete = false) const = 0;
     void dumpExtensions(TInfoSink &infoSink) const;
 
     virtual bool isReadOnly() const { return ! writable; }

--- a/glslang/MachineIndependent/SymbolTable.h
+++ b/glslang/MachineIndependent/SymbolTable.h
@@ -116,8 +116,8 @@ public:
     }
     virtual int getNumExtensions() const { return extensions == nullptr ? 0 : (int)extensions->size(); }
     virtual const char** getExtensions() const { return extensions->data(); }
-    virtual void dump(TInfoSink &infoSink, bool complete = false) const = 0;
-    void dumpExtensions(TInfoSink &infoSink) const;
+    virtual void dump(TInfoSink& infoSink, bool complete = false) const = 0;
+    void dumpExtensions(TInfoSink& infoSink) const;
 
     virtual bool isReadOnly() const { return ! writable; }
     virtual void makeReadOnly() { writable = false; }
@@ -193,7 +193,7 @@ public:
     }
     virtual const char** getMemberExtensions(int member) const { return (*memberExtensions)[member].data(); }
 
-    virtual void dump(TInfoSink &infoSink, bool complete = false) const;
+    virtual void dump(TInfoSink& infoSink, bool complete = false) const;
 
 protected:
     explicit TVariable(const TVariable&);
@@ -314,7 +314,7 @@ public:
     virtual TParameter& operator[](int i) { assert(writable); return parameters[i]; }
     virtual const TParameter& operator[](int i) const { return parameters[i]; }
 
-    virtual void dump(TInfoSink &infoSink, bool complete = false) const override;
+    virtual void dump(TInfoSink& infoSink, bool complete = false) const override;
 
 protected:
     explicit TFunction(const TFunction&);
@@ -374,7 +374,7 @@ public:
     virtual const char** getExtensions() const override { return anonContainer.getMemberExtensions(memberNumber); }
 
     virtual int getAnonId() const { return anonId; }
-    virtual void dump(TInfoSink &infoSink, bool complete = false) const override;
+    virtual void dump(TInfoSink& infoSink, bool complete = false) const override;
 
 protected:
     explicit TAnonMember(const TAnonMember&);
@@ -542,7 +542,7 @@ public:
 
     void relateToOperator(const char* name, TOperator op);
     void setFunctionExtensions(const char* name, int num, const char* const extensions[]);
-    void dump(TInfoSink &infoSink, bool complete = false) const;
+    void dump(TInfoSink& infoSink, bool complete = false) const;
     TSymbolTableLevel* clone() const;
     void readOnly();
 
@@ -843,7 +843,7 @@ public:
     }
 
     int getMaxSymbolId() { return uniqueId; }
-    void dump(TInfoSink &infoSink, bool complete = false) const;
+    void dump(TInfoSink& infoSink, bool complete = false) const;
     void copyTable(const TSymbolTable& copyOf);
 
     void setPreviousDefaultPrecisions(TPrecisionQualifier *p) { table[currentLevel()]->setPreviousDefaultPrecisions(p); }

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -234,6 +234,7 @@ enum EShMessages {
     EShMsgHlslEnable16BitTypes  = (1 << 11), // enable use of 16-bit types in SPIR-V for HLSL
     EShMsgHlslLegalization  = (1 << 12), // enable HLSL Legalization messages
     EShMsgHlslDX9Compatible = (1 << 13), // enable HLSL DX9 compatible mode (right now only for samplers)
+    EShMsgBuiltinSymbolTable = (1 << 14), // print the builtin symbol table
 };
 
 //


### PR DESCRIPTION
introduces EShMsgBuiltinSymbolTable and corresponding --dump-builtin-symbols command line to output the builtin symbols with all details. The intention is for tools that may want to use the data for auto-completion and tooltips or create the ability to provide overloaded functions.

TSymbol::dump functions have option to do "complete" print
bugfix in TType::getCompleteString, structure can be null for block