### PR TITLE
Added GLSL version override functionality and CLI

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -1261,6 +1261,8 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
             shader->setSourceEntryPoint(sourceEntryPointName);
         }
 
+        shader->setOverrideVersion(GlslVersion);
+
         std::string intrinsicString = getIntrinsic(compUnit.text, compUnit.count);
 
         PreambleString = "";
@@ -1362,7 +1364,7 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
 #ifndef GLSLANG_WEB
         if (Options & EOptionOutputPreprocessed) {
             std::string str;
-            if (shader->preprocess(&Resources, defaultVersion, ENoProfile, false, GlslVersion, false, messages, &str, includer)) {
+            if (shader->preprocess(&Resources, defaultVersion, ENoProfile, false, false, messages, &str, includer)) {
                 PutsIfNonEmpty(str.c_str());
             } else {
                 CompileFailed = true;
@@ -1373,7 +1375,7 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
         }
 #endif
 
-        if (! shader->parse(&Resources, defaultVersion, GlslVersion, false, messages, includer))
+        if (! shader->parse(&Resources, defaultVersion, false, messages, includer))
             CompileFailed = true;
 
         program.addShader(shader);

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -191,6 +191,9 @@ glslang::EShTargetClientVersion ClientVersion;       // not valid until Client i
 glslang::EShTargetLanguage TargetLanguage = glslang::EShTargetNone;
 glslang::EShTargetLanguageVersion TargetVersion;     // not valid until TargetLanguage is set
 
+// GLSL version
+int GlslVersion = 0; // GLSL version specified on CLI, overrides #version in shader source
+
 std::vector<std::string> Processes;                     // what should be recorded by OpModuleProcessed, or equivalent
 
 // Per descriptor-set binding base data
@@ -653,6 +656,48 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
                                lowerword == "flatten-uniform-array"  ||
                                lowerword == "fua") {
                         Options |= EOptionFlattenUniformArrays;
+                    } else if (lowerword == "glsl-version") {
+                        if (argc > 1) {
+                            if (strcmp(argv[1], "100") == 0) {
+                                GlslVersion = 100;
+                            } else if (strcmp(argv[1], "110") == 0) {
+                                GlslVersion = 110;
+                            } else if (strcmp(argv[1], "120") == 0) {
+                                GlslVersion = 120;
+                            } else if (strcmp(argv[1], "130") == 0) {
+                                GlslVersion = 130;
+                            } else if (strcmp(argv[1], "140") == 0) {
+                                GlslVersion = 140;
+                            } else if (strcmp(argv[1], "150") == 0) {
+                                GlslVersion = 150;
+                            } else if (strcmp(argv[1], "300es") == 0) {
+                                GlslVersion = 300;
+                            } else if (strcmp(argv[1], "310es") == 0) {
+                                GlslVersion = 310;
+                            } else if (strcmp(argv[1], "320es") == 0) {
+                                GlslVersion = 320;
+                            } else if (strcmp(argv[1], "330") == 0) {
+                                GlslVersion = 330;
+                            } else if (strcmp(argv[1], "400") == 0) {
+                                GlslVersion = 400;
+                            } else if (strcmp(argv[1], "410") == 0) {
+                                GlslVersion = 410;
+                            } else if (strcmp(argv[1], "420") == 0) {
+                                GlslVersion = 420;
+                            } else if (strcmp(argv[1], "430") == 0) {
+                                GlslVersion = 430;
+                            } else if (strcmp(argv[1], "440") == 0) {
+                                GlslVersion = 440;
+                            } else if (strcmp(argv[1], "450") == 0) {
+                                GlslVersion = 450;
+                            } else if (strcmp(argv[1], "460") == 0) {
+                                GlslVersion = 460;
+                            } else
+                                Error("--glsl-version expected one of: 100, 110, 120, 130, 140, 150,\n"
+                                      "300es, 310es, 320es, 330\n"
+                                      "400, 410, 420, 430, 440, 450, 460");
+                        }
+                        bumpArg();
                     } else if (lowerword == "hlsl-offsets") {
                         Options |= EOptionHlslOffsets;
                     } else if (lowerword == "hlsl-iomap" ||
@@ -1317,7 +1362,7 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
 #ifndef GLSLANG_WEB
         if (Options & EOptionOutputPreprocessed) {
             std::string str;
-            if (shader->preprocess(&Resources, defaultVersion, ENoProfile, false, false, messages, &str, includer)) {
+            if (shader->preprocess(&Resources, defaultVersion, ENoProfile, false, GlslVersion, false, messages, &str, includer)) {
                 PutsIfNonEmpty(str.c_str());
             } else {
                 CompileFailed = true;
@@ -1328,7 +1373,7 @@ void CompileAndLinkShaderUnits(std::vector<ShaderCompUnit> compUnits)
         }
 #endif
 
-        if (! shader->parse(&Resources, defaultVersion, false, messages, includer))
+        if (! shader->parse(&Resources, defaultVersion, GlslVersion, false, messages, includer))
             CompileFailed = true;
 
         program.addShader(shader);
@@ -1850,6 +1895,11 @@ void usage()
            "  -dumpfullversion | -dumpversion   print bare major.minor.patchlevel\n"
            "  --flatten-uniform-arrays | --fua  flatten uniform texture/sampler arrays to\n"
            "                                    scalars\n"
+           "  --glsl-version {100 | 110 | 120 | 130 | 140 | 150 |\n"
+           "                300es | 310es | 320es | 330\n"
+           "                400 | 410 | 420 | 430 | 440 | 450 | 460}\n"
+           "                                    set GLSL version, overrides #version\n"
+           "                                    in shader sourcen\n"
            "  --hlsl-offsets                    allow block offsets to follow HLSL rules\n"
            "                                    works independently of source language\n"
            "  --hlsl-iomap                      perform IO mapping in HLSL register space\n"

--- a/Test/baseResults/glsl.versionOverride.comp.out
+++ b/Test/baseResults/glsl.versionOverride.comp.out
@@ -1,0 +1,1 @@
+glsl.versionOverride.comp

--- a/Test/baseResults/glsl.versionOverride.frag.out
+++ b/Test/baseResults/glsl.versionOverride.frag.out
@@ -1,0 +1,1 @@
+glsl.versionOverride.frag

--- a/Test/baseResults/glsl.versionOverride.geom.out
+++ b/Test/baseResults/glsl.versionOverride.geom.out
@@ -1,0 +1,1 @@
+glsl.versionOverride.geom

--- a/Test/baseResults/glsl.versionOverride.tesc.out
+++ b/Test/baseResults/glsl.versionOverride.tesc.out
@@ -1,0 +1,1 @@
+glsl.versionOverride.tesc

--- a/Test/baseResults/glsl.versionOverride.tese.out
+++ b/Test/baseResults/glsl.versionOverride.tese.out
@@ -1,0 +1,1 @@
+glsl.versionOverride.tese

--- a/Test/baseResults/glsl.versionOverride.vert.out
+++ b/Test/baseResults/glsl.versionOverride.vert.out
@@ -1,0 +1,1 @@
+glsl.versionOverride.vert

--- a/Test/glsl.versionOverride.comp
+++ b/Test/glsl.versionOverride.comp
@@ -4,7 +4,7 @@ glslangValidator.exe --glsl-version 460 -V -S comp -o glsl.versionOverride.comp.
 
 */
 
-#version 330
+#version 110
 
 void main() 
 {

--- a/Test/glsl.versionOverride.comp
+++ b/Test/glsl.versionOverride.comp
@@ -1,0 +1,11 @@
+/*
+
+glslangValidator.exe --glsl-version 460 -V -S comp -o glsl.versionOverride.comp.out glsl.versionOverride.comp
+
+*/
+
+#version 330
+
+void main() 
+{
+}  

--- a/Test/glsl.versionOverride.frag
+++ b/Test/glsl.versionOverride.frag
@@ -4,7 +4,7 @@ glslangValidator.exe --glsl-version 420 -V -S frag -o glsl.versionOverride.frag.
 
 */
 
-#version 330
+#version 110
 
 void main()
 {

--- a/Test/glsl.versionOverride.frag
+++ b/Test/glsl.versionOverride.frag
@@ -1,0 +1,11 @@
+/*
+
+glslangValidator.exe --glsl-version 420 -V -S frag -o glsl.versionOverride.frag.out glsl.versionOverride.frag
+
+*/
+
+#version 330
+
+void main()
+{
+}

--- a/Test/glsl.versionOverride.geom
+++ b/Test/glsl.versionOverride.geom
@@ -4,7 +4,7 @@ glslangValidator.exe --glsl-version 430 -V -S geom -o glsl.versionOverride.geom.
 
 */
 
-#version 330
+#version 110
 
 layout (points) in;
 layout (line_strip, max_vertices = 2) out;

--- a/Test/glsl.versionOverride.geom
+++ b/Test/glsl.versionOverride.geom
@@ -1,0 +1,16 @@
+/*
+
+glslangValidator.exe --glsl-version 430 -V -S geom -o glsl.versionOverride.geom.out glsl.versionOverride.geom
+
+*/
+
+#version 330
+
+layout (points) in;
+layout (line_strip, max_vertices = 2) out;
+
+void main() {    
+    EmitVertex();
+    EmitVertex();   
+    EndPrimitive();
+}  

--- a/Test/glsl.versionOverride.tesc
+++ b/Test/glsl.versionOverride.tesc
@@ -4,7 +4,7 @@ glslangValidator.exe --glsl-version 440 -V -S tesc -o glsl.versionOverride.tesc.
 
 */
 
-#version 330
+#version 110
 
 layout(vertices = 3) out;
 

--- a/Test/glsl.versionOverride.tesc
+++ b/Test/glsl.versionOverride.tesc
@@ -1,0 +1,13 @@
+/*
+
+glslangValidator.exe --glsl-version 440 -V -S tesc -o glsl.versionOverride.tesc.out glsl.versionOverride.tesc
+
+*/
+
+#version 330
+
+layout(vertices = 3) out;
+
+void main() 
+{
+}  

--- a/Test/glsl.versionOverride.tese
+++ b/Test/glsl.versionOverride.tese
@@ -4,7 +4,7 @@ glslangValidator.exe --glsl-version 450 -V -S tese -o glsl.versionOverride.tese.
 
 */
 
-#version 330
+#version 110
 
 layout(triangles) in;
 

--- a/Test/glsl.versionOverride.tese
+++ b/Test/glsl.versionOverride.tese
@@ -1,0 +1,13 @@
+/*
+
+glslangValidator.exe --glsl-version 450 -V -S tese -o glsl.versionOverride.tese.out glsl.versionOverride.tese
+
+*/
+
+#version 330
+
+layout(triangles) in;
+
+void main() 
+{
+}  

--- a/Test/glsl.versionOverride.vert
+++ b/Test/glsl.versionOverride.vert
@@ -1,0 +1,11 @@
+/*
+
+glslangValidator.exe --glsl-version 410 -V -S vert -o glsl.versionOverride.vert.out glsl.versionOverride.vert
+
+*/
+
+#version 330
+
+void main()
+{
+}

--- a/Test/glsl.versionOverride.vert
+++ b/Test/glsl.versionOverride.vert
@@ -4,7 +4,7 @@ glslangValidator.exe --glsl-version 410 -V -S vert -o glsl.versionOverride.vert.
 
 */
 
-#version 330
+#version 110
 
 void main()
 {

--- a/Test/runtests
+++ b/Test/runtests
@@ -298,6 +298,22 @@ diff -b $BASEDIR/hlsl.autosampledtextures.frag.out $TARGETDIR/hlsl.autosampledte
 run --auto-sampled-textures -H -Od -S frag glsl.autosampledtextures.frag > $TARGETDIR/glsl.autosampledtextures.frag.out
 diff -b $BASEDIR/glsl.autosampledtextures.frag.out $TARGETDIR/glsl.autosampledtextures.frag.out || HASERROR=1
 
+# Test --glsl-version
+#
+echo "Testing --glsl-version"
+run --glsl-version 410 -V -S vert glsl.versionOverride.vert > $TARGETDIR/glsl.versionOverride.vert.out
+diff -b $BASEDIR/glsl.versionOverride.vert.out $TARGETDIR/glsl.versionOverride.vert.out || HASERROR=1
+run --glsl-version 420 -V -S frag glsl.versionOverride.frag > $TARGETDIR/glsl.versionOverride.frag.out
+diff -b $BASEDIR/glsl.versionOverride.frag.out $TARGETDIR/glsl.versionOverride.frag.out || HASERROR=1
+run --glsl-version 430 -V -S geom glsl.versionOverride.geom > $TARGETDIR/glsl.versionOverride.geom.out
+diff -b $BASEDIR/glsl.versionOverride.geom.out $TARGETDIR/glsl.versionOverride.geom.out || HASERROR=1
+run --glsl-version 440 -V -S tesc glsl.versionOverride.tesc > $TARGETDIR/glsl.versionOverride.tesc.out
+diff -b $BASEDIR/glsl.versionOverride.tesc.out $TARGETDIR/glsl.versionOverride.tesc.out || HASERROR=1
+run --glsl-version 450 -V -S tese glsl.versionOverride.tese > $TARGETDIR/glsl.versionOverride.tese.out
+diff -b $BASEDIR/glsl.versionOverride.tese.out $TARGETDIR/glsl.versionOverride.tese.out || HASERROR=1
+run --glsl-version 460 -V -S comp glsl.versionOverride.comp > $TARGETDIR/glsl.versionOverride.comp.out
+diff -b $BASEDIR/glsl.versionOverride.comp.out $TARGETDIR/glsl.versionOverride.comp.out || HASERROR=1
+
 #
 # Final checking
 #

--- a/glslang/CInterface/glslang_c_interface.cpp
+++ b/glslang/CInterface/glslang_c_interface.cpp
@@ -57,6 +57,7 @@ static_assert(sizeof(glslang_resource_t) == sizeof(TBuiltInResource), "");
 typedef struct glslang_shader_s {
     glslang::TShader* shader;
     std::string preprocessedGLSL;
+    int glslVersion;
 } glslang_shader_t;
 
 typedef struct glslang_program_s {
@@ -373,7 +374,11 @@ GLSLANG_EXPORT void glslang_shader_set_options(glslang_shader_t* shader, int opt
     if (options & GLSLANG_SHADER_VULKAN_RULES_RELAXED) {
         shader->shader->setEnvInputVulkanRulesRelaxed();
     }
+}
 
+GLSLANG_EXPORT void glslang_shader_set_glsl_version(glslang_shader_t* shader, int version)
+{
+    shader->glslVersion = version;
 }
 
 GLSLANG_EXPORT const char* glslang_shader_get_preprocessed_code(glslang_shader_t* shader)
@@ -390,6 +395,7 @@ GLSLANG_EXPORT int glslang_shader_preprocess(glslang_shader_t* shader, const gls
         input->default_version,
         c_shader_profile(input->default_profile),
         input->force_default_version_and_profile != 0,
+        shader->glslVersion,
         input->forward_compatible != 0,
         (EShMessages)c_shader_messages(input->messages),
         &shader->preprocessedGLSL,
@@ -405,6 +411,7 @@ GLSLANG_EXPORT int glslang_shader_parse(glslang_shader_t* shader, const glslang_
     return shader->shader->parse(
         reinterpret_cast<const TBuiltInResource*>(input->resource),
         input->default_version,
+        shader->glslVersion,
         input->forward_compatible != 0,
         (EShMessages)c_shader_messages(input->messages)
     );

--- a/glslang/CInterface/glslang_c_interface.cpp
+++ b/glslang/CInterface/glslang_c_interface.cpp
@@ -57,7 +57,6 @@ static_assert(sizeof(glslang_resource_t) == sizeof(TBuiltInResource), "");
 typedef struct glslang_shader_s {
     glslang::TShader* shader;
     std::string preprocessedGLSL;
-    int glslVersion;
 } glslang_shader_t;
 
 typedef struct glslang_program_s {
@@ -378,7 +377,7 @@ GLSLANG_EXPORT void glslang_shader_set_options(glslang_shader_t* shader, int opt
 
 GLSLANG_EXPORT void glslang_shader_set_glsl_version(glslang_shader_t* shader, int version)
 {
-    shader->glslVersion = version;
+    shader->shader->setOverrideVersion(version);
 }
 
 GLSLANG_EXPORT const char* glslang_shader_get_preprocessed_code(glslang_shader_t* shader)
@@ -395,7 +394,6 @@ GLSLANG_EXPORT int glslang_shader_preprocess(glslang_shader_t* shader, const gls
         input->default_version,
         c_shader_profile(input->default_profile),
         input->force_default_version_and_profile != 0,
-        shader->glslVersion,
         input->forward_compatible != 0,
         (EShMessages)c_shader_messages(input->messages),
         &shader->preprocessedGLSL,
@@ -411,7 +409,6 @@ GLSLANG_EXPORT int glslang_shader_parse(glslang_shader_t* shader, const glslang_
     return shader->shader->parse(
         reinterpret_cast<const TBuiltInResource*>(input->resource),
         input->default_version,
-        shader->glslVersion,
         input->forward_compatible != 0,
         (EShMessages)c_shader_messages(input->messages)
     );

--- a/glslang/Include/glslang_c_interface.h
+++ b/glslang/Include/glslang_c_interface.h
@@ -227,6 +227,7 @@ GLSLANG_EXPORT void glslang_shader_delete(glslang_shader_t* shader);
 GLSLANG_EXPORT void glslang_shader_shift_binding(glslang_shader_t* shader, glslang_resource_type_t res, unsigned int base);
 GLSLANG_EXPORT void glslang_shader_shift_binding_for_set(glslang_shader_t* shader, glslang_resource_type_t res, unsigned int base, unsigned int set);
 GLSLANG_EXPORT void glslang_shader_set_options(glslang_shader_t* shader, int options); // glslang_shader_options_t
+GLSLANG_EXPORT void glslang_shader_set_glsl_version(glslang_shader_t* shader, int version);
 GLSLANG_EXPORT int glslang_shader_preprocess(glslang_shader_t* shader, const glslang_input_t* input);
 GLSLANG_EXPORT int glslang_shader_parse(glslang_shader_t* shader, const glslang_input_t* input);
 GLSLANG_EXPORT const char* glslang_shader_get_preprocessed_code(glslang_shader_t* shader);

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1483,7 +1483,6 @@ int ShCompile(
     const TBuiltInResource* resources,
     int /*debugOptions*/,
     int defaultVersion,        // use 100 for ES environment, 110 for desktop
-    int overrideVersion,       // use 0 if not overriding GLSL version
     bool forwardCompatible,    // give errors for use of deprecated features
     EShMessages messages       // warnings/errors/AST; things to print out
     )
@@ -1505,7 +1504,7 @@ int ShCompile(
     TIntermediate intermediate(compiler->getLanguage());
     TShader::ForbidIncluder includer;
     bool success = CompileDeferred(compiler, shaderStrings, numStrings, inputLengths, nullptr,
-                                   "", optLevel, resources, defaultVersion, ENoProfile, false, overrideVersion,
+                                   "", optLevel, resources, defaultVersion, ENoProfile, false, 0,
                                    forwardCompatible, messages, intermediate, includer);
 
     //
@@ -1766,7 +1765,7 @@ public:
 };
 
 TShader::TShader(EShLanguage s)
-    : stage(s), lengths(nullptr), stringNames(nullptr), preamble("")
+    : stage(s), lengths(nullptr), stringNames(nullptr), preamble(""), overrideVersion(0)
 {
     pool = new TPoolAllocator;
     infoSink = new TInfoSink;
@@ -1833,6 +1832,11 @@ void TShader::addProcesses(const std::vector<std::string>& p)
 void  TShader::setUniqueId(unsigned long long id)
 {
     intermediate->setUniqueId(id);
+}
+
+void TShader::setOverrideVersion(int version)
+{
+    overrideVersion = version;
 }
 
 void TShader::setInvertY(bool invert)                   { intermediate->setInvertY(invert); }
@@ -1904,7 +1908,7 @@ void TShader::setFlattenUniformArrays(bool flatten)     { intermediate->setFlatt
 //
 // Returns true for success.
 //
-bool TShader::parse(const TBuiltInResource* builtInResources, int defaultVersion, EProfile defaultProfile, bool forceDefaultVersionAndProfile, int overrideVersion,
+bool TShader::parse(const TBuiltInResource* builtInResources, int defaultVersion, EProfile defaultProfile, bool forceDefaultVersionAndProfile,
                     bool forwardCompatible, EShMessages messages, Includer& includer)
 {
     if (! InitThread())
@@ -1929,7 +1933,7 @@ bool TShader::parse(const TBuiltInResource* builtInResources, int defaultVersion
 // is not an officially supported or fully working path.
 bool TShader::preprocess(const TBuiltInResource* builtInResources,
                          int defaultVersion, EProfile defaultProfile,
-                         bool forceDefaultVersionAndProfile, int overrideVersion,
+                         bool forceDefaultVersionAndProfile,
                          bool forwardCompatible, EShMessages message,
                          std::string* output_string,
                          Includer& includer)

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -334,7 +334,6 @@ GLSLANG_EXPORT int ShCompile(
     const TBuiltInResource *resources,
     int debugOptions,
     int defaultVersion = 110,            // use 100 for ES environment, overridden by #version in shader
-    int overrideVersion = 0,             // overrides #version in GLSL shader, use 0 to disable
     bool forwardCompatible = false,      // give errors for use of deprecated features
     EShMessages messages = EShMsgDefault // warnings and errors
     );
@@ -471,6 +470,7 @@ public:
     GLSLANG_EXPORT void setSourceEntryPoint(const char* sourceEntryPointName);
     GLSLANG_EXPORT void addProcesses(const std::vector<std::string>&);
     GLSLANG_EXPORT void setUniqueId(unsigned long long id);
+    GLSLANG_EXPORT void setOverrideVersion(int version);
 
     // IO resolver binding data: see comments in ShaderLang.cpp
     GLSLANG_EXPORT void setShiftBinding(TResourceType res, unsigned int base);
@@ -648,33 +648,33 @@ public:
 
     GLSLANG_EXPORT bool parse(
         const TBuiltInResource*, int defaultVersion, EProfile defaultProfile,
-        bool forceDefaultVersionAndProfile, int overrideVersion, bool forwardCompatible,
+        bool forceDefaultVersionAndProfile, bool forwardCompatible,
         EShMessages, Includer&);
 
-    bool parse(const TBuiltInResource* res, int defaultVersion, EProfile defaultProfile, bool forceDefaultVersionAndProfile, int overrideVersion,
+    bool parse(const TBuiltInResource* res, int defaultVersion, EProfile defaultProfile, bool forceDefaultVersionAndProfile,
                bool forwardCompatible, EShMessages messages)
     {
         TShader::ForbidIncluder includer;
-        return parse(res, defaultVersion, defaultProfile, forceDefaultVersionAndProfile, overrideVersion, forwardCompatible, messages, includer);
+        return parse(res, defaultVersion, defaultProfile, forceDefaultVersionAndProfile, forwardCompatible, messages, includer);
     }
 
     // Equivalent to parse() without a default profile and without forcing defaults.
-    bool parse(const TBuiltInResource* builtInResources, int defaultVersion, int overrideVersion, bool forwardCompatible, EShMessages messages)
+    bool parse(const TBuiltInResource* builtInResources, int defaultVersion, bool forwardCompatible, EShMessages messages)
     {
-        return parse(builtInResources, defaultVersion, ENoProfile, false, overrideVersion, forwardCompatible, messages);
+        return parse(builtInResources, defaultVersion, ENoProfile, false, forwardCompatible, messages);
     }
 
-    bool parse(const TBuiltInResource* builtInResources, int defaultVersion, int overrideVersion, bool forwardCompatible, EShMessages messages,
+    bool parse(const TBuiltInResource* builtInResources, int defaultVersion, bool forwardCompatible, EShMessages messages,
                Includer& includer)
     {
-        return parse(builtInResources, defaultVersion, ENoProfile, false, overrideVersion, forwardCompatible, messages, includer);
+        return parse(builtInResources, defaultVersion, ENoProfile, false, forwardCompatible, messages, includer);
     }
 
     // NOTE: Doing just preprocessing to obtain a correct preprocessed shader string
     // is not an officially supported or fully working path.
     GLSLANG_EXPORT bool preprocess(
         const TBuiltInResource* builtInResources, int defaultVersion,
-        EProfile defaultProfile, bool forceDefaultVersionAndProfile, int overrideVersion,
+        EProfile defaultProfile, bool forceDefaultVersionAndProfile,
         bool forwardCompatible, EShMessages message, std::string* outputString,
         Includer& includer);
 
@@ -706,6 +706,9 @@ protected:
 
     // a function in the source string can be renamed FROM this TO the name given in setEntryPoint.
     std::string sourceEntryPointName;
+
+    // overrides #version in shader source or default version if #version isn't present
+    int overrideVersion;
 
     TEnvironment environment;
 

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -334,6 +334,7 @@ GLSLANG_EXPORT int ShCompile(
     const TBuiltInResource *resources,
     int debugOptions,
     int defaultVersion = 110,            // use 100 for ES environment, overridden by #version in shader
+    int overrideVersion = 0,             // overrides #version in GLSL shader, use 0 to disable
     bool forwardCompatible = false,      // give errors for use of deprecated features
     EShMessages messages = EShMsgDefault // warnings and errors
     );
@@ -647,33 +648,33 @@ public:
 
     GLSLANG_EXPORT bool parse(
         const TBuiltInResource*, int defaultVersion, EProfile defaultProfile,
-        bool forceDefaultVersionAndProfile, bool forwardCompatible,
+        bool forceDefaultVersionAndProfile, int overrideVersion, bool forwardCompatible,
         EShMessages, Includer&);
 
-    bool parse(const TBuiltInResource* res, int defaultVersion, EProfile defaultProfile, bool forceDefaultVersionAndProfile,
+    bool parse(const TBuiltInResource* res, int defaultVersion, EProfile defaultProfile, bool forceDefaultVersionAndProfile, int overrideVersion,
                bool forwardCompatible, EShMessages messages)
     {
         TShader::ForbidIncluder includer;
-        return parse(res, defaultVersion, defaultProfile, forceDefaultVersionAndProfile, forwardCompatible, messages, includer);
+        return parse(res, defaultVersion, defaultProfile, forceDefaultVersionAndProfile, overrideVersion, forwardCompatible, messages, includer);
     }
 
     // Equivalent to parse() without a default profile and without forcing defaults.
-    bool parse(const TBuiltInResource* builtInResources, int defaultVersion, bool forwardCompatible, EShMessages messages)
+    bool parse(const TBuiltInResource* builtInResources, int defaultVersion, int overrideVersion, bool forwardCompatible, EShMessages messages)
     {
-        return parse(builtInResources, defaultVersion, ENoProfile, false, forwardCompatible, messages);
+        return parse(builtInResources, defaultVersion, ENoProfile, false, overrideVersion, forwardCompatible, messages);
     }
 
-    bool parse(const TBuiltInResource* builtInResources, int defaultVersion, bool forwardCompatible, EShMessages messages,
+    bool parse(const TBuiltInResource* builtInResources, int defaultVersion, int overrideVersion, bool forwardCompatible, EShMessages messages,
                Includer& includer)
     {
-        return parse(builtInResources, defaultVersion, ENoProfile, false, forwardCompatible, messages, includer);
+        return parse(builtInResources, defaultVersion, ENoProfile, false, overrideVersion, forwardCompatible, messages, includer);
     }
 
     // NOTE: Doing just preprocessing to obtain a correct preprocessed shader string
     // is not an officially supported or fully working path.
     GLSLANG_EXPORT bool preprocess(
         const TBuiltInResource* builtInResources, int defaultVersion,
-        EProfile defaultProfile, bool forceDefaultVersionAndProfile,
+        EProfile defaultProfile, bool forceDefaultVersionAndProfile, int overrideVersion,
         bool forwardCompatible, EShMessages message, std::string* outputString,
         Includer& includer);
 

--- a/gtests/TestFixture.h
+++ b/gtests/TestFixture.h
@@ -200,7 +200,7 @@ public:
         if (!entryPointName.empty()) shader->setEntryPoint(entryPointName.c_str());
         return shader->parse(
                 (resources ? resources : &glslang::DefaultTBuiltInResource),
-                defaultVersion, 0, isForwardCompatible, controls);
+                defaultVersion, isForwardCompatible, controls);
     }
 
     // Compiles and links the given source |code| of the given shader
@@ -635,7 +635,7 @@ public:
         glslang::TShader::ForbidIncluder includer;
         const bool success = shader.preprocess(
             &glslang::DefaultTBuiltInResource, defaultVersion, defaultProfile,
-            forceVersionProfile, 0, isForwardCompatible, (EShMessages)(EShMsgOnlyPreprocessor | EShMsgCascadingErrors),
+            forceVersionProfile, isForwardCompatible, (EShMessages)(EShMsgOnlyPreprocessor | EShMsgCascadingErrors),
             &ppShader, includer);
 
         std::string log = shader.getInfoLog();

--- a/gtests/TestFixture.h
+++ b/gtests/TestFixture.h
@@ -200,7 +200,7 @@ public:
         if (!entryPointName.empty()) shader->setEntryPoint(entryPointName.c_str());
         return shader->parse(
                 (resources ? resources : &glslang::DefaultTBuiltInResource),
-                defaultVersion, isForwardCompatible, controls);
+                defaultVersion, 0, isForwardCompatible, controls);
     }
 
     // Compiles and links the given source |code| of the given shader
@@ -635,7 +635,7 @@ public:
         glslang::TShader::ForbidIncluder includer;
         const bool success = shader.preprocess(
             &glslang::DefaultTBuiltInResource, defaultVersion, defaultProfile,
-            forceVersionProfile, isForwardCompatible, (EShMessages)(EShMsgOnlyPreprocessor | EShMsgCascadingErrors),
+            forceVersionProfile, 0, isForwardCompatible, (EShMessages)(EShMsgOnlyPreprocessor | EShMsgCascadingErrors),
             &ppShader, includer);
 
         std::string log = shader.getInfoLog();


### PR DESCRIPTION
PR to address question assekd in ##2850.

This change list allows a user to override the GLSL version from the
command line or through the C and C++ interfaces. This will override the
override happens in ProcessDeferred() before DeduceVersionProfile() so
the process should still error out if the version is insufficient for
the shader code.

- Added --glsl-version <version> to CLI.
- Added parameter to route glslVersion as override version to
  preprocessor and parse functions to C++ interface.
- Updated C interface with function to override GLSL version.