### PR TITLE
Emit OpLine before OpFunction

### DIFF
--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -351,6 +351,10 @@ public:
     Function* makeFunctionEntry(Decoration precision, Id returnType, const char* name,
         const std::vector<Id>& paramTypes, const std::vector<std::vector<Decoration>>& precisions, Block **entry = 0);
 
+    // Update an existing function made with makeFunctionEntry() to given
+    // source-line association. Improves debug information quality.
+    void updateFunctionEntrySourceLine(const char* name, const char* filename, int line);
+
     // Create a return. An 'implicit' return is one not appearing in the source
     // code.  In the case of an implicit return, no post-return block is inserted.
     void makeReturn(bool implicit, Id retVal = 0);
@@ -853,6 +857,9 @@ public:
 
     // map from include file name ids to their contents
     std::map<spv::Id, const std::string*> includeFiles;
+
+    // map from entry point names to their function indices
+    std::unordered_map<std::string, size_t> functionNames;
 
     // The stream for outputting warnings and errors.
     SpvBuildLogger* logger;

--- a/SPIRV/spvIR.h
+++ b/SPIRV/spvIR.h
@@ -375,8 +375,23 @@ public:
             DecorationRelaxedPrecision : NoPrecision;
     }
 
+    void setSourceLine(Id inSource, int inLine)
+    {
+        sourceFileStringId = inSource;
+        line = inLine;
+    }
+
     void dump(std::vector<unsigned int>& out) const
     {
+        // OpLine
+        if (sourceFileStringId != NoResult) {
+            Instruction line(OpLine);
+            line.addIdOperand(sourceFileStringId);
+            line.addImmediateOperand(this->line);
+            line.addImmediateOperand(0);
+            line.dump(out);
+        }
+
         // OpFunction
         functionInstruction.dump(out);
 
@@ -401,6 +416,8 @@ protected:
     bool implicitThis;  // true if this is a member function expecting to be passed a 'this' as the first argument
     bool reducedPrecisionReturn;
     std::set<int> reducedPrecisionParams;  // list of parameter indexes that need a relaxed precision arg
+    Id sourceFileStringId;
+    int line;
 };
 
 //
@@ -462,7 +479,7 @@ protected:
 // - all the OpFunctionParameter instructions
 __inline Function::Function(Id id, Id resultType, Id functionType, Id firstParamId, Module& parent)
     : parent(parent), functionInstruction(id, resultType, OpFunction), implicitThis(false),
-      reducedPrecisionReturn(false)
+      reducedPrecisionReturn(false), sourceFileStringId(NoResult), line(0)
 {
     // OpFunction
     functionInstruction.addImmediateOperand(FunctionControlMaskNone);

--- a/Test/baseResults/hlsl.pp.line2.frag.out
+++ b/Test/baseResults/hlsl.pp.line2.frag.out
@@ -9,7 +9,7 @@ hlsl.pp.line2.frag
                               EntryPoint Fragment 5  "MainPs" 71 75
                               ExecutionMode 5 OriginUpperLeft
                1:             String  "hlsl.pp.line2.frag"
-              17:             String  "foo.frag"
+              11:             String  "foo.frag"
               32:             String  "foo.h"
               42:             String  "foo2.h"
                               Source HLSL 500 1  "// OpModuleProcessed auto-map-locations
@@ -64,10 +64,10 @@ PS_OUTPUT MainPs ( PS_INPUT i )
                               Name 5  "MainPs"
                               Name 9  "PS_INPUT"
                               MemberName 9(PS_INPUT) 0  "vTextureCoords"
-                              Name 12  "PS_OUTPUT"
-                              MemberName 12(PS_OUTPUT) 0  "vColor"
-                              Name 15  "@MainPs(struct-PS_INPUT-vf21;"
-                              Name 14  "i"
+                              Name 13  "PS_OUTPUT"
+                              MemberName 13(PS_OUTPUT) 0  "vColor"
+                              Name 16  "@MainPs(struct-PS_INPUT-vf21;"
+                              Name 15  "i"
                               Name 19  "PerViewConstantBuffer_t"
                               MemberName 19(PerViewConstantBuffer_t) 0  "g_nDataIdx"
                               MemberName 19(PerViewConstantBuffer_t) 1  "g_nDataIdx2"
@@ -97,9 +97,9 @@ PS_OUTPUT MainPs ( PS_INPUT i )
                8:             TypeVector 7(float) 2
      9(PS_INPUT):             TypeStruct 8(fvec2)
               10:             TypePointer Function 9(PS_INPUT)
-              11:             TypeVector 7(float) 4
-   12(PS_OUTPUT):             TypeStruct 11(fvec4)
-              13:             TypeFunction 12(PS_OUTPUT) 10(ptr)
+              12:             TypeVector 7(float) 4
+   13(PS_OUTPUT):             TypeStruct 12(fvec4)
+              14:             TypeFunction 13(PS_OUTPUT) 10(ptr)
               18:             TypeInt 32 0
 19(PerViewConstantBuffer_t):             TypeStruct 18(int) 18(int) 18(int)
               20:             TypePointer PushConstant 19(PerViewConstantBuffer_t)
@@ -112,7 +112,7 @@ PS_OUTPUT MainPs ( PS_INPUT i )
               33:             TypePointer Function 18(int)
               35:     22(int) Constant 0
               39:     22(int) Constant 1
-              43:             TypePointer Function 12(PS_OUTPUT)
+              43:             TypePointer Function 13(PS_OUTPUT)
               45:             TypeImage 7(float) 2D sampled format:Unknown
               46:     18(int) Constant 128
               47:             TypeArray 45 46
@@ -124,32 +124,35 @@ PS_OUTPUT MainPs ( PS_INPUT i )
     56(g_sAniso):     55(ptr) Variable UniformConstant
               58:             TypeSampledImage 45
               60:             TypePointer Function 8(fvec2)
-              64:             TypePointer Function 11(fvec4)
+              64:             TypePointer Function 12(fvec4)
               70:             TypePointer Input 8(fvec2)
 71(i.vTextureCoords):     70(ptr) Variable Input
-              74:             TypePointer Output 11(fvec4)
+              74:             TypePointer Output 12(fvec4)
 75(@entryPointOutput.vColor):     74(ptr) Variable Output
+                              Line 11 23 0
        5(MainPs):           3 Function None 4
                6:             Label
            69(i):     10(ptr) Variable Function
        76(param):     10(ptr) Variable Function
-                              Line 17 23 0
+                              Line 11 23 0
+                              Line 11 23 0
               72:    8(fvec2) Load 71(i.vTextureCoords)
               73:     60(ptr) AccessChain 69(i) 35
                               Store 73 72
               77: 9(PS_INPUT) Load 69(i)
                               Store 76(param) 77
-              78:12(PS_OUTPUT) FunctionCall 15(@MainPs(struct-PS_INPUT-vf21;) 76(param)
-              79:   11(fvec4) CompositeExtract 78 0
+              78:13(PS_OUTPUT) FunctionCall 16(@MainPs(struct-PS_INPUT-vf21;) 76(param)
+              79:   12(fvec4) CompositeExtract 78 0
                               Store 75(@entryPointOutput.vColor) 79
                               Return
                               FunctionEnd
-15(@MainPs(struct-PS_INPUT-vf21;):12(PS_OUTPUT) Function None 13
-           14(i):     10(ptr) FunctionParameter
-              16:             Label
+                              Line 1 23 0
+16(@MainPs(struct-PS_INPUT-vf21;):13(PS_OUTPUT) Function None 14
+           15(i):     10(ptr) FunctionParameter
+              17:             Label
            34(u):     33(ptr) Variable Function
    44(ps_output):     43(ptr) Variable Function
-                              Line 17 47 0
+                              Line 11 47 0
               25:     24(ptr) AccessChain 21 23
               26:     18(int) Load 25
               29:    27(bool) INotEqual 26 28
@@ -174,12 +177,12 @@ PS_OUTPUT MainPs ( PS_INPUT i )
               53:          45 Load 52
               57:          54 Load 56(g_sAniso)
               59:          58 SampledImage 53 57
-              61:     60(ptr) AccessChain 14(i) 35
+              61:     60(ptr) AccessChain 15(i) 35
               62:    8(fvec2) Load 61
-              63:   11(fvec4) ImageSampleImplicitLod 59 62
+              63:   12(fvec4) ImageSampleImplicitLod 59 62
               65:     64(ptr) AccessChain 44(ps_output) 35
                               Store 65 63
                               Line 42 105 0
-              66:12(PS_OUTPUT) Load 44(ps_output)
+              66:13(PS_OUTPUT) Load 44(ps_output)
                               ReturnValue 66
                               FunctionEnd

--- a/Test/baseResults/hlsl.pp.line3.frag.out
+++ b/Test/baseResults/hlsl.pp.line3.frag.out
@@ -120,10 +120,12 @@ PS_OUTPUT MainPs ( PS_INPUT i )
 69(i.vTextureCoords):     68(ptr) Variable Input
               72:             TypePointer Output 12(fvec4)
 73(@entryPointOutput.vColor):     72(ptr) Variable Output
+                              Line 1 23 0
        6(MainPs):           4 Function None 5
                7:             Label
            67(i):     11(ptr) Variable Function
        74(param):     11(ptr) Variable Function
+                              Line 1 23 0
                               Line 1 23 0
               70:    9(fvec2) Load 69(i.vTextureCoords)
               71:     58(ptr) AccessChain 67(i) 34
@@ -135,6 +137,7 @@ PS_OUTPUT MainPs ( PS_INPUT i )
                               Store 73(@entryPointOutput.vColor) 77
                               Return
                               FunctionEnd
+                              Line 1 23 0
 16(@MainPs(struct-PS_INPUT-vf21;):13(PS_OUTPUT) Function None 14
            15(i):     11(ptr) FunctionParameter
               17:             Label

--- a/Test/baseResults/hlsl.pp.line4.frag.out
+++ b/Test/baseResults/hlsl.pp.line4.frag.out
@@ -9,7 +9,7 @@ hlsl.pp.line4.frag
                               EntryPoint Fragment 5  "MainPs" 70 74
                               ExecutionMode 5 OriginUpperLeft
                1:             String  "hlsl.pp.line4.frag"
-              17:             String  "C:\\Users\\Greg\\shaders\\line\\foo4.frag"
+              11:             String  "C:\\Users\\Greg\\shaders\\line\\foo4.frag"
               32:             String  "C:\\Users\\Greg\\shaders\\line\\u1.h"
                               Source HLSL 500 1  "// OpModuleProcessed auto-map-locations
 // OpModuleProcessed auto-map-bindings
@@ -86,7 +86,7 @@ PS_OUTPUT MainPs ( PS_INPUT i )
                4:             TypeFunction 3
                7:             TypeFloat 32
                8:             TypeVector 7(float) 2
-              11:             TypeVector 7(float) 4
+              12:             TypeVector 7(float) 4
               18:             TypeInt 32 0
 19(PerViewConstantBuffer_t):             TypeStruct 18(int) 18(int) 18(int)
               20:             TypePointer PushConstant 19(PerViewConstantBuffer_t)
@@ -110,13 +110,15 @@ PS_OUTPUT MainPs ( PS_INPUT i )
               57:             TypeSampledImage 44
               69:             TypePointer Input 8(fvec2)
 70(i.vTextureCoords):     69(ptr) Variable Input
-              73:             TypePointer Output 11(fvec4)
+              73:             TypePointer Output 12(fvec4)
 74(@entryPointOutput.vColor):     73(ptr) Variable Output
+                              Line 11 25 0
        5(MainPs):           3 Function None 4
+                              NoLine
                6:             Label
-                              Line 17 25 0
+                              Line 11 25 0
               71:    8(fvec2) Load 70(i.vTextureCoords)
-                              Line 17 29 0
+                              Line 11 29 0
               83:     24(ptr) AccessChain 21 23
               84:     18(int) Load 83
               85:    27(bool) INotEqual 84 28
@@ -128,19 +130,19 @@ PS_OUTPUT MainPs ( PS_INPUT i )
               88:     18(int)   Load 87
                                 Branch 92
               89:               Label
-                                Line 17 32 0
+                                Line 11 32 0
               90:     24(ptr)   AccessChain 21 39
               91:     18(int)   Load 90
                                 Branch 92
               92:             Label
              115:     18(int) Phi 88 86 91 89
-                              Line 17 33 0
+                              Line 11 33 0
               94:     50(ptr) AccessChain 48(g_tColor) 115
               95:          44 Load 94
               96:          53 Load 55(g_sAniso)
               97:          57 SampledImage 95 96
-             100:   11(fvec4) ImageSampleImplicitLod 97 71
-                              Line 17 25 0
+             100:   12(fvec4) ImageSampleImplicitLod 97 71
+                              Line 11 25 0
                               Store 74(@entryPointOutput.vColor) 100
                               Return
                               FunctionEnd

--- a/Test/baseResults/hlsl.round.dx9.frag.out
+++ b/Test/baseResults/hlsl.round.dx9.frag.out
@@ -56,10 +56,13 @@ gl_FragCoord origin is upper left
                8:             TypeVector 7(float) 4
                9:             TypePointer Function 8(fvec4)
               10:             TypeFunction 8(fvec4) 9(ptr)
+                              Line 1 0 0
          5(main):           3 Function None 4
                6:             Label
+                              Line 1 2 0
                               Return
                               FunctionEnd
+                              Line 1 2 0
 12(PixelShaderFunction(vf4;):    8(fvec4) Function None 10
        11(input):      9(ptr) FunctionParameter
               13:             Label

--- a/Test/baseResults/hlsl.sample.dx9.frag.out
+++ b/Test/baseResults/hlsl.sample.dx9.frag.out
@@ -477,9 +477,11 @@ using depth_any
 128(@entryPointOutput.Color):    127(ptr) Variable Output
              131:             TypePointer Output 7(float)
 132(@entryPointOutput.Depth):    131(ptr) Variable Output
+                              Line 1 15 0
          5(main):           3 Function None 4
                6:             Label
 125(flattenTemp):    109(ptr) Variable Function
+                              Line 1 15 0
                               Line 1 15 0
              126:9(PS_OUTPUT) FunctionCall 11(@main()
                               Store 125(flattenTemp) 126
@@ -491,6 +493,7 @@ using depth_any
                               Store 132(@entryPointOutput.Depth) 134
                               Return
                               FunctionEnd
+                              Line 1 15 0
       11(@main():9(PS_OUTPUT) Function None 10
               12:             Label
     14(ColorOut):     13(ptr) Variable Function

--- a/Test/baseResults/hlsl.sample.dx9.vert.out
+++ b/Test/baseResults/hlsl.sample.dx9.vert.out
@@ -215,14 +215,17 @@ Shader version: 500
               53:    7(float) Constant 1073741824
               60:             TypePointer Output 8(fvec4)
 61(@entryPointOutput.Pos):     60(ptr) Variable Output
+                              Line 1 11 0
          5(main):           3 Function None 4
                6:             Label
+                              Line 1 11 0
                               Line 1 11 0
               62:9(VS_OUTPUT) FunctionCall 11(@main()
               63:    8(fvec4) CompositeExtract 62 0
                               Store 61(@entryPointOutput.Pos) 63
                               Return
                               FunctionEnd
+                              Line 1 11 0
       11(@main():9(VS_OUTPUT) Function None 10
               12:             Label
       14(PosOut):     13(ptr) Variable Function

--- a/Test/baseResults/spv.debugInfo.1.1.frag.out
+++ b/Test/baseResults/spv.debugInfo.1.1.frag.out
@@ -136,11 +136,13 @@ void main()
              109:      7(int) Constant 1
              111:             TypePointer Output 10(float)
              114:   10(float) Constant 1092616192
+                              Line 1 28 0
          5(main):           3 Function None 4
                6:             Label
        57(param):      9(ptr) Variable Function
            97(i):     19(ptr) Variable Function
              116:     16(ptr) Variable Function
+                              Line 1 16 0
                               Line 1 30 0
               59:     58(ptr) AccessChain 56 18
               60:       53(S) Load 59
@@ -237,6 +239,7 @@ void main()
              118:             Label
                               Return
                               FunctionEnd
+                              Line 1 16 0
 14(foo(struct-S-i11;):   11(fvec4) Function None 12
            13(s):      9(ptr) FunctionParameter
               15:             Label

--- a/Test/baseResults/spv.debugInfo.frag.out
+++ b/Test/baseResults/spv.debugInfo.frag.out
@@ -137,11 +137,13 @@ void main()
              109:      7(int) Constant 1
              111:             TypePointer Output 10(float)
              114:   10(float) Constant 1092616192
+                              Line 1 28 0
          5(main):           3 Function None 4
                6:             Label
        57(param):      9(ptr) Variable Function
            97(i):     19(ptr) Variable Function
              116:     16(ptr) Variable Function
+                              Line 1 16 0
                               Line 1 30 0
               59:     58(ptr) AccessChain 56 18
               60:       53(S) Load 59
@@ -238,6 +240,7 @@ void main()
              118:             Label
                               Return
                               FunctionEnd
+                              Line 1 16 0
 14(foo(struct-S-i11;):   11(fvec4) Function None 12
            13(s):      9(ptr) FunctionParameter
               15:             Label

--- a/Test/baseResults/spv.hlslDebugInfo.frag.out
+++ b/Test/baseResults/spv.hlslDebugInfo.frag.out
@@ -44,13 +44,16 @@ float4 origMain() : SV_Position
               13:    8(fvec4) ConstantComposite 12 12 12 12
               16:             TypePointer Output 8(fvec4)
 17(@entryPointOutput):     16(ptr) Variable Output
+                              Line 1 2 0
       5(newMain):           3 Function None 4
                6:             Label
+                              Line 1 2 0
                               Line 1 2 0
               18:    8(fvec4) FunctionCall 10(@newMain()
                               Store 17(@entryPointOutput) 18
                               Return
                               FunctionEnd
+                              Line 1 2 0
    10(@newMain():    8(fvec4) Function None 9
               11:             Label
                               Line 1 3 0

--- a/Test/baseResults/spv.pp.line.frag.out
+++ b/Test/baseResults/spv.pp.line.frag.out
@@ -92,6 +92,7 @@ void main()
            56(u):     55(ptr) Variable Input
               58:             TypePointer Input 7(float)
        59(blend):     58(ptr) Variable Input
+                              Line 1 11 0
          5(main):           3 Function None 4
                6:             Label
    9(blendscale):      8(ptr) Variable Function


### PR DESCRIPTION
This ensures useful source line association for other tools, such as [AMDVLK's fork of SPIRV-LLVM-Translator](https://github.com/GPUOpen-Drivers/llpc/blob/2bd4eb104a93a61614f398826814e60cfc312fbc/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp#L64). Emitting `OpLine` before `OpFunction` enables instructions generated automatically _in support of a function_ (such as setting a hypothetical stack frame, or - in the case of AMD GPUs - moving data out of implicitly pre-populated registers) to be associated with source code, rather than being untraceable.

After this change, source file name information survives the entire compilation pipeline, from source to the DWARF info in the AMDGPU ELF.