### PR TITLE
EndStreamPrimitive not supported when there is #extension GL_ARB_gpu_shader5

### DIFF
--- a/Test/EndStreamPrimitive.geom
+++ b/Test/EndStreamPrimitive.geom
@@ -1,0 +1,20 @@
+#version 150 core
+#extension GL_ARB_gpu_shader5 : require
+layout(points) in;
+layout(points, max_vertices = 1) out;
+layout(stream=0) out float output1;
+layout(stream=0) out float output2;
+layout(stream=1) out float output3;
+layout(stream=1) out float output4;
+uniform uint stream;
+void main() {
+
+    output1 = 1.0;
+    output2 = 2.0;
+    EmitStreamVertex(0);
+    EndStreamPrimitive(0);
+    output3 = 3.0;
+    output4 = 4.0;
+    EmitStreamVertex(1);
+    EndStreamPrimitive(1);
+}

--- a/Test/baseResults/150.geom.out
+++ b/Test/baseResults/150.geom.out
@@ -2,8 +2,8 @@
 ERROR: 0:15: 'fromVertex' : block instance name redefinition 
 ERROR: 0:19: 'fromVertex' : redefinition 
 ERROR: 0:21: 'fooC' : block instance name redefinition 
-ERROR: 0:29: 'EmitStreamVertex' : no matching overloaded function found 
-ERROR: 0:30: 'EndStreamPrimitive' : no matching overloaded function found 
+ERROR: 0:29: 'if the verison is 150 , the EmitStreamVertex and EndStreamPrimitive only support at extension GL_ARB_gpu_shader5' : required extension not requested: GL_ARB_gpu_shader5
+ERROR: 0:30: 'if the verison is 150 , the EmitStreamVertex and EndStreamPrimitive only support at extension GL_ARB_gpu_shader5' : required extension not requested: GL_ARB_gpu_shader5
 ERROR: 0:44: 'stream' : can only be used on an output 
 ERROR: 0:45: 'stream' : can only be used on an output 
 ERROR: 0:46: 'stream' : can only be used on an output 
@@ -49,10 +49,12 @@ ERROR: node is still EOpNull!
 0:27    Sequence
 0:27      EmitVertex ( global void)
 0:28      EndPrimitive ( global void)
-0:29      Constant:
-0:29        0.000000
-0:30      Constant:
-0:30        0.000000
+0:29      EmitStreamVertex ( global void)
+0:29        Constant:
+0:29          1 (const int)
+0:30      EndStreamPrimitive ( global void)
+0:30        Constant:
+0:30          0 (const int)
 0:32      move second child to first child ( temp 3-component vector of float)
 0:32        color: direct index for structure (layout( stream=0) out 3-component vector of float)
 0:32          'anon@0' (layout( stream=0) out block{layout( stream=0) out 3-component vector of float color})
@@ -190,10 +192,12 @@ ERROR: node is still EOpNull!
 0:27    Sequence
 0:27      EmitVertex ( global void)
 0:28      EndPrimitive ( global void)
-0:29      Constant:
-0:29        0.000000
-0:30      Constant:
-0:30        0.000000
+0:29      EmitStreamVertex ( global void)
+0:29        Constant:
+0:29          1 (const int)
+0:30      EndStreamPrimitive ( global void)
+0:30        Constant:
+0:30          0 (const int)
 0:32      move second child to first child ( temp 3-component vector of float)
 0:32        color: direct index for structure (layout( stream=0) out 3-component vector of float)
 0:32          'anon@0' (layout( stream=0) out block{layout( stream=0) out 3-component vector of float color})

--- a/Test/baseResults/EndStreamPrimitive.geom.out
+++ b/Test/baseResults/EndStreamPrimitive.geom.out
@@ -1,0 +1,97 @@
+EndStreamPrimitive.geom
+WARNING: 0:2: '#extension' : extension is only partially supported: GL_ARB_gpu_shader5
+
+Shader version: 150
+Requested GL_ARB_gpu_shader5
+invocations = -1
+max_vertices = 1
+input primitive = points
+output primitive = points
+0:? Sequence
+0:10  Function Definition: main( ( global void)
+0:10    Function Parameters: 
+0:12    Sequence
+0:12      move second child to first child ( temp float)
+0:12        'output1' (layout( stream=0) out float)
+0:12        Constant:
+0:12          1.000000
+0:13      move second child to first child ( temp float)
+0:13        'output2' (layout( stream=0) out float)
+0:13        Constant:
+0:13          2.000000
+0:14      EmitStreamVertex ( global void)
+0:14        Constant:
+0:14          0 (const int)
+0:15      EndStreamPrimitive ( global void)
+0:15        Constant:
+0:15          0 (const int)
+0:16      move second child to first child ( temp float)
+0:16        'output3' (layout( stream=1) out float)
+0:16        Constant:
+0:16          3.000000
+0:17      move second child to first child ( temp float)
+0:17        'output4' (layout( stream=1) out float)
+0:17        Constant:
+0:17          4.000000
+0:18      EmitStreamVertex ( global void)
+0:18        Constant:
+0:18          1 (const int)
+0:19      EndStreamPrimitive ( global void)
+0:19        Constant:
+0:19          1 (const int)
+0:?   Linker Objects
+0:?     'output1' (layout( stream=0) out float)
+0:?     'output2' (layout( stream=0) out float)
+0:?     'output3' (layout( stream=1) out float)
+0:?     'output4' (layout( stream=1) out float)
+0:?     'stream' ( uniform uint)
+
+
+Linked geometry stage:
+
+
+Shader version: 150
+Requested GL_ARB_gpu_shader5
+invocations = 1
+max_vertices = 1
+input primitive = points
+output primitive = points
+0:? Sequence
+0:10  Function Definition: main( ( global void)
+0:10    Function Parameters: 
+0:12    Sequence
+0:12      move second child to first child ( temp float)
+0:12        'output1' (layout( stream=0) out float)
+0:12        Constant:
+0:12          1.000000
+0:13      move second child to first child ( temp float)
+0:13        'output2' (layout( stream=0) out float)
+0:13        Constant:
+0:13          2.000000
+0:14      EmitStreamVertex ( global void)
+0:14        Constant:
+0:14          0 (const int)
+0:15      EndStreamPrimitive ( global void)
+0:15        Constant:
+0:15          0 (const int)
+0:16      move second child to first child ( temp float)
+0:16        'output3' (layout( stream=1) out float)
+0:16        Constant:
+0:16          3.000000
+0:17      move second child to first child ( temp float)
+0:17        'output4' (layout( stream=1) out float)
+0:17        Constant:
+0:17          4.000000
+0:18      EmitStreamVertex ( global void)
+0:18        Constant:
+0:18          1 (const int)
+0:19      EndStreamPrimitive ( global void)
+0:19        Constant:
+0:19          1 (const int)
+0:?   Linker Objects
+0:?     'output1' (layout( stream=0) out float)
+0:?     'output2' (layout( stream=0) out float)
+0:?     'output3' (layout( stream=1) out float)
+0:?     'output4' (layout( stream=1) out float)
+0:?     'stream' ( uniform uint)
+

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -4270,7 +4270,7 @@ void TBuiltIns::initialize(int version, EProfile profile, const SpvVersion& spvV
         //
         //============================================================================
 
-        if (profile != EEsProfile && version >= 400) {
+        if (profile != EEsProfile && (version >= 400 || version == 150)) {
             stageBuiltins[EShLangGeometry].append(
                 "void EmitStreamVertex(int);"
                 "void EndStreamPrimitive(int);"

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -2495,6 +2495,8 @@ void TParseContext::builtInOpCheck(const TSourceLoc& loc, const TFunction& fnCan
 
     case EOpEmitStreamVertex:
     case EOpEndStreamPrimitive:
+        if (version == 150)
+            requireExtensions(loc, 1, &E_GL_ARB_gpu_shader5, "if the verison is 150 , the EmitStreamVertex and EndStreamPrimitive only support at extension GL_ARB_gpu_shader5");
         intermediate.setMultiStream();
         break;
 

--- a/gtests/AST.FromFile.cpp
+++ b/gtests/AST.FromFile.cpp
@@ -291,6 +291,7 @@ INSTANTIATE_TEST_SUITE_P(
         "GL_ARB_draw_instanced.vert",
         "GL_ARB_fragment_coord_conventions.vert",
         "BestMatchFunction.vert",
+        "EndStreamPrimitive.geom"
     })),
     FileNameAsCustomTestSuffix
 );


### PR DESCRIPTION
Fix the issue https://github.com/KhronosGroup/glslang/issues/2734.


