### PR TITLE
Add new rules for update of license-checker

### DIFF
--- a/license-checker.cfg
+++ b/license-checker.cfg
@@ -21,7 +21,13 @@
                 "glslang/OSDependent/Web/glslang.*.js",
 
                 "glslang/MachineIndependent/glslang_tab.cpp",
-                "glslang/MachineIndependent/glslang_tab.cpp.h"
+                "glslang/MachineIndependent/glslang_tab.cpp.h",
+
+                "**.md",
+                "build/**",
+                "out/**",
+                "Test/**",
+                "External/spirv-tools/**"
             ]
         }
     ],


### PR DESCRIPTION
`license-checker` will be updated to support `**` based wildcards. As part of this, `license-checker` will now traverse into subdirectories that would previously be excluded when the parent directory is excluded.

This change adds new rules that work with both the old version and new, to ease migration.