### PR TITLE
for link validation, match blocks by block-name, not instance-name

### DIFF
--- a/Test/baseResults/150.tesc.out
+++ b/Test/baseResults/150.tesc.out
@@ -960,6 +960,9 @@ Linked tessellation evaluation stage:
 ERROR: Linking tessellation evaluation stage: can't handle multiple entry points per stage
 ERROR: Linking tessellation evaluation stage: Multiple function bodies in multiple compilation units for the same signature in the same stage:
     main(
+ERROR: Linking tessellation evaluation stage: Types must match:
+ERROR: Linking tessellation evaluation stage: Storage qualifiers must match:
+    anon@0: " out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 3-element array of float ClipDistance gl_ClipDistance}" versus " in 32-element array of block{ in 1-element array of float ClipDistance gl_ClipDistance}"
 ERROR: Linking tessellation evaluation stage: can't handle multiple entry points per stage
 ERROR: Linking tessellation evaluation stage: Contradictory input layout primitives
 ERROR: Linking tessellation evaluation stage: Contradictory input vertex spacing
@@ -1590,7 +1593,6 @@ ERROR: node is still EOpNull!
 0:?     'badp2' ( flat patch in 4-component vector of float)
 0:?     'badp3' ( noperspective patch in 4-component vector of float)
 0:?     'badp4' ( patch sample in 3-component vector of float)
-0:?     'gl_in' ( in 32-element array of block{ in 1-element array of float ClipDistance gl_ClipDistance})
 0:?     'ina' ( in 2-component vector of float)
 0:?     'inb' ( in 32-element array of 2-component vector of float)
 0:?     'inc' ( in 32-element array of 2-component vector of float)

--- a/Test/baseResults/link.multiAnonBlocksInvalid.0.0.vert.out
+++ b/Test/baseResults/link.multiAnonBlocksInvalid.0.0.vert.out
@@ -1,0 +1,163 @@
+link.multiAnonBlocksInvalid.0.0.vert
+Shader version: 430
+0:? Sequence
+0:24  Function Definition: main( ( global void)
+0:24    Function Parameters: 
+0:26    Sequence
+0:26      move second child to first child ( temp 4-component vector of float)
+0:26        'oColor' ( smooth out 4-component vector of float)
+0:26        component-wise multiply ( temp 4-component vector of float)
+0:26          color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:26            'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:26            Constant:
+0:26              0 (const uint)
+0:26          Function Call: getColor2( ( global 4-component vector of float)
+0:27      move second child to first child ( temp 4-component vector of float)
+0:27        v1: direct index for structure ( out 4-component vector of float)
+0:27          'anon@1' ( out block{ out 4-component vector of float v1})
+0:27          Constant:
+0:27            0 (const uint)
+0:27        color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:27          'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:27          Constant:
+0:27            0 (const uint)
+0:29      move second child to first child ( temp 4-component vector of float)
+0:29        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
+0:29          'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:29          Constant:
+0:29            0 (const uint)
+0:29        matrix-times-vector ( temp 4-component vector of float)
+0:29          uProj: direct index for structure (layout( column_major std140 offset=0) uniform 4X4 matrix of float)
+0:29            'anon@0' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj})
+0:29            Constant:
+0:29              0 (const uint)
+0:29          Function Call: getWorld( ( global 4-component vector of float)
+0:?   Linker Objects
+0:?     'anon@0' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj})
+0:?     'anon@1' ( out block{ out 4-component vector of float v1})
+0:?     'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:?     'oColor' ( smooth out 4-component vector of float)
+0:?     'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+link.multiAnonBlocksInvalid.0.1.vert
+Shader version: 430
+0:? Sequence
+0:23  Function Definition: getColor2( ( global 4-component vector of float)
+0:23    Function Parameters: 
+0:25    Sequence
+0:25      Branch: Return with expression
+0:25        color2: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:25          'anon@0' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color2})
+0:25          Constant:
+0:25            0 (const uint)
+0:28  Function Definition: getWorld( ( global 4-component vector of float)
+0:28    Function Parameters: 
+0:30    Sequence
+0:30      Branch: Return with expression
+0:30        matrix-times-vector ( temp 4-component vector of float)
+0:30          uWorld: direct index for structure (layout( column_major std140 offset=64) uniform 4X4 matrix of float)
+0:30            'anon@1' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:30            Constant:
+0:30              1 (const uint)
+0:30          'P' ( in 4-component vector of float)
+0:31      move second child to first child ( temp 4-component vector of float)
+0:31        v2: direct index for structure ( out 4-component vector of float)
+0:31          'anon@2' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:31          Constant:
+0:31            1 (const uint)
+0:31        Constant:
+0:31          1.000000
+0:31          1.000000
+0:31          1.000000
+0:31          1.000000
+0:?   Linker Objects
+0:?     'anon@0' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color2})
+0:?     'anon@1' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:?     'anon@2' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:?     'P' ( in 4-component vector of float)
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+
+Linked vertex stage:
+
+ERROR: Linking vertex stage: Types must match:
+    anon@2: "layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2}" versus "layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color2}"
+ERROR: Linking vertex stage: Types must match:
+    anon@0: "layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj}" versus "layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld}"
+ERROR: Linking vertex stage: Types must match:
+    anon@1: " out block{ out 4-component vector of float v1}" versus " out block{ out 4-component vector of float v1,  out 4-component vector of float v2}"
+
+Shader version: 430
+0:? Sequence
+0:24  Function Definition: main( ( global void)
+0:24    Function Parameters: 
+0:26    Sequence
+0:26      move second child to first child ( temp 4-component vector of float)
+0:26        'oColor' ( smooth out 4-component vector of float)
+0:26        component-wise multiply ( temp 4-component vector of float)
+0:26          color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:26            'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:26            Constant:
+0:26              0 (const uint)
+0:26          Function Call: getColor2( ( global 4-component vector of float)
+0:27      move second child to first child ( temp 4-component vector of float)
+0:27        v1: direct index for structure ( out 4-component vector of float)
+0:27          'anon@1' ( out block{ out 4-component vector of float v1})
+0:27          Constant:
+0:27            0 (const uint)
+0:27        color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:27          'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:27          Constant:
+0:27            0 (const uint)
+0:29      move second child to first child ( temp 4-component vector of float)
+0:29        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
+0:29          'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:29          Constant:
+0:29            0 (const uint)
+0:29        matrix-times-vector ( temp 4-component vector of float)
+0:29          uProj: direct index for structure (layout( column_major std140 offset=0) uniform 4X4 matrix of float)
+0:29            'anon@0' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj})
+0:29            Constant:
+0:29              0 (const uint)
+0:29          Function Call: getWorld( ( global 4-component vector of float)
+0:23  Function Definition: getColor2( ( global 4-component vector of float)
+0:23    Function Parameters: 
+0:25    Sequence
+0:25      Branch: Return with expression
+0:25        color2: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:25          'anon@0' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color2})
+0:25          Constant:
+0:25            0 (const uint)
+0:28  Function Definition: getWorld( ( global 4-component vector of float)
+0:28    Function Parameters: 
+0:30    Sequence
+0:30      Branch: Return with expression
+0:30        matrix-times-vector ( temp 4-component vector of float)
+0:30          uWorld: direct index for structure (layout( column_major std140 offset=64) uniform 4X4 matrix of float)
+0:30            'anon@1' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:30            Constant:
+0:30              1 (const uint)
+0:30          'P' ( in 4-component vector of float)
+0:31      move second child to first child ( temp 4-component vector of float)
+0:31        v2: direct index for structure ( out 4-component vector of float)
+0:31          'anon@2' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:31          Constant:
+0:31            1 (const uint)
+0:31        Constant:
+0:31          1.000000
+0:31          1.000000
+0:31          1.000000
+0:31          1.000000
+0:?   Linker Objects
+0:?     'anon@0' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj})
+0:?     'anon@1' ( out block{ out 4-component vector of float v1})
+0:?     'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:?     'oColor' ( smooth out 4-component vector of float)
+0:?     'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+0:?     'P' ( in 4-component vector of float)
+

--- a/Test/baseResults/link.multiAnonBlocksValid.0.0.vert.out
+++ b/Test/baseResults/link.multiAnonBlocksValid.0.0.vert.out
@@ -1,0 +1,157 @@
+link.multiAnonBlocksValid.0.0.vert
+Shader version: 430
+0:? Sequence
+0:26  Function Definition: main( ( global void)
+0:26    Function Parameters: 
+0:28    Sequence
+0:28      move second child to first child ( temp 4-component vector of float)
+0:28        'oColor' ( smooth out 4-component vector of float)
+0:28        component-wise multiply ( temp 4-component vector of float)
+0:28          color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:28            'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:28            Constant:
+0:28              0 (const uint)
+0:28          Function Call: getColor2( ( global 4-component vector of float)
+0:29      move second child to first child ( temp 4-component vector of float)
+0:29        v1: direct index for structure ( out 4-component vector of float)
+0:29          'anon@1' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:29          Constant:
+0:29            0 (const uint)
+0:29        color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:29          'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:29          Constant:
+0:29            0 (const uint)
+0:31      move second child to first child ( temp 4-component vector of float)
+0:31        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
+0:31          'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:31          Constant:
+0:31            0 (const uint)
+0:31        matrix-times-vector ( temp 4-component vector of float)
+0:31          uProj: direct index for structure (layout( column_major std140 offset=0) uniform 4X4 matrix of float)
+0:31            'anon@0' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:31            Constant:
+0:31              0 (const uint)
+0:31          Function Call: getWorld( ( global 4-component vector of float)
+0:?   Linker Objects
+0:?     'anon@0' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:?     'anon@1' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:?     'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:?     'oColor' ( smooth out 4-component vector of float)
+0:?     'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+link.multiAnonBlocksValid.0.1.vert
+Shader version: 430
+0:? Sequence
+0:24  Function Definition: getColor2( ( global 4-component vector of float)
+0:24    Function Parameters: 
+0:26    Sequence
+0:26      Branch: Return with expression
+0:26        color2: direct index for structure (layout( column_major std140 offset=16) uniform 4-component vector of float)
+0:26          'anon@0' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:26          Constant:
+0:26            1 (const uint)
+0:29  Function Definition: getWorld( ( global 4-component vector of float)
+0:29    Function Parameters: 
+0:31    Sequence
+0:31      Branch: Return with expression
+0:31        matrix-times-vector ( temp 4-component vector of float)
+0:31          uWorld: direct index for structure (layout( column_major std140 offset=64) uniform 4X4 matrix of float)
+0:31            'anon@1' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:31            Constant:
+0:31              1 (const uint)
+0:31          'P' ( in 4-component vector of float)
+0:32      move second child to first child ( temp 4-component vector of float)
+0:32        v2: direct index for structure ( out 4-component vector of float)
+0:32          'anon@2' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:32          Constant:
+0:32            1 (const uint)
+0:32        Constant:
+0:32          1.000000
+0:32          1.000000
+0:32          1.000000
+0:32          1.000000
+0:?   Linker Objects
+0:?     'anon@0' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:?     'anon@1' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:?     'anon@2' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:?     'P' ( in 4-component vector of float)
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+
+Linked vertex stage:
+
+
+Shader version: 430
+0:? Sequence
+0:26  Function Definition: main( ( global void)
+0:26    Function Parameters: 
+0:28    Sequence
+0:28      move second child to first child ( temp 4-component vector of float)
+0:28        'oColor' ( smooth out 4-component vector of float)
+0:28        component-wise multiply ( temp 4-component vector of float)
+0:28          color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:28            'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:28            Constant:
+0:28              0 (const uint)
+0:28          Function Call: getColor2( ( global 4-component vector of float)
+0:29      move second child to first child ( temp 4-component vector of float)
+0:29        v1: direct index for structure ( out 4-component vector of float)
+0:29          'anon@1' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:29          Constant:
+0:29            0 (const uint)
+0:29        color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:29          'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:29          Constant:
+0:29            0 (const uint)
+0:31      move second child to first child ( temp 4-component vector of float)
+0:31        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
+0:31          'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:31          Constant:
+0:31            0 (const uint)
+0:31        matrix-times-vector ( temp 4-component vector of float)
+0:31          uProj: direct index for structure (layout( column_major std140 offset=0) uniform 4X4 matrix of float)
+0:31            'anon@0' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:31            Constant:
+0:31              0 (const uint)
+0:31          Function Call: getWorld( ( global 4-component vector of float)
+0:24  Function Definition: getColor2( ( global 4-component vector of float)
+0:24    Function Parameters: 
+0:26    Sequence
+0:26      Branch: Return with expression
+0:26        color2: direct index for structure (layout( column_major std140 offset=16) uniform 4-component vector of float)
+0:26          'anon@0' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:26          Constant:
+0:26            1 (const uint)
+0:29  Function Definition: getWorld( ( global 4-component vector of float)
+0:29    Function Parameters: 
+0:31    Sequence
+0:31      Branch: Return with expression
+0:31        matrix-times-vector ( temp 4-component vector of float)
+0:31          uWorld: direct index for structure (layout( column_major std140 offset=64) uniform 4X4 matrix of float)
+0:31            'anon@1' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:31            Constant:
+0:31              1 (const uint)
+0:31          'P' ( in 4-component vector of float)
+0:32      move second child to first child ( temp 4-component vector of float)
+0:32        v2: direct index for structure ( out 4-component vector of float)
+0:32          'anon@2' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:32          Constant:
+0:32            1 (const uint)
+0:32        Constant:
+0:32          1.000000
+0:32          1.000000
+0:32          1.000000
+0:32          1.000000
+0:?   Linker Objects
+0:?     'anon@0' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:?     'anon@1' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:?     'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:?     'oColor' ( smooth out 4-component vector of float)
+0:?     'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+0:?     'P' ( in 4-component vector of float)
+

--- a/Test/baseResults/link.multiBlocksInvalid.0.0.vert.out
+++ b/Test/baseResults/link.multiBlocksInvalid.0.0.vert.out
@@ -1,0 +1,163 @@
+link.multiBlocksInvalid.0.0.vert
+Shader version: 430
+0:? Sequence
+0:23  Function Definition: main( ( global void)
+0:23    Function Parameters: 
+0:25    Sequence
+0:25      move second child to first child ( temp 4-component vector of float)
+0:25        'oColor' ( smooth out 4-component vector of float)
+0:25        component-wise multiply ( temp 4-component vector of float)
+0:25          color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:25            'uC' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1})
+0:25            Constant:
+0:25              0 (const int)
+0:25          Function Call: getColor2( ( global 4-component vector of float)
+0:26      move second child to first child ( temp 4-component vector of float)
+0:26        v1: direct index for structure ( out 4-component vector of float)
+0:26          'oV' ( out block{ out 4-component vector of float v1})
+0:26          Constant:
+0:26            0 (const int)
+0:26        color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:26          'uC' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1})
+0:26          Constant:
+0:26            0 (const int)
+0:28      move second child to first child ( temp 4-component vector of float)
+0:28        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
+0:28          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:28          Constant:
+0:28            0 (const uint)
+0:28        matrix-times-vector ( temp 4-component vector of float)
+0:28          uProj: direct index for structure (layout( column_major std140 offset=0) uniform 4X4 matrix of float)
+0:28            'uD' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj})
+0:28            Constant:
+0:28              0 (const int)
+0:28          Function Call: getWorld( ( global 4-component vector of float)
+0:?   Linker Objects
+0:?     'uD' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj})
+0:?     'oV' ( out block{ out 4-component vector of float v1})
+0:?     'uC' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1})
+0:?     'oColor' ( smooth out 4-component vector of float)
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+link.multiBlocksInvalid.0.1.vert
+Shader version: 430
+0:? Sequence
+0:21  Function Definition: getColor2( ( global 4-component vector of float)
+0:21    Function Parameters: 
+0:23    Sequence
+0:23      Branch: Return with expression
+0:23        color2: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:23          'uColorB' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color2})
+0:23          Constant:
+0:23            0 (const int)
+0:26  Function Definition: getWorld( ( global 4-component vector of float)
+0:26    Function Parameters: 
+0:28    Sequence
+0:28      Branch: Return with expression
+0:28        matrix-times-vector ( temp 4-component vector of float)
+0:28          uWorld: direct index for structure (layout( column_major std140 offset=0) uniform 4X4 matrix of float)
+0:28            'uDefaultB' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uWorld})
+0:28            Constant:
+0:28              0 (const int)
+0:28          'P' ( in 4-component vector of float)
+0:29      move second child to first child ( temp 4-component vector of float)
+0:29        v2: direct index for structure ( out 4-component vector of float)
+0:29          'oVert' ( out block{ out 4-component vector of float v2})
+0:29          Constant:
+0:29            0 (const int)
+0:29        Constant:
+0:29          1.000000
+0:29          1.000000
+0:29          1.000000
+0:29          1.000000
+0:?   Linker Objects
+0:?     'uColorB' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color2})
+0:?     'uDefaultB' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uWorld})
+0:?     'oVert' ( out block{ out 4-component vector of float v2})
+0:?     'P' ( in 4-component vector of float)
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+
+Linked vertex stage:
+
+ERROR: Linking vertex stage: Types must match:
+    uC: "layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1}" versus "layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color2}"
+ERROR: Linking vertex stage: Types must match:
+    uD: "layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj}" versus "layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uWorld}"
+ERROR: Linking vertex stage: Types must match:
+    oV: " out block{ out 4-component vector of float v1}" versus " out block{ out 4-component vector of float v2}"
+
+Shader version: 430
+0:? Sequence
+0:23  Function Definition: main( ( global void)
+0:23    Function Parameters: 
+0:25    Sequence
+0:25      move second child to first child ( temp 4-component vector of float)
+0:25        'oColor' ( smooth out 4-component vector of float)
+0:25        component-wise multiply ( temp 4-component vector of float)
+0:25          color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:25            'uC' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1})
+0:25            Constant:
+0:25              0 (const int)
+0:25          Function Call: getColor2( ( global 4-component vector of float)
+0:26      move second child to first child ( temp 4-component vector of float)
+0:26        v1: direct index for structure ( out 4-component vector of float)
+0:26          'oV' ( out block{ out 4-component vector of float v1})
+0:26          Constant:
+0:26            0 (const int)
+0:26        color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:26          'uC' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1})
+0:26          Constant:
+0:26            0 (const int)
+0:28      move second child to first child ( temp 4-component vector of float)
+0:28        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
+0:28          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:28          Constant:
+0:28            0 (const uint)
+0:28        matrix-times-vector ( temp 4-component vector of float)
+0:28          uProj: direct index for structure (layout( column_major std140 offset=0) uniform 4X4 matrix of float)
+0:28            'uD' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj})
+0:28            Constant:
+0:28              0 (const int)
+0:28          Function Call: getWorld( ( global 4-component vector of float)
+0:21  Function Definition: getColor2( ( global 4-component vector of float)
+0:21    Function Parameters: 
+0:23    Sequence
+0:23      Branch: Return with expression
+0:23        color2: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:23          'uColorB' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color2})
+0:23          Constant:
+0:23            0 (const int)
+0:26  Function Definition: getWorld( ( global 4-component vector of float)
+0:26    Function Parameters: 
+0:28    Sequence
+0:28      Branch: Return with expression
+0:28        matrix-times-vector ( temp 4-component vector of float)
+0:28          uWorld: direct index for structure (layout( column_major std140 offset=0) uniform 4X4 matrix of float)
+0:28            'uDefaultB' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uWorld})
+0:28            Constant:
+0:28              0 (const int)
+0:28          'P' ( in 4-component vector of float)
+0:29      move second child to first child ( temp 4-component vector of float)
+0:29        v2: direct index for structure ( out 4-component vector of float)
+0:29          'oVert' ( out block{ out 4-component vector of float v2})
+0:29          Constant:
+0:29            0 (const int)
+0:29        Constant:
+0:29          1.000000
+0:29          1.000000
+0:29          1.000000
+0:29          1.000000
+0:?   Linker Objects
+0:?     'uD' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj})
+0:?     'oV' ( out block{ out 4-component vector of float v1})
+0:?     'uC' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1})
+0:?     'oColor' ( smooth out 4-component vector of float)
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+0:?     'P' ( in 4-component vector of float)
+

--- a/Test/baseResults/link.multiBlocksValid.0.0.vert.out
+++ b/Test/baseResults/link.multiBlocksValid.0.0.vert.out
@@ -1,0 +1,157 @@
+link.multiBlocksValid.0.0.vert
+Shader version: 430
+0:? Sequence
+0:26  Function Definition: main( ( global void)
+0:26    Function Parameters: 
+0:28    Sequence
+0:28      move second child to first child ( temp 4-component vector of float)
+0:28        'oColor' ( smooth out 4-component vector of float)
+0:28        component-wise multiply ( temp 4-component vector of float)
+0:28          color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:28            'uC' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:28            Constant:
+0:28              0 (const int)
+0:28          Function Call: getColor2( ( global 4-component vector of float)
+0:29      move second child to first child ( temp 4-component vector of float)
+0:29        v1: direct index for structure ( out 4-component vector of float)
+0:29          'oV' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:29          Constant:
+0:29            0 (const int)
+0:29        color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:29          'uC' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:29          Constant:
+0:29            0 (const int)
+0:31      move second child to first child ( temp 4-component vector of float)
+0:31        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
+0:31          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:31          Constant:
+0:31            0 (const uint)
+0:31        matrix-times-vector ( temp 4-component vector of float)
+0:31          uProj: direct index for structure (layout( column_major std140 offset=0) uniform 4X4 matrix of float)
+0:31            'uD' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:31            Constant:
+0:31              0 (const int)
+0:31          Function Call: getWorld( ( global 4-component vector of float)
+0:?   Linker Objects
+0:?     'uD' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:?     'oV' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:?     'uC' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:?     'oColor' ( smooth out 4-component vector of float)
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+link.multiBlocksValid.0.1.vert
+Shader version: 430
+0:? Sequence
+0:24  Function Definition: getColor2( ( global 4-component vector of float)
+0:24    Function Parameters: 
+0:26    Sequence
+0:26      Branch: Return with expression
+0:26        color2: direct index for structure (layout( column_major std140 offset=16) uniform 4-component vector of float)
+0:26          'uColorB' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:26          Constant:
+0:26            1 (const int)
+0:29  Function Definition: getWorld( ( global 4-component vector of float)
+0:29    Function Parameters: 
+0:31    Sequence
+0:31      Branch: Return with expression
+0:31        matrix-times-vector ( temp 4-component vector of float)
+0:31          uWorld: direct index for structure (layout( column_major std140 offset=64) uniform 4X4 matrix of float)
+0:31            'uDefaultB' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:31            Constant:
+0:31              1 (const int)
+0:31          'P' ( in 4-component vector of float)
+0:32      move second child to first child ( temp 4-component vector of float)
+0:32        v2: direct index for structure ( out 4-component vector of float)
+0:32          'oVert' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:32          Constant:
+0:32            1 (const int)
+0:32        Constant:
+0:32          1.000000
+0:32          1.000000
+0:32          1.000000
+0:32          1.000000
+0:?   Linker Objects
+0:?     'uColorB' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:?     'uDefaultB' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:?     'oVert' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:?     'P' ( in 4-component vector of float)
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+
+Linked vertex stage:
+
+
+Shader version: 430
+0:? Sequence
+0:26  Function Definition: main( ( global void)
+0:26    Function Parameters: 
+0:28    Sequence
+0:28      move second child to first child ( temp 4-component vector of float)
+0:28        'oColor' ( smooth out 4-component vector of float)
+0:28        component-wise multiply ( temp 4-component vector of float)
+0:28          color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:28            'uC' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:28            Constant:
+0:28              0 (const int)
+0:28          Function Call: getColor2( ( global 4-component vector of float)
+0:29      move second child to first child ( temp 4-component vector of float)
+0:29        v1: direct index for structure ( out 4-component vector of float)
+0:29          'oV' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:29          Constant:
+0:29            0 (const int)
+0:29        color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:29          'uC' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:29          Constant:
+0:29            0 (const int)
+0:31      move second child to first child ( temp 4-component vector of float)
+0:31        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
+0:31          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:31          Constant:
+0:31            0 (const uint)
+0:31        matrix-times-vector ( temp 4-component vector of float)
+0:31          uProj: direct index for structure (layout( column_major std140 offset=0) uniform 4X4 matrix of float)
+0:31            'uD' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:31            Constant:
+0:31              0 (const int)
+0:31          Function Call: getWorld( ( global 4-component vector of float)
+0:24  Function Definition: getColor2( ( global 4-component vector of float)
+0:24    Function Parameters: 
+0:26    Sequence
+0:26      Branch: Return with expression
+0:26        color2: direct index for structure (layout( column_major std140 offset=16) uniform 4-component vector of float)
+0:26          'uColorB' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:26          Constant:
+0:26            1 (const int)
+0:29  Function Definition: getWorld( ( global 4-component vector of float)
+0:29    Function Parameters: 
+0:31    Sequence
+0:31      Branch: Return with expression
+0:31        matrix-times-vector ( temp 4-component vector of float)
+0:31          uWorld: direct index for structure (layout( column_major std140 offset=64) uniform 4X4 matrix of float)
+0:31            'uDefaultB' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:31            Constant:
+0:31              1 (const int)
+0:31          'P' ( in 4-component vector of float)
+0:32      move second child to first child ( temp 4-component vector of float)
+0:32        v2: direct index for structure ( out 4-component vector of float)
+0:32          'oVert' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:32          Constant:
+0:32            1 (const int)
+0:32        Constant:
+0:32          1.000000
+0:32          1.000000
+0:32          1.000000
+0:32          1.000000
+0:?   Linker Objects
+0:?     'uD' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:?     'oV' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:?     'uC' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:?     'oColor' ( smooth out 4-component vector of float)
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+0:?     'P' ( in 4-component vector of float)
+

--- a/Test/baseResults/link.multiBlocksValid.1.0.vert.out
+++ b/Test/baseResults/link.multiBlocksValid.1.0.vert.out
@@ -1,0 +1,157 @@
+link.multiBlocksValid.1.0.vert
+Shader version: 430
+0:? Sequence
+0:26  Function Definition: main( ( global void)
+0:26    Function Parameters: 
+0:28    Sequence
+0:28      move second child to first child ( temp 4-component vector of float)
+0:28        'oColor' ( smooth out 4-component vector of float)
+0:28        component-wise multiply ( temp 4-component vector of float)
+0:28          color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:28            'c' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:28            Constant:
+0:28              0 (const int)
+0:28          Function Call: getColor2( ( global 4-component vector of float)
+0:29      move second child to first child ( temp 4-component vector of float)
+0:29        v1: direct index for structure ( out 4-component vector of float)
+0:29          'b' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:29          Constant:
+0:29            0 (const int)
+0:29        color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:29          'c' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:29          Constant:
+0:29            0 (const int)
+0:31      move second child to first child ( temp 4-component vector of float)
+0:31        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
+0:31          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:31          Constant:
+0:31            0 (const uint)
+0:31        matrix-times-vector ( temp 4-component vector of float)
+0:31          uProj: direct index for structure (layout( column_major std140 offset=0) uniform 4X4 matrix of float)
+0:31            'a' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:31            Constant:
+0:31              0 (const int)
+0:31          Function Call: getWorld( ( global 4-component vector of float)
+0:?   Linker Objects
+0:?     'a' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:?     'b' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:?     'c' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:?     'oColor' ( smooth out 4-component vector of float)
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+link.multiBlocksValid.1.1.vert
+Shader version: 430
+0:? Sequence
+0:24  Function Definition: getColor2( ( global 4-component vector of float)
+0:24    Function Parameters: 
+0:26    Sequence
+0:26      Branch: Return with expression
+0:26        color2: direct index for structure (layout( column_major std140 offset=16) uniform 4-component vector of float)
+0:26          'a' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:26          Constant:
+0:26            1 (const int)
+0:29  Function Definition: getWorld( ( global 4-component vector of float)
+0:29    Function Parameters: 
+0:31    Sequence
+0:31      Branch: Return with expression
+0:31        matrix-times-vector ( temp 4-component vector of float)
+0:31          uWorld: direct index for structure (layout( column_major std140 offset=64) uniform 4X4 matrix of float)
+0:31            'b' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:31            Constant:
+0:31              1 (const int)
+0:31          'P' ( in 4-component vector of float)
+0:32      move second child to first child ( temp 4-component vector of float)
+0:32        v2: direct index for structure ( out 4-component vector of float)
+0:32          'c' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:32          Constant:
+0:32            1 (const int)
+0:32        Constant:
+0:32          1.000000
+0:32          1.000000
+0:32          1.000000
+0:32          1.000000
+0:?   Linker Objects
+0:?     'a' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:?     'b' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:?     'c' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:?     'P' ( in 4-component vector of float)
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+
+Linked vertex stage:
+
+
+Shader version: 430
+0:? Sequence
+0:26  Function Definition: main( ( global void)
+0:26    Function Parameters: 
+0:28    Sequence
+0:28      move second child to first child ( temp 4-component vector of float)
+0:28        'oColor' ( smooth out 4-component vector of float)
+0:28        component-wise multiply ( temp 4-component vector of float)
+0:28          color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:28            'c' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:28            Constant:
+0:28              0 (const int)
+0:28          Function Call: getColor2( ( global 4-component vector of float)
+0:29      move second child to first child ( temp 4-component vector of float)
+0:29        v1: direct index for structure ( out 4-component vector of float)
+0:29          'b' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:29          Constant:
+0:29            0 (const int)
+0:29        color1: direct index for structure (layout( column_major std140 offset=0) uniform 4-component vector of float)
+0:29          'c' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:29          Constant:
+0:29            0 (const int)
+0:31      move second child to first child ( temp 4-component vector of float)
+0:31        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
+0:31          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:31          Constant:
+0:31            0 (const uint)
+0:31        matrix-times-vector ( temp 4-component vector of float)
+0:31          uProj: direct index for structure (layout( column_major std140 offset=0) uniform 4X4 matrix of float)
+0:31            'a' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:31            Constant:
+0:31              0 (const int)
+0:31          Function Call: getWorld( ( global 4-component vector of float)
+0:24  Function Definition: getColor2( ( global 4-component vector of float)
+0:24    Function Parameters: 
+0:26    Sequence
+0:26      Branch: Return with expression
+0:26        color2: direct index for structure (layout( column_major std140 offset=16) uniform 4-component vector of float)
+0:26          'a' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:26          Constant:
+0:26            1 (const int)
+0:29  Function Definition: getWorld( ( global 4-component vector of float)
+0:29    Function Parameters: 
+0:31    Sequence
+0:31      Branch: Return with expression
+0:31        matrix-times-vector ( temp 4-component vector of float)
+0:31          uWorld: direct index for structure (layout( column_major std140 offset=64) uniform 4X4 matrix of float)
+0:31            'b' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:31            Constant:
+0:31              1 (const int)
+0:31          'P' ( in 4-component vector of float)
+0:32      move second child to first child ( temp 4-component vector of float)
+0:32        v2: direct index for structure ( out 4-component vector of float)
+0:32          'c' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:32          Constant:
+0:32            1 (const int)
+0:32        Constant:
+0:32          1.000000
+0:32          1.000000
+0:32          1.000000
+0:32          1.000000
+0:?   Linker Objects
+0:?     'a' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float uProj, layout( column_major std140 offset=64) uniform 4X4 matrix of float uWorld})
+0:?     'b' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
+0:?     'c' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
+0:?     'oColor' ( smooth out 4-component vector of float)
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+0:?     'P' ( in 4-component vector of float)
+

--- a/Test/baseResults/link.vk.pcNamingInvalid.0.0.vert.out
+++ b/Test/baseResults/link.vk.pcNamingInvalid.0.0.vert.out
@@ -1,0 +1,111 @@
+link.vk.pcNamingInvalid.0.0.vert
+Shader version: 450
+0:? Sequence
+0:16  Function Definition: main( ( global void)
+0:16    Function Parameters: 
+0:18    Sequence
+0:18      move second child to first child ( temp highp 4-component vector of float)
+0:18        'oColor' ( smooth out highp 4-component vector of float)
+0:18        component-wise multiply ( temp highp 4-component vector of float)
+0:18          color1: direct index for structure (layout( column_major std430 offset=128) uniform highp 4-component vector of float)
+0:18            'a' (layout( column_major std430 push_constant) uniform block{layout( column_major std430 offset=0) uniform highp 4X4 matrix of float uWorld, layout( column_major std430 offset=64) uniform highp 4X4 matrix of float uProj, layout( column_major std430 offset=128) uniform highp 4-component vector of float color1, layout( column_major std430 offset=144) uniform highp 4-component vector of float color2})
+0:18            Constant:
+0:18              2 (const int)
+0:18          Function Call: getColor2( ( global highp 4-component vector of float)
+0:20      move second child to first child ( temp highp 4-component vector of float)
+0:20        gl_Position: direct index for structure ( gl_Position highp 4-component vector of float Position)
+0:20          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  out unsized 1-element array of float CullDistance gl_CullDistance})
+0:20          Constant:
+0:20            0 (const uint)
+0:20        matrix-times-vector ( temp highp 4-component vector of float)
+0:20          uProj: direct index for structure (layout( column_major std430 offset=64) uniform highp 4X4 matrix of float)
+0:20            'a' (layout( column_major std430 push_constant) uniform block{layout( column_major std430 offset=0) uniform highp 4X4 matrix of float uWorld, layout( column_major std430 offset=64) uniform highp 4X4 matrix of float uProj, layout( column_major std430 offset=128) uniform highp 4-component vector of float color1, layout( column_major std430 offset=144) uniform highp 4-component vector of float color2})
+0:20            Constant:
+0:20              1 (const int)
+0:20          Function Call: getWorld( ( global highp 4-component vector of float)
+0:?   Linker Objects
+0:?     'a' (layout( column_major std430 push_constant) uniform block{layout( column_major std430 offset=0) uniform highp 4X4 matrix of float uWorld, layout( column_major std430 offset=64) uniform highp 4X4 matrix of float uProj, layout( column_major std430 offset=128) uniform highp 4-component vector of float color1, layout( column_major std430 offset=144) uniform highp 4-component vector of float color2})
+0:?     'oColor' ( smooth out highp 4-component vector of float)
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  out unsized 1-element array of float CullDistance gl_CullDistance})
+
+link.vk.pcNamingInvalid.0.1.vert
+Shader version: 450
+0:? Sequence
+0:13  Function Definition: getColor2( ( global highp 4-component vector of float)
+0:13    Function Parameters: 
+0:15    Sequence
+0:15      Branch: Return with expression
+0:15        color2: direct index for structure (layout( column_major std430 offset=144) uniform highp 4-component vector of float)
+0:15          'a' (layout( column_major std430 push_constant) uniform block{layout( column_major std430 offset=0) uniform highp 4X4 matrix of float uWorld, layout( column_major std430 offset=64) uniform highp 4X4 matrix of float uProj, layout( column_major std430 offset=128) uniform highp 4-component vector of float color1, layout( column_major std430 offset=144) uniform highp 4-component vector of float color2})
+0:15          Constant:
+0:15            3 (const int)
+0:18  Function Definition: getWorld( ( global highp 4-component vector of float)
+0:18    Function Parameters: 
+0:20    Sequence
+0:20      Branch: Return with expression
+0:20        matrix-times-vector ( temp highp 4-component vector of float)
+0:20          uWorld: direct index for structure (layout( column_major std430 offset=0) uniform highp 4X4 matrix of float)
+0:20            'a' (layout( column_major std430 push_constant) uniform block{layout( column_major std430 offset=0) uniform highp 4X4 matrix of float uWorld, layout( column_major std430 offset=64) uniform highp 4X4 matrix of float uProj, layout( column_major std430 offset=128) uniform highp 4-component vector of float color1, layout( column_major std430 offset=144) uniform highp 4-component vector of float color2})
+0:20            Constant:
+0:20              0 (const int)
+0:20          'P' ( in highp 4-component vector of float)
+0:?   Linker Objects
+0:?     'a' (layout( column_major std430 push_constant) uniform block{layout( column_major std430 offset=0) uniform highp 4X4 matrix of float uWorld, layout( column_major std430 offset=64) uniform highp 4X4 matrix of float uProj, layout( column_major std430 offset=128) uniform highp 4-component vector of float color1, layout( column_major std430 offset=144) uniform highp 4-component vector of float color2})
+0:?     'P' ( in highp 4-component vector of float)
+
+
+Linked vertex stage:
+
+ERROR: Linking vertex stage: Only one push_constant block is allowed per stage
+
+Shader version: 450
+0:? Sequence
+0:16  Function Definition: main( ( global void)
+0:16    Function Parameters: 
+0:18    Sequence
+0:18      move second child to first child ( temp highp 4-component vector of float)
+0:18        'oColor' ( smooth out highp 4-component vector of float)
+0:18        component-wise multiply ( temp highp 4-component vector of float)
+0:18          color1: direct index for structure (layout( column_major std430 offset=128) uniform highp 4-component vector of float)
+0:18            'a' (layout( column_major std430 push_constant) uniform block{layout( column_major std430 offset=0) uniform highp 4X4 matrix of float uWorld, layout( column_major std430 offset=64) uniform highp 4X4 matrix of float uProj, layout( column_major std430 offset=128) uniform highp 4-component vector of float color1, layout( column_major std430 offset=144) uniform highp 4-component vector of float color2})
+0:18            Constant:
+0:18              2 (const int)
+0:18          Function Call: getColor2( ( global highp 4-component vector of float)
+0:20      move second child to first child ( temp highp 4-component vector of float)
+0:20        gl_Position: direct index for structure ( gl_Position highp 4-component vector of float Position)
+0:20          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  out 1-element array of float CullDistance gl_CullDistance})
+0:20          Constant:
+0:20            0 (const uint)
+0:20        matrix-times-vector ( temp highp 4-component vector of float)
+0:20          uProj: direct index for structure (layout( column_major std430 offset=64) uniform highp 4X4 matrix of float)
+0:20            'a' (layout( column_major std430 push_constant) uniform block{layout( column_major std430 offset=0) uniform highp 4X4 matrix of float uWorld, layout( column_major std430 offset=64) uniform highp 4X4 matrix of float uProj, layout( column_major std430 offset=128) uniform highp 4-component vector of float color1, layout( column_major std430 offset=144) uniform highp 4-component vector of float color2})
+0:20            Constant:
+0:20              1 (const int)
+0:20          Function Call: getWorld( ( global highp 4-component vector of float)
+0:13  Function Definition: getColor2( ( global highp 4-component vector of float)
+0:13    Function Parameters: 
+0:15    Sequence
+0:15      Branch: Return with expression
+0:15        color2: direct index for structure (layout( column_major std430 offset=144) uniform highp 4-component vector of float)
+0:15          'a' (layout( column_major std430 push_constant) uniform block{layout( column_major std430 offset=0) uniform highp 4X4 matrix of float uWorld, layout( column_major std430 offset=64) uniform highp 4X4 matrix of float uProj, layout( column_major std430 offset=128) uniform highp 4-component vector of float color1, layout( column_major std430 offset=144) uniform highp 4-component vector of float color2})
+0:15          Constant:
+0:15            3 (const int)
+0:18  Function Definition: getWorld( ( global highp 4-component vector of float)
+0:18    Function Parameters: 
+0:20    Sequence
+0:20      Branch: Return with expression
+0:20        matrix-times-vector ( temp highp 4-component vector of float)
+0:20          uWorld: direct index for structure (layout( column_major std430 offset=0) uniform highp 4X4 matrix of float)
+0:20            'a' (layout( column_major std430 push_constant) uniform block{layout( column_major std430 offset=0) uniform highp 4X4 matrix of float uWorld, layout( column_major std430 offset=64) uniform highp 4X4 matrix of float uProj, layout( column_major std430 offset=128) uniform highp 4-component vector of float color1, layout( column_major std430 offset=144) uniform highp 4-component vector of float color2})
+0:20            Constant:
+0:20              0 (const int)
+0:20          'P' ( in highp 4-component vector of float)
+0:?   Linker Objects
+0:?     'a' (layout( column_major std430 push_constant) uniform block{layout( column_major std430 offset=0) uniform highp 4X4 matrix of float uWorld, layout( column_major std430 offset=64) uniform highp 4X4 matrix of float uProj, layout( column_major std430 offset=128) uniform highp 4-component vector of float color1, layout( column_major std430 offset=144) uniform highp 4-component vector of float color2})
+0:?     'oColor' ( smooth out highp 4-component vector of float)
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  out 1-element array of float CullDistance gl_CullDistance})
+0:?     'a' (layout( column_major std430 push_constant) uniform block{layout( column_major std430 offset=0) uniform highp 4X4 matrix of float uWorld, layout( column_major std430 offset=64) uniform highp 4X4 matrix of float uProj, layout( column_major std430 offset=128) uniform highp 4-component vector of float color1, layout( column_major std430 offset=144) uniform highp 4-component vector of float color2})
+0:?     'P' ( in highp 4-component vector of float)
+
+Validation failed
+SPIR-V is not generated for failed compile or link

--- a/Test/link.multiAnonBlocksInvalid.0.0.vert
+++ b/Test/link.multiAnonBlocksInvalid.0.0.vert
@@ -1,0 +1,30 @@
+#version 430
+layout (std140) uniform Block
+{
+	mat4 uProj;
+};
+
+out Vertex
+{
+	vec4 v1;
+};
+
+layout (std140) uniform ColorBlock
+{
+	vec4 color1;
+	vec4 color2;
+};
+
+vec4 getWorld();
+vec4 getColor2();
+
+out vec4 oColor;
+
+void
+main()
+{
+	oColor = color1 * getColor2();
+	v1 = color1;
+
+	gl_Position = uProj * getWorld();
+}

--- a/Test/link.multiAnonBlocksInvalid.0.1.vert
+++ b/Test/link.multiAnonBlocksInvalid.0.1.vert
@@ -1,0 +1,33 @@
+#version 430
+
+layout (std140) uniform ColorBlock
+{
+	vec4 color2;
+};
+
+layout (std140) uniform Block
+{
+	mat4 uProj;
+	mat4 uWorld;
+};
+
+out Vertex
+{
+	vec4 v1;
+	vec4 v2;
+};
+
+
+in vec4 P;
+
+vec4 getColor2()
+{
+	return color2;
+}
+
+vec4 getWorld()
+{
+	return uWorld * P;
+	v2 = vec4(1);
+}
+

--- a/Test/link.multiAnonBlocksValid.0.0.vert
+++ b/Test/link.multiAnonBlocksValid.0.0.vert
@@ -1,0 +1,32 @@
+#version 430
+layout (std140) uniform Block
+{
+	mat4 uProj;
+	mat4 uWorld;
+};
+
+out Vertex
+{
+	vec4 v1;
+	vec4 v2;
+};
+
+layout (std140) uniform ColorBlock
+{
+	vec4 color1;
+	vec4 color2;
+};
+
+vec4 getWorld();
+vec4 getColor2();
+
+out vec4 oColor;
+
+void
+main()
+{
+	oColor = color1 * getColor2();
+	v1 = color1;
+
+	gl_Position = uProj * getWorld();
+}

--- a/Test/link.multiAnonBlocksValid.0.1.vert
+++ b/Test/link.multiAnonBlocksValid.0.1.vert
@@ -1,0 +1,34 @@
+#version 430
+
+layout (std140) uniform ColorBlock
+{
+	vec4 color1;
+	vec4 color2;
+};
+
+layout (std140) uniform Block
+{
+	mat4 uProj;
+	mat4 uWorld;
+};
+
+out Vertex
+{
+	vec4 v1;
+	vec4 v2;
+};
+
+
+in vec4 P;
+
+vec4 getColor2()
+{
+	return color2;
+}
+
+vec4 getWorld()
+{
+	return uWorld * P;
+	v2 = vec4(1);
+}
+

--- a/Test/link.multiBlocksInvalid.0.0.vert
+++ b/Test/link.multiBlocksInvalid.0.0.vert
@@ -1,0 +1,29 @@
+#version 430
+layout (std140) uniform Block
+{
+	mat4 uProj;
+} uD;
+
+out Vertex
+{
+	vec4 v1;
+} oV;
+
+layout (std140) uniform ColorBlock
+{
+	vec4 color1;
+} uC;
+
+vec4 getWorld();
+vec4 getColor2();
+
+out vec4 oColor;
+
+void
+main()
+{
+	oColor = uC.color1 * getColor2();
+	oV.v1 = uC.color1;
+
+	gl_Position = uD.uProj * getWorld();
+}

--- a/Test/link.multiBlocksInvalid.0.1.vert
+++ b/Test/link.multiBlocksInvalid.0.1.vert
@@ -1,0 +1,31 @@
+#version 430
+
+layout (std140) uniform ColorBlock
+{
+	vec4 color2;
+} uColorB;
+
+layout (std140) uniform Block
+{
+	mat4 uWorld;
+} uDefaultB;
+
+out Vertex
+{
+	vec4 v2;
+} oVert;
+
+
+in vec4 P;
+
+vec4 getColor2()
+{
+	return uColorB.color2;
+}
+
+vec4 getWorld()
+{
+	return uDefaultB.uWorld * P;
+	oVert.v2 = vec4(1);
+}
+

--- a/Test/link.multiBlocksValid.0.0.vert
+++ b/Test/link.multiBlocksValid.0.0.vert
@@ -1,0 +1,32 @@
+#version 430
+layout (std140) uniform Block
+{
+	mat4 uProj;
+	mat4 uWorld;
+} uD;
+
+out Vertex
+{
+	vec4 v1;
+	vec4 v2;
+} oV;
+
+layout (std140) uniform ColorBlock
+{
+	vec4 color1;
+	vec4 color2;
+} uC;
+
+vec4 getWorld();
+vec4 getColor2();
+
+out vec4 oColor;
+
+void
+main()
+{
+	oColor = uC.color1 * getColor2();
+	oV.v1 = uC.color1;
+
+	gl_Position = uD.uProj * getWorld();
+}

--- a/Test/link.multiBlocksValid.0.1.vert
+++ b/Test/link.multiBlocksValid.0.1.vert
@@ -1,0 +1,34 @@
+#version 430
+
+layout (std140) uniform ColorBlock
+{
+	vec4 color1;
+	vec4 color2;
+} uColorB;
+
+layout (std140) uniform Block
+{
+	mat4 uProj;
+	mat4 uWorld;
+} uDefaultB;
+
+out Vertex
+{
+	vec4 v1;
+	vec4 v2;
+} oVert;
+
+
+in vec4 P;
+
+vec4 getColor2()
+{
+	return uColorB.color2;
+}
+
+vec4 getWorld()
+{
+	return uDefaultB.uWorld * P;
+	oVert.v2 = vec4(1);
+}
+

--- a/Test/link.multiBlocksValid.1.0.vert
+++ b/Test/link.multiBlocksValid.1.0.vert
@@ -1,0 +1,32 @@
+#version 430
+layout (std140) uniform Block
+{
+	mat4 uProj;
+	mat4 uWorld;
+} a;
+
+out Vertex
+{
+	vec4 v1;
+	vec4 v2;
+} b;
+
+layout (std140) uniform ColorBlock
+{
+	vec4 color1;
+	vec4 color2;
+} c;
+
+vec4 getWorld();
+vec4 getColor2();
+
+out vec4 oColor;
+
+void
+main()
+{
+	oColor = c.color1 * getColor2();
+	b.v1 = c.color1;
+
+	gl_Position = a.uProj * getWorld();
+}

--- a/Test/link.multiBlocksValid.1.1.vert
+++ b/Test/link.multiBlocksValid.1.1.vert
@@ -1,0 +1,34 @@
+#version 430
+
+layout (std140) uniform ColorBlock
+{
+	vec4 color1;
+	vec4 color2;
+} a;
+
+layout (std140) uniform Block
+{
+	mat4 uProj;
+	mat4 uWorld;
+} b;
+
+out Vertex
+{
+	vec4 v1;
+	vec4 v2;
+} c;
+
+
+in vec4 P;
+
+vec4 getColor2()
+{
+	return a.color2;
+}
+
+vec4 getWorld()
+{
+	return b.uWorld * P;
+	c.v2 = vec4(1);
+}
+

--- a/Test/link.vk.pcNamingInvalid.0.0.vert
+++ b/Test/link.vk.pcNamingInvalid.0.0.vert
@@ -1,0 +1,21 @@
+#version 450
+layout (push_constant) uniform Block
+{
+	mat4 uWorld;
+	mat4 uProj;
+	vec4 color1;
+	vec4 color2;
+} a;
+
+vec4 getWorld();
+vec4 getColor2();
+
+out vec4 oColor;
+
+void
+main()
+{
+	oColor = a.color1 * getColor2();
+
+	gl_Position = a.uProj * getWorld();
+}

--- a/Test/link.vk.pcNamingInvalid.0.1.vert
+++ b/Test/link.vk.pcNamingInvalid.0.1.vert
@@ -1,0 +1,22 @@
+#version 450
+
+layout (push_constant) uniform Block2
+{
+	mat4 uWorld;
+	mat4 uProj;
+	vec4 color1;
+	vec4 color2;
+} a;
+
+in vec4 P;
+
+vec4 getColor2()
+{
+	return a.color2;
+}
+
+vec4 getWorld()
+{
+	return a.uWorld * P;
+}
+

--- a/glslang/MachineIndependent/linkValidate.cpp
+++ b/glslang/MachineIndependent/linkValidate.cpp
@@ -447,7 +447,20 @@ void TIntermediate::mergeLinkerObjects(TInfoSink& infoSink, TIntermSequence& lin
             TIntermSymbol* symbol = linkerObjects[linkObj]->getAsSymbolNode();
             TIntermSymbol* unitSymbol = unitLinkerObjects[unitLinkObj]->getAsSymbolNode();
             assert(symbol && unitSymbol);
-            if (symbol->getName() == unitSymbol->getName()) {
+
+            bool isSameSymbol = false;
+            // If they are both blocks, match up by the block-name
+            // not the identifier name
+            if (symbol->getType().getBasicType() == EbtBlock &&
+                unitSymbol->getType().getBasicType() == EbtBlock) {
+
+                isSameSymbol = symbol->getType().getTypeName() ==
+                                unitSymbol->getType().getTypeName();
+            } else if (symbol->getName() == unitSymbol->getName()) {
+                isSameSymbol = true;
+			}
+
+            if (isSameSymbol) {
                 // filter out copy
                 merge = false;
 

--- a/gtests/Link.FromFile.Vk.cpp
+++ b/gtests/Link.FromFile.Vk.cpp
@@ -115,7 +115,6 @@ INSTANTIATE_TEST_CASE_P(
 			"link.vk.differentPC.0.2.frag"},
 		{"link.vk.differentPC.1.0.frag", "link.vk.differentPC.1.1.frag",
 			"link.vk.differentPC.1.2.frag"},
-        {"link.vk.pcNamingValid.0.0.vert", "link.vk.pcNamingValid.0.1.vert"},
         {"link.vk.pcNamingInvalid.0.0.vert", "link.vk.pcNamingInvalid.0.1.vert"},
     }))
 );

--- a/gtests/Link.FromFile.Vk.cpp
+++ b/gtests/Link.FromFile.Vk.cpp
@@ -115,6 +115,8 @@ INSTANTIATE_TEST_CASE_P(
 			"link.vk.differentPC.0.2.frag"},
 		{"link.vk.differentPC.1.0.frag", "link.vk.differentPC.1.1.frag",
 			"link.vk.differentPC.1.2.frag"},
+        {"link.vk.pcNamingValid.0.0.vert", "link.vk.pcNamingValid.0.1.vert"},
+        {"link.vk.pcNamingInvalid.0.0.vert", "link.vk.pcNamingInvalid.0.1.vert"},
     }))
 );
 // clang-format on

--- a/gtests/Link.FromFile.cpp
+++ b/gtests/Link.FromFile.cpp
@@ -100,7 +100,12 @@ INSTANTIATE_TEST_CASE_P(
         {"150.tesc", "150.tese", "400.tesc", "400.tese", "410.tesc", "420.tesc", "420.tese"},
         {"max_vertices_0.geom"},
         {"es-link1.frag", "es-link2.frag"},
-        {"missingBodies.vert"}
+        {"missingBodies.vert"},
+        {"link.multiAnonBlocksInvalid.0.0.vert", "link.multiAnonBlocksInvalid.0.1.vert"},
+        {"link.multiAnonBlocksValid.0.0.vert", "link.multiAnonBlocksValid.0.1.vert"},
+        {"link.multiBlocksInvalid.0.0.vert", "link.multiBlocksInvalid.0.1.vert"},
+        {"link.multiBlocksValid.0.0.vert", "link.multiBlocksValid.0.1.vert"},
+        {"link.multiBlocksValid.1.0.vert", "link.multiBlocksValid.1.1.vert"},
     }))
 );
 // clang-format on


### PR DESCRIPTION
Fixes #2136

Also the output from 150.tesc.out test case changed due to
mismatch from gl_PerVertex declaration that previously wasn't
picked up, but is now.