### PR TITLE
Do not automatically build broken SHARED library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,6 @@ option(BUILD_EXTERNAL "Build external dependencies in /External" ON)
 
 set(LIB_TYPE STATIC)
 
-if(BUILD_SHARED_LIBS)
-    set(LIB_TYPE SHARED)
-endif()
-
 option(SKIP_GLSLANG_INSTALL "Skip installation" ${SKIP_GLSLANG_INSTALL})
 if(NOT ${SKIP_GLSLANG_INSTALL})
   set(ENABLE_GLSLANG_INSTALL ON)


### PR DESCRIPTION
glslang automatically sets `SHARED` library type upon detection of CMake `BUILD_SHARED_LIBS` setting, whereas glslang can't actually build as `SHARED` library (many build errors that no one seems interested to fix in the short term)
glslang shared lib build is broken, as per https://github.com/KhronosGroup/glslang/issues/1421
It does not make sense that glslang therefore choses `SHARED` library type when CMake `BUILD_SHARED_LIBS` global setting is on. This breaks the builds of any project embedding glslang that would like to use the `BUILD_SHARED_LIBS` setting
The proper behavior is to actually always explicitly pass `STATIC` for glslang libraries until glslang can actually build as `SHARED` (maybe one day), and if one day this is fixed, the proper way is to not pass anything (either `SHARED` or `STATIC`), and CMake will chose a type based on `BUILD_SHARED_LIBS` setting