### PR TITLE
Add support for GL_ARB_explicit_uniform_location

### DIFF
--- a/Test/130.frag
+++ b/Test/130.frag
@@ -167,3 +167,12 @@ void qux2()
 }
 
 layout(early_fragment_tests) out;         // ERROR
+
+#extension GL_ARB_explicit_uniform_location : enable
+
+layout(location = 3) uniform vec4 ucolor0; // ERROR: explicit attrib location is also required for version < 330
+
+#extension GL_ARB_explicit_attrib_location : enable
+
+layout(location = 4) uniform vec4 ucolor1;
+

--- a/Test/330.frag
+++ b/Test/330.frag
@@ -150,3 +150,16 @@ void fooKeyMem()
 }
 
 layout(location=28, index=2) out vec4 outIndex2; // ERROR index out of range
+
+layout(location=4) uniform vec4 ucolor0; // ERROR: extension is not enabled
+
+#extension GL_ARB_explicit_uniform_location : enable
+
+layout(location=5) uniform vec4 ucolor1;
+
+layout(location=6) uniform ColorsBuffer // ERROR: location cannot be applied in uniform buffer block
+{
+    vec4 colors[128];
+} colorsBuffer;
+
+

--- a/Test/baseResults/130.frag.out
+++ b/Test/baseResults/130.frag.out
@@ -29,10 +29,13 @@ ERROR: 0:153: 'early_fragment_tests' : not supported for this version or the ena
 ERROR: 0:154: 'image load store' : not supported for this version or the enabled extensions 
 ERROR: 0:154: 'iimage2D' : Reserved word. 
 ERROR: 0:169: 'early_fragment_tests' : can only apply to 'in' 
-ERROR: 28 compilation errors.  No code generated.
+ERROR: 0:173: 'location qualifier on uniform or buffer' : not supported for this version or the enabled extensions 
+ERROR: 29 compilation errors.  No code generated.
 
 
 Shader version: 130
+Requested GL_ARB_explicit_attrib_location
+Requested GL_ARB_explicit_uniform_location
 Requested GL_ARB_gpu_shader5
 Requested GL_ARB_separate_shader_objects
 Requested GL_ARB_shader_image_load_store
@@ -402,12 +405,16 @@ ERROR: node is still EOpNull!
 0:?     'gl_FogFragCoord' ( smooth in float)
 0:?     'iimg2Dbad' (layout( r32i) uniform iimage2D)
 0:?     'iimg2D' (layout( r32i) uniform iimage2D)
+0:?     'ucolor0' (layout( location=3) uniform 4-component vector of float)
+0:?     'ucolor1' (layout( location=4) uniform 4-component vector of float)
 
 
 Linked fragment stage:
 
 
 Shader version: 130
+Requested GL_ARB_explicit_attrib_location
+Requested GL_ARB_explicit_uniform_location
 Requested GL_ARB_gpu_shader5
 Requested GL_ARB_separate_shader_objects
 Requested GL_ARB_shader_image_load_store
@@ -457,4 +464,6 @@ ERROR: node is still EOpNull!
 0:?     'gl_FogFragCoord' ( smooth in float)
 0:?     'iimg2Dbad' (layout( r32i) uniform iimage2D)
 0:?     'iimg2D' (layout( r32i) uniform iimage2D)
+0:?     'ucolor0' (layout( location=3) uniform 4-component vector of float)
+0:?     'ucolor1' (layout( location=4) uniform 4-component vector of float)
 

--- a/Test/baseResults/330.frag.out
+++ b/Test/baseResults/330.frag.out
@@ -40,11 +40,14 @@ ERROR: 0:140: 'assign' :  cannot convert from ' const float' to ' temp 2-compone
 ERROR: 0:141: 'textureQueryLod' : no matching overloaded function found 
 ERROR: 0:141: 'assign' :  cannot convert from ' const float' to ' temp 2-component vector of float'
 ERROR: 0:152: 'index' : value must be 0 or 1 
-ERROR: 41 compilation errors.  No code generated.
+ERROR: 0:154: 'location qualifier on uniform or buffer' : not supported for this version or the enabled extensions 
+ERROR: 0:160: 'location' : cannot apply to uniform or buffer block 
+ERROR: 43 compilation errors.  No code generated.
 
 
 Shader version: 330
 Requested GL_ARB_enhanced_layouts
+Requested GL_ARB_explicit_uniform_location
 Requested GL_ARB_separate_shader_objects
 ERROR: node is still EOpNull!
 0:8  Function Definition: main( ( global void)
@@ -126,6 +129,9 @@ ERROR: node is still EOpNull!
 0:?     'precise' ( global int)
 0:?     'KeyMem' ( global structure{ global int precise})
 0:?     'outIndex2' (layout( location=28 index=0) out 4-component vector of float)
+0:?     'ucolor0' (layout( location=4) uniform 4-component vector of float)
+0:?     'ucolor1' (layout( location=5) uniform 4-component vector of float)
+0:?     'colorsBuffer' (layout( location=6 column_major shared) uniform block{layout( column_major shared) uniform 128-element array of 4-component vector of float colors})
 
 
 Linked fragment stage:
@@ -135,6 +141,7 @@ ERROR: Linking fragment stage: Cannot use both gl_FragColor and gl_FragData
 
 Shader version: 330
 Requested GL_ARB_enhanced_layouts
+Requested GL_ARB_explicit_uniform_location
 Requested GL_ARB_separate_shader_objects
 ERROR: node is still EOpNull!
 0:8  Function Definition: main( ( global void)
@@ -191,4 +198,7 @@ ERROR: node is still EOpNull!
 0:?     'precise' ( global int)
 0:?     'KeyMem' ( global structure{ global int precise})
 0:?     'outIndex2' (layout( location=28 index=0) out 4-component vector of float)
+0:?     'ucolor0' (layout( location=4) uniform 4-component vector of float)
+0:?     'ucolor1' (layout( location=5) uniform 4-component vector of float)
+0:?     'colorsBuffer' (layout( location=6 column_major shared) uniform block{layout( column_major shared) uniform 128-element array of 4-component vector of float colors})
 

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -5101,7 +5101,8 @@ void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publi
         return;
     } else if (id == "location") {
         profileRequires(loc, EEsProfile, 300, nullptr, "location");
-        const char* exts[2] = { E_GL_ARB_separate_shader_objects, E_GL_ARB_explicit_attrib_location };
+        const char* exts[2] = { E_GL_ARB_separate_shader_objects, E_GL_ARB_explicit_attrib_location }; 
+        // GL_ARB_explicit_uniform_location requires 330 or GL_ARB_explicit_attrib_location we do not need to add it here
         profileRequires(loc, ~EEsProfile, 330, 2, exts, "location");
         if ((unsigned int)value >= TQualifier::layoutLocationEnd)
             error(loc, "location is too large", id.c_str(), "");
@@ -5858,8 +5859,11 @@ void TParseContext::layoutQualifierCheck(const TSourceLoc& loc, const TQualifier
         case EvqBuffer:
         {
             const char* feature = "location qualifier on uniform or buffer";
-            requireProfile(loc, EEsProfile | ECoreProfile | ECompatibilityProfile, feature);
-            profileRequires(loc, ECoreProfile | ECompatibilityProfile, 430, nullptr, feature);
+            requireProfile(loc, EEsProfile | ECoreProfile | ECompatibilityProfile | ENoProfile, feature);
+            profileRequires(loc, ~EEsProfile, 330, E_GL_ARB_explicit_attrib_location, feature);
+            if (!isEsProfile() && (extensionTurnedOn(E_GL_ARB_explicit_attrib_location) || version >= 330)) {
+                profileRequires(loc, ~EEsProfile, 430, E_GL_ARB_explicit_uniform_location, feature);
+            }
             profileRequires(loc, EEsProfile, 310, nullptr, feature);
             break;
         }

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -5861,9 +5861,7 @@ void TParseContext::layoutQualifierCheck(const TSourceLoc& loc, const TQualifier
             const char* feature = "location qualifier on uniform or buffer";
             requireProfile(loc, EEsProfile | ECoreProfile | ECompatibilityProfile | ENoProfile, feature);
             profileRequires(loc, ~EEsProfile, 330, E_GL_ARB_explicit_attrib_location, feature);
-            if (!isEsProfile() && (extensionTurnedOn(E_GL_ARB_explicit_attrib_location) || version >= 330)) {
-                profileRequires(loc, ~EEsProfile, 430, E_GL_ARB_explicit_uniform_location, feature);
-            }
+            profileRequires(loc, ~EEsProfile, 430, E_GL_ARB_explicit_uniform_location, feature);
             profileRequires(loc, EEsProfile, 310, nullptr, feature);
             break;
         }

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -174,6 +174,7 @@ void TParseVersions::initializeExtensionBehavior()
     extensionBehavior[E_GL_ARB_texture_cube_map_array]       = EBhDisable;
     extensionBehavior[E_GL_ARB_shader_texture_lod]           = EBhDisable;
     extensionBehavior[E_GL_ARB_explicit_attrib_location]     = EBhDisable;
+    extensionBehavior[E_GL_ARB_explicit_uniform_location]    = EBhDisable;
     extensionBehavior[E_GL_ARB_shader_image_load_store]      = EBhDisable;
     extensionBehavior[E_GL_ARB_shader_atomic_counters]       = EBhDisable;
     extensionBehavior[E_GL_ARB_shader_draw_parameters]       = EBhDisable;
@@ -370,6 +371,7 @@ void TParseVersions::getPreamble(std::string& preamble)
             "#define GL_ARB_texture_cube_map_array 1\n"
             "#define GL_ARB_shader_texture_lod 1\n"
             "#define GL_ARB_explicit_attrib_location 1\n"
+            "#define GL_ARB_explicit_uniform_location 1\n"
             "#define GL_ARB_shader_image_load_store 1\n"
             "#define GL_ARB_shader_atomic_counters 1\n"
             "#define GL_ARB_shader_draw_parameters 1\n"

--- a/glslang/MachineIndependent/Versions.h
+++ b/glslang/MachineIndependent/Versions.h
@@ -126,6 +126,7 @@ const char* const E_GL_ARB_enhanced_layouts             = "GL_ARB_enhanced_layou
 const char* const E_GL_ARB_texture_cube_map_array       = "GL_ARB_texture_cube_map_array";
 const char* const E_GL_ARB_shader_texture_lod           = "GL_ARB_shader_texture_lod";
 const char* const E_GL_ARB_explicit_attrib_location     = "GL_ARB_explicit_attrib_location";
+const char* const E_GL_ARB_explicit_uniform_location    = "GL_ARB_explicit_uniform_location";
 const char* const E_GL_ARB_shader_image_load_store      = "GL_ARB_shader_image_load_store";
 const char* const E_GL_ARB_shader_atomic_counters       = "GL_ARB_shader_atomic_counters";
 const char* const E_GL_ARB_shader_draw_parameters       = "GL_ARB_shader_draw_parameters";


### PR DESCRIPTION
This enables usage of explicit location on uniforms without the requirement of GLSL 430 version
Also added tests