### PR TITLE
Fix export configurations paths for Unixes

### DIFF
--- a/OGLCompilersDLL/CMakeLists.txt
+++ b/OGLCompilersDLL/CMakeLists.txt
@@ -42,7 +42,6 @@ if(WIN32)
 endif(WIN32)
 
 if(ENABLE_GLSLANG_INSTALL)
-    install(TARGETS OGLCompiler EXPORT OGLCompilerTargets
+    install(TARGETS OGLCompiler EXPORT glslangConfig
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-	install(EXPORT OGLCompilerTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 endif(ENABLE_GLSLANG_INSTALL)

--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -111,28 +111,22 @@ endif(WIN32)
 if(ENABLE_GLSLANG_INSTALL)
     if(BUILD_SHARED_LIBS)
         if (ENABLE_SPVREMAPPER)
-            install(TARGETS SPVRemapper EXPORT SPVRemapperTargets
+            install(TARGETS SPVRemapper EXPORT glslangConfig
                     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
         endif()
-        install(TARGETS SPIRV EXPORT SPIRVTargets
+        install(TARGETS SPIRV EXPORT glslangConfig
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     else()
         if (ENABLE_SPVREMAPPER)
-            install(TARGETS SPVRemapper EXPORT SPVRemapperTargets
+            install(TARGETS SPVRemapper EXPORT glslangConfig
                     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
         endif()
-        install(TARGETS SPIRV EXPORT SPIRVTargets
+        install(TARGETS SPIRV EXPORT glslangConfig
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endif()
-
-    if (ENABLE_SPVREMAPPER)
-        install(EXPORT SPVRemapperTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
-    endif()
-
-    install(EXPORT SPIRVTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 
     install(FILES ${HEADERS} ${SPVREMAP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/glslang/SPIRV/)
 endif(ENABLE_GLSLANG_INSTALL)

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -88,24 +88,21 @@ if(WIN32)
 endif(WIN32)
 
 if(ENABLE_GLSLANG_INSTALL)
-    install(TARGETS glslangValidator EXPORT glslangValidatorTargets
+    install(TARGETS glslangValidator EXPORT glslangConfig
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-    install(EXPORT glslangValidatorTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 
     if(ENABLE_SPVREMAPPER)
-        install(TARGETS spirv-remap EXPORT spirv-remapTargets
+        install(TARGETS spirv-remap EXPORT glslangConfig
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-        install(EXPORT spirv-remapTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
     endif()
 
     if(BUILD_SHARED_LIBS)
-        install(TARGETS glslang-default-resource-limits EXPORT glslang-default-resource-limitsTargets
+        install(TARGETS glslang-default-resource-limits EXPORT glslangConfig
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     else()
-        install(TARGETS glslang-default-resource-limits EXPORT glslang-default-resource-limitsTargets
+        install(TARGETS glslang-default-resource-limits EXPORT glslangConfig
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endif()
-    install(EXPORT glslang-default-resource-limitsTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 endif(ENABLE_GLSLANG_INSTALL)

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -200,17 +200,18 @@ endif(WIN32)
 if(ENABLE_GLSLANG_INSTALL)
     if(BUILD_SHARED_LIBS)
         install(TARGETS glslang
-                EXPORT  glslangTargets
+                EXPORT glslangConfig
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     else()
         install(TARGETS glslang MachineIndependent GenericCodeGen
-                EXPORT  glslangTargets
+                EXPORT glslangConfig
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endif()
 
-    install(EXPORT glslangTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+    install(EXPORT glslangConfig NAMESPACE glslang::
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/glslang)
 
     set(ALL_HEADERS
         ${GLSLANG_HEADERS}

--- a/glslang/OSDependent/Unix/CMakeLists.txt
+++ b/glslang/OSDependent/Unix/CMakeLists.txt
@@ -44,16 +44,15 @@ if(${CMAKE_VERSION} VERSION_LESS "3.1.0" OR CMAKE_CROSSCOMPILING)
     # Also needed when cross-compiling to work around
     # https://gitlab.kitware.com/cmake/cmake/issues/16920
     find_package(Threads)
-    target_link_libraries(OSDependent ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(OSDependent PRIVATE ${CMAKE_THREAD_LIBS_INIT})
 else()
     # This is the recommended way, so we use it for 3.1+.
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads)
-    target_link_libraries(OSDependent Threads::Threads)
+    target_link_libraries(OSDependent PRIVATE Threads::Threads)
 endif()
 
 if(ENABLE_GLSLANG_INSTALL)
-    install(TARGETS OSDependent EXPORT OSDependentTargets
+    install(TARGETS OSDependent EXPORT glslangConfig
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-	install(EXPORT OSDependentTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 endif(ENABLE_GLSLANG_INSTALL)

--- a/glslang/OSDependent/Windows/CMakeLists.txt
+++ b/glslang/OSDependent/Windows/CMakeLists.txt
@@ -48,7 +48,6 @@ if(WIN32)
 endif(WIN32)
 
 if(ENABLE_GLSLANG_INSTALL)
-    install(TARGETS OSDependent EXPORT OSDependentTargets
+    install(TARGETS OSDependent EXPORT glslangConfig
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-	install(EXPORT OSDependentTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 endif(ENABLE_GLSLANG_INSTALL)

--- a/hlsl/CMakeLists.txt
+++ b/hlsl/CMakeLists.txt
@@ -47,13 +47,12 @@ endif()
 
 if(ENABLE_GLSLANG_INSTALL)
     if(BUILD_SHARED_LIBS)
-        install(TARGETS HLSL EXPORT HLSLTargets
+        install(TARGETS HLSL EXPORT glslangConfig
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     else()
-        install(TARGETS HLSL EXPORT HLSLTargets
+        install(TARGETS HLSL EXPORT glslangConfig
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endif()
-	install(EXPORT HLSLTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 endif(ENABLE_GLSLANG_INSTALL)


### PR DESCRIPTION
Note that I mention Arch Linux because it is the system I base my example on, but this fix is for all platforms including Windows if installed correctly.

## Current State
The current way glslang installs its export targets makes them impossible to find using command cmake patterns.

I am using Arch Linux and here is where the official glslang package installs the cmake configuration
```
/usr/lib/cmake/HLSLTargets-release.cmake
/usr/lib/cmake/HLSLTargets.cmake
/usr/lib/cmake/OGLCompilerTargets-release.cmake
/usr/lib/cmake/OGLCompilerTargets.cmake
/usr/lib/cmake/OSDependentTargets-release.cmake
/usr/lib/cmake/OSDependentTargets.cmake
/usr/lib/cmake/SPIRVTargets-release.cmake
/usr/lib/cmake/SPIRVTargets.cmake
/usr/lib/cmake/SPVRemapperTargets-release.cmake
/usr/lib/cmake/SPVRemapperTargets.cmake
/usr/lib/cmake/glslang-default-resource-limitsTargets-release.cmake
/usr/lib/cmake/glslang-default-resource-limitsTargets.cmake
/usr/lib/cmake/glslangTargets-release.cmake
/usr/lib/cmake/glslangTargets.cmake
/usr/lib/cmake/glslangValidatorTargets-release.cmake
/usr/lib/cmake/glslangValidatorTargets.cmake
/usr/lib/cmake/spirv-remapTargets-release.cmake
/usr/lib/cmake/spirv-remapTargets.cmake
```
The location actually makes it impossible for `find_package(glslang)` to find them in `CONFIG` mode.

According to the [cmake docs](https://cmake.org/cmake/help/v3.16/command/find_package.html), cmake will look in the following directories (for Arch Linux):
```
/usr/(lib*|share)/cmake/glslang*/
/usr/(lib*|share)/glslang*/
/usr/(lib*|share)/glslang*/(cmake|CMake)/
/usr/glslang*/(lib*|share)/cmake/<name>*/
/usr/glslang*/(lib*|share)/glslang*/
/usr/glslang*/(lib*|share)/glslang*/(cmake|CMake)/
```

As we can see, none of these paths match the installation.

Secondly, unless otherwise specified, cmake will look for a file called `<name>Config.cmake` or `<lower-case-name>-config.cmake`. The names are currenly suffixed with `Targets` when they should be suffixed with `Config`.

Thirdly, it is modern cmake convention that if there are multiple targets under the same package umbrella, that namespace and components be used.

Prior to this fix using `glslangValidator` required the following cmake command
```
find_program(GLSLANG_VALIDATOR NAMES glslangValidator)
```

## Suggested Fix

This PR fixed the three stated problems by adding the package name to the exported configurations.
The names of the configs now have `Config` as a suffix.
The different targets are now components in the `glslang::` namespace.
There is now only one configuration file which provides all the targets.
```
/usr/lib/cmake/glslang/glslangConfig.cmake
```

In CMake, the targets are now easy to access:
```cmake
find_package(Threads)
find_package(glslang REQUIRED COMPONENTS glslang glslangValidator)
target_link_libraries(example PRIVATE glslang::glslang)

add_custom_target(validator-version
  COMMAND glslang::glslangValidator -v)
```
Now using `glslangValidator` requires only `find_package(glslang)` which will find the path with the help of CMake and the config.

## Known Limitation

I believe this was a pre-existing issue, but using `glslang` on Unix requires `Threads`.
If the user doesn't do `find_package(Threads)` prior to `find_package(glslang)`, they get the following message when configuring:
```
CMake Error at CMakeLists.txt:1 (add_executable):
  Target "example" links to target "Threads::Threads" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
```

## Alternative fix
There is another way to generate a Config file which would leave the `*Target.cmake` files in place.
It would require maintaining a `glslangConfig.cmake` template file which imports the `*Target.cmake` files.
This requires a little more care from the maintainers as it is no longer created automatically by CMake and requires detecting platforms and options such as `ENABLE_HLSL`.
On the plus side, the user would not have to do `find_package(Threads)` prior to `find_package(glslang)`, as @mathstuf pointed out in the comments.

An example of such a configuration is found there:
https://cmake.org/cmake/help/v3.17/manual/cmake-packages.7.html#creating-a-package-configuration-file