### PR TITLE
HLSL: Add better diagnostic when using in/out qualifiers in global scope

### DIFF
--- a/Test/baseResults/hlsl.inoutquals.negative.frag.out
+++ b/Test/baseResults/hlsl.inoutquals.negative.frag.out
@@ -1,0 +1,43 @@
+hlsl.inoutquals.negative.frag
+ERROR: 0:1: 'invalid1' : in/out qualifiers are only valid on parameters 
+ERROR: 0:2: 'invalid2' : in/out qualifiers are only valid on parameters 
+ERROR: 0:3: 'invalid3' : in/out qualifiers are only valid on parameters 
+ERROR: 0:4: 'invalid4' : in/out qualifiers are only valid on parameters 
+ERROR: 4 compilation errors.  No code generated.
+
+
+Shader version: 500
+gl_FragCoord origin is upper left
+ERROR: node is still EOpNull!
+0:6  Function Definition: @main( ( temp void)
+0:6    Function Parameters: 
+0:6  Function Definition: main( ( temp void)
+0:6    Function Parameters: 
+0:?     Sequence
+0:6      Function Call: @main( ( temp void)
+0:?   Linker Objects
+0:?     'invalid1' ( in float)
+0:?     'invalid2' ( inout float)
+0:?     'invalid3' ( inout float)
+0:?     'invalid4' ( out float)
+
+
+Linked fragment stage:
+
+
+Shader version: 500
+gl_FragCoord origin is upper left
+ERROR: node is still EOpNull!
+0:6  Function Definition: @main( ( temp void)
+0:6    Function Parameters: 
+0:6  Function Definition: main( ( temp void)
+0:6    Function Parameters: 
+0:?     Sequence
+0:6      Function Call: @main( ( temp void)
+0:?   Linker Objects
+0:?     'invalid1' ( in float)
+0:?     'invalid2' ( inout float)
+0:?     'invalid3' ( inout float)
+0:?     'invalid4' ( out float)
+
+SPIR-V is not generated for failed compile or link

--- a/Test/hlsl.inoutquals.negative.frag
+++ b/Test/hlsl.inoutquals.negative.frag
@@ -1,0 +1,7 @@
+in float invalid1;
+in out float invalid2;
+inout float invalid3;
+out float invalid4;
+
+void main() {
+}

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -239,6 +239,7 @@ INSTANTIATE_TEST_CASE_P(
         {"hlsl.implicitBool.frag", "main"},
         {"hlsl.inf.vert", "main"},
         {"hlsl.inoutquals.frag", "main"},
+        {"hlsl.inoutquals.negative.frag", "main"},
         {"hlsl.init.frag", "ShaderFunction"},
         {"hlsl.init2.frag", "main"},
         {"hlsl.isfinite.frag", "main"},

--- a/hlsl/hlslGrammar.cpp
+++ b/hlsl/hlslGrammar.cpp
@@ -382,6 +382,16 @@ bool HlslGrammar::acceptDeclaration(TIntermNode*& nodeList)
     if (forbidDeclarators)
         return true;
 
+    // Check if there are invalid in/out qualifiers
+    switch (declaredType.getQualifier().storage) {
+    case EvqIn:
+    case EvqOut:
+    case EvqInOut:
+        parseContext.error(token.loc, "in/out qualifiers are only valid on parameters", token.string->c_str(), "");
+    default:
+        break;
+    }
+
     // declarator_list
     //    : declarator
     //         : identifier


### PR DESCRIPTION
Fixes #2252