### PR TITLE
TextureOffset not support sampler2DArrayShadow sampler until 430.

### DIFF
--- a/Test/baseResults/textureoffset_sampler2darrayshadow.vert.out
+++ b/Test/baseResults/textureoffset_sampler2darrayshadow.vert.out
@@ -1,4 +1,63 @@
 textureoffset_sampler2darrayshadow.vert
-ERROR: 0:9: 'sampler' : TextureOffset not support the sampler2DArrayShadow :  version <= 420
-ERROR: 0:9: '' : compilation terminated
-ERROR: 2 compilation errors.  No code generated
+ERROR: 0:9: 'sampler' : TextureOffset does not support sampler2DArrayShadow :  ES Profile
+ERROR: 1 compilation errors.  No code generated.
+
+
+Shader version: 300
+ERROR: node is still EOpNull!
+0:7  Function Definition: main( ( global void)
+0:7    Function Parameters: 
+0:9    Sequence
+0:9      move second child to first child ( temp highp 4-component vector of float)
+0:9        'gl_Position' ( gl_Position highp 4-component vector of float Position)
+0:9        Construct vec4 ( temp highp 4-component vector of float)
+0:9          textureOffset ( global mediump float)
+0:9            's' ( uniform mediump sampler2DArrayShadow)
+0:9            Constant:
+0:9              0.000000
+0:9              0.000000
+0:9              0.000000
+0:9              0.000000
+0:9            Constant:
+0:9              0 (const int)
+0:9              0 (const int)
+0:10      move second child to first child ( temp highp 4-component vector of float)
+0:10        'gl_Position' ( gl_Position highp 4-component vector of float Position)
+0:10        'dEQP_Position' ( in highp 4-component vector of float)
+0:?   Linker Objects
+0:?     'dEQP_Position' ( in highp 4-component vector of float)
+0:?     's' ( uniform mediump sampler2DArrayShadow)
+0:?     'gl_VertexID' ( gl_VertexId highp int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId highp int InstanceId)
+
+
+Linked vertex stage:
+
+
+Shader version: 300
+ERROR: node is still EOpNull!
+0:7  Function Definition: main( ( global void)
+0:7    Function Parameters: 
+0:9    Sequence
+0:9      move second child to first child ( temp highp 4-component vector of float)
+0:9        'gl_Position' ( gl_Position highp 4-component vector of float Position)
+0:9        Construct vec4 ( temp highp 4-component vector of float)
+0:9          textureOffset ( global mediump float)
+0:9            's' ( uniform mediump sampler2DArrayShadow)
+0:9            Constant:
+0:9              0.000000
+0:9              0.000000
+0:9              0.000000
+0:9              0.000000
+0:9            Constant:
+0:9              0 (const int)
+0:9              0 (const int)
+0:10      move second child to first child ( temp highp 4-component vector of float)
+0:10        'gl_Position' ( gl_Position highp 4-component vector of float Position)
+0:10        'dEQP_Position' ( in highp 4-component vector of float)
+0:?   Linker Objects
+0:?     'dEQP_Position' ( in highp 4-component vector of float)
+0:?     's' ( uniform mediump sampler2DArrayShadow)
+0:?     'gl_VertexID' ( gl_VertexId highp int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId highp int InstanceId)
+

--- a/Test/baseResults/textureoffset_sampler2darrayshadow.vert.out
+++ b/Test/baseResults/textureoffset_sampler2darrayshadow.vert.out
@@ -1,0 +1,4 @@
+textureoffset_sampler2darrayshadow.vert
+ERROR: 0:9: 'sampler' : TextureOffset not support the sampler2DArrayShadow :  version <= 420
+ERROR: 0:9: '' : compilation terminated
+ERROR: 2 compilation errors.  No code generated

--- a/Test/textureoffset_sampler2darrayshadow.vert
+++ b/Test/textureoffset_sampler2darrayshadow.vert
@@ -1,0 +1,11 @@
+#version 300 es
+precision mediump float;
+in highp vec4 dEQP_Position;
+
+uniform mediump sampler2DArrayShadow s;
+
+void main()
+{
+	gl_Position = vec4(textureOffset(s, vec4(0), ivec2(0)));
+	gl_Position = dEQP_Position;
+}

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -115,6 +115,7 @@ struct TSampler {   // misnomer now; includes images, textures without sampler, 
 #endif
 
     bool is1D()          const { return dim == Esd1D; }
+    bool is2D()          const { return dim == Esd2D; }
     bool isBuffer()      const { return dim == EsdBuffer; }
     bool isRect()        const { return dim == EsdRect; }
     bool isSubpass()     const { return dim == EsdSubpass; }

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -2191,6 +2191,16 @@ void TParseContext::builtInOpCheck(const TSourceLoc& loc, const TFunction& fnCan
                               "[gl_MinProgramTexelOffset, gl_MaxProgramTexelOffset]");
                 }
             }
+
+            if (callNode.getOp() == EOpTextureOffset) {
+                TSampler s = arg0->getType().getSampler();
+                if (s.is2D() && s.isArrayed() && s.isShadow()) {
+                    if (isEsProfile())
+                        error(loc, "TextureOffset does not support sampler2DArrayShadow : ", "sampler", "ES Profile");
+                    else if (version <= 420)
+                        error(loc, "TextureOffset does not support sampler2DArrayShadow : ", "sampler", "version <= 420");
+                }
+            }
         }
 
         break;

--- a/gtests/AST.FromFile.cpp
+++ b/gtests/AST.FromFile.cpp
@@ -281,6 +281,7 @@ INSTANTIATE_TEST_SUITE_P(
         "terminate.frag",
         "terminate.vert",
         "negativeWorkGroupSize.comp",
+        "textureoffset_sampler2darrayshadow.vert",
     })),
     FileNameAsCustomTestSuffix
 );


### PR DESCRIPTION
Hi ,
glslang should report an error about textureOffset , because textureOffset not support sampler2DArrayShadow sampler until 430.

shader

#version 300 es
precision mediump float;
in highp vec4 dEQP_Position;
uniform mediump sampler2DArrayShadow s;
void main()
{
                gl_Position = vec4(textureOffset(s, vec4(0), ivec2(0)));
                gl_Position = dEQP_Position;
}
Reference:

https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.20.pdf
https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.30.pdf
