### PR TITLE
Add setters for true and false blocks of selection nodes, copying the pattern already used for the condition.

### DIFF
--- a/glslang/Include/intermediate.h
+++ b/glslang/Include/intermediate.h
@@ -1677,7 +1677,9 @@ public:
     virtual TIntermTyped* getCondition() const { return condition; }
     virtual void setCondition(TIntermTyped* c) { condition = c; }
     virtual TIntermNode* getTrueBlock() const { return trueBlock; }
+    virtual void setTrueBlock(TIntermTyped* tb) { trueBlock = tb; }
     virtual TIntermNode* getFalseBlock() const { return falseBlock; }
+    virtual void setFalseBlock(TIntermTyped* fb) { falseBlock = fb; }
     virtual       TIntermSelection* getAsSelectionNode()       { return this; }
     virtual const TIntermSelection* getAsSelectionNode() const { return this; }
 


### PR DESCRIPTION
Following up on #2600, this should allow us to manipulate selection nodes more cleanly than having to recreate them.