### PR TITLE
SPIR-V postprocessing: WEB case only needs CFG mods

### DIFF
--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -687,10 +687,17 @@ public:
     // based on the resulting SPIR-V.
     void postProcess();
 
+    // Prune unreachable blocks in the CFG and remove unneeded decorations.
+    void postProcessCFG();
+
+#ifndef GLSLANG_WEB
+    // Add capabilities, extensions based on instructions in the module.
+    void postProcessFeatures();
     // Hook to visit each instruction in a block in a function
     void postProcess(Instruction&);
     // Hook to visit each non-32-bit sized float/int operation in a block.
     void postProcessType(const Instruction&, spv::Id typeId);
+#endif
 
     void dump(std::vector<unsigned int>&) const;
 

--- a/SPIRV/SpvPostProcess.cpp
+++ b/SPIRV/SpvPostProcess.cpp
@@ -58,6 +58,7 @@ namespace spv {
 
 namespace spv {
 
+#ifndef GLSLANG_WEB
 // Hook to visit each operand type and result type of an instruction.
 // Will be called multiple times for one instruction, once for each typed
 // operand and the result.
@@ -319,9 +320,10 @@ void Builder::postProcess(Instruction& inst)
         }
     }
 }
+#endif
 
 // comment in header
-void Builder::postProcess()
+void Builder::postProcessCFG()
 {
     // reachableBlocks is the set of blockss reached via control flow, or which are
     // unreachable continue targert or unreachable merge.
@@ -377,7 +379,11 @@ void Builder::postProcess()
             return unreachableDefinitions.count(decoration_id) != 0;
         }),
         decorations.end());
+}
 
+#ifndef GLSLANG_WEB
+// comment in header
+void Builder::postProcessFeatures() {
     // Add per-instruction capabilities, extensions, etc.,
 
     // Look for any 8/16 bit type in physical storage buffer class, and set the
@@ -430,6 +436,15 @@ void Builder::postProcess()
             }
         }
     }
+}
+#endif
+
+// comment in header
+void Builder::postProcess() {
+  postProcessCFG();
+#ifndef GLSLANG_WEB
+  postProcessFeatures();
+#endif
 }
 
 }; // end spv namespace


### PR DESCRIPTION
The SPIR-V post-processing to discover capabilities and
extensions does not apply to WebGPU compilation.  So don't include
that code.

This reclaims some of the code space added by #1943