### PR TITLE
Fix option replacement when flags are empty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ elseif(MSVC)
     if(NOT ENABLE_RTTI)
         string(FIND "${CMAKE_CXX_FLAGS}" "/GR" MSVC_HAS_GR)
         if(MSVC_HAS_GR)
-            string(REGEX REPLACE /GR /GR- CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+            string(REGEX REPLACE "/GR" "/GR-" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
         else()
             add_compile_options(/GR-) # Disable RTTI
         endif()


### PR DESCRIPTION
When cmake is executed from MSVC with empty `CMAKE_CXX_FLAGS`, `string(REGEX...)` fails because not enough parameters are passed.