### PR TITLE
fix error message for vertex struct input

### DIFF
--- a/Test/baseResults/300layout.vert.out
+++ b/Test/baseResults/300layout.vert.out
@@ -1,6 +1,6 @@
 300layout.vert
 ERROR: 0:7: 'vertex input arrays' : not supported with this profile: es
-ERROR: 0:8: 'in' : cannot be a structure or array 
+ERROR: 0:8: 'in' : cannot be a structure 
 ERROR: 0:8: 's' : A structure containing an array is not allowed as input in ES 
 ERROR: 0:8: 'vertex input arrays' : not supported with this profile: es
 ERROR: 0:8: 'location' : overlapping use of location 10

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -4013,7 +4013,7 @@ void TParseContext::globalQualifierTypeCheck(const TSourceLoc& loc, const TQuali
         switch (language) {
         case EShLangVertex:
             if (publicType.basicType == EbtStruct) {
-                error(loc, "cannot be a structure or array", GetStorageQualifierString(qualifier.storage), "");
+                error(loc, "cannot be a structure", GetStorageQualifierString(qualifier.storage), "");
                 return;
             }
             if (publicType.arraySizes) {


### PR DESCRIPTION
Vertex shaders can have pipeline inputs that are arrays, but not structure
inputs. (GLSL 4.5 section 4.3.4)

But the error message for struct inputs says "cannot be a structure or array".
This PR removes the "or array" part.

Note: The array case is handled immediately after the check for
structure type.