### PR TITLE
Remove __DATE__ and __TIME__ usage

### DIFF
--- a/StandAlone/spirv-remap.cpp
+++ b/StandAlone/spirv-remap.cpp
@@ -227,7 +227,7 @@ namespace {
                 }
             }
             else if (arg == "--version" || arg == "-V") {
-                std::cout << basename(argv[0]) << " version 0.97 " << __DATE__ << " " << __TIME__ << std::endl;
+                std::cout << basename(argv[0]) << " version 0.97" << std::endl;
                 exit(0);
             } else if (arg == "--input" || arg == "-i") {
                 // Collect input files


### PR DESCRIPTION
These macros result in a non-deterministic build.  In chromium, these
macros are specifically set to empty, resulting in a compile error.

Revealed by this change: 1f5799c155d30b90871c79d4ca92f8da4d3f3872