### PR TITLE
GN build (for Chromium): enable HLSL in dependents.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -37,6 +37,8 @@ spirv_tools_dir = glslang_spirv_tools_dir
 
 config("glslang_public") {
   include_dirs = [ "." ]
+
+  defines = [ "ENABLE_HLSL=1" ]
 }
 
 source_set("glslang_sources") {
@@ -131,10 +133,7 @@ source_set("glslang_sources") {
     "glslang/Public/ShaderLang.h",
   ]
 
-  defines = [
-    "ENABLE_OPT=1",
-    "ENABLE_HLSL=1",
-  ]
+  defines = [ "ENABLE_OPT=1" ]
 
   if (is_win) {
     sources += [ "glslang/OSDependent/Windows/ossource.cpp" ]
@@ -157,8 +156,8 @@ source_set("glslang_sources") {
   }
   if (is_win && !is_clang) {
     cflags = [
-      "/wd4018", # signed/unsigned mismatch
-      "/wd4189", # local variable is initialized but not referenced
+      "/wd4018",  # signed/unsigned mismatch
+      "/wd4189",  # local variable is initialized but not referenced
     ]
   }
 
@@ -173,7 +172,9 @@ source_set("glslang_default_resource_limits_sources") {
     "StandAlone/ResourceLimits.cpp",
     "StandAlone/ResourceLimits.h",
   ]
-  deps = [ ":glslang_sources" ]
+  deps = [
+    ":glslang_sources",
+  ]
   public_configs = [ ":glslang_public" ]
 }
 


### PR DESCRIPTION
The previous fix for this only enabled HLSL internally in glslang which
means that dependent using HLSL, for example shaderc, failed
compilation.

Also contains noop changes done by `gn format`