### PR TITLE
Add support for ARB_gpu_shader_fp64

### DIFF
--- a/Test/150.frag
+++ b/Test/150.frag
@@ -49,3 +49,12 @@ int primitiveID()
    return gl_PrimitiveID;
    gl_PerFragment; // ERROR, block name can't get reused
 }
+
+in double type1;    // ERROR
+#extension GL_ARB_gpu_shader_fp64 : enable
+double type2;
+double type3 = 2.0;
+int absTest = sqrt(type3);
+double absTest2 = sqrt(type3);
+double absTest3 = sqrt(2);
+float dk = sqrt(11);

--- a/Test/baseResults/150.frag.out
+++ b/Test/baseResults/150.frag.out
@@ -5,10 +5,15 @@ ERROR: 0:6: 'layout qualifier' : can only apply origin_upper_left and pixel_cent
 ERROR: 0:14: 'gl_FragCoord' : cannot redeclare after use 
 ERROR: 0:50: 'gl_PerFragment' : cannot be used (maybe an instance name is needed) 
 ERROR: 0:50: 'gl_PerFragment' : undeclared identifier 
-ERROR: 6 compilation errors.  No code generated.
+ERROR: 0:53: 'double' : Reserved word. 
+ERROR: 0:53: 'double' : not supported for this version or the enabled extensions 
+ERROR: 0:53: 'double' : must be qualified as flat in
+ERROR: 0:57: '=' :  cannot convert from ' global double' to ' global int'
+ERROR: 10 compilation errors.  No code generated.
 
 
 Shader version: 150
+Requested GL_ARB_gpu_shader_fp64
 gl_FragCoord pixel center is integer
 gl_FragCoord origin is upper left
 ERROR: node is still EOpNull!
@@ -109,6 +114,26 @@ ERROR: node is still EOpNull!
 0:49      Branch: Return with expression
 0:49        'gl_PrimitiveID' ( flat in int PrimitiveID)
 0:50      'gl_PerFragment' ( temp float)
+0:56  Sequence
+0:56    move second child to first child ( temp double)
+0:56      'type3' ( global double)
+0:56      Constant:
+0:56        2.000000
+0:58  Sequence
+0:58    move second child to first child ( temp double)
+0:58      'absTest2' ( global double)
+0:58      sqrt ( global double)
+0:58        'type3' ( global double)
+0:59  Sequence
+0:59    move second child to first child ( temp double)
+0:59      'absTest3' ( global double)
+0:59      Constant:
+0:59        1.414214
+0:60  Sequence
+0:60    move second child to first child ( temp float)
+0:60      'dk' ( global float)
+0:60      Constant:
+0:60        3.316625
 0:?   Linker Objects
 0:?     'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
 0:?     'foo' ( smooth in 4-component vector of float)
@@ -123,12 +148,20 @@ ERROR: node is still EOpNull!
 0:?     'p2' ( flat in 2-component vector of int)
 0:?     'p3' ( flat in 3-component vector of int)
 0:?     'samp' ( flat in int)
+0:?     'type1' ( smooth in double)
+0:?     'type2' ( global double)
+0:?     'type3' ( global double)
+0:?     'absTest' ( global int)
+0:?     'absTest2' ( global double)
+0:?     'absTest3' ( global double)
+0:?     'dk' ( global float)
 
 
 Linked fragment stage:
 
 
 Shader version: 150
+Requested GL_ARB_gpu_shader_fp64
 gl_FragCoord pixel center is integer
 gl_FragCoord origin is upper left
 ERROR: node is still EOpNull!
@@ -144,6 +177,26 @@ ERROR: node is still EOpNull!
 0:18      'patch' ( global float)
 0:18      Constant:
 0:18        3.100000
+0:56  Sequence
+0:56    move second child to first child ( temp double)
+0:56      'type3' ( global double)
+0:56      Constant:
+0:56        2.000000
+0:58  Sequence
+0:58    move second child to first child ( temp double)
+0:58      'absTest2' ( global double)
+0:58      sqrt ( global double)
+0:58        'type3' ( global double)
+0:59  Sequence
+0:59    move second child to first child ( temp double)
+0:59      'absTest3' ( global double)
+0:59      Constant:
+0:59        1.414214
+0:60  Sequence
+0:60    move second child to first child ( temp float)
+0:60      'dk' ( global float)
+0:60      Constant:
+0:60        3.316625
 0:?   Linker Objects
 0:?     'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
 0:?     'foo' ( smooth in 4-component vector of float)
@@ -158,4 +211,11 @@ ERROR: node is still EOpNull!
 0:?     'p2' ( flat in 2-component vector of int)
 0:?     'p3' ( flat in 3-component vector of int)
 0:?     'samp' ( flat in int)
+0:?     'type1' ( smooth in double)
+0:?     'type2' ( global double)
+0:?     'type3' ( global double)
+0:?     'absTest' ( global int)
+0:?     'absTest2' ( global double)
+0:?     'absTest3' ( global double)
+0:?     'dk' ( global float)
 

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -690,7 +690,7 @@ void TBuiltIns::initialize(int version, EProfile profile, const SpvVersion& spvV
     //
     // double functions added to desktop 4.00, but not fma, frexp, ldexp, or pack/unpack
     //
-    if (profile != EEsProfile && version >= 400) {
+    if (profile != EEsProfile && version >= 150) {  // ARB_gpu_shader_fp64
         commonBuiltins.append(
 
             "double sqrt(double);"
@@ -1298,15 +1298,15 @@ void TBuiltIns::initialize(int version, EProfile profile, const SpvVersion& spvV
             "vec3   fma(vec3,   vec3,   vec3  );"
             "vec4   fma(vec4,   vec4,   vec4  );"
             "\n");
+    }
 
-        if (profile != EEsProfile) {
+    if (profile != EEsProfile && version >= 150) {  // ARB_gpu_shader_fp64
             commonBuiltins.append(
                 "double fma(double, double, double);"
                 "dvec2  fma(dvec2,  dvec2,  dvec2 );"
                 "dvec3  fma(dvec3,  dvec3,  dvec3 );"
                 "dvec4  fma(dvec4,  dvec4,  dvec4 );"
                 "\n");
-        }
     }
 
     if ((profile == EEsProfile && version >= 310) ||
@@ -1325,7 +1325,7 @@ void TBuiltIns::initialize(int version, EProfile profile, const SpvVersion& spvV
             "\n");
     }
 
-    if (profile != EEsProfile && version >= 400) {
+    if (profile != EEsProfile && version >= 150) { // ARB_gpu_shader_fp64
         commonBuiltins.append(
             "double frexp(double, out int);"
             "dvec2  frexp( dvec2, out ivec2);"

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -6091,7 +6091,7 @@ const TFunction* TParseContext::findFunction(const TSourceLoc& loc, const TFunct
     if (isEsProfile() || version < 120)
         function = findFunctionExact(loc, call, builtIn);
     else if (version < 400)
-        function = findFunction120(loc, call, builtIn);
+        function = extensionTurnedOn(E_GL_ARB_gpu_shader_fp64) ? findFunction400(loc, call, builtIn) : findFunction120(loc, call, builtIn);
     else if (explicitTypesEnabled)
         function = findFunctionExplicitTypes(loc, call, builtIn);
     else

--- a/glslang/MachineIndependent/Scan.cpp
+++ b/glslang/MachineIndependent/Scan.cpp
@@ -1166,7 +1166,10 @@ int TScanContext::tokenizeIdentifier()
     case DVEC3:
     case DVEC4:
         afterType = true;
-        if (parseContext.isEsProfile() || parseContext.version < 400)
+        if (parseContext.isEsProfile() || parseContext.version < 150 ||
+            (!parseContext.symbolTable.atBuiltInLevel() &&
+              parseContext.version < 400 &&
+             !parseContext.extensionTurnedOn(E_GL_ARB_gpu_shader_fp64)))
             reservedWord();
         return keyword;
 
@@ -1741,7 +1744,9 @@ int TScanContext::dMat()
         return keyword;
     }
 
-    if (!parseContext.isEsProfile() && parseContext.version >= 400)
+    if (!parseContext.isEsProfile() && (parseContext.version >= 400 ||
+        parseContext.symbolTable.atBuiltInLevel() ||
+        (parseContext.version >= 150 && parseContext.extensionTurnedOn(E_GL_ARB_gpu_shader_fp64))))
         return keyword;
 
     if (parseContext.isForwardCompatible())

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -925,11 +925,10 @@ void TParseVersions::fullIntegerCheck(const TSourceLoc& loc, const char* op)
 }
 
 // Call for any operation needing GLSL double data-type support.
-void TParseVersions::doubleCheck(const TSourceLoc& loc, const char* op, bool builtIn)
+void TParseVersions::doubleCheck(const TSourceLoc& loc, const char* op)
 {
-    requireProfile(loc, ECoreProfile | ECompatibilityProfile, op);
-    if (!builtIn)
-        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 400, E_GL_ARB_gpu_shader_fp64, op);
+    //requireProfile(loc, ECoreProfile | ECompatibilityProfile, op);
+    profileRequires(loc, ECoreProfile | ECompatibilityProfile, 400, E_GL_ARB_gpu_shader_fp64, op);
 }
 
 // Call for any operation needing GLSL float16 data-type support.

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -184,6 +184,7 @@ void TParseVersions::initializeExtensionBehavior()
     extensionBehavior[E_GL_ARB_shader_texture_image_samples] = EBhDisable;
     extensionBehavior[E_GL_ARB_viewport_array]               = EBhDisable;
     extensionBehavior[E_GL_ARB_gpu_shader_int64]             = EBhDisable;
+    extensionBehavior[E_GL_ARB_gpu_shader_fp64]              = EBhDisable;
     extensionBehavior[E_GL_ARB_shader_ballot]                = EBhDisable;
     extensionBehavior[E_GL_ARB_sparse_texture2]              = EBhDisable;
     extensionBehavior[E_GL_ARB_sparse_texture_clamp]         = EBhDisable;
@@ -394,6 +395,7 @@ void TParseVersions::getPreamble(std::string& preamble)
             "#define GL_ARB_shader_texture_image_samples 1\n"
             "#define GL_ARB_viewport_array 1\n"
             "#define GL_ARB_gpu_shader_int64 1\n"
+            "#define GL_ARB_gpu_shader_fp64 1\n"
             "#define GL_ARB_shader_ballot 1\n"
             "#define GL_ARB_sparse_texture2 1\n"
             "#define GL_ARB_sparse_texture_clamp 1\n"
@@ -923,10 +925,11 @@ void TParseVersions::fullIntegerCheck(const TSourceLoc& loc, const char* op)
 }
 
 // Call for any operation needing GLSL double data-type support.
-void TParseVersions::doubleCheck(const TSourceLoc& loc, const char* op)
+void TParseVersions::doubleCheck(const TSourceLoc& loc, const char* op, bool builtIn)
 {
     requireProfile(loc, ECoreProfile | ECompatibilityProfile, op);
-    profileRequires(loc, ECoreProfile | ECompatibilityProfile, 400, nullptr, op);
+    if (!builtIn)
+        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 400, E_GL_ARB_gpu_shader_fp64, op);
 }
 
 // Call for any operation needing GLSL float16 data-type support.

--- a/glslang/MachineIndependent/Versions.h
+++ b/glslang/MachineIndependent/Versions.h
@@ -136,6 +136,7 @@ const char* const E_GL_ARB_derivative_control           = "GL_ARB_derivative_con
 const char* const E_GL_ARB_shader_texture_image_samples = "GL_ARB_shader_texture_image_samples";
 const char* const E_GL_ARB_viewport_array               = "GL_ARB_viewport_array";
 const char* const E_GL_ARB_gpu_shader_int64             = "GL_ARB_gpu_shader_int64";
+const char* const E_GL_ARB_gpu_shader_fp64              = "GL_ARB_gpu_shader_fp64";
 const char* const E_GL_ARB_shader_ballot                = "GL_ARB_shader_ballot";
 const char* const E_GL_ARB_sparse_texture2              = "GL_ARB_sparse_texture2";
 const char* const E_GL_ARB_sparse_texture_clamp         = "GL_ARB_sparse_texture_clamp";

--- a/glslang/MachineIndependent/glslang.m4
+++ b/glslang/MachineIndependent/glslang.m4
@@ -402,7 +402,9 @@ GLSLANG_WEB_EXCLUDE_ON
         $$ = parseContext.intermediate.addConstantUnion((unsigned short)$1.u, $1.loc, true);
     }
     | DOUBLECONSTANT {
-        parseContext.doubleCheck($1.loc, "double literal");
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double literal");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double literal");
         $$ = parseContext.intermediate.addConstantUnion($1.d, EbtDouble, $1.loc, true);
     }
     | FLOAT16CONSTANT {
@@ -1751,7 +1753,9 @@ type_specifier_nonarray
     }
 GLSLANG_WEB_EXCLUDE_ON
     | DOUBLE {
-        parseContext.doubleCheck($1.loc, "double", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
     }
@@ -1811,19 +1815,25 @@ GLSLANG_WEB_EXCLUDE_ON
         $$.basicType = EbtUint64;
     }
     | DVEC2 {
-        parseContext.doubleCheck($1.loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double vector");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double vector");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setVector(2);
     }
     | DVEC3 {
-        parseContext.doubleCheck($1.loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double vector");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double vector");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setVector(3);
     }
     | DVEC4 {
-        parseContext.doubleCheck($1.loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double vector");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double vector");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setVector(4);
@@ -2027,73 +2037,97 @@ GLSLANG_WEB_EXCLUDE_ON
         $$.setVector(4);
     }
     | DMAT2 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 2);
     }
     | DMAT3 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 3);
     }
     | DMAT4 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 4);
     }
     | DMAT2X2 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 2);
     }
     | DMAT2X3 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 3);
     }
     | DMAT2X4 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 4);
     }
     | DMAT3X2 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 2);
     }
     | DMAT3X3 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 3);
     }
     | DMAT3X4 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 4);
     }
     | DMAT4X2 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 2);
     }
     | DMAT4X3 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 3);
     }
     | DMAT4X4 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 4);

--- a/glslang/MachineIndependent/glslang.m4
+++ b/glslang/MachineIndependent/glslang.m4
@@ -1751,7 +1751,7 @@ type_specifier_nonarray
     }
 GLSLANG_WEB_EXCLUDE_ON
     | DOUBLE {
-        parseContext.doubleCheck($1.loc, "double");
+        parseContext.doubleCheck($1.loc, "double", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
     }
@@ -1811,19 +1811,19 @@ GLSLANG_WEB_EXCLUDE_ON
         $$.basicType = EbtUint64;
     }
     | DVEC2 {
-        parseContext.doubleCheck($1.loc, "double vector");
+        parseContext.doubleCheck($1.loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setVector(2);
     }
     | DVEC3 {
-        parseContext.doubleCheck($1.loc, "double vector");
+        parseContext.doubleCheck($1.loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setVector(3);
     }
     | DVEC4 {
-        parseContext.doubleCheck($1.loc, "double vector");
+        parseContext.doubleCheck($1.loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setVector(4);
@@ -2027,73 +2027,73 @@ GLSLANG_WEB_EXCLUDE_ON
         $$.setVector(4);
     }
     | DMAT2 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 2);
     }
     | DMAT3 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 3);
     }
     | DMAT4 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 4);
     }
     | DMAT2X2 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 2);
     }
     | DMAT2X3 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 3);
     }
     | DMAT2X4 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 4);
     }
     | DMAT3X2 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 2);
     }
     | DMAT3X3 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 3);
     }
     | DMAT3X4 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 4);
     }
     | DMAT4X2 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 2);
     }
     | DMAT4X3 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 3);
     }
     | DMAT4X4 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 4);

--- a/glslang/MachineIndependent/glslang.y
+++ b/glslang/MachineIndependent/glslang.y
@@ -402,7 +402,9 @@ primary_expression
         $$ = parseContext.intermediate.addConstantUnion((unsigned short)$1.u, $1.loc, true);
     }
     | DOUBLECONSTANT {
-        parseContext.doubleCheck($1.loc, "double literal");
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double literal");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double literal");
         $$ = parseContext.intermediate.addConstantUnion($1.d, EbtDouble, $1.loc, true);
     }
     | FLOAT16CONSTANT {
@@ -1751,7 +1753,9 @@ type_specifier_nonarray
     }
 
     | DOUBLE {
-        parseContext.doubleCheck($1.loc, "double", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
     }
@@ -1811,19 +1815,25 @@ type_specifier_nonarray
         $$.basicType = EbtUint64;
     }
     | DVEC2 {
-        parseContext.doubleCheck($1.loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double vector");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double vector");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setVector(2);
     }
     | DVEC3 {
-        parseContext.doubleCheck($1.loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double vector");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double vector");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setVector(3);
     }
     | DVEC4 {
-        parseContext.doubleCheck($1.loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double vector");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double vector");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setVector(4);
@@ -2027,73 +2037,97 @@ type_specifier_nonarray
         $$.setVector(4);
     }
     | DMAT2 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 2);
     }
     | DMAT3 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 3);
     }
     | DMAT4 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 4);
     }
     | DMAT2X2 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 2);
     }
     | DMAT2X3 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 3);
     }
     | DMAT2X4 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 4);
     }
     | DMAT3X2 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 2);
     }
     | DMAT3X3 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 3);
     }
     | DMAT3X4 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 4);
     }
     | DMAT4X2 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 2);
     }
     | DMAT4X3 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 3);
     }
     | DMAT4X4 {
-        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile($1.loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck($1.loc, "double matrix");
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 4);

--- a/glslang/MachineIndependent/glslang.y
+++ b/glslang/MachineIndependent/glslang.y
@@ -1751,7 +1751,7 @@ type_specifier_nonarray
     }
 
     | DOUBLE {
-        parseContext.doubleCheck($1.loc, "double");
+        parseContext.doubleCheck($1.loc, "double", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
     }
@@ -1811,19 +1811,19 @@ type_specifier_nonarray
         $$.basicType = EbtUint64;
     }
     | DVEC2 {
-        parseContext.doubleCheck($1.loc, "double vector");
+        parseContext.doubleCheck($1.loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setVector(2);
     }
     | DVEC3 {
-        parseContext.doubleCheck($1.loc, "double vector");
+        parseContext.doubleCheck($1.loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setVector(3);
     }
     | DVEC4 {
-        parseContext.doubleCheck($1.loc, "double vector");
+        parseContext.doubleCheck($1.loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setVector(4);
@@ -2027,73 +2027,73 @@ type_specifier_nonarray
         $$.setVector(4);
     }
     | DMAT2 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 2);
     }
     | DMAT3 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 3);
     }
     | DMAT4 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 4);
     }
     | DMAT2X2 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 2);
     }
     | DMAT2X3 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 3);
     }
     | DMAT2X4 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(2, 4);
     }
     | DMAT3X2 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 2);
     }
     | DMAT3X3 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 3);
     }
     | DMAT3X4 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(3, 4);
     }
     | DMAT4X2 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 2);
     }
     | DMAT4X3 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 3);
     }
     | DMAT4X4 {
-        parseContext.doubleCheck($1.loc, "double matrix");
+        parseContext.doubleCheck($1.loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         $$.init($1.loc, parseContext.symbolTable.atGlobalLevel());
         $$.basicType = EbtDouble;
         $$.setMatrix(4, 4);

--- a/glslang/MachineIndependent/glslang_tab.cpp
+++ b/glslang/MachineIndependent/glslang_tab.cpp
@@ -4279,7 +4279,9 @@ yyreduce:
   case 15:
 #line 404 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double literal");
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double literal");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double literal");
         (yyval.interm.intermTypedNode) = parseContext.intermediate.addConstantUnion((yyvsp[0].lex).d, EbtDouble, (yyvsp[0].lex).loc, true);
     }
 #line 4286 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
@@ -6498,7 +6500,9 @@ yyreduce:
   case 228:
 #line 1753 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
     }
@@ -6618,7 +6622,9 @@ yyreduce:
   case 240:
 #line 1813 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double vector");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double vector");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setVector(2);
@@ -6629,7 +6635,9 @@ yyreduce:
   case 241:
 #line 1819 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double vector");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double vector");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setVector(3);
@@ -6640,7 +6648,9 @@ yyreduce:
   case 242:
 #line 1825 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double vector");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double vector");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setVector(4);
@@ -7014,7 +7024,9 @@ yyreduce:
   case 276:
 #line 2029 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 2);
@@ -7025,7 +7037,9 @@ yyreduce:
   case 277:
 #line 2035 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 3);
@@ -7036,7 +7050,9 @@ yyreduce:
   case 278:
 #line 2041 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(4, 4);
@@ -7047,7 +7063,9 @@ yyreduce:
   case 279:
 #line 2047 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 2);
@@ -7058,7 +7076,9 @@ yyreduce:
   case 280:
 #line 2053 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 3);
@@ -7069,7 +7089,9 @@ yyreduce:
   case 281:
 #line 2059 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 4);
@@ -7080,7 +7102,9 @@ yyreduce:
   case 282:
 #line 2065 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 2);
@@ -7091,7 +7115,9 @@ yyreduce:
   case 283:
 #line 2071 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 3);
@@ -7102,7 +7128,9 @@ yyreduce:
   case 284:
 #line 2077 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 4);
@@ -7113,7 +7141,9 @@ yyreduce:
   case 285:
 #line 2083 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(4, 2);
@@ -7124,7 +7154,9 @@ yyreduce:
   case 286:
 #line 2089 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(4, 3);
@@ -7135,7 +7167,9 @@ yyreduce:
   case 287:
 #line 2095 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
+        parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
+        if (! parseContext.symbolTable.atBuiltInLevel())
+            parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(4, 4);

--- a/glslang/MachineIndependent/glslang_tab.cpp
+++ b/glslang/MachineIndependent/glslang_tab.cpp
@@ -6498,7 +6498,7 @@ yyreduce:
   case 228:
 #line 1753 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
     }
@@ -6618,7 +6618,7 @@ yyreduce:
   case 240:
 #line 1813 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double vector");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setVector(2);
@@ -6629,7 +6629,7 @@ yyreduce:
   case 241:
 #line 1819 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double vector");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setVector(3);
@@ -6640,7 +6640,7 @@ yyreduce:
   case 242:
 #line 1825 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double vector");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setVector(4);
@@ -7014,7 +7014,7 @@ yyreduce:
   case 276:
 #line 2029 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 2);
@@ -7025,7 +7025,7 @@ yyreduce:
   case 277:
 #line 2035 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 3);
@@ -7036,7 +7036,7 @@ yyreduce:
   case 278:
 #line 2041 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(4, 4);
@@ -7047,7 +7047,7 @@ yyreduce:
   case 279:
 #line 2047 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 2);
@@ -7058,7 +7058,7 @@ yyreduce:
   case 280:
 #line 2053 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 3);
@@ -7069,7 +7069,7 @@ yyreduce:
   case 281:
 #line 2059 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 4);
@@ -7080,7 +7080,7 @@ yyreduce:
   case 282:
 #line 2065 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 2);
@@ -7091,7 +7091,7 @@ yyreduce:
   case 283:
 #line 2071 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 3);
@@ -7102,7 +7102,7 @@ yyreduce:
   case 284:
 #line 2077 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 4);
@@ -7113,7 +7113,7 @@ yyreduce:
   case 285:
 #line 2083 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(4, 2);
@@ -7124,7 +7124,7 @@ yyreduce:
   case 286:
 #line 2089 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(4, 3);
@@ -7135,7 +7135,7 @@ yyreduce:
   case 287:
 #line 2095 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix");
+        parseContext.doubleCheck((yyvsp[0].lex).loc, "double matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(4, 4);

--- a/glslang/MachineIndependent/parseVersions.h
+++ b/glslang/MachineIndependent/parseVersions.h
@@ -102,7 +102,7 @@ public:
     void updateExtensionBehavior(const char* const extension, TExtensionBehavior) { }
     void checkExtensionStage(const TSourceLoc&, const char* const extension) { }
     void fullIntegerCheck(const TSourceLoc&, const char* op) { }
-    void doubleCheck(const TSourceLoc&, const char* op, bool builtIn = false) { }
+    void doubleCheck(const TSourceLoc&, const char* op) { }
     bool float16Arithmetic() { return false; }
     void requireFloat16Arithmetic(const TSourceLoc& loc, const char* op, const char* featureDesc) { }
     bool int16Arithmetic() { return false; }
@@ -142,7 +142,7 @@ public:
     virtual void fullIntegerCheck(const TSourceLoc&, const char* op);
 
     virtual void unimplemented(const TSourceLoc&, const char* featureDesc);
-    virtual void doubleCheck(const TSourceLoc&, const char* op, bool builtIn = false);
+    virtual void doubleCheck(const TSourceLoc&, const char* op);
     virtual void float16Check(const TSourceLoc&, const char* op, bool builtIn = false);
     virtual void float16ScalarVectorCheck(const TSourceLoc&, const char* op, bool builtIn = false);
     virtual bool float16Arithmetic();

--- a/glslang/MachineIndependent/parseVersions.h
+++ b/glslang/MachineIndependent/parseVersions.h
@@ -102,7 +102,7 @@ public:
     void updateExtensionBehavior(const char* const extension, TExtensionBehavior) { }
     void checkExtensionStage(const TSourceLoc&, const char* const extension) { }
     void fullIntegerCheck(const TSourceLoc&, const char* op) { }
-    void doubleCheck(const TSourceLoc&, const char* op) { }
+    void doubleCheck(const TSourceLoc&, const char* op, bool builtIn = false) { }
     bool float16Arithmetic() { return false; }
     void requireFloat16Arithmetic(const TSourceLoc& loc, const char* op, const char* featureDesc) { }
     bool int16Arithmetic() { return false; }
@@ -142,7 +142,7 @@ public:
     virtual void fullIntegerCheck(const TSourceLoc&, const char* op);
 
     virtual void unimplemented(const TSourceLoc&, const char* featureDesc);
-    virtual void doubleCheck(const TSourceLoc&, const char* op);
+    virtual void doubleCheck(const TSourceLoc&, const char* op, bool builtIn = false);
     virtual void float16Check(const TSourceLoc&, const char* op, bool builtIn = false);
     virtual void float16ScalarVectorCheck(const TSourceLoc&, const char* op, bool builtIn = false);
     virtual bool float16Arithmetic();


### PR DESCRIPTION
GLSL Version : >= 150

Purpose:
Allow users to use features by enabling this extension, even in low versions.

Extension Name:
ARB_gpu_shader_fp64

Builtin-variables:
Nah

Builtin-functions:
functions overloaded for this extension, please check registry in reference.

Keywords:
Double

Features:
add support for type "double", also related functions/builtin functions
overloaded for DOUBLE. "double vector" input should be in
ARB_vertex_attrib_64bit

Reference:
https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_gpu_shader_fp64.txt