### PR TITLE
only declare compatibility gl_ variables in compatibility mode

### DIFF
--- a/Test/baseResults/150.frag.out
+++ b/Test/baseResults/150.frag.out
@@ -3,7 +3,6 @@ ERROR: 0:4: 'redeclaration' : cannot redeclare with different qualification: gl_
 ERROR: 0:5: 'redeclaration' : cannot redeclare with different qualification: gl_FragCoord
 ERROR: 0:6: 'layout qualifier' : can only apply origin_upper_left and pixel_center_origin to gl_FragCoord 
 ERROR: 0:14: 'gl_FragCoord' : cannot redeclare after use 
-ERROR: 0:50: 'gl_PerFragment' : cannot be used (maybe an instance name is needed) 
 ERROR: 0:50: 'gl_PerFragment' : undeclared identifier 
 ERROR: 0:53: 'double' : Reserved word. 
 ERROR: 0:53: 'double' : not supported for this version or the enabled extensions 
@@ -18,7 +17,7 @@ ERROR: 0:154: 'assign' :  cannot convert from ' const float' to ' temp 2-compone
 ERROR: 0:155: 'textureQueryLod' : no matching overloaded function found 
 ERROR: 0:155: 'assign' :  cannot convert from ' const float' to ' temp 2-component vector of float'
 ERROR: 0:183: 'mix' : required extension not requested: GL_EXT_shader_integer_mix
-ERROR: 19 compilation errors.  No code generated.
+ERROR: 18 compilation errors.  No code generated.
 
 
 Shader version: 150

--- a/Test/baseResults/150.vert.out
+++ b/Test/baseResults/150.vert.out
@@ -1,10 +1,12 @@
 150.vert
+ERROR: 0:18: 'gl_ClipVertex' : undeclared identifier 
+ERROR: 0:18: 'assign' :  cannot convert from ' in 4-component vector of float' to ' temp float'
 ERROR: 0:26: 'a' : cannot redeclare a user-block member array 
 ERROR: 0:28: 'double' : Reserved word. 
 ERROR: 0:28: 'double' : not supported for this version or the enabled extensions 
 ERROR: 0:28: 'vertex-shader `double` type input' : not supported for this version or the enabled extensions 
 ERROR: 0:3001: '#error' : line of this error should be 3001  
-ERROR: 5 compilation errors.  No code generated.
+ERROR: 7 compilation errors.  No code generated.
 
 
 Shader version: 150
@@ -15,20 +17,20 @@ ERROR: node is still EOpNull!
 0:15    Sequence
 0:15      move second child to first child ( temp 4-component vector of float)
 0:15        gl_Position: direct index for structure ( invariant gl_Position 4-component vector of float Position)
-0:15          'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 4-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:15          'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 4-element array of float ClipDistance gl_ClipDistance})
 0:15          Constant:
 0:15            0 (const uint)
 0:15        'iv4' ( in 4-component vector of float)
 0:16      move second child to first child ( temp float)
 0:16        gl_PointSize: direct index for structure ( gl_PointSize float PointSize)
-0:16          'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 4-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:16          'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 4-element array of float ClipDistance gl_ClipDistance})
 0:16          Constant:
 0:16            1 (const uint)
 0:16        'ps' ( uniform float)
 0:17      move second child to first child ( temp float)
 0:17        direct index ( temp float ClipDistance)
 0:17          gl_ClipDistance: direct index for structure ( out 4-element array of float ClipDistance)
-0:17            'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 4-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:17            'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 4-element array of float ClipDistance gl_ClipDistance})
 0:17            Constant:
 0:17              2 (const uint)
 0:17          Constant:
@@ -37,12 +39,7 @@ ERROR: node is still EOpNull!
 0:17          'iv4' ( in 4-component vector of float)
 0:17          Constant:
 0:17            0 (const int)
-0:18      move second child to first child ( temp 4-component vector of float)
-0:18        gl_ClipVertex: direct index for structure ( gl_ClipVertex 4-component vector of float ClipVertex)
-0:18          'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 4-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
-0:18          Constant:
-0:18            3 (const uint)
-0:18        'iv4' ( in 4-component vector of float)
+0:18      'gl_ClipVertex' ( temp float)
 0:?   Linker Objects
 0:?     'iv4' ( in 4-component vector of float)
 0:?     'ps' ( uniform float)
@@ -67,7 +64,6 @@ ERROR: node is still EOpNull!
 
 Linked vertex stage:
 
-ERROR: Linking vertex stage: Can only use one of gl_ClipDistance or gl_ClipVertex (gl_ClipDistance is preferred)
 
 Shader version: 150
 Requested GL_ARB_vertex_attrib_64bit
@@ -77,20 +73,20 @@ ERROR: node is still EOpNull!
 0:15    Sequence
 0:15      move second child to first child ( temp 4-component vector of float)
 0:15        gl_Position: direct index for structure ( invariant gl_Position 4-component vector of float Position)
-0:15          'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 4-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:15          'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 4-element array of float ClipDistance gl_ClipDistance})
 0:15          Constant:
 0:15            0 (const uint)
 0:15        'iv4' ( in 4-component vector of float)
 0:16      move second child to first child ( temp float)
 0:16        gl_PointSize: direct index for structure ( gl_PointSize float PointSize)
-0:16          'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 4-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:16          'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 4-element array of float ClipDistance gl_ClipDistance})
 0:16          Constant:
 0:16            1 (const uint)
 0:16        'ps' ( uniform float)
 0:17      move second child to first child ( temp float)
 0:17        direct index ( temp float ClipDistance)
 0:17          gl_ClipDistance: direct index for structure ( out 4-element array of float ClipDistance)
-0:17            'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 4-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:17            'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 4-element array of float ClipDistance gl_ClipDistance})
 0:17            Constant:
 0:17              2 (const uint)
 0:17          Constant:
@@ -99,12 +95,7 @@ ERROR: node is still EOpNull!
 0:17          'iv4' ( in 4-component vector of float)
 0:17          Constant:
 0:17            0 (const int)
-0:18      move second child to first child ( temp 4-component vector of float)
-0:18        gl_ClipVertex: direct index for structure ( gl_ClipVertex 4-component vector of float ClipVertex)
-0:18          'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 4-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
-0:18          Constant:
-0:18            3 (const uint)
-0:18        'iv4' ( in 4-component vector of float)
+0:18      'gl_ClipVertex' ( temp float)
 0:?   Linker Objects
 0:?     'iv4' ( in 4-component vector of float)
 0:?     'ps' ( uniform float)

--- a/Test/baseResults/400.frag.out
+++ b/Test/baseResults/400.frag.out
@@ -4,7 +4,7 @@ ERROR: 0:22: 'textureGatherOffset(...)' : must be a compile-time constant: compo
 ERROR: 0:23: 'textureGatherOffset(...)' : must be 0, 1, 2, or 3: component argument
 ERROR: 0:30: 'location qualifier on input' : not supported for this version or the enabled extensions 
 ERROR: 0:38: 'location qualifier on uniform or buffer' : not supported for this version or the enabled extensions 
-ERROR: 0:40: 'redeclaration' : cannot apply layout qualifier to gl_Color
+ERROR: 0:40: 'gl_Color' : identifiers starting with "gl_" are reserved 
 ERROR: 0:41: 'redeclaration' : cannot change qualification of gl_ClipDistance
 ERROR: 0:43: 'gl_FragCoord' : cannot redeclare after use 
 ERROR: 0:51: 'texel offset' : argument must be compile-time constant 
@@ -516,7 +516,7 @@ ERROR: node is still EOpNull!
 0:?     'vl' (layout( location=4) smooth in 4-component vector of float)
 0:?     'vl2' (layout( location=6) smooth in 4-component vector of float)
 0:?     'uv3' (layout( location=3) uniform 3-component vector of float)
-0:?     'anon@0' ( in block{ in float FogFragCoord gl_FogFragCoord,  in unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  smooth in 4-component vector of float Color gl_Color,  in 4-component vector of float SecondaryColor gl_SecondaryColor})
+0:?     'gl_Color' (layout( location=5) smooth in 4-component vector of float)
 0:?     'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
 0:?     'u2drs' ( uniform sampler2DRectShadow)
 0:?     'patchIn' ( smooth patch in 4-component vector of float)
@@ -691,7 +691,7 @@ ERROR: node is still EOpNull!
 0:?     'vl' (layout( location=4) smooth in 4-component vector of float)
 0:?     'vl2' (layout( location=6) smooth in 4-component vector of float)
 0:?     'uv3' (layout( location=3) uniform 3-component vector of float)
-0:?     'anon@0' ( in block{ in float FogFragCoord gl_FogFragCoord,  in 1-element array of 4-component vector of float TexCoord gl_TexCoord,  smooth in 4-component vector of float Color gl_Color,  in 4-component vector of float SecondaryColor gl_SecondaryColor})
+0:?     'gl_Color' (layout( location=5) smooth in 4-component vector of float)
 0:?     'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
 0:?     'u2drs' ( uniform sampler2DRectShadow)
 0:?     'patchIn' ( smooth patch in 4-component vector of float)

--- a/Test/baseResults/430scope.vert.out
+++ b/Test/baseResults/430scope.vert.out
@@ -63,7 +63,7 @@ ERROR: node is still EOpNull!
 0:47          3.000000
 0:49      move second child to first child ( temp 4-component vector of float)
 0:49        gl_Position: direct index for structure ( invariant gl_Position 4-component vector of float Position)
-0:49          'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:49          'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance})
 0:49          Constant:
 0:49            0 (const uint)
 0:49        Construct vec4 ( temp 4-component vector of float)
@@ -168,7 +168,7 @@ ERROR: node is still EOpNull!
 0:47          3.000000
 0:49      move second child to first child ( temp 4-component vector of float)
 0:49        gl_Position: direct index for structure ( invariant gl_Position 4-component vector of float Position)
-0:49          'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:49          'anon@0' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance})
 0:49          Constant:
 0:49            0 (const uint)
 0:49        Construct vec4 ( temp 4-component vector of float)

--- a/Test/baseResults/450.vert.out
+++ b/Test/baseResults/450.vert.out
@@ -34,7 +34,7 @@ ERROR: node is still EOpNull!
 0:9          gl_CullDistance: direct index for structure ( out 3-element array of float CullDistance)
 0:9            'anon@0' ( out block{ out 3-element array of float CullDistance gl_CullDistance})
 0:9            Constant:
-0:9              10 (const uint)
+0:9              3 (const uint)
 0:9          Constant:
 0:9            2 (const int)
 0:9        Constant:
@@ -98,7 +98,7 @@ ERROR: node is still EOpNull!
 0:9          gl_CullDistance: direct index for structure ( out 3-element array of float CullDistance)
 0:9            'anon@0' ( out block{ out 3-element array of float CullDistance gl_CullDistance})
 0:9            Constant:
-0:9              10 (const uint)
+0:9              3 (const uint)
 0:9          Constant:
 0:9            2 (const int)
 0:9        Constant:

--- a/Test/baseResults/cppSimple.vert.out
+++ b/Test/baseResults/cppSimple.vert.out
@@ -134,7 +134,7 @@ ERROR: node is still EOpNull!
 0:65          0.050000
 0:69      move second child to first child ( temp 4-component vector of float)
 0:69        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
-0:69          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:69          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance})
 0:69          Constant:
 0:69            0 (const uint)
 0:69        Construct vec4 ( temp 4-component vector of float)
@@ -174,7 +174,7 @@ ERROR: node is still EOpNull!
 12:20033    Sequence
 12:20033      move second child to first child ( temp 4-component vector of float)
 12:20033        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
-12:20033          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+12:20033          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance})
 12:20033          Constant:
 12:20033            0 (const uint)
 12:20033        Constant:
@@ -188,7 +188,7 @@ ERROR: node is still EOpNull!
 12:9011      'RECURSE' ( global int)
 0:?   Linker Objects
 0:?     'sum' ( global float)
-0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance})
 0:?     'linenumber' ( global int)
 0:?     'filenumber' ( global int)
 0:?     'version' ( global int)
@@ -246,7 +246,7 @@ ERROR: node is still EOpNull!
 0:65          0.050000
 0:69      move second child to first child ( temp 4-component vector of float)
 0:69        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
-0:69          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:69          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance})
 0:69          Constant:
 0:69            0 (const uint)
 0:69        Construct vec4 ( temp 4-component vector of float)
@@ -287,7 +287,7 @@ ERROR: node is still EOpNull!
 12:9011      'RECURSE' ( global int)
 0:?   Linker Objects
 0:?     'sum' ( global float)
-0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance})
 0:?     'linenumber' ( global int)
 0:?     'filenumber' ( global int)
 0:?     'version' ( global int)

--- a/Test/baseResults/link.multiAnonBlocksInvalid.0.0.vert.out
+++ b/Test/baseResults/link.multiAnonBlocksInvalid.0.0.vert.out
@@ -29,7 +29,7 @@ ERROR: node is still EOpNull!
 0:49            0 (const uint)
 0:51      move second child to first child ( temp 4-component vector of float)
 0:51        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
-0:51          'anon@4' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:51          'anon@4' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance})
 0:51          Constant:
 0:51            0 (const uint)
 0:51        matrix-times-vector ( temp 4-component vector of float)
@@ -44,7 +44,7 @@ ERROR: node is still EOpNull!
 0:?     'anon@2' ( out block{ out 4-component vector of float v1})
 0:?     'myName' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float m})
 0:?     'oColor' ( smooth out 4-component vector of float)
-0:?     'anon@4' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'anon@4' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance})
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 
@@ -126,7 +126,7 @@ ERROR: node is still EOpNull!
 0:49            0 (const uint)
 0:51      move second child to first child ( temp 4-component vector of float)
 0:51        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
-0:51          'anon@4' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:51          'anon@4' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance})
 0:51          Constant:
 0:51            0 (const uint)
 0:51        matrix-times-vector ( temp 4-component vector of float)
@@ -169,7 +169,7 @@ ERROR: node is still EOpNull!
 0:?     'anon@2' ( out block{ out 4-component vector of float v1})
 0:?     'myName' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4X4 matrix of float m})
 0:?     'oColor' ( smooth out 4-component vector of float)
-0:?     'anon@4' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'anon@4' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance})
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 0:?     'anon@0' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color2})

--- a/Test/baseResults/link.multiAnonBlocksValid.0.0.vert.out
+++ b/Test/baseResults/link.multiAnonBlocksValid.0.0.vert.out
@@ -23,7 +23,7 @@ Shader version: 430
 0:35            0 (const uint)
 0:37      move second child to first child ( temp 4-component vector of float)
 0:37        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
-0:37          'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:37          'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance})
 0:37          Constant:
 0:37            0 (const uint)
 0:37        matrix-times-vector ( temp 4-component vector of float)
@@ -37,7 +37,7 @@ Shader version: 430
 0:?     'anon@1' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
 0:?     'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
 0:?     'oColor' ( smooth out 4-component vector of float)
-0:?     'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance})
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 
@@ -108,7 +108,7 @@ Shader version: 430
 0:35            0 (const uint)
 0:37      move second child to first child ( temp 4-component vector of float)
 0:37        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
-0:37          'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:37          'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance})
 0:37          Constant:
 0:37            0 (const uint)
 0:37        matrix-times-vector ( temp 4-component vector of float)
@@ -150,7 +150,7 @@ Shader version: 430
 0:?     'anon@1' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
 0:?     'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
 0:?     'oColor' ( smooth out 4-component vector of float)
-0:?     'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'anon@3' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance})
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 0:?     'P' ( in 4-component vector of float)

--- a/Test/baseResults/link.multiBlocksInvalid.0.0.vert.out
+++ b/Test/baseResults/link.multiBlocksInvalid.0.0.vert.out
@@ -28,7 +28,7 @@ Shader version: 430
 0:37              0 (const int)
 0:39      move second child to first child ( temp 4-component vector of float)
 0:39        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
-0:39          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:39          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance})
 0:39          Constant:
 0:39            0 (const uint)
 0:39        matrix-times-vector ( temp 4-component vector of float)
@@ -43,7 +43,7 @@ Shader version: 430
 0:?     'uC' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1})
 0:?     'uBufC' (layout( column_major std430) buffer block{layout( column_major std430 offset=0) buffer 4-component vector of float color1})
 0:?     'oColor' ( smooth out 4-component vector of float)
-0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance})
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 
@@ -132,7 +132,7 @@ Shader version: 430
 0:37              0 (const int)
 0:39      move second child to first child ( temp 4-component vector of float)
 0:39        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
-0:39          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:39          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance})
 0:39          Constant:
 0:39            0 (const uint)
 0:39        matrix-times-vector ( temp 4-component vector of float)
@@ -175,7 +175,7 @@ Shader version: 430
 0:?     'uC' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1})
 0:?     'uBufC' (layout( column_major std430) buffer block{layout( column_major std430 offset=0) buffer 4-component vector of float color1})
 0:?     'oColor' ( smooth out 4-component vector of float)
-0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance})
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 0:?     'P' ( in 4-component vector of float)

--- a/Test/baseResults/link.multiBlocksValid.1.0.vert.out
+++ b/Test/baseResults/link.multiBlocksValid.1.0.vert.out
@@ -23,7 +23,7 @@ Shader version: 430
 0:29            0 (const int)
 0:31      move second child to first child ( temp 4-component vector of float)
 0:31        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
-0:31          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:31          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance})
 0:31          Constant:
 0:31            0 (const uint)
 0:31        matrix-times-vector ( temp 4-component vector of float)
@@ -37,7 +37,7 @@ Shader version: 430
 0:?     'b' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
 0:?     'c' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
 0:?     'oColor' ( smooth out 4-component vector of float)
-0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance})
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 
@@ -114,7 +114,7 @@ Shader version: 430
 0:29            0 (const int)
 0:31      move second child to first child ( temp 4-component vector of float)
 0:31        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
-0:31          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:31          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance})
 0:31          Constant:
 0:31            0 (const uint)
 0:31        matrix-times-vector ( temp 4-component vector of float)
@@ -156,7 +156,7 @@ Shader version: 430
 0:?     'b' ( out block{ out 4-component vector of float v1,  out 4-component vector of float v2})
 0:?     'c' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 4-component vector of float color1, layout( column_major std140 offset=16) uniform 4-component vector of float color2})
 0:?     'oColor' ( smooth out 4-component vector of float)
-0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance})
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 0:?     'P' ( in 4-component vector of float)

--- a/Test/baseResults/specExamples.frag.out
+++ b/Test/baseResults/specExamples.frag.out
@@ -16,6 +16,7 @@ ERROR: 0:102: 'color' : redefinition
 ERROR: 0:112: 'redeclaration' : all redeclarations must use the same depth layout on gl_FragDepth
 ERROR: 0:118: 'redeclaration' : all redeclarations must use the same depth layout on gl_FragDepth
 ERROR: 0:121: 'redeclaration' : all redeclarations must use the same depth layout on gl_FragDepth
+ERROR: 0:123: 'gl_Color' : identifiers starting with "gl_" are reserved 
 ERROR: 0:172: 'x' : undeclared identifier 
 ERROR: 0:172: '[]' : scalar integer expression required 
 ERROR: 0:175: 'x' : undeclared identifier 
@@ -37,7 +38,7 @@ ERROR: 0:226: 'in' : not allowed in nested scope
 ERROR: 0:227: 'in' : not allowed in nested scope 
 ERROR: 0:228: 'in' : not allowed in nested scope 
 ERROR: 0:232: 'out' : not allowed in nested scope 
-ERROR: 38 compilation errors.  No code generated.
+ERROR: 39 compilation errors.  No code generated.
 
 
 Shader version: 430
@@ -320,7 +321,7 @@ ERROR: node is still EOpNull!
 0:?     'factor' (layout( location=3 index=1) out 4-component vector of float)
 0:?     'colors' (layout( location=2) out 3-element array of 4-component vector of float)
 0:?     'gl_FragDepth' ( gl_FragDepth float FragDepth)
-0:?     'anon@2' ( in block{ in float FogFragCoord gl_FogFragCoord,  in unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  flat in 4-component vector of float Color gl_Color,  in 4-component vector of float SecondaryColor gl_SecondaryColor})
+0:?     'gl_Color' ( flat in 4-component vector of float)
 
 
 Linked fragment stage:
@@ -595,5 +596,5 @@ ERROR: node is still EOpNull!
 0:?     'factor' (layout( location=3 index=1) out 4-component vector of float)
 0:?     'colors' (layout( location=2) out 3-element array of 4-component vector of float)
 0:?     'gl_FragDepth' ( gl_FragDepth float FragDepth)
-0:?     'anon@2' ( in block{ in float FogFragCoord gl_FogFragCoord,  in 1-element array of 4-component vector of float TexCoord gl_TexCoord,  flat in 4-component vector of float Color gl_Color,  in 4-component vector of float SecondaryColor gl_SecondaryColor})
+0:?     'gl_Color' ( flat in 4-component vector of float)
 

--- a/Test/baseResults/specExamples.vert.out
+++ b/Test/baseResults/specExamples.vert.out
@@ -24,7 +24,8 @@ ERROR: 0:95: 'binding' : atomic_uint binding is too large; see gl_MaxAtomicCount
 ERROR: 0:96: 'binding' : atomic_uint binding is too large; see gl_MaxAtomicCounterBindings 
 ERROR: 0:97: 'binding' : atomic_uint binding is too large; see gl_MaxAtomicCounterBindings 
 ERROR: 0:106: '' : vertex input cannot be further qualified 
-ERROR: 0:106: 'redeclaration' : cannot change storage, memory, or auxiliary qualification of gl_FrontColor
+ERROR: 0:106: 'gl_FrontColor' : identifiers starting with "gl_" are reserved 
+ERROR: 0:107: 'redeclaration' : cannot change storage, memory, or auxiliary qualification of gl_FrontColor
 ERROR: 0:112: 'ColorIvn' : identifier not previously declared 
 ERROR: 0:132: 'shared' : not supported in this stage: vertex
 ERROR: 0:134: '' : function does not return a value: funcA
@@ -33,7 +34,7 @@ ERROR: 0:153: '' : function does not return a value: func3
 ERROR: 0:169: 'format' : image formats must match 
 ERROR: 0:170: 'coherent' : argument cannot drop memory qualifier when passed to formal parameter 
 ERROR: 0:170: 'format' : image formats must match 
-ERROR: 34 compilation errors.  No code generated.
+ERROR: 35 compilation errors.  No code generated.
 
 
 Shader version: 430
@@ -297,7 +298,7 @@ ERROR: node is still EOpNull!
 0:?     'b2' (layout( binding=2) uniform atomic_uint)
 0:?     'c2' (layout( binding=3) uniform atomic_uint)
 0:?     'd2' (layout( binding=2) uniform atomic_uint)
-0:?     'anon@5' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  flat out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'gl_FrontColor' ( flat in 4-component vector of float)
 0:?     'ColorInv' ( smooth out 3-component vector of float)
 0:?     'Color4' ( invariant centroid smooth out 3-component vector of float)
 0:?     'position' ( noContraction smooth out 4-component vector of float)
@@ -580,7 +581,7 @@ ERROR: node is still EOpNull!
 0:?     'b2' (layout( binding=2) uniform atomic_uint)
 0:?     'c2' (layout( binding=3) uniform atomic_uint)
 0:?     'd2' (layout( binding=2) uniform atomic_uint)
-0:?     'anon@5' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  flat out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'gl_FrontColor' ( flat in 4-component vector of float)
 0:?     'ColorInv' ( smooth out 3-component vector of float)
 0:?     'Color4' ( invariant centroid smooth out 3-component vector of float)
 0:?     'position' ( noContraction smooth out 4-component vector of float)

--- a/Test/baseResults/specExamplesConf.vert.out
+++ b/Test/baseResults/specExamplesConf.vert.out
@@ -25,7 +25,8 @@ ERROR: 0:95: 'binding' : atomic_uint binding is too large; see gl_MaxAtomicCount
 ERROR: 0:96: 'binding' : atomic_uint binding is too large; see gl_MaxAtomicCounterBindings 
 ERROR: 0:97: 'binding' : atomic_uint binding is too large; see gl_MaxAtomicCounterBindings 
 ERROR: 0:106: '' : vertex input cannot be further qualified 
-ERROR: 0:106: 'redeclaration' : cannot change storage, memory, or auxiliary qualification of gl_FrontColor
+ERROR: 0:106: 'gl_FrontColor' : identifiers starting with "gl_" are reserved 
+ERROR: 0:107: 'redeclaration' : cannot change storage, memory, or auxiliary qualification of gl_FrontColor
 ERROR: 0:112: 'ColorIvn' : identifier not previously declared 
 ERROR: 0:132: 'shared' : not supported in this stage: vertex
 ERROR: 0:134: '' : function does not return a value: funcA
@@ -34,7 +35,7 @@ ERROR: 0:153: '' : function does not return a value: func3
 ERROR: 0:169: 'format' : image formats must match 
 ERROR: 0:170: 'coherent' : argument cannot drop memory qualifier when passed to formal parameter 
 ERROR: 0:170: 'format' : image formats must match 
-ERROR: 35 compilation errors.  No code generated.
+ERROR: 36 compilation errors.  No code generated.
 
 
 Shader version: 430
@@ -298,7 +299,7 @@ ERROR: node is still EOpNull!
 0:?     'b2' (layout( binding=2) uniform atomic_uint)
 0:?     'c2' (layout( binding=3) uniform atomic_uint)
 0:?     'd2' (layout( binding=2) uniform atomic_uint)
-0:?     'anon@5' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  flat out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'gl_FrontColor' ( flat in 4-component vector of float)
 0:?     'ColorInv' ( smooth out 3-component vector of float)
 0:?     'Color4' ( invariant centroid smooth out 3-component vector of float)
 0:?     'position' ( noContraction smooth out 4-component vector of float)
@@ -581,7 +582,7 @@ ERROR: node is still EOpNull!
 0:?     'b2' (layout( binding=2) uniform atomic_uint)
 0:?     'c2' (layout( binding=3) uniform atomic_uint)
 0:?     'd2' (layout( binding=2) uniform atomic_uint)
-0:?     'anon@5' ( out block{ invariant gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  flat out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'gl_FrontColor' ( flat in 4-component vector of float)
 0:?     'ColorInv' ( smooth out 3-component vector of float)
 0:?     'Color4' ( invariant centroid smooth out 3-component vector of float)
 0:?     'position' ( noContraction smooth out 4-component vector of float)

--- a/Test/baseResults/versionsErrors.vert.out
+++ b/Test/baseResults/versionsErrors.vert.out
@@ -13,7 +13,7 @@ ERROR: node is still EOpNull!
 0:44    Sequence
 0:44      move second child to first child ( temp 4-component vector of float)
 0:44        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
-0:44          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:44          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance})
 0:44          Constant:
 0:44            0 (const uint)
 0:44        Construct vec4 ( temp 4-component vector of float)
@@ -24,7 +24,7 @@ ERROR: node is still EOpNull!
 0:?   Linker Objects
 0:?     'color' ( in 3-component vector of float)
 0:?     'foo' ( uniform sampler2DRect)
-0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out unsized 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance})
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 
@@ -40,7 +40,7 @@ ERROR: node is still EOpNull!
 0:44    Sequence
 0:44      move second child to first child ( temp 4-component vector of float)
 0:44        gl_Position: direct index for structure ( gl_Position 4-component vector of float Position)
-0:44          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:44          'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance})
 0:44          Constant:
 0:44            0 (const uint)
 0:44        Construct vec4 ( temp 4-component vector of float)
@@ -51,7 +51,7 @@ ERROR: node is still EOpNull!
 0:?   Linker Objects
 0:?     'color' ( in 3-component vector of float)
 0:?     'foo' ( uniform sampler2DRect)
-0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  gl_ClipVertex 4-component vector of float ClipVertex gl_ClipVertex,  out 4-component vector of float FrontColor gl_FrontColor,  out 4-component vector of float BackColor gl_BackColor,  out 4-component vector of float FrontSecondaryColor gl_FrontSecondaryColor,  out 4-component vector of float BackSecondaryColor gl_BackSecondaryColor,  out 1-element array of 4-component vector of float TexCoord gl_TexCoord,  out float FogFragCoord gl_FogFragCoord})
+0:?     'anon@0' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance})
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -483,7 +483,8 @@ void TBuiltIns::relateTabledBuiltins(int /* version */, EProfile /* profile */, 
 
 inline bool IncludeLegacy(int version, EProfile profile, const SpvVersion& spvVersion)
 {
-    return profile != EEsProfile && (version <= 130 || (spvVersion.spv == 0 && ARBCompatibility) || profile == ECompatibilityProfile);
+    return profile != EEsProfile && (version <= 130 || (spvVersion.spv == 0 && version == 140 && ARBCompatibility) ||
+           profile == ECompatibilityProfile);
 }
 
 // Construct TBuiltInParseables base class.  This can be used for language-common constructs.
@@ -7278,7 +7279,8 @@ void TBuiltIns::initialize(const TBuiltInResource &resources, int version, EProf
         snprintf(builtInConstant, maxSize, "const int  gl_MaxVertexUniformComponents = %d;", resources.maxVertexUniformComponents);
         s.append(builtInConstant);
 
-        if (version < 150 || ARBCompatibility) {
+        // Moved from just being deprecated into compatibility profile only as of 4.20
+        if (version < 420 || profile == ECompatibilityProfile) {
             snprintf(builtInConstant, maxSize, "const int  gl_MaxVaryingFloats = %d;", resources.maxVaryingFloats);
             s.append(builtInConstant);
         }


### PR DESCRIPTION
avoid declaring them in GLSL 1.50+ if core profile is chosen by the version statement

fixes #2663

It seems like the ARBCompatibility variable is meant to act as if the hosting GL context was created with WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB. However I think this should only be inherited into the GLSL compiler for GLSL 1.40. 1.50+ should use what is declared by the #version statement. 

For the test cases that were changed, here are my thoughts:

430scope.vert
cppSimple.vert
link.multiAnonBlocksInvalid.0.0.vert
link.multiAnonBlocksValid.0.0.vert
link.multiBlocksInvalid.0.0.vert
link.multiBlocksValid.1.0.vert
versionsErrors.vert:
New output seems correct, the variables are just no longer declared:

150.vert:
core profile - gl_ClipVertex shouldn't be declared, new error is correct.

150.frag:
not sure why we lost an error message here, seem like the extra error was superfluous anyways.

400.frag:
core profile - gl_Color shouldn't even exist, previous redeclaration error makes no sense.

450.vert:
not sure about this one.

specExamples.frag:
specExamples.vert:
I don't see why was these were considered valid code. They are both core profile, so using the deprecated variables should have been an error.
