### PR TITLE
Revert changes that migrate to `thread_local`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,23 +279,17 @@ function(glslang_add_build_info_dependency target)
     add_dependencies(${target} glslang-build-info)
 endfunction()
 
-# glslang_default_to_hidden_visibility() makes the symbol visibility hidden by
-# default for <target>.
-function(glslang_default_to_hidden_visibility target)
-    if(NOT WIN32)
-        target_compile_options(${target} PRIVATE "-fvisibility=hidden")
-    endif()
-endfunction()
-
 # glslang_only_export_explicit_symbols() makes the symbol visibility hidden by
-# default for <target>, and sets the GLSLANG_IS_SHARED_LIBRARY define, and 
-# GLSLANG_EXPORTING to 1 when specifically building <target>.
+# default for <target> when building shared libraries, and sets the
+# GLSLANG_IS_SHARED_LIBRARY define, and GLSLANG_EXPORTING to 1 when specifically
+# building <target>.
 function(glslang_only_export_explicit_symbols target)
-    glslang_default_to_hidden_visibility(${target})
     if(BUILD_SHARED_LIBS)
         target_compile_definitions(${target} PUBLIC "GLSLANG_IS_SHARED_LIBRARY=1")
         if(WIN32)
             target_compile_definitions(${target} PRIVATE "GLSLANG_EXPORTING=1")
+        else()
+            target_compile_options(${target} PRIVATE "-fvisibility=hidden")
         endif()
     endif()
 endfunction()

--- a/OGLCompilersDLL/CMakeLists.txt
+++ b/OGLCompilersDLL/CMakeLists.txt
@@ -36,7 +36,6 @@ set(SOURCES InitializeDll.cpp InitializeDll.h)
 add_library(OGLCompiler STATIC ${SOURCES})
 set_property(TARGET OGLCompiler PROPERTY FOLDER glslang)
 set_property(TARGET OGLCompiler PROPERTY POSITION_INDEPENDENT_CODE ON)
-glslang_default_to_hidden_visibility(OGLCompiler)
 
 if(WIN32)
     source_group("Source" FILES ${SOURCES})

--- a/OGLCompilersDLL/InitializeDll.cpp
+++ b/OGLCompilersDLL/InitializeDll.cpp
@@ -32,6 +32,134 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
+#define SH_EXPORTING
+
+#include <cassert>
+
+#include "InitializeDll.h"
+#include "../glslang/Include/InitializeGlobals.h"
+#include "../glslang/Public/ShaderLang.h"
+#include "../glslang/Include/PoolAlloc.h"
+
 namespace glslang {
+
+OS_TLSIndex ThreadInitializeIndex = OS_INVALID_TLS_INDEX;
+
+// Per-process initialization.
+// Needs to be called at least once before parsing, etc. is done.
+// Will also do thread initialization for the calling thread; other
+// threads will need to do that explicitly.
+bool InitProcess()
+{
+    glslang::GetGlobalLock();
+
+    if (ThreadInitializeIndex != OS_INVALID_TLS_INDEX) {
+        //
+        // Function is re-entrant.
+        //
+
+        glslang::ReleaseGlobalLock();
+        return true;
+    }
+
+    ThreadInitializeIndex = OS_AllocTLSIndex();
+
+    if (ThreadInitializeIndex == OS_INVALID_TLS_INDEX) {
+        assert(0 && "InitProcess(): Failed to allocate TLS area for init flag");
+
+        glslang::ReleaseGlobalLock();
+        return false;
+    }
+
+    if (! InitializePoolIndex()) {
+        assert(0 && "InitProcess(): Failed to initialize global pool");
+
+        glslang::ReleaseGlobalLock();
+        return false;
+    }
+
+    if (! InitThread()) {
+        assert(0 && "InitProcess(): Failed to initialize thread");
+
+        glslang::ReleaseGlobalLock();
+        return false;
+    }
+
+    glslang::ReleaseGlobalLock();
+    return true;
+}
+
+// Per-thread scoped initialization.
+// Must be called at least once by each new thread sharing the
+// symbol tables, etc., needed to parse.
+bool InitThread()
+{
+    //
+    // This function is re-entrant
+    //
+    if (ThreadInitializeIndex == OS_INVALID_TLS_INDEX) {
+        assert(0 && "InitThread(): Process hasn't been initalised.");
+        return false;
+    }
+
+    if (OS_GetTLSValue(ThreadInitializeIndex) != 0)
+        return true;
+
+    if (! OS_SetTLSValue(ThreadInitializeIndex, (void *)1)) {
+        assert(0 && "InitThread(): Unable to set init flag.");
+        return false;
+    }
+
+    glslang::SetThreadPoolAllocator(nullptr);
+
+    return true;
+}
+
+// Not necessary to call this: InitThread() is reentrant, and the need
+// to do per thread tear down has been removed.
+//
+// This is kept, with memory management removed, to satisfy any exiting
+// calls to it that rely on it.
+bool DetachThread()
+{
+    bool success = true;
+
+    if (ThreadInitializeIndex == OS_INVALID_TLS_INDEX)
+        return true;
+
+    //
+    // Function is re-entrant and this thread may not have been initialized.
+    //
+    if (OS_GetTLSValue(ThreadInitializeIndex) != 0) {
+        if (!OS_SetTLSValue(ThreadInitializeIndex, (void *)0)) {
+            assert(0 && "DetachThread(): Unable to clear init flag.");
+            success = false;
+        }
+    }
+
+    return success;
+}
+
+// Not necessary to call this: InitProcess() is reentrant.
+//
+// This is kept, with memory management removed, to satisfy any exiting
+// calls to it that rely on it.
+//
+// Users of glslang should call shFinalize() or glslang::FinalizeProcess() for
+// process-scoped memory tear down.
+bool DetachProcess()
+{
+    bool success = true;
+
+    if (ThreadInitializeIndex == OS_INVALID_TLS_INDEX)
+        return true;
+
+    success = DetachThread();
+
+    OS_FreeTLSIndex(ThreadInitializeIndex);
+    ThreadInitializeIndex = OS_INVALID_TLS_INDEX;
+
+    return success;
+}
 
 } // end namespace glslang

--- a/OGLCompilersDLL/InitializeDll.h
+++ b/OGLCompilersDLL/InitializeDll.h
@@ -38,10 +38,10 @@
 
 namespace glslang {
 
-inline bool InitProcess()   { return true; } // DEPRECATED
-inline bool InitThread()    { return true; } // DEPRECATED
-inline bool DetachThread()  { return true; } // DEPRECATED
-inline bool DetachProcess() { return true; } // DEPRECATED
+bool InitProcess();
+bool InitThread();
+bool DetachThread();  // not called from standalone, perhaps other tools rely on parts of it
+bool DetachProcess(); // not called from standalone, perhaps other tools rely on parts of it
 
 } // end namespace glslang
 

--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -43,7 +43,8 @@ set(SOURCES
     CInterface/spirv_c_interface.cpp)
 
 set(SPVREMAP_SOURCES
-    SPVRemapper.cpp)
+    SPVRemapper.cpp
+    doc.cpp)
 
 set(HEADERS
     bitutils.h
@@ -68,7 +69,6 @@ set(SPVREMAP_HEADERS
     doc.h)
 
 add_library(SPIRV ${LIB_TYPE} ${SOURCES} ${HEADERS})
-target_link_libraries(SPIRV PRIVATE MachineIndependent)
 set_property(TARGET SPIRV PROPERTY FOLDER glslang)
 set_property(TARGET SPIRV PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_include_directories(SPIRV PUBLIC
@@ -79,7 +79,6 @@ glslang_add_build_info_dependency(SPIRV)
 
 if (ENABLE_SPVREMAPPER)
     add_library(SPVRemapper ${LIB_TYPE} ${SPVREMAP_SOURCES} ${SPVREMAP_HEADERS})
-    target_link_libraries(SPVRemapper PRIVATE SPIRV)
     set_property(TARGET SPVRemapper PROPERTY FOLDER glslang)
     set_property(TARGET SPVRemapper PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
@@ -96,10 +95,12 @@ if(ENABLE_OPT)
         PRIVATE ${spirv-tools_SOURCE_DIR}/include
         PRIVATE ${spirv-tools_SOURCE_DIR}/source
     )
-    target_link_libraries(SPIRV PRIVATE SPIRV-Tools-opt)
+    target_link_libraries(SPIRV PRIVATE MachineIndependent SPIRV-Tools-opt)
     target_include_directories(SPIRV PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../External>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/External>)
+else()
+    target_link_libraries(SPIRV PRIVATE MachineIndependent)
 endif(ENABLE_OPT)
 
 if(WIN32)

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -52,7 +52,6 @@ add_library(GenericCodeGen STATIC
     GenericCodeGen/Link.cpp)
 set_property(TARGET GenericCodeGen PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET GenericCodeGen PROPERTY FOLDER glslang)
-glslang_default_to_hidden_visibility(GenericCodeGen)
 
 ################################################################################
 # MachineIndependent
@@ -134,7 +133,6 @@ endif(ENABLE_HLSL)
 add_library(MachineIndependent STATIC ${MACHINEINDEPENDENT_SOURCES} ${MACHINEINDEPENDENT_HEADERS})
 set_property(TARGET MachineIndependent PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET MachineIndependent PROPERTY FOLDER glslang)
-glslang_only_export_explicit_symbols(MachineIndependent)
 
 glslang_add_build_info_dependency(MachineIndependent)
 
@@ -170,7 +168,7 @@ set_target_properties(glslang PROPERTIES
     POSITION_INDEPENDENT_CODE ON
     VERSION   "${GLSLANG_VERSION}"
     SOVERSION "${GLSLANG_VERSION_MAJOR}")
-target_link_libraries(glslang PRIVATE OGLCompiler MachineIndependent)
+target_link_libraries(glslang PRIVATE OGLCompiler OSDependent MachineIndependent)
 target_include_directories(glslang PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)

--- a/glslang/Include/InitializeGlobals.h
+++ b/glslang/Include/InitializeGlobals.h
@@ -37,7 +37,7 @@
 
 namespace glslang {
 
-inline bool InitializePoolIndex() { return true; } // DEPRECATED: No need to call
+bool InitializePoolIndex();
 
 } // end namespace glslang
 

--- a/glslang/MachineIndependent/PoolAlloc.cpp
+++ b/glslang/MachineIndependent/PoolAlloc.cpp
@@ -35,28 +35,34 @@
 #include "../Include/Common.h"
 #include "../Include/PoolAlloc.h"
 
+#include "../Include/InitializeGlobals.h"
+#include "../OSDependent/osinclude.h"
+
 namespace glslang {
 
-namespace {
-thread_local TPoolAllocator* threadPoolAllocator = nullptr;
-
-TPoolAllocator* GetDefaultThreadPoolAllocator()
-{
-    thread_local TPoolAllocator defaultAllocator;
-    return &defaultAllocator;
-}
-} // anonymous namespace
+// Process-wide TLS index
+OS_TLSIndex PoolIndex;
 
 // Return the thread-specific current pool.
 TPoolAllocator& GetThreadPoolAllocator()
 {
-    return *(threadPoolAllocator ? threadPoolAllocator : GetDefaultThreadPoolAllocator());
+    return *static_cast<TPoolAllocator*>(OS_GetTLSValue(PoolIndex));
 }
 
 // Set the thread-specific current pool.
 void SetThreadPoolAllocator(TPoolAllocator* poolAllocator)
 {
-    threadPoolAllocator = poolAllocator;
+    OS_SetTLSValue(PoolIndex, poolAllocator);
+}
+
+// Process-wide set up of the TLS pool storage.
+bool InitializePoolIndex()
+{
+    // Allocate a TLS index.
+    if ((PoolIndex = OS_AllocTLSIndex()) == OS_INVALID_TLS_INDEX)
+        return false;
+
+    return true;
 }
 
 //


### PR DESCRIPTION
iOS 8 does not support `thread_local`, which is still in use.
Another approach will have to be found.

This change is a revert of the following changes:

a3845240 - "Simplify PoolAlloc with use of thread_local."
abf92c80 - "Deprecate InitializeDll functions"
33585c87 - "Limit visibility of symbols for internal libraries"

Issue: #2346