### PR TITLE
#2861 macos gcc build failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,14 @@ CMAKE_DEPENDENT_OPTION(ENABLE_HLSL
 option(ENABLE_RTTI "Enables RTTI" OFF)
 option(ENABLE_EXCEPTIONS "Enables Exceptions" OFF)
 option(ENABLE_OPT "Enables spirv-opt capability if present" ON)
-option(ENABLE_PCH "Enables Precompiled header" ON)
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+    # Workaround for CMake behavior on Mac OS with gcc, cmake generates -Xarch_* arguments
+    # which gcc rejects
+    option(ENABLE_PCH "Enables Precompiled header" OFF)
+else()
+    option(ENABLE_PCH "Enables Precompiled header" ON)
+endif()
 option(ENABLE_CTEST "Enables testing" ON)
 
 if(ENABLE_GLSLANG_INSTALL AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
         add_compile_options(-Werror=deprecated-copy)
     endif()
 
-    if(NOT CMAKE_VERSION VERSION_LESS "3.13")
+    if(NOT CMAKE_VERSION VERSION_LESS "3.13" AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         # Error if there's symbols that are not found at link time.
         # add_link_options() was added in CMake 3.13 - if using an earlier
         # version don't set this - it should be caught by presubmits anyway.


### PR DESCRIPTION
Closes #2861

This PR adds a few minor changes for building with gcc on Mac OS X. It changes the default for `ENABLE_PCH` to `OFF` for that particular configuration and avoids adding the --no-undefined linker flag since it isn't valid for the default MacOS linker.

I changed the default for ENABLE_PCH rather than disabling entirely so that it would still be configurable and existing builds shouldn't break. However, it should now work out-of-the-box after cloning.