### PR TITLE
Build/Test: Dropping VS 2013 allows using the latest googletests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,9 +48,6 @@ install:
   - C:/Python27/python.exe update_glslang_sources.py
   - set PATH=C:\ninja;C:\Python36;%PATH%
   - git clone https://github.com/google/googletest.git External/googletest
-  - cd External/googletest
-  - git checkout 440527a61e1c91188195f7de212c63c77e8f0a45
-  - cd ../..
 
 build:
   parallel: true  # enable MSBuild parallel builds

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ branch.
 ### Dependencies
 
 * A C++11 compiler.
-  (For MSVS: 2015 is recommended, 2013 is fully supported/tested, and 2010 support is attempted, but not tested.)
+  (For MSVS: use 2015 or later.)
 * [CMake][cmake]: for generating compilation targets.
 * make: _Linux_, ninja is an alternative, if configured.
 * [Python 3.x][python]: for executing SPIRV-Tools scripts. (Optional if not using SPIRV-Tools and the 'External' subdirectory does not exist.)
@@ -123,15 +123,6 @@ git clone https://github.com/KhronosGroup/glslang.git
 ```bash
 cd <the directory glslang was cloned to, "External" will be a subdirectory>
 git clone https://github.com/google/googletest.git External/googletest
-```
-
-If you want to use googletest with Visual Studio 2013, you also need to check out an older version:
-
-```bash
-# to use googletest with Visual Studio 2013
-cd External/googletest
-git checkout 440527a61e1c91188195f7de212c63c77e8f0a45
-cd ../..
 ```
 
 If you wish to assure that SPIR-V generated from HLSL is legal for Vulkan,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,9 +6,9 @@ load(
 
 http_archive(
     name = "com_google_googletest",
-    sha256 = "ef9e2e12e7bf115ee48b427ae171fc869eeaf1b532c0fcfd982f6a353d2471b4",
-    strip_prefix = "googletest-37ae1fc5e6be26f367d76c078beabd7024fed53a",
-    urls = ["https://github.com/google/googletest/archive/37ae1fc5e6be26f367d76c078beabd7024fed53a.zip"],  # 2018-07-16
+    sha256 = "94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91",
+    strip_prefix = "googletest-release-1.10.0",
+    urls = ["https://github.com/google/googletest/archive/release-1.10.0.zip"],  # 3-Oct-2019
 )
 
 http_archive(

--- a/gtests/AST.FromFile.cpp
+++ b/gtests/AST.FromFile.cpp
@@ -59,7 +59,7 @@ TEST_P(CompileToAstTestNV, FromFile)
 }
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, CompileToAstTest,
     ::testing::ValuesIn(std::vector<std::string>({
         "sample.frag",
@@ -282,7 +282,7 @@ INSTANTIATE_TEST_CASE_P(
     FileNameAsCustomTestSuffix
 );
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, CompileToAstTestNV,
     ::testing::ValuesIn(std::vector<std::string>({
         "nvShaderNoperspectiveInterpolation.frag",

--- a/gtests/Config.FromFile.cpp
+++ b/gtests/Config.FromFile.cpp
@@ -95,7 +95,7 @@ TEST_P(ConfigTest, FromFile)
 }
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, ConfigTest,
     ::testing::ValuesIn(std::vector<TestCaseSpec>({
         {"specExamples.vert", "baseResults/test.conf", "specExamplesConf.vert.out", (EShMessages)(EShMsgAST | EShMsgCascadingErrors)},

--- a/gtests/HexFloat.cpp
+++ b/gtests/HexFloat.cpp
@@ -77,7 +77,7 @@ TEST_P(HexDoubleTest, DecodeCorrectly) {
   EXPECT_THAT(Decode<double>(GetParam().second), Eq(GetParam().first));
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Float32Tests, HexFloatTest,
     ::testing::ValuesIn(std::vector<std::pair<FloatProxy<float>, std::string>>({
         {0.f, "0x0p+0"},
@@ -129,7 +129,7 @@ INSTANTIATE_TEST_CASE_P(
 
     })));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Float32NanTests, HexFloatTest,
     ::testing::ValuesIn(std::vector<std::pair<FloatProxy<float>, std::string>>({
         // Various NAN and INF cases
@@ -147,7 +147,7 @@ INSTANTIATE_TEST_CASE_P(
         {uint32_t(0x7FFFFFFF), "0x1.fffffep+128"},   // +nan
     })));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Float64Tests, HexDoubleTest,
     ::testing::ValuesIn(
         std::vector<std::pair<FloatProxy<double>, std::string>>({
@@ -220,7 +220,7 @@ INSTANTIATE_TEST_CASE_P(
 
         })));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Float64NanTests, HexDoubleTest,
     ::testing::ValuesIn(std::vector<
                         std::pair<FloatProxy<double>, std::string>>({
@@ -262,7 +262,7 @@ TEST_P(DecodeHexDoubleTest, DecodeCorrectly) {
   EXPECT_THAT(Decode<double>(GetParam().first), Eq(GetParam().second));
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Float32DecodeTests, DecodeHexFloatTest,
     ::testing::ValuesIn(std::vector<std::pair<std::string, FloatProxy<float>>>({
         {"0x0p+000", 0.f},
@@ -284,7 +284,7 @@ INSTANTIATE_TEST_CASE_P(
         {"0x0.4p+0", 0.25f},
     })));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Float32DecodeInfTests, DecodeHexFloatTest,
     ::testing::ValuesIn(std::vector<std::pair<std::string, FloatProxy<float>>>({
         // inf cases
@@ -294,7 +294,7 @@ INSTANTIATE_TEST_CASE_P(
         {"-0x32p+127", uint32_t(0xFF800000)},  // -inf
     })));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Float64DecodeTests, DecodeHexDoubleTest,
     ::testing::ValuesIn(
         std::vector<std::pair<std::string, FloatProxy<double>>>({
@@ -317,7 +317,7 @@ INSTANTIATE_TEST_CASE_P(
             {"0x0.4p+0", 0.25},
         })));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Float64DecodeInfTests, DecodeHexDoubleTest,
     ::testing::ValuesIn(
         std::vector<std::pair<std::string, FloatProxy<double>>>({
@@ -465,7 +465,7 @@ TEST_P(FloatProxyDoubleTest, EncodeCorrectly) {
       Eq(GetParam().second));
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Float32Tests, FloatProxyFloatTest,
     ::testing::ValuesIn(std::vector<std::pair<FloatProxy<float>, std::string>>({
         // Zero
@@ -497,7 +497,7 @@ INSTANTIATE_TEST_CASE_P(
         {-std::numeric_limits<float>::infinity(), "-0x1p+128"},
     })));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Float64Tests, FloatProxyDoubleTest,
     ::testing::ValuesIn(
         std::vector<std::pair<FloatProxy<double>, std::string>>({
@@ -747,7 +747,7 @@ TEST_P(HexFloatRoundTest, RoundDownToFP16) {
 }
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(F32ToF16, HexFloatRoundTest,
+INSTANTIATE_TEST_SUITE_P(F32ToF16, HexFloatRoundTest,
   ::testing::ValuesIn(std::vector<RoundSignificandCase>(
   {
     {float_fractions({0}), std::make_pair(half_bits_set({}), false), spvutils::kRoundToZero},
@@ -828,7 +828,7 @@ TEST_P(HexFloatRoundUpSignificandTest, Widening) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(F16toF32, HexFloatRoundUpSignificandTest,
+INSTANTIATE_TEST_SUITE_P(F16toF32, HexFloatRoundUpSignificandTest,
   // 0xFC00 of the source 16-bit hex value cover the sign and the exponent.
   // They are ignored for this test.
   ::testing::ValuesIn(std::vector<UpCastSignificandCase>(
@@ -879,7 +879,7 @@ TEST_P(HexFloatFP32To16Tests, NarrowingCasts) {
 const uint16_t positive_infinity = 0x7C00;
 const uint16_t negative_infinity = 0xFC00;
 
-INSTANTIATE_TEST_CASE_P(F32ToF16, HexFloatFP32To16Tests,
+INSTANTIATE_TEST_SUITE_P(F32ToF16, HexFloatFP32To16Tests,
   ::testing::ValuesIn(std::vector<DownCastTest>(
   {
     // Exactly representable as half.
@@ -944,7 +944,7 @@ TEST_P(HexFloatFP16To32Tests, WideningCasts) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(F16ToF32, HexFloatFP16To32Tests,
+INSTANTIATE_TEST_SUITE_P(F16ToF32, HexFloatFP16To32Tests,
   ::testing::ValuesIn(std::vector<UpCastCase>(
   {
     {0x0000, 0.f},
@@ -1039,7 +1039,7 @@ FloatParseCase<T> GoodFloatParseCase(std::string literal, bool negate_value,
   return FloatParseCase<T>{literal, negate_value, true, proxy_expected_value};
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     FloatParse, ParseNormalFloatTest,
     ::testing::ValuesIn(std::vector<FloatParseCase<float>>{
         // Failing cases due to trivially incorrect syntax.
@@ -1090,7 +1090,7 @@ TEST_P(ParseNormalFloat16Test, Samples) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Float16Parse, ParseNormalFloat16Test,
     ::testing::ValuesIn(std::vector<FloatParseCase<Float16>>{
         // Failing cases due to trivially incorrect syntax.
@@ -1137,7 +1137,7 @@ TEST_P(FloatProxyParseOverflowFloatTest, Sample) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     FloatOverflow, FloatProxyParseOverflowFloatTest,
     ::testing::ValuesIn(std::vector<OverflowParseCase<float>>({
         {"0", true, 0.0f},
@@ -1164,7 +1164,7 @@ TEST_P(FloatProxyParseOverflowDoubleTest, Sample) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     DoubleOverflow, FloatProxyParseOverflowDoubleTest,
     ::testing::ValuesIn(std::vector<OverflowParseCase<double>>({
         {"0", true, 0.0},
@@ -1193,7 +1193,7 @@ TEST_P(FloatProxyParseOverflowFloat16Test, Sample) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Float16Overflow, FloatProxyParseOverflowFloat16Test,
     ::testing::ValuesIn(std::vector<OverflowParseCase<uint16_t>>({
         {"0", true, uint16_t{0}},

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -129,7 +129,7 @@ TEST_P(HlslLegalDebugTest, FromFile)
 }
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ToSpirv, HlslCompileTest,
     ::testing::ValuesIn(std::vector<FileNameEntryPointPair>{
         {"hlsl.amend.frag", "f1"},
@@ -430,7 +430,7 @@ INSTANTIATE_TEST_CASE_P(
 // clang-format on
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ToSpirv, HlslVulkan1_1CompileTest,
     ::testing::ValuesIn(std::vector<FileNameEntryPointPair>{
         {"hlsl.wavebroadcast.comp", "CSMain"},
@@ -448,7 +448,7 @@ INSTANTIATE_TEST_CASE_P(
 // clang-format on
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ToSpirv, HlslCompileAndFlattenTest,
     ::testing::ValuesIn(std::vector<FileNameEntryPointPair>{
         {"hlsl.array.flatten.frag", "main"},
@@ -460,7 +460,7 @@ INSTANTIATE_TEST_CASE_P(
 
 #if ENABLE_OPT
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ToSpirv, HlslLegalizeTest,
     ::testing::ValuesIn(std::vector<FileNameEntryPointPair>{
         {"hlsl.aliasOpaque.frag", "main"},
@@ -478,7 +478,7 @@ INSTANTIATE_TEST_CASE_P(
 #endif
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ToSpirv, HlslDebugTest,
     ::testing::ValuesIn(std::vector<FileNameEntryPointPair>{
         {"hlsl.pp.line2.frag", "MainPs"}
@@ -486,7 +486,7 @@ INSTANTIATE_TEST_CASE_P(
     FileNameAsCustomTestSuffix
 );
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ToSpirv, HlslDX9CompatibleTest,
     ::testing::ValuesIn(std::vector<FileNameEntryPointPair>{
         {"hlsl.sample.dx9.frag", "main"},
@@ -496,7 +496,7 @@ INSTANTIATE_TEST_CASE_P(
 );
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ToSpirv, HlslLegalDebugTest,
     ::testing::ValuesIn(std::vector<FileNameEntryPointPair>{
         {"hlsl.pp.line4.frag", "MainPs"}

--- a/gtests/Link.FromFile.Vk.cpp
+++ b/gtests/Link.FromFile.Vk.cpp
@@ -109,7 +109,7 @@ TEST_P(LinkTestVulkan, FromFile)
 }
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, LinkTestVulkan,
     ::testing::ValuesIn(std::vector<std::vector<std::string>>({
         {"link1.vk.frag", "link2.vk.frag"},

--- a/gtests/Link.FromFile.cpp
+++ b/gtests/Link.FromFile.cpp
@@ -86,7 +86,7 @@ TEST_P(LinkTest, FromFile)
 }
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, LinkTest,
     ::testing::ValuesIn(std::vector<std::vector<std::string>>({
         {"mains1.frag", "mains2.frag", "noMain1.geom", "noMain2.geom"},

--- a/gtests/Pp.FromFile.cpp
+++ b/gtests/Pp.FromFile.cpp
@@ -47,7 +47,7 @@ TEST_P(PreprocessingTest, FromFile)
 }
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, PreprocessingTest,
     ::testing::ValuesIn(std::vector<std::string>({
         "preprocessor.bad_arg.vert",

--- a/gtests/Remap.FromFile.cpp
+++ b/gtests/Remap.FromFile.cpp
@@ -80,7 +80,7 @@ TEST_P(RemapTest, FromFile)
 }
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ToSpirv, RemapTest,
     ::testing::ValuesIn(std::vector<RemapTestArgs>{
             // GLSL remapper tests

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -213,7 +213,7 @@ TEST_P(CompileUpgradeTextureToSampledTextureAndDropSamplersTest, FromFile)
 }
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, CompileVulkanToSpirvTest,
     ::testing::ValuesIn(std::vector<std::string>({
         // Test looping constructs.
@@ -450,7 +450,7 @@ INSTANTIATE_TEST_CASE_P(
 // Cases with deliberately unreachable code.
 // By default the compiler will aggressively eliminate
 // unreachable merges and continues.
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     GlslWithDeadCode, CompileVulkanToSpirvDeadCodeElimTest,
     ::testing::ValuesIn(std::vector<std::string>({
         "spv.dead-after-continue.vert",
@@ -465,7 +465,7 @@ INSTANTIATE_TEST_CASE_P(
 );
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, CompileVulkanToDebugSpirvTest,
     ::testing::ValuesIn(std::vector<std::string>({
         "spv.pp.line.frag",
@@ -474,7 +474,7 @@ INSTANTIATE_TEST_CASE_P(
 );
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, CompileVulkan1_1ToSpirvTest,
     ::testing::ValuesIn(std::vector<std::string>({
         "spv.1.3.8bitstorage-ubo.vert",
@@ -530,7 +530,7 @@ INSTANTIATE_TEST_CASE_P(
 );
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, CompileToSpirv14Test,
     ::testing::ValuesIn(std::vector<std::string>({
         "spv.1.4.LoopControl.frag",
@@ -566,7 +566,7 @@ INSTANTIATE_TEST_CASE_P(
 );
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Hlsl, HlslIoMap,
     ::testing::ValuesIn(std::vector<IoMapData>{
         { "spv.register.autoassign.frag", "main_ep", 5, 10, 0, 20, 30, true, false },
@@ -586,7 +586,7 @@ INSTANTIATE_TEST_CASE_P(
 );
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Hlsl, GlslIoMap,
     ::testing::ValuesIn(std::vector<IoMapData>{
         { "spv.glsl.register.autoassign.frag", "main", 5, 10, 0, 20, 30, true, false },
@@ -596,7 +596,7 @@ INSTANTIATE_TEST_CASE_P(
 );
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, CompileOpenGLToSpirvTest,
     ::testing::ValuesIn(std::vector<std::string>({
         "spv.460.frag",
@@ -621,7 +621,7 @@ INSTANTIATE_TEST_CASE_P(
     FileNameAsCustomTestSuffix
 );
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, VulkanSemantics,
     ::testing::ValuesIn(std::vector<std::string>({
         "vulkan.frag",
@@ -633,7 +633,7 @@ INSTANTIATE_TEST_CASE_P(
     FileNameAsCustomTestSuffix
 );
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, OpenGLSemantics,
     ::testing::ValuesIn(std::vector<std::string>({
         "glspv.esversion.vert",
@@ -645,7 +645,7 @@ INSTANTIATE_TEST_CASE_P(
     FileNameAsCustomTestSuffix
 );
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, VulkanAstSemantics,
     ::testing::ValuesIn(std::vector<std::string>({
         "vulkan.ast.vert",
@@ -653,7 +653,7 @@ INSTANTIATE_TEST_CASE_P(
     FileNameAsCustomTestSuffix
 );
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, CompileVulkanToSpirvTestAMD,
     ::testing::ValuesIn(std::vector<std::string>({
         "spv.16bitxfb.vert",
@@ -669,7 +669,7 @@ INSTANTIATE_TEST_CASE_P(
     FileNameAsCustomTestSuffix
 );
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, CompileVulkanToSpirvTestNV,
     ::testing::ValuesIn(std::vector<std::string>({
     "spv.sampleMaskOverrideCoverage.frag",
@@ -717,7 +717,7 @@ INSTANTIATE_TEST_CASE_P(
 FileNameAsCustomTestSuffix
 );
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Glsl, CompileUpgradeTextureToSampledTextureAndDropSamplersTest,
     ::testing::ValuesIn(std::vector<std::string>({
       "spv.texture.sampler.transform.frag",


### PR DESCRIPTION
These have a new spelling: INSTANTIATE_TEST_CASE_P -> INSTANTIATE_TEST_SUITE_P