### PR TITLE
TPpToken: Fix compiling on clang-10

### DIFF
--- a/glslang/MachineIndependent/preprocessor/PpContext.h
+++ b/glslang/MachineIndependent/preprocessor/PpContext.h
@@ -105,13 +105,13 @@ public:
     }
 
     // Used for comparing macro definitions, so checks what is relevant for that.
-    bool operator==(const TPpToken& right)
+    bool operator==(const TPpToken& right) const
     {
         return space == right.space &&
                ival == right.ival && dval == right.dval && i64val == right.i64val &&
                strncmp(name, right.name, MaxTokenLength) == 0;
     }
-    bool operator!=(const TPpToken& right) { return ! operator==(right); }
+    bool operator!=(const TPpToken& right) const { return ! operator==(right); }
 
     TSourceLoc loc;
     // True if a space (for white space or a removed comment) should also be


### PR DESCRIPTION
Currently glslang fails to compile on clang with the following error:
```
FAILED: hecl/extern/boo/glslang/glslang/CMakeFiles/glslang.dir/MachineIndependent/preprocessor/Pp.cpp.o 
/usr/bin/clang++  -DENABLE_OPT=0 -DFMT_EXCEPTIONS=0 -Ihecl -I../hecl/extern/boo/glslang/glslang/.. -g -fPIC   -msse2 -fno-plt -fno-rtti -fno-exceptions -Wall -Wno-multichar -Werror=implicit-fallthrough -Wno-unknown-warning-option -Wno-lto-type-mismatch -Wno-unused-variable -Wno-unused-private-field -Wno-unused-function -Wno-sign-compare -Wno-unknown-pragmas -Werror -fno-limit-debug-info -Wno-implicit-fallthrough -Wno-strict-aliasing -pthread -std=gnu++2a -MD -MT hecl/extern/boo/glslang/glslang/CMakeFiles/glslang.dir/MachineIndependent/preprocessor/Pp.cpp.o -MF hecl/extern/boo/glslang/glslang/CMakeFiles/glslang.dir/MachineIndependent/preprocessor/Pp.cpp.o.d -o hecl/extern/boo/glslang/glslang/CMakeFiles/glslang.dir/MachineIndependent/preprocessor/Pp.cpp.o -c ../hecl/extern/boo/glslang/glslang/MachineIndependent/preprocessor/Pp.cpp
../hecl/extern/boo/glslang/glslang/MachineIndependent/preprocessor/Pp.cpp:200:60: error: use of overloaded operator '!=' is ambiguous (with operand types 'glslang::TPpToken' and 'glslang::TPpToken')
                    if (oldToken != newToken || oldPpToken != newPpToken) {
                                                ~~~~~~~~~~ ^  ~~~~~~~~~~
../hecl/extern/boo/glslang/glslang/MachineIndependent/preprocessor/PpContext.h:114:10: note: candidate function
    bool operator!=(const TPpToken& right) { return ! operator==(right); }
         ^
../hecl/extern/boo/glslang/glslang/MachineIndependent/preprocessor/PpContext.h:108:10: note: candidate function
    bool operator==(const TPpToken& right)
         ^
../hecl/extern/boo/glslang/glslang/MachineIndependent/preprocessor/PpContext.h:108:10: note: candidate function (with reversed parameter order)
1 error generated.
```
Simply making the equality operators `const` resolves this issue.