### PR TITLE
fix error message for hlslGrammar::acceptConstructor

### DIFF
--- a/glslang/HLSL/hlslGrammar.cpp
+++ b/glslang/HLSL/hlslGrammar.cpp
@@ -3244,7 +3244,7 @@ bool HlslGrammar::acceptConstructor(TIntermTyped*& node)
         }
 
         // hook it up
-        node = parseContext.handleFunctionCall(arguments->getLoc(), constructorFunction, arguments);
+        node = parseContext.handleFunctionCall(token.loc, constructorFunction, arguments);
 
         return node != nullptr;
     }


### PR DESCRIPTION
The error message when compiling an erroneous HLSL constructor statement (e.g. `float4(1,1,1)`) always reports line `0:0`, and an empty string as the source file.

This is because `arguments->getLoc()` fetches a default-initialised `loc`from a freshly generated `TIntermNode` (via `arguments`). 

This was probably not intended. Taking the current token's loc via `token.loc` appears to solve the issue.

## minimal test case: 

Compile the following file (named `test.vert`) via `glslangValidator -V -D test.vert`
```hlsl
float4 main() {
	return float4(1,1,1);
}
```
This currently returns the following (incomplete) error message: 
```text
test.vert
ERROR: 0:0: 'constructor' : not enough data provided for construction 
```

A more complete error message would be: 
```text
test.vert
ERROR: test.vert:3: 'constructor' : not enough data provided for construction
```

Note that the latter error message mentions the correct file name, and the correct line where the error occurs in the source file.