### PR TITLE
Set CMake policy CMP0054 to NEW to silence warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ cmake_minimum_required(VERSION 2.8.12)
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
 
 project(glslang LANGUAGES CXX)
 


### PR DESCRIPTION
CMAKE_SYSTEM_NAME variable might evaluate to existing variable such as
CYGWIN. This setting also matches with SPIRV-Tools.

Warning was introduced with commit https://github.com/KhronosGroup/glslang/commit/17a83a9b33aa84addf51b7d2ee6e7ce2aec158ca

```
CMake Warning (dev) at glslang/glslang/CMakeLists.txt:36 (elseif):
  Policy CMP0054 is not set: Only interpret if() arguments as variables or
  keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  Quoted variables like "CYGWIN" will no longer be dereferenced when the
  policy is set to NEW.  Since the policy is not set the OLD behavior will be
  used.
```

SPIRV-Tools commit regarding `CMP0054` was: https://github.com/KhronosGroup/SPIRV-Tools/commit/190b0d3162004e359605cec57dfcb6af75ca86ca