### PR TITLE
Add missing comma from license-checker.cfg

### DIFF
--- a/license-checker.cfg
+++ b/license-checker.cfg
@@ -21,7 +21,7 @@
                 "glslang/OSDependent/Web/glslang.*.js",
 
                 "glslang/MachineIndependent/glslang_tab.cpp",
-                "glslang/MachineIndependent/glslang_tab.cpp.h"
+                "glslang/MachineIndependent/glslang_tab.cpp.h",
 
                 "glslang/MachineIndependent/glslang_angle_tab.cpp",
                 "glslang/MachineIndependent/glslang_angle_tab.cpp.h"


### PR DESCRIPTION
Fixes license checker presubmit.