### PR TITLE
Forbid memoryBarrierAtomicCounter for Vulkan compiles

### DIFF
--- a/Test/baseResults/spv.atomicCounter.comp.out
+++ b/Test/baseResults/spv.atomicCounter.comp.out
@@ -1,0 +1,15 @@
+spv.atomicCounter.comp
+ERROR: 0:5: 'atomic counter types' : not allowed when using GLSL for Vulkan 
+ERROR: 0:7: 'atomic counter types' : not allowed when using GLSL for Vulkan 
+ERROR: 0:14: 'atomic counter types' : not allowed when using GLSL for Vulkan 
+ERROR: 0:16: 'atomicCounterIncrement' : no matching overloaded function found 
+ERROR: 0:16: 'return' : type does not match, or is not convertible to, the function's return type 
+ERROR: 0:21: 'memoryBarrierAtomicCounter' : no matching overloaded function found 
+ERROR: 0:23: 'atomicCounter' : no matching overloaded function found 
+ERROR: 0:23: '=' :  cannot convert from ' const float' to ' temp highp uint'
+ERROR: 0:24: 'atomicCounterDecrement' : no matching overloaded function found 
+ERROR: 0:25: 'atomicCounterIncrement' : no matching overloaded function found 
+ERROR: 10 compilation errors.  No code generated.
+
+
+SPIR-V is not generated for failed compile or link

--- a/Test/spv.atomicCounter.comp
+++ b/Test/spv.atomicCounter.comp
@@ -1,0 +1,26 @@
+#version 450
+
+
+
+layout(binding = 0) uniform atomic_uint counter;
+
+layout(binding = 0, offset = 4) uniform atomic_uint countArr[4];
+shared uint value;
+
+int arrX[gl_WorkGroupSize.x];
+int arrY[gl_WorkGroupSize.y];
+int arrZ[gl_WorkGroupSize.z];
+
+uint func(atomic_uint c)
+{
+    return atomicCounterIncrement(c);
+}
+
+void main()
+{
+    memoryBarrierAtomicCounter();
+    func(counter);
+    uint val = atomicCounter(countArr[2]);
+    atomicCounterDecrement(counter);
+    atomicCounterIncrement(counter);
+}

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -4067,10 +4067,10 @@ void TBuiltIns::initialize(int version, EProfile profile, const SpvVersion& spvV
     }
 #ifndef GLSLANG_WEB
     if ((profile != EEsProfile && version >= 420) || esBarrier) {
-        commonBuiltins.append(
-            "void memoryBarrierAtomicCounter();"
-            "void memoryBarrierImage();"
-            );
+        if (spvVersion.vulkan == 0) {
+            commonBuiltins.append("void memoryBarrierAtomicCounter();");
+        }
+        commonBuiltins.append("void memoryBarrierImage();");
     }
     if ((profile != EEsProfile && version >= 450) || (profile == EEsProfile && version >= 320)) {
         stageBuiltins[EShLangMeshNV].append(

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -271,6 +271,7 @@ INSTANTIATE_TEST_CASE_P(
         "spv.always-discard2.frag",
         "spv.arbPostDepthCoverage.frag",
         "spv.arbPostDepthCoverage_Error.frag",
+        "spv.atomicCounter.comp",
         "spv.bitCast.frag",
         "spv.bool.vert",
         "spv.boolInBlock.frag",


### PR DESCRIPTION
I got a bug report that this builtin function generates this validation error in Vulkan:

```
 [ UNASSIGNED-CoreValidation-Shader-InconsistentSpirv ] Object: VK_NULL_HANDLE (Type = 0) | SPIR-V module not valid: MemoryBarrier: expected Memory Semantics to include a Vulkan-supported storage class
 OpMemoryBarrier %uint_1 %uint_1032  
```

I think it was just an oversight that we didn't remove this along with the atomic_uint types. This is arguably either invalid code or a nop, and I think it's best to just forbid it.

See https://github.com/KhronosGroup/GLSL/pull/112 for the corresponding spec change. 