### PR TITLE
Remove unused variable Num_string_literal_EXTs

### DIFF
--- a/glslang/MachineIndependent/preprocessor/PpScanner.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpScanner.cpp
@@ -1192,7 +1192,6 @@ int TPpContext::tokenize(TPpToken& ppToken)
             // GLSL allows string literals with GL_EXT_debug_printf.
             if (ifdepth == 0 && parseContext.intermediate.getSource() != EShSourceHlsl) {
               const char* const string_literal_EXTs[] = { E_GL_EXT_debug_printf, E_GL_EXT_spirv_intrinsics };
-              const int Num_string_literal_EXTs = sizeof(string_literal_EXTs) / sizeof(string_literal_EXTs[0]);
               parseContext.requireExtensions(ppToken.loc, 2, string_literal_EXTs, "string literal");
               if (!parseContext.extensionTurnedOn(E_GL_EXT_debug_printf) &&
                   !parseContext.extensionTurnedOn(E_GL_EXT_spirv_intrinsics))


### PR DESCRIPTION
Remove an unused variable that causes build failures in downstream
repository.