### PR TITLE
"Switch" with no statements till end

### DIFF
--- a/Test/430.comp
+++ b/Test/430.comp
@@ -79,6 +79,12 @@ void fooaoeu() {
      double globalCoef = 1.0;
      int i = globalCoef;            // ERROR, can't convert from double to int
      double di = i;
+     int j = 0;
+     switch(j)                       // ERROR
+     {
+     case 1: break;
+     default:
+     }
 }
 
 in inb {     // ERROR

--- a/Test/baseResults/430.comp.out
+++ b/Test/baseResults/430.comp.out
@@ -14,9 +14,10 @@ ERROR: 0:54: 'local_size' : can only apply to 'in'
 ERROR: 0:54: 'local_size' : can only apply to 'in' 
 ERROR: 0:68: 'assign' :  l-value required "ro" (can't modify a readonly buffer)
 ERROR: 0:80: '=' :  cannot convert from ' temp double' to ' temp int'
-ERROR: 0:84: 'input block' : not supported in this stage: compute
-ERROR: 0:88: 'output block' : not supported in this stage: compute
-ERROR: 17 compilation errors.  No code generated.
+ERROR: 0:83: 'switch' : last case/default label not followed by statements 
+ERROR: 0:90: 'input block' : not supported in this stage: compute
+ERROR: 0:94: 'output block' : not supported in this stage: compute
+ERROR: 18 compilation errors.  No code generated.
 
 
 Shader version: 430
@@ -123,6 +124,24 @@ ERROR: node is still EOpNull!
 0:81          'di' ( temp double)
 0:81          Convert int to double ( temp double)
 0:81            'i' ( temp int)
+0:82      Sequence
+0:82        move second child to first child ( temp int)
+0:82          'j' ( temp int)
+0:82          Constant:
+0:82            0 (const int)
+0:83      switch
+0:83      condition
+0:83        'j' ( temp int)
+0:83      body
+0:83        Sequence
+0:85          case:  with expression
+0:85            Constant:
+0:85              1 (const int)
+0:?           Sequence
+0:85            Branch: Break
+0:86          default: 
+0:83          Sequence
+0:83            Branch: Break
 0:?   Linker Objects
 0:?     'gl_WorkGroupSize' ( const 3-component vector of uint WorkGroupSize)
 0:?       2 (const uint)

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -8295,7 +8295,8 @@ TIntermNode* TParseContext::addSwitch(const TSourceLoc& loc, TIntermTyped* expre
         // "it is an error to have no statement between a label and the end of the switch statement."
         // The specifications were updated to remove this (being ill-defined what a "statement" was),
         // so, this became a warning.  However, 3.0 tests still check for the error.
-        if (isEsProfile() && version <= 300 && ! relaxedErrors())
+        if (((profile == EEsProfile && version <= 300) || (profile != EEsProfile && version < 440)) &&
+            !relaxedErrors())
             error(loc, "last case/default label not followed by statements", "switch", "");
         else
             warn(loc, "last case/default label not followed by statements", "switch", "");


### PR DESCRIPTION
From version 440, according to spec, GLSL

"Removed the rule about having no statement between a label and the end of the switch statement; existing compiler errors for this can turn into a warning.".

So this should be treated as a warning since version 440, but still error before version 440 for NoESProfile