### PR TITLE
Kokoro: Split linux cmake cfgs into static/shared

### DIFF
--- a/kokoro/linux-clang-cmake/build-docker.sh
+++ b/kokoro/linux-clang-cmake/build-docker.sh
@@ -46,5 +46,5 @@ using ninja-1.10.0
 echo "Building..."
 mkdir /build && cd /build
 
-cmake "$ROOT_DIR" -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$(pwd)/install"
+cmake "$ROOT_DIR" -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS
 ninja install

--- a/kokoro/linux-clang-cmake/build.sh
+++ b/kokoro/linux-clang-cmake/build.sh
@@ -43,5 +43,6 @@ docker run --rm -i \
   --workdir "${ROOT_DIR}" \
   --env ROOT_DIR="${ROOT_DIR}" \
   --env SCRIPT_DIR="${SCRIPT_DIR}" \
+  --env BUILD_SHARED_LIBS="${BUILD_SHARED_LIBS:-0}" \
   --entrypoint "${SCRIPT_DIR}/build-docker.sh" \
   "gcr.io/shaderc-build/radial-build:latest"

--- a/kokoro/linux-clang-cmake/shared/continuous.cfg
+++ b/kokoro/linux-clang-cmake/shared/continuous.cfg
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright (C) 2020 Google, Inc.
 #
 # All rights reserved.
@@ -33,18 +31,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-set -e # Fail on any error.
+# Continuous build configuration.
+build_file: "glslang/kokoro/linux-clang-cmake/build.sh"
 
-. /bin/using.sh # Declare the bash `using` function for configuring toolchains.
-
-set -x # Display commands being run.
-
-using cmake-3.17.2
-using gcc-9
-using ninja-1.10.0
-
-echo "Building..."
-mkdir /build && cd /build
-
-cmake "$ROOT_DIR" -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS
-ninja install
+env_vars {
+  key: "BUILD_SHARED_LIBS"
+  value: "1"
+}

--- a/kokoro/linux-clang-cmake/shared/presubmit.cfg
+++ b/kokoro/linux-clang-cmake/shared/presubmit.cfg
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright (C) 2020 Google, Inc.
 #
 # All rights reserved.
@@ -33,18 +31,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-set -e # Fail on any error.
+# Presubmit build configuration.
+build_file: "glslang/kokoro/linux-clang-cmake/build.sh"
 
-. /bin/using.sh # Declare the bash `using` function for configuring toolchains.
-
-set -x # Display commands being run.
-
-using cmake-3.17.2
-using gcc-9
-using ninja-1.10.0
-
-echo "Building..."
-mkdir /build && cd /build
-
-cmake "$ROOT_DIR" -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS
-ninja install
+env_vars {
+  key: "BUILD_SHARED_LIBS"
+  value: "1"
+}

--- a/kokoro/linux-clang-cmake/static/continuous.cfg
+++ b/kokoro/linux-clang-cmake/static/continuous.cfg
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright (C) 2020 Google, Inc.
 #
 # All rights reserved.
@@ -33,18 +31,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-set -e # Fail on any error.
+# Continuous build configuration.
+build_file: "glslang/kokoro/linux-clang-cmake/build.sh"
 
-. /bin/using.sh # Declare the bash `using` function for configuring toolchains.
-
-set -x # Display commands being run.
-
-using cmake-3.17.2
-using gcc-9
-using ninja-1.10.0
-
-echo "Building..."
-mkdir /build && cd /build
-
-cmake "$ROOT_DIR" -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS
-ninja install
+env_vars {
+  key: "BUILD_SHARED_LIBS"
+  value: "0"
+}

--- a/kokoro/linux-clang-cmake/static/presubmit.cfg
+++ b/kokoro/linux-clang-cmake/static/presubmit.cfg
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright (C) 2020 Google, Inc.
 #
 # All rights reserved.
@@ -33,18 +31,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-set -e # Fail on any error.
+# Presubmit build configuration.
+build_file: "glslang/kokoro/linux-clang-cmake/build.sh"
 
-. /bin/using.sh # Declare the bash `using` function for configuring toolchains.
-
-set -x # Display commands being run.
-
-using cmake-3.17.2
-using gcc-9
-using ninja-1.10.0
-
-echo "Building..."
-mkdir /build && cd /build
-
-cmake "$ROOT_DIR" -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS
-ninja install
+env_vars {
+  key: "BUILD_SHARED_LIBS"
+  value: "0"
+}

--- a/kokoro/linux-gcc-cmake/build.sh
+++ b/kokoro/linux-gcc-cmake/build.sh
@@ -43,5 +43,6 @@ docker run --rm -i \
   --workdir "${ROOT_DIR}" \
   --env ROOT_DIR="${ROOT_DIR}" \
   --env SCRIPT_DIR="${SCRIPT_DIR}" \
+  --env BUILD_SHARED_LIBS="${BUILD_SHARED_LIBS:-0}" \
   --entrypoint "${SCRIPT_DIR}/build-docker.sh" \
   "gcr.io/shaderc-build/radial-build:latest"

--- a/kokoro/linux-gcc-cmake/shared/continuous.cfg
+++ b/kokoro/linux-gcc-cmake/shared/continuous.cfg
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright (C) 2020 Google, Inc.
 #
 # All rights reserved.
@@ -33,18 +31,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-set -e # Fail on any error.
+# Continuous build configuration.
+build_file: "glslang/kokoro/linux-gcc-cmake/build.sh"
 
-. /bin/using.sh # Declare the bash `using` function for configuring toolchains.
-
-set -x # Display commands being run.
-
-using cmake-3.17.2
-using gcc-9
-using ninja-1.10.0
-
-echo "Building..."
-mkdir /build && cd /build
-
-cmake "$ROOT_DIR" -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS
-ninja install
+env_vars {
+  key: "BUILD_SHARED_LIBS"
+  value: "1"
+}

--- a/kokoro/linux-gcc-cmake/shared/presubmit.cfg
+++ b/kokoro/linux-gcc-cmake/shared/presubmit.cfg
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright (C) 2020 Google, Inc.
 #
 # All rights reserved.
@@ -33,18 +31,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-set -e # Fail on any error.
+# Presubmit build configuration.
+build_file: "glslang/kokoro/linux-gcc-cmake/build.sh"
 
-. /bin/using.sh # Declare the bash `using` function for configuring toolchains.
-
-set -x # Display commands being run.
-
-using cmake-3.17.2
-using gcc-9
-using ninja-1.10.0
-
-echo "Building..."
-mkdir /build && cd /build
-
-cmake "$ROOT_DIR" -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS
-ninja install
+env_vars {
+  key: "BUILD_SHARED_LIBS"
+  value: "1"
+}

--- a/kokoro/linux-gcc-cmake/static/continuous.cfg
+++ b/kokoro/linux-gcc-cmake/static/continuous.cfg
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright (C) 2020 Google, Inc.
 #
 # All rights reserved.
@@ -33,18 +31,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-set -e # Fail on any error.
+# Continuous build configuration.
+build_file: "glslang/kokoro/linux-gcc-cmake/build.sh"
 
-. /bin/using.sh # Declare the bash `using` function for configuring toolchains.
-
-set -x # Display commands being run.
-
-using cmake-3.17.2
-using gcc-9
-using ninja-1.10.0
-
-echo "Building..."
-mkdir /build && cd /build
-
-cmake "$ROOT_DIR" -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS
-ninja install
+env_vars {
+  key: "BUILD_SHARED_LIBS"
+  value: "0"
+}

--- a/kokoro/linux-gcc-cmake/static/presubmit.cfg
+++ b/kokoro/linux-gcc-cmake/static/presubmit.cfg
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright (C) 2020 Google, Inc.
 #
 # All rights reserved.
@@ -33,18 +31,10 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-set -e # Fail on any error.
+# Presubmit build configuration.
+build_file: "glslang/kokoro/linux-gcc-cmake/build.sh"
 
-. /bin/using.sh # Declare the bash `using` function for configuring toolchains.
-
-set -x # Display commands being run.
-
-using cmake-3.17.2
-using gcc-9
-using ninja-1.10.0
-
-echo "Building..."
-mkdir /build && cd /build
-
-cmake "$ROOT_DIR" -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS
-ninja install
+env_vars {
+  key: "BUILD_SHARED_LIBS"
+  value: "0"
+}


### PR DESCRIPTION
Allows for testing of generation of both static libraries and shared objects.

The old configs are staying in place until I'm confident everything is working correctly.

Issues: #1421, #1484, #2283