### PR TITLE
CMake: Split "is emscripten" config from "enable glslang.js"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,12 +32,29 @@ option(ENABLE_SPVREMAPPER "Enables building of SPVRemapper" ON)
 
 option(ENABLE_GLSLANG_BINARIES "Builds glslangValidator and spirv-remap" ON)
 
-option(ENABLE_GLSLANG_WEB "Reduces glslang to minimum needed for web use" OFF)
-option(ENABLE_GLSLANG_WEB_DEVEL "For ENABLE_GLSLANG_WEB builds, enables compilation error messages" OFF)
-option(ENABLE_EMSCRIPTEN_SINGLE_FILE "If using Emscripten, enables SINGLE_FILE build" OFF)
-option(ENABLE_EMSCRIPTEN_ENVIRONMENT_NODE "If using Emscripten, builds to run on Node instead of Web" OFF)
+option(ENABLE_GLSLANG_JS
+    "If using Emscripten, build glslang.js. Otherwise, builds a sample executable for binary-size testing." OFF)
+CMAKE_DEPENDENT_OPTION(ENABLE_GLSLANG_WEBMIN
+    "Reduces glslang to minimum needed for web use"
+    OFF "ENABLE_GLSLANG_JS"
+    OFF)
+CMAKE_DEPENDENT_OPTION(ENABLE_GLSLANG_WEBMIN_DEVEL
+    "For ENABLE_GLSLANG_WEBMIN builds, enables compilation error messages"
+    OFF "ENABLE_GLSLANG_WEBMIN"
+    OFF)
+CMAKE_DEPENDENT_OPTION(ENABLE_EMSCRIPTEN_SINGLE_FILE
+    "If using Emscripten, enables SINGLE_FILE build"
+    OFF "ENABLE_GLSLANG_JS AND EMSCRIPTEN"
+    OFF)
+CMAKE_DEPENDENT_OPTION(ENABLE_EMSCRIPTEN_ENVIRONMENT_NODE
+    "If using Emscripten, builds to run on Node instead of Web"
+    OFF "ENABLE_GLSLANG_JS AND EMSCRIPTEN"
+    OFF)
 
-CMAKE_DEPENDENT_OPTION(ENABLE_HLSL "Enables HLSL input support" ON "NOT ENABLE_GLSLANG_WEB" OFF)
+CMAKE_DEPENDENT_OPTION(ENABLE_HLSL
+    "Enables HLSL input support"
+    ON "NOT ENABLE_GLSLANG_WEBMIN"
+    OFF)
 
 option(ENABLE_OPT "Enables spirv-opt capability if present" ON)
 option(ENABLE_PCH "Enables Precompiled header" ON)
@@ -77,12 +94,12 @@ if(ENABLE_HLSL)
     add_definitions(-DENABLE_HLSL)
 endif(ENABLE_HLSL)
 
-if(ENABLE_GLSLANG_WEB)
+if(ENABLE_GLSLANG_WEBMIN)
     add_definitions(-DGLSLANG_WEB)
-    if(ENABLE_GLSLANG_WEB_DEVEL)
+    if(ENABLE_GLSLANG_WEBMIN_DEVEL)
         add_definitions(-DGLSLANG_WEB_DEVEL)
-    endif(ENABLE_GLSLANG_WEB_DEVEL)
-endif(ENABLE_GLSLANG_WEB)
+    endif(ENABLE_GLSLANG_WEBMIN_DEVEL)
+endif(ENABLE_GLSLANG_WEBMIN)
 
 if(WIN32)
     set(CMAKE_DEBUG_POSTFIX "d")
@@ -113,29 +130,14 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "MSVC")
     add_compile_options(/GR-) # Disable RTTI
 endif()
 
-if(EMSCRIPTEN)
-    add_compile_options(-Os -fno-exceptions)
-    add_compile_options("SHELL: -s WASM=1")
-    add_compile_options("SHELL: -s WASM_OBJECT_FILES=0")
-    add_link_options(-Os)
-    add_link_options("SHELL: -s FILESYSTEM=0")
-    add_link_options("SHELL: --llvm-lto 1")
-    add_link_options("SHELL: --closure 1")
-    add_link_options("SHELL: -s ALLOW_MEMORY_GROWTH=1")
-
-    if(ENABLE_EMSCRIPTEN_SINGLE_FILE)
-        add_link_options("SHELL: -s SINGLE_FILE=1")
-    endif(ENABLE_EMSCRIPTEN_SINGLE_FILE)
-else()
-    if(ENABLE_GLSLANG_WEB)
-        if(MSVC)
-            add_compile_options(/Os /GR-)
-        else()
-            add_compile_options(-Os -fno-exceptions)
-            add_link_options(-Os)
-        endif()
-    endif(ENABLE_GLSLANG_WEB)
-endif(EMSCRIPTEN)
+if(ENABLE_GLSLANG_JS)
+    if(MSVC)
+        add_compile_options(/Os /GR-)
+    else()
+        add_compile_options(-Os -fno-exceptions)
+        add_link_options(-Os)
+    endif()
+endif(ENABLE_GLSLANG_JS)
 
 # Request C++11
 if(${CMAKE_VERSION} VERSION_LESS 3.1)

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ Use the steps in [Build Steps](#build-steps), with the following notes/exception
   + execute `updateGrammar web` from the glslang subdirectory
     (or if using your own scripts, `m4` needs a `-DGLSLANG_WEB` argument)
   + set `-DENABLE_HLSL=OFF -DBUILD_TESTING=OFF -DENABLE_OPT=OFF -DINSTALL_GTEST=OFF`
-  + turn on `-DENABLE_GLSLANG_WEB=ON`
+  + turn on `-DENABLE_GLSLANG_JS=ON`
+  + optionally, for a minimum-size binary, turn on `-DENABLE_GLSLANG_WEBMIN=ON`
   + optionally, for GLSL compilation error messages, turn on `-DENABLE_GLSLANG_WEB_DEVEL=ON`
 * `emsdk` needs to be present in your executable search path, *PATH* for
   Bash-like environments

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -6,9 +6,10 @@ else(WIN32)
     message("unknown platform")
 endif(WIN32)
 
-if(EMSCRIPTEN OR ENABLE_GLSLANG_WEB)
+if(EMSCRIPTEN OR ENABLE_GLSLANG_JS)
+    # May be enabled on non-Emscripten builds for binary-size testing.
     add_subdirectory(OSDependent/Web)
-endif(EMSCRIPTEN OR ENABLE_GLSLANG_WEB)
+endif(EMSCRIPTEN OR ENABLE_GLSLANG_JS)
 
 set(SOURCES
     MachineIndependent/glslang.m4
@@ -86,8 +87,8 @@ set_property(TARGET glslang PROPERTY FOLDER glslang)
 set_property(TARGET glslang PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(glslang OGLCompiler OSDependent)
 target_include_directories(glslang PUBLIC 
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
-	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 if(WIN32 AND BUILD_SHARED_LIBS)
     set_target_properties(glslang PROPERTIES PREFIX "")
@@ -115,7 +116,7 @@ if(ENABLE_GLSLANG_INSTALL)
         install(TARGETS glslang EXPORT glslangTargets
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endif()
-	install(EXPORT glslangTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+    install(EXPORT glslangTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 endif(ENABLE_GLSLANG_INSTALL)
 
 if(ENABLE_GLSLANG_INSTALL)

--- a/glslang/OSDependent/Web/CMakeLists.txt
+++ b/glslang/OSDependent/Web/CMakeLists.txt
@@ -1,24 +1,34 @@
-add_executable(glslang.js "glslang.js.cpp")
-glslang_set_link_args(glslang.js)
-target_link_libraries(glslang.js glslang SPIRV)
-if(EMSCRIPTEN)
-    set_target_properties(glslang.js PROPERTIES
-        OUTPUT_NAME "glslang"
-        SUFFIX ".js")
-    em_link_pre_js(glslang.js "${CMAKE_CURRENT_SOURCE_DIR}/glslang.pre.js")
+if(ENABLE_GLSLANG_JS)
+    add_executable(glslang.js "glslang.js.cpp")
+    glslang_set_link_args(glslang.js)
+    target_link_libraries(glslang.js glslang SPIRV)
 
-    target_link_options(glslang.js PRIVATE
-        "SHELL:--bind -s MODULARIZE=1")
-    if(ENABLE_EMSCRIPTEN_ENVIRONMENT_NODE)
-        target_link_options(glslang.js PRIVATE
-            "SHELL:-s ENVIRONMENT=node -s BINARYEN_ASYNC_COMPILATION=0")
-    else()
-        target_link_options(glslang.js PRIVATE
-            "SHELL:-s ENVIRONMENT=web,worker")
-    endif()
+    if(EMSCRIPTEN)
+        set_target_properties(glslang.js PROPERTIES
+            OUTPUT_NAME "glslang"
+            SUFFIX ".js")
+        em_link_pre_js(glslang.js "${CMAKE_CURRENT_SOURCE_DIR}/glslang.pre.js")
 
-    if(NOT ENABLE_EMSCRIPTEN_ENVIRONMENT_NODE)
-        add_custom_command(TARGET glslang.js POST_BUILD
-            COMMAND cat ${CMAKE_CURRENT_SOURCE_DIR}/glslang.after.js >> ${CMAKE_CURRENT_BINARY_DIR}/glslang.js)
-    endif()
-endif(EMSCRIPTEN)
+        target_link_options(glslang.js PRIVATE "SHELL: -Os")
+        target_link_options(glslang.js PRIVATE "SHELL: --llvm-lto 1")
+        target_link_options(glslang.js PRIVATE "SHELL: --closure 1")
+        target_link_options(glslang.js PRIVATE "SHELL: -s MODULARIZE=1")
+        target_link_options(glslang.js PRIVATE "SHELL: -s ALLOW_MEMORY_GROWTH=1")
+        target_link_options(glslang.js PRIVATE "SHELL: -s FILESYSTEM=0")
+
+        if(ENABLE_EMSCRIPTEN_SINGLE_FILE)
+            target_link_options(glslang.js "SHELL: -s SINGLE_FILE=1")
+        endif(ENABLE_EMSCRIPTEN_SINGLE_FILE)
+
+        if(ENABLE_EMSCRIPTEN_ENVIRONMENT_NODE)
+            target_link_options(glslang.js PRIVATE "SHELL: -s ENVIRONMENT=node -s BINARYEN_ASYNC_COMPILATION=0")
+        else()
+            target_link_options(glslang.js PRIVATE "SHELL: -s ENVIRONMENT=web,worker")
+        endif()
+
+        if(NOT ENABLE_EMSCRIPTEN_ENVIRONMENT_NODE)
+            add_custom_command(TARGET glslang.js POST_BUILD
+                COMMAND cat ${CMAKE_CURRENT_SOURCE_DIR}/glslang.after.js >> ${CMAKE_CURRENT_BINARY_DIR}/glslang.js)
+        endif()
+    endif(EMSCRIPTEN)
+endif(ENABLE_GLSLANG_JS)

--- a/glslang/OSDependent/Web/glslang.js.cpp
+++ b/glslang/OSDependent/Web/glslang.js.cpp
@@ -277,7 +277,7 @@ void main() { })";
     uint32_t* output;
     size_t output_len;
 
-    void* id = convert_glsl_to_spirv(input, 4, false, &output, &output_len);
+    void* id = convert_glsl_to_spirv(input, 4, false, glslang::EShTargetSpv_1_0, &output, &output_len);
     assert(output != nullptr);
     assert(output_len != 0);
     destroy_output_buffer(id);


### PR DESCRIPTION
This should enable glslang to be used as a dependency of other projects
that target WebAssembly, instead of assuming "EMSCRIPTEN" => "Want
glslang.js".

Should fix #2072.