### PR TITLE
glslang didn't check the index for unsized array.

### DIFF
--- a/glslang/MachineIndependent/ParseContextBase.cpp
+++ b/glslang/MachineIndependent/ParseContextBase.cpp
@@ -270,6 +270,10 @@ void TParseContextBase::checkIndex(const TSourceLoc& loc, const TType& type, int
             error(loc, "", "[", "array index out of range '%d'", index);
             index = type.getOuterArraySize() - 1;
         }
+        else if (type.getQualifier().builtIn == EbvSampleMask && index >= type.getImplicitArraySize()) {
+            error(loc, "", "[", "array index out of range '%d'", index);
+            index = type.getImplicitArraySize() - 1;
+        }
     } else if (type.isVector()) {
         if (index >= type.getVectorSize()) {
             error(loc, "", "[", "vector index out of range '%d'", index);


### PR DESCRIPTION
Purpose:
Allow glslang to check unsized array size of SampleMask.

Modification:
Add checks for SampleMask as it is unsized.