### PR TITLE
Add basic GN configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.a
 *.so
 *.exe
+*.gclient_entries
 .vscode/
 tags
 TAGS
@@ -11,3 +12,4 @@ Test/localResults/
 External/googletest
 External/spirv-tools
 out/
+third_party/llvm-build

--- a/.gn
+++ b/.gn
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 Google, Inc.
+# Copyright (C) 2020 The Khronos Group Inc.
 #
 # All rights reserved.
 #
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #
@@ -31,7 +31,9 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# These are variables that are overridable by projects that include glslang.
+buildconfig = "//build/config/BUILDCONFIG.gn"
 
-# The path to glslang dependencies.
-glslang_spirv_tools_dir = "//External/spirv-tools"
+default_args = {
+    clang_use_chrome_plugins = false
+    use_custom_libcxx = false
+}

--- a/DEPS
+++ b/DEPS
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 Google, Inc.
+# Copyright (C) 2020 The Khronos Group Inc.
 #
 # All rights reserved.
 #
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #
@@ -31,7 +31,47 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# These are variables that are overridable by projects that include glslang.
+use_relative_paths = True
 
-# The path to glslang dependencies.
-glslang_spirv_tools_dir = "//External/spirv-tools"
+gclient_gn_args_file = 'build/config/gclient_args.gni'
+
+vars = {
+  'chromium_git': 'https://chromium.googlesource.com',
+  'build_with_chromium': False,
+}
+
+deps = {
+
+  './build': {
+    'url': '{chromium_git}/chromium/src/build.git@85ee3b7692e5284f08bd3c9459fb5685eed7b838',
+    'condition': 'not build_with_chromium',
+  },
+
+  './buildtools': {
+    'url': '{chromium_git}/chromium/src/buildtools.git@4be464e050b3d05060471788f926b34c641db9fd',
+    'condition': 'not build_with_chromium',
+  },
+
+  './tools/clang': {
+    'url': '{chromium_git}/chromium/src/tools/clang.git@3a982adabb720aa8f3e3885d40bf3fe506990157',
+    'condition': 'not build_with_chromium',
+  },
+
+}
+
+hooks = [
+  {
+    'name': 'sysroot_x64',
+    'pattern': '.',
+    'condition': 'checkout_linux and (checkout_x64 and not build_with_chromium)',
+    'action': ['python', './build/linux/sysroot_scripts/install-sysroot.py',
+               '--arch=x64'],
+  },
+  {
+    # Note: On Win, this should run after win_toolchain, as it may use it.
+    'name': 'clang',
+    'pattern': '.',
+    'action': ['python', './tools/clang/scripts/update.py'],
+    'condition': 'not build_with_chromium',
+  },
+]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The applied stage-specific rules are based on the file extension:
 There is also a non-shader extension
 * `.conf` for a configuration file of limits, see usage statement for example
 
-## Building
+## Building (CMake)
 
 Instead of building manually, you can also download the binaries for your
 platform directly from the [master-tot release][master-tot-release] on GitHub.
@@ -183,6 +183,35 @@ cmake --build . --config Release --target install
 
 If using MSVC, after running CMake to configure, use the
 Configuration Manager to check the `INSTALL` project.
+
+### Building (GN)
+
+glslang can also be built with the [GN build system](https://gn.googlesource.com/gn/).
+
+#### 1) Install `depot_tools`
+
+Download [depot_tools.zip](https://storage.googleapis.com/chrome-infra/depot_tools.zip),
+extract to a directory, and add this directory to your `PATH`.
+
+#### 2) Synchronize dependencies and generate build files
+
+This only needs to be done once after updating `glslang`.
+
+With the current directory set to your `glslang` checkout, type:
+
+```bash
+gclient sync --gclientfile=standalone.gclient
+gn gen out/Default
+```
+
+#### 3) Build
+
+With the current directory set to your `glslang` checkout, type:
+
+```bash
+cd out/Default
+ninja
+```
 
 ### If you need to change the GLSL grammar
 

--- a/build_overrides/build.gni
+++ b/build_overrides/build.gni
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 Google, Inc.
+# Copyright (C) 2020 The Khronos Group Inc.
 #
 # All rights reserved.
 #
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #
@@ -31,7 +31,9 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# These are variables that are overridable by projects that include glslang.
-
-# The path to glslang dependencies.
-glslang_spirv_tools_dir = "//External/spirv-tools"
+declare_args() {
+    build_with_chromium = false
+    linux_use_bundled_binutils_override = true
+    ignore_elf32_limitations = true
+    use_system_xcode = true
+}

--- a/build_overrides/spirv_tools.gni
+++ b/build_overrides/spirv_tools.gni
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 Google, Inc.
+# Copyright (C) 2020 The Khronos Group Inc.
 #
 # All rights reserved.
 #
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #
@@ -31,7 +31,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# These are variables that are overridable by projects that include glslang.
+# We are building inside glslang
+spirv_tools_standalone = false
 
-# The path to glslang dependencies.
-glslang_spirv_tools_dir = "//External/spirv-tools"
+# Paths to SPIRV-Tools dependencies
+spirv_tools_spirv_headers_dir = "//External/spirv-tools/external/spirv-headers"

--- a/standalone.gclient
+++ b/standalone.gclient
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 Google, Inc.
+# Copyright (C) 2020 The Khronos Group Inc.
 #
 # All rights reserved.
 #
@@ -14,7 +14,7 @@
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
 #
-#    Neither the name of Google Inc. nor the names of its
+#    Neither the name of The Khronos Group Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #
@@ -31,7 +31,12 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# These are variables that are overridable by projects that include glslang.
-
-# The path to glslang dependencies.
-glslang_spirv_tools_dir = "//External/spirv-tools"
+solutions = [
+  { "name"        : ".",
+    "url"         : "https://github.com/KhronosGroup/glslang",
+    "deps_file"   : "DEPS",
+    "managed"     : False,
+    "custom_deps" : {
+    },
+  },
+]


### PR DESCRIPTION
This allows glslang to be build standalone using the gn build system.

To build with gn:

```
gclient sync --gclientfile=standalone.gclient
gn gen out/default
cd out/default
ninja
```

Issue: #2421