### PR TITLE
Exposed #856 as --hlsl-sampled-textures in the StandAlone

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -111,7 +111,7 @@ bool NaNClamp = false;
 bool stripDebugInfo = false;
 bool beQuiet = false;
 bool VulkanRulesRelaxed = false;
-bool hlslSampledTextures = false;
+bool autoSampledTextures = false;
 
 //
 // Return codes from main/exit().
@@ -656,8 +656,8 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
                         HlslEnable16BitTypes = true;
                     } else if (lowerword == "hlsl-dx9-compatible") {
                         HlslDX9compatible = true;
-                    } else if (lowerword == "hlsl-sampled-textures") { 
-                        hlslSampledTextures = true;
+                    } else if (lowerword == "auto-sampled-textures") { 
+                        autoSampledTextures = true;
                     } else if (lowerword == "invert-y" ||  // synonyms
                                lowerword == "iy") {
                         Options |= EOptionInvertY;
@@ -1192,7 +1192,7 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
         shader->setNoStorageFormat((Options & EOptionNoStorageFormat) != 0);
         shader->setResourceSetBinding(baseResourceSetBinding[compUnit.stage]);
 
-        if (hlslSampledTextures)
+        if (autoSampledTextures)
             shader->setTextureSamplerTransformMode(EShTexSampTransUpgradeTextureRemoveSampler);
 
         if (Options & EOptionAutoMapBindings)

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -111,6 +111,7 @@ bool NaNClamp = false;
 bool stripDebugInfo = false;
 bool beQuiet = false;
 bool VulkanRulesRelaxed = false;
+bool hlslSampledTextures = false;
 
 //
 // Return codes from main/exit().
@@ -655,6 +656,8 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
                         HlslEnable16BitTypes = true;
                     } else if (lowerword == "hlsl-dx9-compatible") {
                         HlslDX9compatible = true;
+                    } else if (lowerword == "hlsl-sampled-textures") { 
+                        hlslSampledTextures = true;
                     } else if (lowerword == "invert-y" ||  // synonyms
                                lowerword == "iy") {
                         Options |= EOptionInvertY;
@@ -1188,6 +1191,9 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
         }
         shader->setNoStorageFormat((Options & EOptionNoStorageFormat) != 0);
         shader->setResourceSetBinding(baseResourceSetBinding[compUnit.stage]);
+
+        if (hlslSampledTextures)
+            shader->setTextureSamplerTransformMode(EShTexSampTransUpgradeTextureRemoveSampler);
 
         if (Options & EOptionAutoMapBindings)
             shader->setAutoMapBindings(true);


### PR DESCRIPTION
This PR exposes the automatic Texture*D and SampleState merging introduced in #856 to the StandAlone application via --hlsl-sampled-textures. This closes #2611.

Since the new C++ API is only used in link mode, I am not sure whether exposing this functionality is possible via ShCompile. I only implemented it for link mode.