### PR TITLE
Remove GLSLANG_BUILD_PIC flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,14 +107,6 @@ if(USE_CCACHE)
     endif(CCACHE_FOUND)
 endif()
 
-# If projects are statically importing glslang targets into a shared library
-# then they'll likely need to build with -fPIC. This can be enabled by setting
-# GLSLANG_BUILD_PIC to 1 before calling add_subdirectory() to import glslang.
-# Note: -fPIC is automatically used when BUILD_SHARED_LIBS is enabled.
-if(NOT DEFINED GLSLANG_BUILD_PIC)
-    option(GLSLANG_BUILD_PIC "Compile glslang with -fPIC" OFF)
-endif()
-
 # Precompiled header macro. Parameters are source file list and filename for pch cpp file.
 macro(glslang_pch SRCS PCHCPP)
   if(MSVC AND CMAKE_GENERATOR MATCHES "^Visual Studio" AND NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" AND ENABLE_PCH)
@@ -160,9 +152,6 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
     add_compile_options(-Wall -Wmaybe-uninitialized -Wuninitialized -Wunused -Wunused-local-typedefs
                         -Wunused-parameter -Wunused-value  -Wunused-variable -Wunused-but-set-parameter -Wunused-but-set-variable -fno-exceptions)
     add_compile_options(-Wno-reorder)  # disable this from -Wall, since it happens all over.
-    if(BUILD_SHARED_LIBS OR GLSLANG_BUILD_PIC)
-        add_compile_options(-fPIC)
-    endif()
     if(NOT ENABLE_RTTI)
         add_compile_options(-fno-rtti)
     endif()
@@ -183,9 +172,6 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" AND NOT MSVC)
     add_compile_options(-Wall -Wuninitialized -Wunused -Wunused-local-typedefs
                         -Wunused-parameter -Wunused-value  -Wunused-variable)
     add_compile_options(-Wno-reorder)  # disable this from -Wall, since it happens all over.
-    if(BUILD_SHARED_LIBS OR GLSLANG_BUILD_PIC)
-        add_compile_options(-fPIC)
-    endif()
     if(NOT ENABLE_RTTI)
         add_compile_options(-fno-rtti)
     endif()

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -50,6 +50,7 @@ endif(EMSCRIPTEN OR ENABLE_GLSLANG_JS)
 add_library(GenericCodeGen STATIC
     GenericCodeGen/CodeGen.cpp
     GenericCodeGen/Link.cpp)
+set_property(TARGET GenericCodeGen PROPERTY FOLDER glslang)
 
 ################################################################################
 # MachineIndependent
@@ -129,7 +130,7 @@ if(ENABLE_HLSL)
 endif(ENABLE_HLSL)
 
 add_library(MachineIndependent STATIC ${MACHINEINDEPENDENT_SOURCES} ${MACHINEINDEPENDENT_HEADERS})
-
+set_property(TARGET MachineIndependent PROPERTY FOLDER glslang)
 glslang_pch(SOURCES MachineIndependent/pch.cpp)
 
 target_link_libraries(MachineIndependent PRIVATE OGLCompiler OSDependent GenericCodeGen)

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -50,6 +50,7 @@ endif(EMSCRIPTEN OR ENABLE_GLSLANG_JS)
 add_library(GenericCodeGen STATIC
     GenericCodeGen/CodeGen.cpp
     GenericCodeGen/Link.cpp)
+set_property(TARGET GenericCodeGen PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET GenericCodeGen PROPERTY FOLDER glslang)
 
 ################################################################################
@@ -130,6 +131,7 @@ if(ENABLE_HLSL)
 endif(ENABLE_HLSL)
 
 add_library(MachineIndependent STATIC ${MACHINEINDEPENDENT_SOURCES} ${MACHINEINDEPENDENT_HEADERS})
+set_property(TARGET MachineIndependent PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET MachineIndependent PROPERTY FOLDER glslang)
 glslang_pch(SOURCES MachineIndependent/pch.cpp)
 


### PR DESCRIPTION
On closer inspection, it appears that nearly all the targets use the `POSITION_INDEPENDENT_CODE` target option anyway.
Simplify all this away by always being PIC.