### PR TITLE
TextureOffset not support sampler2DArrayShadow sampler until 430

### DIFF
--- a/Test/baseResults/textureoffset_sampler2darrayshadow.vert.out
+++ b/Test/baseResults/textureoffset_sampler2darrayshadow.vert.out
@@ -1,0 +1,4 @@
+textureoffset_sampler2darrayshadow.vert
+ERROR: 0:9: 'texel offset' : TextureOffset not support the sampler2DArrayShadow :  version <= 420
+ERROR: 0:9: '' : compilation terminated
+ERROR: 2 compilation errors.  No code generated

--- a/Test/textureoffset_sampler2darrayshadow.vert
+++ b/Test/textureoffset_sampler2darrayshadow.vert
@@ -1,0 +1,11 @@
+#version 300 es
+precision mediump float;
+in highp vec4 dEQP_Position;
+
+uniform mediump sampler2DArrayShadow s;
+
+void main()
+{
+	gl_Position = vec4(textureOffset(s, vec4(0), ivec2(0)));
+	gl_Position = dEQP_Position;
+}

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -115,6 +115,7 @@ struct TSampler {   // misnomer now; includes images, textures without sampler, 
 #endif
 
     bool is1D()          const { return dim == Esd1D; }
+    bool is2D()          const { return dim == Esd2D; }
     bool isBuffer()      const { return dim == EsdBuffer; }
     bool isRect()        const { return dim == EsdRect; }
     bool isSubpass()     const { return dim == EsdSubpass; }

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -2185,6 +2185,13 @@ void TParseContext::builtInOpCheck(const TSourceLoc& loc, const TFunction& fnCan
                               "[gl_MinProgramTexelOffset, gl_MaxProgramTexelOffset]");
                 }
             }
+
+            if (callNode.getOp() == EOpTextureOffset && version <= 420) {
+                TSampler s = arg0->getType().getSampler();
+                if (s.is2D() && s.isArrayed() && s.isShadow())
+                    error(loc, "TextureOffset not support the sampler2DArrayShadow : ", "texel offset",
+                          "version <= 420");
+            }
         }
 
         break;


### PR DESCRIPTION
Hi ,
glslang should report an error about textureOffset , because textureOffset not support sampler2DArrayShadow sampler until 430.

**shader** 
```
#version 300 es
precision mediump float;
in highp vec4 dEQP_Position;
uniform mediump sampler2DArrayShadow s;
void main()
{
                gl_Position = vec4(textureOffset(s, vec4(0), ivec2(0)));
                gl_Position = dEQP_Position;
}
```
**Reference**:
- https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.20.pdf
- https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.30.pdf


