### PR TITLE
Use one element to represent the last member of SSBO which is unsized…

### DIFF
--- a/glslang/MachineIndependent/linkValidate.cpp
+++ b/glslang/MachineIndependent/linkValidate.cpp
@@ -1494,7 +1494,9 @@ int TIntermediate::getBaseAlignment(const TType& type, int& size, int& stride, T
         RoundToPow2(size, alignment);
         stride = size;  // uses full matrix size for stride of an array of matrices (not quite what rule 6/8, but what's expected)
                         // uses the assumption for rule 10 in the comment above
-        size = stride * type.getOuterArraySize();
+        // use one element to represent the last member of SSBO which is unsized array
+        int arraySize = (type.isUnsizedArray() && (type.getOuterArraySize() == 0)) ? 1 : type.getOuterArraySize();
+        size = stride * arraySize;
         return alignment;
     }
 


### PR DESCRIPTION
Purpose:
The size of precedingMemberUnsizedArray which is unsized array wasn't calculated.
Sulotion: Add unsized array size into block size.

Shader Type:
Comp.

Reference:
According to Spec:
For the property BUFFER_DATA_SIZE, the implementation-dependent minimum
total buffer object size is written to params. This value is the size, in basic
machine units, required to hold all active variables associated with an active uniform
block, shader storage block, or atomic counter buffer. If the final member of
an active shader storage block is an array with no declared size, the minimum buffer
size is computed assuming the array was declared as an array with one element.