### PR TITLE
glslang should report a error for Feature: last case/default label not followed by statements'. 

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -9188,10 +9188,13 @@ TIntermNode* TParseContext::addSwitch(const TSourceLoc& loc, TIntermTyped* expre
         // "it is an error to have no statement between a label and the end of the switch statement."
         // The specifications were updated to remove this (being ill-defined what a "statement" was),
         // so, this became a warning.  However, 3.0 tests still check for the error.
-        if (isEsProfile() && version <= 300 && ! relaxedErrors())
+        if (isEsProfile() && (version <= 300 || version >= 320) && ! relaxedErrors())
+            error(loc, "last case/default label not followed by statements", "switch", "");
+        else if (!isEsProfile() && (version <= 430 || version >= 460))
             error(loc, "last case/default label not followed by statements", "switch", "");
         else
             warn(loc, "last case/default label not followed by statements", "switch", "");
+
 
         // emulate a break for error recovery
         lastStatements = intermediate.makeAggregate(intermediate.addBranch(EOpBreak, loc));


### PR DESCRIPTION
the ol430 spec says:
**_Fall through labels are allowed, but it is a compile-time error to have no statement between a label and the end of the switch statement._** 

So if the glsl version <=430 , glslang should report a error for Feature: last case/default label not followed by statements'. 

**shader:**
```
#version 430
precision mediump float;
in highp vec4 dEQP_Position;

void main ()
{
	switch (1)
	{
		case 0: break;
		case 1:
	}
	gl_Position = dEQP_Position;
}
```

**specs:**

[1] https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.30.pdf
[2] https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.40.pdf


