### PR TITLE
Add implementation dependent limit for uniform buffer bindings

### DIFF
--- a/StandAlone/ResourceLimits.cpp
+++ b/StandAlone/ResourceLimits.cpp
@@ -120,6 +120,7 @@ const TBuiltInResource DefaultTBuiltInResource = {
     /* .MaxFragmentAtomicCounterBuffers = */ 1,
     /* .MaxCombinedAtomicCounterBuffers = */ 1,
     /* .MaxAtomicCounterBufferSize = */ 16384,
+    /* .MaxUniformBufferBindings = */ 2147483647, // int32_max, implementation dependent value
     /* .MaxTransformFeedbackBuffers = */ 4,
     /* .MaxTransformFeedbackInterleavedComponents = */ 64,
     /* .MaxCullDistances = */ 8,

--- a/glslang/Include/ResourceLimits.h
+++ b/glslang/Include/ResourceLimits.h
@@ -128,6 +128,7 @@ struct TBuiltInResource {
     int maxFragmentAtomicCounterBuffers;
     int maxCombinedAtomicCounterBuffers;
     int maxAtomicCounterBufferSize;
+    int maxUniformBufferBindings;
     int maxTransformFeedbackBuffers;
     int maxTransformFeedbackInterleavedComponents;
     int maxCullDistances;

--- a/glslang/Include/glslang_c_interface.h
+++ b/glslang/Include/glslang_c_interface.h
@@ -134,6 +134,7 @@ typedef struct glslang_resource_s {
     int max_fragment_atomic_counter_buffers;
     int max_combined_atomic_counter_buffers;
     int max_atomic_counter_buffer_size;
+    int max_uniform_buffer_bindings;
     int max_transform_feedback_buffers;
     int max_transform_feedback_interleaved_components;
     int max_cull_distances;

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -5751,6 +5751,12 @@ void TParseContext::layoutTypeCheck(const TSourceLoc& loc, const TType& type)
                 return;
             }
         }
+        if (type.getBasicType() == EbtBlock) {
+            if (qualifier.layoutBinding >= (unsigned int)resources.maxUniformBufferBindings) {
+                error(loc, "uniform block binding is too large; no more than ", "binding", "%d", resources.maxUniformBufferBindings);
+                return;
+            }
+        }
     } else if (!intermediate.getAutoMapBindings()) {
         // some types require bindings
 


### PR DESCRIPTION
GLSL could correctly check uniform bindings for atomic counter and samplers. But failing to check binding limit for uniform block.

As other two cases use built-in MAX variables for checking and to provide to users to fetch and check, a new limit variable for uniform block could be used for limit checking and also shader coding usage.

GLSL doesn't have a built-in level variable for this, so we don't set it as a built-in, but an implementation dependent limit.

PS. uniform buffer bindings is an implementation dependent value, introduced in OpenGL Spec but not from glslang spec. We just want to use this macro to report limit error during compilation, otherwise any wired bindings (like 10k) could pass compilation and lead to unexpected errors.