### PR TITLE
Fix off-by-1 bug in gl_MaxCombinedTextureImageUnits check

### DIFF
--- a/Test/420.vert
+++ b/Test/420.vert
@@ -159,3 +159,4 @@ void qlod()
 }
 
 layout(binding=0) writeonly uniform image1D badArray[];
+layout(binding = 74) uniform sampler2D u_sampler0[6];

--- a/Test/baseResults/420.vert.out
+++ b/Test/baseResults/420.vert.out
@@ -306,6 +306,7 @@ ERROR: node is still EOpNull!
 0:?     'samp1D' ( uniform sampler1D)
 0:?     'samp1Ds' ( uniform sampler1DShadow)
 0:?     'badArray' (layout( binding=0) writeonly uniform unsized 1-element array of image1D)
+0:?     'u_sampler0' (layout( binding=74) uniform 6-element array of sampler2D)
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 
@@ -388,6 +389,7 @@ ERROR: node is still EOpNull!
 0:?     'samp1D' ( uniform sampler1D)
 0:?     'samp1Ds' ( uniform sampler1DShadow)
 0:?     'badArray' (layout( binding=0) writeonly uniform 1-element array of image1D)
+0:?     'u_sampler0' (layout( binding=74) uniform 6-element array of sampler2D)
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -5913,16 +5913,12 @@ void TParseContext::layoutTypeCheck(const TSourceLoc& loc, const TType& type)
         if (type.getBasicType() == EbtSampler) {
             int lastBinding = qualifier.layoutBinding;
             if (type.isArray()) {
-                if (spvVersion.vulkan > 0)
-                    lastBinding += 1;
-                else {
+                if (spvVersion.vulkan == 0) {
                     if (type.isSizedArray())
-                        lastBinding += type.getCumulativeArraySize();
+                        lastBinding += (type.getCumulativeArraySize() - 1);
                     else {
-                        lastBinding += 1;
 #ifndef GLSLANG_WEB
-                        if (spvVersion.vulkan == 0)
-                            warn(loc, "assuming binding count of one for compile-time checking of binding numbers for unsized array", "[]", "");
+                        warn(loc, "assuming binding count of one for compile-time checking of binding numbers for unsized array", "[]", "");
 #endif
                     }
                 }


### PR DESCRIPTION
The problem was only with arrays of samplers.

Fixes #2552