### PR TITLE
Remove useless semicolon

### DIFF
--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -864,7 +864,7 @@ public:
                 return true;
         }
         return false;
-    };
+    }
 
     void addToCallGraph(TInfoSink&, const TString& caller, const TString& callee);
     void merge(TInfoSink&, TIntermediate&);


### PR DESCRIPTION
The extra semicolon causes a build failure if warnings are turned up high, and
warnings-as-errors is on. (-Werror=extra-semi)