### PR TITLE
Add flag to check whether offset is implicit or explicit

### DIFF
--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -553,6 +553,7 @@ public:
     // having a constant_id is not sufficient: expressions have no id, but are still specConstant
     bool specConstant : 1;
     bool nonUniform   : 1;
+    bool explicitOffset   : 1;
 
 #ifdef GLSLANG_WEB
     bool isWriteOnly() const { return false; }

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -5135,6 +5135,7 @@ void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publi
             profileRequires(loc, EEsProfile, 310, nullptr, feature);
         }
         publicType.qualifier.layoutOffset = value;
+        publicType.qualifier.explicitOffset = true;
         if (nonLiteral)
             error(loc, "needs a literal integer", "offset", "");
         return;


### PR DESCRIPTION
When we use unsized array in shader storage buffer, glslang calculate the offset during delcaring the block, it may lead to incorrect block offsets when its implicit array size changed.

So here is what we do:
1. For GLSL, we add flag explicitOffset in TQualifier, and set it when layout offset is specified explicitly
2. By using this flag we could tell difference as whether it is an explicit offset, and recalculate the block member offset conditionally in OpenGL.