### PR TITLE
Initialize variable to avoid uninitialized variable warnings in Clang

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -7077,11 +7077,11 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
             }
             node = intermediate.setAggregateOperator(node, EOpConstructCooperativeMatrix, type, node->getLoc());
         } else {
-            TOperator op;
+            TOperator op = EOpNull;
             switch (type.getBasicType()) {
             default:
                 assert(0);
-                return nullptr;
+                break;
             case EbtInt:
             {
                 switch (node->getType().getBasicType()) {
@@ -7090,9 +7090,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
                     case EbtUint8:   op = EOpConvUint8ToInt;    break;
                     case EbtInt8:    op = EOpConvInt8ToInt;     break;
                     case EbtUint:    op = EOpConvUintToInt;     break;
-                    default:
-                        assert(0);
-                        return nullptr;
+                    default: assert(0);
                 }
 
             }
@@ -7106,9 +7104,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
                     case EbtInt8:    op = EOpConvInt8ToUint;    break;
                     case EbtInt:     op = EOpConvIntToUint;      break;
                     case EbtUint:    op = EOpConvUintToInt8;     break;
-                    default:
-                        assert(0);
-                        return nullptr;
+                    default: assert(0);
                 }
 
             }
@@ -7122,9 +7118,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
                     case EbtUint8:   op = EOpConvUint8ToInt8;    break;
                     case EbtInt:     op = EOpConvIntToInt8;      break;
                     case EbtUint:    op = EOpConvUintToInt8;     break;
-                    default:
-                        assert(0);
-                        return nullptr;
+                    default: assert(0);
                 }
 
             }
@@ -7136,9 +7130,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
                     case EbtInt8:    op = EOpConvInt8ToUint8;    break;
                     case EbtInt:     op = EOpConvIntToUint8;     break;
                     case EbtUint:    op = EOpConvUintToUint8;    break;
-                    default:
-                        assert(0);
-                        return nullptr;
+                    default: assert(0);
                 }
             }
                 break;
@@ -7150,9 +7142,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
                     case EbtUint8:   op = EOpConvUint8ToFloat;    break;
                     case EbtInt:     op = EOpConvIntToFloat;      break;
                     case EbtUint:    op = EOpConvUintToFloat;     break;
-                    default:
-                        assert(0);
-                        return nullptr;
+                    default: assert(0);
                 }
             }
                 break;
@@ -7164,9 +7154,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
                     case EbtUint8:  op = EOpConvUint8ToFloat16;  break;
                     case EbtInt:    op = EOpConvIntToFloat16;    break;
                     case EbtUint:   op = EOpConvUintToFloat16;   break;
-                    default:
-                        assert(0);
-                        return nullptr;
+                    default: assert(0);
                 }
             }
                 break;

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -7081,7 +7081,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
             switch (type.getBasicType()) {
             default:
                 assert(0);
-                break;
+                return nullptr;
             case EbtInt:
             {
                 switch (node->getType().getBasicType()) {
@@ -7090,7 +7090,9 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
                     case EbtUint8:   op = EOpConvUint8ToInt;    break;
                     case EbtInt8:    op = EOpConvInt8ToInt;     break;
                     case EbtUint:    op = EOpConvUintToInt;     break;
-                    default: assert(0);
+                    default:
+                        assert(0);
+                        return nullptr;
                 }
 
             }
@@ -7104,7 +7106,9 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
                     case EbtInt8:    op = EOpConvInt8ToUint;    break;
                     case EbtInt:     op = EOpConvIntToUint;      break;
                     case EbtUint:    op = EOpConvUintToInt8;     break;
-                    default: assert(0);
+                    default:
+                        assert(0);
+                        return nullptr;
                 }
 
             }
@@ -7118,7 +7122,9 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
                     case EbtUint8:   op = EOpConvUint8ToInt8;    break;
                     case EbtInt:     op = EOpConvIntToInt8;      break;
                     case EbtUint:    op = EOpConvUintToInt8;     break;
-                    default: assert(0);
+                    default:
+                        assert(0);
+                        return nullptr;
                 }
 
             }
@@ -7130,7 +7136,9 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
                     case EbtInt8:    op = EOpConvInt8ToUint8;    break;
                     case EbtInt:     op = EOpConvIntToUint8;     break;
                     case EbtUint:    op = EOpConvUintToUint8;    break;
-                    default: assert(0);
+                    default:
+                        assert(0);
+                        return nullptr;
                 }
             }
                 break;
@@ -7142,7 +7150,9 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
                     case EbtUint8:   op = EOpConvUint8ToFloat;    break;
                     case EbtInt:     op = EOpConvIntToFloat;      break;
                     case EbtUint:    op = EOpConvUintToFloat;     break;
-                    default: assert(0);
+                    default:
+                        assert(0);
+                        return nullptr;
                 }
             }
                 break;
@@ -7154,7 +7164,9 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
                     case EbtUint8:  op = EOpConvUint8ToFloat16;  break;
                     case EbtInt:    op = EOpConvIntToFloat16;    break;
                     case EbtUint:   op = EOpConvUintToFloat16;   break;
-                    default: assert(0);
+                    default:
+                        assert(0);
+                        return nullptr;
                 }
             }
                 break;


### PR DESCRIPTION
In the current version of the code on non-debug builds these cases
will fallthrough, since assert is a no-op, and eventually make a call
passing in |op| which hasn't been initialized. clang is currently
throwing a warning about this behaviour when integrating downstream.

This patch changes the behaviour, so that in any branch that has an
assert now has a return nullptr, to indicate failure after it and
avoid the uninitialized variable usage.