### PR TITLE
WIP: Implement swizzles containing 0 and 1 to represent numbers not indexes.

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.h
+++ b/glslang/MachineIndependent/ParseHelper.h
@@ -217,7 +217,8 @@ protected:
         /* output */ bool& tie);
 
     virtual void parseSwizzleSelector(const TSourceLoc&, const TString&, int size,
-                                      TSwizzleSelectors<TVectorSelector>&);
+                                      TSwizzleSelectors<TVectorSelector>&, bool& numeric);
+    virtual void replicateRValue(TIntermTyped* node, int n, TVector<TIntermTyped*>& replicates);
 
     // Manage the global uniform block (default uniforms in GLSL, $Global in HLSL)
     TVariable* globalUniformBlock;     // the actual block, inserted into the symbol table
@@ -316,6 +317,8 @@ public:
     TIntermTyped* handleUnaryMath(const TSourceLoc&, const char* str, TOperator op, TIntermTyped* childNode);
     TIntermTyped* handleDotDereference(const TSourceLoc&, TIntermTyped* base, const TString& field);
     TIntermTyped* handleDotSwizzle(const TSourceLoc&, TIntermTyped* base, const TString& field);
+    TIntermTyped* handleNumericDotSwizzle(const TSourceLoc&, TIntermTyped* base,
+        const TSwizzleSelectors<TVectorSelector>&);
     void blockMemberExtensionCheck(const TSourceLoc&, const TIntermTyped* base, int member, const TString& memberName);
     TFunction* handleFunctionDeclarator(const TSourceLoc&, TFunction& function, bool prototype);
     TIntermAggregate* handleFunctionDefinition(const TSourceLoc&, TFunction&);

--- a/hlsl/hlslParseHelper.cpp
+++ b/hlsl/hlslParseHelper.cpp
@@ -952,7 +952,8 @@ TIntermTyped* HlslParseContext::handleDotDereference(const TSourceLoc& loc, TInt
         }
     } else if (base->isVector() || base->isScalar()) {
         TSwizzleSelectors<TVectorSelector> selectors;
-        parseSwizzleSelector(loc, field, base->getVectorSize(), selectors);
+        bool numeric = false;
+        parseSwizzleSelector(loc, field, base->getVectorSize(), selectors, numeric);
 
         if (base->isScalar()) {
             if (selectors.size() == 1)


### PR DESCRIPTION
Add numeric swizzles, as suggested in twitter, to support things like `v.xyz1`.  Just 0 and 1 are supported, mixed in with the normal letter swizzlers.

While this looks trivial, it is actually quite involved to do it without changing the output interface.

Perhaps, this should only be done though as changing the output interface by adding a new operator that means this.

Without that, trying to magically keep existing back ends working and support the new feature, a numeric swizzle turns into something far more complex than a normal swizzle.

For example, a normal swizzle might turn into the subtree:

`(v++).yx`  ->  `swizzle(increment(v), yx)`

While a similar numeric swizzle requires:

```
(v++).yx1 -> sequence(assign(temp, increment(v)),
                      constructVec3(index(symbol(temp), 1),
                                    index(symbol(temp), 0),
                                    fold(convertToFloat(1))))
```

Where, the desired obvious simplifications of that are all special cases.

This PR still leaves some of the as TBD, and begs the question of instead only doing it by widening the output interface.