### PR TITLE
Fix scope definition in ES 100.

### DIFF
--- a/Test/100scope.vert
+++ b/Test/100scope.vert
@@ -2,7 +2,7 @@
 
 int f(int a, int b, int c)
 {
-	int a = b;  // ERROR, redefinition
+	int a = b;
 
     {
 		float a = float(a) + 1.0;

--- a/Test/baseResults/100scope.vert.out
+++ b/Test/baseResults/100scope.vert.out
@@ -1,5 +1,4 @@
 100scope.vert
-ERROR: 0:5: 'a' : redefinition 
 ERROR: 0:17: 'b' : function name is redeclaration of existing name 
 ERROR: 0:20: 'c' : redefinition 
 ERROR: 0:22: 'f' : redefinition 
@@ -13,7 +12,7 @@ ERROR: 0:57: 'z' : undeclared identifier
 ERROR: 0:57: 'z' : redefinition 
 ERROR: 0:73: 'degrees' : can't use function syntax on variable 
 ERROR: 0:76: 'vertex-shader struct output' : not supported for this version or the enabled extensions 
-ERROR: 14 compilation errors.  No code generated.
+ERROR: 13 compilation errors.  No code generated.
 
 
 Shader version: 100
@@ -23,18 +22,22 @@ ERROR: node is still EOpNull!
 0:3      'a' ( in highp int)
 0:3      'b' ( in highp int)
 0:3      'c' ( in highp int)
-0:?     Sequence
+0:5    Sequence
+0:5      Sequence
+0:5        move second child to first child ( temp highp int)
+0:5          'a' ( temp highp int)
+0:5          'b' ( in highp int)
 0:8      Sequence
 0:8        Sequence
 0:8          move second child to first child ( temp highp float)
 0:8            'a' ( temp highp float)
 0:8            add ( temp highp float)
 0:8              Convert int to float ( temp highp float)
-0:8                'a' ( in highp int)
+0:8                'a' ( temp highp int)
 0:8              Constant:
 0:8                1.000000
 0:11      Branch: Return with expression
-0:11        'a' ( in highp int)
+0:11        'a' ( temp highp int)
 0:25  Function Definition: cos(f1; ( global highp float)
 0:25    Function Parameters: 
 0:25      'x' ( in highp float)
@@ -138,18 +141,22 @@ ERROR: node is still EOpNull!
 0:3      'a' ( in highp int)
 0:3      'b' ( in highp int)
 0:3      'c' ( in highp int)
-0:?     Sequence
+0:5    Sequence
+0:5      Sequence
+0:5        move second child to first child ( temp highp int)
+0:5          'a' ( temp highp int)
+0:5          'b' ( in highp int)
 0:8      Sequence
 0:8        Sequence
 0:8          move second child to first child ( temp highp float)
 0:8            'a' ( temp highp float)
 0:8            add ( temp highp float)
 0:8              Convert int to float ( temp highp float)
-0:8                'a' ( in highp int)
+0:8                'a' ( temp highp int)
 0:8              Constant:
 0:8                1.000000
 0:11      Branch: Return with expression
-0:11        'a' ( in highp int)
+0:11        'a' ( temp highp int)
 0:36  Function Definition: main( ( global void)
 0:36    Function Parameters: 
 0:?     Sequence

--- a/glslang/MachineIndependent/ParseHelper.h
+++ b/glslang/MachineIndependent/ParseHelper.h
@@ -84,6 +84,7 @@ public:
             scopeMangler("::"),
             symbolTable(symbolTable),
             statementNestingLevel(0), loopNestingLevel(0), structNestingLevel(0), controlFlowNestingLevel(0),
+            currentFunctionType(nullptr),
             postEntryPointReturn(false),
             contextPragma(true, false),
             beginInvocationInterlockCount(0), endInvocationInterlockCount(0),

--- a/glslang/MachineIndependent/glslang.m4
+++ b/glslang/MachineIndependent/glslang.m4
@@ -3842,6 +3842,14 @@ function_definition
     : function_prototype {
         $1.function = parseContext.handleFunctionDeclarator($1.loc, *$1.function, false /* not prototype */);
         $1.intermNode = parseContext.handleFunctionDefinition($1.loc, *$1.function);
+
+        // For ES 100 only, according to ES shading language 100 spec: A function
+        // body has a scope nested inside the function's definition.
+        if (parseContext.profile == EEsProfile && parseContext.version == 100)
+        {
+            parseContext.symbolTable.push();
+            ++parseContext.statementNestingLevel;
+        }
     }
     compound_statement_no_new_scope {
         //   May be best done as post process phase on intermediate code
@@ -3857,6 +3865,17 @@ function_definition
         $$->getAsAggregate()->setOptimize(parseContext.contextPragma.optimize);
         $$->getAsAggregate()->setDebug(parseContext.contextPragma.debug);
         $$->getAsAggregate()->setPragmaTable(parseContext.contextPragma.pragmaTable);
+
+        // Set currentFunctionType to empty pointer when goes outside of the function
+        parseContext.currentFunctionType = nullptr;
+
+        // For ES 100 only, according to ES shading language 100 spec: A function
+        // body has a scope nested inside the function's definition.
+        if (parseContext.profile == EEsProfile && parseContext.version == 100)
+        {
+            parseContext.symbolTable.pop(&parseContext.defaultPrecision[0]);
+            --parseContext.statementNestingLevel;
+        }
     }
     ;
 

--- a/glslang/MachineIndependent/glslang.y
+++ b/glslang/MachineIndependent/glslang.y
@@ -3842,6 +3842,14 @@ function_definition
     : function_prototype {
         $1.function = parseContext.handleFunctionDeclarator($1.loc, *$1.function, false /* not prototype */);
         $1.intermNode = parseContext.handleFunctionDefinition($1.loc, *$1.function);
+
+        // For ES 100 only, according to ES shading language 100 spec: A function
+        // body has a scope nested inside the function's definition.
+        if (parseContext.profile == EEsProfile && parseContext.version == 100)
+        {
+            parseContext.symbolTable.push();
+            ++parseContext.statementNestingLevel;
+        }
     }
     compound_statement_no_new_scope {
         //   May be best done as post process phase on intermediate code
@@ -3857,6 +3865,17 @@ function_definition
         $$->getAsAggregate()->setOptimize(parseContext.contextPragma.optimize);
         $$->getAsAggregate()->setDebug(parseContext.contextPragma.debug);
         $$->getAsAggregate()->setPragmaTable(parseContext.contextPragma.pragmaTable);
+
+        // Set currentFunctionType to empty pointer when goes outside of the function
+        parseContext.currentFunctionType = nullptr;
+
+        // For ES 100 only, according to ES shading language 100 spec: A function
+        // body has a scope nested inside the function's definition.
+        if (parseContext.profile == EEsProfile && parseContext.version == 100)
+        {
+            parseContext.symbolTable.pop(&parseContext.defaultPrecision[0]);
+            --parseContext.statementNestingLevel;
+        }
     }
     ;
 

--- a/glslang/MachineIndependent/glslang_tab.cpp
+++ b/glslang/MachineIndependent/glslang_tab.cpp
@@ -1012,8 +1012,8 @@ static const yytype_uint16 yyrline[] =
     3603,  3611,  3615,  3628,  3632,  3639,  3639,  3659,  3662,  3668,
     3680,  3692,  3696,  3703,  3703,  3718,  3718,  3734,  3734,  3755,
     3758,  3764,  3767,  3773,  3777,  3784,  3789,  3794,  3801,  3804,
-    3813,  3817,  3826,  3829,  3833,  3842,  3842,  3865,  3871,  3874,
-    3879,  3882
+    3813,  3817,  3826,  3829,  3833,  3842,  3842,  3884,  3890,  3893,
+    3898,  3901
 };
 #endif
 
@@ -10298,12 +10298,20 @@ yyreduce:
     {
         (yyvsp[0].interm).function = parseContext.handleFunctionDeclarator((yyvsp[0].interm).loc, *(yyvsp[0].interm).function, false /* not prototype */);
         (yyvsp[0].interm).intermNode = parseContext.handleFunctionDefinition((yyvsp[0].interm).loc, *(yyvsp[0].interm).function);
+
+        // For ES 100 only, according to ES shading language 100 spec: A function
+        // body has a scope nested inside the function's definition.
+        if (parseContext.profile == EEsProfile && parseContext.version == 100)
+        {
+            parseContext.symbolTable.push();
+            ++parseContext.statementNestingLevel;
+        }
     }
-#line 10303 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
+#line 10311 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
     break;
 
   case 586:
-#line 3846 "MachineIndependent/glslang.y" /* yacc.c:1646  */
+#line 3854 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
         //   May be best done as post process phase on intermediate code
         if (parseContext.currentFunctionType->getBasicType() != EbtVoid && ! parseContext.functionReturnsValue)
@@ -10318,53 +10326,64 @@ yyreduce:
         (yyval.interm.intermNode)->getAsAggregate()->setOptimize(parseContext.contextPragma.optimize);
         (yyval.interm.intermNode)->getAsAggregate()->setDebug(parseContext.contextPragma.debug);
         (yyval.interm.intermNode)->getAsAggregate()->setPragmaTable(parseContext.contextPragma.pragmaTable);
+
+        // Set currentFunctionType to empty pointer when goes outside of the function
+        parseContext.currentFunctionType = nullptr;
+
+        // For ES 100 only, according to ES shading language 100 spec: A function
+        // body has a scope nested inside the function's definition.
+        if (parseContext.profile == EEsProfile && parseContext.version == 100)
+        {
+            parseContext.symbolTable.pop(&parseContext.defaultPrecision[0]);
+            --parseContext.statementNestingLevel;
+        }
     }
-#line 10323 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
+#line 10342 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
     break;
 
   case 587:
-#line 3865 "MachineIndependent/glslang.y" /* yacc.c:1646  */
+#line 3884 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
         (yyval.interm.attributes) = (yyvsp[-2].interm.attributes);
         parseContext.requireExtensions((yyvsp[-4].lex).loc, 1, &E_GL_EXT_control_flow_attributes, "attribute");
     }
-#line 10332 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
+#line 10351 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
     break;
 
   case 588:
-#line 3871 "MachineIndependent/glslang.y" /* yacc.c:1646  */
+#line 3890 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
         (yyval.interm.attributes) = (yyvsp[0].interm.attributes);
     }
-#line 10340 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
+#line 10359 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
     break;
 
   case 589:
-#line 3874 "MachineIndependent/glslang.y" /* yacc.c:1646  */
+#line 3893 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
         (yyval.interm.attributes) = parseContext.mergeAttributes((yyvsp[-2].interm.attributes), (yyvsp[0].interm.attributes));
     }
-#line 10348 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
+#line 10367 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
     break;
 
   case 590:
-#line 3879 "MachineIndependent/glslang.y" /* yacc.c:1646  */
+#line 3898 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
         (yyval.interm.attributes) = parseContext.makeAttributes(*(yyvsp[0].lex).string);
     }
-#line 10356 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
+#line 10375 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
     break;
 
   case 591:
-#line 3882 "MachineIndependent/glslang.y" /* yacc.c:1646  */
+#line 3901 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
         (yyval.interm.attributes) = parseContext.makeAttributes(*(yyvsp[-3].lex).string, (yyvsp[-1].interm.intermTypedNode));
     }
-#line 10364 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
+#line 10383 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
     break;
 
 
-#line 10368 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
+#line 10387 "MachineIndependent/glslang_tab.cpp" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -10592,5 +10611,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 3887 "MachineIndependent/glslang.y" /* yacc.c:1906  */
+#line 3906 "MachineIndependent/glslang.y" /* yacc.c:1906  */
 


### PR DESCRIPTION
1. Add tokens related to IMAGE SHADOW.

2. Allow redefinition with a same name in parameter list. Only in ES 100.
" If it is declared as a parameter in a function definition, it is scoped until the end of that function definition.  A function body has a scope nested inside the function’s definition."