### PR TITLE
CMake: Compile with -fPIC when building SOs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,9 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
     add_compile_options(-Wall -Wmaybe-uninitialized -Wuninitialized -Wunused -Wunused-local-typedefs
                         -Wunused-parameter -Wunused-value  -Wunused-variable -Wunused-but-set-parameter -Wunused-but-set-variable -fno-exceptions)
     add_compile_options(-Wno-reorder)  # disable this from -Wall, since it happens all over.
+    if(BUILD_SHARED_LIBS)
+        add_compile_options(-fPIC)
+    endif()
     if(NOT ENABLE_RTTI)
         add_compile_options(-fno-rtti)
     endif()
@@ -132,6 +135,9 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" AND NOT MSVC)
     add_compile_options(-Wall -Wuninitialized -Wunused -Wunused-local-typedefs
                         -Wunused-parameter -Wunused-value  -Wunused-variable)
     add_compile_options(-Wno-reorder)  # disable this from -Wall, since it happens all over.
+    if(BUILD_SHARED_LIBS)
+        add_compile_options(-fPIC)
+    endif()
     if(NOT ENABLE_RTTI)
         add_compile_options(-fno-rtti)
     endif()


### PR DESCRIPTION
Without this embedding static libraries into shared libraries may result in link time errors.

Issue: #2283