### PR TITLE
Add a --depfile option in Standalone mode

### DIFF
--- a/StandAlone/DirStackFileIncluder.h
+++ b/StandAlone/DirStackFileIncluder.h
@@ -40,6 +40,7 @@
 #include <string>
 #include <fstream>
 #include <algorithm>
+#include <set>
 
 #include "./../glslang/Public/ShaderLang.h"
 
@@ -84,12 +85,18 @@ public:
         }
     }
 
+    virtual std::set<std::string> getIncludedFiles()
+    {
+        return includedFiles;
+    }
+
     virtual ~DirStackFileIncluder() override { }
 
 protected:
     typedef char tUserDataElement;
     std::vector<std::string> directoryStack;
     int externalLocalDirectoryCount;
+    std::set<std::string> includedFiles;
 
     // Search for a valid "local" path based on combining the stack of include
     // directories and the nominal name of the header.
@@ -108,6 +115,7 @@ protected:
             std::ifstream file(path, std::ios_base::binary | std::ios_base::ate);
             if (file) {
                 directoryStack.push_back(getDirectory(path));
+                includedFiles.insert(path);
                 return newIncludeResult(path, file, (int)file.tellg());
             }
         }

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -58,6 +58,7 @@
 #include <map>
 #include <memory>
 #include <thread>
+#include <set>
 
 #include "../glslang/OSDependent/osinclude.h"
 
@@ -165,6 +166,7 @@ int ReflectOptions = EShReflectionDefault;
 int Options = 0;
 const char* ExecutableName = nullptr;
 const char* binaryFileName = nullptr;
+const char* depencyFileName = nullptr;
 const char* entryPointName = nullptr;
 const char* sourceEntryPointName = nullptr;
 const char* shaderStageName = nullptr;
@@ -798,6 +800,11 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
                         break;
                     } else if (lowerword == "quiet") {
                         beQuiet = true;
+                    } else if (lowerword == "depfile") {
+                        if (argc <= 1)
+                            Error("no <depfile-name> provided", lowerword.c_str());
+                        depencyFileName = argv[1];
+                        bumpArg();
                     } else if (lowerword == "version") {
                         Options |= EOptionDumpVersions;
                     } else if (lowerword == "help") {
@@ -1135,6 +1142,23 @@ struct ShaderCompUnit {
     }
 };
 
+// Writes a depfile similar to gcc -MMD foo.c
+bool writeDepFile(std::string depfile, std::vector<std::string>& binaryFiles, const std::vector<std::string>& sources)
+{
+    std::ofstream file(depfile);
+    if (file.fail())
+        return false;
+
+    for (auto it = binaryFiles.begin(); it != binaryFiles.end(); it++) {
+        file << *it << ":";
+        for (auto it = sources.begin(); it != sources.end(); it++) {
+            file << " " << *it;
+        }
+        file << std::endl;
+    }
+    return true;
+}
+
 //
 // For linking mode: Will independently parse each compilation unit, but then put them
 // in the same program and link them together, making at most one linked module per
@@ -1151,6 +1175,12 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
     EShMessages messages = EShMsgDefault;
     SetMessageOptions(messages);
 
+    DirStackFileIncluder includer;
+    std::for_each(IncludeDirectoryList.rbegin(), IncludeDirectoryList.rend(), [&includer](const std::string& dir) {
+        includer.pushExternalLocalDirectory(dir); });
+
+    std::vector<std::string> sources;
+
     //
     // Per-shader processing...
     //
@@ -1158,6 +1188,9 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
     glslang::TProgram& program = *new glslang::TProgram;
     for (auto it = compUnits.cbegin(); it != compUnits.cend(); ++it) {
         const auto &compUnit = *it;
+        for (int i = 0; i < compUnit.count; i++) {
+            sources.push_back(compUnit.fileNameList[i]);
+        }
         glslang::TShader* shader = new glslang::TShader(compUnit.stage);
         shader->setStringsWithLengthsAndNames(compUnit.text, NULL, compUnit.fileNameList, compUnit.count);
         if (entryPointName)
@@ -1252,9 +1285,6 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
 
         const int defaultVersion = Options & EOptionDefaultDesktop ? 110 : 100;
 
-        DirStackFileIncluder includer;
-        std::for_each(IncludeDirectoryList.rbegin(), IncludeDirectoryList.rend(), [&includer](const std::string& dir) {
-            includer.pushExternalLocalDirectory(dir); });
 #ifndef GLSLANG_WEB
         if (Options & EOptionOutputPreprocessed) {
             std::string str;
@@ -1314,6 +1344,8 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
     }
 #endif
 
+    std::vector<std::string> outputFiles;
+
     // Dump SPIR-V
     if (Options & EOptionSpv) {
         if (CompileFailed || LinkFailed)
@@ -1343,6 +1375,8 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
                         } else {
                             glslang::OutputSpvBin(spirv, GetBinaryName((EShLanguage)stage));
                         }
+
+                        outputFiles.push_back(GetBinaryName((EShLanguage)stage));
 #ifndef GLSLANG_WEB
                         if (!SpvToolsDisassembler && (Options & EOptionHumanReadableSpv))
                             spv::Disassemble(std::cout, spirv);
@@ -1351,6 +1385,13 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
                 }
             }
         }
+    }
+
+    if (depencyFileName && !(CompileFailed || LinkFailed)) {
+        std::set<std::string> includedFiles = includer.getIncludedFiles();
+        sources.insert(sources.end(), includedFiles.begin(), includedFiles.end());
+
+        writeDepFile(depencyFileName, outputFiles, sources);
     }
 
     // Free everything up, program has to go before the shaders
@@ -1773,6 +1814,7 @@ void usage()
            "  --auto-map-locations | --aml      automatically locate input/output lacking\n"
            "                                    'location' (fragile, not cross stage)\n"
            "  --client {vulkan<ver>|opengl<ver>} see -V and -G\n"
+           "  --depfile <file>                  writes depfile for build systems\n"
            "  --dump-builtin-symbols            prints builtin symbol table prior each compile\n"
            "  -dumpfullversion | -dumpversion   print bare major.minor.patchlevel\n"
            "  --flatten-uniform-arrays | --fua  flatten uniform texture/sampler arrays to\n"

--- a/Test/baseResults/hlsl.dashI.vert.d.out
+++ b/Test/baseResults/hlsl.dashI.vert.d.out
@@ -1,0 +1,1 @@
+vert.spv: hlsl.dashI.vert ./bar.h ./parent.h inc1/path1/local.h inc1/path1/notHere.h inc1/path2/remote.h

--- a/Test/baseResults/hlsl.include.vert.d.out
+++ b/Test/baseResults/hlsl.include.vert.d.out
@@ -1,0 +1,1 @@
+vert.spv: ../Test/hlsl.include.vert ../Test/./inc1/bar.h ../Test/./inc1/foo.h ../Test/bar.h ../Test/inc2/bar.h ../Test/inc2/foo.h ../Test/parent.h

--- a/Test/runtests
+++ b/Test/runtests
@@ -191,6 +191,16 @@ run -D -Od -e MainPs -H -Od -g hlsl.pp.line3.frag > $TARGETDIR/hlsl.pp.line3.fra
 diff -b $BASEDIR/hlsl.pp.line3.frag.out $TARGETDIR/hlsl.pp.line3.frag.out || HASERROR=1
 
 #
+# Testing --depfile
+#
+
+echo "Testing --depfile"
+run -D -Od -e main -H --depfile $TARGETDIR/hlsl.include.vert.d.out -Od ../Test/hlsl.include.vert > $TARGETDIR/hlsl.include.vert.out
+diff -b $BASEDIR/hlsl.include.vert.d.out $TARGETDIR/hlsl.include.vert.d.out || HASERROR=1
+run -D -Od -e main -H --depfile $TARGETDIR/hlsl.dashI.vert.d.out -Od -Iinc1/path1 -Iinc1/path2 hlsl.dashI.vert > $TARGETDIR/hlsl.dashI.vert.out
+diff -b $BASEDIR/hlsl.dashI.vert.d.out $TARGETDIR/hlsl.dashI.vert.d.out || HASERROR=1
+
+#
 # Testing -D and -U
 #
 echo "Testing -D and -U"


### PR DESCRIPTION
The output is similar to gcc -MMD and can be used by build systems like meson to automatically recompile shaders if an included header was changed.

Meson integration example:

```meson
shader_src = [
    'foo.frag',
    'bar.vert',
]

glsl_compiler = find_program('glslangValidator')
glsl_generator = generator(
    glsl_compiler,
    output    : [ '@BASENAME@.h' ],
    arguments : [ '-V', '--vn', '@BASENAME@', '@INPUT@', '-o', '@OUTPUT@', '--depfile', '@DEPFILE@' ],
    depfile   : '@DEPFILE@',
)

shaders = glsl_generator.process(shader_src)
```