### PR TITLE
allow textureLod for sampler2DShadow

### DIFF
--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -6601,8 +6601,6 @@ void TBuiltIns::addSamplingFunctions(TSampler sampler, const TString& typeName, 
 
             if (lod && (sampler.isBuffer() || sampler.isRect() || sampler.isMultiSample() || !sampler.isCombined()))
                 continue;
-            if (lod && sampler.dim == Esd2D && sampler.arrayed && sampler.shadow)
-                continue;
             if (lod && sampler.dim == EsdCube && sampler.shadow)
                 continue;
 


### PR DESCRIPTION
it is perfectly supported in spirv tools and everywhere, it is just not parsed by glslang