### PR TITLE
Returned using find_host_package for PythonInterp 3 instead of find_pachage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,7 +297,7 @@ else()
 endif()
 
 if(BUILD_EXTERNAL AND IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/External)
-    find_package(PythonInterp 3 REQUIRED)
+    find_host_package(PythonInterp 3 REQUIRED)
 
     # We depend on these for later projects, so they should come first.
     add_subdirectory(External)


### PR DESCRIPTION
Hi, GLSLANG Team.

I changed this logic here: https://github.com/KhronosGroup/glslang/pull/2526/commits/05798c17fb17d339d66e064a407e75ceae4c0316
It was originally fixed here: https://github.com/KhronosGroup/glslang/commit/967fa92d14acea305267574faf63ebe753de98c4

Could you review & accept small change, pls?

Best regards, Proydakov Evgeny.