### PR TITLE
Add new rules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,12 @@
 *.a
 *.so
 *.exe
+.vscode/
 tags
 TAGS
+bazel-*
 build/
 Test/localResults/
 External/googletest
 External/spirv-tools
+out/


### PR DESCRIPTION
`.vscode/` ignores Visual Studio Code user config files.
`bazel-*` ignores bazel build system symlinks.
`out/` ignores the default output directory for Visual Studio generated files.