### PR TITLE
atomic counter offset should align to 4 (compute shader)

### DIFF
--- a/Test/atomic_uint.frag
+++ b/Test/atomic_uint.frag
@@ -1,6 +1,7 @@
 #version 420 core
 
 layout(binding = 0) uniform atomic_uint counter;
+layout(binding = 0, offset = 9) uniform atomic_uint counter;
 
 uint func(atomic_uint c)
 {
@@ -41,7 +42,7 @@ uniform atomic_uint aNoBind;                          // ERROR, no binding
 layout(binding=0, offset=32) uniform atomic_uint aOffset;
 layout(binding=0, offset=4) uniform atomic_uint;
 layout(binding=0) uniform atomic_uint bar3;           // offset is 4
-layout(binding=0) uniform atomic_uint ac[3];          // offset = 8
+layout(binding=0) uniform atomic_uint ac[2];          // offset = 8
 layout(binding=0) uniform atomic_uint ad;             // offset = 20
 layout(offset=8) uniform atomic_uint bar4;            // ERROR, no binding
 layout(binding = 0, offset = 12) uniform atomic_uint overlap;  // ERROR, overlapping offsets

--- a/Test/baseResults/atomic_uint.frag.out
+++ b/Test/baseResults/atomic_uint.frag.out
@@ -1,64 +1,65 @@
 atomic_uint.frag
-ERROR: 0:10: 'atomic_uint' : samplers and atomic_uints cannot be output parameters 
-ERROR: 0:12: 'return' : type does not match, or is not convertible to, the function's return type 
-ERROR: 0:18: 'atomic_uint' : atomic_uints can only be used in uniform variables or function parameters: non_uniform_counter
-ERROR: 0:23: 'binding' : atomic_uint binding is too large; see gl_MaxAtomicCounterBindings 
-ERROR: 0:28: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type 'layout( binding=0 offset=0) uniform atomic_uint' and a right operand of type 'layout( binding=0 offset=0) uniform atomic_uint' (or there is no acceptable conversion)
-ERROR: 0:29: '-' :  wrong operand type no operation '-' exists that takes an operand of type layout( binding=0 offset=0) uniform atomic_uint (or there is no acceptable conversion)
-ERROR: 0:31: '[]' : scalar integer expression required 
-ERROR: 0:34: 'assign' :  l-value required "counter" (can't modify a uniform)
-ERROR: 0:34: 'assign' :  cannot convert from ' const int' to 'layout( binding=0 offset=0) uniform atomic_uint'
-ERROR: 0:37: 'atomic_uint' : atomic_uints can only be used in uniform variables or function parameters: acin
-ERROR: 0:38: 'atomic_uint' : atomic_uints can only be used in uniform variables or function parameters: acg
-ERROR: 0:47: 'offset' : atomic counters sharing the same offset: 12
-ERROR: 0:48: 'binding' : atomic_uint binding is too large; see gl_MaxAtomicCounterBindings 
-ERROR: 13 compilation errors.  No code generated.
+ERROR: 0:4: 'counter' : redefinition 
+ERROR: 0:11: 'atomic_uint' : samplers and atomic_uints cannot be output parameters 
+ERROR: 0:13: 'return' : type does not match, or is not convertible to, the function's return type 
+ERROR: 0:19: 'atomic_uint' : atomic_uints can only be used in uniform variables or function parameters: non_uniform_counter
+ERROR: 0:24: 'binding' : atomic_uint binding is too large; see gl_MaxAtomicCounterBindings 
+ERROR: 0:29: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type 'layout( binding=0 offset=0) uniform atomic_uint' and a right operand of type 'layout( binding=0 offset=0) uniform atomic_uint' (or there is no acceptable conversion)
+ERROR: 0:30: '-' :  wrong operand type no operation '-' exists that takes an operand of type layout( binding=0 offset=0) uniform atomic_uint (or there is no acceptable conversion)
+ERROR: 0:32: '[]' : scalar integer expression required 
+ERROR: 0:35: 'assign' :  l-value required "counter" (can't modify a uniform)
+ERROR: 0:35: 'assign' :  cannot convert from ' const int' to 'layout( binding=0 offset=0) uniform atomic_uint'
+ERROR: 0:38: 'atomic_uint' : atomic_uints can only be used in uniform variables or function parameters: acin
+ERROR: 0:39: 'atomic_uint' : atomic_uints can only be used in uniform variables or function parameters: acg
+ERROR: 0:48: 'offset' : atomic counters sharing the same offset: 12
+ERROR: 0:49: 'binding' : atomic_uint binding is too large; see gl_MaxAtomicCounterBindings 
+ERROR: 14 compilation errors.  No code generated.
 
 
 Shader version: 420
 ERROR: node is still EOpNull!
-0:5  Function Definition: func(au1; ( global uint)
-0:5    Function Parameters: 
-0:5      'c' ( in atomic_uint)
-0:7    Sequence
-0:7      Branch: Return with expression
-0:7        AtomicCounterIncrement ( global uint)
-0:7          'c' ( in atomic_uint)
-0:10  Function Definition: func2(au1; ( global uint)
-0:10    Function Parameters: 
-0:10      'c' ( out atomic_uint)
-0:12    Sequence
-0:12      Branch: Return with expression
-0:12        'counter' (layout( binding=0 offset=0) uniform atomic_uint)
+0:6  Function Definition: func(au1; ( global uint)
+0:6    Function Parameters: 
+0:6      'c' ( in atomic_uint)
+0:8    Sequence
+0:8      Branch: Return with expression
+0:8        AtomicCounterIncrement ( global uint)
+0:8          'c' ( in atomic_uint)
+0:11  Function Definition: func2(au1; ( global uint)
+0:11    Function Parameters: 
+0:11      'c' ( out atomic_uint)
+0:13    Sequence
 0:13      Branch: Return with expression
-0:13        AtomicCounter ( global uint)
-0:13          'counter' (layout( binding=0 offset=0) uniform atomic_uint)
-0:16  Function Definition: main( ( global void)
-0:16    Function Parameters: 
+0:13        'counter' (layout( binding=0 offset=0) uniform atomic_uint)
+0:14      Branch: Return with expression
+0:14        AtomicCounter ( global uint)
+0:14          'counter' (layout( binding=0 offset=0) uniform atomic_uint)
+0:17  Function Definition: main( ( global void)
+0:17    Function Parameters: 
 0:?     Sequence
-0:19      Sequence
-0:19        move second child to first child ( temp uint)
-0:19          'val' ( temp uint)
-0:19          AtomicCounter ( global uint)
-0:19            'counter' (layout( binding=0 offset=0) uniform atomic_uint)
-0:20      AtomicCounterDecrement ( global uint)
-0:20        'counter' (layout( binding=0 offset=0) uniform atomic_uint)
-0:26  Function Definition: opac( ( global void)
-0:26    Function Parameters: 
-0:28    Sequence
-0:28      'counter' (layout( binding=0 offset=0) uniform atomic_uint)
+0:20      Sequence
+0:20        move second child to first child ( temp uint)
+0:20          'val' ( temp uint)
+0:20          AtomicCounter ( global uint)
+0:20            'counter' (layout( binding=0 offset=0) uniform atomic_uint)
+0:21      AtomicCounterDecrement ( global uint)
+0:21        'counter' (layout( binding=0 offset=0) uniform atomic_uint)
+0:27  Function Definition: opac( ( global void)
+0:27    Function Parameters: 
+0:29    Sequence
 0:29      'counter' (layout( binding=0 offset=0) uniform atomic_uint)
-0:31      indirect index ( temp int)
-0:31        'a' ( temp 3-element array of int)
-0:31        'counter' (layout( binding=0 offset=0) uniform atomic_uint)
-0:32      direct index (layout( binding=1 offset=3) temp atomic_uint)
-0:32        'countArr' (layout( binding=1 offset=3) uniform 4-element array of atomic_uint)
-0:32        Constant:
-0:32          2 (const int)
-0:33      indirect index (layout( binding=1 offset=3) temp atomic_uint)
+0:30      'counter' (layout( binding=0 offset=0) uniform atomic_uint)
+0:32      indirect index ( temp int)
+0:32        'a' ( temp 3-element array of int)
+0:32        'counter' (layout( binding=0 offset=0) uniform atomic_uint)
+0:33      direct index (layout( binding=1 offset=3) temp atomic_uint)
 0:33        'countArr' (layout( binding=1 offset=3) uniform 4-element array of atomic_uint)
-0:33        'i' ( uniform int)
-0:34      'counter' (layout( binding=0 offset=0) uniform atomic_uint)
+0:33        Constant:
+0:33          2 (const int)
+0:34      indirect index (layout( binding=1 offset=3) temp atomic_uint)
+0:34        'countArr' (layout( binding=1 offset=3) uniform 4-element array of atomic_uint)
+0:34        'i' ( uniform int)
+0:35      'counter' (layout( binding=0 offset=0) uniform atomic_uint)
 0:?   Linker Objects
 0:?     'counter' (layout( binding=0 offset=0) uniform atomic_uint)
 0:?     'countArr' (layout( binding=1 offset=3) uniform 4-element array of atomic_uint)
@@ -68,8 +69,8 @@ ERROR: node is still EOpNull!
 0:?     'aNoBind' ( uniform atomic_uint)
 0:?     'aOffset' (layout( binding=0 offset=32) uniform atomic_uint)
 0:?     'bar3' (layout( binding=0 offset=4) uniform atomic_uint)
-0:?     'ac' (layout( binding=0 offset=8) uniform 3-element array of atomic_uint)
-0:?     'ad' (layout( binding=0 offset=20) uniform atomic_uint)
+0:?     'ac' (layout( binding=0 offset=8) uniform 2-element array of atomic_uint)
+0:?     'ad' (layout( binding=0 offset=16) uniform atomic_uint)
 0:?     'bar4' (layout( offset=8) uniform atomic_uint)
 0:?     'overlap' (layout( binding=0 offset=12) uniform atomic_uint)
 0:?     'bigBind' (layout( binding=20) uniform atomic_uint)
@@ -80,16 +81,16 @@ Linked fragment stage:
 
 Shader version: 420
 ERROR: node is still EOpNull!
-0:16  Function Definition: main( ( global void)
-0:16    Function Parameters: 
+0:17  Function Definition: main( ( global void)
+0:17    Function Parameters: 
 0:?     Sequence
-0:19      Sequence
-0:19        move second child to first child ( temp uint)
-0:19          'val' ( temp uint)
-0:19          AtomicCounter ( global uint)
-0:19            'counter' (layout( binding=0 offset=0) uniform atomic_uint)
-0:20      AtomicCounterDecrement ( global uint)
-0:20        'counter' (layout( binding=0 offset=0) uniform atomic_uint)
+0:20      Sequence
+0:20        move second child to first child ( temp uint)
+0:20          'val' ( temp uint)
+0:20          AtomicCounter ( global uint)
+0:20            'counter' (layout( binding=0 offset=0) uniform atomic_uint)
+0:21      AtomicCounterDecrement ( global uint)
+0:21        'counter' (layout( binding=0 offset=0) uniform atomic_uint)
 0:?   Linker Objects
 0:?     'counter' (layout( binding=0 offset=0) uniform atomic_uint)
 0:?     'countArr' (layout( binding=1 offset=3) uniform 4-element array of atomic_uint)
@@ -99,8 +100,8 @@ ERROR: node is still EOpNull!
 0:?     'aNoBind' ( uniform atomic_uint)
 0:?     'aOffset' (layout( binding=0 offset=32) uniform atomic_uint)
 0:?     'bar3' (layout( binding=0 offset=4) uniform atomic_uint)
-0:?     'ac' (layout( binding=0 offset=8) uniform 3-element array of atomic_uint)
-0:?     'ad' (layout( binding=0 offset=20) uniform atomic_uint)
+0:?     'ac' (layout( binding=0 offset=8) uniform 2-element array of atomic_uint)
+0:?     'ad' (layout( binding=0 offset=16) uniform atomic_uint)
 0:?     'bar4' (layout( offset=8) uniform atomic_uint)
 0:?     'overlap' (layout( binding=0 offset=12) uniform atomic_uint)
 0:?     'bigBind' (layout( binding=20) uniform atomic_uint)

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -6035,6 +6035,10 @@ void TParseContext::fixOffset(const TSourceLoc& loc, TSymbol& symbol)
                 offset = qualifier.layoutOffset;
             else
                 offset = atomicUintOffsets[qualifier.layoutBinding];
+
+            if (offset % 4 != 0)
+                error(loc, "atomic counters offset should align based on 4:", "offset", "%d", offset);
+
             symbol.getWritableType().getQualifier().layoutOffset = offset;
 
             // Check for overlap


### PR DESCRIPTION
atomic counter offset should align to 4

Ref:
glspec46.core - 6.8 BufferObjectState
offset restriction multiple of 4 