### PR TITLE
8. io mapping refine & qualifier member check & resolver expand

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -1444,7 +1444,7 @@ TGlslangToSpvTraverser::TGlslangToSpvTraverser(unsigned int spvVersion,
     // Add the source extensions
     const auto& sourceExtensions = glslangIntermediate->getRequestedExtensions();
     for (auto it = sourceExtensions.begin(); it != sourceExtensions.end(); ++it)
-        builder.addSourceExtension(it->first.c_str());
+        builder.addSourceExtension(it->c_str());
 
     // Add the top-level modes for this shader.
 

--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -1444,7 +1444,7 @@ TGlslangToSpvTraverser::TGlslangToSpvTraverser(unsigned int spvVersion,
     // Add the source extensions
     const auto& sourceExtensions = glslangIntermediate->getRequestedExtensions();
     for (auto it = sourceExtensions.begin(); it != sourceExtensions.end(); ++it)
-        builder.addSourceExtension(it->c_str());
+        builder.addSourceExtension(it->first.c_str());
 
     // Add the top-level modes for this shader.
 
@@ -3929,6 +3929,8 @@ void TGlslangToSpvTraverser::decorateStructType(const glslang::TType& type,
     // Name and decorate the non-hidden members
     int offset = -1;
     int locationOffset = 0;  // for use within the members of this struct
+    bool memberLocationInvalid = type.isArrayOfArrays() ||
+        (type.isArray() && (type.getQualifier().isArrayedIo(glslangIntermediate->getStage()) == false));
     for (int i = 0; i < (int)glslangMembers->size(); i++) {
         glslang::TType& glslangMember = *(*glslangMembers)[i].type;
         int member = i;
@@ -3981,7 +3983,7 @@ void TGlslangToSpvTraverser::decorateStructType(const glslang::TType& type,
         // just track whether a member needs to be decorated.
         // Ignore member locations if the container is an array, as that's
         // ill-specified and decisions have been made to not allow this.
-        if (! type.isArray() && memberQualifier.hasLocation())
+        if (!memberLocationInvalid && memberQualifier.hasLocation())
             builder.addMemberDecoration(spvType, member, spv::DecorationLocation, memberQualifier.layoutLocation);
 
         if (qualifier.hasLocation())      // track for upcoming inheritance

--- a/Test/baseResults/300layout.vert.out
+++ b/Test/baseResults/300layout.vert.out
@@ -1,6 +1,7 @@
 300layout.vert
 ERROR: 0:7: 'vertex input arrays' : not supported with this profile: es
 ERROR: 0:8: 'in' : cannot be a structure or array 
+ERROR: 0:8: 's' : A structure containing an array is not allowed as input in ES 
 ERROR: 0:8: 'vertex input arrays' : not supported with this profile: es
 ERROR: 0:8: 'location' : overlapping use of location 10
 ERROR: 0:12: 'layout' : cannot specify matrix layout on a variable declaration 
@@ -18,7 +19,7 @@ ERROR: 0:50: 'shared' : not supported for this version or the enabled extensions
 ERROR: 0:50: 'shared' : not supported in this stage: vertex
 ERROR: 0:54: 'layout' : cannot specify packing on a variable declaration 
 ERROR: 0:57: 'location' : overlapping use of location 40
-ERROR: 19 compilation errors.  No code generated.
+ERROR: 20 compilation errors.  No code generated.
 
 
 Shader version: 300

--- a/Test/baseResults/310.frag.out
+++ b/Test/baseResults/310.frag.out
@@ -40,10 +40,14 @@ ERROR: 0:112: 'out' : cannot be a matrix
 ERROR: 0:114: 'in' : cannot be bool 
 ERROR: 0:115: 'sampler2D' : sampler/image types can only be used in uniform variables or function parameters: ino
 ERROR: 0:117: 'fragment-shader array-of-array input' : not supported with this profile: es
+ERROR: 0:120: 'S' : A structure containing an array is not allowed as input in ES 
 ERROR: 0:120: 'fragment-shader array-of-struct input' : not supported with this profile: es
+ERROR: 0:121: 'S' : A structure containing an array is not allowed as input in ES 
 ERROR: 0:121: 'fragment-shader array-of-struct input' : not supported with this profile: es
 ERROR: 0:123: 'fragment-shader struct input containing an array' : not supported with this profile: es
+ERROR: 0:123: 'SA' : A structure containing an array is not allowed as input in ES 
 ERROR: 0:125: 'fragment-shader struct input containing structure' : not supported with this profile: es
+ERROR: 0:125: 'SS' : A structure containing an struct is not allowed as input in ES 
 ERROR: 0:133: 'output block' : not supported in this stage: fragment
 ERROR: 0:138: '' : cannot nest a structure definition inside a structure or block 
 ERROR: 0:146: 'location' : overlapping use of location 13
@@ -139,7 +143,7 @@ ERROR: 0:461: 'func' : function already has a body
 ERROR: 0:463: 'return' : void function cannot return a value 
 ERROR: 0:472: '=' :  cannot convert from ' temp mediump uint' to ' temp mediump int'
 ERROR: 0:485: '=' :  cannot convert from ' global mediump int' to ' temp mediump uint'
-ERROR: 132 compilation errors.  No code generated.
+ERROR: 136 compilation errors.  No code generated.
 
 
 Shader version: 310

--- a/Test/baseResults/310.vert.out
+++ b/Test/baseResults/310.vert.out
@@ -21,6 +21,7 @@ ERROR: 0:105: 'location' : overlapping use of location 12
 ERROR: 0:107: 'input block' : not supported in this stage: vertex
 ERROR: 0:109: 'gl_PerVertex' : block redeclaration has extra members 
 ERROR: 0:119: 'gl_PointSize' : member of nameless block was not redeclared 
+ERROR: 0:119: 'assign' :  l-value required "gl_PerVertex" (can't modify void)
 ERROR: 0:119: 'assign' :  cannot convert from ' const float' to ' gl_PointSize highp void PointSize'
 ERROR: 0:122: 'gl_PerVertex' : can only redeclare a built-in block once, and before any use 
 ERROR: 0:127: 'flat/smooth/noperspective' : cannot use interpolation qualifiers on an interface block 
@@ -96,7 +97,7 @@ ERROR: 0:389: 'sample' : Reserved word.
 ERROR: 0:400: 'interpolateAtCentroid' : no matching overloaded function found 
 ERROR: 0:401: 'interpolateAtSample' : no matching overloaded function found 
 ERROR: 0:402: 'interpolateAtOffset' : no matching overloaded function found 
-ERROR: 93 compilation errors.  No code generated.
+ERROR: 94 compilation errors.  No code generated.
 
 
 Shader version: 310

--- a/Test/baseResults/320.vert.out
+++ b/Test/baseResults/320.vert.out
@@ -4,6 +4,7 @@ ERROR: 0:14: 'location' : overlapping use of location 12
 ERROR: 0:16: 'input block' : not supported in this stage: vertex
 ERROR: 0:18: 'gl_PerVertex' : block redeclaration has extra members 
 ERROR: 0:28: 'gl_PointSize' : member of nameless block was not redeclared 
+ERROR: 0:28: 'assign' :  l-value required "gl_PerVertex" (can't modify void)
 ERROR: 0:28: 'assign' :  cannot convert from ' const float' to ' gl_PointSize highp void PointSize'
 ERROR: 0:31: 'gl_PerVertex' : can only redeclare a built-in block once, and before any use 
 ERROR: 0:36: 'flat/smooth/noperspective' : cannot use interpolation qualifiers on an interface block 
@@ -33,7 +34,7 @@ ERROR: 0:211: '=' :  cannot convert from ' const float' to ' temp highp 3-compon
 ERROR: 0:252: 'interpolateAtCentroid' : no matching overloaded function found 
 ERROR: 0:253: 'interpolateAtSample' : no matching overloaded function found 
 ERROR: 0:254: 'interpolateAtOffset' : no matching overloaded function found 
-ERROR: 34 compilation errors.  No code generated.
+ERROR: 35 compilation errors.  No code generated.
 
 
 Shader version: 320

--- a/Test/baseResults/410.geom.out
+++ b/Test/baseResults/410.geom.out
@@ -5,9 +5,10 @@ ERROR: 0:20: 'gl_PerVertex' : can only redeclare a built-in block once, and befo
 ERROR: 0:32: 'gl_Position' : no such field in structure 
 ERROR: 0:32: '=' :  cannot convert from ' temp block{ in float PointSize gl_PointSize}' to ' temp 4-component vector of float'
 ERROR: 0:33: 'gl_Position' : member of nameless block was not redeclared 
+ERROR: 0:33: 'assign' :  l-value required "gl_PerVertex" (can't modify void)
 ERROR: 0:33: 'assign' :  cannot convert from ' const 4-component vector of float' to 'layout( stream=0) gl_Position void Position'
 WARNING: 0:38: 'return' : type conversion on return values was not explicitly allowed until version 420 
-ERROR: 7 compilation errors.  No code generated.
+ERROR: 8 compilation errors.  No code generated.
 
 
 Shader version: 410

--- a/Test/baseResults/hlsl.structbuffer.append.fn.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.append.fn.frag.out
@@ -190,13 +190,13 @@ Validation failed
                               Decorate 9 BufferBlock
                               Decorate 12 BufferBlock
                               Decorate 49(sbuf_a) DescriptorSet 0
-                              Decorate 49(sbuf_a) Binding 4
+                              Decorate 49(sbuf_a) Binding 0
                               Decorate 50(sbuf_a@count) DescriptorSet 0
-                              Decorate 50(sbuf_a@count) Binding 6
+                              Decorate 50(sbuf_a@count) Binding 0
                               Decorate 51(sbuf_c) DescriptorSet 0
-                              Decorate 51(sbuf_c) Binding 5
+                              Decorate 51(sbuf_c) Binding 1
                               Decorate 52(sbuf_c@count) DescriptorSet 0
-                              Decorate 52(sbuf_c@count) Binding 7
+                              Decorate 52(sbuf_c@count) Binding 0
                               Decorate 58(pos) Flat
                               Decorate 58(pos) Location 0
                               Decorate 61(@entryPointOutput) Location 0

--- a/Test/baseResults/hlsl.structbuffer.fn.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.fn.frag.out
@@ -191,9 +191,9 @@ Validation failed
                               Decorate 18 BufferBlock
                               Decorate 20 BufferBlock
                               Decorate 47(sbuf2) DescriptorSet 0
-                              Decorate 47(sbuf2) Binding 2
+                              Decorate 47(sbuf2) Binding 0
                               Decorate 48(sbuf2@count) DescriptorSet 0
-                              Decorate 48(sbuf2@count) Binding 3
+                              Decorate 48(sbuf2@count) Binding 0
                               Decorate 50(sbuf) DescriptorSet 0
                               Decorate 50(sbuf) Binding 10
                               Decorate 63(pos) Flat

--- a/Test/baseResults/link.vk.multiBlocksValid.0.0.vert.out
+++ b/Test/baseResults/link.vk.multiBlocksValid.0.0.vert.out
@@ -211,7 +211,7 @@ Shader version: 430
                               Name 70  "BufferBlock"
                               MemberName 70(BufferBlock) 0  "p"
                               Name 72  "uBuf"
-                              Decorate 14(oColor) Location 4
+                              Decorate 14(oColor) Location 2
                               MemberDecorate 16(ColorBlock) 0 Offset 0
                               MemberDecorate 16(ColorBlock) 1 Offset 16
                               MemberDecorate 16(ColorBlock) 2 Offset 32
@@ -224,7 +224,7 @@ Shader version: 430
                               Decorate 28(uColorBuf) DescriptorSet 0
                               Decorate 28(uColorBuf) Binding 0
                               Decorate 32(Vertex) Block
-                              Decorate 34(oV) Location 2
+                              Decorate 34(oV) Location 0
                               MemberDecorate 40(gl_PerVertex) 0 BuiltIn Position
                               MemberDecorate 40(gl_PerVertex) 1 BuiltIn PointSize
                               MemberDecorate 40(gl_PerVertex) 2 BuiltIn ClipDistance

--- a/Test/baseResults/link.vk.multiBlocksValid.1.0.geom.out
+++ b/Test/baseResults/link.vk.multiBlocksValid.1.0.geom.out
@@ -304,7 +304,7 @@ output primitive = triangle_strip
                               MemberName 95(BufferBlock) 0  "p"
                               Name 97  "uBuf"
                               Name 100  "P"
-                              Decorate 18(oColor) Location 2
+                              Decorate 18(oColor) Location 1
                               MemberDecorate 20(ColorBlock) 0 Offset 0
                               MemberDecorate 20(ColorBlock) 1 Offset 16
                               MemberDecorate 20(ColorBlock) 2 Offset 32
@@ -326,16 +326,16 @@ output primitive = triangle_strip
                               Decorate 50(uM) DescriptorSet 0
                               Decorate 50(uM) Binding 0
                               Decorate 59(Vertex) Block
-                              Decorate 61(oV) Location 1
+                              Decorate 61(oV) Location 0
                               Decorate 64(Vertex) Block
-                              Decorate 68(iV) Location 0
+                              Decorate 68(iV) Location 1
                               MemberDecorate 95(BufferBlock) 0 ColMajor
                               MemberDecorate 95(BufferBlock) 0 Offset 0
                               MemberDecorate 95(BufferBlock) 0 MatrixStride 16
                               Decorate 95(BufferBlock) BufferBlock
                               Decorate 97(uBuf) DescriptorSet 0
                               Decorate 97(uBuf) Binding 1
-                              Decorate 100(P) Location 4
+                              Decorate 100(P) Location 0
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeFloat 32

--- a/Test/baseResults/spv.specConstant.vert.out
+++ b/Test/baseResults/spv.specConstant.vert.out
@@ -11,7 +11,7 @@ spv.specConstant.vert
                               Source GLSL 400
                               Name 4  "main"
                               Name 9  "arraySize"
-                              Name 14  "foo(vf4[s4546];"
+                              Name 14  "foo(vf4[s805310914];"
                               Name 13  "p"
                               Name 17  "builtin_spec_constant("
                               Name 20  "color"
@@ -106,10 +106,10 @@ spv.specConstant.vert
                               Store 20(color) 46
               48:          10 Load 22(ucol)
                               Store 47(param) 48
-              49:           2 FunctionCall 14(foo(vf4[s4546];) 47(param)
+              49:           2 FunctionCall 14(foo(vf4[s805310914];) 47(param)
                               Return
                               FunctionEnd
-14(foo(vf4[s4546];):           2 Function None 12
+14(foo(vf4[s805310914];):           2 Function None 12
            13(p):     11(ptr) FunctionParameter
               15:             Label
               54:     24(ptr) AccessChain 53(dupUcol) 23

--- a/glslang/Include/intermediate.h
+++ b/glslang/Include/intermediate.h
@@ -1282,6 +1282,8 @@ public:
     TIntermTyped* getConstSubtree() const { return constSubtree; }
 #ifndef GLSLANG_WEB
     void setFlattenSubset(int subset) { flattenSubset = subset; }
+    virtual const TString& getAccessName() ;
+
     int getFlattenSubset() const { return flattenSubset; } // -1 means full object
 #endif
 

--- a/glslang/Include/intermediate.h
+++ b/glslang/Include/intermediate.h
@@ -1282,7 +1282,7 @@ public:
     TIntermTyped* getConstSubtree() const { return constSubtree; }
 #ifndef GLSLANG_WEB
     void setFlattenSubset(int subset) { flattenSubset = subset; }
-    virtual const TString& getAccessName() ;
+    virtual const TString& getAccessName() const;
 
     int getFlattenSubset() const { return flattenSubset; } // -1 means full object
 #endif

--- a/glslang/MachineIndependent/IntermTraverse.cpp
+++ b/glslang/MachineIndependent/IntermTraverse.cpp
@@ -72,9 +72,10 @@ void TIntermConstantUnion::traverse(TIntermTraverser *it)
 }
 
 const TString& TIntermSymbol::getAccessName() const {
-    return IsAnonymous(getName()) && getBasicType() == EbtBlock ?
-        getType().getTypeName() :
-        getName();
+    if (getBasicType() == EbtBlock)
+        return getType().getTypeName();
+    else
+        return getName();
 }
 
 //

--- a/glslang/MachineIndependent/IntermTraverse.cpp
+++ b/glslang/MachineIndependent/IntermTraverse.cpp
@@ -71,7 +71,7 @@ void TIntermConstantUnion::traverse(TIntermTraverser *it)
     it->visitConstantUnion(this);
 }
 
-const TString& TIntermSymbol::getAccessName(){
+const TString& TIntermSymbol::getAccessName() const {
     return IsAnonymous(getName()) && getBasicType() == EbtBlock ?
         getType().getTypeName() :
         getName();

--- a/glslang/MachineIndependent/IntermTraverse.cpp
+++ b/glslang/MachineIndependent/IntermTraverse.cpp
@@ -71,6 +71,12 @@ void TIntermConstantUnion::traverse(TIntermTraverser *it)
     it->visitConstantUnion(this);
 }
 
+const TString& TIntermSymbol::getAccessName(){
+    return IsAnonymous(getName()) && getBasicType() == EbtBlock ?
+        getType().getTypeName() :
+        getName();
+}
+
 //
 // Traverse a binary node.
 //

--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -113,7 +113,7 @@ TIntermSymbol* TIntermediate::addSymbol(const TType& type, const TSourceLoc& loc
 //
 // Returns nullptr if the working conversions and promotions could not be found.
 //
-TIntermTyped* TIntermediate::addBinaryMath(TOperator op, TIntermTyped* left, TIntermTyped* right, const TSourceLoc& loc)
+TIntermTyped* TIntermediate::addBinaryMath(TOperator op, TIntermTyped* left, TIntermTyped* right, TSourceLoc loc)
 {
     // No operations work on blocks
     if (left->getType().getBasicType() == EbtBlock || right->getType().getBasicType() == EbtBlock)
@@ -227,8 +227,7 @@ TIntermTyped* TIntermediate::addBinaryMath(TOperator op, TIntermTyped* left, TIn
 //
 // Low level: add binary node (no promotions or other argument modifications)
 //
-TIntermBinary* TIntermediate::addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right,
-    const TSourceLoc& loc) const
+TIntermBinary* TIntermediate::addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right, TSourceLoc loc) const
 {
     // build the node
     TIntermBinary* node = new TIntermBinary(op);
@@ -242,8 +241,7 @@ TIntermBinary* TIntermediate::addBinaryNode(TOperator op, TIntermTyped* left, TI
 //
 // like non-type form, but sets node's type.
 //
-TIntermBinary* TIntermediate::addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right,
-    const TSourceLoc& loc, const TType& type) const
+TIntermBinary* TIntermediate::addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right, TSourceLoc loc, const TType& type) const
 {
     TIntermBinary* node = addBinaryNode(op, left, right, loc);
     node->setType(type);
@@ -253,7 +251,7 @@ TIntermBinary* TIntermediate::addBinaryNode(TOperator op, TIntermTyped* left, TI
 //
 // Low level: add unary node (no promotions or other argument modifications)
 //
-TIntermUnary* TIntermediate::addUnaryNode(TOperator op, TIntermTyped* child, const TSourceLoc& loc) const
+TIntermUnary* TIntermediate::addUnaryNode(TOperator op, TIntermTyped* child, TSourceLoc loc) const
 {
     TIntermUnary* node = new TIntermUnary(op);
     node->setLoc(loc.line != 0 ? loc : child->getLoc());
@@ -265,8 +263,7 @@ TIntermUnary* TIntermediate::addUnaryNode(TOperator op, TIntermTyped* child, con
 //
 // like non-type form, but sets node's type.
 //
-TIntermUnary* TIntermediate::addUnaryNode(TOperator op, TIntermTyped* child, const TSourceLoc& loc, const TType& type)
-    const
+TIntermUnary* TIntermediate::addUnaryNode(TOperator op, TIntermTyped* child, TSourceLoc loc, const TType& type) const
 {
     TIntermUnary* node = addUnaryNode(op, child, loc);
     node->setType(type);
@@ -281,8 +278,7 @@ TIntermUnary* TIntermediate::addUnaryNode(TOperator op, TIntermTyped* child, con
 // Returns nullptr if the 'right' type could not be converted to match the 'left' type,
 // or the resulting operation cannot be properly promoted.
 //
-TIntermTyped* TIntermediate::addAssign(TOperator op, TIntermTyped* left, TIntermTyped* right,
-    const TSourceLoc& loc)
+TIntermTyped* TIntermediate::addAssign(TOperator op, TIntermTyped* left, TIntermTyped* right, TSourceLoc loc)
 {
     // No block assignment
     if (left->getType().getBasicType() == EbtBlock || right->getType().getBasicType() == EbtBlock)
@@ -337,8 +333,7 @@ TIntermTyped* TIntermediate::addAssign(TOperator op, TIntermTyped* left, TInterm
 // Returns the added node.
 // The caller should set the type of the returned node.
 //
-TIntermTyped* TIntermediate::addIndex(TOperator op, TIntermTyped* base, TIntermTyped* index,
-    const TSourceLoc& loc)
+TIntermTyped* TIntermediate::addIndex(TOperator op, TIntermTyped* base, TIntermTyped* index, TSourceLoc loc)
 {
     // caller should set the type
     return addBinaryNode(op, base, index, loc);
@@ -349,8 +344,7 @@ TIntermTyped* TIntermediate::addIndex(TOperator op, TIntermTyped* base, TIntermT
 //
 // Returns the added node.
 //
-TIntermTyped* TIntermediate::addUnaryMath(TOperator op, TIntermTyped* child,
-    const TSourceLoc& loc)
+TIntermTyped* TIntermediate::addUnaryMath(TOperator op, TIntermTyped* child, TSourceLoc loc)
 {
     if (child == 0)
         return nullptr;
@@ -496,8 +490,7 @@ TIntermTyped* TIntermediate::addBuiltInFunctionCall(const TSourceLoc& loc, TOper
 // Returns an aggregate node, which could be the one passed in if
 // it was already an aggregate.
 //
-TIntermTyped* TIntermediate::setAggregateOperator(TIntermNode* node, TOperator op, const TType& type,
-    const TSourceLoc& loc)
+TIntermTyped* TIntermediate::setAggregateOperator(TIntermNode* node, TOperator op, const TType& type, TSourceLoc loc)
 {
     TIntermAggregate* aggNode;
 
@@ -512,6 +505,8 @@ TIntermTyped* TIntermediate::setAggregateOperator(TIntermNode* node, TOperator o
             //
             aggNode = new TIntermAggregate();
             aggNode->getSequence().push_back(node);
+            if (loc.line == 0)
+                loc = node->getLoc();
         }
     } else
         aggNode = new TIntermAggregate();
@@ -520,8 +515,8 @@ TIntermTyped* TIntermediate::setAggregateOperator(TIntermNode* node, TOperator o
     // Set the operator.
     //
     aggNode->setOperator(op);
-    if (loc.line != 0 || node != nullptr)
-        aggNode->setLoc(loc.line != 0 ? loc : node->getLoc());
+    if (loc.line != 0)
+        aggNode->setLoc(loc);
 
     aggNode->setType(type);
 

--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -113,7 +113,7 @@ TIntermSymbol* TIntermediate::addSymbol(const TType& type, const TSourceLoc& loc
 //
 // Returns nullptr if the working conversions and promotions could not be found.
 //
-TIntermTyped* TIntermediate::addBinaryMath(TOperator op, TIntermTyped* left, TIntermTyped* right, TSourceLoc loc)
+TIntermTyped* TIntermediate::addBinaryMath(TOperator op, TIntermTyped* left, TIntermTyped* right, const TSourceLoc& loc)
 {
     // No operations work on blocks
     if (left->getType().getBasicType() == EbtBlock || right->getType().getBasicType() == EbtBlock)
@@ -227,7 +227,8 @@ TIntermTyped* TIntermediate::addBinaryMath(TOperator op, TIntermTyped* left, TIn
 //
 // Low level: add binary node (no promotions or other argument modifications)
 //
-TIntermBinary* TIntermediate::addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right, TSourceLoc loc) const
+TIntermBinary* TIntermediate::addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right,
+    const TSourceLoc& loc) const
 {
     // build the node
     TIntermBinary* node = new TIntermBinary(op);
@@ -241,7 +242,8 @@ TIntermBinary* TIntermediate::addBinaryNode(TOperator op, TIntermTyped* left, TI
 //
 // like non-type form, but sets node's type.
 //
-TIntermBinary* TIntermediate::addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right, TSourceLoc loc, const TType& type) const
+TIntermBinary* TIntermediate::addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right,
+    const TSourceLoc& loc, const TType& type) const
 {
     TIntermBinary* node = addBinaryNode(op, left, right, loc);
     node->setType(type);
@@ -251,7 +253,7 @@ TIntermBinary* TIntermediate::addBinaryNode(TOperator op, TIntermTyped* left, TI
 //
 // Low level: add unary node (no promotions or other argument modifications)
 //
-TIntermUnary* TIntermediate::addUnaryNode(TOperator op, TIntermTyped* child, TSourceLoc loc) const
+TIntermUnary* TIntermediate::addUnaryNode(TOperator op, TIntermTyped* child, const TSourceLoc& loc) const
 {
     TIntermUnary* node = new TIntermUnary(op);
     node->setLoc(loc.line != 0 ? loc : child->getLoc());
@@ -263,7 +265,8 @@ TIntermUnary* TIntermediate::addUnaryNode(TOperator op, TIntermTyped* child, TSo
 //
 // like non-type form, but sets node's type.
 //
-TIntermUnary* TIntermediate::addUnaryNode(TOperator op, TIntermTyped* child, TSourceLoc loc, const TType& type) const
+TIntermUnary* TIntermediate::addUnaryNode(TOperator op, TIntermTyped* child, const TSourceLoc& loc, const TType& type)
+    const
 {
     TIntermUnary* node = addUnaryNode(op, child, loc);
     node->setType(type);
@@ -278,7 +281,8 @@ TIntermUnary* TIntermediate::addUnaryNode(TOperator op, TIntermTyped* child, TSo
 // Returns nullptr if the 'right' type could not be converted to match the 'left' type,
 // or the resulting operation cannot be properly promoted.
 //
-TIntermTyped* TIntermediate::addAssign(TOperator op, TIntermTyped* left, TIntermTyped* right, TSourceLoc loc)
+TIntermTyped* TIntermediate::addAssign(TOperator op, TIntermTyped* left, TIntermTyped* right,
+    const TSourceLoc& loc)
 {
     // No block assignment
     if (left->getType().getBasicType() == EbtBlock || right->getType().getBasicType() == EbtBlock)
@@ -333,7 +337,8 @@ TIntermTyped* TIntermediate::addAssign(TOperator op, TIntermTyped* left, TInterm
 // Returns the added node.
 // The caller should set the type of the returned node.
 //
-TIntermTyped* TIntermediate::addIndex(TOperator op, TIntermTyped* base, TIntermTyped* index, TSourceLoc loc)
+TIntermTyped* TIntermediate::addIndex(TOperator op, TIntermTyped* base, TIntermTyped* index,
+    const TSourceLoc& loc)
 {
     // caller should set the type
     return addBinaryNode(op, base, index, loc);
@@ -344,7 +349,8 @@ TIntermTyped* TIntermediate::addIndex(TOperator op, TIntermTyped* base, TIntermT
 //
 // Returns the added node.
 //
-TIntermTyped* TIntermediate::addUnaryMath(TOperator op, TIntermTyped* child, TSourceLoc loc)
+TIntermTyped* TIntermediate::addUnaryMath(TOperator op, TIntermTyped* child,
+    const TSourceLoc& loc)
 {
     if (child == 0)
         return nullptr;
@@ -490,7 +496,8 @@ TIntermTyped* TIntermediate::addBuiltInFunctionCall(const TSourceLoc& loc, TOper
 // Returns an aggregate node, which could be the one passed in if
 // it was already an aggregate.
 //
-TIntermTyped* TIntermediate::setAggregateOperator(TIntermNode* node, TOperator op, const TType& type, TSourceLoc loc)
+TIntermTyped* TIntermediate::setAggregateOperator(TIntermNode* node, TOperator op, const TType& type,
+    const TSourceLoc& loc)
 {
     TIntermAggregate* aggNode;
 
@@ -505,8 +512,6 @@ TIntermTyped* TIntermediate::setAggregateOperator(TIntermNode* node, TOperator o
             //
             aggNode = new TIntermAggregate();
             aggNode->getSequence().push_back(node);
-            if (loc.line == 0)
-                loc = node->getLoc();
         }
     } else
         aggNode = new TIntermAggregate();
@@ -515,8 +520,8 @@ TIntermTyped* TIntermediate::setAggregateOperator(TIntermNode* node, TOperator o
     // Set the operator.
     //
     aggNode->setOperator(op);
-    if (loc.line != 0)
-        aggNode->setLoc(loc);
+    if (loc.line != 0 || node != nullptr)
+        aggNode->setLoc(loc.line != 0 ? loc : node->getLoc());
 
     aggNode->setType(type);
 

--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -512,8 +512,6 @@ TIntermTyped* TIntermediate::setAggregateOperator(TIntermNode* node, TOperator o
             //
             aggNode = new TIntermAggregate();
             aggNode->getSequence().push_back(node);
-            if (loc.line == 0)
-                loc = node->getLoc();
         }
     } else
         aggNode = new TIntermAggregate();

--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -512,6 +512,8 @@ TIntermTyped* TIntermediate::setAggregateOperator(TIntermNode* node, TOperator o
             //
             aggNode = new TIntermAggregate();
             aggNode->getSequence().push_back(node);
+            if (loc.line == 0)
+                loc = node->getLoc();
         }
     } else
         aggNode = new TIntermAggregate();

--- a/glslang/MachineIndependent/ParseContextBase.cpp
+++ b/glslang/MachineIndependent/ParseContextBase.cpp
@@ -213,11 +213,11 @@ bool TParseContextBase::lValueErrorCheck(const TSourceLoc& loc, const char* op, 
 
     if (symNode)
         error(loc, " l-value required", op, "\"%s\" (%s)", symbol, message);
-    else if (leftMostTypeNode && leftMostTypeNode->getAsSymbolNode() &&
-            binaryNode->getAsOperator()->getOp() == EOpIndexDirectStruct)
-        error(loc, " l-value required", op, "\"%s\" (%s)", leftMostTypeNode->getAsSymbolNode()->getAccessName().c_str(), message);
     else
-        error(loc, " l-value required", op, "(%s)", message);
+        if (binaryNode && binaryNode->getAsOperator()->getOp() == EOpIndexDirectStruct)
+            error(loc, " l-value required", op, "\"%s\" (%s)", leftMostTypeNode->getAsSymbolNode()->getAccessName().c_str(), message);
+        else
+            error(loc, " l-value required", op, "(%s)", message);
 
     return true;
 }
@@ -232,17 +232,17 @@ void TParseContextBase::rValueErrorCheck(const TSourceLoc& loc, const char* op, 
         return;
 
     if (node->getQualifier().isWriteOnly()) {
-        TIntermBinary* binaryNode = node->getAsBinaryNode();
         const TIntermTyped* leftMostTypeNode = TIntermediate::findLValueBase(node, true);
 
         if (symNode != nullptr)
             error(loc, "can't read from writeonly object: ", op, symNode->getName().c_str());
-        else if (leftMostTypeNode && leftMostTypeNode->getAsSymbolNode() &&
-                 (binaryNode->getAsOperator()->getOp() == EOpIndexDirectStruct ||
+        else if (binaryNode &&
+                (binaryNode->getAsOperator()->getOp() == EOpIndexDirectStruct ||
                  binaryNode->getAsOperator()->getOp() == EOpIndexDirect))
             error(loc, "can't read from writeonly object: ", op, leftMostTypeNode->getAsSymbolNode()->getAccessName().c_str());
         else
             error(loc, "can't read from writeonly object: ", op, "");
+
     } else {
         if (binaryNode) {
             switch (binaryNode->getOp()) {

--- a/glslang/MachineIndependent/ParseContextBase.cpp
+++ b/glslang/MachineIndependent/ParseContextBase.cpp
@@ -215,7 +215,10 @@ bool TParseContextBase::lValueErrorCheck(const TSourceLoc& loc, const char* op, 
         error(loc, " l-value required", op, "\"%s\" (%s)", symbol, message);
     else
         if (binaryNode && binaryNode->getAsOperator()->getOp() == EOpIndexDirectStruct)
-            error(loc, " l-value required", op, "\"%s\" (%s)", leftMostTypeNode->getAsSymbolNode()->getAccessName().c_str(), message);
+            if(IsAnonymous(leftMostTypeNode->getAsSymbolNode()->getName()))
+                error(loc, " l-value required", op, "\"%s\" (%s)", leftMostTypeNode->getAsSymbolNode()->getAccessName().c_str(), message);
+            else
+                error(loc, " l-value required", op, "\"%s\" (%s)", leftMostTypeNode->getAsSymbolNode()->getName().c_str(), message);
         else
             error(loc, " l-value required", op, "(%s)", message);
 
@@ -239,7 +242,10 @@ void TParseContextBase::rValueErrorCheck(const TSourceLoc& loc, const char* op, 
         else if (binaryNode &&
                 (binaryNode->getAsOperator()->getOp() == EOpIndexDirectStruct ||
                  binaryNode->getAsOperator()->getOp() == EOpIndexDirect))
-            error(loc, "can't read from writeonly object: ", op, leftMostTypeNode->getAsSymbolNode()->getAccessName().c_str());
+            if(IsAnonymous(leftMostTypeNode->getAsSymbolNode()->getName()))
+                error(loc, "can't read from writeonly object: ", op, leftMostTypeNode->getAsSymbolNode()->getAccessName().c_str());
+            else
+                error(loc, "can't read from writeonly object: ", op, leftMostTypeNode->getAsSymbolNode()->getName().c_str());
         else
             error(loc, "can't read from writeonly object: ", op, "");
 
@@ -288,10 +294,6 @@ void TParseContextBase::checkIndex(const TSourceLoc& loc, const TType& type, int
             index >= type.getOuterArraySize()) {
             error(loc, "", "[", "array index out of range '%d'", index);
             index = type.getOuterArraySize() - 1;
-        }
-        else if (type.getQualifier().builtIn == EbvSampleMask && index >= static_cast<int>((resources.maxSamples + 31u) / 32u)) {
-            error(loc, "", "[", "array index out of range '%d'", index);
-            index = static_cast<int>((resources.maxSamples + 31u) / 32u) - 1;
         }
     } else if (type.isVector()) {
         if (index >= type.getVectorSize()) {

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -3401,7 +3401,7 @@ void TParseContext::globalQualifierFixCheck(const TSourceLoc& loc, TQualifier& q
         // According to GLSL spec: The std430 qualifier is supported only for shader storage blocks; a shader using
         // the std430 qualifier on a uniform block will fail to compile.
         // Only check the global declaration: layout(std430) uniform;
-        if (blockName == nullptr &&  ((messages & EShMsgIgnoreStd430Errors) == 0) &&
+        if (blockName == nullptr &&
             qualifier.layoutPacking == ElpStd430)
         {
             error(loc, "it is invalid to declare std430 qualifier on uniform", "", "");

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -3375,6 +3375,7 @@ void TParseContext::memberQualifierCheck(glslang::TPublicType& publicType)
 void TParseContext::globalQualifierFixCheck(const TSourceLoc& loc, TQualifier& qualifier, bool isMemberCheck)
 {
     bool nonuniformOkay = false;
+    bool isInterface = true;
 
     // move from parameter/unknown qualifiers to pipeline in/out qualifiers
     switch (qualifier.storage) {
@@ -3394,7 +3395,6 @@ void TParseContext::globalQualifierFixCheck(const TSourceLoc& loc, TQualifier& q
         error(loc, "cannot use 'inout' at global scope", "", "");
         break;
     case EvqGlobal:
-    case EvqTemporary:
         nonuniformOkay = true;
         break;
     case EvqUniform:
@@ -3407,7 +3407,13 @@ void TParseContext::globalQualifierFixCheck(const TSourceLoc& loc, TQualifier& q
             error(loc, "it is invalid to declare std430 qualifier on uniform", "", "");
         }
         break;
+    case EvqBuffer:
+    case EvqShared:
+        break;
+    case EvqTemporary:
+        nonuniformOkay = true;
     default:
+        isInterface = false;
         break;
     }
 
@@ -3415,7 +3421,7 @@ void TParseContext::globalQualifierFixCheck(const TSourceLoc& loc, TQualifier& q
         error(loc, "for non-parameter, can only apply to 'in' or no storage qualifier", "nonuniformEXT", "");
 
     // Storage qualifier isn't ready for memberQualifierCheck, we should skip invariantCheck for it.
-    if (!isMemberCheck)
+    if (!isMemberCheck || !isInterface)
         invariantCheck(loc, qualifier);
 }
 
@@ -8226,6 +8232,7 @@ void TParseContext::invariantCheck(const TSourceLoc& loc, const TQualifier& qual
     } else {
         if ((language == EShLangVertex && pipeIn) || (! pipeOut && ! pipeIn))
             error(loc, "can only apply to an output, or to an input in a non-vertex stage\n", "invariant", "");
+        
     }
 }
 

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -3361,7 +3361,7 @@ void TParseContext::transparentOpaqueCheck(const TSourceLoc& loc, const TType& t
 //
 void TParseContext::memberQualifierCheck(glslang::TPublicType& publicType)
 {
-    globalQualifierFixCheck(publicType.loc, publicType.qualifier);
+    globalQualifierFixCheck(publicType.loc, publicType.qualifier, true);
     checkNoShaderLayouts(publicType.loc, publicType.shaderQualifiers);
     if (publicType.qualifier.isNonUniform()) {
         error(publicType.loc, "not allowed on block or structure members", "nonuniformEXT", "");
@@ -3372,7 +3372,7 @@ void TParseContext::memberQualifierCheck(glslang::TPublicType& publicType)
 //
 // Check/fix just a full qualifier (no variables or types yet, but qualifier is complete) at global level.
 //
-void TParseContext::globalQualifierFixCheck(const TSourceLoc& loc, TQualifier& qualifier)
+void TParseContext::globalQualifierFixCheck(const TSourceLoc& loc, TQualifier& qualifier, bool isMemberCheck)
 {
     bool nonuniformOkay = false;
 
@@ -3397,6 +3397,16 @@ void TParseContext::globalQualifierFixCheck(const TSourceLoc& loc, TQualifier& q
     case EvqTemporary:
         nonuniformOkay = true;
         break;
+    case EvqUniform:
+        // According to GLSL spec: The std430 qualifier is supported only for shader storage blocks; a shader using
+        // the std430 qualifier on a uniform block will fail to compile.
+        // Only check the global declaration: layout(std430) uniform;
+        if (blockName == nullptr &&  ((messages & EShMsgIgnoreStd430Errors) == 0) &&
+            qualifier.layoutPacking == ElpStd430)
+        {
+            error(loc, "it is invalid to declare std430 qualifier on uniform", "", "");
+        }
+        break;
     default:
         break;
     }
@@ -3404,7 +3414,9 @@ void TParseContext::globalQualifierFixCheck(const TSourceLoc& loc, TQualifier& q
     if (!nonuniformOkay && qualifier.isNonUniform())
         error(loc, "for non-parameter, can only apply to 'in' or no storage qualifier", "nonuniformEXT", "");
 
-    invariantCheck(loc, qualifier);
+    // Storage qualifier isn't ready for memberQualifierCheck, we should skip invariantCheck for it.
+    if (!isMemberCheck)
+        invariantCheck(loc, qualifier);
 }
 
 //
@@ -4074,6 +4086,9 @@ void TParseContext::checkRuntimeSizable(const TSourceLoc& loc, const TIntermType
 {
     // runtime length implies runtime sizeable, so no problem
     if (isRuntimeLength(base))
+        return;
+
+    if (base.getType().getQualifier().builtIn == EbvSampleMask)
         return;
 
     // Check for last member of a bufferreference type, which is runtime sizeable
@@ -6528,11 +6543,13 @@ void TParseContext::declareTypeDefaults(const TSourceLoc& loc, const TPublicType
             error(loc, "atomic_uint binding is too large", "binding", "");
             return;
         }
-
-        if(publicType.qualifier.hasOffset()) {
+        if (publicType.qualifier.hasOffset())
             atomicUintOffsets[publicType.qualifier.layoutBinding] = publicType.qualifier.layoutOffset;
-        }
         return;
+    }
+
+    if (publicType.arraySizes) {
+        error(loc, "expect an array name", "", "");
     }
 
     if (publicType.qualifier.hasLayout() && !publicType.qualifier.hasBufferReference())
@@ -6618,6 +6635,22 @@ TIntermNode* TParseContext::declareVariable(const TSourceLoc& loc, TString& iden
 
     if (type.getQualifier().storage == EvqShared && type.containsCoopMat())
         error(loc, "qualifier", "Cooperative matrix types must not be used in shared memory", "");
+
+    if (profile == EEsProfile) {
+        if (type.getQualifier().isPipeInput() && type.getBasicType() == EbtStruct) {
+            if (type.getQualifier().isArrayedIo(language)) {
+                TType perVertexType(type, 0);
+                if (perVertexType.containsArray() && perVertexType.containsBuiltIn() == false) {
+                    error(loc, "A per vertex structure containing an array is not allowed as input in ES", type.getTypeName().c_str(), "");
+                }
+            }
+            else if (type.containsArray() && type.containsBuiltIn() == false) {
+                error(loc, "A structure containing an array is not allowed as input in ES", type.getTypeName().c_str(), "");
+            }
+            if (type.containsStructure())
+                error(loc, "A structure containing an struct is not allowed as input in ES", type.getTypeName().c_str(), "");
+        }
+    }
 
     if (identifier != "gl_FragCoord" && (publicType.shaderQualifiers.originUpperLeft || publicType.shaderQualifiers.pixelCenterInteger))
         error(loc, "can only apply origin_upper_left and pixel_center_origin to gl_FragCoord", "layout qualifier", "");
@@ -6940,6 +6973,15 @@ TIntermTyped* TParseContext::convertInitializerList(const TSourceLoc& loc, const
         if (type.getVectorSize() != (int)initList->getSequence().size()) {
             error(loc, "wrong vector size (or rows in a matrix column):", "initializer list", type.getCompleteString().c_str());
             return nullptr;
+        }
+        TBasicType destType = type.getBasicType();
+        for (int i = 0; i < type.getVectorSize(); ++i) {
+            TBasicType initType = initList->getSequence()[i]->getAsTyped()->getBasicType();
+            if (destType != initType && !intermediate.canImplicitlyPromote(initType, destType)) {
+                error(loc, "type mismatch in initializer list", "initializer list", type.getCompleteString().c_str());
+                return nullptr;
+            }
+
         }
     } else {
         error(loc, "unexpected initializer-list type:", "initializer list", type.getCompleteString().c_str());
@@ -7477,10 +7519,10 @@ void TParseContext::declareBlock(const TSourceLoc& loc, TTypeList& typeList, con
         TType& memberType = *typeList[member].type;
         TQualifier& memberQualifier = memberType.getQualifier();
         const TSourceLoc& memberLoc = typeList[member].loc;
-        globalQualifierFixCheck(memberLoc, memberQualifier);
         if (memberQualifier.storage != EvqTemporary && memberQualifier.storage != EvqGlobal && memberQualifier.storage != currentBlockQualifier.storage)
             error(memberLoc, "member storage qualifier cannot contradict block storage qualifier", memberType.getFieldName().c_str(), "");
         memberQualifier.storage = currentBlockQualifier.storage;
+        globalQualifierFixCheck(memberLoc, memberQualifier);
 #ifndef GLSLANG_WEB
         inheritMemoryQualifiers(currentBlockQualifier, memberQualifier);
         if (currentBlockQualifier.perPrimitiveNV)

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -8220,7 +8220,7 @@ void TParseContext::invariantCheck(const TSourceLoc& loc, const TQualifier& qual
 
     bool pipeOut = qualifier.isPipeOutput();
     bool pipeIn = qualifier.isPipeInput();
-    if (version >= 300 || (!isEsProfile() && version >= 420)) {
+    if ((version >= 300 && isEsProfile()) || (!isEsProfile() && version >= 420)) {
         if (! pipeOut)
             error(loc, "can only apply to an output", "invariant", "");
     } else {

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -3375,7 +3375,6 @@ void TParseContext::memberQualifierCheck(glslang::TPublicType& publicType)
 void TParseContext::globalQualifierFixCheck(const TSourceLoc& loc, TQualifier& qualifier, bool isMemberCheck)
 {
     bool nonuniformOkay = false;
-    bool isInterface = true;
 
     // move from parameter/unknown qualifiers to pipeline in/out qualifiers
     switch (qualifier.storage) {
@@ -3395,6 +3394,7 @@ void TParseContext::globalQualifierFixCheck(const TSourceLoc& loc, TQualifier& q
         error(loc, "cannot use 'inout' at global scope", "", "");
         break;
     case EvqGlobal:
+    case EvqTemporary:
         nonuniformOkay = true;
         break;
     case EvqUniform:
@@ -3407,13 +3407,7 @@ void TParseContext::globalQualifierFixCheck(const TSourceLoc& loc, TQualifier& q
             error(loc, "it is invalid to declare std430 qualifier on uniform", "", "");
         }
         break;
-    case EvqBuffer:
-    case EvqShared:
-        break;
-    case EvqTemporary:
-        nonuniformOkay = true;
     default:
-        isInterface = false;
         break;
     }
 
@@ -3421,7 +3415,7 @@ void TParseContext::globalQualifierFixCheck(const TSourceLoc& loc, TQualifier& q
         error(loc, "for non-parameter, can only apply to 'in' or no storage qualifier", "nonuniformEXT", "");
 
     // Storage qualifier isn't ready for memberQualifierCheck, we should skip invariantCheck for it.
-    if (!isMemberCheck || !isInterface)
+    if (!isMemberCheck || structNestingLevel > 0)
         invariantCheck(loc, qualifier);
 }
 
@@ -4646,14 +4640,14 @@ void TParseContext::paramCheckFix(const TSourceLoc& loc, const TQualifier& quali
 
 void TParseContext::nestedBlockCheck(const TSourceLoc& loc)
 {
-    if (structNestingLevel > 0)
+    if (structNestingLevel > 0 || blockNestingLevel > 0)
         error(loc, "cannot nest a block definition inside a structure or block", "", "");
-    ++structNestingLevel;
+    ++blockNestingLevel;
 }
 
 void TParseContext::nestedStructCheck(const TSourceLoc& loc)
 {
-    if (structNestingLevel > 0)
+    if (structNestingLevel > 0 || blockNestingLevel > 0)
         error(loc, "cannot nest a structure definition inside a structure or block", "", "");
     ++structNestingLevel;
 }
@@ -8232,7 +8226,6 @@ void TParseContext::invariantCheck(const TSourceLoc& loc, const TQualifier& qual
     } else {
         if ((language == EShLangVertex && pipeIn) || (! pipeOut && ! pipeIn))
             error(loc, "can only apply to an output, or to an input in a non-vertex stage\n", "invariant", "");
-        
     }
 }
 

--- a/glslang/MachineIndependent/ParseHelper.h
+++ b/glslang/MachineIndependent/ParseHelper.h
@@ -364,7 +364,7 @@ public:
     void accStructCheck(const TSourceLoc & loc, const TType & type, const TString & identifier);
     void transparentOpaqueCheck(const TSourceLoc&, const TType&, const TString& identifier);
     void memberQualifierCheck(glslang::TPublicType&);
-    void globalQualifierFixCheck(const TSourceLoc&, TQualifier&);
+    void globalQualifierFixCheck(const TSourceLoc&, TQualifier&, bool isMemberCheck = false);
     void globalQualifierTypeCheck(const TSourceLoc&, const TQualifier&, const TPublicType&);
     bool structQualifierErrorCheck(const TSourceLoc&, const TPublicType& pType);
     void mergeQualifiers(const TSourceLoc&, TQualifier& dst, const TQualifier& src, bool force);

--- a/glslang/MachineIndependent/ParseHelper.h
+++ b/glslang/MachineIndependent/ParseHelper.h
@@ -83,7 +83,7 @@ public:
           : TParseVersions(interm, version, profile, spvVersion, language, infoSink, forwardCompatible, messages),
             scopeMangler("::"),
             symbolTable(symbolTable),
-            statementNestingLevel(0), loopNestingLevel(0), structNestingLevel(0), controlFlowNestingLevel(0),
+            statementNestingLevel(0), loopNestingLevel(0), structNestingLevel(0), blockNestingLevel(0), controlFlowNestingLevel(0),
             postEntryPointReturn(false),
             contextPragma(true, false),
             beginInvocationInterlockCount(0), endInvocationInterlockCount(0),
@@ -177,7 +177,8 @@ public:
     TSymbolTable& symbolTable;        // symbol table that goes with the current language, version, and profile
     int statementNestingLevel;        // 0 if outside all flow control or compound statements
     int loopNestingLevel;             // 0 if outside all loops
-    int structNestingLevel;           // 0 if outside blocks and structures
+    int structNestingLevel;           // 0 if outside structures
+    int blockNestingLevel;            // 0 if outside blocks
     int controlFlowNestingLevel;      // 0 if outside all flow control
     const TType* currentFunctionType; // the return type of the function that's currently being parsed
     bool functionReturnsValue;        // true if a non-void function has a return

--- a/glslang/MachineIndependent/Scan.cpp
+++ b/glslang/MachineIndependent/Scan.cpp
@@ -982,7 +982,7 @@ int TScanContext::tokenizeIdentifier()
         return keyword;
     case PACKED:
         if ((parseContext.isEsProfile() && parseContext.version < 300) ||
-            (!parseContext.isEsProfile() && parseContext.version < 330))
+            (!parseContext.isEsProfile() && parseContext.version < 140))
             return reservedWord();
         return identifierOrType();
 

--- a/glslang/MachineIndependent/SymbolTable.cpp
+++ b/glslang/MachineIndependent/SymbolTable.cpp
@@ -146,6 +146,8 @@ void TType::buildMangledName(TString& mangledName) const
         if (typeName)
             mangledName += *typeName;
         for (unsigned int i = 0; i < structure->size(); ++i) {
+            if ((*structure)[i].type->getBasicType() == EbtVoid)
+                continue;
             mangledName += '-';
             (*structure)[i].type->buildMangledName(mangledName);
         }

--- a/glslang/MachineIndependent/SymbolTable.h
+++ b/glslang/MachineIndependent/SymbolTable.h
@@ -886,7 +886,7 @@ protected:
     TSymbolTable& operator=(TSymbolTableLevel&);
 
     int currentLevel() const { return static_cast<int>(table.size()) - 1; }
-
+    static const uint32_t LevelFlagBitOffset = 28;
     std::vector<TSymbolTableLevel*> table;
     int uniqueId;     // for unique identification in code generation
     bool noBuiltInRedeclarations;

--- a/glslang/MachineIndependent/SymbolTable.h
+++ b/glslang/MachineIndependent/SymbolTable.h
@@ -613,20 +613,24 @@ public:
     //
 protected:
     static const int globalLevel = 3;
-    bool isSharedLevel(int level)  { return level <= 1; }              // exclude all per-compile levels
-    bool isBuiltInLevel(int level) { return level <= 2; }              // exclude user globals
-    bool isGlobalLevel(int level)  { return level <= globalLevel; }    // include user globals
+    static bool isSharedLevel(int level)  { return level <= 1; }            // exclude all per-compile levels
+    static bool isBuiltInLevel(int level) { return level <= 2; }            // exclude user globals
+    static bool isGlobalLevel(int level)  { return level <= globalLevel; }  // include user globals
 public:
     bool isEmpty() { return table.size() == 0; }
     bool atBuiltInLevel() { return isBuiltInLevel(currentLevel()); }
     bool atGlobalLevel()  { return isGlobalLevel(currentLevel()); }
-
+    static bool isBuiltInSymbol(int uniqueId) {
+        int level = uniqueId >> LevelFlagBitOffset;
+        return isBuiltInLevel(level);
+    }
     void setNoBuiltInRedeclarations() { noBuiltInRedeclarations = true; }
     void setSeparateNameSpaces() { separateNameSpaces = true; }
 
     void push()
     {
         table.push_back(new TSymbolTableLevel);
+        updateUniqueIdLevelFlag();
     }
 
     // Make a new symbol-table level to represent the scope introduced by a structure
@@ -639,6 +643,7 @@ public:
     {
         assert(thisSymbol.getName().size() == 0);
         table.push_back(new TSymbolTableLevel);
+        updateUniqueIdLevelFlag();
         table.back()->setThisLevel();
         insert(thisSymbol);
     }
@@ -648,6 +653,7 @@ public:
         table[currentLevel()]->getPreviousDefaultPrecisions(p);
         delete table.back();
         table.pop_back();
+        updateUniqueIdLevelFlag();
     }
 
     //
@@ -865,6 +871,14 @@ public:
     {
         for (unsigned int level = 0; level < table.size(); ++level)
             table[level]->readOnly();
+    }
+
+    // Add current level in the high-bits of unique id
+    void updateUniqueIdLevelFlag() {
+        // clamp level to avoid overflow
+        uint32_t level = currentLevel() > 7 ? 7 : currentLevel();
+        uniqueId &= ((1 << LevelFlagBitOffset) - 1);
+        uniqueId |= (level << LevelFlagBitOffset);
     }
 
 protected:

--- a/glslang/MachineIndependent/glslang.m4
+++ b/glslang/MachineIndependent/glslang.m4
@@ -905,7 +905,7 @@ declaration
 
 block_structure
     : type_qualifier IDENTIFIER LEFT_BRACE { parseContext.nestedBlockCheck($1.loc); } struct_declaration_list RIGHT_BRACE {
-        --parseContext.structNestingLevel;
+        --parseContext.blockNestingLevel;
         parseContext.blockName = $2.string;
         parseContext.globalQualifierFixCheck($1.loc, $1.qualifier);
         parseContext.checkNoShaderLayouts($1.loc, $1.shaderQualifiers);

--- a/glslang/MachineIndependent/glslang.y
+++ b/glslang/MachineIndependent/glslang.y
@@ -905,7 +905,7 @@ declaration
 
 block_structure
     : type_qualifier IDENTIFIER LEFT_BRACE { parseContext.nestedBlockCheck($1.loc); } struct_declaration_list RIGHT_BRACE {
-        --parseContext.structNestingLevel;
+        --parseContext.blockNestingLevel;
         parseContext.blockName = $2.string;
         parseContext.globalQualifierFixCheck($1.loc, $1.qualifier);
         parseContext.checkNoShaderLayouts($1.loc, $1.shaderQualifiers);

--- a/glslang/MachineIndependent/glslang_tab.cpp
+++ b/glslang/MachineIndependent/glslang_tab.cpp
@@ -5186,7 +5186,7 @@ yyreduce:
   case 104:
 #line 907 "MachineIndependent/glslang.y" /* yacc.c:1646  */
     {
-        --parseContext.structNestingLevel;
+        --parseContext.blockNestingLevel;
         parseContext.blockName = (yyvsp[-4].lex).string;
         parseContext.globalQualifierFixCheck((yyvsp[-5].interm.type).loc, (yyvsp[-5].interm.type).qualifier);
         parseContext.checkNoShaderLayouts((yyvsp[-5].interm.type).loc, (yyvsp[-5].interm.type).shaderQualifiers);

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -1454,9 +1454,10 @@ bool TIoMapper::addStage(EShLanguage stage, TIntermediate& intermediate, TInfoSi
         return TVarEntryInfo::TOrderByPriority()(p1.second, p2.second);
     });
     bool hadError = false;
+    TVarLiveMap* dummyUniformVarMap[EShLangCount] = {};
     TNotifyInOutAdaptor inOutNotify(stage, *resolver);
     TNotifyUniformAdaptor uniformNotify(stage, *resolver);
-    TResolverUniformAdaptor uniformResolve(stage, *resolver, infoSink, hadError);
+    TResolverUniformAdaptor uniformResolve(stage, *resolver, dummyUniformVarMap, infoSink, hadError);
     TResolverInOutAdaptor inOutResolve(stage, *resolver, infoSink, hadError);
     resolver->beginNotifications(stage);
     std::for_each(inVector.begin(), inVector.end(), inOutNotify);
@@ -1563,9 +1564,10 @@ bool TGlslIoMapper::doMap(TIoMapResolver* resolver, TInfoSink& infoSink) {
     resolver->endResolve(EShLangCount);
     if (!hadError) {
         //Resolve uniform location, ubo/ssbo/opaque bindings across stages
-        TResolverUniformAdaptor uniformResolve(EShLangCount, *resolver, infoSink, hadError);
+        TResolverUniformAdaptor uniformResolve(EShLangCount, *resolver, uniformVarMap, infoSink, hadError);
         TResolverInOutAdaptor inOutResolve(EShLangCount, *resolver, infoSink, hadError);
-        TSymbolValidater symbolValidater(*resolver, infoSink, inVarMaps, outVarMaps, uniformVarMap, hadError);
+        TSymbolValidater symbolValidater(*resolver, infoSink, inVarMaps,
+                                         outVarMaps, uniformVarMap, hadError, profile, version);
         TVarLiveVector uniformVector;
         resolver->beginResolve(EShLangCount);
         for (int stage = EShLangVertex; stage < EShLangCount; stage++) {

--- a/glslang/MachineIndependent/iomapper.h
+++ b/glslang/MachineIndependent/iomapper.h
@@ -263,10 +263,12 @@ public:
 class TGlslIoMapper : public TIoMapper {
 public:
     TGlslIoMapper() {
-        memset(inVarMaps,     0, sizeof(TVarLiveMap*)   * EShLangCount);
-        memset(outVarMaps,    0, sizeof(TVarLiveMap*)   * EShLangCount);
-        memset(uniformVarMap, 0, sizeof(TVarLiveMap*)   * EShLangCount);
-        memset(intermediates, 0, sizeof(TIntermediate*) * EShLangCount);
+        memset(inVarMaps,     0, sizeof(TVarLiveMap*)   * (EShLangCount + 1));
+        memset(outVarMaps,    0, sizeof(TVarLiveMap*)   * (EShLangCount + 1));
+        memset(uniformVarMap, 0, sizeof(TVarLiveMap*)   * (EShLangCount + 1));
+        memset(intermediates, 0, sizeof(TIntermediate*) * (EShLangCount + 1));
+        profile = ENoProfile;
+        version = 0;
     }
     virtual ~TGlslIoMapper() {
         for (size_t stage = 0; stage < EShLangCount; stage++) {
@@ -293,6 +295,8 @@ public:
                 *uniformVarMap[EShLangCount];
     TIntermediate* intermediates[EShLangCount];
     bool hadError = false;
+    EProfile profile;
+    int version;
 };
 
 } // end namespace glslang

--- a/glslang/MachineIndependent/iomapper.h
+++ b/glslang/MachineIndependent/iomapper.h
@@ -203,7 +203,6 @@ public:
     void endCollect(EShLanguage) override;
     void reserverStorageSlot(TVarEntryInfo& ent, TInfoSink& infoSink) override;
     void reserverResourceSlot(TVarEntryInfo& ent, TInfoSink& infoSink) override;
-    const TString& getAccessName(const TIntermSymbol*);
     // in/out symbol and uniform symbol are stored in the same resourceSlotMap, the storage key is used to identify each type of symbol.
     // We use stage and storage qualifier to construct a storage key. it can help us identify the same storage resource used in different stage.
     // if a resource is a program resource and we don't need know it usage stage, we can use same stage to build storage key.

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -448,10 +448,10 @@ public:
     TIntermTyped* addConversion(TBasicType convertTo, TIntermTyped* node) const;
     void addBiShapeConversion(TOperator, TIntermTyped*& lhsNode, TIntermTyped*& rhsNode);
     TIntermTyped* addShapeConversion(const TType&, TIntermTyped*);
-    TIntermTyped* addBinaryMath(TOperator, TIntermTyped* left, TIntermTyped* right, const TSourceLoc&);
-    TIntermTyped* addAssign(TOperator op, TIntermTyped* left, TIntermTyped* right, const TSourceLoc&);
-    TIntermTyped* addIndex(TOperator op, TIntermTyped* base, TIntermTyped* index, const TSourceLoc&);
-    TIntermTyped* addUnaryMath(TOperator, TIntermTyped* child, const TSourceLoc&);
+    TIntermTyped* addBinaryMath(TOperator, TIntermTyped* left, TIntermTyped* right, TSourceLoc);
+    TIntermTyped* addAssign(TOperator op, TIntermTyped* left, TIntermTyped* right, TSourceLoc);
+    TIntermTyped* addIndex(TOperator op, TIntermTyped* base, TIntermTyped* index, TSourceLoc);
+    TIntermTyped* addUnaryMath(TOperator, TIntermTyped* child, TSourceLoc);
     TIntermTyped* addBuiltInFunctionCall(const TSourceLoc& line, TOperator, bool unary, TIntermNode*, const TType& returnType);
     bool canImplicitlyPromote(TBasicType from, TBasicType to, TOperator op = EOpNull) const;
     bool isIntegralPromotion(TBasicType from, TBasicType to) const;
@@ -465,7 +465,7 @@ public:
     TIntermAggregate* makeAggregate(TIntermNode* node);
     TIntermAggregate* makeAggregate(TIntermNode* node, const TSourceLoc&);
     TIntermAggregate* makeAggregate(const TSourceLoc&);
-    TIntermTyped* setAggregateOperator(TIntermNode*, TOperator, const TType& type, const TSourceLoc&);
+    TIntermTyped* setAggregateOperator(TIntermNode*, TOperator, const TType& type, TSourceLoc);
     bool areAllChildConst(TIntermAggregate* aggrNode);
     TIntermSelection* addSelection(TIntermTyped* cond, TIntermNodePair code, const TSourceLoc&);
     TIntermTyped* addSelection(TIntermTyped* cond, TIntermTyped* trueBlock, TIntermTyped* falseBlock, const TSourceLoc&);
@@ -494,11 +494,10 @@ public:
 
     // Low level functions to add nodes (no conversions or other higher level transformations)
     // If a type is provided, the node's type will be set to it.
-    TIntermBinary* addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right, const TSourceLoc&) const;
-    TIntermBinary* addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right, const TSourceLoc&,
-        const TType&) const;
-    TIntermUnary* addUnaryNode(TOperator op, TIntermTyped* child, const TSourceLoc&) const;
-    TIntermUnary* addUnaryNode(TOperator op, TIntermTyped* child, const TSourceLoc&, const TType&) const;
+    TIntermBinary* addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right, TSourceLoc) const;
+    TIntermBinary* addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right, TSourceLoc, const TType&) const;
+    TIntermUnary* addUnaryNode(TOperator op, TIntermTyped* child, TSourceLoc) const;
+    TIntermUnary* addUnaryNode(TOperator op, TIntermTyped* child, TSourceLoc, const TType&) const;
 
     // Constant folding (in Constant.cpp)
     TIntermTyped* fold(TIntermAggregate* aggrNode);

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -448,10 +448,10 @@ public:
     TIntermTyped* addConversion(TBasicType convertTo, TIntermTyped* node) const;
     void addBiShapeConversion(TOperator, TIntermTyped*& lhsNode, TIntermTyped*& rhsNode);
     TIntermTyped* addShapeConversion(const TType&, TIntermTyped*);
-    TIntermTyped* addBinaryMath(TOperator, TIntermTyped* left, TIntermTyped* right, TSourceLoc);
-    TIntermTyped* addAssign(TOperator op, TIntermTyped* left, TIntermTyped* right, TSourceLoc);
-    TIntermTyped* addIndex(TOperator op, TIntermTyped* base, TIntermTyped* index, TSourceLoc);
-    TIntermTyped* addUnaryMath(TOperator, TIntermTyped* child, TSourceLoc);
+    TIntermTyped* addBinaryMath(TOperator, TIntermTyped* left, TIntermTyped* right, const TSourceLoc&);
+    TIntermTyped* addAssign(TOperator op, TIntermTyped* left, TIntermTyped* right, const TSourceLoc&);
+    TIntermTyped* addIndex(TOperator op, TIntermTyped* base, TIntermTyped* index, const TSourceLoc&);
+    TIntermTyped* addUnaryMath(TOperator, TIntermTyped* child, const TSourceLoc&);
     TIntermTyped* addBuiltInFunctionCall(const TSourceLoc& line, TOperator, bool unary, TIntermNode*, const TType& returnType);
     bool canImplicitlyPromote(TBasicType from, TBasicType to, TOperator op = EOpNull) const;
     bool isIntegralPromotion(TBasicType from, TBasicType to) const;
@@ -465,7 +465,7 @@ public:
     TIntermAggregate* makeAggregate(TIntermNode* node);
     TIntermAggregate* makeAggregate(TIntermNode* node, const TSourceLoc&);
     TIntermAggregate* makeAggregate(const TSourceLoc&);
-    TIntermTyped* setAggregateOperator(TIntermNode*, TOperator, const TType& type, TSourceLoc);
+    TIntermTyped* setAggregateOperator(TIntermNode*, TOperator, const TType& type, const TSourceLoc&);
     bool areAllChildConst(TIntermAggregate* aggrNode);
     TIntermSelection* addSelection(TIntermTyped* cond, TIntermNodePair code, const TSourceLoc&);
     TIntermTyped* addSelection(TIntermTyped* cond, TIntermTyped* trueBlock, TIntermTyped* falseBlock, const TSourceLoc&);
@@ -494,10 +494,11 @@ public:
 
     // Low level functions to add nodes (no conversions or other higher level transformations)
     // If a type is provided, the node's type will be set to it.
-    TIntermBinary* addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right, TSourceLoc) const;
-    TIntermBinary* addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right, TSourceLoc, const TType&) const;
-    TIntermUnary* addUnaryNode(TOperator op, TIntermTyped* child, TSourceLoc) const;
-    TIntermUnary* addUnaryNode(TOperator op, TIntermTyped* child, TSourceLoc, const TType&) const;
+    TIntermBinary* addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right, const TSourceLoc&) const;
+    TIntermBinary* addBinaryNode(TOperator op, TIntermTyped* left, TIntermTyped* right, const TSourceLoc&,
+        const TType&) const;
+    TIntermUnary* addUnaryNode(TOperator op, TIntermTyped* child, const TSourceLoc&) const;
+    TIntermUnary* addUnaryNode(TOperator op, TIntermTyped* child, const TSourceLoc&, const TType&) const;
 
     // Constant folding (in Constant.cpp)
     TIntermTyped* fold(TIntermAggregate* aggrNode);

--- a/glslang/MachineIndependent/reflection.cpp
+++ b/glslang/MachineIndependent/reflection.cpp
@@ -658,14 +658,17 @@ public:
 
                 blocks.back().numMembers = countAggregateMembers(type);
 
-                EShLanguageMask& stages = blocks.back().stages;
-                stages = static_cast<EShLanguageMask>(stages | 1 << intermediate.getStage());
+                if (updateStageMasks) {
+                    EShLanguageMask& stages = blocks.back().stages;
+                    stages = static_cast<EShLanguageMask>(stages | 1 << intermediate.getStage());
+                }
             }
             else {
                 blockIndex = it->second;
-
-                EShLanguageMask& stages = blocks[blockIndex].stages;
-                stages = static_cast<EShLanguageMask>(stages | 1 << intermediate.getStage());
+                if (updateStageMasks) {
+                    EShLanguageMask& stages = blocks[blockIndex].stages;
+                    stages = static_cast<EShLanguageMask>(stages | 1 << intermediate.getStage());
+                }
             }
         }
 


### PR DESCRIPTION
Fix io mapping issue:
1. refine usage of access name.
2. add validation of interfaces & buffer & uniforms
3. split nest level, for member check of invariant qualifier
4. use new id level setting, help to identify builtins
5. fix issues introduced by vector and usage of for_each in io mapping