### PR TITLE
Return new allocator for copied containers

### DIFF
--- a/glslang/Include/PoolAlloc.h
+++ b/glslang/Include/PoolAlloc.h
@@ -306,6 +306,8 @@ public:
 
     TPoolAllocator& getAllocator() const { return allocator; }
 
+    pool_allocator select_on_container_copy_construction() const { return pool_allocator{}; }
+
 protected:
     pool_allocator& operator=(const pool_allocator&) { return *this; }
     TPoolAllocator& allocator;


### PR DESCRIPTION
Fix #2760.

Implement the optional function select_on_container_copy_contruction to
return a default-contructed allocator for containers that are
copy-constructed. This gives copy-constructed containers a pool
allocator for the current thead.

There may be a similar problem with the copy contructor which takes
allocators of type "Other" but, in practice, there is only one place
where this is being used and the allocators are always the same. (i.e.
executing from the same thread)