### PR TITLE
SPIRV: Add disassembly support for multiple literal strings

### DIFF
--- a/SPIRV/SPVRemapper.cpp
+++ b/SPIRV/SPVRemapper.cpp
@@ -625,6 +625,9 @@ namespace spv {
                 break;
             }
 
+            case spv::OperandVariableLiteralStrings:
+                return nextInst;
+
             // Execution mode might have extra literal operands.  Skip them.
             case spv::OperandExecutionMode:
                 return nextInst;

--- a/SPIRV/disassemble.cpp
+++ b/SPIRV/disassemble.cpp
@@ -519,6 +519,10 @@ void SpirvStream::disassembleInstruction(Id resultId, Id /*typeId*/, Op opCode, 
         case OperandLiteralString:
             numOperands -= disassembleString();
             break;
+        case OperandVariableLiteralStrings:
+            while (numOperands > 0)
+                numOperands -= disassembleString();
+            return;
         case OperandMemoryAccess:
             outputMask(OperandMemoryAccess, stream[word++]);
             --numOperands;

--- a/SPIRV/doc.cpp
+++ b/SPIRV/doc.cpp
@@ -1727,7 +1727,7 @@ void Parameterize()
 
     InstructionDesc[OpDecorateStringGOOGLE].operands.push(OperandId, "'Target'");
     InstructionDesc[OpDecorateStringGOOGLE].operands.push(OperandDecoration, "");
-    InstructionDesc[OpDecorateStringGOOGLE].operands.push(OperandLiteralString, "'Literal String'");
+    InstructionDesc[OpDecorateStringGOOGLE].operands.push(OperandVariableLiteralStrings, "'Literal Strings'");
 
     InstructionDesc[OpMemberDecorate].operands.push(OperandId, "'Structure Type'");
     InstructionDesc[OpMemberDecorate].operands.push(OperandLiteralNumber, "'Member'");
@@ -1737,7 +1737,7 @@ void Parameterize()
     InstructionDesc[OpMemberDecorateStringGOOGLE].operands.push(OperandId, "'Structure Type'");
     InstructionDesc[OpMemberDecorateStringGOOGLE].operands.push(OperandLiteralNumber, "'Member'");
     InstructionDesc[OpMemberDecorateStringGOOGLE].operands.push(OperandDecoration, "");
-    InstructionDesc[OpMemberDecorateStringGOOGLE].operands.push(OperandLiteralString, "'Literal String'");
+    InstructionDesc[OpMemberDecorateStringGOOGLE].operands.push(OperandVariableLiteralStrings, "'Literal Strings'");
 
     InstructionDesc[OpGroupDecorate].operands.push(OperandId, "'Decoration Group'");
     InstructionDesc[OpGroupDecorate].operands.push(OperandVariableIds, "'Targets'");

--- a/SPIRV/doc.h
+++ b/SPIRV/doc.h
@@ -125,6 +125,7 @@ enum OperandClass {
     OperandVariableLiteralId,
     OperandLiteralNumber,
     OperandLiteralString,
+    OperandVariableLiteralStrings,
     OperandSource,
     OperandExecutionModel,
     OperandAddressing,


### PR DESCRIPTION
According to the extension SPV_GOOGLE_decorate_string,
OpDecorateString (or OpMemberDecorateString) ought to be capable of
supporting multiple literal strings. Each literal strings are padded
with null terminator to make word alignment. The layout is:

  `Inst | Target | Decoration | Literal String, Literal String, ...`