### PR TITLE
Fix a bug that uninitialized valuables are accessed

### DIFF
--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -98,7 +98,10 @@ private:
 // A "call" is a pair: <caller, callee>.
 // There can be duplicates. General assumption is the list is small.
 struct TCall {
-    TCall(const TString& pCaller, const TString& pCallee) : caller(pCaller), callee(pCallee) { }
+    TCall(const TString& pCaller, const TString& pCallee)
+        : caller(pCaller), callee(pCallee), visited(true), currentPath(true), errorGiven(true), calleeBodyPosition(0)
+    {
+    }
     TString caller;
     TString callee;
     bool visited;


### PR DESCRIPTION
I fix bugs about

glslang/glslang/MachineIndependent/localintermediate.h:100:8: runtime error: load of value 240, which is not a valid value for type 'bool'
glslang/glslang/MachineIndependent/localintermediate.h:100:8: runtime error: load of value 58, which is not a valid value for type 'bool'
glslang/glslang/MachineIndependent/localintermediate.h:100:8: runtime error: load of value 18, which is not a valid value for type 'bool'

in https://github.com/KhronosGroup/glslang/issues/2112
