### PR TITLE
Remove glslang::pool_allocator::setAllocator

### DIFF
--- a/glslang/Include/PoolAlloc.h
+++ b/glslang/Include/PoolAlloc.h
@@ -304,7 +304,6 @@ public:
     size_type max_size() const { return static_cast<size_type>(-1) / sizeof(T); }
     size_type max_size(int size) const { return static_cast<size_type>(-1) / size; }
 
-    void setAllocator(TPoolAllocator* a) { allocator = *a; }
     TPoolAllocator& getAllocator() const { return allocator; }
 
 protected:


### PR DESCRIPTION
TPoolAllocator is not copy assignable, so this setter could never have
been used. After a recent change (878a24ee2), new versions of Clang
reject this code. Make it compile by removing the method.