### PR TITLE
SPV: Change the key of extBuiltinMap to std::string

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -255,7 +255,7 @@ protected:
     bool nanMinMaxClamp;               // true if use NMin/NMax/NClamp instead of FMin/FMax/FClamp
     spv::Id stdBuiltins;
     spv::Id nonSemanticDebugPrintf;
-    std::unordered_map<const char*, spv::Id> extBuiltinMap;
+    std::unordered_map<std::string, spv::Id> extBuiltinMap;
 
     std::unordered_map<long long, spv::Id> symbolValues;
     std::unordered_set<long long> rValueParameters;  // set of formal function parameters passed as rValues,


### PR DESCRIPTION
Using const char* is not a good choice. We assume strings are always
from spv::E_SPV_XXX definitions. However, it is not the case. We can
store the name strings of extended intruction set in local variables.