### PR TITLE
Fix conformance with -Wextra-tokens

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -3180,7 +3180,7 @@ void TParseContext::accStructNVCheck(const TSourceLoc& loc, const TType& type, c
 
 }
 
-#endif GLSLANG_WEB
+#endif // GLSLANG_WEB
 
 void TParseContext::transparentOpaqueCheck(const TSourceLoc& loc, const TType& type, const TString& identifier)
 {


### PR DESCRIPTION
ANGLE compiles with the flag -Wextra-tokens so this change broke the glslang roll into ANGLE.