### PR TITLE
Parser: Fix wrong names of extension macros

### DIFF
--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -474,11 +474,11 @@ void TParseVersions::getPreamble(std::string& preamble)
             "#define GL_KHR_shader_subgroup_clustered 1\n"
             "#define GL_KHR_shader_subgroup_quad 1\n"
 
-            "#define E_GL_EXT_shader_atomic_int64 1\n"
-            "#define E_GL_EXT_shader_realtime_clock 1\n"
-            "#define E_GL_EXT_ray_tracing 1\n"
-            "#define E_GL_EXT_ray_query 1\n"
-            "#define E_GL_EXT_ray_flags_primitive_culling 1\n"
+            "#define GL_EXT_shader_atomic_int64 1\n"
+            "#define GL_EXT_shader_realtime_clock 1\n"
+            "#define GL_EXT_ray_tracing 1\n"
+            "#define GL_EXT_ray_query 1\n"
+            "#define GL_EXT_ray_flags_primitive_culling 1\n"
 
             "#define GL_AMD_shader_ballot 1\n"
             "#define GL_AMD_shader_trinary_minmax 1\n"


### PR DESCRIPTION
The names of some extension macros are wrong because of coding typos.