### PR TITLE
Override CMAKE_INSTALL_PREFIX only if ENABLE_GLSLANG_INSTALL is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ option(ENABLE_OPT "Enables spirv-opt capability if present" ON)
 option(ENABLE_PCH "Enables Precompiled header" ON)
 option(ENABLE_CTEST "Enables testing" ON)
 
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND WIN32)
+if(ENABLE_GLSLANG_INSTALL AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND WIN32)
     set(CMAKE_INSTALL_PREFIX "install" CACHE STRING "..." FORCE)
 endif()
 


### PR DESCRIPTION
`CMAKE_INSTALL_PREFIX` variable is only useful when you want to run the CMake "install" target so this variable should only be overridden when it is necessary.

It will prevent issue https://github.com/KhronosGroup/glslang/issues/1015 on projects which include glslang but don't need to install it (using SKIP_GLSLANG_INSTALL) .