### PR TITLE
callGraph.push_front -> emplace_front to fix UBSAN

### DIFF
--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -2870,7 +2870,7 @@ void TIntermediate::addToCallGraph(TInfoSink& /*infoSink*/, const TString& calle
             return;
     }
 
-    callGraph.push_front(TCall(caller, callee));
+    callGraph.emplace_front(caller, callee);
 }
 
 //


### PR DESCRIPTION
UBSAN rightly complains on `push_front` here:

    glslang/MachineIndependent/localintermediate.h:100:8: runtime error: load of value 160, which is not a valid value for type 'bool'
    #0 in glslang::TCall::TCall(glslang::TCall&&) glslang/MachineIndependent/localintermediate.h:100
    #1 in void __gnu_cxx::new_allocator<std::_List_node<glslang::TCall> >::construct<glslang::TCall, glslang::TCall>(glslang::TCall*, glslang::TCall&&) /usr/include/c++/10/ext/new_allocator.h:150
    #2 in void std::allocator_traits<std::allocator<std::_List_node<glslang::TCall> > >::construct<glslang::TCall, glslang::TCall>(std::allocator<std::_List_node<glslang::TCall> >&, glslang::TCall*, glslang::TCall&&) /usr/include/c++/10/bits/alloc_traits.h:512
    #3 in std::_List_node<glslang::TCall>* std::__cxx11::list<glslang::TCall, std::allocator<glslang::TCall> >::_M_create_node<glslang::TCall>(glslang::TCall&&) (...)
    #4 in void std::__cxx11::list<glslang::TCall, std::allocator<glslang::TCall> >::_M_insert<glslang::TCall>(std::_List_iterator<glslang::TCall>, glslang::TCall&&) /usr/include/c++/10/bits/stl_list.h:1911
    #5 in std::__cxx11::list<glslang::TCall, std::allocator<glslang::TCall> >::push_front(glslang::TCall&&) /usr/include/c++/10/bits/stl_list.h:1167
    #6 in glslang::TIntermediate::addToCallGraph(TInfoSink&, std::__cxx11::basic_string<char, std::char_traits<char>, glslang::pool_allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, glslang::pool_allocator<char> > const&) glslang/MachineIndependent/Intermediate.cpp:2860

What happens here:

1. TCall's bool fields are not initialized on construction.
2. `push_front` move the `TCall` passed into it.
3. The move constructor copies unitialized bool, which may have an out-of-range value.

What this fix does:

Calls `emplace_back` to ensure no copy/move constructor is called.

Fixes #2222
Refs #2112