### PR TITLE
Update license-checker.cfg with simplified rules

### DIFF
--- a/license-checker.cfg
+++ b/license-checker.cfg
@@ -1,41 +1,51 @@
-{
-    "paths": [
-        {
-            "exclude": [
-                "_config.yml",
-                ".*",
-                "*.md",
-                "CMakeSettings.json",
-                "known_good_khr.json",
-                "known_good.json",
-                "LICENSE.txt",
-                "make-revision",
-                "README-spirv-remap.txt",
-                "WORKSPACE",
+[
+    {
+        "licenses": [
+            "Apache-2.0-Header",
+            "BSD-2-Clause",
+            "BSD-3-Clause",
+            "MIT-0",
+            "MIT"
+        ],
+        "paths": [
+            {
+                "exclude": [
+                    "**.md",
 
-                "gtests/README.md",
-                "External/spirv-tools",
-                "Test/*",
-                "out/*",
-                "glslang/Include/revision.*",
-                "glslang/OSDependent/Web/glslang.*.js",
+                    "_config.yml",
+                    ".*",
+                    "CMakeSettings.json",
+                    "known_good_khr.json",
+                    "known_good.json",
+                    "LICENSE.txt",
+                    "make-revision",
+                    "README-spirv-remap.txt",
+                    "WORKSPACE",
 
-                "glslang/MachineIndependent/glslang_tab.cpp",
-                "glslang/MachineIndependent/glslang_tab.cpp.h",
+                    "glslang/OSDependent/Web/glslang.*.js",
+                    "glslang/MachineIndependent/glslang_tab.cpp",
+                    "glslang/MachineIndependent/glslang_tab.cpp.h",
 
-                "**.md",
-                "build/**",
-                "out/**",
-                "Test/**",
-                "External/spirv-tools/**"
-            ]
-        }
-    ],
-    "licenses": [
-        "Apache-2.0-Header",
-        "BSD-2-Clause",
-        "BSD-3-Clause",
-        "MIT-0",
-        "MIT"
-    ]
-}
+                    "build/**",
+                    "out/**",
+                    "Test/**",
+                    "External/spirv-tools/**"
+                ]
+            }
+        ]
+    },
+    {
+        "licenses": [
+            "GPL-Header"
+        ],
+        "paths": [
+            { "exclude": [ "**" ] },
+            {
+                "include": [
+                    "glslang/MachineIndependent/glslang_tab.cpp",
+                    "glslang/MachineIndependent/glslang_tab.cpp.h"
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
`license-checker` has been updated to support `**` wildcards simplifying the rules, and multiple license configs.

Add a new config for the bison generated files to ensure their licenses don't change.