### PR TITLE
Add new SpirvToolsDisassemble API interface + Improve Doc on existing API interface

### DIFF
--- a/SPIRV/SpvTools.cpp
+++ b/SPIRV/SpvTools.cpp
@@ -44,7 +44,6 @@
 
 #include "SpvTools.h"
 #include "spirv-tools/optimizer.hpp"
-#include "spirv-tools/libspirv.h"
 
 namespace glslang {
 
@@ -114,11 +113,18 @@ void OptimizerMesssageConsumer(spv_message_level_t level, const char *source,
     out << std::endl;
 }
 
-// Use the SPIRV-Tools disassembler to print SPIR-V.
+// Use the SPIRV-Tools disassembler to print SPIR-V using a SPV_ENV_UNIVERSAL_1_3 environment.
 void SpirvToolsDisassemble(std::ostream& out, const std::vector<unsigned int>& spirv)
 {
+    SpirvToolsDisassemble(out, spirv, spv_target_env::SPV_ENV_UNIVERSAL_1_3);
+}
+
+// Use the SPIRV-Tools disassembler to print SPIR-V with a provided SPIR-V environment.
+void SpirvToolsDisassemble(std::ostream& out, const std::vector<unsigned int>& spirv,
+                           spv_target_env requested_context)
+{
     // disassemble
-    spv_context context = spvContextCreate(SPV_ENV_UNIVERSAL_1_3);
+    spv_context context = spvContextCreate(requested_context);
     spv_text text;
     spv_diagnostic diagnostic = nullptr;
     spvBinaryToText(context, spirv.data(), spirv.size(),

--- a/SPIRV/SpvTools.h
+++ b/SPIRV/SpvTools.h
@@ -41,7 +41,7 @@
 #ifndef GLSLANG_SPV_TOOLS_H
 #define GLSLANG_SPV_TOOLS_H
 
-#ifdef ENABLE_OPT
+#if ENABLE_OPT
 #include <vector>
 #include <ostream>
 #include "spirv-tools/libspirv.h"
@@ -63,7 +63,7 @@ struct SpvOptions {
     bool validate;
 };
 
-#ifdef ENABLE_OPT
+#if ENABLE_OPT
 
 // Use the SPIRV-Tools disassembler to print SPIR-V using a SPV_ENV_UNIVERSAL_1_3 environment.
 void SpirvToolsDisassemble(std::ostream& out, const std::vector<unsigned int>& spirv);

--- a/SPIRV/SpvTools.h
+++ b/SPIRV/SpvTools.h
@@ -44,6 +44,7 @@
 #ifdef ENABLE_OPT
 #include <vector>
 #include <ostream>
+#include "spirv-tools/libspirv.h"
 #endif
 
 #include "glslang/MachineIndependent/localintermediate.h"
@@ -64,8 +65,12 @@ struct SpvOptions {
 
 #ifdef ENABLE_OPT
 
-// Use the SPIRV-Tools disassembler to print SPIR-V.
+// Use the SPIRV-Tools disassembler to print SPIR-V using a SPV_ENV_UNIVERSAL_1_3 environment.
 void SpirvToolsDisassemble(std::ostream& out, const std::vector<unsigned int>& spirv);
+
+// Use the SPIRV-Tools disassembler to print SPIR-V with a provided SPIR-V environment.
+void SpirvToolsDisassemble(std::ostream& out, const std::vector<unsigned int>& spirv,
+                           spv_target_env requested_context);
 
 // Apply the SPIRV-Tools validator to generated SPIR-V.
 void SpirvToolsValidate(const glslang::TIntermediate& intermediate, std::vector<unsigned int>& spirv,

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -41,7 +41,6 @@ target_include_directories(glslang-default-resource-limits
                            PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
 
-
 set(SOURCES StandAlone.cpp DirStackFileIncluder.h)
 
 add_executable(glslangValidator ${SOURCES})
@@ -69,6 +68,12 @@ target_link_libraries(glslangValidator ${LIBRARIES})
 target_include_directories(glslangValidator PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../External>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/External>)
+
+if(ENABLE_OPT)
+    target_include_directories(glslangValidator
+        PRIVATE ${spirv-tools_SOURCE_DIR}/include
+    )
+endif(ENABLE_OPT)
 
 if(ENABLE_SPVREMAPPER)
     set(REMAPPER_SOURCES spirv-remap.cpp)

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -83,6 +83,12 @@ if(BUILD_TESTING)
                                    ${gmock_SOURCE_DIR}/include
                                    ${gtest_SOURCE_DIR}/include)
 
+        if(ENABLE_OPT)
+            target_include_directories(glslangtests
+                PRIVATE ${spirv-tools_SOURCE_DIR}/include
+            )
+        endif(ENABLE_OPT)
+
         set(LIBRARIES
             glslang OSDependent OGLCompiler glslang
             SPIRV glslang-default-resource-limits)


### PR DESCRIPTION
This addresses the problems highlighted in: #2405

- Add more flexible SpirvToolsDisassemble interface to allow specifying spv_target_env for disassembly output.
- Improve documentation on existing SpirvToolsDisassemble interface.