### PR TITLE
Limit visibility of symbols for internal libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,17 +279,23 @@ function(glslang_add_build_info_dependency target)
     add_dependencies(${target} glslang-build-info)
 endfunction()
 
+# glslang_default_to_hidden_visibility() makes the symbol visibility hidden by
+# default for <target>.
+function(glslang_default_to_hidden_visibility target)
+    if(NOT WIN32)
+        target_compile_options(${target} PRIVATE "-fvisibility=hidden")
+    endif()
+endfunction()
+
 # glslang_only_export_explicit_symbols() makes the symbol visibility hidden by
-# default for <target> when building shared libraries, and sets the
-# GLSLANG_IS_SHARED_LIBRARY define, and GLSLANG_EXPORTING to 1 when specifically
-# building <target>.
+# default for <target>, and sets the GLSLANG_IS_SHARED_LIBRARY define, and 
+# GLSLANG_EXPORTING to 1 when specifically building <target>.
 function(glslang_only_export_explicit_symbols target)
+    glslang_default_to_hidden_visibility(${target})
     if(BUILD_SHARED_LIBS)
         target_compile_definitions(${target} PUBLIC "GLSLANG_IS_SHARED_LIBRARY=1")
         if(WIN32)
             target_compile_definitions(${target} PRIVATE "GLSLANG_EXPORTING=1")
-        else()
-            target_compile_options(${target} PRIVATE "-fvisibility=hidden")
         endif()
     endif()
 endfunction()

--- a/OGLCompilersDLL/CMakeLists.txt
+++ b/OGLCompilersDLL/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SOURCES InitializeDll.cpp InitializeDll.h)
 add_library(OGLCompiler STATIC ${SOURCES})
 set_property(TARGET OGLCompiler PROPERTY FOLDER glslang)
 set_property(TARGET OGLCompiler PROPERTY POSITION_INDEPENDENT_CODE ON)
+glslang_default_to_hidden_visibility(OGLCompiler)
 
 if(WIN32)
     source_group("Source" FILES ${SOURCES})

--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -43,8 +43,7 @@ set(SOURCES
     CInterface/spirv_c_interface.cpp)
 
 set(SPVREMAP_SOURCES
-    SPVRemapper.cpp
-    doc.cpp)
+    SPVRemapper.cpp)
 
 set(HEADERS
     bitutils.h
@@ -69,6 +68,7 @@ set(SPVREMAP_HEADERS
     doc.h)
 
 add_library(SPIRV ${LIB_TYPE} ${SOURCES} ${HEADERS})
+target_link_libraries(SPIRV PRIVATE MachineIndependent)
 set_property(TARGET SPIRV PROPERTY FOLDER glslang)
 set_property(TARGET SPIRV PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_include_directories(SPIRV PUBLIC
@@ -79,6 +79,7 @@ glslang_add_build_info_dependency(SPIRV)
 
 if (ENABLE_SPVREMAPPER)
     add_library(SPVRemapper ${LIB_TYPE} ${SPVREMAP_SOURCES} ${SPVREMAP_HEADERS})
+    target_link_libraries(SPVRemapper PRIVATE SPIRV)
     set_property(TARGET SPVRemapper PROPERTY FOLDER glslang)
     set_property(TARGET SPVRemapper PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
@@ -95,12 +96,10 @@ if(ENABLE_OPT)
         PRIVATE ${spirv-tools_SOURCE_DIR}/include
         PRIVATE ${spirv-tools_SOURCE_DIR}/source
     )
-    target_link_libraries(SPIRV PRIVATE MachineIndependent SPIRV-Tools-opt)
+    target_link_libraries(SPIRV PRIVATE SPIRV-Tools-opt)
     target_include_directories(SPIRV PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../External>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/External>)
-else()
-    target_link_libraries(SPIRV PRIVATE MachineIndependent)
 endif(ENABLE_OPT)
 
 if(WIN32)

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(GenericCodeGen STATIC
     GenericCodeGen/Link.cpp)
 set_property(TARGET GenericCodeGen PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET GenericCodeGen PROPERTY FOLDER glslang)
+glslang_default_to_hidden_visibility(GenericCodeGen)
 
 ################################################################################
 # MachineIndependent
@@ -133,6 +134,7 @@ endif(ENABLE_HLSL)
 add_library(MachineIndependent STATIC ${MACHINEINDEPENDENT_SOURCES} ${MACHINEINDEPENDENT_HEADERS})
 set_property(TARGET MachineIndependent PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET MachineIndependent PROPERTY FOLDER glslang)
+glslang_only_export_explicit_symbols(MachineIndependent)
 
 glslang_add_build_info_dependency(MachineIndependent)
 
@@ -168,7 +170,7 @@ set_target_properties(glslang PROPERTIES
     POSITION_INDEPENDENT_CODE ON
     VERSION   "${GLSLANG_VERSION}"
     SOVERSION "${GLSLANG_VERSION_MAJOR}")
-target_link_libraries(glslang PRIVATE OGLCompiler OSDependent MachineIndependent)
+target_link_libraries(glslang PRIVATE OGLCompiler MachineIndependent)
 target_include_directories(glslang PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)


### PR DESCRIPTION
Also remove `SPIRV/doc.cpp` from the `SPVRemapper` target as this is part of `SPIRV`, causing ODR violations. Instead have
`SPVRemapper` link against `SPIRV`.

Fixes: #2346 