### PR TITLE
Add in header for uint32_t definition

### DIFF
--- a/glslang/MachineIndependent/iomapper.h
+++ b/glslang/MachineIndependent/iomapper.h
@@ -36,6 +36,7 @@
 #ifndef _IOMAPPER_INCLUDED
 #define _IOMAPPER_INCLUDED
 
+#include <cstdint>
 #include "LiveTraverser.h"
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
This is needed for stricter/newer MSVC builds of downstream users.