### PR TITLE
Add EXT_shader_integer_mix

### DIFF
--- a/glslang/MachineIndependent/Initialize.h
+++ b/glslang/MachineIndependent/Initialize.h
@@ -93,6 +93,7 @@ public:
 protected:
     void addTabledBuiltins(int version, EProfile profile, const SpvVersion& spvVersion);
     void relateTabledBuiltins(int version, EProfile profile, const SpvVersion& spvVersion, EShLanguage, TSymbolTable&);
+    void setTabledBuiltinExtensions(int version, EProfile profile, const SpvVersion& spvVersion, EShLanguage, TSymbolTable&);
     void add2ndGenerationSamplingImaging(int version, EProfile profile, const SpvVersion& spvVersion);
     void addSubpassSampling(TSampler, const TString& typeName, int version, EProfile profile);
     void addQueryFunctions(TSampler, const TString& typeName, int version, EProfile profile);

--- a/glslang/MachineIndependent/SymbolTable.cpp
+++ b/glslang/MachineIndependent/SymbolTable.cpp
@@ -314,6 +314,36 @@ void TSymbolTableLevel::setFunctionExtensions(const char* name, int num, const c
     }
 }
 
+// Make the function with the given name and argument types require an extension(s).
+// Should only be used for a version/profile that actually needs the extension(s).
+void TSymbolTableLevel::setFunctionExtensions(const char* name, int num, const char* const extensions[], int argNum, const TType* const args[])
+{
+    tLevel::const_iterator candidate = level.lower_bound(name);
+    while (candidate != level.end()) {
+        const TString& candidateName = (*candidate).first;
+        TString::size_type parenAt = candidateName.find_first_of('(');
+        if (parenAt != candidateName.npos && candidateName.compare(0, parenAt, name) == 0) {
+            TFunction* function = (*candidate).second->getAsFunction();
+            bool match = true;
+            // Check whether argument types match
+            for (int argIdx = 0; argIdx < argNum; ++argIdx) {
+                auto pArgType = (*function)[argIdx].type;
+                if (!pArgType->sameElementType(*args[argIdx])) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) {
+                function->setExtensions(num, extensions);
+                break;
+            }
+        }
+        else
+            break;
+        ++candidate;
+    }
+}
+
 //
 // Make all symbols in this table level read only.
 //

--- a/glslang/MachineIndependent/SymbolTable.h
+++ b/glslang/MachineIndependent/SymbolTable.h
@@ -551,6 +551,7 @@ public:
 
     void relateToOperator(const char* name, TOperator op);
     void setFunctionExtensions(const char* name, int num, const char* const extensions[]);
+    void setFunctionExtensions(const char* name, int num, const char* const extensions[], int argNum, const TType* const args[]);
 #ifndef GLSLANG_WEB
     void dump(TInfoSink& infoSink, bool complete = false) const;
 #endif
@@ -825,6 +826,12 @@ public:
     {
         for (unsigned int level = 0; level < table.size(); ++level)
             table[level]->setFunctionExtensions(name, num, extensions);
+    }
+
+    void setFunctionExtensions(const char* name, int num, const char* const extensions[], int argNum, const TType* const args[])
+    {
+        for (unsigned int level = 0; level < table.size(); ++level)
+            table[level]->setFunctionExtensions(name, num, extensions, argNum, args);
     }
 
     void setVariableExtensions(const char* name, int numExts, const char* const extensions[])

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -295,6 +295,7 @@ void TParseVersions::initializeExtensionBehavior()
     extensionBehavior[E_GL_EXT_device_group]             = EBhDisable;
     extensionBehavior[E_GL_EXT_multiview]                = EBhDisable;
     extensionBehavior[E_GL_EXT_shader_realtime_clock]    = EBhDisable;
+    extensionBehavior[E_GL_EXT_shader_integer_mix]       = EBhDisable;
 
     // OVR extensions
     extensionBehavior[E_GL_OVR_multiview]                = EBhDisable;
@@ -431,8 +432,9 @@ void TParseVersions::getPreamble(std::string& preamble)
             "#define GL_KHR_shader_subgroup_clustered 1\n"
             "#define GL_KHR_shader_subgroup_quad 1\n"
 
-            "#define E_GL_EXT_shader_atomic_int64 1\n"
-            "#define E_GL_EXT_shader_realtime_clock 1\n"
+            "#define GL_EXT_shader_atomic_int64 1\n"
+            "#define GL_EXT_shader_realtime_clock 1\n"
+            "#define GL_EXT_shader_integer_mix 1\n"
 
             "#define GL_AMD_shader_ballot 1\n"
             "#define GL_AMD_shader_trinary_minmax 1\n"

--- a/glslang/MachineIndependent/Versions.h
+++ b/glslang/MachineIndependent/Versions.h
@@ -185,6 +185,7 @@ const char* const E_GL_EXT_buffer_reference2                = "GL_EXT_buffer_ref
 const char* const E_GL_EXT_buffer_reference_uvec2           = "GL_EXT_buffer_reference_uvec2";
 const char* const E_GL_EXT_demote_to_helper_invocation      = "GL_EXT_demote_to_helper_invocation";
 const char* const E_GL_EXT_shader_realtime_clock            = "GL_EXT_shader_realtime_clock";
+const char* const E_GL_EXT_shader_integer_mix               = "GL_EXT_shader_integer_mix";
 const char* const E_GL_EXT_debug_printf                     = "GL_EXT_debug_printf";
 
 // Arrays of extensions for the above viewportEXTs duplications


### PR DESCRIPTION
Purpose:
Add extension EXT_shader_integer_mix

Modification:
1. Add extension GL_EXT_shader_integer_mix related variables
2. Modify BaseFunctions to bind mix function to correct extensions
3. Add function setTabledBuiltinExtensions to bind extensions for all functions in builtin tables
4. Add function setFunctionExtensions, it only bind extension when both function name and argument types are matched.
5. Add function GetTableBuiltinArgTypes to get function argument types according to builtin function definition.