### PR TITLE
Kokoro: Correct the `build_file' path to build.sh

### DIFF
--- a/kokoro/license-check/continuous.cfg
+++ b/kokoro/license-check/continuous.cfg
@@ -32,4 +32,4 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # Continuous build configuration.
-build_file: "glslang/kokoro/license-check.sh"
+build_file: "glslang/kokoro/license-check/build.sh"

--- a/kokoro/license-check/presubmit.cfg
+++ b/kokoro/license-check/presubmit.cfg
@@ -32,4 +32,4 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # Presubmit build configuration.
-build_file: "glslang/kokoro/license-check.sh"
+build_file: "glslang/kokoro/license-check/build.sh"


### PR DESCRIPTION
Fix stupid typo in https://github.com/KhronosGroup/glslang/pull/2310