### PR TITLE
Add an spirv option to control default binding

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -8121,7 +8121,11 @@ spv::Id TGlslangToSpvTraverser::getSymbolId(const glslang::TIntermSymbol* symbol
         builder.addDecoration(id, spv::DecorationBinding, symbol->getQualifier().layoutBinding);
     else if (IsDescriptorResource(symbol->getType())) {
         // default to 0
-        builder.addDecoration(id, spv::DecorationBinding, 0);
+        // If default is disable, binding to -1
+        if (options.defaultBinding)
+            builder.addDecoration(id, spv::DecorationBinding, 0);
+        else
+            builder.addDecoration(id, spv::DecorationBinding, -1, true);
     }
     if (symbol->getQualifier().hasAttachment())
         builder.addDecoration(id, spv::DecorationInputAttachmentIndex, symbol->getQualifier().layoutAttachment);

--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -1202,7 +1202,7 @@ void Builder::addMemberName(Id id, int memberNumber, const char* string)
     names.push_back(std::unique_ptr<Instruction>(name));
 }
 
-void Builder::addDecoration(Id id, Decoration decoration, int num)
+void Builder::addDecoration(Id id, Decoration decoration, int num, bool allowIllegal)
 {
     if (decoration == spv::DecorationMax)
         return;
@@ -1210,7 +1210,7 @@ void Builder::addDecoration(Id id, Decoration decoration, int num)
     Instruction* dec = new Instruction(OpDecorate);
     dec->addIdOperand(id);
     dec->addImmediateOperand(decoration);
-    if (num >= 0)
+    if (allowIllegal || num >= 0)
         dec->addImmediateOperand(num);
 
     decorations.push_back(std::unique_ptr<Instruction>(dec));

--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -316,7 +316,7 @@ public:
     void addExecutionMode(Function*, ExecutionMode mode, int value1 = -1, int value2 = -1, int value3 = -1);
     void addName(Id, const char* name);
     void addMemberName(Id, int member, const char* name);
-    void addDecoration(Id, Decoration, int num = -1);
+    void addDecoration(Id, Decoration, int num = -1, bool allowIllegal = false);
     void addDecoration(Id, Decoration, const char*);
     void addDecorationId(Id id, Decoration, Id idDecoration);
     void addMemberDecoration(Id, unsigned int member, Decoration, int num = -1);

--- a/SPIRV/SpvTools.h
+++ b/SPIRV/SpvTools.h
@@ -53,12 +53,14 @@ namespace glslang {
 
 struct SpvOptions {
     SpvOptions() : generateDebugInfo(false), disableOptimizer(true),
-        optimizeSize(false), disassemble(false), validate(false) { }
+        optimizeSize(false), disassemble(false), validate(false),
+        defaultBinding(true) { }
     bool generateDebugInfo;
     bool disableOptimizer;
     bool optimizeSize;
     bool disassemble;
     bool validate;
+    bool defaultBinding;
 };
 
 #ifdef ENABLE_OPT


### PR DESCRIPTION
Turn off this option can help use generate a no-default binding spirv.
default binding should be generate in iomapper. so if we not do io mapper auto binding, we should get a spirv code without auto binding.
related issue https://github.com/KhronosGroup/glslang/issues/2221