### PR TITLE
TIntermediate::promoteConstantUnion(): fix conversion to int8

### DIFF
--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -3902,7 +3902,7 @@ TIntermTyped* TIntermediate::promoteConstantUnion(TBasicType promoteTo, TIntermC
         case EbtFloat16: PROMOTE(setDConst, double, Get); break; \
         case EbtFloat: PROMOTE(setDConst, double, Get); break; \
         case EbtDouble: PROMOTE(setDConst, double, Get); break; \
-        case EbtInt8: PROMOTE(setI8Const, char, Get); break; \
+        case EbtInt8: PROMOTE(setI8Const, signed char, Get); break; \
         case EbtInt16: PROMOTE(setI16Const, short, Get); break; \
         case EbtInt: PROMOTE(setIConst, int, Get); break; \
         case EbtInt64: PROMOTE(setI64Const, long long, Get); break; \


### PR DESCRIPTION
The signedness of type char is implementation-defined in C++. The conversion to (signed) int8 currently uses a cast to char, which is undefined for negative values when the type char is implemented as unsigned (e.g., on s390x). Thus, fix to cast to "signed char", which has the intended semantic on all implementations.

Fixes #2807

Tested on Linux on s390x and x86-64 and Windows on x86-64.