### PR TITLE
GLSL/SPV: Fix #1900: Drop const on literal when doing an object copy.

### DIFF
--- a/Test/baseResults/nonuniform.frag.out
+++ b/Test/baseResults/nonuniform.frag.out
@@ -40,6 +40,13 @@ ERROR: node is still EOpNull!
 0:27                2 (const int)
 0:28      'nu_li' ( nonuniform temp int)
 0:29      'nu_li' ( nonuniform temp int)
+0:30      move second child to first child ( temp int)
+0:30        'nu_li' ( nonuniform temp int)
+0:30        indirect index ( nonuniform temp int)
+0:30          'table' ( temp 5-element array of int)
+0:30          copy object ( nonuniform temp int)
+0:30            Constant:
+0:30              3 (const int)
 0:?   Linker Objects
 0:?     'nonuniformEXT' ( global int)
 0:?     'nu_inv4' ( smooth nonuniform in 4-component vector of float)
@@ -83,6 +90,13 @@ ERROR: node is still EOpNull!
 0:27                2 (const int)
 0:28      'nu_li' ( nonuniform temp int)
 0:29      'nu_li' ( nonuniform temp int)
+0:30      move second child to first child ( temp int)
+0:30        'nu_li' ( nonuniform temp int)
+0:30        indirect index ( nonuniform temp int)
+0:30          'table' ( temp 5-element array of int)
+0:30          copy object ( nonuniform temp int)
+0:30            Constant:
+0:30              3 (const int)
 0:?   Linker Objects
 0:?     'nonuniformEXT' ( global int)
 0:?     'nu_inv4' ( smooth nonuniform in 4-component vector of float)

--- a/Test/nonuniform.frag
+++ b/Test/nonuniform.frag
@@ -22,12 +22,12 @@ void main()
     nonuniformEXT const int nu_ci = 2; // ERROR, const
 
     foo(nu_li, nu_li);
-
+    int table[5];
     int a;
     nu_li = nonuniformEXT(a) + nonuniformEXT(a * 2);
     nu_li = nonuniformEXT(a, a);       // ERROR, too many arguments
     nu_li = nonuniformEXT();           // ERROR, no arguments
+    nu_li = table[nonuniformEXT(3)];
 }
-
 layout(location=1) in struct S { float a; nonuniformEXT float b; } ins;  // ERROR, not on member
 layout(location=3) in inbName { float a; nonuniformEXT float b; } inb;   // ERROR, not on member


### PR DESCRIPTION
This makes the type correct from the beginning, which should be more robust.