### PR TITLE
Modify max binding checks for atomic_uint

### DIFF
--- a/Test/450.comp
+++ b/Test/450.comp
@@ -1,5 +1,8 @@
 #version 450 core
 layout(local_size_x = 0) in; // ERROR, 0 not allowed
+
+layout(binding=10000) uniform atomic_uint;     // ERROR
+
 void main()
 {
     shared float f;   // ERROR shared must be global

--- a/Test/baseResults/450.comp.out
+++ b/Test/baseResults/450.comp.out
@@ -1,14 +1,15 @@
 450.comp
 ERROR: 0:2: 'local_size_x' : must be at least 1 
-ERROR: 0:5: 'shared' : not allowed in nested scope 
-ERROR: 2 compilation errors.  No code generated.
+ERROR: 0:4: 'binding' : atomic_uint binding is too large 
+ERROR: 0:8: 'shared' : not allowed in nested scope 
+ERROR: 3 compilation errors.  No code generated.
 
 
 Shader version: 450
 local_size = (1, 1, 1)
 ERROR: node is still EOpNull!
-0:3  Function Definition: main( ( global void)
-0:3    Function Parameters: 
+0:6  Function Definition: main( ( global void)
+0:6    Function Parameters: 
 0:?   Linker Objects
 
 
@@ -18,7 +19,7 @@ Linked compute stage:
 Shader version: 450
 local_size = (1, 1, 1)
 ERROR: node is still EOpNull!
-0:3  Function Definition: main( ( global void)
-0:3    Function Parameters: 
+0:6  Function Definition: main( ( global void)
+0:6    Function Parameters: 
 0:?   Linker Objects
 

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -6380,13 +6380,15 @@ const TFunction* TParseContext::findFunctionExplicitTypes(const TSourceLoc& loc,
 void TParseContext::declareTypeDefaults(const TSourceLoc& loc, const TPublicType& publicType)
 {
 #ifndef GLSLANG_WEB
-    if (publicType.basicType == EbtAtomicUint && publicType.qualifier.hasBinding() &&
-        publicType.qualifier.hasOffset()) {
+    if (publicType.basicType == EbtAtomicUint && publicType.qualifier.hasBinding()) {
         if (publicType.qualifier.layoutBinding >= (unsigned int)resources.maxAtomicCounterBindings) {
             error(loc, "atomic_uint binding is too large", "binding", "");
             return;
         }
-        atomicUintOffsets[publicType.qualifier.layoutBinding] = publicType.qualifier.layoutOffset;
+
+        if(publicType.qualifier.hasOffset()) {
+            atomicUintOffsets[publicType.qualifier.layoutBinding] = publicType.qualifier.layoutOffset;
+        }
         return;
     }
 


### PR DESCRIPTION
Wrong logic entry,

when declare atomic_uint binding without offset declaration, glslang won't check max atomic uint binding.