### PR TITLE
find Python and add External subdir only if BUILD_EXTERNAL option was set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ include(GNUInstallDirs)
 include(CMakeDependentOption)
 
 option(BUILD_SHARED_LIBS "Build Shared Libraries" OFF)
+option(BUILD_EXTERNAL "Build external dependencies in /External" ON)
 
 set(LIB_TYPE STATIC)
 
@@ -148,12 +149,12 @@ endfunction(glslang_set_link_args)
 
 # CMake needs to find the right version of python, right from the beginning,
 # otherwise, it will find the wrong version and fail later
-if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/External)
+if(BUILD_EXTERNAL AND IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/External)
     find_package(PythonInterp 3 REQUIRED)
+	
+	# We depend on these for later projects, so they should come first.
+	add_subdirectory(External)
 endif()
-
-# We depend on these for later projects, so they should come first.
-add_subdirectory(External)
 
 if(NOT TARGET SPIRV-Tools-opt)
     set(ENABLE_OPT OFF)


### PR DESCRIPTION
find Python and add External subdir only if BUILD_EXTERNAL option was set set (on by default) and /External dir exists