### PR TITLE
Fixed cmake generation warning for regeneration project build files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,15 +31,15 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-project(glslang
-    LANGUAGES CXX)
-
+cmake_minimum_required(VERSION 2.8.12)
 # increase to 3.1 once all major distributions
 # include a version of CMake >= 3.1
-cmake_minimum_required(VERSION 2.8.12)
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()
+
+project(glslang LANGUAGES CXX)
+
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Enable compile commands database

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,9 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 2.8.12)
 # increase to 3.1 once all major distributions
 # include a version of CMake >= 3.1
+cmake_minimum_required(VERSION 2.8.12)
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()


### PR DESCRIPTION
Hi, GLSLANG Team.

Then I'm trying to regenerate project build files I see cmake warning.
As I see from kitware cmake main repo we should use 'cmake_minimum_version' before 'project' directive:

https://github.com/Kitware/CMake/blob/master/CMakeLists.txt

Could you verify and accept my changes, pls?

[BEFORE]:

% cmake ..
CMake Warning (dev) at CMakeLists.txt:35 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    CMAKE_PROJECT_VERSION
    CMAKE_PROJECT_VERSION_MAJOR
    CMAKE_PROJECT_VERSION_MINOR
    CMAKE_PROJECT_VERSION_PATCH
This warning is for project developers.  Use -Wno-dev to suppress it.

-- No build type selected, default to Debug
-- Found PythonInterp: /usr/local/bin/python3 (found version "3.9")
-- Found PythonInterp: /usr/local/bin/python3 (found suitable version "3.9", minimum required is "3")
-- optimizer enabled
-- Google Mock found - building tests
-- Configuring done

[AFTER]:

% cmake ..
-- No build type selected, default to Debug
-- Google Mock was not found - tests based on that will not build
-- Configuring done
-- Generating done

Best regards, Proydakov Evgeny