### PR TITLE
CMake: break up glslang into smaller static libs

### DIFF
--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -60,12 +60,12 @@ if(ENABLE_OPT)
         PRIVATE ${spirv-tools_SOURCE_DIR}/include
         PRIVATE ${spirv-tools_SOURCE_DIR}/source
     )
-    target_link_libraries(SPIRV glslang SPIRV-Tools-opt)
+    target_link_libraries(SPIRV PRIVATE MachineIndependent SPIRV-Tools-opt)
     target_include_directories(SPIRV PUBLIC
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../External>
 		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/External>)
 else()
-    target_link_libraries(SPIRV glslang)
+    target_link_libraries(SPIRV PRIVATE MachineIndependent)
 endif(ENABLE_OPT)
 
 if(WIN32)

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -11,7 +11,17 @@ if(EMSCRIPTEN OR ENABLE_GLSLANG_JS)
     add_subdirectory(OSDependent/Web)
 endif(EMSCRIPTEN OR ENABLE_GLSLANG_JS)
 
-set(SOURCES
+################################################################################
+# GenericCodeGen
+################################################################################
+add_library(GenericCodeGen STATIC
+    GenericCodeGen/CodeGen.cpp
+    GenericCodeGen/Link.cpp)
+
+################################################################################
+# MachineIndependent
+################################################################################
+set(MACHINEINDEPENDENT_SOURCES
     MachineIndependent/glslang.m4
     MachineIndependent/glslang.y
     MachineIndependent/glslang_tab.cpp
@@ -41,26 +51,9 @@ set(SOURCES
     MachineIndependent/preprocessor/PpScanner.cpp
     MachineIndependent/preprocessor/PpTokens.cpp
     MachineIndependent/propagateNoContraction.cpp
-    GenericCodeGen/CodeGen.cpp
-    GenericCodeGen/Link.cpp
-    CInterface/glslang_c_interface.cpp)
+)
 
-set(HEADERS
-    Public/ShaderLang.h
-    Include/arrays.h
-    Include/BaseTypes.h
-    Include/Common.h
-    Include/ConstantUnion.h
-    Include/glslang_c_interface.h
-    Include/glslang_c_shader_types.h
-    Include/InfoSink.h
-    Include/InitializeGlobals.h
-    Include/intermediate.h
-    Include/PoolAlloc.h
-    Include/ResourceLimits.h
-    Include/revision.h
-    Include/ShHandle.h
-    Include/Types.h
+set(MACHINEINDEPENDENT_HEADERS
     MachineIndependent/attribute.h
     MachineIndependent/glslang_tab.cpp.h
     MachineIndependent/gl_types.h
@@ -78,12 +71,11 @@ set(HEADERS
     MachineIndependent/parseVersions.h
     MachineIndependent/propagateNoContraction.h
     MachineIndependent/preprocessor/PpContext.h
-    MachineIndependent/preprocessor/PpTokens.h)
-
-glslang_pch(SOURCES MachineIndependent/pch.cpp)
+    MachineIndependent/preprocessor/PpTokens.h
+)
 
 if(ENABLE_HLSL)
-    list(APPEND SOURCES
+    list(APPEND MACHINEINDEPENDENT_SOURCES
         HLSL/hlslAttributes.cpp
         HLSL/hlslParseHelper.cpp
         HLSL/hlslScanContext.cpp
@@ -92,7 +84,7 @@ if(ENABLE_HLSL)
         HLSL/hlslGrammar.cpp
         HLSL/hlslParseables.cpp)
 
-    list(APPEND HEADERS
+    list(APPEND MACHINEINDEPENDENT_HEADERS
         HLSL/hlslAttributes.h
         HLSL/hlslParseHelper.h
         HLSL/hlslTokens.h
@@ -103,10 +95,39 @@ if(ENABLE_HLSL)
         HLSL/hlslParseables.h)
 endif(ENABLE_HLSL)
 
-add_library(glslang ${LIB_TYPE} ${BISON_GLSLParser_OUTPUT_SOURCE} ${SOURCES} ${HEADERS})
+add_library(MachineIndependent STATIC ${MACHINEINDEPENDENT_SOURCES} ${MACHINEINDEPENDENT_HEADERS})
+
+glslang_pch(SOURCES MachineIndependent/pch.cpp)
+
+target_link_libraries(MachineIndependent PRIVATE OGLCompiler OSDependent GenericCodeGen)
+
+################################################################################
+# glslang
+################################################################################
+set(GLSLANG_SOURCES
+    CInterface/glslang_c_interface.cpp)
+
+set(GLSLANG_HEADERS
+    Public/ShaderLang.h
+    Include/arrays.h
+    Include/BaseTypes.h
+    Include/Common.h
+    Include/ConstantUnion.h
+    Include/glslang_c_interface.h
+    Include/glslang_c_shader_types.h
+    Include/InfoSink.h
+    Include/InitializeGlobals.h
+    Include/intermediate.h
+    Include/PoolAlloc.h
+    Include/ResourceLimits.h
+    Include/revision.h
+    Include/ShHandle.h
+    Include/Types.h)
+
+add_library(glslang ${LIB_TYPE} ${BISON_GLSLParser_OUTPUT_SOURCE} ${GLSLANG_SOURCES} ${GLSLANG_HEADERS})
 set_property(TARGET glslang PROPERTY FOLDER glslang)
 set_property(TARGET glslang PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(glslang OGLCompiler OSDependent)
+target_link_libraries(glslang PRIVATE OGLCompiler OSDependent MachineIndependent)
 target_include_directories(glslang PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
@@ -115,6 +136,9 @@ if(WIN32 AND BUILD_SHARED_LIBS)
     set_target_properties(glslang PROPERTIES PREFIX "")
 endif()
 
+################################################################################
+# source_groups
+################################################################################
 if(WIN32)
     source_group("Public" REGULAR_EXPRESSION "Public/*")
     source_group("MachineIndependent" REGULAR_EXPRESSION "MachineIndependent/[^/]*")
@@ -125,21 +149,29 @@ if(WIN32)
     source_group("CInterface" REGULAR_EXPRESSION "CInterface/*")
 endif(WIN32)
 
+################################################################################
+# install
+################################################################################
 if(ENABLE_GLSLANG_INSTALL)
     if(BUILD_SHARED_LIBS)
-        install(TARGETS glslang EXPORT glslangTargets
+        install(TARGETS glslang
+                EXPORT  glslangTargets
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     else()
-        install(TARGETS glslang EXPORT glslangTargets
+        install(TARGETS glslang MachineIndependent GenericCodeGen
+                EXPORT  glslangTargets
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endif()
-    install(EXPORT glslangTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
-endif(ENABLE_GLSLANG_INSTALL)
 
-if(ENABLE_GLSLANG_INSTALL)
-    foreach(file ${HEADERS})
+    install(EXPORT glslangTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+
+    set(ALL_HEADERS
+        ${GLSLANG_HEADERS}
+        ${MACHINEINDEPENDENT_HEADERS})
+
+    foreach(file ${ALL_HEADERS})
         get_filename_component(dir ${file} DIRECTORY)
         install(FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/glslang/${dir})
     endforeach()


### PR DESCRIPTION
Add `GenericCodeGen` and `MachineIndependent` static library targets.
Privately import both of these into the `glslang` target.
Privately import `MachineIndependent` into the  `SPIRV` target.

This is done to break the dependency of `libglslang.so` non-public APIs from `libspirv.so`,
which will become problematic once `glslang` hides its non-public symbols.

| File                      | Before     |     After  |
|---------------------------|-----------:|-----------:|
| `libGenericCodeGen.a`     |  -         |   `527716` |
| `libglslang.a`            | `68175944` |   `512938` |
| `libHLSL.a`               |     `1428` |     `1428` |
| `libMachineIndependent.a` |  -         | `67132202` |
| `libOGLCompiler.a`        |    `75908` |    `75908` |
| `libOSDependent.a`        |    `23768` |    `23768` |
| `libSPIRV.a`              | `15710210` | `15710210` |
| `libSPVRemapper.a`        |  `3250894` |  `3250894` |

| File                                    | Before     |     After  |
|-----------------------------------------|-----------:|-----------:|
| `libglslang-default-resource-limits.so` |   `117032` |   `117032` |
| `libglslang.so`                         | `22380688` | `22368216` |
| `libHLSL.so`                            |     `7520` |     `7520` |
| `libOGLCompiler.a`                      |    `75908` |    `75908` |
| `libOSDependent.a`                      |    `23768` |    `23768` |
| `libSPIRV.so`                           |  `7288336` | `28151016` |
| `libSPVRemapper.so`                     |  `1940208` |  `1940208` |

Issues: #2283, #1484