### PR TITLE
Add support for ARB_shader_storage_buffer_object extension

### DIFF
--- a/Test/420.vert
+++ b/Test/420.vert
@@ -159,3 +159,15 @@ void qlod()
 }
 
 layout(binding=0) writeonly uniform image1D badArray[];
+
+buffer fblock   // error
+{
+    int value;
+} fblock;
+
+#extension GL_ARB_shader_storage_buffer_object : enable
+
+buffer fblock1
+{
+    int value;
+} fblock1;

--- a/Test/baseResults/130.frag.out
+++ b/Test/baseResults/130.frag.out
@@ -30,7 +30,7 @@ ERROR: 0:156: 'early_fragment_tests' : not supported for this version or the ena
 ERROR: 0:157: 'image load store' : not supported for this version or the enabled extensions 
 ERROR: 0:157: 'iimage2D' : Reserved word. 
 ERROR: 0:172: 'early_fragment_tests' : can only apply to 'in' 
-ERROR: 0:176: 'location qualifier on uniform or buffer' : not supported for this version or the enabled extensions 
+ERROR: 0:176: 'location qualifier on uniform' : not supported for this version or the enabled extensions 
 ERROR: 30 compilation errors.  No code generated.
 
 

--- a/Test/baseResults/330.frag.out
+++ b/Test/baseResults/330.frag.out
@@ -14,16 +14,16 @@ ERROR: 0:48: 'non-literal layout-id value' : not supported for this version or t
 ERROR: 0:52: 'f2' : cannot use layout qualifiers on structure members 
 ERROR: 0:57: 'location on block member' : not supported for this version or the enabled extensions 
 ERROR: 0:62: 'location on block member' : can only use in an in/out block 
-ERROR: 0:62: 'location qualifier on uniform or buffer' : not supported for this version or the enabled extensions 
-ERROR: 0:60: 'location qualifier on uniform or buffer' : not supported for this version or the enabled extensions 
+ERROR: 0:62: 'location qualifier on uniform' : not supported for this version or the enabled extensions 
+ERROR: 0:60: 'location qualifier on uniform' : not supported for this version or the enabled extensions 
 ERROR: 0:60: 'location' : cannot apply to uniform or buffer block 
 ERROR: 0:68: 'layout-id value' : cannot be negative 
 ERROR: 0:69: 'layout-id value' : cannot be negative 
 ERROR: 0:76: 'f2' : cannot use layout qualifiers on structure members 
 ERROR: 0:91: 'location on block member' : can only use in an in/out block 
-ERROR: 0:91: 'location qualifier on uniform or buffer' : not supported for this version or the enabled extensions 
+ERROR: 0:91: 'location qualifier on uniform' : not supported for this version or the enabled extensions 
 ERROR: 0:91: 'location' : overlapping use of location 3
-ERROR: 0:89: 'location qualifier on uniform or buffer' : not supported for this version or the enabled extensions 
+ERROR: 0:89: 'location qualifier on uniform' : not supported for this version or the enabled extensions 
 ERROR: 0:89: 'location' : cannot apply to uniform or buffer block 
 ERROR: 0:94: 'location' : either the block needs a location, or all members need a location, or no members have a location 
 ERROR: 0:108: 'A' : cannot use layout qualifiers on structure members 
@@ -40,7 +40,7 @@ ERROR: 0:140: 'assign' :  cannot convert from ' const float' to ' temp 2-compone
 ERROR: 0:141: 'textureQueryLod' : no matching overloaded function found 
 ERROR: 0:141: 'assign' :  cannot convert from ' const float' to ' temp 2-component vector of float'
 ERROR: 0:152: 'index' : value must be 0 or 1 
-ERROR: 0:154: 'location qualifier on uniform or buffer' : not supported for this version or the enabled extensions 
+ERROR: 0:154: 'location qualifier on uniform' : not supported for this version or the enabled extensions 
 ERROR: 0:160: 'location' : cannot apply to uniform or buffer block 
 ERROR: 43 compilation errors.  No code generated.
 

--- a/Test/baseResults/400.frag.out
+++ b/Test/baseResults/400.frag.out
@@ -3,7 +3,7 @@ ERROR: 0:18: 'textureGatherOffsets(...)' : must be a compile-time constant: offs
 ERROR: 0:22: 'textureGatherOffset(...)' : must be a compile-time constant: component argument
 ERROR: 0:23: 'textureGatherOffset(...)' : must be 0, 1, 2, or 3: component argument
 ERROR: 0:30: 'location qualifier on input' : not supported for this version or the enabled extensions 
-ERROR: 0:38: 'location qualifier on uniform or buffer' : not supported for this version or the enabled extensions 
+ERROR: 0:38: 'location qualifier on uniform' : not supported for this version or the enabled extensions 
 ERROR: 0:40: 'redeclaration' : cannot apply layout qualifier to gl_Color
 ERROR: 0:41: 'redeclaration' : cannot change qualification of gl_ClipDistance
 ERROR: 0:43: 'gl_FragCoord' : cannot redeclare after use 

--- a/Test/baseResults/420.vert.out
+++ b/Test/baseResults/420.vert.out
@@ -55,7 +55,8 @@ ERROR: 0:157: 'assign' :  cannot convert from ' const float' to ' temp int'
 ERROR: 0:158: 'textureQueryLevels' : no matching overloaded function found 
 ERROR: 0:158: 'assign' :  cannot convert from ' const float' to ' temp int'
 WARNING: 0:161: '[]' : assuming binding count of one for compile-time checking of binding numbers for unsized array 
-ERROR: 54 compilation errors.  No code generated.
+ERROR: 0:163: '' :  syntax error, unexpected IDENTIFIER
+ERROR: 55 compilation errors.  No code generated.
 
 
 Shader version: 420

--- a/Test/baseResults/spv.specConstant.vert.out
+++ b/Test/baseResults/spv.specConstant.vert.out
@@ -11,7 +11,7 @@ spv.specConstant.vert
                               Source GLSL 400
                               Name 4  "main"
                               Name 9  "arraySize"
-                              Name 14  "foo(vf4[s4530];"
+                              Name 14  "foo(vf4[s4546];"
                               Name 13  "p"
                               Name 17  "builtin_spec_constant("
                               Name 20  "color"
@@ -102,10 +102,10 @@ spv.specConstant.vert
                               Store 20(color) 46
               48:          10 Load 22(ucol)
                               Store 47(param) 48
-              49:           2 FunctionCall 14(foo(vf4[s4530];) 47(param)
+              49:           2 FunctionCall 14(foo(vf4[s4546];) 47(param)
                               Return
                               FunctionEnd
-14(foo(vf4[s4530];):           2 Function None 12
+14(foo(vf4[s4546];):           2 Function None 12
            13(p):     11(ptr) FunctionParameter
               15:             Label
               54:     24(ptr) AccessChain 53(dupUcol) 23

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -148,6 +148,7 @@ EProfile EDesktopProfile = static_cast<EProfile>(ENoProfile | ECoreProfile | ECo
 #ifdef GLSLANG_WEB
     const Versioning* Es300Desktop130 = nullptr;
     const Versioning* Es310Desktop430 = nullptr;
+    const Versioning* Es310Desktop400 = nullptr;
 #else
     const Versioning Es300Desktop130Version[] = { { EEsProfile,      0, 300, 0, nullptr },
                                                   { EDesktopProfile, 0, 130, 0, nullptr },
@@ -163,6 +164,11 @@ EProfile EDesktopProfile = static_cast<EProfile>(ENoProfile | ECoreProfile | ECo
                                                   { EDesktopProfile, 0, 450, 0, nullptr },
                                                   { EBadProfile } };
     const Versioning* Es310Desktop450 = &Es310Desktop450Version[0];
+
+    const Versioning Es310Desktop400Version[] = { { EEsProfile,      0, 310, 0, nullptr },
+                                                  { EDesktopProfile, 0, 400, 0, nullptr },
+                                                  { EBadProfile } };
+    const Versioning* Es310Desktop400 = &Es310Desktop400Version[0];
 #endif
 
 // The main descriptor of what a set of function prototypes can look like, and
@@ -257,14 +263,14 @@ const BuiltInFunction BaseFunctions[] = {
     { EOpGreaterThanEqual, "greaterThanEqual", 2,   TypeU,     ClassBNS,     Es300Desktop130 },
     { EOpVectorEqual,      "equal",            2,   TypeU,     ClassBNS,     Es300Desktop130 },
     { EOpVectorNotEqual,   "notEqual",         2,   TypeU,     ClassBNS,     Es300Desktop130 },
-    { EOpAtomicAdd,        "atomicAdd",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop430 },
-    { EOpAtomicMin,        "atomicMin",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop430 },
-    { EOpAtomicMax,        "atomicMax",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop430 },
-    { EOpAtomicAnd,        "atomicAnd",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop430 },
-    { EOpAtomicOr,         "atomicOr",         2,   TypeIU,    ClassV1FIOCV, Es310Desktop430 },
-    { EOpAtomicXor,        "atomicXor",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop430 },
-    { EOpAtomicExchange,   "atomicExchange",   2,   TypeIU,    ClassV1FIOCV, Es310Desktop430 },
-    { EOpAtomicCompSwap,   "atomicCompSwap",   3,   TypeIU,    ClassV1FIOCV, Es310Desktop430 },
+    { EOpAtomicAdd,        "atomicAdd",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
+    { EOpAtomicMin,        "atomicMin",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
+    { EOpAtomicMax,        "atomicMax",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
+    { EOpAtomicAnd,        "atomicAnd",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
+    { EOpAtomicOr,         "atomicOr",         2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
+    { EOpAtomicXor,        "atomicXor",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
+    { EOpAtomicExchange,   "atomicExchange",   2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
+    { EOpAtomicCompSwap,   "atomicCompSwap",   3,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
 #ifndef GLSLANG_WEB
     { EOpMix,              "mix",              3,   TypeB,     ClassRegular, Es310Desktop450 },
     { EOpMix,              "mix",              3,   TypeIU,    ClassLB,      Es310Desktop450 },
@@ -7497,6 +7503,18 @@ void TBuiltIns::identifyBuiltIns(int version, EProfile profile, const SpvVersion
         BuiltInVariable("gl_SecondaryColor", EbvSecondaryColor, symbolTable);
 
         // built-in functions
+
+        // ARB_shader_storage_buffer_object
+        if (profile != EEsProfile && version < 430 && version >= 400) {
+            symbolTable.setFunctionExtensions("atomicAdd", 1, &E_GL_ARB_shader_storage_buffer_object);
+            symbolTable.setFunctionExtensions("atomicMin", 1, &E_GL_ARB_shader_storage_buffer_object);
+            symbolTable.setFunctionExtensions("atomicMax", 1, &E_GL_ARB_shader_storage_buffer_object);
+            symbolTable.setFunctionExtensions("atomicAnd", 1, &E_GL_ARB_shader_storage_buffer_object);
+            symbolTable.setFunctionExtensions("atomicOr", 1, &E_GL_ARB_shader_storage_buffer_object);
+            symbolTable.setFunctionExtensions("atomicXor", 1, &E_GL_ARB_shader_storage_buffer_object);
+            symbolTable.setFunctionExtensions("atomicExchange", 1, &E_GL_ARB_shader_storage_buffer_object);
+            symbolTable.setFunctionExtensions("atomicCompSwap", 1, &E_GL_ARB_shader_storage_buffer_object);
+        }
 
         if (profile == EEsProfile) {
             if (spvVersion.spv == 0) {

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -4874,7 +4874,7 @@ void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publi
 #ifndef GLSLANG_WEB
     if (id == TQualifier::getLayoutPackingString(ElpStd430)) {
         requireProfile(loc, EEsProfile | ECoreProfile | ECompatibilityProfile, "std430");
-        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 430, nullptr, "std430");
+        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 430,  E_GL_ARB_shader_storage_buffer_object, "std430");
         profileRequires(loc, EEsProfile, 310, nullptr, "std430");
         publicType.qualifier.layoutPacking = ElpStd430;
         return;
@@ -5914,12 +5914,20 @@ void TParseContext::layoutQualifierCheck(const TSourceLoc& loc, const TQualifier
         }
 #endif
         case EvqUniform:
-        case EvqBuffer:
         {
-            const char* feature = "location qualifier on uniform or buffer";
+            const char* feature = "location qualifier on uniform";
             requireProfile(loc, EEsProfile | ECoreProfile | ECompatibilityProfile | ENoProfile, feature);
             profileRequires(loc, ~EEsProfile, 330, E_GL_ARB_explicit_attrib_location, feature);
             profileRequires(loc, ~EEsProfile, 430, E_GL_ARB_explicit_uniform_location, feature);
+            profileRequires(loc, EEsProfile, 310, nullptr, feature);
+            break;
+        }
+        case EvqBuffer:
+        {
+            const char* feature = "location qualifier on buffer";
+            requireProfile(loc, EEsProfile | ECoreProfile | ECompatibilityProfile | ENoProfile, feature);
+            profileRequires(loc, ~EEsProfile, 330, E_GL_ARB_explicit_attrib_location, feature);
+            profileRequires(loc, ~EEsProfile, 430, Num_ARB_shader_storage_buffer_location, ARB_shader_storage_buffer_location, feature);
             profileRequires(loc, EEsProfile, 310, nullptr, feature);
             break;
         }
@@ -7636,7 +7644,7 @@ void TParseContext::blockStageIoCheck(const TSourceLoc& loc, const TQualifier& q
         break;
     case EvqBuffer:
         requireProfile(loc, EEsProfile | ECoreProfile | ECompatibilityProfile, "buffer block");
-        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 430, nullptr, "buffer block");
+        profileRequires(loc, ECoreProfile | ECompatibilityProfile, 430, E_GL_ARB_shader_storage_buffer_object, "buffer block");
         profileRequires(loc, EEsProfile, 310, nullptr, "buffer block");
         break;
     case EvqVaryingIn:

--- a/glslang/MachineIndependent/Scan.cpp
+++ b/glslang/MachineIndependent/Scan.cpp
@@ -908,7 +908,9 @@ int TScanContext::tokenizeIdentifier()
     case BUFFER:
         afterBuffer = true;
         if ((parseContext.isEsProfile() && parseContext.version < 310) ||
-            (!parseContext.isEsProfile() && parseContext.version < 430))
+            (!parseContext.isEsProfile() &&
+             ((parseContext.version < 430 && !parseContext.extensionTurnedOn(E_GL_ARB_shader_storage_buffer_object)) ||
+              parseContext.version < 400)))
             return identifierOrType();
         return keyword;
 

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -169,6 +169,7 @@ void TParseVersions::initializeExtensionBehavior()
     extensionBehavior[E_GL_ARB_gpu_shader5]                  = EBhDisablePartial;
     extensionBehavior[E_GL_ARB_separate_shader_objects]      = EBhDisable;
     extensionBehavior[E_GL_ARB_compute_shader]               = EBhDisable;
+    extensionBehavior[E_GL_ARB_shader_storage_buffer_object] = EBhDisable;
     extensionBehavior[E_GL_ARB_tessellation_shader]          = EBhDisable;
     extensionBehavior[E_GL_ARB_enhanced_layouts]             = EBhDisable;
     extensionBehavior[E_GL_ARB_texture_cube_map_array]       = EBhDisable;
@@ -380,6 +381,7 @@ void TParseVersions::getPreamble(std::string& preamble)
             "#define GL_ARB_gpu_shader5 1\n"
             "#define GL_ARB_separate_shader_objects 1\n"
             "#define GL_ARB_compute_shader 1\n"
+            "#define GL_ARB_shader_storage_buffer_object 1\n"
             "#define GL_ARB_tessellation_shader 1\n"
             "#define GL_ARB_enhanced_layouts 1\n"
             "#define GL_ARB_texture_cube_map_array 1\n"

--- a/glslang/MachineIndependent/Versions.h
+++ b/glslang/MachineIndependent/Versions.h
@@ -124,6 +124,7 @@ const char* const E_GL_ARB_texture_gather               = "GL_ARB_texture_gather
 const char* const E_GL_ARB_gpu_shader5                  = "GL_ARB_gpu_shader5";
 const char* const E_GL_ARB_separate_shader_objects      = "GL_ARB_separate_shader_objects";
 const char* const E_GL_ARB_compute_shader               = "GL_ARB_compute_shader";
+const char* const E_GL_ARB_shader_storage_buffer_object = "GL_ARB_shader_storage_buffer_object";
 const char* const E_GL_ARB_tessellation_shader          = "GL_ARB_tessellation_shader";
 const char* const E_GL_ARB_enhanced_layouts             = "GL_ARB_enhanced_layouts";
 const char* const E_GL_ARB_texture_cube_map_array       = "GL_ARB_texture_cube_map_array";
@@ -312,6 +313,9 @@ const int Num_AEP_texture_buffer = sizeof(AEP_texture_buffer)/sizeof(AEP_texture
 
 const char* const AEP_texture_cube_map_array[] = { E_GL_EXT_texture_cube_map_array, E_GL_OES_texture_cube_map_array };
 const int Num_AEP_texture_cube_map_array = sizeof(AEP_texture_cube_map_array)/sizeof(AEP_texture_cube_map_array[0]);
+
+const char* const ARB_shader_storage_buffer_location[] = { E_GL_ARB_explicit_uniform_location, E_GL_ARB_shader_storage_buffer_object };
+const int Num_ARB_shader_storage_buffer_location = sizeof(ARB_shader_storage_buffer_location)/sizeof(ARB_shader_storage_buffer_location[0]);
 
 } // end namespace glslang
 


### PR DESCRIPTION
GLSL Version : >= 420

Purpose:
Allow users to use features by enabling this extension, even in low versions.

Extension Name:
ARB_shader_storage_buffer_object

Builtin-variables:
Nah

Builtin-functions: (uint/int)
atomicAdd
atomicMin
atomicMax
atomicAnd
atomicOr
atomicXor
atomicExchange
atomicCompSwap

Keywords:
buffer

Features:
std430/location on buffer
buffer block

Reference:
https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_shader_storage_buffer_object.txt