### PR TITLE
Add googletest as submodule instead of manually cloning

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,7 +47,7 @@ matrix:
 install:
   - C:/Python27/python.exe update_glslang_sources.py
   - set PATH=C:\ninja;C:\Python36;%PATH%
-  - git clone https://github.com/google/googletest.git External/googletest
+  - git submodule sync && git submodule update --init --recursive
   - cd External/googletest
   - git checkout 440527a61e1c91188195f7de212c63c77e8f0a45
   - cd ../..

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ tags
 TAGS
 build/
 Test/localResults/
-External/googletest
 External/spirv-tools

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "External/googletest"]
+	path = External/googletest
+	url = https://github.com/google/googletest.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ addons:
       - clang-3.6
 
 install:
+  - git submodule sync && git submodule update --init --recursive
   # Make sure that clang-3.6 is selected on Linux.
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$CC" == "clang" ]]; then
       export CC=clang-3.6 CXX=clang++-3.6;
@@ -61,7 +62,6 @@ install:
     fi
 
 before_script:
-  - git clone --depth=1 https://github.com/google/googletest.git External/googletest
   - ./update_glslang_sources.py
 
 script:

--- a/README.md
+++ b/README.md
@@ -106,17 +106,14 @@ shell or some other shell of your choosing.
 
 #### 1) Check-Out this project
 
+Clone the repository recursively to initialize all submodules, omit the `--recursive`-flag if you do not intend to use googletest.
+
 ```bash
 cd <parent of where you want glslang to be>
-git clone https://github.com/KhronosGroup/glslang.git
+git clone --recursive https://github.com/KhronosGroup/glslang.git
 ```
 
 #### 2) Check-Out External Projects
-
-```bash
-cd <the directory glslang was cloned to, "External" will be a subdirectory>
-git clone https://github.com/google/googletest.git External/googletest
-```
 
 If you want to use googletest with Visual Studio 2013, you also need to check out an older version:
 


### PR DESCRIPTION
Title pretty much says it. You can now clone googletest by cloning the repository recursively. If you do not intend to use googletest you can simply omit the `--recursive`-flag in the `git clone` command