### PR TITLE
Fixed msvc 2019 nmake compiler warnings for SPIRV-Tools.

### DIFF
--- a/External/CMakeLists.txt
+++ b/External/CMakeLists.txt
@@ -1,6 +1,3 @@
-# Suppress all warnings from external projects.
-set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS -w)
-
 if(BUILD_TESTING)
     if(TARGET gmock)
         message(STATUS "Google Mock already configured - use it")
@@ -19,7 +16,12 @@ if(BUILD_TESTING)
             gmock_main)
         foreach(target ${GTEST_TARGETS})
             set_property(TARGET ${target} PROPERTY FOLDER gtest)
+            set_property(TARGET ${target} PROPERTY COMPILE_OPTIONS -w)
         endforeach()
+        if(MSVC)
+            set_property(TARGET gmock PROPERTY COMPILE_OPTIONS /wd5046)
+        endif()
+
         mark_as_advanced(gmock_build_tests
             BUILD_GMOCK
             BUILD_GTEST
@@ -41,4 +43,3 @@ if(ENABLE_OPT AND NOT TARGET SPIRV-Tools-opt)
         add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/spirv-tools spirv-tools)
     endif()
 endif()
-


### PR DESCRIPTION
How to reproduce:

Visual Studio 2019 x64 command port

mkdir build-msvc2019
cd build-msvc2019
cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LIBDIR=install ..
nmake

BEFORE:

[  5%] Building CXX object External/spirv-tools/source/CMakeFiles/SPIRV-Tools.dir/libspirv.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/w'
libspirv.cpp
[  5%] Building CXX object External/spirv-tools/source/CMakeFiles/SPIRV-Tools.dir/name_mapper.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/w'
name_mapper.cpp
[  5%] Building CXX object External/spirv-tools/source/CMakeFiles/SPIRV-Tools.dir/opcode.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/w'
opcode.cpp
[  5%] Building CXX object External/spirv-tools/source/CMakeFiles/SPIRV-Tools.dir/operand.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/w'
operand.cpp
[  6%] Building CXX object External/spirv-tools/source/CMakeFiles/SPIRV-Tools.dir/parsed_operand.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/w'
parsed_operand.cpp
[  6%] Building CXX object External/spirv-tools/source/CMakeFiles/SPIRV-Tools.dir/print.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/w'

AFTER:

 30%] Building CXX object source/CMakeFiles/SPIRV-Tools-shared.dir/libspirv.cpp.obj
libspirv.cpp
[ 30%] Building CXX object source/CMakeFiles/SPIRV-Tools-shared.dir/name_mapper.cpp.obj
name_mapper.cpp
[ 30%] Building CXX object source/CMakeFiles/SPIRV-Tools-shared.dir/opcode.cpp.obj
opcode.cpp
[ 31%] Building CXX object source/CMakeFiles/SPIRV-Tools-shared.dir/operand.cpp.obj
operand.cpp
[ 31%] Building CXX object source/CMakeFiles/SPIRV-Tools-shared.dir/parsed_operand.cpp.obj
parsed_operand.cpp
[ 31%] Building CXX object source/CMakeFiles/SPIRV-Tools-shared.dir/print.cpp.obj
print.cpp