### PR TITLE
Check for ENABLE_SPVREMAPPER flag in CMakeList files.

### DIFF
--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -36,7 +36,7 @@ set(SPVREMAP_HEADERS
 add_library(SPIRV ${LIB_TYPE} ${SOURCES} ${HEADERS})
 set_property(TARGET SPIRV PROPERTY FOLDER glslang)
 set_property(TARGET SPIRV PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_include_directories(SPIRV PUBLIC 
+target_include_directories(SPIRV PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
@@ -91,7 +91,10 @@ if(ENABLE_GLSLANG_INSTALL)
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endif()
 
-    install(EXPORT SPVRemapperTargets DESTINATION lib/cmake)
+    if (ENABLE_SPVREMAPPER)
+        install(EXPORT SPVRemapperTargets DESTINATION lib/cmake)
+    endif()
+
     install(EXPORT SPIRVTargets DESTINATION lib/cmake)
 
     install(FILES ${HEADERS} ${SPVREMAP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/SPIRV/)

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -9,20 +9,19 @@ target_include_directories(glslang-default-resource-limits
 
 
 set(SOURCES StandAlone.cpp DirStackFileIncluder.h)
-set(REMAPPER_SOURCES spirv-remap.cpp)
 
 add_executable(glslangValidator ${SOURCES})
-add_executable(spirv-remap ${REMAPPER_SOURCES})
 set_property(TARGET glslangValidator PROPERTY FOLDER tools)
-set_property(TARGET spirv-remap PROPERTY FOLDER tools)
 glslang_set_link_args(glslangValidator)
-glslang_set_link_args(spirv-remap)
 
 set(LIBRARIES
     glslang
     SPIRV
-    SPVRemapper
     glslang-default-resource-limits)
+
+if(ENABLE_SPVREMAPPER)
+    set(LIBRARIES ${LIBRARIES} SPVRemapper)
+endif()
 
 if(WIN32)
     set(LIBRARIES ${LIBRARIES} psapi)
@@ -33,10 +32,17 @@ elseif(UNIX)
 endif(WIN32)
 
 target_link_libraries(glslangValidator ${LIBRARIES})
-target_link_libraries(spirv-remap ${LIBRARIES})
-target_include_directories(glslangValidator PUBLIC 
+target_include_directories(glslangValidator PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../External>
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/External>)
+
+if(ENABLE_SPVREMAPPER)
+    set(REMAPPER_SOURCES spirv-remap.cpp)
+    add_executable(spirv-remap ${REMAPPER_SOURCES})
+    set_property(TARGET spirv-remap PROPERTY FOLDER tools)
+    glslang_set_link_args(spirv-remap)
+    target_link_libraries(spirv-remap ${LIBRARIES})
+endif()
 
 if(WIN32)
     source_group("Source" FILES ${SOURCES})
@@ -45,13 +51,14 @@ endif(WIN32)
 if(ENABLE_GLSLANG_INSTALL)
     install(TARGETS glslangValidator EXPORT glslangValidatorTargets
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(EXPORT glslangValidatorTargets DESTINATION lib/cmake)
 
-    install(TARGETS spirv-remap EXPORT spirv-remapTargets
+    if(ENABLE_SPVREMAPPER)
+        install(TARGETS spirv-remap EXPORT spirv-remapTargets
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-	
-	install(EXPORT glslangValidatorTargets DESTINATION lib/cmake)
-	install(EXPORT spirv-remapTargets DESTINATION lib/cmake)
-            
+        install(EXPORT spirv-remapTargets DESTINATION lib/cmake)
+    endif()
+
     if(BUILD_SHARED_LIBS)
         install(TARGETS glslang-default-resource-limits EXPORT glslang-default-resource-limitsTargets
                 LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -20,10 +20,12 @@ if(BUILD_TESTING)
             ${CMAKE_CURRENT_SOURCE_DIR}/Link.FromFile.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Link.FromFile.Vk.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Pp.FromFile.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/Spv.FromFile.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/Spv.FromFile.cpp)
 
-            # -- Remapper tests
-            ${CMAKE_CURRENT_SOURCE_DIR}/Remap.FromFile.cpp)
+        if(ENABLE_SPVREMAPPER)
+            set(TEST_SOURCES ${TEST_SOURCES}
+                ${CMAKE_CURRENT_SOURCE_DIR}/Remap.FromFile.cpp)
+        endif()
 
         glslang_pch(TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/pch.cpp)
 
@@ -49,8 +51,13 @@ if(BUILD_TESTING)
                                    ${gtest_SOURCE_DIR}/include)
 
         set(LIBRARIES
-            SPVRemapper glslang OSDependent OGLCompiler glslang
+            glslang OSDependent OGLCompiler glslang
             SPIRV glslang-default-resource-limits)
+
+        if(ENABLE_SPVREMAPPER)
+            set(LIBRARIES ${LIBRARIES} SPVRemapper)
+        endif()
+
         if(ENABLE_HLSL)
             set(LIBRARIES ${LIBRARIES} HLSL)
         endif(ENABLE_HLSL)


### PR DESCRIPTION
There is a flag to disable the SPVRemapper during the GLSLang build.
That flag is check in some, but not all spots so if you try to build
with SPVRemapper disabled you get CMake errors and compile errors.

This CL fixs up the build so building with -DENABLE_SPVREMAPPER=0 will
complete correclty.