### PR TITLE
Add support for extension GL_ARB_shader_image_size

### DIFF
--- a/Test/420.frag
+++ b/Test/420.frag
@@ -12,3 +12,8 @@ layout(depth_less) in float depth; // ERROR: depth_less only applies to gl_FragD
 layout(depth_any) out float gl_FragDepth;  // ERROR, done after use
 
 layout(binding=0) uniform atomic_uint a[];
+
+uniform writeonly image2D      i2D;
+ivec2 iv2dim = imageSize(i2D); // ERROR: imageSize called without enabling GL_ARB_shader_image_size extension
+#extension GL_ARB_shader_image_size : enable
+ivec2 iv2dim1 = imageSize(i2D);

--- a/Test/baseResults/420.frag.out
+++ b/Test/baseResults/420.frag.out
@@ -3,10 +3,12 @@ ERROR: 0:4: 'redeclaration' : all redeclarations must use the same depth layout 
 ERROR: 0:11: 'layout qualifier' : can only apply depth layout to gl_FragDepth 
 ERROR: 0:12: 'gl_FragDepth' : cannot redeclare after use 
 ERROR: 0:14: 'atomic_uint' : array must be explicitly sized 
-ERROR: 4 compilation errors.  No code generated.
+ERROR: 0:17: 'imageSize' : required extension not requested: GL_ARB_shader_image_size
+ERROR: 5 compilation errors.  No code generated.
 
 
 Shader version: 420
+Requested GL_ARB_shader_image_size
 using depth_any
 ERROR: node is still EOpNull!
 0:6  Function Definition: main( ( global void)
@@ -16,16 +18,30 @@ ERROR: node is still EOpNull!
 0:8        'gl_FragDepth' ( gl_FragDepth float FragDepth)
 0:8        Constant:
 0:8          0.300000
+0:17  Sequence
+0:17    move second child to first child ( temp 2-component vector of int)
+0:17      'iv2dim' ( global 2-component vector of int)
+0:17      imageQuerySize ( global 2-component vector of int)
+0:17        'i2D' ( writeonly uniform image2D)
+0:19  Sequence
+0:19    move second child to first child ( temp 2-component vector of int)
+0:19      'iv2dim1' ( global 2-component vector of int)
+0:19      imageQuerySize ( global 2-component vector of int)
+0:19        'i2D' ( writeonly uniform image2D)
 0:?   Linker Objects
 0:?     'gl_FragDepth' ( gl_FragDepth float FragDepth)
 0:?     'depth' ( smooth in float)
 0:?     'a' (layout( binding=0 offset=0) uniform unsized 1-element array of atomic_uint)
+0:?     'i2D' ( writeonly uniform image2D)
+0:?     'iv2dim' ( global 2-component vector of int)
+0:?     'iv2dim1' ( global 2-component vector of int)
 
 
 Linked fragment stage:
 
 
 Shader version: 420
+Requested GL_ARB_shader_image_size
 using depth_any
 ERROR: node is still EOpNull!
 0:6  Function Definition: main( ( global void)
@@ -35,8 +51,21 @@ ERROR: node is still EOpNull!
 0:8        'gl_FragDepth' ( gl_FragDepth float FragDepth)
 0:8        Constant:
 0:8          0.300000
+0:17  Sequence
+0:17    move second child to first child ( temp 2-component vector of int)
+0:17      'iv2dim' ( global 2-component vector of int)
+0:17      imageQuerySize ( global 2-component vector of int)
+0:17        'i2D' ( writeonly uniform image2D)
+0:19  Sequence
+0:19    move second child to first child ( temp 2-component vector of int)
+0:19      'iv2dim1' ( global 2-component vector of int)
+0:19      imageQuerySize ( global 2-component vector of int)
+0:19        'i2D' ( writeonly uniform image2D)
 0:?   Linker Objects
 0:?     'gl_FragDepth' ( gl_FragDepth float FragDepth)
 0:?     'depth' ( smooth in float)
 0:?     'a' (layout( binding=0 offset=0) uniform 1-element array of atomic_uint)
+0:?     'i2D' ( writeonly uniform image2D)
+0:?     'iv2dim' ( global 2-component vector of int)
+0:?     'iv2dim1' ( global 2-component vector of int)
 

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -5805,7 +5805,7 @@ void TBuiltIns::addQueryFunctions(TSampler sampler, const TString& typeName, int
     return;
 #endif
 
-    if (sampler.isImage() && ((profile == EEsProfile && version < 310) || (profile != EEsProfile && version < 430)))
+    if (sampler.isImage() && ((profile == EEsProfile && version < 310) || (profile != EEsProfile && version < 420)))
         return;
 
     if (profile == EEsProfile)
@@ -7821,6 +7821,10 @@ void TBuiltIns::identifyBuiltIns(int version, EProfile profile, const SpvVersion
             symbolTable.setFunctionExtensions("floatBitsToUint", 1, &E_GL_ARB_shader_bit_encoding);
             symbolTable.setFunctionExtensions("intBitsToFloat", 1, &E_GL_ARB_shader_bit_encoding);
             symbolTable.setFunctionExtensions("uintBitsToFloat", 1, &E_GL_ARB_shader_bit_encoding);
+        }
+
+        if (profile != EEsProfile && version < 430 ) {
+            symbolTable.setFunctionExtensions("imageSize", 1, &E_GL_ARB_shader_image_size);
         }
 
         symbolTable.setVariableExtensions("gl_DeviceIndex",  1, &E_GL_EXT_device_group);

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -198,6 +198,7 @@ void TParseVersions::initializeExtensionBehavior()
     extensionBehavior[E_GL_ARB_uniform_buffer_object]        = EBhDisable;
     extensionBehavior[E_GL_ARB_sample_shading]               = EBhDisable;
     extensionBehavior[E_GL_ARB_shader_bit_encoding]          = EBhDisable;
+    extensionBehavior[E_GL_ARB_shader_image_size]            = EBhDisable;
 
     extensionBehavior[E_GL_KHR_shader_subgroup_basic]            = EBhDisable;
     extensionBehavior[E_GL_KHR_shader_subgroup_vote]             = EBhDisable;
@@ -406,6 +407,7 @@ void TParseVersions::getPreamble(std::string& preamble)
             "#define GL_ARB_sparse_texture_clamp 1\n"
             "#define GL_ARB_shader_stencil_export 1\n"
             "#define GL_ARB_sample_shading 1\n"
+            "#define GL_ARB_shader_image_size 1\n"
 //            "#define GL_ARB_cull_distance 1\n"    // present for 4.5, but need extension control over block members
             "#define GL_ARB_post_depth_coverage 1\n"
             "#define GL_ARB_fragment_shader_interlock 1\n"

--- a/glslang/MachineIndependent/Versions.h
+++ b/glslang/MachineIndependent/Versions.h
@@ -153,6 +153,7 @@ const char* const E_GL_ARB_shader_clock                 = "GL_ARB_shader_clock";
 const char* const E_GL_ARB_uniform_buffer_object        = "GL_ARB_uniform_buffer_object";
 const char* const E_GL_ARB_sample_shading               = "GL_ARB_sample_shading";
 const char* const E_GL_ARB_shader_bit_encoding          = "GL_ARB_shader_bit_encoding";
+const char* const E_GL_ARB_shader_image_size            = "GL_ARB_shader_image_size";
 
 const char* const E_GL_KHR_shader_subgroup_basic            = "GL_KHR_shader_subgroup_basic";
 const char* const E_GL_KHR_shader_subgroup_vote             = "GL_KHR_shader_subgroup_vote";


### PR DESCRIPTION
Based on #2183 which should be merged first. And then the file 150.frag.out needs to be updated, before merging the change.