### PR TITLE
Fix uninitialized use of TIntermediate::resource

### DIFF
--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -2016,7 +2016,7 @@ bool TProgram::linkStage(EShLanguage stage, EShMessages messages)
         intermediate[stage] = new TIntermediate(stage,
                                                 firstIntermediate->getVersion(),
                                                 firstIntermediate->getProfile());
-
+        intermediate[stage]->setLimits(firstIntermediate->getLimits());
 
         // The new TIntermediate must use the same origin as the original TIntermediates.
         // Otherwise linking will fail due to different coordinate systems.

--- a/glslang/MachineIndependent/linkValidate.cpp
+++ b/glslang/MachineIndependent/linkValidate.cpp
@@ -736,10 +736,10 @@ void TIntermediate::finalCheck(TInfoSink& infoSink, bool keepUncalled)
 
         // "The resulting stride (implicit or explicit), when divided by 4, must be less than or equal to the
         // implementation-dependent constant gl_MaxTransformFeedbackInterleavedComponents."
-        if (xfbBuffers[b].stride > (unsigned int)(4 * resources.maxTransformFeedbackInterleavedComponents)) {
+        if (xfbBuffers[b].stride > (unsigned int)(4 * resources->maxTransformFeedbackInterleavedComponents)) {
             error(infoSink, "xfb_stride is too large:");
             infoSink.info.prefix(EPrefixError);
-            infoSink.info << "    xfb_buffer " << (unsigned int)b << ", components (1/4 stride) needed are " << xfbBuffers[b].stride/4 << ", gl_MaxTransformFeedbackInterleavedComponents is " << resources.maxTransformFeedbackInterleavedComponents << "\n";
+            infoSink.info << "    xfb_buffer " << (unsigned int)b << ", components (1/4 stride) needed are " << xfbBuffers[b].stride/4 << ", gl_MaxTransformFeedbackInterleavedComponents is " << resources->maxTransformFeedbackInterleavedComponents << "\n";
         }
     }
 


### PR DESCRIPTION
TIntermediate was constructed without initializing any of the `resources` fields, and `TProgram::linkStage()` was not calling `TIntermediate::setLimits()` after constructing new `TIntermediate`s for non-first stages.

Fields of `resources` were then read in `TIntermediate::finalCheck()` triggering undefined behavior.

This CL makes three changes:
1. `TIntermediate::setLimits()` is now called for non-first stages by copying the `firstIntermediate`'s limits. This ensures that the `resources` fields is initialized, fixing the bug.
2. `TIntermediate::resources` is now wrapped in a `MustBeAssigned<>` helper struct, asserting in non-release builds that this field is always initialized before reading.
3. `TIntermediate::resources` is now zero-initialized, so that if the `TIntermediate::resources` field is not set in a release build
    (and so the `assert()` will be disabled) behavior is still deterministic.


Fixes #2423