### PR TITLE
fix incorrect error when multiple compilation units don't declare lay…

### DIFF
--- a/Test/baseResults/150.tesc.out
+++ b/Test/baseResults/150.tesc.out
@@ -936,7 +936,6 @@ ERROR: Linking tessellation control stage: can't handle multiple entry points pe
 ERROR: Linking tessellation control stage: Multiple function bodies in multiple compilation units for the same signature in the same stage:
     main(
 ERROR: Linking tessellation control stage: can't handle multiple entry points per stage
-ERROR: Linking tessellation control stage: Contradictory layout vertices values
 ERROR: Linking tessellation control stage: Multiple function bodies in multiple compilation units for the same signature in the same stage:
     main(
 ERROR: Linking tessellation control stage: Multiple function bodies in multiple compilation units for the same signature in the same stage:
@@ -961,7 +960,6 @@ ERROR: Linking tessellation evaluation stage: can't handle multiple entry points
 ERROR: Linking tessellation evaluation stage: Multiple function bodies in multiple compilation units for the same signature in the same stage:
     main(
 ERROR: Linking tessellation evaluation stage: can't handle multiple entry points per stage
-ERROR: Linking tessellation evaluation stage: Contradictory input layout primitives
 ERROR: Linking tessellation evaluation stage: Contradictory input vertex spacing
 ERROR: Linking tessellation evaluation stage: Contradictory triangle ordering
 ERROR: Linking tessellation evaluation stage: Multiple function bodies in multiple compilation units for the same signature in the same stage:

--- a/Test/baseResults/contradict_0.geom.out
+++ b/Test/baseResults/contradict_0.geom.out
@@ -1,0 +1,63 @@
+contradict_0.geom
+Shader version: 330
+invocations = -1
+max_vertices = 4
+input primitive = points
+output primitive = triangle_strip
+0:? Sequence
+0:8  Function Definition: main( ( global void)
+0:8    Function Parameters: 
+0:10    Sequence
+0:10      Sequence
+0:10        move second child to first child ( temp float)
+0:10          'v' ( temp float)
+0:10          Function Call: getV( ( global float)
+0:11      EndPrimitive ( global void)
+0:12      EndPrimitive ( global void)
+0:?   Linker Objects
+
+contradict_1.geom
+Shader version: 330
+invocations = -1
+max_vertices = 6
+input primitive = lines
+output primitive = line_strip
+0:? Sequence
+0:6  Function Definition: getV( ( global float)
+0:6    Function Parameters: 
+0:8    Sequence
+0:8      Branch: Return with expression
+0:8        Constant:
+0:8          1.000000
+0:?   Linker Objects
+
+
+Linked geometry stage:
+
+ERROR: Linking geometry stage: Contradictory layout max_vertices values
+ERROR: Linking geometry stage: Contradictory input layout primitives
+ERROR: Linking geometry stage: Contradictory output layout primitives
+
+Shader version: 330
+invocations = 1
+max_vertices = 4
+input primitive = points
+output primitive = triangle_strip
+0:? Sequence
+0:8  Function Definition: main( ( global void)
+0:8    Function Parameters: 
+0:10    Sequence
+0:10      Sequence
+0:10        move second child to first child ( temp float)
+0:10          'v' ( temp float)
+0:10          Function Call: getV( ( global float)
+0:11      EndPrimitive ( global void)
+0:12      EndPrimitive ( global void)
+0:6  Function Definition: getV( ( global float)
+0:6    Function Parameters: 
+0:8    Sequence
+0:8      Branch: Return with expression
+0:8        Constant:
+0:8          1.000000
+0:?   Linker Objects
+

--- a/Test/contradict_0.geom
+++ b/Test/contradict_0.geom
@@ -1,0 +1,13 @@
+#version 330
+
+layout(points) in;
+layout(triangle_strip, max_vertices = 4) out;
+
+float getV();
+
+void main (void)
+{
+    float v = getV();
+    EndPrimitive();
+    EndPrimitive();
+}

--- a/Test/contradict_1.geom
+++ b/Test/contradict_1.geom
@@ -1,0 +1,9 @@
+#version 330
+
+layout(lines) in;
+layout(line_strip, max_vertices = 6) out;
+
+float getV()
+{
+    return 1.0;
+}

--- a/glslang/MachineIndependent/linkValidate.cpp
+++ b/glslang/MachineIndependent/linkValidate.cpp
@@ -153,7 +153,7 @@ void TIntermediate::mergeModes(TInfoSink& infoSink, TIntermediate& unit)
 
     if (vertices == TQualifier::layoutNotSet)
         vertices = unit.vertices;
-    else if (vertices != unit.vertices) {
+    else if (unit.vertices != TQualifier::layoutNotSet && vertices != unit.vertices) {
         if (language == EShLangGeometry || language == EShLangMeshNV)
             error(infoSink, "Contradictory layout max_vertices values");
         else if (language == EShLangTessControl)
@@ -172,12 +172,12 @@ void TIntermediate::mergeModes(TInfoSink& infoSink, TIntermediate& unit)
 
     if (inputPrimitive == ElgNone)
         inputPrimitive = unit.inputPrimitive;
-    else if (inputPrimitive != unit.inputPrimitive)
+    else if (unit.inputPrimitive != ElgNone && inputPrimitive != unit.inputPrimitive)
         error(infoSink, "Contradictory input layout primitives");
 
     if (outputPrimitive == ElgNone)
         outputPrimitive = unit.outputPrimitive;
-    else if (outputPrimitive != unit.outputPrimitive)
+    else if (unit.outputPrimitive != ElgNone && outputPrimitive != unit.outputPrimitive)
         error(infoSink, "Contradictory output layout primitives");
 
     if (originUpperLeft != unit.originUpperLeft || pixelCenterInteger != unit.pixelCenterInteger)

--- a/gtests/Link.FromFile.cpp
+++ b/gtests/Link.FromFile.cpp
@@ -99,6 +99,7 @@ INSTANTIATE_TEST_CASE_P(
         {"empty.frag", "empty2.frag", "empty3.frag"},
         {"150.tesc", "150.tese", "400.tesc", "400.tese", "410.tesc", "420.tesc", "420.tese"},
         {"max_vertices_0.geom"},
+        {"contradict_0.geom", "contradict_1.geom"},
         {"es-link1.frag", "es-link2.frag"},
         {"missingBodies.vert"},
         {"link.multiAnonBlocksInvalid.0.0.vert", "link.multiAnonBlocksInvalid.0.1.vert"},


### PR DESCRIPTION
…outs

when using multiple compilation units, input/output layouts don't need
to be declared in every unit.