### PR TITLE
Fix mat4x2(scalar) constructor.

### DIFF
--- a/Test/baseResults/matrix.frag.out
+++ b/Test/baseResults/matrix.frag.out
@@ -242,6 +242,36 @@ Shader version: 130
 0:54              'un34' ( uniform 4X4 matrix of float)
 0:54              'um43' ( uniform 4X4 matrix of float)
 0:54            'v' ( smooth in 4-component vector of float)
+0:56      Sequence
+0:56        move second child to first child ( temp 4X2 matrix of float)
+0:56          'm42' ( temp 4X2 matrix of float)
+0:56          Constant:
+0:56            42.000000
+0:56            0.000000
+0:56            0.000000
+0:56            42.000000
+0:56            0.000000
+0:56            0.000000
+0:56            0.000000
+0:56            0.000000
+0:57      Test condition and select ( temp void)
+0:57        Condition
+0:57        Compare Equal ( temp bool)
+0:57          'm42' ( temp 4X2 matrix of float)
+0:57          Constant:
+0:57            42.000000
+0:57            0.000000
+0:57            0.000000
+0:57            42.000000
+0:57            0.000000
+0:57            0.000000
+0:57            0.000000
+0:57            0.000000
+0:57        true case
+0:58        Sequence
+0:58          add second child into first child ( temp 4-component vector of float)
+0:58            'gl_FragColor' ( fragColor 4-component vector of float FragColor)
+0:58            'v' ( smooth in 4-component vector of float)
 0:?   Linker Objects
 0:?     'colorTransform' ( uniform 3X3 matrix of float)
 0:?     'Color' ( smooth in 3-component vector of float)
@@ -495,6 +525,36 @@ Shader version: 130
 0:54              'un34' ( uniform 4X4 matrix of float)
 0:54              'um43' ( uniform 4X4 matrix of float)
 0:54            'v' ( smooth in 4-component vector of float)
+0:56      Sequence
+0:56        move second child to first child ( temp 4X2 matrix of float)
+0:56          'm42' ( temp 4X2 matrix of float)
+0:56          Constant:
+0:56            42.000000
+0:56            0.000000
+0:56            0.000000
+0:56            42.000000
+0:56            0.000000
+0:56            0.000000
+0:56            0.000000
+0:56            0.000000
+0:57      Test condition and select ( temp void)
+0:57        Condition
+0:57        Compare Equal ( temp bool)
+0:57          'm42' ( temp 4X2 matrix of float)
+0:57          Constant:
+0:57            42.000000
+0:57            0.000000
+0:57            0.000000
+0:57            42.000000
+0:57            0.000000
+0:57            0.000000
+0:57            0.000000
+0:57            0.000000
+0:57        true case
+0:58        Sequence
+0:58          add second child into first child ( temp 4-component vector of float)
+0:58            'gl_FragColor' ( fragColor 4-component vector of float FragColor)
+0:58            'v' ( smooth in 4-component vector of float)
 0:?   Linker Objects
 0:?     'colorTransform' ( uniform 3X3 matrix of float)
 0:?     'Color' ( smooth in 3-component vector of float)

--- a/Test/matrix.frag
+++ b/Test/matrix.frag
@@ -33,15 +33,15 @@ void main()
         gl_FragColor += m * v;
         gl_FragColor += v * (m - n);
    }
-    
+
 #ifdef TEST_POST_110
     mat3x4 m34 = outerProduct(v, u);
     m34 += mat4(v.x);
     m34 += mat4(u, u.x, u, u.x, u, u.x, u.x);
 #else
-    mat4 m34 = mat4(v.x*u.x, v.x*u.y, v.x*u.z, v.x*u.w, 
-                    v.y*u.x, v.y*u.y, v.y*u.z, v.y*u.w, 
-                    v.z*u.x, v.z*u.y, v.z*u.z, v.z*u.w, 
+    mat4 m34 = mat4(v.x*u.x, v.x*u.y, v.x*u.z, v.x*u.w,
+                    v.y*u.x, v.y*u.y, v.y*u.z, v.y*u.w,
+                    v.z*u.x, v.z*u.y, v.z*u.z, v.z*u.w,
                     v.w*u.x, v.w*u.y, v.w*u.z, v.w*u.w);
     m34 += mat4(v.x);
     m34 += mat4(u, u.x, u, u.x, u, u.x, u.x);
@@ -52,4 +52,9 @@ void main()
         gl_FragColor += m34 * u;
     else
         gl_FragColor += (un34 * um43) * v;
+
+    mat4x2 m42 = mat4x2(42);
+    if (m42 == mat4x2(42, 0, 0, 42, 0, 0, 0, 0)) {
+        gl_FragColor += v;
+    }
 }

--- a/glslang/MachineIndependent/parseConst.cpp
+++ b/glslang/MachineIndependent/parseConst.cpp
@@ -166,31 +166,30 @@ void TConstTraverser::visitConstantUnion(TIntermConstantUnion* node)
                 }
             } else {
                 // matrix from vector or scalar
-                int count = 0;
-                const int startIndex = index;
                 int nodeComps = node->getType().computeNumComponents();
-                for (int i = startIndex; i < endIndex; i++) {
-                    if (i >= instanceSize)
-                        return;
-                    if (nodeComps == 1) {
-                        // If there is a single scalar parameter to a matrix
-                        // constructor, it is used to initialize all the
-                        // components on the matrix's diagonal, with the
-                        // remaining components initialized to 0.0.
-                        if (i == startIndex || (i - startIndex) % (matrixRows + 1) == 0 )
-                            leftUnionArray[i] = rightUnionArray[count];
-                        else
-                            leftUnionArray[i].setDConst(0.0);
-                    } else {
+                if (nodeComps == 1) {
+                    for (int c = 0; c < matrixCols; ++c) {
+                        for (int r = 0; r < matrixRows; ++r) {
+                            if (r == c)
+                                leftUnionArray[index] = rightUnionArray[0];
+                            else
+                                leftUnionArray[index].setDConst(0.0);
+                            index++;
+                        }
+                    }
+                } else {
+                    int count = 0;
+                    for (int i = index; i < endIndex; i++) {
+                        if (i >= instanceSize)
+                            return;
+
                         // construct the matrix in column-major order, from
                         // the components provided, in order
                         leftUnionArray[i] = rightUnionArray[count];
-                    }
 
-                    index++;
-
-                    if (nodeComps > 1)
+                        index++;
                         count++;
+                    }
                 }
             }
         }


### PR DESCRIPTION
As described in #2645, 4x2 matrices constructed with a scalar are handled improperly and contain an additional unwanted scalar value. This PR adds a test for this issue and fixes the constant-matrix handling code.