### PR TITLE
Common: include standard headers before doing any defines

### DIFF
--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -37,6 +37,17 @@
 #ifndef _COMMON_INCLUDED_
 #define _COMMON_INCLUDED_
 
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <list>
+#include <map>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #if defined(__ANDROID__) || (defined(_MSC_VER) && _MSC_VER < 1700)
 #include <sstream>
@@ -92,18 +103,6 @@ std::string to_string(const T& val) {
     #pragma warning(disable : 4514) // unused inline method
     #pragma warning(disable : 4201) // nameless union
 #endif
-
-#include <set>
-#include <unordered_set>
-#include <vector>
-#include <map>
-#include <unordered_map>
-#include <list>
-#include <algorithm>
-#include <string>
-#include <cstdio>
-#include <cstdlib>
-#include <cassert>
 
 #include "PoolAlloc.h"
 


### PR DESCRIPTION
currently, due to

```c++
#if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/) || defined MINGW_HAS_SECURE_API
    #include <basetsd.h>
    #ifndef snprintf
    #define snprintf sprintf_s
    #endif
    #define safe_vsprintf(buf,max,format,args) vsnprintf_s((buf), (max), (max), (format), (args))
```

defining `snprintf` to `sprintf_s` essentially unconditionally, this will break the
stdio.h+cstdio system header for mingw-w64 g++ in msys2 with shaderc
https://github.com/google/shaderc/issues/1065

an alternative change would be
https://raw.githubusercontent.com/shinchiro/mpv-winbuild-cmake/master/packages/glslang-0001-fix-gcc-10.1-error.patch
in which the `|| defined MINGW_HAS_SECURE_API` part is removed


possibly related https://github.com/KhronosGroup/glslang/issues/2232