### PR TITLE
Revert port GL_EXT_shader_realtime_clock to GL_EXT_spirv_intrinsics

### DIFF
--- a/glslang/ExtensionHeaders/GL_EXT_shader_realtime_clock.glsl
+++ b/glslang/ExtensionHeaders/GL_EXT_shader_realtime_clock.glsl
@@ -36,19 +36,3 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //
 
-#extension GL_EXT_spirv_intrinsics : enable
-#extension GL_ARB_gpu_shader_int64 : enable
-
-uvec2 clockRealtime2x32EXT(void) {
-    spirv_instruction (extensions = ["SPV_KHR_shader_clock"], capabilities = [5055], id = 5056)
-    uvec2 clockRealtime2x32EXT_internal(uint scope);
-    
-    return clockRealtime2x32EXT_internal(1 /*Device scope*/);
-}
-
-uint64_t clockRealtimeEXT(void) {
-    spirv_instruction (extensions = ["SPV_KHR_shader_clock"], capabilities = [5055], id = 5056)
-    uint64_t clockRealtimeEXT_internal(uint scope);
-    
-    return clockRealtimeEXT_internal(1 /*Device scope*/);
-}

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -4553,11 +4553,13 @@ void TBuiltIns::initialize(int version, EProfile profile, const SpvVersion& spvV
             "\n");
     }
 
-    // GL_ARB_shader_clock
+    // GL_ARB_shader_clock& GL_EXT_shader_realtime_clock
     if (profile != EEsProfile && version >= 450) {
         commonBuiltins.append(
             "uvec2 clock2x32ARB();"
             "uint64_t clockARB();"
+            "uvec2 clockRealtime2x32EXT();"
+            "uint64_t clockRealtimeEXT();"
             "\n");
     }
 
@@ -8323,6 +8325,9 @@ void TBuiltIns::identifyBuiltIns(int version, EProfile profile, const SpvVersion
 
         symbolTable.setFunctionExtensions("clockARB",     1, &E_GL_ARB_shader_clock);
         symbolTable.setFunctionExtensions("clock2x32ARB", 1, &E_GL_ARB_shader_clock);
+
+        symbolTable.setFunctionExtensions("clockRealtimeEXT", 1, &E_GL_EXT_shader_realtime_clock);
+        symbolTable.setFunctionExtensions("clockRealtime2x32EXT", 1, &E_GL_EXT_shader_realtime_clock);
 
         if (profile == EEsProfile && version < 320) {
             symbolTable.setVariableExtensions("gl_PrimitiveID",  Num_AEP_geometry_shader, AEP_geometry_shader);


### PR DESCRIPTION
It was not visable via glslang library interface. Blocking SDK build.