### PR TITLE
Fix GN build and presubmits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *.a
 *.so
 *.exe
-*.gclient_entries
 .vscode/
 tags
 TAGS
@@ -12,4 +11,10 @@ Test/localResults/
 External/googletest
 External/spirv-tools
 out/
-third_party/llvm-build
+
+# GN generated files
+.cipd/
+*.gclient_entries
+third_party/
+buildtools/
+tools/

--- a/DEPS
+++ b/DEPS
@@ -75,3 +75,8 @@ hooks = [
     'condition': 'not build_with_chromium',
   },
 ]
+
+recursedeps = [
+  # buildtools provides clang_format, libc++, and libc++abi
+  'buildtools',
+]

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ This only needs to be done once after updating `glslang`.
 With the current directory set to your `glslang` checkout, type:
 
 ```bash
+./update_glslang_sources.py
 gclient sync --gclientfile=standalone.gclient
 gn gen out/Default
 ```

--- a/kokoro/linux-clang-gn/build.sh
+++ b/kokoro/linux-clang-gn/build.sh
@@ -43,6 +43,7 @@ docker run --rm -i \
   --workdir "${ROOT_DIR}" \
   --env ROOT_DIR="${ROOT_DIR}" \
   --env SCRIPT_DIR="${SCRIPT_DIR}" \
-  --env BUILD_SHARED_LIBS="${BUILD_SHARED_LIBS:-0}" \
   --entrypoint "${SCRIPT_DIR}/build-docker.sh" \
   "gcr.io/shaderc-build/radial-build:latest"
+
+sudo chown -R "$(id -u):$(id -g)" "${ROOT_DIR}"

--- a/kokoro/linux-clang-gn/continuous.cfg
+++ b/kokoro/linux-clang-gn/continuous.cfg
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright (C) 2020 Google, Inc.
 #
 # All rights reserved.
@@ -33,23 +31,5 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-set -e # Fail on any error.
-set -x # Display commands being run.
-
-echo "Fetching external projects..."
-./update_glslang_sources.py
-
-echo "Fetching depot_tools..."
-mkdir -p /tmp/depot_tools
-curl https://storage.googleapis.com/chrome-infra/depot_tools.zip -o /tmp/depot_tools.zip
-unzip /tmp/depot_tools.zip -d /tmp/depot_tools
-rm /tmp/depot_tools.zip
-export PATH="/tmp/depot_tools:$PATH"
-
-echo "Syncing client..."
-gclient sync --gclientfile=standalone.gclient
-gn gen out/Default
-
-echo "Building..."
-cd out/Default
-ninja
+# Continuous build configuration.
+build_file: "glslang/kokoro/linux-clang-gn/build.sh"

--- a/kokoro/linux-clang-gn/presubmit.cfg
+++ b/kokoro/linux-clang-gn/presubmit.cfg
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright (C) 2020 Google, Inc.
 #
 # All rights reserved.
@@ -33,23 +31,5 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-set -e # Fail on any error.
-set -x # Display commands being run.
-
-echo "Fetching external projects..."
-./update_glslang_sources.py
-
-echo "Fetching depot_tools..."
-mkdir -p /tmp/depot_tools
-curl https://storage.googleapis.com/chrome-infra/depot_tools.zip -o /tmp/depot_tools.zip
-unzip /tmp/depot_tools.zip -d /tmp/depot_tools
-rm /tmp/depot_tools.zip
-export PATH="/tmp/depot_tools:$PATH"
-
-echo "Syncing client..."
-gclient sync --gclientfile=standalone.gclient
-gn gen out/Default
-
-echo "Building..."
-cd out/Default
-ninja
+# Presubmit build configuration.
+build_file: "glslang/kokoro/linux-clang-gn/build.sh"


### PR DESCRIPTION
Add missing `.cfg` files for GN presubmit.
Add missing `recursedeps` in the `DEPS` file.
Call `./update_glslang_sources.py` before attempting to build.
Add more GN spew to the `.gitignore` file.

Fixes https://github.com/KhronosGroup/glslang/issues/2421
Related: https://github.com/KhronosGroup/glslang/issues/2413