### PR TITLE
Fix GLSLANG_IS_SHARED_LIBRARY define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,8 +210,8 @@ endif()
 # GLSLANG_IS_SHARED_LIBRARY define, and GLSLANG_EXPORTING to 1 when specifically
 # building <target>.
 function(glslang_only_export_explicit_symbols target)
-    target_compile_definitions(${target} PUBLIC "GLSLANG_IS_SHARED_LIBRARY=1")
     if(BUILD_SHARED_LIBS)
+        target_compile_definitions(${target} PUBLIC "GLSLANG_IS_SHARED_LIBRARY=1")
         if(WIN32)
             target_compile_definitions(${target} PRIVATE "GLSLANG_EXPORTING=1")
         else()

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -58,12 +58,12 @@
         #endif
     #elif __GNUC__ >= 4
         #define GLSLANG_EXPORT __attribute__((visibility("default")))
-    #else
-        #define GLSLANG_EXPORT
     #endif
-#else // GLSLANG_IS_SHARED_LIBRARY
-    #define GLSLANG_EXPORT
 #endif // GLSLANG_IS_SHARED_LIBRARY
+
+#ifndef GLSLANG_EXPORT
+#define GLSLANG_EXPORT
+#endif
 
 //
 // This is the platform independent interface between an OGL driver


### PR DESCRIPTION
It was incorrectly always being set, causing linker warnings for MSVC builds.
Also simplify the preprocessor nesting in `glslang\Public\ShaderLang.h`