### PR TITLE
Fix build error with Chromium & ANGLE

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -317,7 +317,7 @@ executable("spirv-remap") {
   defines = [ "ENABLE_OPT=1" ]
   deps = [ ":glslang_sources" ]
 
-  include_dirs += [ "${spirv_tools_dir}/include" ]
+  include_dirs = [ "${spirv_tools_dir}/include" ]
 
   configs -= _configs_to_remove
   configs += _configs_to_add


### PR DESCRIPTION
Getting error about undefined symbol (include_dir) at line 320.
Was trying to append to a non-existant variable.

Bug #2445