### PR TITLE
Change const char* to std::string for extBuiltinMap in GlslangToSpv

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -251,7 +251,7 @@ protected:
     bool nanMinMaxClamp;               // true if use NMin/NMax/NClamp instead of FMin/FMax/FClamp
     spv::Id stdBuiltins;
     spv::Id nonSemanticDebugPrintf;
-    std::unordered_map<const char*, spv::Id> extBuiltinMap;
+    std::unordered_map<std::string, spv::Id> extBuiltinMap;
 
     std::unordered_map<int, spv::Id> symbolValues;
     std::unordered_set<int> rValueParameters;  // set of formal function parameters passed as rValues,


### PR DESCRIPTION
`extBuiltinMap` is defined as the map <libName, libId>. `const char*` as
the key is not correct. Actually, we care the content of the string
rather than pointer value. The problem is not exposed because we always
use pre-defined const string `spv::E_SPV_XXX`. If the usage is changed
to this, the problem of redefinitions occurs because `getExtBuiltins()`
is malfunction.

```
  std::string ext1("XXX");
  getExtBuiltIns(ext1.c_str());

  std::string ext2("XXX");
  getExtBuiltins(ext2.c_str());
```