### PR TITLE
BUILD.gn: Fix fuchsia build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -33,6 +33,19 @@
 
 import("//build_overrides/glslang.gni")
 
+# Both Chromium and Fuchsia use by default a set of warning errors
+# that is far too strict to compile this project. These are also
+# typically appended after |cflags|, overriding target-specific
+# definitions. To work around this, determine which configs to
+# add and remove in order to succesfully build the project.
+if (defined(is_fuchsia_tree) && is_fuchsia_tree) {
+  _configs_to_remove = [ "//build/config:default_warnings" ]
+  _configs_to_add = []
+} else {
+  _configs_to_remove = [ "//build/config/compiler:chromium_code" ]
+  _configs_to_add = [ "//build/config/compiler:no_chromium_code" ]
+}
+
 spirv_tools_dir = glslang_spirv_tools_dir
 
 config("glslang_public") {
@@ -182,8 +195,8 @@ source_set("glslang_sources") {
     "${spirv_tools_dir}:spvtools_val",
   ]
 
-  configs -= [ "//build/config/compiler:chromium_code" ]
-  configs += [ "//build/config/compiler:no_chromium_code" ]
+  configs -= _configs_to_remove
+  configs += _configs_to_add
 }
 
 source_set("glslang_default_resource_limits_sources") {
@@ -196,8 +209,8 @@ source_set("glslang_default_resource_limits_sources") {
   ]
   public_configs = [ ":glslang_public" ]
 
-  configs -= [ "//build/config/compiler:chromium_code" ]
-  configs += [ "//build/config/compiler:no_chromium_code" ]
+  configs -= _configs_to_remove
+  configs += _configs_to_add
 }
 
 executable("glslang_validator") {
@@ -214,8 +227,8 @@ executable("glslang_validator") {
     ":glslang_sources",
   ]
 
-  configs -= [ "//build/config/compiler:chromium_code" ]
-  configs += [ "//build/config/compiler:no_chromium_code" ]
+  configs -= _configs_to_remove
+  configs += _configs_to_add
 }
 
 executable("spirv-remap") {
@@ -227,6 +240,6 @@ executable("spirv-remap") {
     ":glslang_sources",
   ]
 
-  configs -= [ "//build/config/compiler:chromium_code" ]
-  configs += [ "//build/config/compiler:no_chromium_code" ]
+  configs -= _configs_to_remove
+  configs += _configs_to_add
 }


### PR DESCRIPTION
The Fuchsia platform build and the Chromium one use a completely
different set of configs to specify default warnings. The previous
version of BUILD.gn worked with Chromium, but failed to build
with Fuchsia.

This CL fixes the issue by identifying said configs and reusing
them consistently.

Change-Id: I7de526a57d2f14eb93c03e06401d2c3059d35e9a