### PR TITLE
Fixed msvc 2019 nmake noexcept build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,9 @@ elseif(MSVC)
     endif()
     if(ENABLE_EXCEPTIONS)
         add_compile_options(/EHsc) # Enable Exceptions
+	else()
+        string(REGEX REPLACE /EHsc "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}) # Try to remove default /EHsc cxx_flag
+        add_compile_definitions(_HAS_EXCEPTIONS=0)
     endif()
 endif()
 


### PR DESCRIPTION
By default cmake generates cxx_flags with /EHsc parameter.
I updated CMAKE_CXX_FLAGS string and removed /EHsc, also I added compile defenitions _HAS_EXCEPTIONS=0, it is mandatory for noexcept build with MSVC STL implementation.
Output files became smaller.

How to reproduce:

Visual Studio 2019 x64 command port

mkdir build-msvc2019
cd build-msvc2019
cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LIBDIR=install ..
nmake

CXX FLAGS BEFORE:

-- CMAKE_C_FLAGS:   /DWIN32 /D_WINDOWS /W3
-- CMAKE_CXX_FLAGS: /DWIN32 /D_WINDOWS /W3 /GR- /EHsc
-- CMAKE_CXX_FLAGS_DEBUG:   /MDd /Zi /Ob0 /Od /RTC1
-- CMAKE_CXX_FLAGS_RELEASE: /MD /O2 /Ob2 /DNDEBUG
-- ENABLE_RTTI:       OFF
-- ENABLE_EXCEPTIONS: OFF

OUTPUT SIZE BEFORE:

Build folder size: 61,8 MB (64 808 580 bytes)

GLSLANG SIZE BEFORE:

glslang.lib 22,7 MB (23 887 150 bytes)

CXX FLAGS AFTER:

-- CMAKE_C_FLAGS:   /DWIN32 /D_WINDOWS /W3
-- CMAKE_CXX_FLAGS: /DWIN32 /D_WINDOWS /W3 /GR-
-- CMAKE_CXX_FLAGS_DEBUG:   /MDd /Zi /Ob0 /Od /RTC1
-- CMAKE_CXX_FLAGS_RELEASE: /MD /O2 /Ob2 /DNDEBUG
-- ENABLE_RTTI:       OFF
-- ENABLE_EXCEPTIONS: OFF

OUTPUT SIZE AFTER:

Build folder size: 58,4 MB (61 331 179 bytes)

GLSLANG SIZE AFTER:

glslang.lib 21,6 MB (22 655 252 bytes)