### PR TITLE
Do not propagate packing qualifiers to scalars or vectors

### DIFF
--- a/Test/440.frag
+++ b/Test/440.frag
@@ -151,3 +151,18 @@ int layer()
 {
     return gl_Layer;
 }
+
+// The std140 layout qualifier should NOT propagate all the way down to
+// the vec3. It is unnecessary and it breaks downstream AST consumers,
+// notably LunarGlass.
+
+struct PointLight_t
+{
+    vec3 vPositionWs ;
+} ;
+
+layout( std140, row_major ) uniform PerViewLightData_t
+{
+
+    PointLight_t g_pointLightData [ 128 ] ;
+} ;

--- a/Test/baseResults/440.frag.out
+++ b/Test/baseResults/440.frag.out
@@ -118,6 +118,7 @@ ERROR: node is still EOpNull!
 0:?     'aconst' ( global 4-element array of int)
 0:?     'bconst' ( global 64-element array of int)
 0:?     'sampInArray' ( smooth sample in 4-element array of 3-component vector of float)
+0:?     'anon@0' (layout( row_major std140) uniform block{layout( row_major std140 offset=0) uniform 128-element array of structure{ global 3-component vector of float vPositionWs} g_pointLightData})
 
 
 Linked fragment stage:
@@ -162,4 +163,5 @@ ERROR: node is still EOpNull!
 0:?     'aconst' ( global 4-element array of int)
 0:?     'bconst' ( global 64-element array of int)
 0:?     'sampInArray' ( smooth sample in 4-element array of 3-component vector of float)
+0:?     'anon@0' (layout( row_major std140) uniform block{layout( row_major std140 offset=0) uniform 128-element array of structure{ global 3-component vector of float vPositionWs} g_pointLightData})
 

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -1738,6 +1738,7 @@ public:
 
     virtual bool isScalar() const { return ! isVector() && ! isMatrix() && ! isStruct() && ! isArray(); }
     virtual bool isScalarOrVec1() const { return isScalar() || vector1; }
+    virtual bool isScalarOrVector() const { return !isMatrix() && !isStruct() && !isArray(); }
     virtual bool isVector() const { return vectorSize > 1 || vector1; }
     virtual bool isMatrix() const { return matrixCols ? true : false; }
     virtual bool isArray()  const { return arraySizes != nullptr; }

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -8524,8 +8524,8 @@ void TParseContext::fixBlockUniformLayoutMatrix(TQualifier& qualifier, TTypeList
 }
 
 //
-// Spread LayoutPacking to block member, if a  block member is a struct, we need spread LayoutPacking to
-// this struct member too. and keep this rule for recursive.
+// Spread LayoutPacking to matrix or aggregate block members. If a block member is a struct or
+// array of struct, spread LayoutPacking recursively to its matrix or aggregate members.
 //
 void TParseContext::fixBlockUniformLayoutPacking(TQualifier& qualifier, TTypeList* originTypeList,
                                                  TTypeList* tmpTypeList)
@@ -8534,11 +8534,13 @@ void TParseContext::fixBlockUniformLayoutPacking(TQualifier& qualifier, TTypeLis
     for (unsigned int member = 0; member < originTypeList->size(); ++member) {
         if (qualifier.layoutPacking != ElpNone) {
             if (tmpTypeList == nullptr) {
-                if ((*originTypeList)[member].type->getQualifier().layoutPacking == ElpNone) {
+                if ((*originTypeList)[member].type->getQualifier().layoutPacking == ElpNone &&
+                    !(*originTypeList)[member].type->isScalarOrVector()) {
                     (*originTypeList)[member].type->getQualifier().layoutPacking = qualifier.layoutPacking;
                 }
             } else {
-                if ((*tmpTypeList)[member].type->getQualifier().layoutPacking == ElpNone) {
+                if ((*tmpTypeList)[member].type->getQualifier().layoutPacking == ElpNone &&
+                    !(*tmpTypeList)[member].type->isScalarOrVector()) {
                     (*tmpTypeList)[member].type->getQualifier().layoutPacking = qualifier.layoutPacking;
                 }
             }


### PR DESCRIPTION
Packing qualifiers have no practical effect on scalars or vectors
so this is unnecessary and its confusing tools downstream that
consume the AST.