### PR TITLE
Use NOT ... VERSION_LESS instead of VERSION_GREATER_EQUAL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
                         -Wunused-parameter -Wunused-value  -Wunused-variable -Wunused-but-set-parameter -Wunused-but-set-variable -fno-exceptions)
     add_compile_options(-Wno-reorder)  # disable this from -Wall, since it happens all over.
     add_compile_options(-fno-rtti)
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "9.0.0")
+    if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0.0")
         add_compile_options(-Werror=deprecated-copy)
     endif()
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")


### PR DESCRIPTION
#1940 added a use of VERSION_GREATER_EQUAL, which requires cmake 3.7. This breaks CTS when I try to update the glslang commit hash. Workaround this by using NOT ... VERSION_LESS, which is supported at least back to cmake 3.0.