### PR TITLE
Error when initializing rayQuery with assignment

### DIFF
--- a/Test/baseResults/rayQuery-initialization.Error.comp.out
+++ b/Test/baseResults/rayQuery-initialization.Error.comp.out
@@ -1,0 +1,6 @@
+rayQuery-initialization.Error.comp
+ERROR: 0:7: '=' : ray queries can only be initialized by using the rayQueryInitializeEXT intrinsic: bar
+ERROR: 1 compilation errors.  No code generated.
+
+
+SPIR-V is not generated for failed compile or link

--- a/Test/rayQuery-initialization.Error.comp
+++ b/Test/rayQuery-initialization.Error.comp
@@ -1,0 +1,8 @@
+#version 460
+
+#extension GL_EXT_ray_query : enable
+
+void main () {
+    rayQueryEXT foo;
+    rayQueryEXT bar = foo;
+}

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -6561,6 +6561,12 @@ TIntermNode* TParseContext::declareVariable(const TSourceLoc& loc, TString& iden
     type.copyArrayInnerSizes(publicType.arraySizes);
     arrayOfArrayVersionCheck(loc, type.getArraySizes());
 
+    if (initializer) {
+        if (type.getBasicType() == EbtRayQuery) {
+            error(loc, "ray queries can only be initialized by using the rayQueryInitializeEXT intrinsic:", "=", identifier.c_str());
+        }
+    }
+
     if (type.isCoopMat()) {
         intermediate.setUseVulkanMemoryModel();
         intermediate.setUseStorageBuffer();

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -238,6 +238,7 @@ INSTANTIATE_TEST_SUITE_P(
         "rayQuery-committed.Error.rgen",
         "rayQuery-allOps.comp",
         "rayQuery-allOps.frag",
+        "rayQuery-initialization.Error.comp",
         "spv.set.vert",
         "spv.double.comp",
         "spv.100ops.frag",

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -1,6 +1,7 @@
  //
 // Copyright (C) 2016 Google, Inc.
 // Copyright (C) 2019 ARM Limited.
+// Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
 //
 // All rights reserved.
 //


### PR DESCRIPTION
This PR adds an error check to prevent initialization of ray query objects via assignment, since there are no valid constructors for the ray query object, and ray query objects cannot be copied. Without this change, the code in the new test generates an OpLoad/OpStore pair, which is invalid.