### PR TITLE
Fixed compile warning in reflection.cpp for ENABLE_HLSL = 0 build. [-Wunused-parameter]

### DIFF
--- a/glslang/MachineIndependent/reflection.cpp
+++ b/glslang/MachineIndependent/reflection.cpp
@@ -1138,6 +1138,8 @@ void TReflection::buildCounterIndices(const TIntermediate& intermediate)
         if (index >= 0)
             indexToUniformBlock[i].counterIndex = index;
     }
+#else
+    (void)intermediate;
 #endif
 }
 


### PR DESCRIPTION
Hi, KhronosGroup glslang Team.

I fixed compile warning for build with disabled HLSL.
Could you review and accept my changes, pls?

[339/369] Building CXX object glslang/CMakeFiles/MachineIndependent.dir/MachineIndependent/reflection.cpp.o
../glslang/MachineIndependent/reflection.cpp:1130:60: warning: unused parameter 'intermediate' [-Wunused-parameter]
void TReflection::buildCounterIndices(const TIntermediate& intermediate)
                                                           ^
1 warning generated.
[369/369] Linking CXX executable gtests/glslangtests

You can see this warning online here:

https://github.com/Tencent/ncnn/runs/1556708847?check_suite_focus=true

Best regards, Proydakov Evgeny.