### PR TITLE
Fixed msvc 2019 nmake compiler warnings with RTTI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,12 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" AND NOT MSVC)
     endif()
 elseif(MSVC)
     if(NOT ENABLE_RTTI)
-        add_compile_options(/GR-) # Disable RTTI
+        string(FIND "${CMAKE_CXX_FLAGS}" "/GR" MSVC_HAS_GR)
+        if(MSVC_HAS_GR)
+            string(REGEX REPLACE /GR /GR- CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+        else()
+            add_compile_options(/GR-) # Disable RTTI
+        endif()
     endif()
     if(ENABLE_EXCEPTIONS)
         add_compile_options(/EHsc) # Enable Exceptions


### PR DESCRIPTION
By default cmake generates cxx_flags with `/GR` parameter.
I updated CMAKE_CXX_FLAGS string and replaced `/GR` -> `/GR-`

How to reproduce:

Visual Studio 2019 x64 command port

mkdir build-msvc2019
cd build-msvc2019
cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LIBDIR=install ..
nmake

COMPILATION BEFORE:

Scanning dependencies of target OSDependent
[  1%] Building CXX object glslang/OSDependent/Windows/CMakeFiles/OSDependent.dir/ossource.cpp.obj
cl : Command line warning D9025 : overriding '/GR' with '/GR-'
ossource.cpp
[  3%] Linking CXX static library OSDependent.lib
[  3%] Built target OSDependent
Scanning dependencies of target OGLCompiler
[  4%] Building CXX object OGLCompilersDLL/CMakeFiles/OGLCompiler.dir/InitializeDll.cpp.obj
cl : Command line warning D9025 : overriding '/GR' with '/GR-'
InitializeDll.cpp
[  6%] Linking CXX static library OGLCompiler.lib
[  6%] Built target OGLCompiler
Scanning dependencies of target glslang
[  7%] Building CXX object glslang/CMakeFiles/glslang.dir/MachineIndependent/glslang_tab.cpp.obj
cl : Command line warning D9025 : overriding '/GR' with '/GR-'
glslang_tab.cpp
[  9%] Building CXX object glslang/CMakeFiles/glslang.dir/MachineIndependent/attribute.cpp.obj
cl : Command line warning D9025 : overriding '/GR' with '/GR-'

FLAGS BEFORE:

-- CMAKE_C_FLAGS:   /DWIN32 /D_WINDOWS /W3
-- CMAKE_CXX_FLAGS: /DWIN32 /D_WINDOWS /W3 /GR /EHsc
-- CMAKE_CXX_FLAGS_DEBUG:   /MDd /Zi /Ob0 /Od /RTC1
-- CMAKE_CXX_FLAGS_RELEASE: /MD /O2 /Ob2 /DNDEBUG

COMPILATION AFTER:

[  1%] Building CXX object glslang/OSDependent/Windows/CMakeFiles/OSDependent.dir/ossource.cpp.obj
ossource.cpp
[  3%] Linking CXX static library OSDependent.lib
[  3%] Built target OSDependent
[  4%] Building CXX object OGLCompilersDLL/CMakeFiles/OGLCompiler.dir/InitializeDll.cpp.obj
InitializeDll.cpp
[  6%] Linking CXX static library OGLCompiler.lib
[  6%] Built target OGLCompiler
[  7%] Building CXX object glslang/CMakeFiles/glslang.dir/MachineIndependent/glslang_tab.cpp.obj
glslang_tab.cpp
[  9%] Building CXX object glslang/CMakeFiles/glslang.dir/MachineIndependent/attribute.cpp.obj

FLAGS AFTER:

-- CMAKE_C_FLAGS:   /DWIN32 /D_WINDOWS /W3
-- CMAKE_CXX_FLAGS: /DWIN32 /D_WINDOWS /W3 /GR- /EHsc
-- CMAKE_CXX_FLAGS_DEBUG:   /MDd /Zi /Ob0 /Od /RTC1
-- CMAKE_CXX_FLAGS_RELEASE: /MD /O2 /Ob2 /DNDEBUG