### PR TITLE
Do not use PropagateLineInfoPass and RedundantLineInfoElimPass

### DIFF
--- a/SPIRV/SpvTools.cpp
+++ b/SPIRV/SpvTools.cpp
@@ -174,10 +174,7 @@ void SpirvToolsTransform(const glslang::TIntermediate& intermediate, std::vector
     // line information into all SPIR-V instructions. This avoids loss of
     // information when instructions are deleted or moved. Later, remove
     // redundant information to minimize final SPRIR-V size.
-    if (options->generateDebugInfo) {
-        optimizer.RegisterPass(spvtools::CreatePropagateLineInfoPass());
-    }
-    else if (options->stripDebugInfo) {
+    if (options->stripDebugInfo) {
         optimizer.RegisterPass(spvtools::CreateStripDebugInfoPass());
     }
     optimizer.RegisterPass(spvtools::CreateWrapOpKillPass());
@@ -207,9 +204,6 @@ void SpirvToolsTransform(const glslang::TIntermediate& intermediate, std::vector
     }
     optimizer.RegisterPass(spvtools::CreateAggressiveDCEPass());
     optimizer.RegisterPass(spvtools::CreateCFGCleanupPass());
-    if (options->generateDebugInfo) {
-        optimizer.RegisterPass(spvtools::CreateRedundantLineInfoElimPass());
-    }
 
     spvtools::OptimizerOptions spvOptOptions;
     optimizer.SetTargetEnv(MapToSpirvToolsEnv(intermediate.getSpv(), logger));

--- a/known_good.json
+++ b/known_good.json
@@ -5,7 +5,7 @@
       "site" : "github",
       "subrepo" : "KhronosGroup/SPIRV-Tools",
       "subdir" : "External/spirv-tools",
-      "commit" : "a1d38174b1f7d2651c718ae661886d606cb50a32"
+      "commit" : "56d0f50357a192602216bfc4873e714905323e35"
     },
     {
       "name" : "spirv-tools/external/spirv-headers",


### PR DESCRIPTION
Since spirv-opt will remove PropagateLineInfoPass and
RedundantLineInfoElimPass, glslang should not use it. spirv-opt will
propagate the line instructions and eliminate the redundant lines by
default in IR loading/emission.