### PR TITLE
[GLSL][PP] extension pp check after non-pp tokens

### DIFF
--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
+++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
@@ -873,6 +873,16 @@ int TPpContext::CPPextension(TPpToken* ppToken)
     int token = scanToken(ppToken);
     char extensionName[MaxTokenLength + 1];
 
+    // extension directives must occur before any non-preprocessor tokens
+    if (parseContext.getPpContext()->nonMacroStarted == true) {
+        if (parseContext.relaxedErrors())
+            parseContext.ppWarn(ppToken->loc, "extension directives must occur before any non-preprocessor tokens", "#extension", "");
+        else
+            parseContext.ppError(ppToken->loc, "extension directives must occur before any non-preprocessor tokens", "#extension", "");
+        return token;
+    }
+
+
     if (token=='\n') {
         parseContext.ppError(ppToken->loc, "extension name not specified", "#extension", "");
         return token;

--- a/glslang/MachineIndependent/preprocessor/PpContext.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpContext.cpp
@@ -93,6 +93,7 @@ TPpContext::TPpContext(TParseContextBase& pc, const std::string& rootFileName, T
     for (elsetracker = 0; elsetracker < maxIfNesting; elsetracker++)
         elseSeen[elsetracker] = false;
     elsetracker = 0;
+    nonMacroStarted = false;
 
     strtodStream.imbue(std::locale::classic());
 }

--- a/glslang/MachineIndependent/preprocessor/PpContext.h
+++ b/glslang/MachineIndependent/preprocessor/PpContext.h
@@ -341,6 +341,7 @@ public:
         return (existingMacroIt == macroDefs.end()) ? nullptr : &(existingMacroIt->second);
     }
     void addMacroDef(int atom, MacroSymbol& macroDef) { macroDefs[atom] = macroDef; }
+    bool nonMacroStarted;
 
 protected:
     TPpContext(TPpContext&);

--- a/glslang/MachineIndependent/preprocessor/PpScanner.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpScanner.cpp
@@ -1092,6 +1092,9 @@ int TPpContext::tokenize(TPpToken& ppToken)
         if (token == '\n')
             continue;
 
+        // the extension directives must occur before any non-preprocessor tokens.
+        parseContext.getPpContext()->nonMacroStarted = true;
+
         // expand macros
         if (token == PpAtomIdentifier) {
             switch (MacroExpand(&ppToken, false, true)) {


### PR DESCRIPTION
**[Purpose]**

Currently we lack of checking whether "#extension" is used after any non-pp tokens/statements.

According to spec, this situation should be treated as an error.

Here is a fix for issues with following pattern:

**[Shader]**
...

void main{
...
}

GLSL should notify users that this would lead to a compilation error as "#extension" should not be used after non-pp tokens.

**[Concerns]**
I don't know whether it is OK to use a simple flag/mask attribute to represent current pp state.
Or, should I add this check following a different way?

I will add tests if this change is OK according to your concerns.