### PR TITLE
Use int instead of enum for EShLanguageMask.

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -5255,7 +5255,7 @@ void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publi
         // setup."
         intermediate.setXfbMode();
         const char* feature = "transform feedback qualifier";
-        requireStage(loc, (EShLanguageMask)(EShLangVertexMask | EShLangGeometryMask | EShLangTessControlMask | EShLangTessEvaluationMask), feature);
+        requireStage(loc, EShLangVertexMask | EShLangGeometryMask | EShLangTessControlMask | EShLangTessEvaluationMask, feature);
         requireProfile(loc, ECoreProfile | ECompatibilityProfile, feature);
         profileRequires(loc, ECoreProfile | ECompatibilityProfile, 440, E_GL_ARB_enhanced_layouts, feature);
         if (id == "xfb_buffer") {
@@ -5913,7 +5913,7 @@ void TParseContext::layoutQualifierCheck(const TSourceLoc& loc, const TQualifier
             if (isEsProfile() && version < 310)
                 requireStage(loc, EShLangVertex, feature);
             else
-                requireStage(loc, (EShLanguageMask)~EShLangComputeMask, feature);
+                requireStage(loc, ~EShLangComputeMask, feature);
             if (language == EShLangVertex) {
                 const char* exts[2] = { E_GL_ARB_separate_shader_objects, E_GL_ARB_explicit_attrib_location };
                 profileRequires(loc, ~EEsProfile, 330, 2, exts, feature);
@@ -5930,7 +5930,7 @@ void TParseContext::layoutQualifierCheck(const TSourceLoc& loc, const TQualifier
             if (isEsProfile() && version < 310)
                 requireStage(loc, EShLangFragment, feature);
             else
-                requireStage(loc, (EShLanguageMask)~EShLangComputeMask, feature);
+                requireStage(loc, ~EShLangComputeMask, feature);
             if (language == EShLangFragment) {
                 const char* exts[2] = { E_GL_ARB_separate_shader_objects, E_GL_ARB_explicit_attrib_location };
                 profileRequires(loc, ~EEsProfile, 330, 2, exts, feature);
@@ -7673,8 +7673,8 @@ void TParseContext::blockStageIoCheck(const TSourceLoc& loc, const TQualifier& q
         profileRequires(loc, ~EEsProfile, 150, E_GL_ARB_separate_shader_objects, "input block");
         // It is a compile-time error to have an input block in a vertex shader or an output block in a fragment shader
         // "Compute shaders do not permit user-defined input variables..."
-        requireStage(loc, (EShLanguageMask)(EShLangTessControlMask|EShLangTessEvaluationMask|EShLangGeometryMask|
-            EShLangFragmentMask|EShLangMeshNVMask), "input block");
+        requireStage(loc, EShLangTessControlMask|EShLangTessEvaluationMask|EShLangGeometryMask|
+            EShLangFragmentMask|EShLangMeshNVMask, "input block");
         if (language == EShLangFragment) {
             profileRequires(loc, EEsProfile, 320, Num_AEP_shader_io_blocks, AEP_shader_io_blocks, "fragment input block");
         } else if (language == EShLangMeshNV && ! qualifier.isTaskMemory()) {
@@ -7683,8 +7683,8 @@ void TParseContext::blockStageIoCheck(const TSourceLoc& loc, const TQualifier& q
         break;
     case EvqVaryingOut:
         profileRequires(loc, ~EEsProfile, 150, E_GL_ARB_separate_shader_objects, "output block");
-        requireStage(loc, (EShLanguageMask)(EShLangVertexMask|EShLangTessControlMask|EShLangTessEvaluationMask|
-            EShLangGeometryMask|EShLangMeshNVMask|EShLangTaskNVMask), "output block");
+        requireStage(loc, EShLangVertexMask|EShLangTessControlMask|EShLangTessEvaluationMask|
+            EShLangGeometryMask|EShLangMeshNVMask|EShLangTaskNVMask, "output block");
         // ES 310 can have a block before shader_io is turned on, so skip this test for built-ins
         if (language == EShLangVertex && ! parsingBuiltins) {
             profileRequires(loc, EEsProfile, 320, Num_AEP_shader_io_blocks, AEP_shader_io_blocks, "vertex output block");
@@ -7697,26 +7697,26 @@ void TParseContext::blockStageIoCheck(const TSourceLoc& loc, const TQualifier& q
 #ifndef GLSLANG_WEB
     case EvqPayload:
         profileRequires(loc, ~EEsProfile, 460, 2, extsrt, "rayPayloadNV block");
-        requireStage(loc, (EShLanguageMask)(EShLangRayGenMask | EShLangAnyHitMask | EShLangClosestHitMask | EShLangMissMask),
+        requireStage(loc, EShLangRayGenMask | EShLangAnyHitMask | EShLangClosestHitMask | EShLangMissMask,
             "rayPayloadNV block");
         break;
     case EvqPayloadIn:
         profileRequires(loc, ~EEsProfile, 460, 2, extsrt, "rayPayloadInNV block");
-        requireStage(loc, (EShLanguageMask)(EShLangAnyHitMask | EShLangClosestHitMask | EShLangMissMask),
+        requireStage(loc, EShLangAnyHitMask | EShLangClosestHitMask | EShLangMissMask,
             "rayPayloadInNV block");
         break;
     case EvqHitAttr:
         profileRequires(loc, ~EEsProfile, 460, 2, extsrt, "hitAttributeNV block");
-        requireStage(loc, (EShLanguageMask)(EShLangIntersectMask | EShLangAnyHitMask | EShLangClosestHitMask), "hitAttributeNV block");
+        requireStage(loc, EShLangIntersectMask | EShLangAnyHitMask | EShLangClosestHitMask, "hitAttributeNV block");
         break;
     case EvqCallableData:
         profileRequires(loc, ~EEsProfile, 460, 2, extsrt, "callableDataNV block");
-        requireStage(loc, (EShLanguageMask)(EShLangRayGenMask | EShLangClosestHitMask | EShLangMissMask | EShLangCallableMask),
+        requireStage(loc, EShLangRayGenMask | EShLangClosestHitMask | EShLangMissMask | EShLangCallableMask,
             "callableDataNV block");
         break;
     case EvqCallableDataIn:
         profileRequires(loc, ~EEsProfile, 460, 2, extsrt, "callableDataInNV block");
-        requireStage(loc, (EShLanguageMask)(EShLangCallableMask), "callableDataInNV block");
+        requireStage(loc, EShLangCallableMask, "callableDataInNV block");
         break;
 #endif
     default:

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -571,7 +571,7 @@ const char* StageName(EShLanguage stage)
 //
 // Operation: If the current stage is not present, give an error message.
 //
-void TParseVersions::requireStage(const TSourceLoc& loc, EShLanguageMask languageMask, const char* featureDesc)
+void TParseVersions::requireStage(const TSourceLoc& loc, int languageMask, const char* featureDesc)
 {
     if (((1 << language) & languageMask) == 0)
         error(loc, "not supported in this stage:", featureDesc, StageName(language));
@@ -917,7 +917,7 @@ void TParseVersions::checkExtensionStage(const TSourceLoc& loc, const char * con
 {
     // GL_NV_mesh_shader extension is only allowed in task/mesh shaders
     if (strcmp(extension, "GL_NV_mesh_shader") == 0) {
-        requireStage(loc, (EShLanguageMask)(EShLangTaskNVMask | EShLangMeshNVMask | EShLangFragmentMask),
+        requireStage(loc, EShLangTaskNVMask | EShLangMeshNVMask | EShLangFragmentMask,
                      "#extension GL_NV_mesh_shader");
         profileRequires(loc, ECoreProfile, 450, 0, "#extension GL_NV_mesh_shader");
         profileRequires(loc, EEsProfile, 320, 0, "#extension GL_NV_mesh_shader");

--- a/glslang/MachineIndependent/glslang.m4
+++ b/glslang/MachineIndependent/glslang.m4
@@ -1225,7 +1225,7 @@ GLSLANG_WEB_EXCLUDE_ON
     | PERPRIMITIVENV {
         // No need for profile version or extension check. Shader stage already checks both.
         parseContext.globalCheck($1.loc, "perprimitiveNV");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangFragmentMask | EShLangMeshNVMask), "perprimitiveNV");
+        parseContext.requireStage($1.loc, EShLangFragmentMask | EShLangMeshNVMask, "perprimitiveNV");
         // Fragment shader stage doesn't check for extension. So we explicitly add below extension check.
         if (parseContext.language == EShLangFragment)
             parseContext.requireExtensions($1.loc, 1, &E_GL_NV_mesh_shader, "perprimitiveNV");
@@ -1242,7 +1242,7 @@ GLSLANG_WEB_EXCLUDE_ON
     | PERTASKNV {
         // No need for profile version or extension check. Shader stage already checks both.
         parseContext.globalCheck($1.loc, "taskNV");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangTaskNVMask | EShLangMeshNVMask), "taskNV");
+        parseContext.requireStage($1.loc, EShLangTaskNVMask | EShLangMeshNVMask, "taskNV");
         $$.init($1.loc);
         $$.qualifier.perTaskNV = true;
     }
@@ -1374,7 +1374,7 @@ storage_qualifier
         parseContext.globalCheck($1.loc, "shared");
         parseContext.profileRequires($1.loc, ECoreProfile | ECompatibilityProfile, 430, E_GL_ARB_compute_shader, "shared");
         parseContext.profileRequires($1.loc, EEsProfile, 310, 0, "shared");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangComputeMask | EShLangMeshNVMask | EShLangTaskNVMask), "shared");
+        parseContext.requireStage($1.loc, EShLangComputeMask | EShLangMeshNVMask | EShLangTaskNVMask, "shared");
         $$.init($1.loc);
         $$.qualifier.storage = EvqShared;
     }
@@ -1412,7 +1412,7 @@ GLSLANG_WEB_EXCLUDE_ON
     }
     | PATCH {
         parseContext.globalCheck($1.loc, "patch");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangTessControlMask | EShLangTessEvaluationMask), "patch");
+        parseContext.requireStage($1.loc, EShLangTessControlMask | EShLangTessEvaluationMask, "patch");
         $$.init($1.loc);
         $$.qualifier.patch = true;
     }
@@ -1423,78 +1423,78 @@ GLSLANG_WEB_EXCLUDE_ON
     }
     | HITATTRNV {
         parseContext.globalCheck($1.loc, "hitAttributeNV");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangIntersectMask | EShLangClosestHitMask
-            | EShLangAnyHitMask), "hitAttributeNV");
+        parseContext.requireStage($1.loc, EShLangIntersectMask | EShLangClosestHitMask
+            | EShLangAnyHitMask, "hitAttributeNV");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_NV_ray_tracing, "hitAttributeNV");
         $$.init($1.loc);
         $$.qualifier.storage = EvqHitAttr;
     }
     | HITATTREXT {
         parseContext.globalCheck($1.loc, "hitAttributeEXT");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangIntersectMask | EShLangClosestHitMask
-            | EShLangAnyHitMask), "hitAttributeEXT");
+        parseContext.requireStage($1.loc, EShLangIntersectMask | EShLangClosestHitMask
+            | EShLangAnyHitMask, "hitAttributeEXT");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_EXT_ray_tracing, "hitAttributeNV");
         $$.init($1.loc);
         $$.qualifier.storage = EvqHitAttr;
     }
     | PAYLOADNV {
         parseContext.globalCheck($1.loc, "rayPayloadNV");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangRayGenMask | EShLangClosestHitMask |
-            EShLangAnyHitMask | EShLangMissMask), "rayPayloadNV");
+        parseContext.requireStage($1.loc, EShLangRayGenMask | EShLangClosestHitMask |
+            EShLangAnyHitMask | EShLangMissMask, "rayPayloadNV");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_NV_ray_tracing, "rayPayloadNV");
         $$.init($1.loc);
         $$.qualifier.storage = EvqPayload;
     }
     | PAYLOADEXT {
         parseContext.globalCheck($1.loc, "rayPayloadEXT");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangRayGenMask | EShLangClosestHitMask |
-            EShLangAnyHitMask | EShLangMissMask), "rayPayloadEXT");
+        parseContext.requireStage($1.loc, EShLangRayGenMask | EShLangClosestHitMask |
+            EShLangAnyHitMask | EShLangMissMask, "rayPayloadEXT");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_EXT_ray_tracing, "rayPayloadEXT");
         $$.init($1.loc);
         $$.qualifier.storage = EvqPayload;
     }
     | PAYLOADINNV {
         parseContext.globalCheck($1.loc, "rayPayloadInNV");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangClosestHitMask |
-            EShLangAnyHitMask | EShLangMissMask), "rayPayloadInNV");
+        parseContext.requireStage($1.loc, EShLangClosestHitMask |
+            EShLangAnyHitMask | EShLangMissMask, "rayPayloadInNV");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_NV_ray_tracing, "rayPayloadInNV");
         $$.init($1.loc);
         $$.qualifier.storage = EvqPayloadIn;
     }
     | PAYLOADINEXT {
         parseContext.globalCheck($1.loc, "rayPayloadInEXT");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangClosestHitMask |
-            EShLangAnyHitMask | EShLangMissMask), "rayPayloadInEXT");
+        parseContext.requireStage($1.loc, EShLangClosestHitMask |
+            EShLangAnyHitMask | EShLangMissMask, "rayPayloadInEXT");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_EXT_ray_tracing, "rayPayloadInEXT");
         $$.init($1.loc);
         $$.qualifier.storage = EvqPayloadIn;
     }
     | CALLDATANV {
         parseContext.globalCheck($1.loc, "callableDataNV");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangRayGenMask |
-            EShLangClosestHitMask | EShLangMissMask | EShLangCallableMask), "callableDataNV");
+        parseContext.requireStage($1.loc, EShLangRayGenMask |
+            EShLangClosestHitMask | EShLangMissMask | EShLangCallableMask, "callableDataNV");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_NV_ray_tracing, "callableDataNV");
         $$.init($1.loc);
         $$.qualifier.storage = EvqCallableData;
     }
     | CALLDATAEXT {
         parseContext.globalCheck($1.loc, "callableDataEXT");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangRayGenMask |
-            EShLangClosestHitMask | EShLangMissMask | EShLangCallableMask), "callableDataEXT");
+        parseContext.requireStage($1.loc, EShLangRayGenMask |
+            EShLangClosestHitMask | EShLangMissMask | EShLangCallableMask, "callableDataEXT");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_EXT_ray_tracing, "callableDataEXT");
         $$.init($1.loc);
         $$.qualifier.storage = EvqCallableData;
     }
     | CALLDATAINNV {
         parseContext.globalCheck($1.loc, "callableDataInNV");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangCallableMask), "callableDataInNV");
+        parseContext.requireStage($1.loc, EShLangCallableMask, "callableDataInNV");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_NV_ray_tracing, "callableDataInNV");
         $$.init($1.loc);
         $$.qualifier.storage = EvqCallableDataIn;
     }
     | CALLDATAINEXT {
         parseContext.globalCheck($1.loc, "callableDataInEXT");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangCallableMask), "callableDataInEXT");
+        parseContext.requireStage($1.loc, EShLangCallableMask, "callableDataInEXT");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_EXT_ray_tracing, "callableDataInEXT");
         $$.init($1.loc);
         $$.qualifier.storage = EvqCallableDataIn;

--- a/glslang/MachineIndependent/glslang.y
+++ b/glslang/MachineIndependent/glslang.y
@@ -1225,7 +1225,7 @@ interpolation_qualifier
     | PERPRIMITIVENV {
         // No need for profile version or extension check. Shader stage already checks both.
         parseContext.globalCheck($1.loc, "perprimitiveNV");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangFragmentMask | EShLangMeshNVMask), "perprimitiveNV");
+        parseContext.requireStage($1.loc, EShLangFragmentMask | EShLangMeshNVMask, "perprimitiveNV");
         // Fragment shader stage doesn't check for extension. So we explicitly add below extension check.
         if (parseContext.language == EShLangFragment)
             parseContext.requireExtensions($1.loc, 1, &E_GL_NV_mesh_shader, "perprimitiveNV");
@@ -1242,7 +1242,7 @@ interpolation_qualifier
     | PERTASKNV {
         // No need for profile version or extension check. Shader stage already checks both.
         parseContext.globalCheck($1.loc, "taskNV");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangTaskNVMask | EShLangMeshNVMask), "taskNV");
+        parseContext.requireStage($1.loc, EShLangTaskNVMask | EShLangMeshNVMask, "taskNV");
         $$.init($1.loc);
         $$.qualifier.perTaskNV = true;
     }
@@ -1374,7 +1374,7 @@ storage_qualifier
         parseContext.globalCheck($1.loc, "shared");
         parseContext.profileRequires($1.loc, ECoreProfile | ECompatibilityProfile, 430, E_GL_ARB_compute_shader, "shared");
         parseContext.profileRequires($1.loc, EEsProfile, 310, 0, "shared");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangComputeMask | EShLangMeshNVMask | EShLangTaskNVMask), "shared");
+        parseContext.requireStage($1.loc, EShLangComputeMask | EShLangMeshNVMask | EShLangTaskNVMask, "shared");
         $$.init($1.loc);
         $$.qualifier.storage = EvqShared;
     }
@@ -1412,7 +1412,7 @@ storage_qualifier
     }
     | PATCH {
         parseContext.globalCheck($1.loc, "patch");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangTessControlMask | EShLangTessEvaluationMask), "patch");
+        parseContext.requireStage($1.loc, EShLangTessControlMask | EShLangTessEvaluationMask, "patch");
         $$.init($1.loc);
         $$.qualifier.patch = true;
     }
@@ -1423,78 +1423,78 @@ storage_qualifier
     }
     | HITATTRNV {
         parseContext.globalCheck($1.loc, "hitAttributeNV");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangIntersectMask | EShLangClosestHitMask
-            | EShLangAnyHitMask), "hitAttributeNV");
+        parseContext.requireStage($1.loc, EShLangIntersectMask | EShLangClosestHitMask
+            | EShLangAnyHitMask, "hitAttributeNV");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_NV_ray_tracing, "hitAttributeNV");
         $$.init($1.loc);
         $$.qualifier.storage = EvqHitAttr;
     }
     | HITATTREXT {
         parseContext.globalCheck($1.loc, "hitAttributeEXT");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangIntersectMask | EShLangClosestHitMask
-            | EShLangAnyHitMask), "hitAttributeEXT");
+        parseContext.requireStage($1.loc, EShLangIntersectMask | EShLangClosestHitMask
+            | EShLangAnyHitMask, "hitAttributeEXT");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_EXT_ray_tracing, "hitAttributeNV");
         $$.init($1.loc);
         $$.qualifier.storage = EvqHitAttr;
     }
     | PAYLOADNV {
         parseContext.globalCheck($1.loc, "rayPayloadNV");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangRayGenMask | EShLangClosestHitMask |
-            EShLangAnyHitMask | EShLangMissMask), "rayPayloadNV");
+        parseContext.requireStage($1.loc, EShLangRayGenMask | EShLangClosestHitMask |
+            EShLangAnyHitMask | EShLangMissMask, "rayPayloadNV");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_NV_ray_tracing, "rayPayloadNV");
         $$.init($1.loc);
         $$.qualifier.storage = EvqPayload;
     }
     | PAYLOADEXT {
         parseContext.globalCheck($1.loc, "rayPayloadEXT");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangRayGenMask | EShLangClosestHitMask |
-            EShLangAnyHitMask | EShLangMissMask), "rayPayloadEXT");
+        parseContext.requireStage($1.loc, EShLangRayGenMask | EShLangClosestHitMask |
+            EShLangAnyHitMask | EShLangMissMask, "rayPayloadEXT");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_EXT_ray_tracing, "rayPayloadEXT");
         $$.init($1.loc);
         $$.qualifier.storage = EvqPayload;
     }
     | PAYLOADINNV {
         parseContext.globalCheck($1.loc, "rayPayloadInNV");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangClosestHitMask |
-            EShLangAnyHitMask | EShLangMissMask), "rayPayloadInNV");
+        parseContext.requireStage($1.loc, EShLangClosestHitMask |
+            EShLangAnyHitMask | EShLangMissMask, "rayPayloadInNV");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_NV_ray_tracing, "rayPayloadInNV");
         $$.init($1.loc);
         $$.qualifier.storage = EvqPayloadIn;
     }
     | PAYLOADINEXT {
         parseContext.globalCheck($1.loc, "rayPayloadInEXT");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangClosestHitMask |
-            EShLangAnyHitMask | EShLangMissMask), "rayPayloadInEXT");
+        parseContext.requireStage($1.loc, EShLangClosestHitMask |
+            EShLangAnyHitMask | EShLangMissMask, "rayPayloadInEXT");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_EXT_ray_tracing, "rayPayloadInEXT");
         $$.init($1.loc);
         $$.qualifier.storage = EvqPayloadIn;
     }
     | CALLDATANV {
         parseContext.globalCheck($1.loc, "callableDataNV");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangRayGenMask |
-            EShLangClosestHitMask | EShLangMissMask | EShLangCallableMask), "callableDataNV");
+        parseContext.requireStage($1.loc, EShLangRayGenMask |
+            EShLangClosestHitMask | EShLangMissMask | EShLangCallableMask, "callableDataNV");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_NV_ray_tracing, "callableDataNV");
         $$.init($1.loc);
         $$.qualifier.storage = EvqCallableData;
     }
     | CALLDATAEXT {
         parseContext.globalCheck($1.loc, "callableDataEXT");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangRayGenMask |
-            EShLangClosestHitMask | EShLangMissMask | EShLangCallableMask), "callableDataEXT");
+        parseContext.requireStage($1.loc, EShLangRayGenMask |
+            EShLangClosestHitMask | EShLangMissMask | EShLangCallableMask, "callableDataEXT");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_EXT_ray_tracing, "callableDataEXT");
         $$.init($1.loc);
         $$.qualifier.storage = EvqCallableData;
     }
     | CALLDATAINNV {
         parseContext.globalCheck($1.loc, "callableDataInNV");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangCallableMask), "callableDataInNV");
+        parseContext.requireStage($1.loc, EShLangCallableMask, "callableDataInNV");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_NV_ray_tracing, "callableDataInNV");
         $$.init($1.loc);
         $$.qualifier.storage = EvqCallableDataIn;
     }
     | CALLDATAINEXT {
         parseContext.globalCheck($1.loc, "callableDataInEXT");
-        parseContext.requireStage($1.loc, (EShLanguageMask)(EShLangCallableMask), "callableDataInEXT");
+        parseContext.requireStage($1.loc, EShLangCallableMask, "callableDataInEXT");
         parseContext.profileRequires($1.loc, ECoreProfile, 460, E_GL_EXT_ray_tracing, "callableDataInEXT");
         $$.init($1.loc);
         $$.qualifier.storage = EvqCallableDataIn;

--- a/glslang/MachineIndependent/glslang_tab.cpp
+++ b/glslang/MachineIndependent/glslang_tab.cpp
@@ -5628,7 +5628,7 @@ yyreduce:
     {
         // No need for profile version or extension check. Shader stage already checks both.
         parseContext.globalCheck((yyvsp[0].lex).loc, "perprimitiveNV");
-        parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangFragmentMask | EShLangMeshNVMask), "perprimitiveNV");
+        parseContext.requireStage((yyvsp[0].lex).loc, EShLangFragmentMask | EShLangMeshNVMask, "perprimitiveNV");
         // Fragment shader stage doesn't check for extension. So we explicitly add below extension check.
         if (parseContext.language == EShLangFragment)
             parseContext.requireExtensions((yyvsp[0].lex).loc, 1, &E_GL_NV_mesh_shader, "perprimitiveNV");
@@ -5655,7 +5655,7 @@ yyreduce:
     {
         // No need for profile version or extension check. Shader stage already checks both.
         parseContext.globalCheck((yyvsp[0].lex).loc, "taskNV");
-        parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangTaskNVMask | EShLangMeshNVMask), "taskNV");
+        parseContext.requireStage((yyvsp[0].lex).loc, EShLangTaskNVMask | EShLangMeshNVMask, "taskNV");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.perTaskNV = true;
     }
@@ -5877,7 +5877,7 @@ yyreduce:
         parseContext.globalCheck((yyvsp[0].lex).loc, "shared");
         parseContext.profileRequires((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, 430, E_GL_ARB_compute_shader, "shared");
         parseContext.profileRequires((yyvsp[0].lex).loc, EEsProfile, 310, 0, "shared");
-        parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangComputeMask | EShLangMeshNVMask | EShLangTaskNVMask), "shared");
+        parseContext.requireStage((yyvsp[0].lex).loc, EShLangComputeMask | EShLangMeshNVMask | EShLangTaskNVMask, "shared");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqShared;
     }
@@ -5934,7 +5934,7 @@ yyreduce:
 #line 1413 "glslang.y" /* yacc.c:1646  */
     {
         parseContext.globalCheck((yyvsp[0].lex).loc, "patch");
-        parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangTessControlMask | EShLangTessEvaluationMask), "patch");
+        parseContext.requireStage((yyvsp[0].lex).loc, EShLangTessControlMask | EShLangTessEvaluationMask, "patch");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.patch = true;
     }
@@ -5955,8 +5955,8 @@ yyreduce:
 #line 1424 "glslang.y" /* yacc.c:1646  */
     {
         parseContext.globalCheck((yyvsp[0].lex).loc, "hitAttributeNV");
-        parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangIntersectMask | EShLangClosestHitMask
-            | EShLangAnyHitMask), "hitAttributeNV");
+        parseContext.requireStage((yyvsp[0].lex).loc, EShLangIntersectMask | EShLangClosestHitMask
+            | EShLangAnyHitMask, "hitAttributeNV");
         parseContext.profileRequires((yyvsp[0].lex).loc, ECoreProfile, 460, E_GL_NV_ray_tracing, "hitAttributeNV");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqHitAttr;
@@ -5968,8 +5968,8 @@ yyreduce:
 #line 1432 "glslang.y" /* yacc.c:1646  */
     {
         parseContext.globalCheck((yyvsp[0].lex).loc, "hitAttributeEXT");
-        parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangIntersectMask | EShLangClosestHitMask
-            | EShLangAnyHitMask), "hitAttributeEXT");
+        parseContext.requireStage((yyvsp[0].lex).loc, EShLangIntersectMask | EShLangClosestHitMask
+            | EShLangAnyHitMask, "hitAttributeEXT");
         parseContext.profileRequires((yyvsp[0].lex).loc, ECoreProfile, 460, E_GL_EXT_ray_tracing, "hitAttributeNV");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqHitAttr;
@@ -5981,8 +5981,8 @@ yyreduce:
 #line 1440 "glslang.y" /* yacc.c:1646  */
     {
         parseContext.globalCheck((yyvsp[0].lex).loc, "rayPayloadNV");
-        parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangRayGenMask | EShLangClosestHitMask |
-            EShLangAnyHitMask | EShLangMissMask), "rayPayloadNV");
+        parseContext.requireStage((yyvsp[0].lex).loc, EShLangRayGenMask | EShLangClosestHitMask |
+            EShLangAnyHitMask | EShLangMissMask, "rayPayloadNV");
         parseContext.profileRequires((yyvsp[0].lex).loc, ECoreProfile, 460, E_GL_NV_ray_tracing, "rayPayloadNV");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqPayload;
@@ -5994,8 +5994,8 @@ yyreduce:
 #line 1448 "glslang.y" /* yacc.c:1646  */
     {
         parseContext.globalCheck((yyvsp[0].lex).loc, "rayPayloadEXT");
-        parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangRayGenMask | EShLangClosestHitMask |
-            EShLangAnyHitMask | EShLangMissMask), "rayPayloadEXT");
+        parseContext.requireStage((yyvsp[0].lex).loc, EShLangRayGenMask | EShLangClosestHitMask |
+            EShLangAnyHitMask | EShLangMissMask, "rayPayloadEXT");
         parseContext.profileRequires((yyvsp[0].lex).loc, ECoreProfile, 460, E_GL_EXT_ray_tracing, "rayPayloadEXT");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqPayload;
@@ -6007,8 +6007,8 @@ yyreduce:
 #line 1456 "glslang.y" /* yacc.c:1646  */
     {
         parseContext.globalCheck((yyvsp[0].lex).loc, "rayPayloadInNV");
-        parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangClosestHitMask |
-            EShLangAnyHitMask | EShLangMissMask), "rayPayloadInNV");
+        parseContext.requireStage((yyvsp[0].lex).loc, EShLangClosestHitMask |
+            EShLangAnyHitMask | EShLangMissMask, "rayPayloadInNV");
         parseContext.profileRequires((yyvsp[0].lex).loc, ECoreProfile, 460, E_GL_NV_ray_tracing, "rayPayloadInNV");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqPayloadIn;
@@ -6020,8 +6020,8 @@ yyreduce:
 #line 1464 "glslang.y" /* yacc.c:1646  */
     {
         parseContext.globalCheck((yyvsp[0].lex).loc, "rayPayloadInEXT");
-        parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangClosestHitMask |
-            EShLangAnyHitMask | EShLangMissMask), "rayPayloadInEXT");
+        parseContext.requireStage((yyvsp[0].lex).loc, EShLangClosestHitMask |
+            EShLangAnyHitMask | EShLangMissMask, "rayPayloadInEXT");
         parseContext.profileRequires((yyvsp[0].lex).loc, ECoreProfile, 460, E_GL_EXT_ray_tracing, "rayPayloadInEXT");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqPayloadIn;
@@ -6033,8 +6033,8 @@ yyreduce:
 #line 1472 "glslang.y" /* yacc.c:1646  */
     {
         parseContext.globalCheck((yyvsp[0].lex).loc, "callableDataNV");
-        parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangRayGenMask |
-            EShLangClosestHitMask | EShLangMissMask | EShLangCallableMask), "callableDataNV");
+        parseContext.requireStage((yyvsp[0].lex).loc, EShLangRayGenMask |
+            EShLangClosestHitMask | EShLangMissMask | EShLangCallableMask, "callableDataNV");
         parseContext.profileRequires((yyvsp[0].lex).loc, ECoreProfile, 460, E_GL_NV_ray_tracing, "callableDataNV");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqCallableData;
@@ -6046,8 +6046,8 @@ yyreduce:
 #line 1480 "glslang.y" /* yacc.c:1646  */
     {
         parseContext.globalCheck((yyvsp[0].lex).loc, "callableDataEXT");
-        parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangRayGenMask |
-            EShLangClosestHitMask | EShLangMissMask | EShLangCallableMask), "callableDataEXT");
+        parseContext.requireStage((yyvsp[0].lex).loc, EShLangRayGenMask |
+            EShLangClosestHitMask | EShLangMissMask | EShLangCallableMask, "callableDataEXT");
         parseContext.profileRequires((yyvsp[0].lex).loc, ECoreProfile, 460, E_GL_EXT_ray_tracing, "callableDataEXT");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqCallableData;
@@ -6059,7 +6059,7 @@ yyreduce:
 #line 1488 "glslang.y" /* yacc.c:1646  */
     {
         parseContext.globalCheck((yyvsp[0].lex).loc, "callableDataInNV");
-        parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangCallableMask), "callableDataInNV");
+        parseContext.requireStage((yyvsp[0].lex).loc, EShLangCallableMask, "callableDataInNV");
         parseContext.profileRequires((yyvsp[0].lex).loc, ECoreProfile, 460, E_GL_NV_ray_tracing, "callableDataInNV");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqCallableDataIn;
@@ -6071,7 +6071,7 @@ yyreduce:
 #line 1495 "glslang.y" /* yacc.c:1646  */
     {
         parseContext.globalCheck((yyvsp[0].lex).loc, "callableDataInEXT");
-        parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangCallableMask), "callableDataInEXT");
+        parseContext.requireStage((yyvsp[0].lex).loc, EShLangCallableMask, "callableDataInEXT");
         parseContext.profileRequires((yyvsp[0].lex).loc, ECoreProfile, 460, E_GL_EXT_ray_tracing, "callableDataInEXT");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqCallableDataIn;

--- a/glslang/MachineIndependent/parseVersions.h
+++ b/glslang/MachineIndependent/parseVersions.h
@@ -67,7 +67,7 @@ public:
         spvVersion(spvVersion), 
         intermediate(interm), messages(messages), numErrors(0), currentScanner(0) { }
     virtual ~TParseVersions() { }
-    void requireStage(const TSourceLoc&, EShLanguageMask, const char* featureDesc);
+    void requireStage(const TSourceLoc&, int, const char* featureDesc);
     void requireStage(const TSourceLoc&, EShLanguage, const char* featureDesc);
 #ifdef GLSLANG_WEB
     const EProfile profile = EEsProfile;


### PR DESCRIPTION
The result of bitwise or and bitwise negation of enums should
be int instead of EShLanguageMask. Otherwise it will be an
undefind behavior and will trigger UBsan.
