### PR TITLE
Avoid spurious warning about uninit var

### DIFF
--- a/glslang/MachineIndependent/reflection.cpp
+++ b/glslang/MachineIndependent/reflection.cpp
@@ -639,7 +639,7 @@ public:
 
     int addBlockName(const TString& name, const TType& type, int size)
     {
-        int blockIndex;
+        int blockIndex = 0;
         if (type.isArray()) {
             TType derefType(type, 0);
             for (int e = 0; e < type.getOuterArraySize(); ++e) {


### PR DESCRIPTION
The compiler can't see that the loop in the first "if" will always execute at least once.  So it doesn't know that the blockIndex will actually be initialized before return, so the compiler throws a warning.