### PR TITLE
Remove std::move that is breaking chromium roll

### DIFF
--- a/SPIRV/spvIR.h
+++ b/SPIRV/spvIR.h
@@ -252,7 +252,7 @@ public:
         assert(header != nullptr);
         Instruction* branch = new Instruction(OpBranch);
         branch->addIdOperand(header->getId());
-        addInstruction(std::move(std::unique_ptr<Instruction>(branch)));
+        addInstruction(std::unique_ptr<Instruction>(branch));
         successors.push_back(header);
     }
 


### PR DESCRIPTION
This is causing the following error:
moving a temporary object prevents copy elision
[-Werror,-Wpessimizing-move]