### PR TITLE
[Wconversion] Suppress glslang issue

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -76,6 +76,7 @@ if (!defined(glslang_angle)) {
 
 config("glslang_public") {
   include_dirs = [ "." ]
+  cflags = [ "-Wno-conversion" ]
 }
 
 config("glslang_hlsl") {


### PR DESCRIPTION
The glslang public includes dir contains headers with implicit
conversion issues. Add -Wno-conversion to glslang's public config.

Bug: 60140
Bug: 58162
Change-Id: Iec27cb4242e9fdceddd6a3e02044a0bccfa0ce36
Reviewed-on: https://fuchsia-review.googlesource.com/c/third_party/glslang/+/429054
Reviewed-by: Petr Hosek <phosek@google.com>