### PR TITLE
Add default descriptorset decoration for acceleration structure variables.

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -1292,7 +1292,8 @@ bool IsDescriptorResource(const glslang::TType& type)
     // basically samplerXXX/subpass/sampler/texture are all included
     // if they are the global-scope-class, not the function parameter
     // (or local, if they ever exist) class.
-    if (type.getBasicType() == glslang::EbtSampler)
+    if (type.getBasicType() == glslang::EbtSampler ||
+        type.getBasicType() == glslang::EbtAccStruct)
         return type.getQualifier().isUniformOrBuffer();
 
     // None of the above.

--- a/Test/spv.ext.RayGenShader.rgen
+++ b/Test/spv.ext.RayGenShader.rgen
@@ -1,7 +1,7 @@
 #version 460
 #extension GL_EXT_ray_tracing : enable
 #extension GL_EXT_ray_flags_primitive_culling : enable
-layout(binding = 0, set = 0) uniform accelerationStructureEXT accEXT0;
+layout(binding = 0) uniform accelerationStructureEXT accEXT0;
 layout(binding = 1, set = 0) uniform accelerationStructureEXT accEXT1; // Unused
 layout(binding = 2, r32ui) shadercallcoherent uniform uimage2D imageu;
 layout(location = 0) rayPayloadEXT vec4 payload;


### PR DESCRIPTION
Fixes #2247 

I will file a separate bug for enforcing 'binding' qualifier on this type