### PR TITLE
Fix SPIR-V remapper not remapping OpExtInst instruction set IDs

### DIFF
--- a/SPIRV/SPVRemapper.cpp
+++ b/SPIRV/SPVRemapper.cpp
@@ -544,6 +544,9 @@ namespace spv {
         // Extended instructions: currently, assume everything is an ID.
         // TODO: add whatever data we need for exceptions to that
         if (opCode == spv::OpExtInst) {
+
+            idFn(asId(word)); // Instruction set is an ID that also needs to be mapped
+
             word        += 2; // instruction set, and instruction from set
             numOperands -= 2;
 


### PR DESCRIPTION
SPIR-V Remapper doesn't properly remap the instruction set ID, instead it'll just jump over it. This can be easily triggered by a shader that uses debug printf and then running SPIR-V remapper with `MAP_FUNCS`. This change simply calls the ID function on the instruction set ID as well, then jumps over the known literal.