### PR TITLE
Fix for GCC 9 / Werror=deprecated-copy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,9 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
                         -Wunused-parameter -Wunused-value  -Wunused-variable -Wunused-but-set-parameter -Wunused-but-set-variable -fno-exceptions)
     add_compile_options(-Wno-reorder)  # disable this from -Wall, since it happens all over.
     add_compile_options(-fno-rtti)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "9.0.0")
+        add_compile_options(-Werror=deprecated-copy)
+    endif()
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     add_compile_options(-Wall -Wuninitialized -Wunused -Wunused-local-typedefs
                         -Wunused-parameter -Wunused-value  -Wunused-variable)

--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -512,7 +512,7 @@ public:
         Block &head, &body, &merge, &continue_target;
     private:
         LoopBlocks();
-        LoopBlocks& operator=(const LoopBlocks&);
+        LoopBlocks& operator=(const LoopBlocks&) = delete;
     };
 
     // Start a new loop and prepare the builder to generate code for it.  Until

--- a/glslang/Include/ConstantUnion.h
+++ b/glslang/Include/ConstantUnion.h
@@ -921,7 +921,7 @@ public:
         else
             unionArray =  new TConstUnionVector(size);
     }
-    TConstUnionArray(const TConstUnionArray& a) : unionArray(a.unionArray) { }
+    TConstUnionArray(const TConstUnionArray& a) = default;
     TConstUnionArray(const TConstUnionArray& a, int start, int size)
     {
         unionArray = new TConstUnionVector(size);

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -161,7 +161,7 @@ struct TNotifyUniformAdaptor
     }
 
 private:
-    TNotifyUniformAdaptor& operator=(TNotifyUniformAdaptor&);
+    TNotifyUniformAdaptor& operator=(TNotifyUniformAdaptor&) = delete;
 };
 
 struct TNotifyInOutAdaptor
@@ -180,7 +180,7 @@ struct TNotifyInOutAdaptor
     }
 
 private:
-    TNotifyInOutAdaptor& operator=(TNotifyInOutAdaptor&);
+    TNotifyInOutAdaptor& operator=(TNotifyInOutAdaptor&) = delete;
 };
 
 struct TResolverUniformAdaptor {
@@ -236,7 +236,7 @@ struct TResolverUniformAdaptor {
     bool&           error;
 
 private:
-    TResolverUniformAdaptor& operator=(TResolverUniformAdaptor&);
+    TResolverUniformAdaptor& operator=(TResolverUniformAdaptor&) = delete;
 };
 
 struct TResolverInOutAdaptor {
@@ -283,7 +283,7 @@ struct TResolverInOutAdaptor {
     bool&           error;
 
 private:
-    TResolverInOutAdaptor& operator=(TResolverInOutAdaptor&);
+    TResolverInOutAdaptor& operator=(TResolverInOutAdaptor&) = delete;
 };
 
 // The class is used for reserving explicit uniform locations and ubo/ssbo/opaque bindings
@@ -384,7 +384,7 @@ struct TSymbolValidater
     bool& hadError;
 
 private:
-    TSymbolValidater& operator=(TSymbolValidater&);
+    TSymbolValidater& operator=(TSymbolValidater&) = delete;
 };
 
 struct TSlotCollector {
@@ -398,7 +398,7 @@ struct TSlotCollector {
     TInfoSink& infoSink;
 
 private:
-    TSlotCollector& operator=(TSlotCollector&);
+    TSlotCollector& operator=(TSlotCollector&) = delete;
 };
 
 TDefaultIoResolverBase::TDefaultIoResolverBase(const TIntermediate& intermediate)


### PR DESCRIPTION
Changes to make compiler happier regarding `Werror=deprecated-copy` / rule of three related issues.

Fix proposal for #1939