### PR TITLE
Fixed OpGroupNonUniformQuadBroadcast Direction operand being marked as a literal

### DIFF
--- a/SPIRV/doc.cpp
+++ b/SPIRV/doc.cpp
@@ -2719,7 +2719,7 @@ void Parameterize()
 
     InstructionDesc[OpGroupNonUniformQuadSwap].operands.push(OperandScope, "'Execution'");
     InstructionDesc[OpGroupNonUniformQuadSwap].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformQuadSwap].operands.push(OperandLiteralNumber, "'Direction'");
+    InstructionDesc[OpGroupNonUniformQuadSwap].operands.push(OperandId, "'Direction'");
 
     InstructionDesc[OpSubgroupBallotKHR].operands.push(OperandId, "'Predicate'");
 


### PR DESCRIPTION
The last operand for `OpGroupNonUniformQuadSwap` is incorrectly marked as literal, it's actually an id (see https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpGroupNonUniformQuadBroadcast)

As a result, running:

```
spv::spirvbin_t remapper(0);
remapper.remap(result, spv::spirvbin_base_t::MAP_FUNCS);
```

Will produce invalid SPIR-V when given the following as input:

``` 
 %58 = OpTypeInt 32 0
 %84 = OpConstant %58 0
%489 = OpGroupNonUniformQuadBroadcast %16 %101 %488 %84
```

The remapper will strip `%84` and just treat `84` as literal input to `OpGroupNonUniformQuadBroadcast`, resulting in invalid SPIR-V.