### PR TITLE
SPIR-V: Remove SpvTools.h include from disassemble.cpp

### DIFF
--- a/SPIRV/disassemble.cpp
+++ b/SPIRV/disassemble.cpp
@@ -46,7 +46,6 @@
 
 #include "disassemble.h"
 #include "doc.h"
-#include "SpvTools.h"
 
 namespace spv {
     extern "C" {


### PR DESCRIPTION
disassemble.cpp appears not to be using anything from SpvTools.h, but the inclusion of it prevents standalone building of the SPIR-V portion (for instance, when needed purely for generation and disassembly) without SPIRV-Tools dependency.