### PR TITLE
Fix table key and whitespace

### DIFF
--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -170,7 +170,7 @@ void TParseVersions::initializeExtensionBehavior()
     for (size_t ii = 0; ii < sizeof(exts) / sizeof(exts[0]); ii++) {
         // Add only extensions which require > spv1.0 to save space in map
         if (exts[ii].minSpvVersion > EShTargetSpv_1_0) {
-            extensionMinSpv[E_GL_EXT_ray_tracing] = exts[ii].minSpvVersion;
+            extensionMinSpv[exts[ii].extensionName] = exts[ii].minSpvVersion;
         }
     }
 
@@ -875,7 +875,7 @@ void TParseVersions::updateExtensionBehavior(int line, const char* extension, co
     checkExtensionStage(getCurrentLoc(), extension);
 
     // check if extension has additional requirements
-    extensionRequires(getCurrentLoc(), extension ,behaviorString);
+    extensionRequires(getCurrentLoc(), extension, behaviorString);
 
     // update the requested extension
     updateExtensionBehavior(extension, behavior);


### PR DESCRIPTION
These got lost in the wash with my last revert but are still relevant.