### PR TITLE
Fix OOB write in matrix constructor

### DIFF
--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -2543,7 +2543,7 @@ Id Builder::createMatrixConstructor(Decoration precision, const std::vector<Id>&
         int row = 0;
         int col = 0;
 
-        for (int arg = 0; arg < (int)sources.size(); ++arg) {
+        for (int arg = 0; arg < (int)sources.size() && col < numCols; ++arg) {
             Id argComp = sources[arg];
             for (int comp = 0; comp < getNumComponents(sources[arg]); ++comp) {
                 if (getNumComponents(sources[arg]) > 1) {
@@ -2554,6 +2554,10 @@ Id Builder::createMatrixConstructor(Decoration precision, const std::vector<Id>&
                 if (row == numRows) {
                     row = 0;
                     col++;
+                }
+                if (col == numCols) {
+                    // If more components are provided than fit the matrix, discard the rest.
+                    break;
                 }
             }
         }


### PR DESCRIPTION
In a matrix constructor that takes a number of components, as many
components as necessary must be taken, with the rest discarded, as GLSL
allows more components than necessary to be specified.  For example, the
following:

    mat4 m4 = mat4(v4, v4.yzwx, v4.zwx, v4.zwxy, v4.wxyz);

is equivalent to:

    mat4 m4 = mat4(v4, v4.yzwx, v4.zwx, v4.zwxy, v4.w);

glslang takes the components from the constructor and builds the single
components of the matrix in a 2D array before constructing the matrix
itself.  It however did not check for extra parameters and was thus
writing OOB to said 2D array.  This is fixed in this change

Signed-off-by: Shahbaz Youssefi <shabbyx@gmail.com>