### PR TITLE
Use correct enum type in case statement

### DIFF
--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -731,7 +731,7 @@ void TranslateEnvironment(const TEnvironment* environment, EShMessages& messages
                 source = EShSourceHlsl;
                 messages = static_cast<EShMessages>(messages | EShMsgReadHlsl);
                 break;
-            case EShClientCount:
+            case EShSourceCount:
                 assert(0);
                 break;
             }


### PR DESCRIPTION
Two similarly named enums led to the wrong one being used here, this
is getting caught in the Chromium and Dawn DEPS rolls.