### PR TITLE
Add support for targeting Vulkan 1.2 in the C API

### DIFF
--- a/glslang/CInterface/glslang_c_interface.cpp
+++ b/glslang/CInterface/glslang_c_interface.cpp
@@ -269,6 +269,8 @@ static glslang::EShTargetClientVersion c_shader_client_version(glslang_target_cl
     switch (client_version) {
     case GLSLANG_TARGET_VULKAN_1_1:
         return glslang::EShTargetVulkan_1_1;
+    case GLSLANG_TARGET_VULKAN_1_2:
+        return glslang::EShTargetVulkan_1_2;
     case GLSLANG_TARGET_OPENGL_450:
         return glslang::EShTargetOpenGL_450;
     default:


### PR DESCRIPTION
Currently, setting GLSLANG_TARGET_VULKAN_1_2 means falling back to GLSLANG_TARGET_VULKAN_1_0.