### PR TITLE
Remove unused variable.

### DIFF
--- a/hlsl/hlslParseables.cpp
+++ b/hlsl/hlslParseables.cpp
@@ -334,7 +334,6 @@ glslang::TString& AppendTypeName(glslang::TString& s, const char* argOrder, cons
 inline bool IsValid(const char* cname, char retOrder, char retType, char argOrder, char argType, int dim0, int dim1)
 {
     const bool isVec = (argOrder == 'V');
-    const bool isMat = (argOrder == 'M');
 
     const std::string name(cname);
 


### PR DESCRIPTION
The `isMat` variable is no longer used in the HLSL parser. Removed.