### PR TITLE
Update known good SPIRV-Tools commit

### DIFF
--- a/known_good.json
+++ b/known_good.json
@@ -5,7 +5,7 @@
       "site" : "github",
       "subrepo" : "KhronosGroup/SPIRV-Tools",
       "subdir" : "External/spirv-tools",
-      "commit" : "456cc598afb6d7c264f20cd3a183d85e369bed9a"
+      "commit" : "1fedf72e500b7cf72098a3f800c8ef4b9d9dc84f"
     },
     {
       "name" : "spirv-tools/external/spirv-headers",


### PR DESCRIPTION
Update the known good SPIRV-Tools commit to eventually propagate the commit (https://github.com/KhronosGroup/SPIRV-Tools/commit/1fedf72e500b7cf72098a3f800c8ef4b9d9dc84f) allowing the ray tracing stages in pass instrumentation to the vulkan validation layers (validation layers depends on glslang which depends on spirv-tools).