### PR TITLE
license-checker.cfg: Update rules

### DIFF
--- a/license-checker.cfg
+++ b/license-checker.cfg
@@ -1,6 +1,7 @@
 [
     {
         "licenses": [
+            "Apache-2.0",
             "Apache-2.0-Header",
             "BSD-2-Clause",
             "BSD-3-Clause",
@@ -29,14 +30,19 @@
                     "build/**",
                     "out/**",
                     "Test/**",
-                    "External/spirv-tools/**"
+                    "External/spirv-tools/**",
+
+                    "SPIRV/GLSL.*.h",
+                    "SPIRV/NonSemanticDebugPrintf.h",
+                    "SPIRV/spirv.hpp"
                 ]
             }
         ]
     },
     {
         "licenses": [
-            "GPL-Header"
+            "GPL-Header",
+            "GPL-3.0-or-later"
         ],
         "paths": [
             { "exclude": [ "**" ] },


### PR DESCRIPTION
The license classification rules in github.com/google/licensecheck have been updated.