### PR TITLE
HLSL: Fix incorrect case in name of DX9 cube sampler type

### DIFF
--- a/Test/hlsl.sample.dx9.frag
+++ b/Test/hlsl.sample.dx9.frag
@@ -3,7 +3,7 @@ sampler            g_sam     : register(t0);
 sampler1D          g_sam1D   : register(t1);
 sampler2D          g_sam2D   : register(t2);
 sampler3D          g_sam3D	 : register(t3);
-samplerCube        g_samCube : register(t4);
+samplerCUBE        g_samCube : register(t4);
 
 struct PS_OUTPUT
 {

--- a/hlsl/hlslParseables.cpp
+++ b/hlsl/hlslParseables.cpp
@@ -324,7 +324,7 @@ glslang::TString& AppendTypeName(glslang::TString& s, const char* argOrder, cons
             case 1: s += "1D";                   break;
             case 2: s += (isMS ? "2DMS" : "2D"); break;
             case 3: s += "3D";                   break;
-            case 4: s += "Cube";                 break;
+            case 4: s += (type == 'S'? "CUBE" : "Cube"); break;
             default: s += "UNKNOWN_SAMPLER";     break;
             }
         }

--- a/hlsl/hlslScanContext.cpp
+++ b/hlsl/hlslScanContext.cpp
@@ -317,7 +317,7 @@ void HlslScanContext::fillInKeywordMap()
     (*KeywordMap)["sampler1D"] =               EHTokSampler1d;
     (*KeywordMap)["sampler2D"] =               EHTokSampler2d;
     (*KeywordMap)["sampler3D"] =               EHTokSampler3d;
-    (*KeywordMap)["samplerCube"] =             EHTokSamplerCube;
+    (*KeywordMap)["samplerCUBE"] =             EHTokSamplerCube;
     (*KeywordMap)["sampler_state"] =           EHTokSamplerState;
     (*KeywordMap)["SamplerState"] =            EHTokSamplerState;
     (*KeywordMap)["SamplerComparisonState"] =  EHTokSamplerComparisonState;


### PR DESCRIPTION
The type is named samplerCUBE in HLSL.  I have verified that FXC does not accept samplerCube.