### PR TITLE
Add builtin constants gl_MaxFragmentUniformVectors and gl_MaxVertexUniformVectors.

### DIFF
--- a/Test/410.vert
+++ b/Test/410.vert
@@ -6,4 +6,5 @@ in dmat4 dm4;
 
 void main()
 {
+    int test = gl_MaxFragmentUniformVectors;
 }

--- a/Test/baseResults/410.vert.out
+++ b/Test/baseResults/410.vert.out
@@ -3,6 +3,12 @@ Shader version: 410
 0:? Sequence
 0:7  Function Definition: main( ( global void)
 0:7    Function Parameters: 
+0:9    Sequence
+0:9      Sequence
+0:9        move second child to first child ( temp int)
+0:9          'test' ( temp int)
+0:9          Constant:
+0:9            16 (const int)
 0:?   Linker Objects
 0:?     'd' ( in double)
 0:?     'd3' ( in 3-component vector of double)
@@ -18,6 +24,12 @@ Shader version: 410
 0:? Sequence
 0:7  Function Definition: main( ( global void)
 0:7    Function Parameters: 
+0:9    Sequence
+0:9      Sequence
+0:9        move second child to first child ( temp int)
+0:9          'test' ( temp int)
+0:9          Constant:
+0:9            16 (const int)
 0:?   Linker Objects
 0:?     'd' ( in double)
 0:?     'd3' ( in 3-component vector of double)

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -6627,6 +6627,14 @@ void TBuiltIns::initialize(const TBuiltInResource &resources, int version, EProf
     } else {
         // non-ES profile
 
+        if (version > 400) {
+            snprintf(builtInConstant, maxSize, "const int  gl_MaxVertexUniformVectors = %d;", resources.maxVertexUniformVectors);
+            s.append(builtInConstant);
+
+            snprintf(builtInConstant, maxSize, "const int  gl_MaxFragmentUniformVectors = %d;", resources.maxFragmentUniformVectors);
+            s.append(builtInConstant);
+        }
+
         snprintf(builtInConstant, maxSize, "const int  gl_MaxVertexAttribs = %d;", resources.maxVertexAttribs);
         s.append(builtInConstant);
 


### PR DESCRIPTION
Add builtin constants:

gl_MaxFragmentUniformVectors and gl_MaxVertexUniformVectors.
They should both be available since version 410 for core.