### PR TITLE
Fix warnings about int comparisons of different signness

### DIFF
--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -2376,7 +2376,7 @@ public:
             return false;
 
         // Compare the names and types of all the members, which have to match
-        for (int li = 0, ri = 0; li < structure->size() || ri < right.structure->size(); ++li, ++ri) {
+        for (size_t li = 0, ri = 0; li < structure->size() || ri < right.structure->size(); ++li, ++ri) {
             if (li < structure->size() && ri < right.structure->size()) {
                 if ((*structure)[li].type->getFieldName() == (*right.structure)[ri].type->getFieldName()) {
                     if (*(*structure)[li].type != *(*right.structure)[ri].type)

--- a/gtests/VkRelaxed.FromFile.cpp
+++ b/gtests/VkRelaxed.FromFile.cpp
@@ -234,7 +234,7 @@ TEST_P(VulkanRelaxedTest, FromFile)
 
     if (!resourceSetBindings.empty()) {
         assert(resourceSetBindings.size() == fileNames.size());
-        for (int i = 0; i < shaders.size(); i++)
+        for (size_t i = 0; i < shaders.size(); i++)
             shaders[i]->setResourceSetBinding(resourceSetBindings[i]);
     }
 


### PR DESCRIPTION
Warnings in public headers can trigger warnings-as-errors.