### PR TITLE
Find python interpreter from host when cross-compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,9 +228,15 @@ function(glslang_set_link_args TARGET)
     endif()
 endfunction(glslang_set_link_args)
 
+if(NOT COMMAND find_host_package)
+    macro(find_host_package)
+        find_package(${ARGN})
+    endmacro()
+endif()
+
 # CMake needs to find the right version of python, right from the beginning,
 # otherwise, it will find the wrong version and fail later
-find_package(PythonInterp 3 REQUIRED)
+find_host_package(PythonInterp 3 REQUIRED)
 
 # Root directory for build-time generated include files
 set(GLSLANG_GENERATED_INCLUDEDIR "${CMAKE_BINARY_DIR}/include")


### PR DESCRIPTION
glslang build failed for missing python interpreter when cross-compile glslang for ios

https://github.com/leetal/ios-cmake/blob/master/ios.toolchain.cmake defines a handy find_host_package macro
If it exsits, use find_host_package, like how SPIRV-Tools handle it here

https://github.com/KhronosGroup/SPIRV-Tools/blob/726af6f78f80988271c8b558ae9cc84fa5a65016/CMakeLists.txt#L181
