### PR TITLE
Misc fixes from dgkoch

### DIFF
--- a/SPIRV/disassemble.cpp
+++ b/SPIRV/disassemble.cpp
@@ -701,9 +701,10 @@ static const char* GLSLextNVGetDebugNames(const char* name, unsigned entrypoint)
         strcmp(name, spv::E_SPV_NV_geometry_shader_passthrough) == 0 ||
         strcmp(name, spv::E_ARB_shader_viewport_layer_array) == 0 ||
         strcmp(name, spv::E_SPV_NV_viewport_array2) == 0 ||
-        strcmp(spv::E_SPV_NVX_multiview_per_view_attributes, name) == 0 ||
-        strcmp(spv::E_SPV_NV_fragment_shader_barycentric, name) == 0 ||
-        strcmp(name, spv::E_SPV_NV_mesh_shader) == 0) {
+        strcmp(name, spv::E_SPV_NVX_multiview_per_view_attributes) == 0 ||
+        strcmp(name, spv::E_SPV_NV_fragment_shader_barycentric) == 0 ||
+        strcmp(name, spv::E_SPV_NV_mesh_shader) == 0 ||
+        strcmp(name, spv::E_SPV_NV_shader_image_footprint) == 0) {
         switch (entrypoint) {
         // NV builtins
         case BuiltInViewportMaskNV:                 return "ViewportMaskNV";
@@ -729,6 +730,7 @@ static const char* GLSLextNVGetDebugNames(const char* name, unsigned entrypoint)
         case CapabilityPerViewAttributesNV:         return "PerViewAttributesNV";
         case CapabilityFragmentBarycentricNV:       return "FragmentBarycentricNV";
         case CapabilityMeshShadingNV:               return "MeshShadingNV";
+        case CapabilityImageFootprintNV:            return "ImageFootprintNV";
 
         // NV Decorations
         case DecorationOverrideCoverageNV:          return "OverrideCoverageNV";

--- a/SPIRV/doc.cpp
+++ b/SPIRV/doc.cpp
@@ -882,9 +882,9 @@ const char* CapabilityString(int info)
     case CapabilityStoragePushConstant16:       return "StoragePushConstant16";
     case CapabilityStorageInputOutput16:        return "StorageInputOutput16";
 
-    case CapabilityStorageBuffer8BitAccess:             return "CapabilityStorageBuffer8BitAccess";
-    case CapabilityUniformAndStorageBuffer8BitAccess:   return "CapabilityUniformAndStorageBuffer8BitAccess";
-    case CapabilityStoragePushConstant8:                return "CapabilityStoragePushConstant8";
+    case CapabilityStorageBuffer8BitAccess:             return "StorageBuffer8BitAccess";
+    case CapabilityUniformAndStorageBuffer8BitAccess:   return "UniformAndStorageBuffer8BitAccess";
+    case CapabilityStoragePushConstant8:                return "StoragePushConstant8";
 
     case CapabilityDeviceGroup: return "DeviceGroup";
     case CapabilityMultiView:   return "MultiView";
@@ -913,33 +913,34 @@ const char* CapabilityString(int info)
     case CapabilityComputeDerivativeGroupLinearNV:  return "ComputeDerivativeGroupLinearNV";
     case CapabilityFragmentBarycentricNV:           return "FragmentBarycentricNV";
     case CapabilityMeshShadingNV:                   return "MeshShadingNV";
-//    case CapabilityShadingRateNV:                   return "ShadingRateNV";  // superseded by CapabilityFragmentDensityEXT
+    case CapabilityImageFootprintNV:                return "ImageFootprintNV";
+//    case CapabilityShadingRateNV:                   return "ShadingRateNV";  // superseded by FragmentDensityEXT
 #endif
     case CapabilityFragmentDensityEXT:              return "FragmentDensityEXT";
 
     case CapabilityFragmentFullyCoveredEXT: return "FragmentFullyCoveredEXT";
 
-    case CapabilityShaderNonUniformEXT:                          return "CapabilityShaderNonUniformEXT";
-    case CapabilityRuntimeDescriptorArrayEXT:                    return "CapabilityRuntimeDescriptorArrayEXT";
-    case CapabilityInputAttachmentArrayDynamicIndexingEXT:       return "CapabilityInputAttachmentArrayDynamicIndexingEXT";
-    case CapabilityUniformTexelBufferArrayDynamicIndexingEXT:    return "CapabilityUniformTexelBufferArrayDynamicIndexingEXT";
-    case CapabilityStorageTexelBufferArrayDynamicIndexingEXT:    return "CapabilityStorageTexelBufferArrayDynamicIndexingEXT";
-    case CapabilityUniformBufferArrayNonUniformIndexingEXT:      return "CapabilityUniformBufferArrayNonUniformIndexingEXT";
-    case CapabilitySampledImageArrayNonUniformIndexingEXT:       return "CapabilitySampledImageArrayNonUniformIndexingEXT";
-    case CapabilityStorageBufferArrayNonUniformIndexingEXT:      return "CapabilityStorageBufferArrayNonUniformIndexingEXT";
-    case CapabilityStorageImageArrayNonUniformIndexingEXT:       return "CapabilityStorageImageArrayNonUniformIndexingEXT";
-    case CapabilityInputAttachmentArrayNonUniformIndexingEXT:    return "CapabilityInputAttachmentArrayNonUniformIndexingEXT";
-    case CapabilityUniformTexelBufferArrayNonUniformIndexingEXT: return "CapabilityUniformTexelBufferArrayNonUniformIndexingEXT";
-    case CapabilityStorageTexelBufferArrayNonUniformIndexingEXT: return "CapabilityStorageTexelBufferArrayNonUniformIndexingEXT";
+    case CapabilityShaderNonUniformEXT:                          return "ShaderNonUniformEXT";
+    case CapabilityRuntimeDescriptorArrayEXT:                    return "RuntimeDescriptorArrayEXT";
+    case CapabilityInputAttachmentArrayDynamicIndexingEXT:       return "InputAttachmentArrayDynamicIndexingEXT";
+    case CapabilityUniformTexelBufferArrayDynamicIndexingEXT:    return "UniformTexelBufferArrayDynamicIndexingEXT";
+    case CapabilityStorageTexelBufferArrayDynamicIndexingEXT:    return "StorageTexelBufferArrayDynamicIndexingEXT";
+    case CapabilityUniformBufferArrayNonUniformIndexingEXT:      return "UniformBufferArrayNonUniformIndexingEXT";
+    case CapabilitySampledImageArrayNonUniformIndexingEXT:       return "SampledImageArrayNonUniformIndexingEXT";
+    case CapabilityStorageBufferArrayNonUniformIndexingEXT:      return "StorageBufferArrayNonUniformIndexingEXT";
+    case CapabilityStorageImageArrayNonUniformIndexingEXT:       return "StorageImageArrayNonUniformIndexingEXT";
+    case CapabilityInputAttachmentArrayNonUniformIndexingEXT:    return "InputAttachmentArrayNonUniformIndexingEXT";
+    case CapabilityUniformTexelBufferArrayNonUniformIndexingEXT: return "UniformTexelBufferArrayNonUniformIndexingEXT";
+    case CapabilityStorageTexelBufferArrayNonUniformIndexingEXT: return "StorageTexelBufferArrayNonUniformIndexingEXT";
 
-    case CapabilityVulkanMemoryModelKHR:                return "CapabilityVulkanMemoryModelKHR";
-    case CapabilityVulkanMemoryModelDeviceScopeKHR:     return "CapabilityVulkanMemoryModelDeviceScopeKHR";
+    case CapabilityVulkanMemoryModelKHR:                return "VulkanMemoryModelKHR";
+    case CapabilityVulkanMemoryModelDeviceScopeKHR:     return "VulkanMemoryModelDeviceScopeKHR";
 
-    case CapabilityPhysicalStorageBufferAddressesEXT:   return "CapabilityPhysicalStorageBufferAddressesEXT";
+    case CapabilityPhysicalStorageBufferAddressesEXT:   return "PhysicalStorageBufferAddressesEXT";
 
-    case CapabilityVariablePointers:                    return "CapabilityVariablePointers";
+    case CapabilityVariablePointers:                    return "VariablePointers";
 
-    case CapabilityCooperativeMatrixNV:     return "CapabilityCooperativeMatrixNV";
+    case CapabilityCooperativeMatrixNV:     return "CooperativeMatrixNV";
 
     default: return "Bad";
     }

--- a/Test/140.vert
+++ b/Test/140.vert
@@ -68,7 +68,7 @@ void devi()
 #extension GL_EXT_device_group : enable
 #endif
 
-#ifdef GL_EXT_device_group
+#ifdef GL_EXT_multiview
 #extension GL_EXT_multiview : enable
 #endif
 

--- a/Test/310.frag
+++ b/Test/310.frag
@@ -440,7 +440,7 @@ void devi()
 #extension GL_EXT_device_group : enable
 #endif
 
-#ifdef GL_EXT_device_group
+#ifdef GL_EXT_multiview
 #extension GL_EXT_multiview : enable
 #endif
 

--- a/Test/400.tesc
+++ b/Test/400.tesc
@@ -114,7 +114,7 @@ void devi()
 #extension GL_EXT_device_group : enable
 #endif
 
-#ifdef GL_EXT_device_group
+#ifdef GL_EXT_multiview
 #extension GL_EXT_multiview : enable
 #endif
 

--- a/Test/400.tese
+++ b/Test/400.tese
@@ -114,7 +114,7 @@ void devi()
 #extension GL_EXT_device_group : enable
 #endif
 
-#ifdef GL_EXT_device_group
+#ifdef GL_EXT_multiview
 #extension GL_EXT_multiview : enable
 #endif
 

--- a/Test/baseResults/spv.1.3.8bitstorage-ssbo.vert.out
+++ b/Test/baseResults/spv.1.3.8bitstorage-ssbo.vert.out
@@ -4,7 +4,7 @@ spv.1.3.8bitstorage-ssbo.vert
 // Id's are bound by 28
 
                               Capability Shader
-                              Capability CapabilityStorageBuffer8BitAccess
+                              Capability StorageBuffer8BitAccess
                               Extension  "SPV_KHR_8bit_storage"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.1.3.8bitstorage-ubo.vert.out
+++ b/Test/baseResults/spv.1.3.8bitstorage-ubo.vert.out
@@ -4,7 +4,7 @@ spv.1.3.8bitstorage-ubo.vert
 // Id's are bound by 29
 
                               Capability Shader
-                              Capability CapabilityUniformAndStorageBuffer8BitAccess
+                              Capability UniformAndStorageBuffer8BitAccess
                               Extension  "SPV_KHR_8bit_storage"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.1.3.coopmat.comp.out
+++ b/Test/baseResults/spv.1.3.coopmat.comp.out
@@ -4,9 +4,9 @@ spv.1.3.coopmat.comp
 // Id's are bound by 52
 
                               Capability Shader
-                              Capability CapabilityVariablePointers
-                              Capability CapabilityVulkanMemoryModelKHR
-                              Capability CapabilityCooperativeMatrixNV
+                              Capability VariablePointers
+                              Capability VulkanMemoryModelKHR
+                              Capability CooperativeMatrixNV
                               Extension  "SPV_KHR_vulkan_memory_model"
                               Extension  "SPV_NV_cooperative_matrix"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.8bitstorage-int.frag.out
+++ b/Test/baseResults/spv.8bitstorage-int.frag.out
@@ -4,7 +4,7 @@ spv.8bitstorage-int.frag
 // Id's are bound by 172
 
                               Capability Shader
-                              Capability CapabilityUniformAndStorageBuffer8BitAccess
+                              Capability UniformAndStorageBuffer8BitAccess
                               Extension  "SPV_KHR_8bit_storage"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.8bitstorage-ssbo.vert.out
+++ b/Test/baseResults/spv.8bitstorage-ssbo.vert.out
@@ -4,7 +4,7 @@ spv.8bitstorage-ssbo.vert
 // Id's are bound by 28
 
                               Capability Shader
-                              Capability CapabilityUniformAndStorageBuffer8BitAccess
+                              Capability UniformAndStorageBuffer8BitAccess
                               Extension  "SPV_KHR_8bit_storage"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.8bitstorage-ubo.vert.out
+++ b/Test/baseResults/spv.8bitstorage-ubo.vert.out
@@ -4,7 +4,7 @@ spv.8bitstorage-ubo.vert
 // Id's are bound by 29
 
                               Capability Shader
-                              Capability CapabilityUniformAndStorageBuffer8BitAccess
+                              Capability UniformAndStorageBuffer8BitAccess
                               Extension  "SPV_KHR_8bit_storage"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.8bitstorage-uint.frag.out
+++ b/Test/baseResults/spv.8bitstorage-uint.frag.out
@@ -4,7 +4,7 @@ spv.8bitstorage-uint.frag
 // Id's are bound by 173
 
                               Capability Shader
-                              Capability CapabilityUniformAndStorageBuffer8BitAccess
+                              Capability UniformAndStorageBuffer8BitAccess
                               Extension  "SPV_KHR_8bit_storage"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.bufferhandle1.frag.out
+++ b/Test/baseResults/spv.bufferhandle1.frag.out
@@ -4,8 +4,8 @@ spv.bufferhandle1.frag
 // Id's are bound by 52
 
                               Capability Shader
-                              Capability CapabilityVulkanMemoryModelKHR
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability VulkanMemoryModelKHR
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                               Extension  "SPV_KHR_storage_buffer_storage_class"
                               Extension  "SPV_KHR_vulkan_memory_model"

--- a/Test/baseResults/spv.bufferhandle10.frag.out
+++ b/Test/baseResults/spv.bufferhandle10.frag.out
@@ -4,8 +4,8 @@ spv.bufferhandle10.frag
 // Id's are bound by 40
 
                               Capability Shader
-                              Capability CapabilityVulkanMemoryModelKHR
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability VulkanMemoryModelKHR
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                               Extension  "SPV_KHR_storage_buffer_storage_class"
                               Extension  "SPV_KHR_vulkan_memory_model"

--- a/Test/baseResults/spv.bufferhandle11.frag.out
+++ b/Test/baseResults/spv.bufferhandle11.frag.out
@@ -7,8 +7,8 @@ WARNING: 0:6: '' : all default precisions are highp; use precision statements to
 // Id's are bound by 60
 
                               Capability Shader
-                              Capability CapabilityStorageBuffer8BitAccess
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability StorageBuffer8BitAccess
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                               Extension  "SPV_KHR_8bit_storage"
                               Extension  "SPV_KHR_storage_buffer_storage_class"

--- a/Test/baseResults/spv.bufferhandle12.frag.out
+++ b/Test/baseResults/spv.bufferhandle12.frag.out
@@ -8,7 +8,7 @@ WARNING: 0:6: '' : all default precisions are highp; use precision statements to
 
                               Capability Shader
                               Capability StorageUniformBufferBlock16
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                               Extension  "SPV_KHR_16bit_storage"
                               Extension  "SPV_KHR_storage_buffer_storage_class"

--- a/Test/baseResults/spv.bufferhandle13.frag.out
+++ b/Test/baseResults/spv.bufferhandle13.frag.out
@@ -4,7 +4,7 @@ spv.bufferhandle13.frag
 // Id's are bound by 58
 
                               Capability Shader
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                               Extension  "SPV_KHR_storage_buffer_storage_class"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.bufferhandle14.frag.out
+++ b/Test/baseResults/spv.bufferhandle14.frag.out
@@ -4,7 +4,7 @@ spv.bufferhandle14.frag
 // Id's are bound by 46
 
                               Capability Shader
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel PhysicalStorageBuffer64EXT GLSL450

--- a/Test/baseResults/spv.bufferhandle15.frag.out
+++ b/Test/baseResults/spv.bufferhandle15.frag.out
@@ -7,7 +7,7 @@ WARNING: 0:16: '' : all default precisions are highp; use precision statements t
 // Id's are bound by 60
 
                               Capability Shader
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                               Extension  "SPV_KHR_storage_buffer_storage_class"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.bufferhandle16.frag.out
+++ b/Test/baseResults/spv.bufferhandle16.frag.out
@@ -5,7 +5,7 @@ spv.bufferhandle16.frag
 
                               Capability Shader
                               Capability Int64
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel PhysicalStorageBuffer64EXT GLSL450

--- a/Test/baseResults/spv.bufferhandle18.frag.out
+++ b/Test/baseResults/spv.bufferhandle18.frag.out
@@ -5,7 +5,7 @@ spv.bufferhandle18.frag
 
                               Capability Shader
                               Capability Int64
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel PhysicalStorageBuffer64EXT GLSL450

--- a/Test/baseResults/spv.bufferhandle2.frag.out
+++ b/Test/baseResults/spv.bufferhandle2.frag.out
@@ -4,7 +4,7 @@ spv.bufferhandle2.frag
 // Id's are bound by 45
 
                               Capability Shader
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                               Extension  "SPV_KHR_storage_buffer_storage_class"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.bufferhandle3.frag.out
+++ b/Test/baseResults/spv.bufferhandle3.frag.out
@@ -4,7 +4,7 @@ spv.bufferhandle3.frag
 // Id's are bound by 50
 
                               Capability Shader
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                               Extension  "SPV_KHR_storage_buffer_storage_class"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.bufferhandle4.frag.out
+++ b/Test/baseResults/spv.bufferhandle4.frag.out
@@ -4,7 +4,7 @@ spv.bufferhandle4.frag
 // Id's are bound by 61
 
                               Capability Shader
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                               Extension  "SPV_KHR_storage_buffer_storage_class"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.bufferhandle5.frag.out
+++ b/Test/baseResults/spv.bufferhandle5.frag.out
@@ -4,7 +4,7 @@ spv.bufferhandle5.frag
 // Id's are bound by 22
 
                               Capability Shader
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel PhysicalStorageBuffer64EXT GLSL450

--- a/Test/baseResults/spv.bufferhandle6.frag.out
+++ b/Test/baseResults/spv.bufferhandle6.frag.out
@@ -4,7 +4,7 @@ spv.bufferhandle6.frag
 // Id's are bound by 165
 
                               Capability Shader
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                               Extension  "SPV_KHR_storage_buffer_storage_class"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.bufferhandle7.frag.out
+++ b/Test/baseResults/spv.bufferhandle7.frag.out
@@ -4,7 +4,7 @@ spv.bufferhandle7.frag
 // Id's are bound by 24
 
                               Capability Shader
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                               Extension  "SPV_KHR_storage_buffer_storage_class"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.bufferhandle8.frag.out
+++ b/Test/baseResults/spv.bufferhandle8.frag.out
@@ -4,7 +4,7 @@ spv.bufferhandle8.frag
 // Id's are bound by 27
 
                               Capability Shader
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                               Extension  "SPV_KHR_storage_buffer_storage_class"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.bufferhandle9.frag.out
+++ b/Test/baseResults/spv.bufferhandle9.frag.out
@@ -5,7 +5,7 @@ spv.bufferhandle9.frag
 
                               Capability Shader
                               Capability Int64
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
+                              Capability PhysicalStorageBufferAddressesEXT
                               Extension  "SPV_EXT_physical_storage_buffer"
                               Extension  "SPV_KHR_storage_buffer_storage_class"
                1:             ExtInstImport  "GLSL.std.450"

--- a/Test/baseResults/spv.coopmat.comp.out
+++ b/Test/baseResults/spv.coopmat.comp.out
@@ -6,9 +6,9 @@ spv.coopmat.comp
                               Capability Shader
                               Capability Float16
                               Capability StorageUniformBufferBlock16
-                              Capability CapabilityVulkanMemoryModelKHR
-                              Capability CapabilityPhysicalStorageBufferAddressesEXT
-                              Capability CapabilityCooperativeMatrixNV
+                              Capability VulkanMemoryModelKHR
+                              Capability PhysicalStorageBufferAddressesEXT
+                              Capability CooperativeMatrixNV
                               Extension  "SPV_EXT_physical_storage_buffer"
                               Extension  "SPV_KHR_16bit_storage"
                               Extension  "SPV_KHR_storage_buffer_storage_class"

--- a/Test/baseResults/spv.int8.frag.out
+++ b/Test/baseResults/spv.int8.frag.out
@@ -9,7 +9,7 @@ spv.int8.frag
                               Capability Int64
                               Capability Int16
                               Capability Int8
-                              Capability CapabilityUniformAndStorageBuffer8BitAccess
+                              Capability UniformAndStorageBuffer8BitAccess
                               Extension  "SPV_KHR_8bit_storage"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.memoryScopeSemantics.comp.out
+++ b/Test/baseResults/spv.memoryScopeSemantics.comp.out
@@ -6,8 +6,8 @@ spv.memoryScopeSemantics.comp
                               Capability Shader
                               Capability Int64
                               Capability Int64Atomics
-                              Capability CapabilityVulkanMemoryModelKHR
-                              Capability CapabilityVulkanMemoryModelDeviceScopeKHR
+                              Capability VulkanMemoryModelKHR
+                              Capability VulkanMemoryModelDeviceScopeKHR
                               Extension  "SPV_KHR_vulkan_memory_model"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical VulkanKHR

--- a/Test/baseResults/spv.nonuniform.frag.out
+++ b/Test/baseResults/spv.nonuniform.frag.out
@@ -7,18 +7,18 @@ spv.nonuniform.frag
                               Capability InputAttachment
                               Capability SampledBuffer
                               Capability ImageBuffer
-                              Capability CapabilityShaderNonUniformEXT
-                              Capability CapabilityRuntimeDescriptorArrayEXT
-                              Capability CapabilityInputAttachmentArrayDynamicIndexingEXT
-                              Capability CapabilityUniformTexelBufferArrayDynamicIndexingEXT
-                              Capability CapabilityStorageTexelBufferArrayDynamicIndexingEXT
-                              Capability CapabilityUniformBufferArrayNonUniformIndexingEXT
-                              Capability CapabilitySampledImageArrayNonUniformIndexingEXT
-                              Capability CapabilityStorageBufferArrayNonUniformIndexingEXT
-                              Capability CapabilityStorageImageArrayNonUniformIndexingEXT
-                              Capability CapabilityInputAttachmentArrayNonUniformIndexingEXT
-                              Capability CapabilityUniformTexelBufferArrayNonUniformIndexingEXT
-                              Capability CapabilityStorageTexelBufferArrayNonUniformIndexingEXT
+                              Capability ShaderNonUniformEXT
+                              Capability RuntimeDescriptorArrayEXT
+                              Capability InputAttachmentArrayDynamicIndexingEXT
+                              Capability UniformTexelBufferArrayDynamicIndexingEXT
+                              Capability StorageTexelBufferArrayDynamicIndexingEXT
+                              Capability UniformBufferArrayNonUniformIndexingEXT
+                              Capability SampledImageArrayNonUniformIndexingEXT
+                              Capability StorageBufferArrayNonUniformIndexingEXT
+                              Capability StorageImageArrayNonUniformIndexingEXT
+                              Capability InputAttachmentArrayNonUniformIndexingEXT
+                              Capability UniformTexelBufferArrayNonUniformIndexingEXT
+                              Capability StorageTexelBufferArrayNonUniformIndexingEXT
                               Extension  "SPV_EXT_descriptor_indexing"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.nonuniform2.frag.out
+++ b/Test/baseResults/spv.nonuniform2.frag.out
@@ -5,9 +5,9 @@ spv.nonuniform2.frag
 
                               Capability Shader
                               Capability ImageBuffer
-                              Capability CapabilityShaderNonUniformEXT
-                              Capability CapabilityRuntimeDescriptorArrayEXT
-                              Capability CapabilityStorageTexelBufferArrayNonUniformIndexingEXT
+                              Capability ShaderNonUniformEXT
+                              Capability RuntimeDescriptorArrayEXT
+                              Capability StorageTexelBufferArrayNonUniformIndexingEXT
                               Extension  "SPV_EXT_descriptor_indexing"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450

--- a/Test/baseResults/spv.shaderImageFootprint.frag.out
+++ b/Test/baseResults/spv.shaderImageFootprint.frag.out
@@ -5,7 +5,7 @@ spv.shaderImageFootprint.frag
 
                               Capability Shader
                               Capability MinLod
-                              Capability Bad
+                              Capability ImageFootprintNV
                               Extension  "SPV_NV_shader_image_footprint"
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450


### PR DESCRIPTION
1) Fix include guard for GL_EXT_multiview

2) Return consistent names from CapabilityString
 - Don't prefix with "Capability" since the majority of them don't.
- Also add missing CapabilityImageFootprintNV