### PR TITLE
License headers: s/Google/The Khronos Group

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/ChooseMSVCCRT.cmake
+++ b/ChooseMSVCCRT.cmake
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/External/CMakeLists.txt
+++ b/External/CMakeLists.txt
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/OGLCompilersDLL/CMakeLists.txt
+++ b/OGLCompilersDLL/CMakeLists.txt
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/glslang/OSDependent/Unix/CMakeLists.txt
+++ b/glslang/OSDependent/Unix/CMakeLists.txt
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/glslang/OSDependent/Web/CMakeLists.txt
+++ b/glslang/OSDependent/Web/CMakeLists.txt
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/glslang/OSDependent/Windows/CMakeLists.txt
+++ b/glslang/OSDependent/Windows/CMakeLists.txt
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/glslang/updateGrammar
+++ b/glslang/updateGrammar
@@ -16,7 +16,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/hlsl/CMakeLists.txt
+++ b/hlsl/CMakeLists.txt
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/ndk_test/Android.mk
+++ b/ndk_test/Android.mk
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #

--- a/ndk_test/jni/Application.mk
+++ b/ndk_test/jni/Application.mk
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #


### PR DESCRIPTION
This was a copy-paste screwup, where the first line of the copyright had the company name was updated, but the company name mid way though was not.