### PR TITLE
Remove glslang.y from gn sources

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -106,7 +106,6 @@ source_set("glslang_sources") {
     "glslang/MachineIndependent/attribute.cpp",
     "glslang/MachineIndependent/attribute.h",
     "glslang/MachineIndependent/gl_types.h",
-    "glslang/MachineIndependent/glslang.y",
     "glslang/MachineIndependent/glslang_tab.cpp",
     "glslang/MachineIndependent/glslang_tab.cpp.h",
     "glslang/MachineIndependent/intermOut.cpp",


### PR DESCRIPTION
No behavior changes.  Please see [1] for why this is necessary.

[1] https://bugs.chromium.org/p/chromium/issues/detail?id=964411