### PR TITLE
Attempt to fix chromium builds

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -242,7 +242,6 @@ template("glslang_sources_common") {
 
     if (invoker.enable_opt) {
       deps += [
-        ":glslang_build_info",
         "${spirv_tools_dir}:spvtools_opt",
         "${spirv_tools_dir}:spvtools_val",
       ]
@@ -289,6 +288,7 @@ executable("glslang_validator") {
   deps = [
     ":glslang_default_resource_limits_sources",
     ":glslang_sources",
+    ":glslang_build_info",
   ]
   public_configs = [ ":glslang_hlsl" ]
 


### PR DESCRIPTION
It would seem that `glslang_sources` has a private dependency on `glslang_build_info`, so `glslang_validator` cannot transitively `#include` the generated `glslang/build_info.h` header.

Add `glslang_build_info` as a direct dependency to `glslang_validator`.
Also remove the duplicate dependency on `glslang_build_info` in `glslang_sources_common`

Note: This is a speculative fix as I can build Chromium fine without these changes.
Not sure what's different between these build environments.