### PR TITLE
Add option ENABLE_CTEST to skip testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ CMAKE_DEPENDENT_OPTION(ENABLE_HLSL "Enables HLSL input support" ON "NOT ENABLE_G
 
 option(ENABLE_OPT "Enables spirv-opt capability if present" ON)
 option(ENABLE_PCH "Enables Precompiled header" ON)
+option(ENABLE_CTEST "Enables testing" ON)
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND WIN32)
     set(CMAKE_INSTALL_PREFIX "install" CACHE STRING "..." FORCE)
@@ -67,8 +68,10 @@ macro(glslang_pch SRCS PCHCPP)
 endmacro(glslang_pch)
 
 project(glslang)
-# make testing optional
-include(CTest)
+
+if(ENABLE_CTEST)
+    include(CTest)
+endif()
 
 if(ENABLE_HLSL)
     add_definitions(-DENABLE_HLSL)
@@ -183,7 +186,9 @@ add_subdirectory(SPIRV)
 if(ENABLE_HLSL)
     add_subdirectory(hlsl)
 endif(ENABLE_HLSL)
-add_subdirectory(gtests)
+if(ENABLE_CTEST)
+    add_subdirectory(gtests)
+endif()
 
 if(BUILD_TESTING)
     # glslang-testsuite runs a bash script on Windows.


### PR DESCRIPTION
Added CMake option ENABLE_CTEST to skip testing.

Set to ON by default to retain original behavior.