### PR TITLE
Add support for ARB_uniform_buffer_object

### DIFF
--- a/Test/120.vert
+++ b/Test/120.vert
@@ -201,3 +201,15 @@ int mac;
 
 #define macr(A,B) A ## B
 int macr(qrs,tuv);
+
+layout(std140) uniform BlockName    // ERROR
+{
+    int test;
+};
+
+#extension GL_ARB_uniform_buffer_object : enable
+
+layout(std140) uniform BlockName
+{
+    int test;
+};

--- a/Test/baseResults/120.vert.out
+++ b/Test/baseResults/120.vert.out
@@ -79,7 +79,8 @@ ERROR: 0:192: 'assign' :  l-value required (can't modify a const)
 ERROR: 0:195: 'gl_ModelViewMatrix' : identifiers starting with "gl_" are reserved 
 ERROR: 0:200: 'token pasting (##)' : not supported for this version or the enabled extensions 
 ERROR: 0:203: 'token pasting (##)' : not supported for this version or the enabled extensions 
-ERROR: 80 compilation errors.  No code generated.
+ERROR: 0:205: '' :  syntax error, unexpected IDENTIFIER
+ERROR: 81 compilation errors.  No code generated.
 
 
 Shader version: 120

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -7609,7 +7609,7 @@ void TParseContext::blockStageIoCheck(const TSourceLoc& loc, const TQualifier& q
     switch (qualifier.storage) {
     case EvqUniform:
         profileRequires(loc, EEsProfile, 300, nullptr, "uniform block");
-        profileRequires(loc, ENoProfile, 140, nullptr, "uniform block");
+        profileRequires(loc, ENoProfile, 140, E_GL_ARB_uniform_buffer_object, "uniform block");
         if (currentBlockQualifier.layoutPacking == ElpStd430 && ! currentBlockQualifier.isPushConstant())
             requireExtensions(loc, 1, &E_GL_EXT_scalar_block_layout, "std430 requires the buffer storage qualifier");
         break;

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -192,6 +192,7 @@ void TParseVersions::initializeExtensionBehavior()
     extensionBehavior[E_GL_ARB_shader_viewport_layer_array]  = EBhDisable;
     extensionBehavior[E_GL_ARB_fragment_shader_interlock]    = EBhDisable;
     extensionBehavior[E_GL_ARB_shader_clock]                 = EBhDisable;
+    extensionBehavior[E_GL_ARB_uniform_buffer_object]        = EBhDisable;
 
     extensionBehavior[E_GL_KHR_shader_subgroup_basic]            = EBhDisable;
     extensionBehavior[E_GL_KHR_shader_subgroup_vote]             = EBhDisable;
@@ -397,6 +398,7 @@ void TParseVersions::getPreamble(std::string& preamble)
 //            "#define GL_ARB_cull_distance 1\n"    // present for 4.5, but need extension control over block members
             "#define GL_ARB_post_depth_coverage 1\n"
             "#define GL_ARB_fragment_shader_interlock 1\n"
+            "#define GL_ARB_uniform_buffer_object 1\n"
             "#define GL_EXT_shader_non_constant_global_initializers 1\n"
             "#define GL_EXT_shader_image_load_formatted 1\n"
             "#define GL_EXT_post_depth_coverage 1\n"

--- a/glslang/MachineIndependent/Versions.h
+++ b/glslang/MachineIndependent/Versions.h
@@ -144,6 +144,7 @@ const char* const E_GL_ARB_post_depth_coverage          = "GL_ARB_post_depth_cov
 const char* const E_GL_ARB_shader_viewport_layer_array  = "GL_ARB_shader_viewport_layer_array";
 const char* const E_GL_ARB_fragment_shader_interlock    = "GL_ARB_fragment_shader_interlock";
 const char* const E_GL_ARB_shader_clock                 = "GL_ARB_shader_clock";
+const char* const E_GL_ARB_uniform_buffer_object        = "GL_ARB_uniform_buffer_object";
 
 const char* const E_GL_KHR_shader_subgroup_basic            = "GL_KHR_shader_subgroup_basic";
 const char* const E_GL_KHR_shader_subgroup_vote             = "GL_KHR_shader_subgroup_vote";


### PR DESCRIPTION
GLSL Version : >= 120

Purpose:
Allow users to use features by enabling this extension, even in low versions. Related features have been already supported by SPIR-V and GLSL, just add extensions for users who want to enable this extension in low versions.

Extension Name:
ARB_uniform_buffer_object

Builtin-variables:
Uniform

Builtin-functions:
Nah

Keywords:
Nah

Features:
uniform block

Reference:
https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_uniform_buffer_object.txt