### PR TITLE
Add support for gl_MaxVaryingVectors for ogl.

### DIFF
--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -7283,6 +7283,9 @@ void TBuiltIns::initialize(const TBuiltInResource &resources, int version, EProf
 
             snprintf(builtInConstant, maxSize, "const int  gl_MaxFragmentUniformVectors = %d;", resources.maxFragmentUniformVectors);
             s.append(builtInConstant);
+
+            snprintf(builtInConstant, maxSize, "const int  gl_MaxVaryingVectors = %d;", resources.maxVaryingVectors);
+            s.append(builtInConstant);
         }
 
         snprintf(builtInConstant, maxSize, "const int  gl_MaxVertexAttribs = %d;", resources.maxVertexAttribs);


### PR DESCRIPTION


```
#version 450
layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
layout(std430) buffer Output {
  int data; 
} g_out;
void main() 
{ 
  g_out.data = gl_MaxVaryingVectors; 
}
```


https://github.com/KhronosGroup/glslang/issues/2682