### PR TITLE
Fix built-in uniform location

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -3779,6 +3779,8 @@ void TGlslangToSpvTraverser::decorateStructType(const glslang::TType& type,
     // Name and decorate the non-hidden members
     int offset = -1;
     int locationOffset = 0;  // for use within the members of this struct
+    bool memberLocationInvalid = type.isArrayOfArrays() ||
+        (type.isArray() && (type.getQualifier().isArrayedIo(glslangIntermediate->getStage()) == false));
     for (int i = 0; i < (int)glslangMembers->size(); i++) {
         glslang::TType& glslangMember = *(*glslangMembers)[i].type;
         int member = i;
@@ -3831,7 +3833,7 @@ void TGlslangToSpvTraverser::decorateStructType(const glslang::TType& type,
         // just track whether a member needs to be decorated.
         // Ignore member locations if the container is an array, as that's
         // ill-specified and decisions have been made to not allow this.
-        if (! type.isArray() && memberQualifier.hasLocation())
+        if (!memberLocationInvalid && memberQualifier.hasLocation())
             builder.addMemberDecoration(spvType, member, spv::DecorationLocation, memberQualifier.layoutLocation);
 
         if (qualifier.hasLocation())      // track for upcoming inheritance

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -7462,8 +7462,6 @@ void TBuiltIns::identifyBuiltIns(int version, EProfile profile, const SpvVersion
             BuiltInVariable("gl_SampleMask",         EbvSampleMask,     symbolTable);
 
             if (profile != EEsProfile && version < 400) {
-                BuiltInVariable("gl_NumSamples",     EbvSampleMask,     symbolTable);
-
                 symbolTable.setVariableExtensions("gl_SampleMask",     1, &E_GL_ARB_sample_shading);
                 symbolTable.setVariableExtensions("gl_SampleID",       1, &E_GL_ARB_sample_shading);
                 symbolTable.setVariableExtensions("gl_SamplePosition", 1, &E_GL_ARB_sample_shading);

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -5487,8 +5487,10 @@ void TParseContext::mergeObjectLayoutQualifiers(TQualifier& dst, const TQualifie
     if (! inheritOnly) {
         if (src.hasLocation())
             dst.layoutLocation = src.layoutLocation;
-        if (src.hasOffset())
+        if (src.hasOffset()) {
             dst.layoutOffset = src.layoutOffset;
+            dst.explicitOffset = src.explicitOffset;
+        }
         if (src.hasSet())
             dst.layoutSet = src.layoutSet;
         if (src.layoutBinding != TQualifier::layoutBindingEnd)

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -679,7 +679,7 @@ int TDefaultGlslIoResolver::resolveUniformLocation(EShLanguage /*stage*/, TVarEn
         return ent.newLocation = type.getQualifier().layoutLocation;
     } else {
         // no locations added if already present, a built-in variable, a block, or an opaque
-        if (type.getQualifier().hasLocation() || type.isBuiltIn() || type.getBasicType() == EbtBlock ||
+        if (type.getQualifier().hasLocation() || type.getBasicType() == EbtBlock ||
             type.isAtomic() || (type.containsOpaque() && intermediate.getSpv().openGl == 0)) {
             return ent.newLocation = -1;
         }
@@ -818,10 +818,12 @@ void TDefaultGlslIoResolver::endCollect(EShLanguage /*stage*/) {
 
 void TDefaultGlslIoResolver::reserverStorageSlot(TVarEntryInfo& ent, TInfoSink& infoSink) {
     const TType& type = ent.symbol->getType();
-    const TString& name = IsAnonymous(ent.symbol->getName()) ?
-                            ent.symbol->getType().getTypeName()
-                            :
-                            ent.symbol->getName();
+    TString name;
+    if (ent.symbol->getBasicType() == EbtBlock) {
+        name = ent.symbol->getType().getTypeName();
+    } else {
+        name = ent.symbol->getName();
+    }
     TStorageQualifier storage = type.getQualifier().storage;
     EShLanguage stage(EShLangCount);
     switch (storage) {
@@ -881,10 +883,12 @@ void TDefaultGlslIoResolver::reserverStorageSlot(TVarEntryInfo& ent, TInfoSink& 
 
 void TDefaultGlslIoResolver::reserverResourceSlot(TVarEntryInfo& ent, TInfoSink& infoSink) {
     const TType& type = ent.symbol->getType();
-    const TString& name = IsAnonymous(ent.symbol->getName()) ?
-                            ent.symbol->getType().getTypeName()
-                            :
-                            ent.symbol->getName();
+    TString name;
+    if (ent.symbol->getBasicType() == EbtBlock) {
+        name = ent.symbol->getType().getTypeName();
+    } else {
+        name = ent.symbol->getName();
+    }
     int resource = getResourceType(type);
     if (type.getQualifier().hasBinding()) {
         TVarSlotMap& varSlotMap = resourceSlotMap[resource];


### PR DESCRIPTION
Purpose:
Fix built-in uniform locations:
1. Built-in uniform locations actually should be treated as normal uniforms, we need to set its locations.
2. We now re-caculate uniforms' locations during linkage time (compilation location result may be incorrect), when we consume flag explicitOffset in driver, we don't do this. Recalculating unsized uniform locations need this flag.
3. Built-in uniforms could not be treated special, as it can have normal id and location processing.

Modification:

1. Support flag explicitOffset in TParseContext::mergeObjectLayoutQualifiers
2. Ignore isBuiltIn in  TDefaultGlslIoResolver::resolveUniformLocation
3. Correct variable entry name in TDefaultGlslIoResolver::reserverStorageSlot and reserverResourceSlot