### PR TITLE
Skip auto decorating shader record buffer blocks with 'set' and 'binding'.

### DIFF
--- a/Test/baseResults/rayQuery.rgen.out
+++ b/Test/baseResults/rayQuery.rgen.out
@@ -28,8 +28,6 @@ rayQuery.rgen
                               MemberDecorate 26(block) 0 Offset 0
                               MemberDecorate 26(block) 1 Offset 16
                               Decorate 26(block) BufferBlock
-                              Decorate 28 DescriptorSet 0
-                              Decorate 28 Binding 1
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeInt 32 0

--- a/Test/baseResults/spv.RayGenShader.rgen.out
+++ b/Test/baseResults/spv.RayGenShader.rgen.out
@@ -31,8 +31,6 @@ spv.RayGenShader.rgen
                               MemberDecorate 37(block) 0 Offset 0
                               MemberDecorate 37(block) 1 Offset 16
                               Decorate 37(block) BufferBlock
-                              Decorate 39 DescriptorSet 0
-                              Decorate 39 Binding 2
                               Decorate 50(accNV1) DescriptorSet 0
                               Decorate 50(accNV1) Binding 1
                               Decorate 53(payload) Location 0

--- a/Test/baseResults/spv.RayGenShader11.rgen.out
+++ b/Test/baseResults/spv.RayGenShader11.rgen.out
@@ -30,8 +30,6 @@ spv.RayGenShader11.rgen
                               MemberDecorate 37(block) 0 Offset 0
                               MemberDecorate 37(block) 1 Offset 16
                               Decorate 37(block) Block
-                              Decorate 39 DescriptorSet 0
-                              Decorate 39 Binding 1
                               Decorate 52(payload) Location 0
                2:             TypeVoid
                3:             TypeFunction 2

--- a/Test/baseResults/spv.RayGenShaderArray.rgen.out
+++ b/Test/baseResults/spv.RayGenShaderArray.rgen.out
@@ -37,8 +37,6 @@ spv.RayGenShaderArray.rgen
                               MemberDecorate 34(block) 1 Offset 16
                               MemberDecorate 34(block) 2 Offset 28
                               Decorate 34(block) BufferBlock
-                              Decorate 36 DescriptorSet 0
-                              Decorate 36 Binding 2
                               Decorate 60(accNV1) DescriptorSet 0
                               Decorate 60(accNV1) Binding 1
                               Decorate 75 DecorationNonUniformEXT

--- a/Test/baseResults/spv.ext.RayGenSBTlayout.rgen.out
+++ b/Test/baseResults/spv.ext.RayGenSBTlayout.rgen.out
@@ -49,8 +49,6 @@ spv.ext.RayGenSBTlayout.rgen
                               MemberDecorate 36(block) 9 Offset 120
                               MemberDecorate 36(block) 10 Offset 128
                               Decorate 36(block) Block
-                              Decorate 38 DescriptorSet 0
-                              Decorate 38 Binding 0
                               Decorate 60(payload) Location 1
                2:             TypeVoid
                3:             TypeFunction 2

--- a/Test/baseResults/spv.ext.RayGenSBTlayout140.rgen.out
+++ b/Test/baseResults/spv.ext.RayGenSBTlayout140.rgen.out
@@ -49,8 +49,6 @@ spv.ext.RayGenSBTlayout140.rgen
                               MemberDecorate 36(block) 9 Offset 136
                               MemberDecorate 36(block) 10 Offset 144
                               Decorate 36(block) Block
-                              Decorate 38 DescriptorSet 0
-                              Decorate 38 Binding 0
                               Decorate 60(payload) Location 1
                2:             TypeVoid
                3:             TypeFunction 2

--- a/Test/baseResults/spv.ext.RayGenSBTlayout430.rgen.out
+++ b/Test/baseResults/spv.ext.RayGenSBTlayout430.rgen.out
@@ -49,8 +49,6 @@ spv.ext.RayGenSBTlayout430.rgen
                               MemberDecorate 36(block) 9 Offset 120
                               MemberDecorate 36(block) 10 Offset 128
                               Decorate 36(block) Block
-                              Decorate 38 DescriptorSet 0
-                              Decorate 38 Binding 0
                               Decorate 60(payload) Location 1
                2:             TypeVoid
                3:             TypeFunction 2

--- a/Test/baseResults/spv.ext.RayGenSBTlayoutscalar.rgen.out
+++ b/Test/baseResults/spv.ext.RayGenSBTlayoutscalar.rgen.out
@@ -50,8 +50,6 @@ spv.ext.RayGenSBTlayoutscalar.rgen
                               MemberDecorate 36(block) 9 Offset 96
                               MemberDecorate 36(block) 10 Offset 104
                               Decorate 36(block) Block
-                              Decorate 38 DescriptorSet 0
-                              Decorate 38 Binding 0
                               Decorate 60(payload) Location 1
                2:             TypeVoid
                3:             TypeFunction 2

--- a/Test/baseResults/spv.ext.RayGenShader.rgen.out
+++ b/Test/baseResults/spv.ext.RayGenShader.rgen.out
@@ -34,8 +34,6 @@ spv.ext.RayGenShader.rgen
                               MemberDecorate 38(block) 0 Offset 0
                               MemberDecorate 38(block) 1 Offset 16
                               Decorate 38(block) Block
-                              Decorate 40 DescriptorSet 0
-                              Decorate 40 Binding 3
                               Decorate 53(payload) Location 1
                               Decorate 54(accEXT1) DescriptorSet 0
                               Decorate 54(accEXT1) Binding 1

--- a/Test/baseResults/spv.ext.RayGenShader11.rgen.out
+++ b/Test/baseResults/spv.ext.RayGenShader11.rgen.out
@@ -30,8 +30,6 @@ spv.ext.RayGenShader11.rgen
                               MemberDecorate 37(block) 0 Offset 0
                               MemberDecorate 37(block) 1 Offset 16
                               Decorate 37(block) Block
-                              Decorate 39 DescriptorSet 0
-                              Decorate 39 Binding 1
                               Decorate 52(payload) Location 1
                2:             TypeVoid
                3:             TypeFunction 2

--- a/Test/baseResults/spv.ext.RayGenShaderArray.rgen.out
+++ b/Test/baseResults/spv.ext.RayGenShaderArray.rgen.out
@@ -43,8 +43,6 @@ spv.ext.RayGenShaderArray.rgen
                               MemberDecorate 36(block) 3 Offset 32
                               MemberDecorate 36(block) 4 Offset 40
                               Decorate 36(block) Block
-                              Decorate 38 DescriptorSet 0
-                              Decorate 38 Binding 2
                               Decorate 61(payload) Location 1
                               Decorate 65(accEXT1) DescriptorSet 0
                               Decorate 65(accEXT1) Binding 1

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -79,7 +79,7 @@ public:
             target = &inputList;
         else if (base->getQualifier().storage == EvqVaryingOut)
             target = &outputList;
-        else if (base->getQualifier().isUniformOrBuffer() && !base->getQualifier().isPushConstant())
+        else if (base->getQualifier().isUniformOrBuffer() && !base->getQualifier().isPushConstant() && !base->getQualifier().isShaderRecord())
             target = &uniformList;
         // If a global is being visited, then we should also traverse it incase it's evaluation
         // ends up visiting inputs we want to tag as live


### PR DESCRIPTION
Fixes for spec issue : https://gitlab.khronos.org/vulkan/vulkan/-/issues/2881