### PR TITLE
BUILD.gn: Fix file for use with Fuchsia platform build.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -148,6 +148,7 @@ source_set("glslang_sources") {
       "-Wno-inconsistent-missing-override",
       "-Wno-sign-compare",
       "-Wno-unused-variable",
+      "-Wno-missing-field-initializers",
     ]
   }
   if (is_win && !is_clang) {
@@ -183,6 +184,16 @@ executable("glslang_validator") {
   defines = [ "ENABLE_OPT=1" ]
   deps = [
     ":glslang_default_resource_limits_sources",
+    ":glslang_sources",
+  ]
+}
+
+executable("spirv-remap") {
+  sources = [
+    "StandAlone/spirv-remap.cpp",
+  ]
+  defines = [ "ENABLE_OPT=1" ]
+  deps = [
     ":glslang_sources",
   ]
 }


### PR DESCRIPTION
In order to upgrade the version of glslang used by the
Fuchsia platform source tree, BUILD.gn needs to be
slightly modified to care about the case where it is
not used with the Chromium //build configuration:

- Remove a new compiler warning to ensure proper
  compilation with -Werror (which is the default).

- Add a build target for spirv-remap, which is used
  by Fuchsia at build time to optimize the precompiled
  shaders of some of its graphics libraries.