### PR TITLE
glslang: Only export public interface for SOs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,18 @@ include(GNUInstallDirs)
 # Needed for CMAKE_DEPENDENT_OPTION macro
 include(CMakeDependentOption)
 
+project(glslang)
+
+################################################################################
+# System defines
+################################################################################
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set(LINUX TRUE)
+endif()
+
+################################################################################
+# Options
+################################################################################
 option(BUILD_SHARED_LIBS "Build Shared Libraries" OFF)
 option(BUILD_EXTERNAL "Build external dependencies in /External" ON)
 
@@ -85,8 +97,6 @@ macro(glslang_pch SRCS PCHCPP)
     list(APPEND ${SRCS} "${PCHCPP}")
   endif()
 endmacro(glslang_pch)
-
-project(glslang)
 
 if(ENABLE_CTEST)
     include(CTest)

--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -1613,7 +1613,7 @@ TGlslangToSpvTraverser::TGlslangToSpvTraverser(unsigned int spvVersion,
     case EShLangAnyHit:
     case EShLangClosestHit:
     case EShLangMiss:
-    case EShLangCallable: 
+    case EShLangCallable:
     {
         auto& extensions = glslangIntermediate->getRequestedExtensions();
         if (extensions.find("GL_NV_ray_tracing") == extensions.end()) {
@@ -1888,7 +1888,7 @@ bool TGlslangToSpvTraverser::visitBinary(glslang::TVisit /* visit */, glslang::T
                 int dummySize;
                 builder.accessChainPushSwizzle(swizzle, convertGlslangToSpvType(node->getLeft()->getType()),
                                                TranslateCoherent(node->getLeft()->getType()),
-                                               glslangIntermediate->getBaseAlignmentScalar(
+                                               glslang::getBaseAlignmentScalar(
                                                    node->getLeft()->getType(), dummySize));
             } else {
 
@@ -1958,7 +1958,7 @@ bool TGlslangToSpvTraverser::visitBinary(glslang::TVisit /* visit */, glslang::T
                 int dummySize;
                 builder.accessChainPushComponent(index, convertGlslangToSpvType(node->getLeft()->getType()),
                                                 TranslateCoherent(node->getLeft()->getType()),
-                                                glslangIntermediate->getBaseAlignmentScalar(node->getLeft()->getType(),
+                                                glslang::getBaseAlignmentScalar(node->getLeft()->getType(),
                                                 dummySize));
             } else
                 builder.accessChainPush(index, TranslateCoherent(node->getLeft()->getType()),
@@ -1973,7 +1973,7 @@ bool TGlslangToSpvTraverser::visitBinary(glslang::TVisit /* visit */, glslang::T
             int dummySize;
             builder.accessChainPushSwizzle(swizzle, convertGlslangToSpvType(node->getLeft()->getType()),
                                            TranslateCoherent(node->getLeft()->getType()),
-                                           glslangIntermediate->getBaseAlignmentScalar(node->getLeft()->getType(),
+                                           glslang::getBaseAlignmentScalar(node->getLeft()->getType(),
                                                dummySize));
         }
         return false;
@@ -2194,7 +2194,7 @@ bool TGlslangToSpvTraverser::visitUnary(glslang::TVisit /* visit */, glslang::TI
         operandNode = node->getOperand()->getAsBinaryNode()->getLeft();
     else
         operandNode = node->getOperand();
-    
+
     operandNode->traverse(this);
 
     spv::Id operand = spv::NoResult;
@@ -3065,7 +3065,7 @@ bool TGlslangToSpvTraverser::visitAggregate(glslang::TVisit visit, glslang::TInt
             break;
         case 1:
             {
-                OpDecorations decorations = { precision, 
+                OpDecorations decorations = { precision,
                                               TranslateNoContractionDecoration(node->getType().getQualifier()),
                                               TranslateNonUniformDecoration(node->getType().getQualifier()) };
                 result = createUnaryOperation(
@@ -3186,7 +3186,7 @@ bool TGlslangToSpvTraverser::visitSelection(glslang::TVisit /* visit */, glslang
             // smear condition to vector, if necessary (AST is always scalar)
             // Before 1.4, smear like for mix(), starting with 1.4, keep it scalar
             if (glslangIntermediate->getSpv().spv < glslang::EShTargetSpv_1_4 && builder.isVector(trueValue)) {
-                condition = builder.smearScalar(spv::NoPrecision, condition, 
+                condition = builder.smearScalar(spv::NoPrecision, condition,
                                                 builder.makeVectorType(builder.makeBoolType(),
                                                                        builder.getNumComponents(trueValue)));
             }
@@ -3975,7 +3975,7 @@ void TGlslangToSpvTraverser::decorateStructType(const glslang::TType& type,
             builder.addMemberDecoration(spvType, member, spv::DecorationLocation, memberQualifier.layoutLocation);
 
         if (qualifier.hasLocation())      // track for upcoming inheritance
-            locationOffset += glslangIntermediate->computeTypeLocationSize(
+            locationOffset += glslang::computeTypeLocationSize(
                                             glslangMember, glslangIntermediate->getStage());
 
         // component, XFB, others
@@ -4269,7 +4269,7 @@ int TGlslangToSpvTraverser::getArrayStride(const glslang::TType& arrayType, glsl
 {
     int size;
     int stride;
-    glslangIntermediate->getMemberAlignment(arrayType, size, stride, explicitLayout,
+    glslang::getMemberAlignment(arrayType, size, stride, explicitLayout,
         matrixLayout == glslang::ElmRowMajor);
 
     return stride;
@@ -4286,7 +4286,7 @@ int TGlslangToSpvTraverser::getMatrixStride(const glslang::TType& matrixType, gl
 
     int size;
     int stride;
-    glslangIntermediate->getMemberAlignment(elementType, size, stride, explicitLayout,
+    glslang::getMemberAlignment(elementType, size, stride, explicitLayout,
         matrixLayout == glslang::ElmRowMajor);
 
     return stride;
@@ -4329,7 +4329,7 @@ void TGlslangToSpvTraverser::updateMemberOffset(const glslang::TType& structType
 
     int memberSize;
     int dummyStride;
-    int memberAlignment = glslangIntermediate->getMemberAlignment(memberType, memberSize, dummyStride, explicitLayout,
+    int memberAlignment = glslang::getMemberAlignment(memberType, memberSize, dummyStride, explicitLayout,
         matrixLayout == glslang::ElmRowMajor);
 
     // Adjust alignment for HLSL rules
@@ -4340,7 +4340,7 @@ void TGlslangToSpvTraverser::updateMemberOffset(const glslang::TType& structType
     if (glslangIntermediate->usingHlslOffsets() &&
         ! memberType.isArray() && memberType.isVector() && structType.getTypeName().compare("$Global") != 0) {
         int dummySize;
-        int componentAlignment = glslangIntermediate->getBaseAlignmentScalar(memberType, dummySize);
+        int componentAlignment = glslang::getBaseAlignmentScalar(memberType, dummySize);
         if (componentAlignment <= 4)
             memberAlignment = componentAlignment;
     }
@@ -4349,7 +4349,7 @@ void TGlslangToSpvTraverser::updateMemberOffset(const glslang::TType& structType
     glslang::RoundToPow2(currentOffset, memberAlignment);
 
     // Bump up to vec4 if there is a bad straddle
-    if (explicitLayout != glslang::ElpScalar && glslangIntermediate->improperStraddle(memberType, memberSize,
+    if (explicitLayout != glslang::ElpScalar && glslang::improperStraddle(memberType, memberSize,
         currentOffset))
         glslang::RoundToPow2(currentOffset, 16);
 
@@ -5201,10 +5201,10 @@ spv::Id TGlslangToSpvTraverser::createImageTextureFunctionCall(glslang::TIntermO
         assert(builder.isStructType(resultStructType));
 
         //resType (SPIR-V type) contains 6 elements:
-        //Member 0 must be a Boolean type scalar(LOD), 
-        //Member 1 must be a vector of integer type, whose Signedness operand is 0(anchor),  
-        //Member 2 must be a vector of integer type, whose Signedness operand is 0(offset), 
-        //Member 3 must be a vector of integer type, whose Signedness operand is 0(mask), 
+        //Member 0 must be a Boolean type scalar(LOD),
+        //Member 1 must be a vector of integer type, whose Signedness operand is 0(anchor),
+        //Member 2 must be a vector of integer type, whose Signedness operand is 0(offset),
+        //Member 3 must be a vector of integer type, whose Signedness operand is 0(mask),
         //Member 4 must be a scalar of integer type, whose Signedness operand is 0(lod),
         //Member 5 must be a scalar of integer type, whose Signedness operand is 0(granularity).
         std::vector<spv::Id> members;
@@ -5217,7 +5217,7 @@ spv::Id TGlslangToSpvTraverser::createImageTextureFunctionCall(glslang::TIntermO
         //call ImageFootprintNV
         spv::Id res = builder.createTextureCall(precision, resType, sparse, cracked.fetch, cracked.proj,
                                                 cracked.gather, noImplicitLod, params, signExtensionMask());
-        
+
         //copy resType (SPIR-V type) to resultStructType(OpenGL type)
         for (int i = 0; i < 5; i++) {
             builder.clearAccessChain();
@@ -5270,7 +5270,7 @@ spv::Id TGlslangToSpvTraverser::createImageTextureFunctionCall(glslang::TIntermO
     }
 #endif
 
-    std::vector<spv::Id> result( 1, 
+    std::vector<spv::Id> result( 1,
         builder.createTextureCall(precision, resultType(), sparse, cracked.fetch, cracked.proj, cracked.gather,
                                   noImplicitLod, params, signExtensionMask())
     );
@@ -6750,7 +6750,7 @@ spv::Id TGlslangToSpvTraverser::createAtomicOperation(glslang::TOperator op, spv
     } else {
         scopeId = builder.makeUintConstant(spv::ScopeDevice);
     }
-    // semantics default to relaxed 
+    // semantics default to relaxed
     spv::Id semanticsId = builder.makeUintConstant(lvalueCoherentFlags.isVolatile() &&
         glslangIntermediate->usingVulkanMemoryModel() ?
                                                     spv::MemorySemanticsVolatileMask :
@@ -8681,7 +8681,7 @@ void OutputSpvHex(const std::vector<unsigned int>& spirv, const char* baseName, 
     out.open(baseName, std::ios::binary | std::ios::out);
     if (out.fail())
         printf("ERROR: Failed to open file: %s\n", baseName);
-    out << "\t// " << 
+    out << "\t// " <<
         GetSpirvGeneratorVersion() << "." << GLSLANG_MINOR_VERSION << "." << GLSLANG_PATCH_LEVEL <<
         std::endl;
     if (varName != nullptr) {

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -63,7 +63,7 @@
 #include "../glslang/OSDependent/osinclude.h"
 
 extern "C" {
-    SH_IMPORT_EXPORT void ShOutputHtml();
+    GLSLANG_EXPORT void ShOutputHtml();
 }
 
 // Command-line options

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -111,8 +111,16 @@ target_include_directories(glslang PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-if(WIN32 AND BUILD_SHARED_LIBS)
-    set_target_properties(glslang PROPERTIES PREFIX "")
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(glslang PUBLIC "GLSLANG_IS_SHARED_LIBRARY=1")
+    if(WIN32)
+        target_compile_definitions(glslang PRIVATE "GLSLANG_EXPORTING=1")
+        set_target_properties(glslang PROPERTIES PREFIX "")
+    elseif(LINUX)
+        target_compile_options(glslang PRIVATE "-fvisibility=hidden")
+        set_target_properties(glslang PROPERTIES
+            LINK_FLAGS "-Wl,--no-undefined")
+    endif()
 endif()
 
 if(WIN32)
@@ -136,9 +144,7 @@ if(ENABLE_GLSLANG_INSTALL)
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endif()
     install(EXPORT glslangTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
-endif(ENABLE_GLSLANG_INSTALL)
 
-if(ENABLE_GLSLANG_INSTALL)
     foreach(file ${HEADERS})
         get_filename_component(dir ${file} DIRECTORY)
         install(FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/glslang/${dir})

--- a/glslang/Include/Export.h
+++ b/glslang/Include/Export.h
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2020 Google LLC.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//    Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//    Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//    Neither the name of 3Dlabs Inc. Ltd. nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef _GLSLANG_EXPORT_INCLUDED_
+#define _GLSLANG_EXPORT_INCLUDED_
+
+#ifdef GLSLANG_IS_SHARED_LIBRARY
+    #ifdef _WIN32
+        #ifdef GLSLANG_EXPORTING
+            #define GLSLANG_EXPORT __declspec(dllexport)
+        #else
+            #define GLSLANG_EXPORT __declspec(dllimport)
+        #endif
+    #elif __GNUC__ >= 4
+        #define GLSLANG_EXPORT __attribute__((visibility("default")))
+    #else
+        #define GLSLANG_EXPORT
+    #endif
+#else // GLSLANG_IS_SHARED_LIBRARY
+    #define GLSLANG_EXPORT
+#endif // GLSLANG_IS_SHARED_LIBRARY
+
+#endif // _GLSLANG_EXPORT_INCLUDED_

--- a/glslang/Include/PoolAlloc.h
+++ b/glslang/Include/PoolAlloc.h
@@ -37,6 +37,8 @@
 #ifndef _POOLALLOC_INCLUDED_
 #define _POOLALLOC_INCLUDED_
 
+#include "Export.h"
+
 #ifdef _DEBUG
 #  define GUARD_BLOCKS  // define to enable guard block sanity checking
 #endif
@@ -146,35 +148,35 @@ private:
 //
 class TPoolAllocator {
 public:
-    TPoolAllocator(int growthIncrement = 8*1024, int allocationAlignment = 16);
+    GLSLANG_EXPORT TPoolAllocator(int growthIncrement = 8*1024, int allocationAlignment = 16);
 
     //
     // Don't call the destructor just to free up the memory, call pop()
     //
-    ~TPoolAllocator();
+    GLSLANG_EXPORT ~TPoolAllocator();
 
     //
     // Call push() to establish a new place to pop memory too.  Does not
     // have to be called to get things started.
     //
-    void push();
+    GLSLANG_EXPORT void push();
 
     //
     // Call pop() to free all memory allocated since the last call to push(),
     // or if no last call to push, frees all memory since first allocation.
     //
-    void pop();
+    GLSLANG_EXPORT void pop();
 
     //
     // Call popAll() to free all memory allocated.
     //
-    void popAll();
+    GLSLANG_EXPORT void popAll();
 
     //
     // Call allocate() to actually acquire memory.  Returns 0 if no memory
     // available, otherwise a properly aligned pointer to 'numBytes' of memory.
     //
-    void* allocate(size_t numBytes);
+    GLSLANG_EXPORT void* allocate(size_t numBytes);
 
     //
     // There is no deallocate.  The point of this class is that
@@ -250,8 +252,8 @@ private:
 // different times.  But a simple use is to have a global pop
 // with everyone using the same global allocator.
 //
-extern TPoolAllocator& GetThreadPoolAllocator();
-void SetThreadPoolAllocator(TPoolAllocator* poolAllocator);
+GLSLANG_EXPORT extern TPoolAllocator& GetThreadPoolAllocator();
+GLSLANG_EXPORT void SetThreadPoolAllocator(TPoolAllocator* poolAllocator);
 
 //
 // This STL compatible allocator is intended to be used as the allocator

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -316,16 +316,6 @@ typedef TVector<TString*> TIdentifierList;
 // used for TPublicType, TType, others.
 //
 
-enum TLayoutPacking {
-    ElpNone,
-    ElpShared,      // default, but different than saying nothing
-    ElpStd140,
-    ElpStd430,
-    ElpPacked,
-    ElpScalar,
-    ElpCount        // If expanding, see bitfield width below
-};
-
 enum TLayoutMatrix {
     ElmNone,
     ElmRowMajor,
@@ -2214,7 +2204,7 @@ public:
             bool hasHiddenMember = true;
             for (size_t i = 0; i < structure->size(); ++i) {
                 if (! (*structure)[i].type->hiddenMember()) {
-                    if (!hasHiddenMember) 
+                    if (!hasHiddenMember)
                         appendStr(", ");
                     typeString.append((*structure)[i].type->getCompleteString());
                     typeString.append(" ");
@@ -2245,7 +2235,7 @@ public:
     void setStruct(TTypeList* s) { assert(isStruct()); structure = s; }
     TTypeList* getWritableStruct() const { assert(isStruct()); return structure; }  // This should only be used when known to not be sharing with other threads
     void setBasicType(const TBasicType& t) { basicType = t; }
-    
+
     int computeNumComponents() const
     {
         int components = 0;

--- a/glslang/MachineIndependent/linkValidate.cpp
+++ b/glslang/MachineIndependent/linkValidate.cpp
@@ -769,8 +769,8 @@ void TIntermediate::finalCheck(TInfoSink& infoSink, bool keepUncalled)
             error(infoSink, "At least one shader must specify a layout(max_vertices = value)");
         break;
     case EShLangFragment:
-        // for GL_ARB_post_depth_coverage, EarlyFragmentTest is set automatically in 
-        // ParseHelper.cpp. So if we reach here, this must be GL_EXT_post_depth_coverage 
+        // for GL_ARB_post_depth_coverage, EarlyFragmentTest is set automatically in
+        // ParseHelper.cpp. So if we reach here, this must be GL_EXT_post_depth_coverage
         // requiring explicit early_fragment_tests
         if (getPostDepthCoverage() && !getEarlyFragmentTests())
             error(infoSink, "post_depth_coverage requires early_fragment_tests");
@@ -1228,6 +1228,11 @@ bool TIntermediate::addUsedConstantId(int id)
 // Return the size of type, as measured by "locations".
 int TIntermediate::computeTypeLocationSize(const TType& type, EShLanguage stage)
 {
+    return glslang::computeTypeLocationSize(type, stage);
+}
+
+int computeTypeLocationSize(const TType& type, EShLanguage stage)
+{
     // "If the declared input is an array of size n and each element takes m locations, it will be assigned m * n
     // consecutive locations..."
     if (type.isArray()) {
@@ -1444,6 +1449,11 @@ const int baseAlignmentVec4Std140 = 16;
 // Return value is the alignment..
 int TIntermediate::getBaseAlignmentScalar(const TType& type, int& size)
 {
+    return glslang::getBaseAlignmentScalar(type, size);
+}
+
+int getBaseAlignmentScalar(const TType& type, int& size)
+{
 #ifdef GLSLANG_WEB
     size = 4; return 4;
 #endif
@@ -1626,6 +1636,11 @@ int TIntermediate::getBaseAlignment(const TType& type, int& size, int& stride, T
 // To aid the basic HLSL rule about crossing vec4 boundaries.
 bool TIntermediate::improperStraddle(const TType& type, int size, int offset)
 {
+    return glslang::improperStraddle(type, size, offset);
+}
+
+bool improperStraddle(const TType& type, int size, int offset)
+{
     if (! type.isVector() || type.isArray())
         return false;
 
@@ -1675,7 +1690,7 @@ int TIntermediate::getScalarAlignment(const TType& type, int& size, int& stride,
 
     if (type.isVector()) {
         int scalarAlign = getBaseAlignmentScalar(type, size);
-        
+
         size *= type.getVectorSize();
         return scalarAlign;
     }
@@ -1696,15 +1711,21 @@ int TIntermediate::getScalarAlignment(const TType& type, int& size, int& stride,
 
     assert(0);  // all cases should be covered above
     size = 1;
-    return 1;    
+    return 1;
 }
 
-int TIntermediate::getMemberAlignment(const TType& type, int& size, int& stride, TLayoutPacking layoutPacking, bool rowMajor)
+int TIntermediate::getMemberAlignment(const TType& type, int& size, int& stride, TLayoutPacking layoutPacking,
+                                      bool rowMajor)
+{
+    return glslang::getMemberAlignment(type, size, stride, layoutPacking, rowMajor);
+}
+
+int getMemberAlignment(const TType& type, int& size, int& stride, TLayoutPacking layoutPacking, bool rowMajor)
 {
     if (layoutPacking == glslang::ElpScalar) {
-        return getScalarAlignment(type, size, stride, rowMajor);
+        return TIntermediate::getScalarAlignment(type, size, stride, rowMajor);
     } else {
-        return getBaseAlignment(type, size, stride, layoutPacking, rowMajor);
+        return TIntermediate::getBaseAlignment(type, size, stride, layoutPacking, rowMajor);
     }
 }
 

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -357,11 +357,11 @@ public:
     }
     const SpvVersion& getSpv() const { return spvVersion; }
     EShLanguage getStage() const { return language; }
-    void updateRequestedExtension(const char* extension, TExtensionBehavior behavior) { 
+    void updateRequestedExtension(const char* extension, TExtensionBehavior behavior) {
         if(requestedExtensions.find(extension) != requestedExtensions.end()) {
-            requestedExtensions[extension] = behavior; 
+            requestedExtensions[extension] = behavior;
         } else {
-            requestedExtensions.insert(std::make_pair(extension, behavior)); 
+            requestedExtensions.insert(std::make_pair(extension, behavior));
         }
     }
 
@@ -820,14 +820,14 @@ public:
     int checkLocationRange(int set, const TIoRange& range, const TType&, bool& typeCollision);
     int addUsedOffsets(int binding, int offset, int numOffsets);
     bool addUsedConstantId(int id);
-    static int computeTypeLocationSize(const TType&, EShLanguage);
+    static int computeTypeLocationSize(const TType&, EShLanguage); // DEPRECATED: Use glslang::computeTypeLocationSize()
     static int computeTypeUniformLocationSize(const TType&);
 
-    static int getBaseAlignmentScalar(const TType&, int& size);
+    static int getBaseAlignmentScalar(const TType&, int& size); // DEPRECATED: Use glslang::getBaseAlignmentScalar()
     static int getBaseAlignment(const TType&, int& size, int& stride, TLayoutPacking layoutPacking, bool rowMajor);
     static int getScalarAlignment(const TType&, int& size, int& stride, bool rowMajor);
-    static int getMemberAlignment(const TType&, int& size, int& stride, TLayoutPacking layoutPacking, bool rowMajor);
-    static bool improperStraddle(const TType& type, int size, int offset);
+    static int getMemberAlignment(const TType&, int& size, int& stride, TLayoutPacking layoutPacking, bool rowMajor); // DEPRECATED: Use glslang::getMemberAlignment()
+    static bool improperStraddle(const TType& type, int size, int offset);  // DEPRECATED: Use glslang::improperStraddle()
     static void updateOffset(const TType& parentType, const TType& memberType, int& offset, int& memberSize);
     static int getOffset(const TType& type, int index);
     static int getBlockSize(const TType& blockType);

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -37,6 +37,7 @@
 #ifndef _COMPILER_INTERFACE_INCLUDED_
 #define _COMPILER_INTERFACE_INCLUDED_
 
+#include "../Include/Export.h"
 #include "../Include/ResourceLimits.h"
 #include "../MachineIndependent/Versions.h"
 
@@ -44,16 +45,9 @@
 #include <vector>
 
 #ifdef _WIN32
-#define C_DECL __cdecl
-//#ifdef SH_EXPORTING
-//    #define SH_IMPORT_EXPORT __declspec(dllexport)
-//#else
-//    #define SH_IMPORT_EXPORT __declspec(dllimport)
-//#endif
-#define SH_IMPORT_EXPORT
+    #define C_DECL __cdecl
 #else
-#define SH_IMPORT_EXPORT
-#define C_DECL
+    #define C_DECL
 #endif
 
 //
@@ -75,12 +69,12 @@
 //
 // (Call once per process, not once per thread.)
 //
-SH_IMPORT_EXPORT int ShInitialize();
+GLSLANG_EXPORT int ShInitialize();
 
 //
 // Call this at process shutdown to clean up memory.
 //
-SH_IMPORT_EXPORT int ShFinalize();
+GLSLANG_EXPORT int ShFinalize();
 
 //
 // Types of languages the compiler can consume.
@@ -205,7 +199,7 @@ struct TEnvironment {
     TTarget target;           // what to generate
 };
 
-const char* StageName(EShLanguage);
+GLSLANG_EXPORT const char* StageName(EShLanguage);
 
 } // end namespace glslang
 
@@ -306,10 +300,10 @@ typedef void* ShHandle;
 // Driver calls these to create and destroy compiler/linker
 // objects.
 //
-SH_IMPORT_EXPORT ShHandle ShConstructCompiler(const EShLanguage, int debugOptions);  // one per shader
-SH_IMPORT_EXPORT ShHandle ShConstructLinker(const EShExecutable, int debugOptions);  // one per shader pair
-SH_IMPORT_EXPORT ShHandle ShConstructUniformMap();                 // one per uniform namespace (currently entire program object)
-SH_IMPORT_EXPORT void ShDestruct(ShHandle);
+GLSLANG_EXPORT ShHandle ShConstructCompiler(const EShLanguage, int debugOptions);  // one per shader
+GLSLANG_EXPORT ShHandle ShConstructLinker(const EShExecutable, int debugOptions);  // one per shader pair
+GLSLANG_EXPORT ShHandle ShConstructUniformMap();                 // one per uniform namespace (currently entire program object)
+GLSLANG_EXPORT void ShDestruct(ShHandle);
 
 //
 // The return value of ShCompile is boolean, non-zero indicating
@@ -318,7 +312,7 @@ SH_IMPORT_EXPORT void ShDestruct(ShHandle);
 // The info-log should be written by ShCompile into
 // ShHandle, so it can answer future queries.
 //
-SH_IMPORT_EXPORT int ShCompile(
+GLSLANG_EXPORT int ShCompile(
     const ShHandle,
     const char* const shaderStrings[],
     const int numStrings,
@@ -331,7 +325,7 @@ SH_IMPORT_EXPORT int ShCompile(
     EShMessages messages = EShMsgDefault // warnings and errors
     );
 
-SH_IMPORT_EXPORT int ShLinkExt(
+GLSLANG_EXPORT int ShLinkExt(
     const ShHandle,               // linker object
     const ShHandle h[],           // compiler objects to link together
     const int numHandles);
@@ -340,26 +334,26 @@ SH_IMPORT_EXPORT int ShLinkExt(
 // ShSetEncrpytionMethod is a place-holder for specifying
 // how source code is encrypted.
 //
-SH_IMPORT_EXPORT void ShSetEncryptionMethod(ShHandle);
+GLSLANG_EXPORT void ShSetEncryptionMethod(ShHandle);
 
 //
 // All the following return 0 if the information is not
 // available in the object passed down, or the object is bad.
 //
-SH_IMPORT_EXPORT const char* ShGetInfoLog(const ShHandle);
-SH_IMPORT_EXPORT const void* ShGetExecutable(const ShHandle);
-SH_IMPORT_EXPORT int ShSetVirtualAttributeBindings(const ShHandle, const ShBindingTable*);   // to detect user aliasing
-SH_IMPORT_EXPORT int ShSetFixedAttributeBindings(const ShHandle, const ShBindingTable*);     // to force any physical mappings
+GLSLANG_EXPORT const char* ShGetInfoLog(const ShHandle);
+GLSLANG_EXPORT const void* ShGetExecutable(const ShHandle);
+GLSLANG_EXPORT int ShSetVirtualAttributeBindings(const ShHandle, const ShBindingTable*);   // to detect user aliasing
+GLSLANG_EXPORT int ShSetFixedAttributeBindings(const ShHandle, const ShBindingTable*);     // to force any physical mappings
 //
 // Tell the linker to never assign a vertex attribute to this list of physical attributes
 //
-SH_IMPORT_EXPORT int ShExcludeAttributes(const ShHandle, int *attributes, int count);
+GLSLANG_EXPORT int ShExcludeAttributes(const ShHandle, int *attributes, int count);
 
 //
 // Returns the location ID of the named uniform.
 // Returns -1 if error.
 //
-SH_IMPORT_EXPORT int ShGetUniformLocation(const ShHandle uniformMap, const char* name);
+GLSLANG_EXPORT int ShGetUniformLocation(const ShHandle uniformMap, const char* name);
 
 #ifdef __cplusplus
     }  // end extern "C"
@@ -390,19 +384,19 @@ class TInfoSink;
 
 namespace glslang {
 
-const char* GetEsslVersionString();
-const char* GetGlslVersionString();
-int GetKhronosToolId();
+GLSLANG_EXPORT const char* GetEsslVersionString();
+GLSLANG_EXPORT const char* GetGlslVersionString();
+GLSLANG_EXPORT int GetKhronosToolId();
 
 class TIntermediate;
 class TProgram;
 class TPoolAllocator;
 
 // Call this exactly once per process before using anything else
-bool InitializeProcess();
+GLSLANG_EXPORT bool InitializeProcess();
 
 // Call once per process to tear down everything
-void FinalizeProcess();
+GLSLANG_EXPORT void FinalizeProcess();
 
 // Resource type for IO resolver
 enum TResourceType {
@@ -415,6 +409,15 @@ enum TResourceType {
     EResCount
 };
 
+enum TLayoutPacking {
+    ElpNone,
+    ElpShared,      // default, but different than saying nothing
+    ElpStd140,
+    ElpStd430,
+    ElpPacked,
+    ElpScalar,
+    ElpCount        // If expanding, see bitfield width below
+};
 
 // Make one TShader per shader that you will link into a program. Then
 //  - provide the shader through setStrings() or setStringsWithLengths()
@@ -435,40 +438,41 @@ enum TResourceType {
 //
 class TShader {
 public:
-    explicit TShader(EShLanguage);
-    virtual ~TShader();
-    void setStrings(const char* const* s, int n);
-    void setStringsWithLengths(const char* const* s, const int* l, int n);
-    void setStringsWithLengthsAndNames(
+    GLSLANG_EXPORT explicit TShader(EShLanguage);
+    GLSLANG_EXPORT virtual ~TShader();
+    GLSLANG_EXPORT void setStrings(const char* const* s, int n);
+    GLSLANG_EXPORT void setStringsWithLengths(
+        const char* const* s, const int* l, int n);
+    GLSLANG_EXPORT void setStringsWithLengthsAndNames(
         const char* const* s, const int* l, const char* const* names, int n);
     void setPreamble(const char* s) { preamble = s; }
-    void setEntryPoint(const char* entryPoint);
-    void setSourceEntryPoint(const char* sourceEntryPointName);
-    void addProcesses(const std::vector<std::string>&);
+    GLSLANG_EXPORT void setEntryPoint(const char* entryPoint);
+    GLSLANG_EXPORT void setSourceEntryPoint(const char* sourceEntryPointName);
+    GLSLANG_EXPORT void addProcesses(const std::vector<std::string>&);
 
     // IO resolver binding data: see comments in ShaderLang.cpp
-    void setShiftBinding(TResourceType res, unsigned int base);
-    void setShiftSamplerBinding(unsigned int base);  // DEPRECATED: use setShiftBinding
-    void setShiftTextureBinding(unsigned int base);  // DEPRECATED: use setShiftBinding
-    void setShiftImageBinding(unsigned int base);    // DEPRECATED: use setShiftBinding
-    void setShiftUboBinding(unsigned int base);      // DEPRECATED: use setShiftBinding
-    void setShiftUavBinding(unsigned int base);      // DEPRECATED: use setShiftBinding
-    void setShiftCbufferBinding(unsigned int base);  // synonym for setShiftUboBinding
-    void setShiftSsboBinding(unsigned int base);     // DEPRECATED: use setShiftBinding
-    void setShiftBindingForSet(TResourceType res, unsigned int base, unsigned int set);
-    void setResourceSetBinding(const std::vector<std::string>& base);
-    void setAutoMapBindings(bool map);
-    void setAutoMapLocations(bool map);
-    void addUniformLocationOverride(const char* name, int loc);
-    void setUniformLocationBase(int base);
-    void setInvertY(bool invert);
+    GLSLANG_EXPORT void setShiftBinding(TResourceType res, unsigned int base);
+    GLSLANG_EXPORT void setShiftSamplerBinding(unsigned int base);  // DEPRECATED: use setShiftBinding
+    GLSLANG_EXPORT void setShiftTextureBinding(unsigned int base);  // DEPRECATED: use setShiftBinding
+    GLSLANG_EXPORT void setShiftImageBinding(unsigned int base);    // DEPRECATED: use setShiftBinding
+    GLSLANG_EXPORT void setShiftUboBinding(unsigned int base);      // DEPRECATED: use setShiftBinding
+    GLSLANG_EXPORT void setShiftUavBinding(unsigned int base);      // DEPRECATED: use setShiftBinding
+    GLSLANG_EXPORT void setShiftCbufferBinding(unsigned int base);  // synonym for setShiftUboBinding
+    GLSLANG_EXPORT void setShiftSsboBinding(unsigned int base);     // DEPRECATED: use setShiftBinding
+    GLSLANG_EXPORT void setShiftBindingForSet(TResourceType res, unsigned int base, unsigned int set);
+    GLSLANG_EXPORT void setResourceSetBinding(const std::vector<std::string>& base);
+    GLSLANG_EXPORT void setAutoMapBindings(bool map);
+    GLSLANG_EXPORT void setAutoMapLocations(bool map);
+    GLSLANG_EXPORT void addUniformLocationOverride(const char* name, int loc);
+    GLSLANG_EXPORT void setUniformLocationBase(int base);
+    GLSLANG_EXPORT void setInvertY(bool invert);
 #ifdef ENABLE_HLSL
-    void setHlslIoMapping(bool hlslIoMap);
-    void setFlattenUniformArrays(bool flatten);
+    GLSLANG_EXPORT void setHlslIoMapping(bool hlslIoMap);
+    GLSLANG_EXPORT void setFlattenUniformArrays(bool flatten);
 #endif
-    void setNoStorageFormat(bool useUnknownFormat);
-    void setNanMinMaxClamp(bool nanMinMaxClamp);
-    void setTextureSamplerTransformMode(EShTextureSamplerTransformMode mode);
+    GLSLANG_EXPORT void setNoStorageFormat(bool useUnknownFormat);
+    GLSLANG_EXPORT void setNanMinMaxClamp(bool nanMinMaxClamp);
+    GLSLANG_EXPORT void setTextureSamplerTransformMode(EShTextureSamplerTransformMode mode);
 
     // For setting up the environment (cleared to nothingness in the constructor).
     // These must be called so that parsing is done for the right source language and
@@ -608,8 +612,10 @@ public:
         virtual void releaseInclude(IncludeResult*) override { }
     };
 
-    bool parse(const TBuiltInResource*, int defaultVersion, EProfile defaultProfile, bool forceDefaultVersionAndProfile,
-               bool forwardCompatible, EShMessages, Includer&);
+    GLSLANG_EXPORT bool parse(
+        const TBuiltInResource*, int defaultVersion, EProfile defaultProfile,
+        bool forceDefaultVersionAndProfile, bool forwardCompatible,
+        EShMessages, Includer&);
 
     bool parse(const TBuiltInResource* res, int defaultVersion, EProfile defaultProfile, bool forceDefaultVersionAndProfile,
                bool forwardCompatible, EShMessages messages)
@@ -632,13 +638,14 @@ public:
 
     // NOTE: Doing just preprocessing to obtain a correct preprocessed shader string
     // is not an officially supported or fully working path.
-    bool preprocess(const TBuiltInResource* builtInResources,
-                    int defaultVersion, EProfile defaultProfile, bool forceDefaultVersionAndProfile,
-                    bool forwardCompatible, EShMessages message, std::string* outputString,
-                    Includer& includer);
+    GLSLANG_EXPORT bool preprocess(
+        const TBuiltInResource* builtInResources, int defaultVersion,
+        EProfile defaultProfile, bool forceDefaultVersionAndProfile,
+        bool forwardCompatible, EShMessages message, std::string* outputString,
+        Includer& includer);
 
-    const char* getInfoLog();
-    const char* getInfoDebugLog();
+    GLSLANG_EXPORT const char* getInfoLog();
+    GLSLANG_EXPORT const char* getInfoDebugLog();
     EShLanguage getStage() const { return stage; }
     TIntermediate* getIntermediate() const { return intermediate; }
 
@@ -683,11 +690,11 @@ private:
 // Data needed for just a single object at the granularity exchanged by the reflection API
 class TObjectReflection {
 public:
-    TObjectReflection(const std::string& pName, const TType& pType, int pOffset, int pGLDefineType, int pSize, int pIndex);
+    GLSLANG_EXPORT TObjectReflection(const std::string& pName, const TType& pType, int pOffset, int pGLDefineType, int pSize, int pIndex);
 
-    const TType* getType() const { return type; }
-    int getBinding() const;
-    void dump() const;
+    GLSLANG_EXPORT const TType* getType() const { return type; }
+    GLSLANG_EXPORT int getBinding() const;
+    GLSLANG_EXPORT void dump() const;
     static TObjectReflection badReflection() { return TObjectReflection(); }
 
     std::string name;
@@ -802,14 +809,14 @@ public:
 //
 class TProgram {
 public:
-    TProgram();
-    virtual ~TProgram();
+    GLSLANG_EXPORT TProgram();
+    GLSLANG_EXPORT virtual ~TProgram();
     void addShader(TShader* shader) { stages[shader->stage].push_back(shader); }
     std::list<TShader*>& getShaders(EShLanguage stage) { return stages[stage]; }
     // Link Validation interface
-    bool link(EShMessages);
-    const char* getInfoLog();
-    const char* getInfoDebugLog();
+    GLSLANG_EXPORT bool link(EShMessages);
+    GLSLANG_EXPORT const char* getInfoLog();
+    GLSLANG_EXPORT const char* getInfoDebugLog();
 
     TIntermediate* getIntermediate(EShLanguage stage) const { return intermediate[stage]; }
 
@@ -818,24 +825,24 @@ public:
     // Reflection Interface
 
     // call first, to do liveness analysis, index mapping, etc.; returns false on failure
-    bool buildReflection(int opts = EShReflectionDefault);
-    unsigned getLocalSize(int dim) const;                  // return dim'th local size
-    int getReflectionIndex(const char *name) const;
-    int getReflectionPipeIOIndex(const char* name, const bool inOrOut) const;
-    int getNumUniformVariables() const;
-    const TObjectReflection& getUniform(int index) const;
-    int getNumUniformBlocks() const;
-    const TObjectReflection& getUniformBlock(int index) const;
-    int getNumPipeInputs() const;
-    const TObjectReflection& getPipeInput(int index) const;
-    int getNumPipeOutputs() const;
-    const TObjectReflection& getPipeOutput(int index) const;
-    int getNumBufferVariables() const;
-    const TObjectReflection& getBufferVariable(int index) const;
-    int getNumBufferBlocks() const;
-    const TObjectReflection& getBufferBlock(int index) const;
-    int getNumAtomicCounters() const;
-    const TObjectReflection& getAtomicCounter(int index) const;
+    GLSLANG_EXPORT bool buildReflection(int opts = EShReflectionDefault);
+    GLSLANG_EXPORT unsigned getLocalSize(int dim) const;                  // return dim'th local size
+    GLSLANG_EXPORT int getReflectionIndex(const char *name) const;
+    GLSLANG_EXPORT int getReflectionPipeIOIndex(const char* name, const bool inOrOut) const;
+    GLSLANG_EXPORT int getNumUniformVariables() const;
+    GLSLANG_EXPORT const TObjectReflection& getUniform(int index) const;
+    GLSLANG_EXPORT int getNumUniformBlocks() const;
+    GLSLANG_EXPORT const TObjectReflection& getUniformBlock(int index) const;
+    GLSLANG_EXPORT int getNumPipeInputs() const;
+    GLSLANG_EXPORT const TObjectReflection& getPipeInput(int index) const;
+    GLSLANG_EXPORT int getNumPipeOutputs() const;
+    GLSLANG_EXPORT const TObjectReflection& getPipeOutput(int index) const;
+    GLSLANG_EXPORT int getNumBufferVariables() const;
+    GLSLANG_EXPORT const TObjectReflection& getBufferVariable(int index) const;
+    GLSLANG_EXPORT int getNumBufferBlocks() const;
+    GLSLANG_EXPORT const TObjectReflection& getBufferBlock(int index) const;
+    GLSLANG_EXPORT int getNumAtomicCounters() const;
+    GLSLANG_EXPORT const TObjectReflection& getAtomicCounter(int index) const;
 
     // Legacy Reflection Interface - expressed in terms of above interface
 
@@ -902,15 +909,15 @@ public:
     // returns a TType*
     const TType *getAttributeTType(int index) const    { return getPipeInput(index).getType(); }
 
-    void dumpReflection();
+    GLSLANG_EXPORT void dumpReflection();
     // I/O mapping: apply base offsets and map live unbound variables
     // If resolver is not provided it uses the previous approach
     // and respects auto assignment and offsets.
-    bool mapIO(TIoMapResolver* pResolver = nullptr, TIoMapper* pIoMapper = nullptr);
+    GLSLANG_EXPORT bool mapIO(TIoMapResolver* pResolver = nullptr, TIoMapper* pIoMapper = nullptr);
 #endif
 
 protected:
-    bool linkStage(EShLanguage, EShMessages);
+    GLSLANG_EXPORT bool linkStage(EShLanguage, EShMessages);
 
     TPoolAllocator* pool;
     std::list<TShader*> stages[EShLangCount];
@@ -926,6 +933,18 @@ private:
     TProgram(TProgram&);
     TProgram& operator=(TProgram&);
 };
+
+// Recursively figure out how many locations are used up by an input or output type.
+// Return the size of type, as measured by "locations".
+GLSLANG_EXPORT int computeTypeLocationSize(const TType&, EShLanguage);
+
+// Return the size and alignment of a component of the given type.
+// The size is returned in the 'size' parameter
+// Return value is the alignment..
+GLSLANG_EXPORT int getBaseAlignmentScalar(const TType&, int& size);
+
+GLSLANG_EXPORT int getMemberAlignment(const TType&, int& size, int& stride, TLayoutPacking layoutPacking, bool rowMajor);
+GLSLANG_EXPORT bool improperStraddle(const TType& type, int size, int offset);
 
 } // end namespace glslang
 


### PR DESCRIPTION
Default to `-fvisibility=hidden`, and annotate the public glslang interface with `GLSLANG_EXPORT` to change the visibility of these cherry-picked symbols to default.
This is also used by Windows builds for `__declspec(dllexport)`-ing the public DLL interface.

This allows us to classify API changes into those that are publicly backwards compatible, and those that are not.

Note that libSPIRV will likely need similar treatment.