### PR TITLE
Auto push constant blocks

### DIFF
--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -741,6 +741,16 @@ public:
         }
     }
 
+    bool isUniform() const
+    {
+        switch (storage) {
+        case EvqUniform:
+            return true;
+        default:
+            return false;
+        }
+    }
+
     bool isIo() const
     {
         switch (storage) {

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -1648,7 +1648,7 @@ bool TGlslIoMapper::doMap(TIoMapResolver* resolver, TInfoSink& infoSink) {
                     int size, stride;
                     TIntermediate::getBaseAlignment(t, size, stride, autoPushConstantBlockPacking,
                                                     qualifier.layoutMatrix == ElmRowMajor);
-                    if (size <= int(autoPushCosntantMaxSize)) {
+                    if (size <= int(autoPushConstantMaxSize)) {
                         qualifier.setBlockStorage(EbsPushConstant);
                         qualifier.layoutPacking = autoPushConstantBlockPacking;
                         upgraded = true;

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -1633,6 +1633,35 @@ bool TGlslIoMapper::doMap(TIoMapResolver* resolver, TInfoSink& infoSink) {
             return TVarEntryInfo::TOrderByPriority()(p1.second, p2.second);
         });
         resolver->endResolve(EShLangCount);
+        if (autoPushConstantBlockName.length()) {
+            bool upgraded = false;
+            for (size_t stage = 0; stage < EShLangCount; stage++) {
+                if (intermediates[stage] != nullptr) {
+                    TVarLiveMap** pUniformVarMap = uniformResolve.uniformVarMap;
+                    auto at = pUniformVarMap[stage]->find(autoPushConstantBlockName);
+                    if (at == pUniformVarMap[stage]->end())
+                        continue;
+                    TQualifier& qualifier = at->second.symbol->getQualifier();
+                    if (!qualifier.isUniform())
+                        continue;
+                    TType& t = at->second.symbol->getWritableType();
+                    int size, stride;
+                    TIntermediate::getBaseAlignment(t, size, stride, ElpStd140, qualifier.layoutMatrix == ElmRowMajor);
+                    if (size <= int(autoPushCosntantMaxSize)) {
+                        qualifier.setBlockStorage(EbsPushConstant);
+                        upgraded = true;
+                    }
+                }
+            }
+            // If it's been upgraded to push_constant, then remove it from the uniformVector
+            // so it doesn't get a set/binding assigned to it.
+            if (upgraded) {
+                auto at = std::find_if(uniformVector.begin(), uniformVector.end(),
+                                       [this](const TVarLivePair& p) { return p.first == autoPushConstantBlockName; });
+                if (at != uniformVector.end())
+                    uniformVector.erase(at);
+            }
+        }
         for (size_t stage = 0; stage < EShLangCount; stage++) {
             if (intermediates[stage] != nullptr) {
                 // traverse each stage, set new location to each input/output and unifom symbol, set new binding to

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -1646,7 +1646,8 @@ bool TGlslIoMapper::doMap(TIoMapResolver* resolver, TInfoSink& infoSink) {
                         continue;
                     TType& t = at->second.symbol->getWritableType();
                     int size, stride;
-                    TIntermediate::getBaseAlignment(t, size, stride, ElpStd140, qualifier.layoutMatrix == ElmRowMajor);
+                    TIntermediate::getBaseAlignment(t, size, stride, autoPushConstantBlockPacking,
+                                                    qualifier.layoutMatrix == ElmRowMajor);
                     if (size <= int(autoPushCosntantMaxSize)) {
                         qualifier.setBlockStorage(EbsPushConstant);
                         qualifier.layoutPacking = autoPushConstantBlockPacking;

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -1649,6 +1649,7 @@ bool TGlslIoMapper::doMap(TIoMapResolver* resolver, TInfoSink& infoSink) {
                     TIntermediate::getBaseAlignment(t, size, stride, ElpStd140, qualifier.layoutMatrix == ElmRowMajor);
                     if (size <= int(autoPushCosntantMaxSize)) {
                         qualifier.setBlockStorage(EbsPushConstant);
+                        qualifier.layoutPacking = autoPushConstantBlockPacking;
                         upgraded = true;
                     }
                 }

--- a/glslang/MachineIndependent/iomapper.h
+++ b/glslang/MachineIndependent/iomapper.h
@@ -291,7 +291,7 @@ public:
     bool virtual doMap(TIoMapResolver*, TInfoSink&) { return true; }
 };
 
-// I/O mapper for OpenGL
+// I/O mapper for GLSL
 class TGlslIoMapper : public TIoMapper {
 public:
     TGlslIoMapper() {
@@ -301,6 +301,7 @@ public:
         memset(intermediates, 0, sizeof(TIntermediate*) * (EShLangCount + 1));
         profile = ENoProfile;
         version = 0;
+        autoPushCosntantMaxSize = 128;
     }
     virtual ~TGlslIoMapper() {
         for (size_t stage = 0; stage < EShLangCount; stage++) {
@@ -320,6 +321,12 @@ public:
                 intermediates[stage] = nullptr;
         }
     }
+	// If set, the uniform block with the given name will be changed to be backed by
+	// push_constant if it's size is <= maxSize
+    void setAutoPushConstantBlock(const char* name, unsigned int maxSize) {
+        autoPushConstantBlockName = name;
+        autoPushCosntantMaxSize = maxSize;
+    }
     // grow the reflection stage by stage
     bool addStage(EShLanguage, TIntermediate&, TInfoSink&, TIoMapResolver*) override;
     bool doMap(TIoMapResolver*, TInfoSink&) override;
@@ -329,6 +336,10 @@ public:
     bool hadError = false;
     EProfile profile;
     int version;
+
+private:
+    TString autoPushConstantBlockName;
+    unsigned int autoPushCosntantMaxSize;
 };
 
 } // end namespace glslang

--- a/glslang/MachineIndependent/iomapper.h
+++ b/glslang/MachineIndependent/iomapper.h
@@ -302,6 +302,7 @@ public:
         profile = ENoProfile;
         version = 0;
         autoPushCosntantMaxSize = 128;
+        autoPushConstantBlockPacking = ElpStd430;
     }
     virtual ~TGlslIoMapper() {
         for (size_t stage = 0; stage < EShLangCount; stage++) {
@@ -323,9 +324,10 @@ public:
     }
 	// If set, the uniform block with the given name will be changed to be backed by
 	// push_constant if it's size is <= maxSize
-    void setAutoPushConstantBlock(const char* name, unsigned int maxSize) {
+    void setAutoPushConstantBlock(const char* name, unsigned int maxSize, TLayoutPacking packing) {
         autoPushConstantBlockName = name;
         autoPushCosntantMaxSize = maxSize;
+        autoPushConstantBlockPacking = packing;
     }
     // grow the reflection stage by stage
     bool addStage(EShLanguage, TIntermediate&, TInfoSink&, TIoMapResolver*) override;
@@ -340,6 +342,7 @@ public:
 private:
     TString autoPushConstantBlockName;
     unsigned int autoPushCosntantMaxSize;
+    TLayoutPacking autoPushConstantBlockPacking;
 };
 
 } // end namespace glslang

--- a/glslang/MachineIndependent/iomapper.h
+++ b/glslang/MachineIndependent/iomapper.h
@@ -301,7 +301,7 @@ public:
         memset(intermediates, 0, sizeof(TIntermediate*) * (EShLangCount + 1));
         profile = ENoProfile;
         version = 0;
-        autoPushCosntantMaxSize = 128;
+        autoPushConstantMaxSize = 128;
         autoPushConstantBlockPacking = ElpStd430;
     }
     virtual ~TGlslIoMapper() {
@@ -326,7 +326,7 @@ public:
 	// push_constant if it's size is <= maxSize
     void setAutoPushConstantBlock(const char* name, unsigned int maxSize, TLayoutPacking packing) {
         autoPushConstantBlockName = name;
-        autoPushCosntantMaxSize = maxSize;
+        autoPushConstantMaxSize = maxSize;
         autoPushConstantBlockPacking = packing;
     }
     // grow the reflection stage by stage
@@ -341,7 +341,7 @@ public:
 
 private:
     TString autoPushConstantBlockName;
-    unsigned int autoPushCosntantMaxSize;
+    unsigned int autoPushConstantMaxSize;
     TLayoutPacking autoPushConstantBlockPacking;
 };
 

--- a/glslang/MachineIndependent/linkValidate.cpp
+++ b/glslang/MachineIndependent/linkValidate.cpp
@@ -1934,7 +1934,7 @@ int TIntermediate::getBaseAlignment(const TType& type, int& size, int& stride, T
     }
 
     // rule 9
-    if (type.getBasicType() == EbtStruct) {
+    if (type.getBasicType() == EbtStruct || type.getBasicType() == EbtBlock) {
         const TTypeList& memberList = *type.getStruct();
 
         size = 0;


### PR DESCRIPTION
Add ability for the IO remapping to change the backing of a uniform buffer block to push_constant if it fits within a specified maximum size.