### PR TITLE
Fix token-pasting macros not working in preprocessor directives.

### DIFF
--- a/Test/baseResults/tokenPaste.vert.out
+++ b/Test/baseResults/tokenPaste.vert.out
@@ -3,11 +3,11 @@ ERROR: 0:38: '##' : unexpected location
 ERROR: 0:40: '##' : unexpected location; end of replacement list 
 ERROR: 0:49: '##' : combined tokens are too long 
 ERROR: 0:52: '##' : not supported for these tokens 
-ERROR: 0:69: '##' : combined token is invalid 
-ERROR: 0:82: 'macro expansion' : Too few args in Macro rec
-ERROR: 0:82: '##' : unexpected location 
-ERROR: 0:82: '##' : unexpected location 
-ERROR: 0:86: '##' : unexpected location; end of argument 
+ERROR: 0:81: '##' : combined token is invalid 
+ERROR: 0:94: 'macro expansion' : Too few args in Macro rec
+ERROR: 0:94: '##' : unexpected location 
+ERROR: 0:94: '##' : unexpected location 
+ERROR: 0:98: '##' : unexpected location; end of argument 
 ERROR: 9 compilation errors.  No code generated.
 
 
@@ -18,35 +18,35 @@ ERROR: node is still EOpNull!
 0:52      'a' ( global int)
 0:52      Constant:
 0:52        11 (const int)
-0:58  Sequence
-0:58    move second child to first child ( temp int)
-0:58      'cop' ( global int)
-0:58      Constant:
-0:58        160 (const int)
-0:59  Sequence
-0:59    move second child to first child ( temp bool)
-0:59      'dop' ( global bool)
-0:59      Constant:
-0:59        true (const bool)
-0:63  Function Definition: ShouldntExpandToThis( ( global void)
-0:63    Function Parameters: 
-0:65    Sequence
-0:65      Sequence
-0:65        move second child to first child ( temp int)
-0:65          'e' ( temp int)
-0:65          Constant:
-0:65            16 (const int)
-0:66      right shift second child into first child ( temp int)
-0:66        'e' ( temp int)
-0:66        Constant:
-0:66          2 (const int)
-0:69      Sequence
-0:69        move second child to first child ( temp bool)
-0:69          'f' ( temp bool)
-0:69          Compare Greater Than ( temp bool)
-0:69            'e' ( temp int)
-0:69            Constant:
-0:69              5 (const int)
+0:70  Sequence
+0:70    move second child to first child ( temp int)
+0:70      'cop' ( global int)
+0:70      Constant:
+0:70        160 (const int)
+0:71  Sequence
+0:71    move second child to first child ( temp bool)
+0:71      'dop' ( global bool)
+0:71      Constant:
+0:71        true (const bool)
+0:75  Function Definition: ShouldntExpandToThis( ( global void)
+0:75    Function Parameters: 
+0:77    Sequence
+0:77      Sequence
+0:77        move second child to first child ( temp int)
+0:77          'e' ( temp int)
+0:77          Constant:
+0:77            16 (const int)
+0:78      right shift second child into first child ( temp int)
+0:78        'e' ( temp int)
+0:78        Constant:
+0:78          2 (const int)
+0:81      Sequence
+0:81        move second child to first child ( temp bool)
+0:81          'f' ( temp bool)
+0:81          Compare Greater Than ( temp bool)
+0:81            'e' ( temp int)
+0:81            Constant:
+0:81              5 (const int)
 0:?   Linker Objects
 0:?     'SecondExpansion' ( global int)
 0:?     'PostPasteExpansion' ( global int)
@@ -60,6 +60,8 @@ ERROR: node is still EOpNull!
 0:?     'foo875' ( uniform float)
 0:?     'ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF012345' ( global float)
 0:?     'a' ( global int)
+0:?     'seahorse_var' ( uniform float)
+0:?     'sealion_var' ( uniform float)
 0:?     'aop' ( const int)
 0:?       10 (const int)
 0:?     'bop' ( const int)
@@ -83,16 +85,16 @@ ERROR: node is still EOpNull!
 0:52      'a' ( global int)
 0:52      Constant:
 0:52        11 (const int)
-0:58  Sequence
-0:58    move second child to first child ( temp int)
-0:58      'cop' ( global int)
-0:58      Constant:
-0:58        160 (const int)
-0:59  Sequence
-0:59    move second child to first child ( temp bool)
-0:59      'dop' ( global bool)
-0:59      Constant:
-0:59        true (const bool)
+0:70  Sequence
+0:70    move second child to first child ( temp int)
+0:70      'cop' ( global int)
+0:70      Constant:
+0:70        160 (const int)
+0:71  Sequence
+0:71    move second child to first child ( temp bool)
+0:71      'dop' ( global bool)
+0:71      Constant:
+0:71        true (const bool)
 0:?   Linker Objects
 0:?     'SecondExpansion' ( global int)
 0:?     'PostPasteExpansion' ( global int)
@@ -106,6 +108,8 @@ ERROR: node is still EOpNull!
 0:?     'foo875' ( uniform float)
 0:?     'ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF012345' ( global float)
 0:?     'a' ( global int)
+0:?     'seahorse_var' ( uniform float)
+0:?     'sealion_var' ( uniform float)
 0:?     'aop' ( const int)
 0:?       10 (const int)
 0:?     'bop' ( const int)

--- a/Test/tokenPaste.vert
+++ b/Test/tokenPaste.vert
@@ -51,6 +51,18 @@ float simplePaste(ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF01234567
 // non-identifiers
 int a = simplePaste(11,12);
 
+// should work in #if as well
+#define seahorse 1
+#define sealion 0
+#define marine_animal(suffix) (sea ## suffix)
+
+#if marine_animal(horse) // should pass
+uniform float seahorse_var;
+#endif
+#if !marine_animal(lion) // should pass
+uniform float sealion_var;
+#endif
+
 // operators
 #define MAKE_OP(L, R) L ## R
 const int aop = 10;

--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
+++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
@@ -455,6 +455,7 @@ int TPpContext::eval(int token, int precedence, bool shortCircuit, int& res, boo
                 token = scanToken(ppToken);
             }
         } else {
+            token = tokenPaste(token, *ppToken);
             token = evalToToken(token, shortCircuit, res, err, ppToken);
             return eval(token, precedence, shortCircuit, res, err, ppToken);
         }


### PR DESCRIPTION
Fixes #2443.  Macros resulting from token-pasting were not working correctly in macros used in `#if`, whereas it was working for other macros.

Thanks for considering this PR, it would be a big help since it is not trivial for us to work around.