### PR TITLE
Fix calculation of log2 and exp2.

### DIFF
--- a/glslang/MachineIndependent/Constant.cpp
+++ b/glslang/MachineIndependent/Constant.cpp
@@ -599,17 +599,11 @@ TIntermTyped* TIntermConstantUnion::fold(TOperator op, const TType& returnType) 
             newConstArray[i].setDConst(log(unionArray[i].getDConst()));
             break;
         case EOpExp2:
-            {
-                const double inv_log2_e = 0.69314718055994530941723212145818;
-                newConstArray[i].setDConst(exp(unionArray[i].getDConst() * inv_log2_e));
-                break;
-            }
+            newConstArray[i].setDConst(exp2(unionArray[i].getDConst()));
+            break;
         case EOpLog2:
-            {
-                const double log2_e = 1.4426950408889634073599246810019;
-                newConstArray[i].setDConst(log2_e * log(unionArray[i].getDConst()));
-                break;
-            }
+            newConstArray[i].setDConst(log2(unionArray[i].getDConst()));
+            break;
         case EOpSqrt:
             newConstArray[i].setDConst(sqrt(unionArray[i].getDConst()));
             break;


### PR DESCRIPTION
Purpose:
Fix calculation of log2 and exp2.

Modification:
During test, the result of 'const float n = log2(14.0 + float(int(-3.0) - int(3.0)));' is incorrect, the expression is fold to constant at compile-time, but glslang fold the log2() to 1.44 * log(), which made the result incorrect, in fact the system has provided such built-in functions, Also exp2 has the same issues, so the issue about exp2 is also fixed in this change.