### PR TITLE
Add support for ARB_texture_multisample

### DIFF
--- a/Test/140.frag
+++ b/Test/140.frag
@@ -17,6 +17,7 @@ void main()
 #error GL_ES is not set
 #endif
 
+
 in struct S { float f; } s; // ERROR
 
 float patch = 3.1;
@@ -51,3 +52,9 @@ float fooi()
 {
     return i1 + i2;
 }
+
+uniform sampler2DMS aaa1; // ERROR
+
+#extension GL_ARB_texture_multisample : enable
+
+uniform sampler2DMS aaa2;

--- a/Test/baseResults/140.frag.out
+++ b/Test/baseResults/140.frag.out
@@ -1,14 +1,15 @@
 140.frag
 WARNING: 0:3: varying deprecated in version 130; may be removed in future release
 ERROR: 0:17: '#error' : GL_ES is not set  
-ERROR: 0:20: 'fragment-shader struct input' : not supported for this version or the enabled extensions 
-ERROR: 0:24: 'location' : not supported for this version or the enabled extensions 
-ERROR: 0:24: 'location qualifier on input' : not supported for this version or the enabled extensions 
-ERROR: 0:26: 'location' : not supported for this version or the enabled extensions 
-ERROR: 0:26: 'location qualifier on output' : not supported for this version or the enabled extensions 
-ERROR: 0:40: 'assign' :  l-value required "v" (can't modify shader input)
-ERROR: 0:40: 'out' : Non-L-value cannot be passed for 'out' or 'inout' parameters. 
-ERROR: 8 compilation errors.  No code generated.
+ERROR: 0:21: 'fragment-shader struct input' : not supported for this version or the enabled extensions 
+ERROR: 0:25: 'location' : not supported for this version or the enabled extensions 
+ERROR: 0:25: 'location qualifier on input' : not supported for this version or the enabled extensions 
+ERROR: 0:27: 'location' : not supported for this version or the enabled extensions 
+ERROR: 0:27: 'location qualifier on output' : not supported for this version or the enabled extensions 
+ERROR: 0:41: 'assign' :  l-value required "v" (can't modify shader input)
+ERROR: 0:41: 'out' : Non-L-value cannot be passed for 'out' or 'inout' parameters. 
+ERROR: 0:56: '' :  syntax error, unexpected IDENTIFIER, expecting LEFT_BRACE or COMMA or SEMICOLON
+ERROR: 9 compilation errors.  No code generated.
 
 
 Shader version: 140
@@ -25,80 +26,80 @@ ERROR: node is still EOpNull!
 0:12            'gl_ClipDistance' ( smooth in 5-element array of float ClipDistance)
 0:12            Constant:
 0:12              2 (const int)
-0:22  Sequence
-0:22    move second child to first child ( temp float)
-0:22      'patch' ( global float)
-0:22      Constant:
-0:22        3.100000
-0:38  Function Definition: foo( ( global void)
-0:38    Function Parameters: 
-0:40    Sequence
-0:40      Sequence
-0:40        move second child to first child ( temp 2-component vector of float)
-0:40          'r1' ( temp 2-component vector of float)
-0:40          modf ( global 2-component vector of float)
-0:40            vector swizzle ( temp 2-component vector of float)
-0:40              'v' ( smooth in 4-component vector of float)
-0:40              Sequence
-0:40                Constant:
-0:40                  0 (const int)
-0:40                Constant:
-0:40                  1 (const int)
-0:40            vector swizzle ( temp 2-component vector of float)
-0:40              'v' ( smooth in 4-component vector of float)
-0:40              Sequence
-0:40                Constant:
-0:40                  2 (const int)
-0:40                Constant:
-0:40                  3 (const int)
+0:23  Sequence
+0:23    move second child to first child ( temp float)
+0:23      'patch' ( global float)
+0:23      Constant:
+0:23        3.100000
+0:39  Function Definition: foo( ( global void)
+0:39    Function Parameters: 
+0:41    Sequence
 0:41      Sequence
 0:41        move second child to first child ( temp 2-component vector of float)
-0:41          'r2' ( temp 2-component vector of float)
+0:41          'r1' ( temp 2-component vector of float)
 0:41          modf ( global 2-component vector of float)
 0:41            vector swizzle ( temp 2-component vector of float)
-0:41              'o' ( out 4-component vector of float)
+0:41              'v' ( smooth in 4-component vector of float)
 0:41              Sequence
 0:41                Constant:
 0:41                  0 (const int)
 0:41                Constant:
 0:41                  1 (const int)
 0:41            vector swizzle ( temp 2-component vector of float)
-0:41              'o' ( out 4-component vector of float)
+0:41              'v' ( smooth in 4-component vector of float)
 0:41              Sequence
 0:41                Constant:
 0:41                  2 (const int)
 0:41                Constant:
 0:41                  3 (const int)
-0:42      move second child to first child ( temp float)
-0:42        direct index ( temp float)
-0:42          'o' ( out 4-component vector of float)
-0:42          Constant:
-0:42            2 (const int)
-0:42        Function Call: fooi( ( global float)
-0:47  Sequence
-0:47    move second child to first child ( temp float)
-0:47      'i1' ( global float)
-0:47      Test condition and select ( temp float)
-0:47        Condition
-0:47        'gl_FrontFacing' ( gl_FrontFacing bool Face)
-0:47        true case
-0:47        Constant:
-0:47          -2.000000
-0:47        false case
-0:47        Constant:
-0:47          2.000000
+0:42      Sequence
+0:42        move second child to first child ( temp 2-component vector of float)
+0:42          'r2' ( temp 2-component vector of float)
+0:42          modf ( global 2-component vector of float)
+0:42            vector swizzle ( temp 2-component vector of float)
+0:42              'o' ( out 4-component vector of float)
+0:42              Sequence
+0:42                Constant:
+0:42                  0 (const int)
+0:42                Constant:
+0:42                  1 (const int)
+0:42            vector swizzle ( temp 2-component vector of float)
+0:42              'o' ( out 4-component vector of float)
+0:42              Sequence
+0:42                Constant:
+0:42                  2 (const int)
+0:42                Constant:
+0:42                  3 (const int)
+0:43      move second child to first child ( temp float)
+0:43        direct index ( temp float)
+0:43          'o' ( out 4-component vector of float)
+0:43          Constant:
+0:43            2 (const int)
+0:43        Function Call: fooi( ( global float)
 0:48  Sequence
 0:48    move second child to first child ( temp float)
-0:48      'i2' ( global float)
-0:48      Constant:
-0:48        102.000000
-0:50  Function Definition: fooi( ( global float)
-0:50    Function Parameters: 
-0:52    Sequence
-0:52      Branch: Return with expression
-0:52        add ( temp float)
-0:52          'i1' ( global float)
-0:52          'i2' ( global float)
+0:48      'i1' ( global float)
+0:48      Test condition and select ( temp float)
+0:48        Condition
+0:48        'gl_FrontFacing' ( gl_FrontFacing bool Face)
+0:48        true case
+0:48        Constant:
+0:48          -2.000000
+0:48        false case
+0:48        Constant:
+0:48          2.000000
+0:49  Sequence
+0:49    move second child to first child ( temp float)
+0:49      'i2' ( global float)
+0:49      Constant:
+0:49        102.000000
+0:51  Function Definition: fooi( ( global float)
+0:51    Function Parameters: 
+0:53    Sequence
+0:53      Branch: Return with expression
+0:53        add ( temp float)
+0:53          'i1' ( global float)
+0:53          'i2' ( global float)
 0:?   Linker Objects
 0:?     'v' ( smooth in 4-component vector of float)
 0:?     'i' ( smooth in 4-component vector of float)
@@ -131,28 +132,28 @@ ERROR: node is still EOpNull!
 0:12            'gl_ClipDistance' ( smooth in 5-element array of float ClipDistance)
 0:12            Constant:
 0:12              2 (const int)
-0:22  Sequence
-0:22    move second child to first child ( temp float)
-0:22      'patch' ( global float)
-0:22      Constant:
-0:22        3.100000
-0:47  Sequence
-0:47    move second child to first child ( temp float)
-0:47      'i1' ( global float)
-0:47      Test condition and select ( temp float)
-0:47        Condition
-0:47        'gl_FrontFacing' ( gl_FrontFacing bool Face)
-0:47        true case
-0:47        Constant:
-0:47          -2.000000
-0:47        false case
-0:47        Constant:
-0:47          2.000000
+0:23  Sequence
+0:23    move second child to first child ( temp float)
+0:23      'patch' ( global float)
+0:23      Constant:
+0:23        3.100000
 0:48  Sequence
 0:48    move second child to first child ( temp float)
-0:48      'i2' ( global float)
-0:48      Constant:
-0:48        102.000000
+0:48      'i1' ( global float)
+0:48      Test condition and select ( temp float)
+0:48        Condition
+0:48        'gl_FrontFacing' ( gl_FrontFacing bool Face)
+0:48        true case
+0:48        Constant:
+0:48          -2.000000
+0:48        false case
+0:48        Constant:
+0:48          2.000000
+0:49  Sequence
+0:49    move second child to first child ( temp float)
+0:49      'i2' ( global float)
+0:49      Constant:
+0:49        102.000000
 0:?   Linker Objects
 0:?     'v' ( smooth in 4-component vector of float)
 0:?     'i' ( smooth in 4-component vector of float)

--- a/glslang/MachineIndependent/Scan.cpp
+++ b/glslang/MachineIndependent/Scan.cpp
@@ -1421,6 +1421,9 @@ int TScanContext::tokenizeIdentifier()
         afterType = true;
         if (parseContext.isEsProfile() && parseContext.version >= 310)
             return keyword;
+        if (!parseContext.isEsProfile() && (parseContext.version > 140 ||
+            (parseContext.version == 140 && parseContext.extensionsTurnedOn(1, &E_GL_ARB_texture_multisample))))
+            return keyword;
         return es30ReservedFromGLSL(150);
 
     case SAMPLER2DMSARRAY:
@@ -1429,6 +1432,9 @@ int TScanContext::tokenizeIdentifier()
         afterType = true;
         if ((parseContext.isEsProfile() && parseContext.version >= 320) ||
             parseContext.extensionsTurnedOn(1, &E_GL_OES_texture_storage_multisample_2d_array))
+            return keyword;
+        if (!parseContext.isEsProfile() && (parseContext.version > 140 ||
+            (parseContext.version == 140 && parseContext.extensionsTurnedOn(1, &E_GL_ARB_texture_multisample))))
             return keyword;
         return es30ReservedFromGLSL(150);
 

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -172,6 +172,7 @@ void TParseVersions::initializeExtensionBehavior()
     extensionBehavior[E_GL_ARB_tessellation_shader]          = EBhDisable;
     extensionBehavior[E_GL_ARB_enhanced_layouts]             = EBhDisable;
     extensionBehavior[E_GL_ARB_texture_cube_map_array]       = EBhDisable;
+    extensionBehavior[E_GL_ARB_texture_multisample]          = EBhDisable;
     extensionBehavior[E_GL_ARB_shader_texture_lod]           = EBhDisable;
     extensionBehavior[E_GL_ARB_explicit_attrib_location]     = EBhDisable;
     extensionBehavior[E_GL_ARB_explicit_uniform_location]    = EBhDisable;
@@ -379,6 +380,7 @@ void TParseVersions::getPreamble(std::string& preamble)
             "#define GL_ARB_tessellation_shader 1\n"
             "#define GL_ARB_enhanced_layouts 1\n"
             "#define GL_ARB_texture_cube_map_array 1\n"
+            "#define GL_ARB_texture_multisample 1\n"
             "#define GL_ARB_shader_texture_lod 1\n"
             "#define GL_ARB_explicit_attrib_location 1\n"
             "#define GL_ARB_explicit_uniform_location 1\n"

--- a/glslang/MachineIndependent/Versions.h
+++ b/glslang/MachineIndependent/Versions.h
@@ -124,6 +124,7 @@ const char* const E_GL_ARB_compute_shader               = "GL_ARB_compute_shader
 const char* const E_GL_ARB_tessellation_shader          = "GL_ARB_tessellation_shader";
 const char* const E_GL_ARB_enhanced_layouts             = "GL_ARB_enhanced_layouts";
 const char* const E_GL_ARB_texture_cube_map_array       = "GL_ARB_texture_cube_map_array";
+const char* const E_GL_ARB_texture_multisample          = "GL_ARB_texture_multisample";
 const char* const E_GL_ARB_shader_texture_lod           = "GL_ARB_shader_texture_lod";
 const char* const E_GL_ARB_explicit_attrib_location     = "GL_ARB_explicit_attrib_location";
 const char* const E_GL_ARB_explicit_uniform_location    = "GL_ARB_explicit_uniform_location";


### PR DESCRIPTION
GLSL Version : >= 140

Purpose:
Allow users to use features by enabling this extension, even in low versions. Related features have been already supported by SPIR-V and GLSL, just add extensions for users who want to enable this extension in low versions.

Extension Name:
ARB_texture_multisample

Builtin-variables:
Nah

Builtin-functions:
Nah

Keywords:
      sampler2DMS, isampler2DMS, usampler2DMS,
      sampler2DMSArray, isampler2DMSArray, usampler2DMSArray

Reference:
https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_texture_multisample.txt