### PR TITLE
Fix warning in build

### DIFF
--- a/glslang/MachineIndependent/SymbolTable.h
+++ b/glslang/MachineIndependent/SymbolTable.h
@@ -698,7 +698,7 @@ public:
     void amendSymbolIdLevel(TSymbol& symbol)
     {
         // clamp level to avoid overflow
-        uint64_t level = currentLevel() > MaxLevelInUniqueID ? MaxLevelInUniqueID : currentLevel();
+        uint64_t level = (uint32_t)currentLevel() > MaxLevelInUniqueID ? MaxLevelInUniqueID : currentLevel();
         uint64_t symbolId = symbol.getUniqueId();
         symbolId &= uniqueIdMask;
         symbolId |= (level << LevelFlagBitOffset);
@@ -889,7 +889,7 @@ public:
     // Add current level in the high-bits of unique id
     void updateUniqueIdLevelFlag() {
         // clamp level to avoid overflow
-        uint64_t level = currentLevel() > MaxLevelInUniqueID ? MaxLevelInUniqueID : currentLevel();
+        uint64_t level = (uint32_t)currentLevel() > MaxLevelInUniqueID ? MaxLevelInUniqueID : currentLevel();
         uniqueId &= uniqueIdMask;
         uniqueId |= (level << LevelFlagBitOffset);
     }


### PR DESCRIPTION
```
glslang/MachineIndependent/SymbolTable.h:892:41: error: comparison of integers of
different signs: 'int' and 'const uint32_t' (aka 'const unsigned int') [-Werror,-Wsign-compare]
            uint64_t level = currentLevel() > MaxLevelInUniqueID ? MaxLevelInUniqueID : currentLevel();
                             ~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~
1 error generated.
```