### PR TITLE
Fixed issues 2496. Used option 4: parse_version.cmake to avoid python3 usage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,55 +234,33 @@ if(NOT COMMAND find_host_package)
     endmacro()
 endif()
 
-# CMake needs to find the right version of python, right from the beginning,
-# otherwise, it will find the wrong version and fail later
-find_host_package(PythonInterp 3 REQUIRED)
-
 # Root directory for build-time generated include files
 set(GLSLANG_GENERATED_INCLUDEDIR "${CMAKE_BINARY_DIR}/include")
 
 ################################################################################
 # Build version information generation
 ################################################################################
+include(parse_version.cmake)
 set(GLSLANG_CHANGES_FILE      "${CMAKE_CURRENT_SOURCE_DIR}/CHANGES.md")
-set(GLSLANG_BUILD_INFO_PY     "${CMAKE_CURRENT_SOURCE_DIR}/build_info.py")
 set(GLSLANG_BUILD_INFO_H_TMPL "${CMAKE_CURRENT_SOURCE_DIR}/build_info.h.tmpl")
 set(GLSLANG_BUILD_INFO_H      "${GLSLANG_GENERATED_INCLUDEDIR}/glslang/build_info.h")
 
-# Command to build the build_info.h file
-add_custom_command(
-    OUTPUT  ${GLSLANG_BUILD_INFO_H}
-    COMMAND ${PYTHON_EXECUTABLE} "${GLSLANG_BUILD_INFO_PY}"
-            ${CMAKE_CURRENT_SOURCE_DIR}
-            "-i" ${GLSLANG_BUILD_INFO_H_TMPL}
-            "-o" ${GLSLANG_BUILD_INFO_H}
-    DEPENDS ${GLSLANG_BUILD_INFO_PY}
-            ${GLSLANG_CHANGES_FILE}
-            ${GLSLANG_BUILD_INFO_H_TMPL}
-    COMMENT "Generating ${GLSLANG_BUILD_INFO_H}")
+parse_version(${GLSLANG_CHANGES_FILE} GLSLANG)
 
-# Target to build the build_info.h file
-add_custom_target(glslang-build-info DEPENDS ${GLSLANG_BUILD_INFO_H})
+function(configurate_version)
+    set(major ${GLSLANG_VERSION_MAJOR})
+    set(minor ${GLSLANG_VERSION_MINOR})
+    set(patch ${GLSLANG_VERSION_PATCH})
+    set(flavor ${GLSLANG_VERSION_FLAVOR})
+    configure_file(${GLSLANG_BUILD_INFO_H_TMPL} ${GLSLANG_BUILD_INFO_H} @ONLY)
+endfunction()
 
-# Populate the CMake GLSLANG_VERSION* variables with the build version
-# information.
-execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} "${GLSLANG_BUILD_INFO_PY}"
-            ${CMAKE_CURRENT_SOURCE_DIR} "<major>.<minor>.<patch><-flavor>;<major>;<minor>;<patch>;<flavor>"
-    OUTPUT_VARIABLE "GLSLANG_VERSIONS"
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-list(GET "GLSLANG_VERSIONS" 0 "GLSLANG_VERSION")
-list(GET "GLSLANG_VERSIONS" 1 "GLSLANG_VERSION_MAJOR")
-list(GET "GLSLANG_VERSIONS" 2 "GLSLANG_VERSION_MINOR")
-list(GET "GLSLANG_VERSIONS" 3 "GLSLANG_VERSION_PATCH")
-list(GET "GLSLANG_VERSIONS" 4 "GLSLANG_VERSION_FLAVOR")
-configure_file(${GLSLANG_CHANGES_FILE} "${CMAKE_CURRENT_BINARY_DIR}/CHANGES.md") # Required to re-run cmake on version change
+configurate_version()
 
 # glslang_add_build_info_dependency() adds the glslang-build-info dependency and
 # generated include directories to target.
 function(glslang_add_build_info_dependency target)
     target_include_directories(${target} PUBLIC $<BUILD_INTERFACE:${GLSLANG_GENERATED_INCLUDEDIR}>)
-    add_dependencies(${target} glslang-build-info)
 endfunction()
 
 # glslang_only_export_explicit_symbols() makes the symbol visibility hidden by
@@ -316,6 +294,8 @@ else()
 endif()
 
 if(BUILD_EXTERNAL AND IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/External)
+    find_package(PythonInterp 3 REQUIRED)
+
     # We depend on these for later projects, so they should come first.
     add_subdirectory(External)
 endif()

--- a/build_info.h.tmpl
+++ b/build_info.h.tmpl
@@ -34,10 +34,10 @@
 #ifndef GLSLANG_BUILD_INFO
 #define GLSLANG_BUILD_INFO
 
-#define GLSLANG_VERSION_MAJOR <major>
-#define GLSLANG_VERSION_MINOR <minor>
-#define GLSLANG_VERSION_PATCH <patch>
-#define GLSLANG_VERSION_FLAVOR "<flavor>"
+#define GLSLANG_VERSION_MAJOR @major@
+#define GLSLANG_VERSION_MINOR @minor@
+#define GLSLANG_VERSION_PATCH @patch@
+#define GLSLANG_VERSION_FLAVOR "@flavor@"
 
 #define GLSLANG_VERSION_GREATER_THAN(major, minor, patch) \
     (((major) > GLSLANG_VERSION_MAJOR) || ((major) == GLSLANG_VERSION_MAJOR && \

--- a/build_info.py
+++ b/build_info.py
@@ -201,13 +201,13 @@ def main():
     software_version = deduce_software_version(directory)
     commit = describe(directory)
     output = template \
-        .replace("<major>", software_version["major"]) \
-        .replace("<minor>", software_version["minor"]) \
-        .replace("<patch>", software_version["patch"]) \
-        .replace("<flavor>", software_version["flavor"]) \
-        .replace("<-flavor>", software_version["-flavor"]) \
-        .replace("<date>", software_version["date"]) \
-        .replace("<commit>", commit)
+        .replace("@major@", software_version["major"]) \
+        .replace("@minor@", software_version["minor"]) \
+        .replace("@patch@", software_version["patch"]) \
+        .replace("@flavor@", software_version["flavor"]) \
+        .replace("@-flavor@", software_version["-flavor"]) \
+        .replace("@date@", software_version["date"]) \
+        .replace("@commit@", commit)
 
     if output_file is None:
         print(output)

--- a/parse_version.cmake
+++ b/parse_version.cmake
@@ -1,0 +1,41 @@
+# Copyright 2020 The Marl Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# parse_version() reads and parses the version string from FILE, assigning the
+# version string to ${PROJECT}_VERSION and the parsed version to
+# ${PROJECT}_VERSION_MAJOR, ${PROJECT}_VERSION_MINOR, ${PROJECT}_VERSION_PATCH,
+# and the optional ${PROJECT}_VERSION_FLAVOR.
+#
+# The version string take one of the forms:
+#    <major>.<minor>.<patch>
+#    <major>.<minor>.<patch>-<flavor>
+function(parse_version FILE PROJECT)
+    configure_file(${FILE} "${CMAKE_CURRENT_BINARY_DIR}/CHANGES.md") # Required to re-run cmake on version change
+    file(READ ${FILE} CHANGES)
+    if(${CHANGES} MATCHES "#+ *([0-9]+)\\.([0-9]+)\\.([0-9]+)(-[a-zA-Z0-9]+)?")
+        set(FLAVOR "")
+        if(NOT "${CMAKE_MATCH_4}" STREQUAL "")
+            string(SUBSTRING ${CMAKE_MATCH_4} 1 -1 FLAVOR)
+        endif()
+        set("${PROJECT}_VERSION_MAJOR"  ${CMAKE_MATCH_1} PARENT_SCOPE)
+        set("${PROJECT}_VERSION_MINOR"  ${CMAKE_MATCH_2} PARENT_SCOPE)
+        set("${PROJECT}_VERSION_PATCH"  ${CMAKE_MATCH_3} PARENT_SCOPE)
+        set("${PROJECT}_VERSION_FLAVOR" ${FLAVOR}        PARENT_SCOPE)
+        set("${PROJECT}_VERSION"
+            "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}${CMAKE_MATCH_4}"
+            PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Unable to parse version from '${FILE}'")
+    endif()
+endfunction()

--- a/parse_version.cmake
+++ b/parse_version.cmake
@@ -1,4 +1,4 @@
-# Copyright 2020 The Marl Authors.
+# Copyright (C) 2020 Google, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Hi, GLSLANG Team.

I implemented fix to project version detection from CHANGED.md without python with approach 4.
https://github.com/KhronosGroup/glslang/issues/2496

Could you review and accept my changes, pls?

Best regards, Proydakov Evgeny.