### PR TITLE
Add the query function to help differentiate defualt shared or declared shared layout qualifer.

### DIFF
--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -899,6 +899,8 @@ public:
 
     TLayoutMatrix  layoutMatrix  : 3;
     TLayoutPacking layoutPacking : 4;
+    bool sharedPackingNotDefault : 1;
+    bool std140PackingNotDefault : 1;
     int layoutOffset;
     int layoutAlign;
 
@@ -980,6 +982,14 @@ public:
     bool hasPacking() const
     {
         return layoutPacking != ElpNone;
+    }
+    bool IsDefaultSharedPacking () const 
+    {
+        return sharedPackingNotDefault;
+    }
+    bool IsDefaultStd140Packing () const 
+    {
+        return std140PackingNotDefault;
     }
     bool hasAlign() const
     {

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -5164,10 +5164,12 @@ void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publi
                 spvRemoved(loc, "shared");
         }
         publicType.qualifier.layoutPacking = ElpShared;
+        publicType.qualifier.sharedPackingNotDefault = true;
         return;
     }
     if (id == TQualifier::getLayoutPackingString(ElpStd140)) {
         publicType.qualifier.layoutPacking = ElpStd140;
+        publicType.qualifier.std140PackingNotDefault = true;
         return;
     }
 #ifndef GLSLANG_WEB


### PR DESCRIPTION
Hi,
    There is a motivation for back-end driver to differentiate between the default shared and declared shared layout qualifier.
It seems that the glslang miss  semantic information for shared keyword at this case.





The glslspec46 says:

The initial state of compilation when not generating SPIR-V is as if the following were declared:

layout(**shared**, column_major) uniform;
layout(**shared**, column_major) buffer;


The glspec46 says :

All members of a named uniform block **declared** with a **shared or std140 layout qualifier** are considered active,
even if they are not referenced in any shader in the program. The uniform block itself is also considered active, even
if no member of the block is referenced.

**shader:**
```
#version 310 es
#extension GL_OES_geometry_shader : require
precision highp float;

layout (points)                           in;
layout (triangle_strip, max_vertices = 6) out;

buffer Positions {
    vec4 position[4]; // referenced in GS
} storage_positions;  // referenced in GS

buffer Ids{
    int ids[4]; // not referenced in GS
} storage_ids;  // not referenced in GS

out vec4 gs_out_color;
void main()
{
    // access shader storage buffers
    gl_Position = storage_positions.position[0] + vec4(0.1, 0.1, 0, 0);
    gs_out_color     = vec4(1.0);
    EmitVertex();
}
```





**reference:**
1. https://github.com/KhronosGroup/glslang/issues/2639
2. https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.60.pdf (ch4.4.5 )
3. https://www.khronos.org/registry/OpenGL/specs/gl/glspec46.core.pdf (ch7.6)

