### PR TITLE
Add Error check flag in io mapper

### DIFF
--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -831,6 +831,7 @@ void TDefaultGlslIoResolver::reserverStorageSlot(TVarEntryInfo& ent, TInfoSink& 
                 if (iter->second != location) {
                     TString errorMsg = "Invalid location: " + name;
                     infoSink.info.message(EPrefixInternalError, errorMsg.c_str());
+                    hasError = true;
                 }
             }
         }
@@ -856,6 +857,7 @@ void TDefaultGlslIoResolver::reserverStorageSlot(TVarEntryInfo& ent, TInfoSink& 
                 if (iter->second != location) {
                     TString errorMsg = "Invalid location: " + name;
                     infoSink.info.message(EPrefixInternalError, errorMsg.c_str());
+                    hasError = true;
                 }
             }
         }
@@ -884,6 +886,7 @@ void TDefaultGlslIoResolver::reserverResourceSlot(TVarEntryInfo& ent, TInfoSink&
             if (iter->second != binding) {
                 TString errorMsg = "Invalid binding: " + name;
                 infoSink.info.message(EPrefixInternalError, errorMsg.c_str());
+                hasError = true;
             }
         }
     }

--- a/glslang/MachineIndependent/iomapper.h
+++ b/glslang/MachineIndependent/iomapper.h
@@ -129,6 +129,7 @@ public:
     uint32_t computeTypeLocationSize(const TType& type, EShLanguage stage);
 
     TSlotSetMap slots;
+    bool hasError = false;
 
 protected:
     TDefaultIoResolverBase(TDefaultIoResolverBase&);


### PR DESCRIPTION
GLSL could detect contradictory uniform binding, but missing error reporting, even if we could now observe error message inside infosink.

Add error check when first time validate uniform binding. 
This error check flag will be used during linking time. To quickly report errors like contradictory uniform bindings.