### PR TITLE
Fix for #2075: removed DefaultTBuiltInResource from glslang_c_interface.cpp

### DIFF
--- a/glslang/CInterface/glslang_c_interface.cpp
+++ b/glslang/CInterface/glslang_c_interface.cpp
@@ -350,15 +350,19 @@ const char* glslang_shader_get_preprocessed_code(glslang_shader_t* shader)
     return shader->preprocessedGLSL.c_str();
 }
 
-int glslang_shader_preprocess(glslang_shader_t* shader, const glslang_input_t* i)
+int glslang_shader_preprocess(glslang_shader_t* shader, const glslang_input_t* input)
 {
     DirStackFileIncluder Includer;
     /* TODO: use custom callbacks if they are available in 'i->callbacks' */
     return shader->shader->preprocess(
-        /* No user-defined resources limit */
-        &glslang::DefaultTBuiltInResource, i->default_version, c_shader_profile(i->default_profile),
-        i->force_default_version_and_profile != 0, i->forward_compatible != 0,
-        (EShMessages)c_shader_messages(i->messages), &shader->preprocessedGLSL, Includer
+        input->resource,
+        input->default_version,
+        c_shader_profile(input->default_profile),
+        input->force_default_version_and_profile != 0,
+        input->forward_compatible != 0,
+        (EShMessages)c_shader_messages(input->messages),
+        &shader->preprocessedGLSL,
+        Includer
     );
 }
 
@@ -368,9 +372,11 @@ int glslang_shader_parse(glslang_shader_t* shader, const glslang_input_t* input)
     shader->shader->setStrings(&preprocessedCStr, 1);
 
     return shader->shader->parse(
-        /* No user-defined resource limits for now */
-        &glslang::DefaultTBuiltInResource, input->default_version, input->forward_compatible != 0,
-        (EShMessages)c_shader_messages(input->messages));
+        input->resource,
+        input->default_version,
+        input->forward_compatible != 0,
+        (EShMessages)c_shader_messages(input->messages)
+    );
 }
 
 const char* glslang_shader_get_info_log(glslang_shader_t* shader) { return shader->shader->getInfoLog(); }

--- a/glslang/Include/glslang_c_interface.h
+++ b/glslang/Include/glslang_c_interface.h
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 typedef struct glslang_shader_s glslang_shader_t;
 typedef struct glslang_program_s glslang_program_t;
+typedef struct TBuiltInResource glslang_resource_t;
 
 typedef struct glslang_input_s {
     glslang_source_t language;
@@ -54,6 +55,7 @@ typedef struct glslang_input_s {
     int force_default_version_and_profile;
     int forward_compatible;
     glslang_messages_t messages;
+    const glslang_resource_t* resource;
 } glslang_input_t;
 
 /* Inclusion result structure allocated by C include_local/include_system callbacks */


### PR DESCRIPTION
Make the C interface consume a user defined `TBuiltInResource`.

Fix for #2075 
Update for PR #2038 
```C++
const glslang_input_t input =
{
	.language = GLSLANG_SOURCE_GLSL,
	.stage = GLSLANG_STAGE_VERTEX,
	.client = GLSLANG_CLIENT_VULKAN,
	.client_version = GLSLANG_TARGET_VULKAN_1_1,
	.target_language = GLSLANG_TARGET_SPV,
	.target_language_version = GLSLANG_TARGET_SPV_1_3,
	.code = shaderCodeVertex,
	.default_version = 100,
	.default_profile = GLSLANG_NO_PROFILE,
	.force_default_version_and_profile = false,
	.forward_compatible = false,
	.messages = GLSLANG_MSG_DEFAULT_BIT,
	.resource = &glslang::DefaultTBuiltInResource,
};
glslang_initialize_process();
glslang_shader_t* shader = glslang_shader_create(&input);
...
```