### PR TITLE
gn: Optionally disable optimizations and HLSL

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -51,164 +51,183 @@ spirv_tools_dir = glslang_spirv_tools_dir
 config("glslang_public") {
   include_dirs = [ "." ]
 
-  defines = [ "ENABLE_HLSL=1" ]
+  if (!glslang_angle) {
+    defines = [ "ENABLE_HLSL=1" ]
+  }
 }
 
-source_set("glslang_sources") {
-  public_configs = [ ":glslang_public" ]
+template("glslang_sources_common") {
+  source_set(target_name) {
+    public_configs = [ ":glslang_public" ]
 
-  sources = [
-    "OGLCompilersDLL/InitializeDll.cpp",
-    "OGLCompilersDLL/InitializeDll.h",
-    "SPIRV/GLSL.ext.AMD.h",
-    "SPIRV/GLSL.ext.EXT.h",
-    "SPIRV/GLSL.ext.KHR.h",
-    "SPIRV/GLSL.ext.NV.h",
-    "SPIRV/GLSL.std.450.h",
-    "SPIRV/GlslangToSpv.cpp",
-    "SPIRV/GlslangToSpv.h",
-    "SPIRV/InReadableOrder.cpp",
-    "SPIRV/Logger.cpp",
-    "SPIRV/Logger.h",
-    "SPIRV/NonSemanticDebugPrintf.h",
-    "SPIRV/SPVRemapper.cpp",
-    "SPIRV/SPVRemapper.h",
-    "SPIRV/SpvBuilder.cpp",
-    "SPIRV/SpvBuilder.h",
-    "SPIRV/SpvPostProcess.cpp",
-    "SPIRV/SpvTools.cpp",
-    "SPIRV/SpvTools.h",
-    "SPIRV/bitutils.h",
-    "SPIRV/disassemble.cpp",
-    "SPIRV/disassemble.h",
-    "SPIRV/doc.cpp",
-    "SPIRV/doc.h",
-    "SPIRV/hex_float.h",
-    "SPIRV/spirv.hpp",
-    "SPIRV/spvIR.h",
-    "glslang/GenericCodeGen/CodeGen.cpp",
-    "glslang/GenericCodeGen/Link.cpp",
-    "glslang/HLSL/hlslAttributes.cpp",
-    "glslang/HLSL/hlslAttributes.h",
-    "glslang/HLSL/hlslGrammar.cpp",
-    "glslang/HLSL/hlslGrammar.h",
-    "glslang/HLSL/hlslOpMap.cpp",
-    "glslang/HLSL/hlslOpMap.h",
-    "glslang/HLSL/hlslParseables.cpp",
-    "glslang/HLSL/hlslParseables.h",
-    "glslang/HLSL/hlslParseHelper.cpp",
-    "glslang/HLSL/hlslParseHelper.h",
-    "glslang/HLSL/hlslScanContext.cpp",
-    "glslang/HLSL/hlslScanContext.h",
-    "glslang/HLSL/hlslTokens.h",
-    "glslang/HLSL/hlslTokenStream.cpp",
-    "glslang/HLSL/hlslTokenStream.h",
-    "glslang/Include/BaseTypes.h",
-    "glslang/Include/Common.h",
-    "glslang/Include/ConstantUnion.h",
-    "glslang/Include/InfoSink.h",
-    "glslang/Include/InitializeGlobals.h",
-    "glslang/Include/PoolAlloc.h",
-    "glslang/Include/ResourceLimits.h",
-    "glslang/Include/ShHandle.h",
-    "glslang/Include/Types.h",
-    "glslang/Include/arrays.h",
-    "glslang/Include/intermediate.h",
-    "glslang/Include/revision.h",
-    "glslang/MachineIndependent/Constant.cpp",
-    "glslang/MachineIndependent/InfoSink.cpp",
-    "glslang/MachineIndependent/Initialize.cpp",
-    "glslang/MachineIndependent/Initialize.h",
-    "glslang/MachineIndependent/IntermTraverse.cpp",
-    "glslang/MachineIndependent/Intermediate.cpp",
-    "glslang/MachineIndependent/LiveTraverser.h",
-    "glslang/MachineIndependent/ParseContextBase.cpp",
-    "glslang/MachineIndependent/ParseHelper.cpp",
-    "glslang/MachineIndependent/ParseHelper.h",
-    "glslang/MachineIndependent/PoolAlloc.cpp",
-    "glslang/MachineIndependent/RemoveTree.cpp",
-    "glslang/MachineIndependent/RemoveTree.h",
-    "glslang/MachineIndependent/Scan.cpp",
-    "glslang/MachineIndependent/Scan.h",
-    "glslang/MachineIndependent/ScanContext.h",
-    "glslang/MachineIndependent/ShaderLang.cpp",
-    "glslang/MachineIndependent/SymbolTable.cpp",
-    "glslang/MachineIndependent/SymbolTable.h",
-    "glslang/MachineIndependent/Versions.cpp",
-    "glslang/MachineIndependent/Versions.h",
-    "glslang/MachineIndependent/attribute.cpp",
-    "glslang/MachineIndependent/attribute.h",
-    "glslang/MachineIndependent/gl_types.h",
-    "glslang/MachineIndependent/glslang_tab.cpp",
-    "glslang/MachineIndependent/glslang_tab.cpp.h",
-    "glslang/MachineIndependent/intermOut.cpp",
-    "glslang/MachineIndependent/iomapper.cpp",
-    "glslang/MachineIndependent/iomapper.h",
-    "glslang/MachineIndependent/limits.cpp",
-    "glslang/MachineIndependent/linkValidate.cpp",
-    "glslang/MachineIndependent/localintermediate.h",
-    "glslang/MachineIndependent/parseConst.cpp",
-    "glslang/MachineIndependent/parseVersions.h",
-    "glslang/MachineIndependent/preprocessor/Pp.cpp",
-    "glslang/MachineIndependent/preprocessor/PpAtom.cpp",
-    "glslang/MachineIndependent/preprocessor/PpContext.cpp",
-    "glslang/MachineIndependent/preprocessor/PpContext.h",
-    "glslang/MachineIndependent/preprocessor/PpScanner.cpp",
-    "glslang/MachineIndependent/preprocessor/PpTokens.cpp",
-    "glslang/MachineIndependent/preprocessor/PpTokens.h",
-    "glslang/MachineIndependent/propagateNoContraction.cpp",
-    "glslang/MachineIndependent/propagateNoContraction.h",
-    "glslang/MachineIndependent/reflection.cpp",
-    "glslang/MachineIndependent/reflection.h",
-    "glslang/OSDependent/osinclude.h",
-    "glslang/Public/ShaderLang.h",
-  ]
-
-  defines = [ "ENABLE_OPT=1" ]
-
-  if (is_win) {
-    sources += [ "glslang/OSDependent/Windows/ossource.cpp" ]
-    defines += [ "GLSLANG_OSINCLUDE_WIN32" ]
-  } else {
-    sources += [ "glslang/OSDependent/Unix/ossource.cpp" ]
-    defines += [ "GLSLANG_OSINCLUDE_UNIX" ]
-  }
-
-  if (is_clang) {
-    cflags = [
-      "-Wno-extra-semi",
-      "-Wno-ignored-qualifiers",
-      "-Wno-implicit-fallthrough",
-      "-Wno-inconsistent-missing-override",
-      "-Wno-sign-compare",
-      "-Wno-unused-variable",
-      "-Wno-missing-field-initializers",
-      "-Wno-newline-eof",
+    sources = [
+      "OGLCompilersDLL/InitializeDll.cpp",
+      "OGLCompilersDLL/InitializeDll.h",
+      "SPIRV/GLSL.ext.AMD.h",
+      "SPIRV/GLSL.ext.EXT.h",
+      "SPIRV/GLSL.ext.KHR.h",
+      "SPIRV/GLSL.ext.NV.h",
+      "SPIRV/GLSL.std.450.h",
+      "SPIRV/GlslangToSpv.cpp",
+      "SPIRV/GlslangToSpv.h",
+      "SPIRV/InReadableOrder.cpp",
+      "SPIRV/Logger.cpp",
+      "SPIRV/Logger.h",
+      "SPIRV/NonSemanticDebugPrintf.h",
+      "SPIRV/SPVRemapper.cpp",
+      "SPIRV/SPVRemapper.h",
+      "SPIRV/SpvBuilder.cpp",
+      "SPIRV/SpvBuilder.h",
+      "SPIRV/SpvPostProcess.cpp",
+      "SPIRV/SpvTools.cpp",
+      "SPIRV/SpvTools.h",
+      "SPIRV/bitutils.h",
+      "SPIRV/disassemble.cpp",
+      "SPIRV/disassemble.h",
+      "SPIRV/doc.cpp",
+      "SPIRV/doc.h",
+      "SPIRV/hex_float.h",
+      "SPIRV/spirv.hpp",
+      "SPIRV/spvIR.h",
+      "glslang/GenericCodeGen/CodeGen.cpp",
+      "glslang/GenericCodeGen/Link.cpp",
+      "glslang/Include/BaseTypes.h",
+      "glslang/Include/Common.h",
+      "glslang/Include/ConstantUnion.h",
+      "glslang/Include/InfoSink.h",
+      "glslang/Include/InitializeGlobals.h",
+      "glslang/Include/PoolAlloc.h",
+      "glslang/Include/ResourceLimits.h",
+      "glslang/Include/ShHandle.h",
+      "glslang/Include/Types.h",
+      "glslang/Include/arrays.h",
+      "glslang/Include/intermediate.h",
+      "glslang/Include/revision.h",
+      "glslang/MachineIndependent/Constant.cpp",
+      "glslang/MachineIndependent/InfoSink.cpp",
+      "glslang/MachineIndependent/Initialize.cpp",
+      "glslang/MachineIndependent/Initialize.h",
+      "glslang/MachineIndependent/IntermTraverse.cpp",
+      "glslang/MachineIndependent/Intermediate.cpp",
+      "glslang/MachineIndependent/LiveTraverser.h",
+      "glslang/MachineIndependent/ParseContextBase.cpp",
+      "glslang/MachineIndependent/ParseHelper.cpp",
+      "glslang/MachineIndependent/ParseHelper.h",
+      "glslang/MachineIndependent/PoolAlloc.cpp",
+      "glslang/MachineIndependent/RemoveTree.cpp",
+      "glslang/MachineIndependent/RemoveTree.h",
+      "glslang/MachineIndependent/Scan.cpp",
+      "glslang/MachineIndependent/Scan.h",
+      "glslang/MachineIndependent/ScanContext.h",
+      "glslang/MachineIndependent/ShaderLang.cpp",
+      "glslang/MachineIndependent/SymbolTable.cpp",
+      "glslang/MachineIndependent/SymbolTable.h",
+      "glslang/MachineIndependent/Versions.cpp",
+      "glslang/MachineIndependent/Versions.h",
+      "glslang/MachineIndependent/attribute.cpp",
+      "glslang/MachineIndependent/attribute.h",
+      "glslang/MachineIndependent/gl_types.h",
+      "glslang/MachineIndependent/glslang_tab.cpp",
+      "glslang/MachineIndependent/glslang_tab.cpp.h",
+      "glslang/MachineIndependent/intermOut.cpp",
+      "glslang/MachineIndependent/iomapper.cpp",
+      "glslang/MachineIndependent/iomapper.h",
+      "glslang/MachineIndependent/limits.cpp",
+      "glslang/MachineIndependent/linkValidate.cpp",
+      "glslang/MachineIndependent/localintermediate.h",
+      "glslang/MachineIndependent/parseConst.cpp",
+      "glslang/MachineIndependent/parseVersions.h",
+      "glslang/MachineIndependent/preprocessor/Pp.cpp",
+      "glslang/MachineIndependent/preprocessor/PpAtom.cpp",
+      "glslang/MachineIndependent/preprocessor/PpContext.cpp",
+      "glslang/MachineIndependent/preprocessor/PpContext.h",
+      "glslang/MachineIndependent/preprocessor/PpScanner.cpp",
+      "glslang/MachineIndependent/preprocessor/PpTokens.cpp",
+      "glslang/MachineIndependent/preprocessor/PpTokens.h",
+      "glslang/MachineIndependent/propagateNoContraction.cpp",
+      "glslang/MachineIndependent/propagateNoContraction.h",
+      "glslang/MachineIndependent/reflection.cpp",
+      "glslang/MachineIndependent/reflection.h",
+      "glslang/OSDependent/osinclude.h",
+      "glslang/Public/ShaderLang.h",
     ]
-  }
-  if (is_win && !is_clang) {
-    cflags = [
-      "/wd4018",  # signed/unsigned mismatch
-      "/wd4189",  # local variable is initialized but not referenced
-    ]
-  }
 
-  deps = [
-    "${spirv_tools_dir}:spvtools_opt",
-    "${spirv_tools_dir}:spvtools_val",
-  ]
+    if (!glslang_angle) {
+      sources += [
+        "glslang/HLSL/hlslAttributes.cpp",
+        "glslang/HLSL/hlslAttributes.h",
+        "glslang/HLSL/hlslGrammar.cpp",
+        "glslang/HLSL/hlslGrammar.h",
+        "glslang/HLSL/hlslOpMap.cpp",
+        "glslang/HLSL/hlslOpMap.h",
+        "glslang/HLSL/hlslParseables.cpp",
+        "glslang/HLSL/hlslParseables.h",
+        "glslang/HLSL/hlslParseHelper.cpp",
+        "glslang/HLSL/hlslParseHelper.h",
+        "glslang/HLSL/hlslScanContext.cpp",
+        "glslang/HLSL/hlslScanContext.h",
+        "glslang/HLSL/hlslTokens.h",
+        "glslang/HLSL/hlslTokenStream.cpp",
+        "glslang/HLSL/hlslTokenStream.h",
+      ]
+    }
 
-  configs -= _configs_to_remove
-  configs += _configs_to_add
+    defines = []
+    if (invoker.enable_opt) {
+      defines += [ "ENABLE_OPT=1" ]
+    }
+
+    if (is_win) {
+      sources += [ "glslang/OSDependent/Windows/ossource.cpp" ]
+      defines += [ "GLSLANG_OSINCLUDE_WIN32" ]
+    } else {
+      sources += [ "glslang/OSDependent/Unix/ossource.cpp" ]
+      defines += [ "GLSLANG_OSINCLUDE_UNIX" ]
+    }
+
+    if (is_clang) {
+      cflags = [
+        "-Wno-extra-semi",
+        "-Wno-ignored-qualifiers",
+        "-Wno-implicit-fallthrough",
+        "-Wno-inconsistent-missing-override",
+        "-Wno-sign-compare",
+        "-Wno-unused-variable",
+        "-Wno-missing-field-initializers",
+        "-Wno-newline-eof",
+      ]
+    }
+    if (is_win && !is_clang) {
+      cflags = [
+        "/wd4018",  # signed/unsigned mismatch
+        "/wd4189",  # local variable is initialized but not referenced
+      ]
+    }
+
+    if (invoker.enable_opt) {
+      deps = [
+        "${spirv_tools_dir}:spvtools_opt",
+        "${spirv_tools_dir}:spvtools_val"
+      ]
+    }
+
+    configs -= _configs_to_remove
+    configs += _configs_to_add
+  }
+}
+
+glslang_sources_common("glslang_sources") {
+  enable_opt = !glslang_angle
+}
+
+glslang_sources_common("glslang_standalone_sources") {
+  enable_opt = true
 }
 
 source_set("glslang_default_resource_limits_sources") {
   sources = [
     "StandAlone/ResourceLimits.cpp",
     "StandAlone/ResourceLimits.h",
-  ]
-  deps = [
-    ":glslang_sources",
   ]
   public_configs = [ ":glslang_public" ]
 
@@ -227,7 +246,7 @@ executable("glslang_validator") {
   defines = [ "ENABLE_OPT=1" ]
   deps = [
     ":glslang_default_resource_limits_sources",
-    ":glslang_sources",
+    ":glslang_standalone_sources",
   ]
 
   configs -= _configs_to_remove
@@ -240,7 +259,7 @@ executable("spirv-remap") {
   ]
   defines = [ "ENABLE_OPT=1" ]
   deps = [
-    ":glslang_sources",
+    ":glslang_standalone_sources",
   ]
 
   configs -= _configs_to_remove


### PR DESCRIPTION
To reduce the binary size of ANGLE, a gn override is added
(glslang_angle) which:

- Controls whether ENABLE_OPT=1 is set
- Customizes the build for the Vulkan backend of ANGLE.  As a first
  step, this removes HLSL functionality which together with no
  optimization shave ~2.5MB off of ANGLE's binary size.

Upcoming changes will add a macro for GLSLANG_ANGLE similar to
GLSLANG_WEB that will strip features from glslang to support only what
ANGLE needs.

Signed-off-by: Shahbaz Youssefi <ShabbyX@gmail.com>