### PR TITLE
Fixed GCC -Wunused-parameter in hlslParseables.cpp.

### DIFF
--- a/glslang/HLSL/hlslParseables.cpp
+++ b/glslang/HLSL/hlslParseables.cpp
@@ -331,7 +331,7 @@ glslang::TString& AppendTypeName(glslang::TString& s, const char* argOrder, cons
 //
 // It is possible that this is not needed, but that would require some tweaking
 // of other rules to get the same results.
-inline bool IsValid(const char* cname, char retOrder, char retType, char argOrder, char argType, int dim0, int dim1)
+inline bool IsValid(const char* cname, char /* retOrder */, char /* retType */, char argOrder, char /* argType */, int dim0, int /* dim1 */)
 {
     const bool isVec = (argOrder == 'V');
 


### PR DESCRIPTION
Warnings before fix:

[3/7] Building CXX object glslang/CMakeFiles/glslang.dir/HLSL/hlslParseables.cpp.o
../glslang/HLSL/hlslParseables.cpp: In function ‘bool {anonymous}::IsValid(const char*, char, char, char, char, int, int)’:
../glslang/HLSL/hlslParseables.cpp:334:45: warning: unused parameter ‘retOrder’ [-Wunused-parameter]
  334 | inline bool IsValid(const char* cname, char retOrder, char retType, char argOrder, char argType, int dim0, int dim1)
      |                                        ~~~~~^~~~~~~~
../glslang/HLSL/hlslParseables.cpp:334:60: warning: unused parameter ‘retType’ [-Wunused-parameter]
  334 | inline bool IsValid(const char* cname, char retOrder, char retType, char argOrder, char argType, int dim0, int dim1)
      |                                                       ~~~~~^~~~~~~
../glslang/HLSL/hlslParseables.cpp:334:89: warning: unused parameter ‘argType’ [-Wunused-parameter]
  334 | inline bool IsValid(const char* cname, char retOrder, char retType, char argOrder, char argType, int dim0, int dim1)
      |                                                                                    ~~~~~^~~~~~~
../glslang/HLSL/hlslParseables.cpp:334:112: warning: unused parameter ‘dim1’ [-Wunused-parameter]
  334 | inline bool IsValid(const char* cname, char retOrder, char retType, char argOrder, char argType, int dim0, int dim1)
      |                                                                                                            ~~~~^~~~