### PR TITLE
HLSL: fix handling of uniform qualifier in entry point parameters

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -4388,8 +4388,10 @@ bool TGlslangToSpvTraverser::writableParam(glslang::TStorageQualifier qualifier)
     assert(qualifier == glslang::EvqIn ||
            qualifier == glslang::EvqOut ||
            qualifier == glslang::EvqInOut ||
+           qualifier == glslang::EvqUniform ||
            qualifier == glslang::EvqConstReadOnly);
-    return qualifier != glslang::EvqConstReadOnly;
+    return qualifier != glslang::EvqConstReadOnly &&
+           qualifier != glslang::EvqUniform;
 }
 
 // Is parameter pass-by-original?

--- a/Test/baseResults/hlsl.function.frag.out
+++ b/Test/baseResults/hlsl.function.frag.out
@@ -26,14 +26,14 @@ ERROR: node is still EOpNull!
 0:12  Function Definition: fun4(u1;u1; ( temp 4-component vector of float)
 0:12    Function Parameters: 
 0:12      'id1' ( in uint)
-0:12      'id2' ( in uint)
+0:12      'id2' ( uniform uint)
 0:?     Sequence
 0:13      Branch: Return with expression
 0:13        Construct vec4 ( temp 4-component vector of float)
 0:13          Convert uint to float ( temp float)
 0:13            component-wise multiply ( temp uint)
 0:13              'id1' ( in uint)
-0:13              'id2' ( in uint)
+0:13              'id2' ( uniform uint)
 0:17  Function Definition: fun1(i1; ( temp 4-component vector of float)
 0:17    Function Parameters: 
 0:17      'index' ( in int)
@@ -84,14 +84,14 @@ ERROR: node is still EOpNull!
 0:12  Function Definition: fun4(u1;u1; ( temp 4-component vector of float)
 0:12    Function Parameters: 
 0:12      'id1' ( in uint)
-0:12      'id2' ( in uint)
+0:12      'id2' ( uniform uint)
 0:?     Sequence
 0:13      Branch: Return with expression
 0:13        Construct vec4 ( temp 4-component vector of float)
 0:13          Convert uint to float ( temp float)
 0:13            component-wise multiply ( temp uint)
 0:13              'id1' ( in uint)
-0:13              'id2' ( in uint)
+0:13              'id2' ( uniform uint)
 0:17  Function Definition: fun1(i1; ( temp 4-component vector of float)
 0:17    Function Parameters: 
 0:17      'index' ( in int)

--- a/hlsl/hlslGrammar.cpp
+++ b/hlsl/hlslGrammar.cpp
@@ -697,7 +697,9 @@ bool HlslGrammar::acceptQualifier(TQualifier& qualifier)
             qualifier.noContraction = true;
             break;
         case EHTokIn:
-            qualifier.storage = (qualifier.storage == EvqOut) ? EvqInOut : EvqIn;
+            if (qualifier.storage != EvqUniform) {
+                qualifier.storage = (qualifier.storage == EvqOut) ? EvqInOut : EvqIn;
+            }
             break;
         case EHTokOut:
             qualifier.storage = (qualifier.storage == EvqIn) ? EvqInOut : EvqOut;


### PR DESCRIPTION
Fixes #2253, which is a rather pressing issue for us.  Feel free to discard this or suggest alternatives if you don't like this approach.

The change in a nutshell: when encountering uniforms in the entry point function parameters, instead of erroneously creating a global input variable for them, it now adds them to the $Global uniform block, from which they are accessed and loaded into the temporary variables in the wrapper function.  Opaque types, like textures, still get added as a global uniform variable of course.

Also contains a fix for use of "uniform in" which is supported in function arguments by FXC and handled as a regular uniform.