### PR TITLE
Cannot specify atomic counter with location.

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -5767,8 +5767,8 @@ void TParseContext::layoutObjectCheck(const TSourceLoc& loc, const TSymbol& symb
                     error(loc, "can only specify on a uniform block", "push_constant", "");
                 if (qualifier.isShaderRecord())
                     error(loc, "can only specify on a buffer block", "shaderRecordNV", "");
-		if (qualifier.hasLocation() && type.isAtomic())
-		    error(loc, "cannot specify atomic counter with location","atomic","");
+                if (qualifier.hasLocation() && type.isAtomic())
+                    error(loc, "cannot specify on atomic counter", "atomic_uint", "");
             }
             break;
         default:

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -5768,7 +5768,7 @@ void TParseContext::layoutObjectCheck(const TSourceLoc& loc, const TSymbol& symb
                 if (qualifier.isShaderRecord())
                     error(loc, "can only specify on a buffer block", "shaderRecordNV", "");
                 if (qualifier.hasLocation() && type.isAtomic())
-                    error(loc, "cannot specify on atomic counter", "atomic_uint", "");
+                    error(loc, "cannot specify on atomic counter", "location", "");
             }
             break;
         default:

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -5767,6 +5767,8 @@ void TParseContext::layoutObjectCheck(const TSourceLoc& loc, const TSymbol& symb
                     error(loc, "can only specify on a uniform block", "push_constant", "");
                 if (qualifier.isShaderRecord())
                     error(loc, "can only specify on a buffer block", "shaderRecordNV", "");
+		if (qualifier.hasLocation() && type.isAtomic())
+		    error(loc, "cannot specify atomic counter with location","atomic","");
             }
             break;
         default:


### PR DESCRIPTION
glslang don't report the errors: atomic counter can not specified with location.


```
#version 310 es
precision highp float;
layout(location = 3, binding = 0, offset = 0) uniform atomic_uint uni0;
in highp vec4 dEQP_Position;
out float out0;

void main()
{
out0 = 0.0;
gl_Position = dEQP_Position;
}
```




Signed-off-by: ZhiqianXia <xzq0528@outlook.com>