### PR TITLE
Make sure glslang_angle has a definition in BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -47,6 +47,9 @@ if (defined(is_fuchsia_tree) && is_fuchsia_tree) {
 }
 
 spirv_tools_dir = glslang_spirv_tools_dir
+if (!defined(glslang_angle)) {
+  glslang_angle = false
+}
 
 config("glslang_public") {
   include_dirs = [ "." ]


### PR DESCRIPTION
Set the value to false if the environment doesn't declare this variable.

This fixes downstream integration issues for environments that at not aware of/use angle.