### PR TITLE
Fix Fuchsia build.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -167,6 +167,7 @@ source_set("glslang_sources") {
       "-Wno-sign-compare",
       "-Wno-unused-variable",
       "-Wno-missing-field-initializers",
+      "-Wno-newline-eof",
     ]
   }
   if (is_win && !is_clang) {


### PR DESCRIPTION
The Fuchsia build is very picky about newlines at the end of files
and will complain loudly about them. Removing the -Wnewline-eof
warning solves the issue.