### PR TITLE
Convert no RTTI rule to be compiler specific

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,10 +88,14 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
     add_compile_options(-Wall -Wmaybe-uninitialized -Wuninitialized -Wunused -Wunused-local-typedefs
                         -Wunused-parameter -Wunused-value  -Wunused-variable -Wunused-but-set-parameter -Wunused-but-set-variable -fno-exceptions)
     add_compile_options(-Wno-reorder)  # disable this from -Wall, since it happens all over.
+    add_compile_options(-fno-rtti)
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     add_compile_options(-Wall -Wuninitialized -Wunused -Wunused-local-typedefs
                         -Wunused-parameter -Wunused-value  -Wunused-variable)
     add_compile_options(-Wno-reorder)  # disable this from -Wall, since it happens all over.
+    add_compile_options(-fno-rtti)
+elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "MSVC")
+    add_compile_options(/GR-) # Disable RTTI
 endif()
 
 # Request C++11
@@ -104,8 +108,6 @@ else()
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
     set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
-
-add_compile_options(-fno-rtti)
 
 function(glslang_set_link_args TARGET)
     # For MinGW compiles, statically link against the GCC and C++ runtimes.


### PR DESCRIPTION
MSVC uses a different flag for disabling RTTI, so is currently
including RTTI information and throwing warnings.