### PR TITLE
fix cases where symbols in the tree didn't get updated during block merging

### DIFF
--- a/Test/baseResults/vk.relaxed.stagelink.0.0.vert.out
+++ b/Test/baseResults/vk.relaxed.stagelink.0.0.vert.out
@@ -1,0 +1,10697 @@
+vk.relaxed.stagelink.0.0.vert
+Shader version: 460
+0:? Sequence
+0:11  Function Definition: main( ( global void)
+0:11    Function Parameters: 
+0:15    Sequence
+0:15      Sequence
+0:15        Sequence
+0:15          move second child to first child ( temp highp 3-component vector of float)
+0:15            'texcoord' ( temp highp 3-component vector of float)
+0:15            Function Call: TDInstanceTexCoord(vf3; ( global highp 3-component vector of float)
+0:15              direct index (layout( location=3) temp highp 3-component vector of float)
+0:15                'uv' (layout( location=3) in 8-element array of highp 3-component vector of float)
+0:15                Constant:
+0:15                  0 (const int)
+0:16        move second child to first child ( temp highp 3-component vector of float)
+0:16          vector swizzle ( temp highp 3-component vector of float)
+0:16            texCoord0: direct index for structure ( out highp 3-component vector of float)
+0:16              'oVert' ( out block{ out highp 4-component vector of float color,  out highp 3-component vector of float worldSpacePos,  out highp 3-component vector of float texCoord0,  flat out highp int cameraIndex,  flat out highp int instance})
+0:16              Constant:
+0:16                2 (const int)
+0:16            Sequence
+0:16              Constant:
+0:16                0 (const int)
+0:16              Constant:
+0:16                1 (const int)
+0:16              Constant:
+0:16                2 (const int)
+0:16          vector swizzle ( temp highp 3-component vector of float)
+0:16            'texcoord' ( temp highp 3-component vector of float)
+0:16            Sequence
+0:16              Constant:
+0:16                0 (const int)
+0:16              Constant:
+0:16                1 (const int)
+0:16              Constant:
+0:16                2 (const int)
+0:20      move second child to first child ( temp highp int)
+0:20        instance: direct index for structure ( flat out highp int)
+0:20          'oVert' ( out block{ out highp 4-component vector of float color,  out highp 3-component vector of float worldSpacePos,  out highp 3-component vector of float texCoord0,  flat out highp int cameraIndex,  flat out highp int instance})
+0:20          Constant:
+0:20            4 (const int)
+0:20        Function Call: TDInstanceID( ( global highp int)
+0:21      Sequence
+0:21        move second child to first child ( temp highp 4-component vector of float)
+0:21          'worldSpacePos' ( temp highp 4-component vector of float)
+0:21          Function Call: TDDeform(vf3; ( global highp 4-component vector of float)
+0:21            'P' (layout( location=0) in highp 3-component vector of float)
+0:22      Sequence
+0:22        move second child to first child ( temp highp 3-component vector of float)
+0:22          'uvUnwrapCoord' ( temp highp 3-component vector of float)
+0:22          Function Call: TDInstanceTexCoord(vf3; ( global highp 3-component vector of float)
+0:22            Function Call: TDUVUnwrapCoord( ( global highp 3-component vector of float)
+0:23      move second child to first child ( temp highp 4-component vector of float)
+0:23        gl_Position: direct index for structure ( gl_Position highp 4-component vector of float Position)
+0:23          'anon@4' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  out unsized 1-element array of float CullDistance gl_CullDistance})
+0:23          Constant:
+0:23            0 (const uint)
+0:23        Function Call: TDWorldToProj(vf4;vf3; ( global highp 4-component vector of float)
+0:23          'worldSpacePos' ( temp highp 4-component vector of float)
+0:23          'uvUnwrapCoord' ( temp highp 3-component vector of float)
+0:32      Sequence
+0:32        move second child to first child ( temp highp int)
+0:32          'cameraIndex' ( temp highp int)
+0:32          Function Call: TDCameraIndex( ( global highp int)
+0:33      move second child to first child ( temp highp int)
+0:33        cameraIndex: direct index for structure ( flat out highp int)
+0:33          'oVert' ( out block{ out highp 4-component vector of float color,  out highp 3-component vector of float worldSpacePos,  out highp 3-component vector of float texCoord0,  flat out highp int cameraIndex,  flat out highp int instance})
+0:33          Constant:
+0:33            3 (const int)
+0:33        'cameraIndex' ( temp highp int)
+0:34      move second child to first child ( temp highp 3-component vector of float)
+0:34        vector swizzle ( temp highp 3-component vector of float)
+0:34          worldSpacePos: direct index for structure ( out highp 3-component vector of float)
+0:34            'oVert' ( out block{ out highp 4-component vector of float color,  out highp 3-component vector of float worldSpacePos,  out highp 3-component vector of float texCoord0,  flat out highp int cameraIndex,  flat out highp int instance})
+0:34            Constant:
+0:34              1 (const int)
+0:34          Sequence
+0:34            Constant:
+0:34              0 (const int)
+0:34            Constant:
+0:34              1 (const int)
+0:34            Constant:
+0:34              2 (const int)
+0:34        vector swizzle ( temp highp 3-component vector of float)
+0:34          'worldSpacePos' ( temp highp 4-component vector of float)
+0:34          Sequence
+0:34            Constant:
+0:34              0 (const int)
+0:34            Constant:
+0:34              1 (const int)
+0:34            Constant:
+0:34              2 (const int)
+0:35      move second child to first child ( temp highp 4-component vector of float)
+0:35        color: direct index for structure ( out highp 4-component vector of float)
+0:35          'oVert' ( out block{ out highp 4-component vector of float color,  out highp 3-component vector of float worldSpacePos,  out highp 3-component vector of float texCoord0,  flat out highp int cameraIndex,  flat out highp int instance})
+0:35          Constant:
+0:35            0 (const int)
+0:35        Function Call: TDInstanceColor(vf4; ( global highp 4-component vector of float)
+0:35          'Cd' (layout( location=2) in highp 4-component vector of float)
+0:?   Linker Objects
+0:?     'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:?     'anon@1' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:?     'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 4-component vector of float nearFar,  global highp 4-component vector of float fog,  global highp 4-component vector of float fogColor,  global highp int renderTOPCameraIndex} uTDCamInfos})
+0:?     'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform structure{ global highp 4-component vector of float ambientColor,  global highp 4-component vector of float nearFar,  global highp 4-component vector of float viewport,  global highp 4-component vector of float viewportRes,  global highp 4-component vector of float fog,  global highp 4-component vector of float fogColor} uTDGeneral})
+0:?     'P' (layout( location=0) in highp 3-component vector of float)
+0:?     'N' (layout( location=1) in highp 3-component vector of float)
+0:?     'Cd' (layout( location=2) in highp 4-component vector of float)
+0:?     'uv' (layout( location=3) in 8-element array of highp 3-component vector of float)
+0:?     'oVert' ( out block{ out highp 4-component vector of float color,  out highp 3-component vector of float worldSpacePos,  out highp 3-component vector of float texCoord0,  flat out highp int cameraIndex,  flat out highp int instance})
+0:?     'anon@4' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out unsized 1-element array of float ClipDistance gl_ClipDistance,  out unsized 1-element array of float CullDistance gl_CullDistance})
+0:?     'gl_VertexIndex' ( in int VertexIndex)
+0:?     'gl_InstanceIndex' ( in int InstanceIndex)
+
+vk.relaxed.stagelink.0.1.vert
+Shader version: 460
+0:? Sequence
+0:176  Function Definition: iTDCamToProj(vf4;vf3;i1;b1; ( global highp 4-component vector of float)
+0:176    Function Parameters: 
+0:176      'v' ( in highp 4-component vector of float)
+0:176      'uv' ( in highp 3-component vector of float)
+0:176      'cameraIndex' ( in highp int)
+0:176      'applyPickMod' ( in bool)
+0:178    Sequence
+0:178      Test condition and select ( temp void)
+0:178        Condition
+0:178        Negate conditional ( temp bool)
+0:178          Function Call: TDInstanceActive( ( global bool)
+0:178        true case
+0:179        Branch: Return with expression
+0:179          Constant:
+0:179            2.000000
+0:179            2.000000
+0:179            2.000000
+0:179            0.000000
+0:180      move second child to first child ( temp highp 4-component vector of float)
+0:180        'v' ( in highp 4-component vector of float)
+0:180        matrix-times-vector ( temp highp 4-component vector of float)
+0:180          proj: direct index for structure (layout( column_major std140) global highp 4X4 matrix of float)
+0:180            direct index (layout( column_major std140 offset=0) temp structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:180              uTDMats: direct index for structure (layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:180                'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:180                Constant:
+0:180                  0 (const uint)
+0:180              Constant:
+0:180                0 (const int)
+0:180            Constant:
+0:180              8 (const int)
+0:180          'v' ( in highp 4-component vector of float)
+0:181      Branch: Return with expression
+0:181        'v' ( in highp 4-component vector of float)
+0:183  Function Definition: iTDWorldToProj(vf4;vf3;i1;b1; ( global highp 4-component vector of float)
+0:183    Function Parameters: 
+0:183      'v' ( in highp 4-component vector of float)
+0:183      'uv' ( in highp 3-component vector of float)
+0:183      'cameraIndex' ( in highp int)
+0:183      'applyPickMod' ( in bool)
+0:184    Sequence
+0:184      Test condition and select ( temp void)
+0:184        Condition
+0:184        Negate conditional ( temp bool)
+0:184          Function Call: TDInstanceActive( ( global bool)
+0:184        true case
+0:185        Branch: Return with expression
+0:185          Constant:
+0:185            2.000000
+0:185            2.000000
+0:185            2.000000
+0:185            0.000000
+0:186      move second child to first child ( temp highp 4-component vector of float)
+0:186        'v' ( in highp 4-component vector of float)
+0:186        matrix-times-vector ( temp highp 4-component vector of float)
+0:186          camProj: direct index for structure (layout( column_major std140) global highp 4X4 matrix of float)
+0:186            direct index (layout( column_major std140 offset=0) temp structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:186              uTDMats: direct index for structure (layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:186                'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:186                Constant:
+0:186                  0 (const uint)
+0:186              Constant:
+0:186                0 (const int)
+0:186            Constant:
+0:186              6 (const int)
+0:186          'v' ( in highp 4-component vector of float)
+0:187      Branch: Return with expression
+0:187        'v' ( in highp 4-component vector of float)
+0:193  Function Definition: TDInstanceID( ( global highp int)
+0:193    Function Parameters: 
+0:194    Sequence
+0:194      Branch: Return with expression
+0:194        add ( temp highp int)
+0:194          'gl_InstanceIndex' ( in highp int InstanceIndex)
+0:194          uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:194            'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:194            Constant:
+0:194              0 (const uint)
+0:196  Function Definition: TDCameraIndex( ( global highp int)
+0:196    Function Parameters: 
+0:197    Sequence
+0:197      Branch: Return with expression
+0:197        Constant:
+0:197          0 (const int)
+0:199  Function Definition: TDUVUnwrapCoord( ( global highp 3-component vector of float)
+0:199    Function Parameters: 
+0:200    Sequence
+0:200      Branch: Return with expression
+0:200        direct index (layout( location=3) temp highp 3-component vector of float)
+0:200          'uv' (layout( location=3) in 8-element array of highp 3-component vector of float)
+0:200          Constant:
+0:200            0 (const int)
+0:205  Function Definition: TDPickID( ( global highp int)
+0:205    Function Parameters: 
+0:209    Sequence
+0:209      Branch: Return with expression
+0:209        Constant:
+0:209          0 (const int)
+0:212  Function Definition: iTDConvertPickId(i1; ( global highp float)
+0:212    Function Parameters: 
+0:212      'id' ( in highp int)
+0:213    Sequence
+0:213      or second child into first child ( temp highp int)
+0:213        'id' ( in highp int)
+0:213        Constant:
+0:213          1073741824 (const int)
+0:214      Branch: Return with expression
+0:214        intBitsToFloat ( global highp float)
+0:214          'id' ( in highp int)
+0:217  Function Definition: TDWritePickingValues( ( global void)
+0:217    Function Parameters: 
+0:224  Function Definition: TDWorldToProj(vf4;vf3; ( global highp 4-component vector of float)
+0:224    Function Parameters: 
+0:224      'v' ( in highp 4-component vector of float)
+0:224      'uv' ( in highp 3-component vector of float)
+0:226    Sequence
+0:226      Branch: Return with expression
+0:226        Function Call: iTDWorldToProj(vf4;vf3;i1;b1; ( global highp 4-component vector of float)
+0:226          'v' ( in highp 4-component vector of float)
+0:226          'uv' ( in highp 3-component vector of float)
+0:226          Function Call: TDCameraIndex( ( global highp int)
+0:226          Constant:
+0:226            true (const bool)
+0:228  Function Definition: TDWorldToProj(vf3;vf3; ( global highp 4-component vector of float)
+0:228    Function Parameters: 
+0:228      'v' ( in highp 3-component vector of float)
+0:228      'uv' ( in highp 3-component vector of float)
+0:230    Sequence
+0:230      Branch: Return with expression
+0:230        Function Call: TDWorldToProj(vf4;vf3; ( global highp 4-component vector of float)
+0:230          Construct vec4 ( temp highp 4-component vector of float)
+0:230            'v' ( in highp 3-component vector of float)
+0:230            Constant:
+0:230              1.000000
+0:230          'uv' ( in highp 3-component vector of float)
+0:232  Function Definition: TDWorldToProj(vf4; ( global highp 4-component vector of float)
+0:232    Function Parameters: 
+0:232      'v' ( in highp 4-component vector of float)
+0:234    Sequence
+0:234      Branch: Return with expression
+0:234        Function Call: TDWorldToProj(vf4;vf3; ( global highp 4-component vector of float)
+0:234          'v' ( in highp 4-component vector of float)
+0:234          Constant:
+0:234            0.000000
+0:234            0.000000
+0:234            0.000000
+0:236  Function Definition: TDWorldToProj(vf3; ( global highp 4-component vector of float)
+0:236    Function Parameters: 
+0:236      'v' ( in highp 3-component vector of float)
+0:238    Sequence
+0:238      Branch: Return with expression
+0:238        Function Call: TDWorldToProj(vf4; ( global highp 4-component vector of float)
+0:238          Construct vec4 ( temp highp 4-component vector of float)
+0:238            'v' ( in highp 3-component vector of float)
+0:238            Constant:
+0:238              1.000000
+0:240  Function Definition: TDPointColor( ( global highp 4-component vector of float)
+0:240    Function Parameters: 
+0:241    Sequence
+0:241      Branch: Return with expression
+0:241        'Cd' (layout( location=2) in highp 4-component vector of float)
+0:?   Linker Objects
+0:?     'P' (layout( location=0) in highp 3-component vector of float)
+0:?     'N' (layout( location=1) in highp 3-component vector of float)
+0:?     'Cd' (layout( location=2) in highp 4-component vector of float)
+0:?     'uv' (layout( location=3) in 8-element array of highp 3-component vector of float)
+0:?     'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:?     'anon@1' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 4-component vector of float position,  global highp 3-component vector of float direction,  global highp 3-component vector of float diffuse,  global highp 4-component vector of float nearFar,  global highp 4-component vector of float lightSize,  global highp 4-component vector of float misc,  global highp 4-component vector of float coneLookupScaleBias,  global highp 4-component vector of float attenScaleBiasRoll, layout( column_major std140) global highp 4X4 matrix of float shadowMapMatrix, layout( column_major std140) global highp 4X4 matrix of float shadowMapCamMatrix,  global highp 4-component vector of float shadowMapRes, layout( column_major std140) global highp 4X4 matrix of float projMapMatrix} uTDLights})
+0:?     'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 3-component vector of float color, layout( column_major std140) global highp 3X3 matrix of float rotate} uTDEnvLights})
+0:?     'uTDEnvLightBuffers' (layout( column_major std430) restrict readonly buffer 1-element array of block{layout( column_major std430 offset=0) restrict readonly buffer 9-element array of highp 3-component vector of float shCoeffs})
+0:?     'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:?     'anon@4' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 4-component vector of float nearFar,  global highp 4-component vector of float fog,  global highp 4-component vector of float fogColor,  global highp int renderTOPCameraIndex} uTDCamInfos})
+0:?     'anon@5' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform structure{ global highp 4-component vector of float ambientColor,  global highp 4-component vector of float nearFar,  global highp 4-component vector of float viewport,  global highp 4-component vector of float viewportRes,  global highp 4-component vector of float fog,  global highp 4-component vector of float fogColor} uTDGeneral})
+0:?     'mTD2DImageOutputs' (layout( rgba8) uniform 1-element array of highp image2D)
+0:?     'mTD2DArrayImageOutputs' (layout( rgba8) uniform 1-element array of highp image2DArray)
+0:?     'mTD3DImageOutputs' (layout( rgba8) uniform 1-element array of highp image3D)
+0:?     'mTDCubeImageOutputs' (layout( rgba8) uniform 1-element array of highp imageCube)
+0:?     'gl_VertexIndex' ( in int VertexIndex)
+0:?     'gl_InstanceIndex' ( in int InstanceIndex)
+
+vk.relaxed.stagelink.0.2.vert
+Shader version: 460
+0:? Sequence
+0:114  Function Definition: TDInstanceTexCoord(i1;vf3; ( global highp 3-component vector of float)
+0:114    Function Parameters: 
+0:114      'index' ( in highp int)
+0:114      't' ( in highp 3-component vector of float)
+0:?     Sequence
+0:116      Sequence
+0:116        move second child to first child ( temp highp int)
+0:116          'coord' ( temp highp int)
+0:116          'index' ( in highp int)
+0:117      Sequence
+0:117        move second child to first child ( temp highp 4-component vector of float)
+0:117          'samp' ( temp highp 4-component vector of float)
+0:117          textureFetch ( global highp 4-component vector of float)
+0:117            'sTDInstanceTexCoord' (layout( binding=16) uniform highp samplerBuffer)
+0:117            'coord' ( temp highp int)
+0:118      move second child to first child ( temp highp float)
+0:118        direct index ( temp highp float)
+0:118          'v' ( temp highp 3-component vector of float)
+0:118          Constant:
+0:118            0 (const int)
+0:118        direct index ( temp highp float)
+0:118          't' ( in highp 3-component vector of float)
+0:118          Constant:
+0:118            0 (const int)
+0:119      move second child to first child ( temp highp float)
+0:119        direct index ( temp highp float)
+0:119          'v' ( temp highp 3-component vector of float)
+0:119          Constant:
+0:119            1 (const int)
+0:119        direct index ( temp highp float)
+0:119          't' ( in highp 3-component vector of float)
+0:119          Constant:
+0:119            1 (const int)
+0:120      move second child to first child ( temp highp float)
+0:120        direct index ( temp highp float)
+0:120          'v' ( temp highp 3-component vector of float)
+0:120          Constant:
+0:120            2 (const int)
+0:120        direct index ( temp highp float)
+0:120          'samp' ( temp highp 4-component vector of float)
+0:120          Constant:
+0:120            0 (const int)
+0:121      move second child to first child ( temp highp 3-component vector of float)
+0:121        vector swizzle ( temp highp 3-component vector of float)
+0:121          't' ( in highp 3-component vector of float)
+0:121          Sequence
+0:121            Constant:
+0:121              0 (const int)
+0:121            Constant:
+0:121              1 (const int)
+0:121            Constant:
+0:121              2 (const int)
+0:121        vector swizzle ( temp highp 3-component vector of float)
+0:121          'v' ( temp highp 3-component vector of float)
+0:121          Sequence
+0:121            Constant:
+0:121              0 (const int)
+0:121            Constant:
+0:121              1 (const int)
+0:121            Constant:
+0:121              2 (const int)
+0:122      Branch: Return with expression
+0:122        't' ( in highp 3-component vector of float)
+0:124  Function Definition: TDInstanceActive(i1; ( global bool)
+0:124    Function Parameters: 
+0:124      'index' ( in highp int)
+0:125    Sequence
+0:125      subtract second child into first child ( temp highp int)
+0:125        'index' ( in highp int)
+0:125        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:125          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:125          Constant:
+0:125            0 (const uint)
+0:127      Sequence
+0:127        move second child to first child ( temp highp int)
+0:127          'coord' ( temp highp int)
+0:127          'index' ( in highp int)
+0:128      Sequence
+0:128        move second child to first child ( temp highp 4-component vector of float)
+0:128          'samp' ( temp highp 4-component vector of float)
+0:128          textureFetch ( global highp 4-component vector of float)
+0:128            'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:128            'coord' ( temp highp int)
+0:129      move second child to first child ( temp highp float)
+0:129        'v' ( temp highp float)
+0:129        direct index ( temp highp float)
+0:129          'samp' ( temp highp 4-component vector of float)
+0:129          Constant:
+0:129            0 (const int)
+0:130      Branch: Return with expression
+0:130        Compare Not Equal ( temp bool)
+0:130          'v' ( temp highp float)
+0:130          Constant:
+0:130            0.000000
+0:132  Function Definition: iTDInstanceTranslate(i1;b1; ( global highp 3-component vector of float)
+0:132    Function Parameters: 
+0:132      'index' ( in highp int)
+0:132      'instanceActive' ( out bool)
+0:133    Sequence
+0:133      Sequence
+0:133        move second child to first child ( temp highp int)
+0:133          'origIndex' ( temp highp int)
+0:133          'index' ( in highp int)
+0:134      subtract second child into first child ( temp highp int)
+0:134        'index' ( in highp int)
+0:134        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:134          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:134          Constant:
+0:134            0 (const uint)
+0:136      Sequence
+0:136        move second child to first child ( temp highp int)
+0:136          'coord' ( temp highp int)
+0:136          'index' ( in highp int)
+0:137      Sequence
+0:137        move second child to first child ( temp highp 4-component vector of float)
+0:137          'samp' ( temp highp 4-component vector of float)
+0:137          textureFetch ( global highp 4-component vector of float)
+0:137            'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:137            'coord' ( temp highp int)
+0:138      move second child to first child ( temp highp float)
+0:138        direct index ( temp highp float)
+0:138          'v' ( temp highp 3-component vector of float)
+0:138          Constant:
+0:138            0 (const int)
+0:138        direct index ( temp highp float)
+0:138          'samp' ( temp highp 4-component vector of float)
+0:138          Constant:
+0:138            1 (const int)
+0:139      move second child to first child ( temp highp float)
+0:139        direct index ( temp highp float)
+0:139          'v' ( temp highp 3-component vector of float)
+0:139          Constant:
+0:139            1 (const int)
+0:139        direct index ( temp highp float)
+0:139          'samp' ( temp highp 4-component vector of float)
+0:139          Constant:
+0:139            2 (const int)
+0:140      move second child to first child ( temp highp float)
+0:140        direct index ( temp highp float)
+0:140          'v' ( temp highp 3-component vector of float)
+0:140          Constant:
+0:140            2 (const int)
+0:140        direct index ( temp highp float)
+0:140          'samp' ( temp highp 4-component vector of float)
+0:140          Constant:
+0:140            3 (const int)
+0:141      move second child to first child ( temp bool)
+0:141        'instanceActive' ( out bool)
+0:141        Compare Not Equal ( temp bool)
+0:141          direct index ( temp highp float)
+0:141            'samp' ( temp highp 4-component vector of float)
+0:141            Constant:
+0:141              0 (const int)
+0:141          Constant:
+0:141            0.000000
+0:142      Branch: Return with expression
+0:142        'v' ( temp highp 3-component vector of float)
+0:144  Function Definition: TDInstanceTranslate(i1; ( global highp 3-component vector of float)
+0:144    Function Parameters: 
+0:144      'index' ( in highp int)
+0:145    Sequence
+0:145      subtract second child into first child ( temp highp int)
+0:145        'index' ( in highp int)
+0:145        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:145          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:145          Constant:
+0:145            0 (const uint)
+0:147      Sequence
+0:147        move second child to first child ( temp highp int)
+0:147          'coord' ( temp highp int)
+0:147          'index' ( in highp int)
+0:148      Sequence
+0:148        move second child to first child ( temp highp 4-component vector of float)
+0:148          'samp' ( temp highp 4-component vector of float)
+0:148          textureFetch ( global highp 4-component vector of float)
+0:148            'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:148            'coord' ( temp highp int)
+0:149      move second child to first child ( temp highp float)
+0:149        direct index ( temp highp float)
+0:149          'v' ( temp highp 3-component vector of float)
+0:149          Constant:
+0:149            0 (const int)
+0:149        direct index ( temp highp float)
+0:149          'samp' ( temp highp 4-component vector of float)
+0:149          Constant:
+0:149            1 (const int)
+0:150      move second child to first child ( temp highp float)
+0:150        direct index ( temp highp float)
+0:150          'v' ( temp highp 3-component vector of float)
+0:150          Constant:
+0:150            1 (const int)
+0:150        direct index ( temp highp float)
+0:150          'samp' ( temp highp 4-component vector of float)
+0:150          Constant:
+0:150            2 (const int)
+0:151      move second child to first child ( temp highp float)
+0:151        direct index ( temp highp float)
+0:151          'v' ( temp highp 3-component vector of float)
+0:151          Constant:
+0:151            2 (const int)
+0:151        direct index ( temp highp float)
+0:151          'samp' ( temp highp 4-component vector of float)
+0:151          Constant:
+0:151            3 (const int)
+0:152      Branch: Return with expression
+0:152        'v' ( temp highp 3-component vector of float)
+0:154  Function Definition: TDInstanceRotateMat(i1; ( global highp 3X3 matrix of float)
+0:154    Function Parameters: 
+0:154      'index' ( in highp int)
+0:155    Sequence
+0:155      subtract second child into first child ( temp highp int)
+0:155        'index' ( in highp int)
+0:155        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:155          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:155          Constant:
+0:155            0 (const uint)
+0:156      Sequence
+0:156        move second child to first child ( temp highp 3-component vector of float)
+0:156          'v' ( temp highp 3-component vector of float)
+0:156          Constant:
+0:156            0.000000
+0:156            0.000000
+0:156            0.000000
+0:157      Sequence
+0:157        move second child to first child ( temp highp 3X3 matrix of float)
+0:157          'm' ( temp highp 3X3 matrix of float)
+0:157          Constant:
+0:157            1.000000
+0:157            0.000000
+0:157            0.000000
+0:157            0.000000
+0:157            1.000000
+0:157            0.000000
+0:157            0.000000
+0:157            0.000000
+0:157            1.000000
+0:161      Branch: Return with expression
+0:161        'm' ( temp highp 3X3 matrix of float)
+0:163  Function Definition: TDInstanceScale(i1; ( global highp 3-component vector of float)
+0:163    Function Parameters: 
+0:163      'index' ( in highp int)
+0:164    Sequence
+0:164      subtract second child into first child ( temp highp int)
+0:164        'index' ( in highp int)
+0:164        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:164          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:164          Constant:
+0:164            0 (const uint)
+0:165      Sequence
+0:165        move second child to first child ( temp highp 3-component vector of float)
+0:165          'v' ( temp highp 3-component vector of float)
+0:165          Constant:
+0:165            1.000000
+0:165            1.000000
+0:165            1.000000
+0:166      Branch: Return with expression
+0:166        'v' ( temp highp 3-component vector of float)
+0:168  Function Definition: TDInstancePivot(i1; ( global highp 3-component vector of float)
+0:168    Function Parameters: 
+0:168      'index' ( in highp int)
+0:169    Sequence
+0:169      subtract second child into first child ( temp highp int)
+0:169        'index' ( in highp int)
+0:169        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:169          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:169          Constant:
+0:169            0 (const uint)
+0:170      Sequence
+0:170        move second child to first child ( temp highp 3-component vector of float)
+0:170          'v' ( temp highp 3-component vector of float)
+0:170          Constant:
+0:170            0.000000
+0:170            0.000000
+0:170            0.000000
+0:171      Branch: Return with expression
+0:171        'v' ( temp highp 3-component vector of float)
+0:173  Function Definition: TDInstanceRotTo(i1; ( global highp 3-component vector of float)
+0:173    Function Parameters: 
+0:173      'index' ( in highp int)
+0:174    Sequence
+0:174      subtract second child into first child ( temp highp int)
+0:174        'index' ( in highp int)
+0:174        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:174          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:174          Constant:
+0:174            0 (const uint)
+0:175      Sequence
+0:175        move second child to first child ( temp highp 3-component vector of float)
+0:175          'v' ( temp highp 3-component vector of float)
+0:175          Constant:
+0:175            0.000000
+0:175            0.000000
+0:175            1.000000
+0:176      Branch: Return with expression
+0:176        'v' ( temp highp 3-component vector of float)
+0:178  Function Definition: TDInstanceRotUp(i1; ( global highp 3-component vector of float)
+0:178    Function Parameters: 
+0:178      'index' ( in highp int)
+0:179    Sequence
+0:179      subtract second child into first child ( temp highp int)
+0:179        'index' ( in highp int)
+0:179        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:179          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:179          Constant:
+0:179            0 (const uint)
+0:180      Sequence
+0:180        move second child to first child ( temp highp 3-component vector of float)
+0:180          'v' ( temp highp 3-component vector of float)
+0:180          Constant:
+0:180            0.000000
+0:180            1.000000
+0:180            0.000000
+0:181      Branch: Return with expression
+0:181        'v' ( temp highp 3-component vector of float)
+0:183  Function Definition: TDInstanceMat(i1; ( global highp 4X4 matrix of float)
+0:183    Function Parameters: 
+0:183      'id' ( in highp int)
+0:184    Sequence
+0:184      Sequence
+0:184        move second child to first child ( temp bool)
+0:184          'instanceActive' ( temp bool)
+0:184          Constant:
+0:184            true (const bool)
+0:185      Sequence
+0:185        move second child to first child ( temp highp 3-component vector of float)
+0:185          't' ( temp highp 3-component vector of float)
+0:185          Function Call: iTDInstanceTranslate(i1;b1; ( global highp 3-component vector of float)
+0:185            'id' ( in highp int)
+0:185            'instanceActive' ( temp bool)
+0:186      Test condition and select ( temp void)
+0:186        Condition
+0:186        Negate conditional ( temp bool)
+0:186          'instanceActive' ( temp bool)
+0:186        true case
+0:188        Sequence
+0:188          Branch: Return with expression
+0:188            Constant:
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:190      Sequence
+0:190        move second child to first child ( temp highp 4X4 matrix of float)
+0:190          'm' ( temp highp 4X4 matrix of float)
+0:190          Constant:
+0:190            1.000000
+0:190            0.000000
+0:190            0.000000
+0:190            0.000000
+0:190            0.000000
+0:190            1.000000
+0:190            0.000000
+0:190            0.000000
+0:190            0.000000
+0:190            0.000000
+0:190            1.000000
+0:190            0.000000
+0:190            0.000000
+0:190            0.000000
+0:190            0.000000
+0:190            1.000000
+0:192      Sequence
+0:192        Sequence
+0:192          move second child to first child ( temp highp 3-component vector of float)
+0:192            'tt' ( temp highp 3-component vector of float)
+0:192            't' ( temp highp 3-component vector of float)
+0:193        add second child into first child ( temp highp float)
+0:193          direct index ( temp highp float)
+0:193            direct index ( temp highp 4-component vector of float)
+0:193              'm' ( temp highp 4X4 matrix of float)
+0:193              Constant:
+0:193                3 (const int)
+0:193            Constant:
+0:193              0 (const int)
+0:193          component-wise multiply ( temp highp float)
+0:193            direct index ( temp highp float)
+0:193              direct index ( temp highp 4-component vector of float)
+0:193                'm' ( temp highp 4X4 matrix of float)
+0:193                Constant:
+0:193                  0 (const int)
+0:193              Constant:
+0:193                0 (const int)
+0:193            direct index ( temp highp float)
+0:193              'tt' ( temp highp 3-component vector of float)
+0:193              Constant:
+0:193                0 (const int)
+0:194        add second child into first child ( temp highp float)
+0:194          direct index ( temp highp float)
+0:194            direct index ( temp highp 4-component vector of float)
+0:194              'm' ( temp highp 4X4 matrix of float)
+0:194              Constant:
+0:194                3 (const int)
+0:194            Constant:
+0:194              1 (const int)
+0:194          component-wise multiply ( temp highp float)
+0:194            direct index ( temp highp float)
+0:194              direct index ( temp highp 4-component vector of float)
+0:194                'm' ( temp highp 4X4 matrix of float)
+0:194                Constant:
+0:194                  0 (const int)
+0:194              Constant:
+0:194                1 (const int)
+0:194            direct index ( temp highp float)
+0:194              'tt' ( temp highp 3-component vector of float)
+0:194              Constant:
+0:194                0 (const int)
+0:195        add second child into first child ( temp highp float)
+0:195          direct index ( temp highp float)
+0:195            direct index ( temp highp 4-component vector of float)
+0:195              'm' ( temp highp 4X4 matrix of float)
+0:195              Constant:
+0:195                3 (const int)
+0:195            Constant:
+0:195              2 (const int)
+0:195          component-wise multiply ( temp highp float)
+0:195            direct index ( temp highp float)
+0:195              direct index ( temp highp 4-component vector of float)
+0:195                'm' ( temp highp 4X4 matrix of float)
+0:195                Constant:
+0:195                  0 (const int)
+0:195              Constant:
+0:195                2 (const int)
+0:195            direct index ( temp highp float)
+0:195              'tt' ( temp highp 3-component vector of float)
+0:195              Constant:
+0:195                0 (const int)
+0:196        add second child into first child ( temp highp float)
+0:196          direct index ( temp highp float)
+0:196            direct index ( temp highp 4-component vector of float)
+0:196              'm' ( temp highp 4X4 matrix of float)
+0:196              Constant:
+0:196                3 (const int)
+0:196            Constant:
+0:196              3 (const int)
+0:196          component-wise multiply ( temp highp float)
+0:196            direct index ( temp highp float)
+0:196              direct index ( temp highp 4-component vector of float)
+0:196                'm' ( temp highp 4X4 matrix of float)
+0:196                Constant:
+0:196                  0 (const int)
+0:196              Constant:
+0:196                3 (const int)
+0:196            direct index ( temp highp float)
+0:196              'tt' ( temp highp 3-component vector of float)
+0:196              Constant:
+0:196                0 (const int)
+0:197        add second child into first child ( temp highp float)
+0:197          direct index ( temp highp float)
+0:197            direct index ( temp highp 4-component vector of float)
+0:197              'm' ( temp highp 4X4 matrix of float)
+0:197              Constant:
+0:197                3 (const int)
+0:197            Constant:
+0:197              0 (const int)
+0:197          component-wise multiply ( temp highp float)
+0:197            direct index ( temp highp float)
+0:197              direct index ( temp highp 4-component vector of float)
+0:197                'm' ( temp highp 4X4 matrix of float)
+0:197                Constant:
+0:197                  1 (const int)
+0:197              Constant:
+0:197                0 (const int)
+0:197            direct index ( temp highp float)
+0:197              'tt' ( temp highp 3-component vector of float)
+0:197              Constant:
+0:197                1 (const int)
+0:198        add second child into first child ( temp highp float)
+0:198          direct index ( temp highp float)
+0:198            direct index ( temp highp 4-component vector of float)
+0:198              'm' ( temp highp 4X4 matrix of float)
+0:198              Constant:
+0:198                3 (const int)
+0:198            Constant:
+0:198              1 (const int)
+0:198          component-wise multiply ( temp highp float)
+0:198            direct index ( temp highp float)
+0:198              direct index ( temp highp 4-component vector of float)
+0:198                'm' ( temp highp 4X4 matrix of float)
+0:198                Constant:
+0:198                  1 (const int)
+0:198              Constant:
+0:198                1 (const int)
+0:198            direct index ( temp highp float)
+0:198              'tt' ( temp highp 3-component vector of float)
+0:198              Constant:
+0:198                1 (const int)
+0:199        add second child into first child ( temp highp float)
+0:199          direct index ( temp highp float)
+0:199            direct index ( temp highp 4-component vector of float)
+0:199              'm' ( temp highp 4X4 matrix of float)
+0:199              Constant:
+0:199                3 (const int)
+0:199            Constant:
+0:199              2 (const int)
+0:199          component-wise multiply ( temp highp float)
+0:199            direct index ( temp highp float)
+0:199              direct index ( temp highp 4-component vector of float)
+0:199                'm' ( temp highp 4X4 matrix of float)
+0:199                Constant:
+0:199                  1 (const int)
+0:199              Constant:
+0:199                2 (const int)
+0:199            direct index ( temp highp float)
+0:199              'tt' ( temp highp 3-component vector of float)
+0:199              Constant:
+0:199                1 (const int)
+0:200        add second child into first child ( temp highp float)
+0:200          direct index ( temp highp float)
+0:200            direct index ( temp highp 4-component vector of float)
+0:200              'm' ( temp highp 4X4 matrix of float)
+0:200              Constant:
+0:200                3 (const int)
+0:200            Constant:
+0:200              3 (const int)
+0:200          component-wise multiply ( temp highp float)
+0:200            direct index ( temp highp float)
+0:200              direct index ( temp highp 4-component vector of float)
+0:200                'm' ( temp highp 4X4 matrix of float)
+0:200                Constant:
+0:200                  1 (const int)
+0:200              Constant:
+0:200                3 (const int)
+0:200            direct index ( temp highp float)
+0:200              'tt' ( temp highp 3-component vector of float)
+0:200              Constant:
+0:200                1 (const int)
+0:201        add second child into first child ( temp highp float)
+0:201          direct index ( temp highp float)
+0:201            direct index ( temp highp 4-component vector of float)
+0:201              'm' ( temp highp 4X4 matrix of float)
+0:201              Constant:
+0:201                3 (const int)
+0:201            Constant:
+0:201              0 (const int)
+0:201          component-wise multiply ( temp highp float)
+0:201            direct index ( temp highp float)
+0:201              direct index ( temp highp 4-component vector of float)
+0:201                'm' ( temp highp 4X4 matrix of float)
+0:201                Constant:
+0:201                  2 (const int)
+0:201              Constant:
+0:201                0 (const int)
+0:201            direct index ( temp highp float)
+0:201              'tt' ( temp highp 3-component vector of float)
+0:201              Constant:
+0:201                2 (const int)
+0:202        add second child into first child ( temp highp float)
+0:202          direct index ( temp highp float)
+0:202            direct index ( temp highp 4-component vector of float)
+0:202              'm' ( temp highp 4X4 matrix of float)
+0:202              Constant:
+0:202                3 (const int)
+0:202            Constant:
+0:202              1 (const int)
+0:202          component-wise multiply ( temp highp float)
+0:202            direct index ( temp highp float)
+0:202              direct index ( temp highp 4-component vector of float)
+0:202                'm' ( temp highp 4X4 matrix of float)
+0:202                Constant:
+0:202                  2 (const int)
+0:202              Constant:
+0:202                1 (const int)
+0:202            direct index ( temp highp float)
+0:202              'tt' ( temp highp 3-component vector of float)
+0:202              Constant:
+0:202                2 (const int)
+0:203        add second child into first child ( temp highp float)
+0:203          direct index ( temp highp float)
+0:203            direct index ( temp highp 4-component vector of float)
+0:203              'm' ( temp highp 4X4 matrix of float)
+0:203              Constant:
+0:203                3 (const int)
+0:203            Constant:
+0:203              2 (const int)
+0:203          component-wise multiply ( temp highp float)
+0:203            direct index ( temp highp float)
+0:203              direct index ( temp highp 4-component vector of float)
+0:203                'm' ( temp highp 4X4 matrix of float)
+0:203                Constant:
+0:203                  2 (const int)
+0:203              Constant:
+0:203                2 (const int)
+0:203            direct index ( temp highp float)
+0:203              'tt' ( temp highp 3-component vector of float)
+0:203              Constant:
+0:203                2 (const int)
+0:204        add second child into first child ( temp highp float)
+0:204          direct index ( temp highp float)
+0:204            direct index ( temp highp 4-component vector of float)
+0:204              'm' ( temp highp 4X4 matrix of float)
+0:204              Constant:
+0:204                3 (const int)
+0:204            Constant:
+0:204              3 (const int)
+0:204          component-wise multiply ( temp highp float)
+0:204            direct index ( temp highp float)
+0:204              direct index ( temp highp 4-component vector of float)
+0:204                'm' ( temp highp 4X4 matrix of float)
+0:204                Constant:
+0:204                  2 (const int)
+0:204              Constant:
+0:204                3 (const int)
+0:204            direct index ( temp highp float)
+0:204              'tt' ( temp highp 3-component vector of float)
+0:204              Constant:
+0:204                2 (const int)
+0:206      Branch: Return with expression
+0:206        'm' ( temp highp 4X4 matrix of float)
+0:208  Function Definition: TDInstanceMat3(i1; ( global highp 3X3 matrix of float)
+0:208    Function Parameters: 
+0:208      'id' ( in highp int)
+0:209    Sequence
+0:209      Sequence
+0:209        move second child to first child ( temp highp 3X3 matrix of float)
+0:209          'm' ( temp highp 3X3 matrix of float)
+0:209          Constant:
+0:209            1.000000
+0:209            0.000000
+0:209            0.000000
+0:209            0.000000
+0:209            1.000000
+0:209            0.000000
+0:209            0.000000
+0:209            0.000000
+0:209            1.000000
+0:210      Branch: Return with expression
+0:210        'm' ( temp highp 3X3 matrix of float)
+0:212  Function Definition: TDInstanceMat3ForNorm(i1; ( global highp 3X3 matrix of float)
+0:212    Function Parameters: 
+0:212      'id' ( in highp int)
+0:213    Sequence
+0:213      Sequence
+0:213        move second child to first child ( temp highp 3X3 matrix of float)
+0:213          'm' ( temp highp 3X3 matrix of float)
+0:213          Function Call: TDInstanceMat3(i1; ( global highp 3X3 matrix of float)
+0:213            'id' ( in highp int)
+0:214      Branch: Return with expression
+0:214        'm' ( temp highp 3X3 matrix of float)
+0:216  Function Definition: TDInstanceColor(i1;vf4; ( global highp 4-component vector of float)
+0:216    Function Parameters: 
+0:216      'index' ( in highp int)
+0:216      'curColor' ( in highp 4-component vector of float)
+0:217    Sequence
+0:217      subtract second child into first child ( temp highp int)
+0:217        'index' ( in highp int)
+0:217        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:217          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:217          Constant:
+0:217            0 (const uint)
+0:219      Sequence
+0:219        move second child to first child ( temp highp int)
+0:219          'coord' ( temp highp int)
+0:219          'index' ( in highp int)
+0:220      Sequence
+0:220        move second child to first child ( temp highp 4-component vector of float)
+0:220          'samp' ( temp highp 4-component vector of float)
+0:220          textureFetch ( global highp 4-component vector of float)
+0:220            'sTDInstanceColor' (layout( binding=17) uniform highp samplerBuffer)
+0:220            'coord' ( temp highp int)
+0:221      move second child to first child ( temp highp float)
+0:221        direct index ( temp highp float)
+0:221          'v' ( temp highp 4-component vector of float)
+0:221          Constant:
+0:221            0 (const int)
+0:221        direct index ( temp highp float)
+0:221          'samp' ( temp highp 4-component vector of float)
+0:221          Constant:
+0:221            0 (const int)
+0:222      move second child to first child ( temp highp float)
+0:222        direct index ( temp highp float)
+0:222          'v' ( temp highp 4-component vector of float)
+0:222          Constant:
+0:222            1 (const int)
+0:222        direct index ( temp highp float)
+0:222          'samp' ( temp highp 4-component vector of float)
+0:222          Constant:
+0:222            1 (const int)
+0:223      move second child to first child ( temp highp float)
+0:223        direct index ( temp highp float)
+0:223          'v' ( temp highp 4-component vector of float)
+0:223          Constant:
+0:223            2 (const int)
+0:223        direct index ( temp highp float)
+0:223          'samp' ( temp highp 4-component vector of float)
+0:223          Constant:
+0:223            2 (const int)
+0:224      move second child to first child ( temp highp float)
+0:224        direct index ( temp highp float)
+0:224          'v' ( temp highp 4-component vector of float)
+0:224          Constant:
+0:224            3 (const int)
+0:224        Constant:
+0:224          1.000000
+0:225      move second child to first child ( temp highp float)
+0:225        direct index ( temp highp float)
+0:225          'curColor' ( in highp 4-component vector of float)
+0:225          Constant:
+0:225            0 (const int)
+0:225        direct index ( temp highp float)
+0:225          'v' ( temp highp 4-component vector of float)
+0:225          Constant:
+0:225            0 (const int)
+0:227      move second child to first child ( temp highp float)
+0:227        direct index ( temp highp float)
+0:227          'curColor' ( in highp 4-component vector of float)
+0:227          Constant:
+0:227            1 (const int)
+0:227        direct index ( temp highp float)
+0:227          'v' ( temp highp 4-component vector of float)
+0:227          Constant:
+0:227            1 (const int)
+0:229      move second child to first child ( temp highp float)
+0:229        direct index ( temp highp float)
+0:229          'curColor' ( in highp 4-component vector of float)
+0:229          Constant:
+0:229            2 (const int)
+0:229        direct index ( temp highp float)
+0:229          'v' ( temp highp 4-component vector of float)
+0:229          Constant:
+0:229            2 (const int)
+0:231      Branch: Return with expression
+0:231        'curColor' ( in highp 4-component vector of float)
+0:233  Function Definition: TDInstanceDeform(i1;vf4; ( global highp 4-component vector of float)
+0:233    Function Parameters: 
+0:233      'id' ( in highp int)
+0:233      'pos' ( in highp 4-component vector of float)
+0:234    Sequence
+0:234      move second child to first child ( temp highp 4-component vector of float)
+0:234        'pos' ( in highp 4-component vector of float)
+0:234        matrix-times-vector ( temp highp 4-component vector of float)
+0:234          Function Call: TDInstanceMat(i1; ( global highp 4X4 matrix of float)
+0:234            'id' ( in highp int)
+0:234          'pos' ( in highp 4-component vector of float)
+0:235      Branch: Return with expression
+0:235        matrix-times-vector ( temp highp 4-component vector of float)
+0:235          world: direct index for structure (layout( column_major std140) global highp 4X4 matrix of float)
+0:235            indirect index (layout( column_major std140 offset=0) temp structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:235              uTDMats: direct index for structure (layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:235                'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:235                Constant:
+0:235                  0 (const uint)
+0:235              Function Call: TDCameraIndex( ( global highp int)
+0:235            Constant:
+0:235              0 (const int)
+0:235          'pos' ( in highp 4-component vector of float)
+0:238  Function Definition: TDInstanceDeformVec(i1;vf3; ( global highp 3-component vector of float)
+0:238    Function Parameters: 
+0:238      'id' ( in highp int)
+0:238      'vec' ( in highp 3-component vector of float)
+0:240    Sequence
+0:240      Sequence
+0:240        move second child to first child ( temp highp 3X3 matrix of float)
+0:240          'm' ( temp highp 3X3 matrix of float)
+0:240          Function Call: TDInstanceMat3(i1; ( global highp 3X3 matrix of float)
+0:240            'id' ( in highp int)
+0:241      Branch: Return with expression
+0:241        matrix-times-vector ( temp highp 3-component vector of float)
+0:241          Construct mat3 ( temp highp 3X3 matrix of float)
+0:241            world: direct index for structure (layout( column_major std140) global highp 4X4 matrix of float)
+0:241              indirect index (layout( column_major std140 offset=0) temp structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:241                uTDMats: direct index for structure (layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:241                  'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:241                  Constant:
+0:241                    0 (const uint)
+0:241                Function Call: TDCameraIndex( ( global highp int)
+0:241              Constant:
+0:241                0 (const int)
+0:241          matrix-times-vector ( temp highp 3-component vector of float)
+0:241            'm' ( temp highp 3X3 matrix of float)
+0:241            'vec' ( in highp 3-component vector of float)
+0:243  Function Definition: TDInstanceDeformNorm(i1;vf3; ( global highp 3-component vector of float)
+0:243    Function Parameters: 
+0:243      'id' ( in highp int)
+0:243      'vec' ( in highp 3-component vector of float)
+0:245    Sequence
+0:245      Sequence
+0:245        move second child to first child ( temp highp 3X3 matrix of float)
+0:245          'm' ( temp highp 3X3 matrix of float)
+0:245          Function Call: TDInstanceMat3ForNorm(i1; ( global highp 3X3 matrix of float)
+0:245            'id' ( in highp int)
+0:246      Branch: Return with expression
+0:246        matrix-times-vector ( temp highp 3-component vector of float)
+0:246          Construct mat3 ( temp highp 3X3 matrix of float)
+0:246            worldForNormals: direct index for structure (layout( column_major std140) global highp 3X3 matrix of float)
+0:246              indirect index (layout( column_major std140 offset=0) temp structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:246                uTDMats: direct index for structure (layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:246                  'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:246                  Constant:
+0:246                    0 (const uint)
+0:246                Function Call: TDCameraIndex( ( global highp int)
+0:246              Constant:
+0:246                13 (const int)
+0:246          matrix-times-vector ( temp highp 3-component vector of float)
+0:246            'm' ( temp highp 3X3 matrix of float)
+0:246            'vec' ( in highp 3-component vector of float)
+0:248  Function Definition: TDInstanceDeform(vf4; ( global highp 4-component vector of float)
+0:248    Function Parameters: 
+0:248      'pos' ( in highp 4-component vector of float)
+0:249    Sequence
+0:249      Branch: Return with expression
+0:249        Function Call: TDInstanceDeform(i1;vf4; ( global highp 4-component vector of float)
+0:249          Function Call: TDInstanceID( ( global highp int)
+0:249          'pos' ( in highp 4-component vector of float)
+0:251  Function Definition: TDInstanceDeformVec(vf3; ( global highp 3-component vector of float)
+0:251    Function Parameters: 
+0:251      'vec' ( in highp 3-component vector of float)
+0:252    Sequence
+0:252      Branch: Return with expression
+0:252        Function Call: TDInstanceDeformVec(i1;vf3; ( global highp 3-component vector of float)
+0:252          Function Call: TDInstanceID( ( global highp int)
+0:252          'vec' ( in highp 3-component vector of float)
+0:254  Function Definition: TDInstanceDeformNorm(vf3; ( global highp 3-component vector of float)
+0:254    Function Parameters: 
+0:254      'vec' ( in highp 3-component vector of float)
+0:255    Sequence
+0:255      Branch: Return with expression
+0:255        Function Call: TDInstanceDeformNorm(i1;vf3; ( global highp 3-component vector of float)
+0:255          Function Call: TDInstanceID( ( global highp int)
+0:255          'vec' ( in highp 3-component vector of float)
+0:257  Function Definition: TDInstanceActive( ( global bool)
+0:257    Function Parameters: 
+0:257    Sequence
+0:257      Branch: Return with expression
+0:257        Function Call: TDInstanceActive(i1; ( global bool)
+0:257          Function Call: TDInstanceID( ( global highp int)
+0:258  Function Definition: TDInstanceTranslate( ( global highp 3-component vector of float)
+0:258    Function Parameters: 
+0:258    Sequence
+0:258      Branch: Return with expression
+0:258        Function Call: TDInstanceTranslate(i1; ( global highp 3-component vector of float)
+0:258          Function Call: TDInstanceID( ( global highp int)
+0:259  Function Definition: TDInstanceRotateMat( ( global highp 3X3 matrix of float)
+0:259    Function Parameters: 
+0:259    Sequence
+0:259      Branch: Return with expression
+0:259        Function Call: TDInstanceRotateMat(i1; ( global highp 3X3 matrix of float)
+0:259          Function Call: TDInstanceID( ( global highp int)
+0:260  Function Definition: TDInstanceScale( ( global highp 3-component vector of float)
+0:260    Function Parameters: 
+0:260    Sequence
+0:260      Branch: Return with expression
+0:260        Function Call: TDInstanceScale(i1; ( global highp 3-component vector of float)
+0:260          Function Call: TDInstanceID( ( global highp int)
+0:261  Function Definition: TDInstanceMat( ( global highp 4X4 matrix of float)
+0:261    Function Parameters: 
+0:261    Sequence
+0:261      Branch: Return with expression
+0:261        Function Call: TDInstanceMat(i1; ( global highp 4X4 matrix of float)
+0:261          Function Call: TDInstanceID( ( global highp int)
+0:263  Function Definition: TDInstanceMat3( ( global highp 3X3 matrix of float)
+0:263    Function Parameters: 
+0:263    Sequence
+0:263      Branch: Return with expression
+0:263        Function Call: TDInstanceMat3(i1; ( global highp 3X3 matrix of float)
+0:263          Function Call: TDInstanceID( ( global highp int)
+0:265  Function Definition: TDInstanceTexCoord(vf3; ( global highp 3-component vector of float)
+0:265    Function Parameters: 
+0:265      't' ( in highp 3-component vector of float)
+0:266    Sequence
+0:266      Branch: Return with expression
+0:266        Function Call: TDInstanceTexCoord(i1;vf3; ( global highp 3-component vector of float)
+0:266          Function Call: TDInstanceID( ( global highp int)
+0:266          't' ( in highp 3-component vector of float)
+0:268  Function Definition: TDInstanceColor(vf4; ( global highp 4-component vector of float)
+0:268    Function Parameters: 
+0:268      'curColor' ( in highp 4-component vector of float)
+0:269    Sequence
+0:269      Branch: Return with expression
+0:269        Function Call: TDInstanceColor(i1;vf4; ( global highp 4-component vector of float)
+0:269          Function Call: TDInstanceID( ( global highp int)
+0:269          'curColor' ( in highp 4-component vector of float)
+0:271  Function Definition: TDSkinnedDeform(vf4; ( global highp 4-component vector of float)
+0:271    Function Parameters: 
+0:271      'pos' ( in highp 4-component vector of float)
+0:271    Sequence
+0:271      Branch: Return with expression
+0:271        'pos' ( in highp 4-component vector of float)
+0:273  Function Definition: TDSkinnedDeformVec(vf3; ( global highp 3-component vector of float)
+0:273    Function Parameters: 
+0:273      'vec' ( in highp 3-component vector of float)
+0:273    Sequence
+0:273      Branch: Return with expression
+0:273        'vec' ( in highp 3-component vector of float)
+0:275  Function Definition: TDFastDeformTangent(vf3;vf4;vf3; ( global highp 3-component vector of float)
+0:275    Function Parameters: 
+0:275      'oldNorm' ( in highp 3-component vector of float)
+0:275      'oldTangent' ( in highp 4-component vector of float)
+0:275      'deformedNorm' ( in highp 3-component vector of float)
+0:276    Sequence
+0:276      Branch: Return with expression
+0:276        vector swizzle ( temp highp 3-component vector of float)
+0:276          'oldTangent' ( in highp 4-component vector of float)
+0:276          Sequence
+0:276            Constant:
+0:276              0 (const int)
+0:276            Constant:
+0:276              1 (const int)
+0:276            Constant:
+0:276              2 (const int)
+0:277  Function Definition: TDBoneMat(i1; ( global highp 4X4 matrix of float)
+0:277    Function Parameters: 
+0:277      'index' ( in highp int)
+0:278    Sequence
+0:278      Branch: Return with expression
+0:278        Constant:
+0:278          1.000000
+0:278          0.000000
+0:278          0.000000
+0:278          0.000000
+0:278          0.000000
+0:278          1.000000
+0:278          0.000000
+0:278          0.000000
+0:278          0.000000
+0:278          0.000000
+0:278          1.000000
+0:278          0.000000
+0:278          0.000000
+0:278          0.000000
+0:278          0.000000
+0:278          1.000000
+0:280  Function Definition: TDDeform(vf4; ( global highp 4-component vector of float)
+0:280    Function Parameters: 
+0:280      'pos' ( in highp 4-component vector of float)
+0:281    Sequence
+0:281      move second child to first child ( temp highp 4-component vector of float)
+0:281        'pos' ( in highp 4-component vector of float)
+0:281        Function Call: TDSkinnedDeform(vf4; ( global highp 4-component vector of float)
+0:281          'pos' ( in highp 4-component vector of float)
+0:282      move second child to first child ( temp highp 4-component vector of float)
+0:282        'pos' ( in highp 4-component vector of float)
+0:282        Function Call: TDInstanceDeform(vf4; ( global highp 4-component vector of float)
+0:282          'pos' ( in highp 4-component vector of float)
+0:283      Branch: Return with expression
+0:283        'pos' ( in highp 4-component vector of float)
+0:286  Function Definition: TDDeform(i1;vf3; ( global highp 4-component vector of float)
+0:286    Function Parameters: 
+0:286      'instanceID' ( in highp int)
+0:286      'p' ( in highp 3-component vector of float)
+0:287    Sequence
+0:287      Sequence
+0:287        move second child to first child ( temp highp 4-component vector of float)
+0:287          'pos' ( temp highp 4-component vector of float)
+0:287          Construct vec4 ( temp highp 4-component vector of float)
+0:287            'p' ( in highp 3-component vector of float)
+0:287            Constant:
+0:287              1.000000
+0:288      move second child to first child ( temp highp 4-component vector of float)
+0:288        'pos' ( temp highp 4-component vector of float)
+0:288        Function Call: TDSkinnedDeform(vf4; ( global highp 4-component vector of float)
+0:288          'pos' ( temp highp 4-component vector of float)
+0:289      move second child to first child ( temp highp 4-component vector of float)
+0:289        'pos' ( temp highp 4-component vector of float)
+0:289        Function Call: TDInstanceDeform(i1;vf4; ( global highp 4-component vector of float)
+0:289          'instanceID' ( in highp int)
+0:289          'pos' ( temp highp 4-component vector of float)
+0:290      Branch: Return with expression
+0:290        'pos' ( temp highp 4-component vector of float)
+0:293  Function Definition: TDDeform(vf3; ( global highp 4-component vector of float)
+0:293    Function Parameters: 
+0:293      'pos' ( in highp 3-component vector of float)
+0:294    Sequence
+0:294      Branch: Return with expression
+0:294        Function Call: TDDeform(i1;vf3; ( global highp 4-component vector of float)
+0:294          Function Call: TDInstanceID( ( global highp int)
+0:294          'pos' ( in highp 3-component vector of float)
+0:297  Function Definition: TDDeformVec(i1;vf3; ( global highp 3-component vector of float)
+0:297    Function Parameters: 
+0:297      'instanceID' ( in highp int)
+0:297      'vec' ( in highp 3-component vector of float)
+0:298    Sequence
+0:298      move second child to first child ( temp highp 3-component vector of float)
+0:298        'vec' ( in highp 3-component vector of float)
+0:298        Function Call: TDSkinnedDeformVec(vf3; ( global highp 3-component vector of float)
+0:298          'vec' ( in highp 3-component vector of float)
+0:299      move second child to first child ( temp highp 3-component vector of float)
+0:299        'vec' ( in highp 3-component vector of float)
+0:299        Function Call: TDInstanceDeformVec(i1;vf3; ( global highp 3-component vector of float)
+0:299          'instanceID' ( in highp int)
+0:299          'vec' ( in highp 3-component vector of float)
+0:300      Branch: Return with expression
+0:300        'vec' ( in highp 3-component vector of float)
+0:303  Function Definition: TDDeformVec(vf3; ( global highp 3-component vector of float)
+0:303    Function Parameters: 
+0:303      'vec' ( in highp 3-component vector of float)
+0:304    Sequence
+0:304      Branch: Return with expression
+0:304        Function Call: TDDeformVec(i1;vf3; ( global highp 3-component vector of float)
+0:304          Function Call: TDInstanceID( ( global highp int)
+0:304          'vec' ( in highp 3-component vector of float)
+0:307  Function Definition: TDDeformNorm(i1;vf3; ( global highp 3-component vector of float)
+0:307    Function Parameters: 
+0:307      'instanceID' ( in highp int)
+0:307      'vec' ( in highp 3-component vector of float)
+0:308    Sequence
+0:308      move second child to first child ( temp highp 3-component vector of float)
+0:308        'vec' ( in highp 3-component vector of float)
+0:308        Function Call: TDSkinnedDeformVec(vf3; ( global highp 3-component vector of float)
+0:308          'vec' ( in highp 3-component vector of float)
+0:309      move second child to first child ( temp highp 3-component vector of float)
+0:309        'vec' ( in highp 3-component vector of float)
+0:309        Function Call: TDInstanceDeformNorm(i1;vf3; ( global highp 3-component vector of float)
+0:309          'instanceID' ( in highp int)
+0:309          'vec' ( in highp 3-component vector of float)
+0:310      Branch: Return with expression
+0:310        'vec' ( in highp 3-component vector of float)
+0:313  Function Definition: TDDeformNorm(vf3; ( global highp 3-component vector of float)
+0:313    Function Parameters: 
+0:313      'vec' ( in highp 3-component vector of float)
+0:314    Sequence
+0:314      Branch: Return with expression
+0:314        Function Call: TDDeformNorm(i1;vf3; ( global highp 3-component vector of float)
+0:314          Function Call: TDInstanceID( ( global highp int)
+0:314          'vec' ( in highp 3-component vector of float)
+0:317  Function Definition: TDSkinnedDeformNorm(vf3; ( global highp 3-component vector of float)
+0:317    Function Parameters: 
+0:317      'vec' ( in highp 3-component vector of float)
+0:318    Sequence
+0:318      move second child to first child ( temp highp 3-component vector of float)
+0:318        'vec' ( in highp 3-component vector of float)
+0:318        Function Call: TDSkinnedDeformVec(vf3; ( global highp 3-component vector of float)
+0:318          'vec' ( in highp 3-component vector of float)
+0:319      Branch: Return with expression
+0:319        'vec' ( in highp 3-component vector of float)
+0:?   Linker Objects
+0:?     'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:?     'anon@1' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 4-component vector of float position,  global highp 3-component vector of float direction,  global highp 3-component vector of float diffuse,  global highp 4-component vector of float nearFar,  global highp 4-component vector of float lightSize,  global highp 4-component vector of float misc,  global highp 4-component vector of float coneLookupScaleBias,  global highp 4-component vector of float attenScaleBiasRoll, layout( column_major std140) global highp 4X4 matrix of float shadowMapMatrix, layout( column_major std140) global highp 4X4 matrix of float shadowMapCamMatrix,  global highp 4-component vector of float shadowMapRes, layout( column_major std140) global highp 4X4 matrix of float projMapMatrix} uTDLights})
+0:?     'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 3-component vector of float color, layout( column_major std140) global highp 3X3 matrix of float rotate} uTDEnvLights})
+0:?     'uTDEnvLightBuffers' (layout( column_major std430) restrict readonly buffer 1-element array of block{layout( column_major std430 offset=0) restrict readonly buffer 9-element array of highp 3-component vector of float shCoeffs})
+0:?     'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:?     'anon@4' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 4-component vector of float nearFar,  global highp 4-component vector of float fog,  global highp 4-component vector of float fogColor,  global highp int renderTOPCameraIndex} uTDCamInfos})
+0:?     'anon@5' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform structure{ global highp 4-component vector of float ambientColor,  global highp 4-component vector of float nearFar,  global highp 4-component vector of float viewport,  global highp 4-component vector of float viewportRes,  global highp 4-component vector of float fog,  global highp 4-component vector of float fogColor} uTDGeneral})
+0:?     'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:?     'sTDInstanceTexCoord' (layout( binding=16) uniform highp samplerBuffer)
+0:?     'sTDInstanceColor' (layout( binding=17) uniform highp samplerBuffer)
+0:?     'gl_VertexIndex' ( in int VertexIndex)
+0:?     'gl_InstanceIndex' ( in int InstanceIndex)
+
+vk.relaxed.stagelink.0.0.frag
+Shader version: 460
+gl_FragCoord origin is upper left
+0:? Sequence
+0:95  Function Definition: main( ( global void)
+0:95    Function Parameters: 
+0:99    Sequence
+0:99      Function Call: TDCheckDiscard( ( global void)
+0:101      Sequence
+0:101        move second child to first child ( temp highp 4-component vector of float)
+0:101          'outcol' ( temp highp 4-component vector of float)
+0:101          Constant:
+0:101            0.000000
+0:101            0.000000
+0:101            0.000000
+0:101            0.000000
+0:103      Sequence
+0:103        move second child to first child ( temp highp 3-component vector of float)
+0:103          'texCoord0' ( temp highp 3-component vector of float)
+0:103          vector swizzle ( temp highp 3-component vector of float)
+0:103            texCoord0: direct index for structure ( in highp 3-component vector of float)
+0:103              'iVert' ( in block{ in highp 4-component vector of float color,  in highp 3-component vector of float worldSpacePos,  in highp 3-component vector of float texCoord0,  flat in highp int cameraIndex,  flat in highp int instance})
+0:103              Constant:
+0:103                2 (const int)
+0:103            Sequence
+0:103              Constant:
+0:103                0 (const int)
+0:103              Constant:
+0:103                1 (const int)
+0:103              Constant:
+0:103                2 (const int)
+0:104      Sequence
+0:104        move second child to first child ( temp highp float)
+0:104          'actualTexZ' ( temp highp float)
+0:104          mod ( global highp float)
+0:104            Convert int to float ( temp highp float)
+0:104              Convert float to int ( temp highp int)
+0:104                direct index ( temp highp float)
+0:104                  'texCoord0' ( temp highp 3-component vector of float)
+0:104                  Constant:
+0:104                    2 (const int)
+0:104            Constant:
+0:104              2048.000000
+0:105      Sequence
+0:105        move second child to first child ( temp highp float)
+0:105          'instanceLoop' ( temp highp float)
+0:105          Floor ( global highp float)
+0:105            Convert int to float ( temp highp float)
+0:105              divide ( temp highp int)
+0:105                Convert float to int ( temp highp int)
+0:105                  direct index ( temp highp float)
+0:105                    'texCoord0' ( temp highp 3-component vector of float)
+0:105                    Constant:
+0:105                      2 (const int)
+0:105                Constant:
+0:105                  2048 (const int)
+0:106      move second child to first child ( temp highp float)
+0:106        direct index ( temp highp float)
+0:106          'texCoord0' ( temp highp 3-component vector of float)
+0:106          Constant:
+0:106            2 (const int)
+0:106        'actualTexZ' ( temp highp float)
+0:107      Sequence
+0:107        move second child to first child ( temp highp 4-component vector of float)
+0:107          'colorMapColor' ( temp highp 4-component vector of float)
+0:107          texture ( global highp 4-component vector of float)
+0:107            'sColorMap' ( uniform highp sampler2DArray)
+0:107            vector swizzle ( temp highp 3-component vector of float)
+0:107              'texCoord0' ( temp highp 3-component vector of float)
+0:107              Sequence
+0:107                Constant:
+0:107                  0 (const int)
+0:107                Constant:
+0:107                  1 (const int)
+0:107                Constant:
+0:107                  2 (const int)
+0:109      Sequence
+0:109        move second child to first child ( temp highp float)
+0:109          'red' ( temp highp float)
+0:109          indirect index ( temp highp float)
+0:109            'colorMapColor' ( temp highp 4-component vector of float)
+0:109            Convert float to int ( temp highp int)
+0:109              'instanceLoop' ( temp highp float)
+0:110      move second child to first child ( temp highp 4-component vector of float)
+0:110        'colorMapColor' ( temp highp 4-component vector of float)
+0:110        Construct vec4 ( temp highp 4-component vector of float)
+0:110          'red' ( temp highp float)
+0:112      add second child into first child ( temp highp 3-component vector of float)
+0:112        vector swizzle ( temp highp 3-component vector of float)
+0:112          'outcol' ( temp highp 4-component vector of float)
+0:112          Sequence
+0:112            Constant:
+0:112              0 (const int)
+0:112            Constant:
+0:112              1 (const int)
+0:112            Constant:
+0:112              2 (const int)
+0:112        component-wise multiply ( temp highp 3-component vector of float)
+0:112          uConstant: direct index for structure ( uniform highp 3-component vector of float)
+0:112            'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal,  uniform highp 3-component vector of float uConstant,  uniform highp float uShadowStrength,  uniform highp 3-component vector of float uShadowColor,  uniform highp 4-component vector of float uDiffuseColor,  uniform highp 4-component vector of float uAmbientColor})
+0:112            Constant:
+0:112              3 (const uint)
+0:112          vector swizzle ( temp highp 3-component vector of float)
+0:112            color: direct index for structure ( in highp 4-component vector of float)
+0:112              'iVert' ( in block{ in highp 4-component vector of float color,  in highp 3-component vector of float worldSpacePos,  in highp 3-component vector of float texCoord0,  flat in highp int cameraIndex,  flat in highp int instance})
+0:112              Constant:
+0:112                0 (const int)
+0:112            Sequence
+0:112              Constant:
+0:112                0 (const int)
+0:112              Constant:
+0:112                1 (const int)
+0:112              Constant:
+0:112                2 (const int)
+0:114      multiply second child into first child ( temp highp 4-component vector of float)
+0:114        'outcol' ( temp highp 4-component vector of float)
+0:114        'colorMapColor' ( temp highp 4-component vector of float)
+0:117      Sequence
+0:117        move second child to first child ( temp highp float)
+0:117          'alpha' ( temp highp float)
+0:117          component-wise multiply ( temp highp float)
+0:117            direct index ( temp highp float)
+0:117              color: direct index for structure ( in highp 4-component vector of float)
+0:117                'iVert' ( in block{ in highp 4-component vector of float color,  in highp 3-component vector of float worldSpacePos,  in highp 3-component vector of float texCoord0,  flat in highp int cameraIndex,  flat in highp int instance})
+0:117                Constant:
+0:117                  0 (const int)
+0:117              Constant:
+0:117                3 (const int)
+0:117            direct index ( temp highp float)
+0:117              'colorMapColor' ( temp highp 4-component vector of float)
+0:117              Constant:
+0:117                3 (const int)
+0:120      move second child to first child ( temp highp 4-component vector of float)
+0:120        'outcol' ( temp highp 4-component vector of float)
+0:120        Function Call: TDDither(vf4; ( global highp 4-component vector of float)
+0:120          'outcol' ( temp highp 4-component vector of float)
+0:122      vector scale second child into first child ( temp highp 3-component vector of float)
+0:122        vector swizzle ( temp highp 3-component vector of float)
+0:122          'outcol' ( temp highp 4-component vector of float)
+0:122          Sequence
+0:122            Constant:
+0:122              0 (const int)
+0:122            Constant:
+0:122              1 (const int)
+0:122            Constant:
+0:122              2 (const int)
+0:122        'alpha' ( temp highp float)
+0:126      Function Call: TDAlphaTest(f1; ( global void)
+0:126        'alpha' ( temp highp float)
+0:128      move second child to first child ( temp highp float)
+0:128        direct index ( temp highp float)
+0:128          'outcol' ( temp highp 4-component vector of float)
+0:128          Constant:
+0:128            3 (const int)
+0:128        'alpha' ( temp highp float)
+0:129      move second child to first child ( temp highp 4-component vector of float)
+0:129        direct index (layout( location=0) temp highp 4-component vector of float)
+0:129          'oFragColor' (layout( location=0) out 1-element array of highp 4-component vector of float)
+0:129          Constant:
+0:129            0 (const int)
+0:129        Function Call: TDOutputSwizzle(vf4; ( global highp 4-component vector of float)
+0:129          'outcol' ( temp highp 4-component vector of float)
+0:135      Sequence
+0:135        Sequence
+0:135          move second child to first child ( temp highp int)
+0:135            'i' ( temp highp int)
+0:135            Constant:
+0:135              1 (const int)
+0:135        Loop with condition tested first
+0:135          Loop Condition
+0:135          Compare Less Than ( temp bool)
+0:135            'i' ( temp highp int)
+0:135            Constant:
+0:135              1 (const int)
+0:135          Loop Body
+0:137          Sequence
+0:137            move second child to first child ( temp highp 4-component vector of float)
+0:137              indirect index (layout( location=0) temp highp 4-component vector of float)
+0:137                'oFragColor' (layout( location=0) out 1-element array of highp 4-component vector of float)
+0:137                'i' ( temp highp int)
+0:137              Constant:
+0:137                0.000000
+0:137                0.000000
+0:137                0.000000
+0:137                0.000000
+0:135          Loop Terminal Expression
+0:135          Post-Increment ( temp highp int)
+0:135            'i' ( temp highp int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal,  uniform highp 3-component vector of float uConstant,  uniform highp float uShadowStrength,  uniform highp 3-component vector of float uShadowColor,  uniform highp 4-component vector of float uDiffuseColor,  uniform highp 4-component vector of float uAmbientColor})
+0:?     'anon@1' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:?     'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 4-component vector of float nearFar,  global highp 4-component vector of float fog,  global highp 4-component vector of float fogColor,  global highp int renderTOPCameraIndex} uTDCamInfos})
+0:?     'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform structure{ global highp 4-component vector of float ambientColor,  global highp 4-component vector of float nearFar,  global highp 4-component vector of float viewport,  global highp 4-component vector of float viewportRes,  global highp 4-component vector of float fog,  global highp 4-component vector of float fogColor} uTDGeneral})
+0:?     'sColorMap' ( uniform highp sampler2DArray)
+0:?     'iVert' ( in block{ in highp 4-component vector of float color,  in highp 3-component vector of float worldSpacePos,  in highp 3-component vector of float texCoord0,  flat in highp int cameraIndex,  flat in highp int instance})
+0:?     'oFragColor' (layout( location=0) out 1-element array of highp 4-component vector of float)
+
+vk.relaxed.stagelink.0.1.frag
+Shader version: 460
+gl_FragCoord origin is upper left
+0:? Sequence
+0:116  Function Definition: TDColor(vf4; ( global highp 4-component vector of float)
+0:116    Function Parameters: 
+0:116      'color' ( in highp 4-component vector of float)
+0:116    Sequence
+0:116      Branch: Return with expression
+0:116        'color' ( in highp 4-component vector of float)
+0:117  Function Definition: TDCheckOrderIndTrans( ( global void)
+0:117    Function Parameters: 
+0:119  Function Definition: TDCheckDiscard( ( global void)
+0:119    Function Parameters: 
+0:120    Sequence
+0:120      Function Call: TDCheckOrderIndTrans( ( global void)
+0:122  Function Definition: TDDither(vf4; ( global highp 4-component vector of float)
+0:122    Function Parameters: 
+0:122      'color' ( in highp 4-component vector of float)
+0:124    Sequence
+0:124      Sequence
+0:124        move second child to first child ( temp highp float)
+0:124          'd' ( temp highp float)
+0:125          direct index ( temp highp float)
+0:125            texture ( global highp 4-component vector of float)
+0:124              'sTDNoiseMap' ( uniform highp sampler2D)
+0:125              divide ( temp highp 2-component vector of float)
+0:125                vector swizzle ( temp highp 2-component vector of float)
+0:125                  'gl_FragCoord' ( gl_FragCoord highp 4-component vector of float FragCoord)
+0:125                  Sequence
+0:125                    Constant:
+0:125                      0 (const int)
+0:125                    Constant:
+0:125                      1 (const int)
+0:125                Constant:
+0:125                  256.000000
+0:125            Constant:
+0:125              0 (const int)
+0:126      subtract second child into first child ( temp highp float)
+0:126        'd' ( temp highp float)
+0:126        Constant:
+0:126          0.500000
+0:127      divide second child into first child ( temp highp float)
+0:127        'd' ( temp highp float)
+0:127        Constant:
+0:127          256.000000
+0:128      Branch: Return with expression
+0:128        Construct vec4 ( temp highp 4-component vector of float)
+0:128          add ( temp highp 3-component vector of float)
+0:128            vector swizzle ( temp highp 3-component vector of float)
+0:128              'color' ( in highp 4-component vector of float)
+0:128              Sequence
+0:128                Constant:
+0:128                  0 (const int)
+0:128                Constant:
+0:128                  1 (const int)
+0:128                Constant:
+0:128                  2 (const int)
+0:128            'd' ( temp highp float)
+0:128          direct index ( temp highp float)
+0:128            'color' ( in highp 4-component vector of float)
+0:128            Constant:
+0:128              3 (const int)
+0:130  Function Definition: TDFrontFacing(vf3;vf3; ( global bool)
+0:130    Function Parameters: 
+0:130      'pos' ( in highp 3-component vector of float)
+0:130      'normal' ( in highp 3-component vector of float)
+0:132    Sequence
+0:132      Branch: Return with expression
+0:132        'gl_FrontFacing' ( gl_FrontFacing bool Face)
+0:134  Function Definition: TDAttenuateLight(i1;f1; ( global highp float)
+0:134    Function Parameters: 
+0:134      'index' ( in highp int)
+0:134      'lightDist' ( in highp float)
+0:136    Sequence
+0:136      Branch: Return with expression
+0:136        Constant:
+0:136          1.000000
+0:138  Function Definition: TDAlphaTest(f1; ( global void)
+0:138    Function Parameters: 
+0:138      'alpha' ( in highp float)
+0:140  Function Definition: TDHardShadow(i1;vf3; ( global highp float)
+0:140    Function Parameters: 
+0:140      'lightIndex' ( in highp int)
+0:140      'worldSpacePos' ( in highp 3-component vector of float)
+0:141    Sequence
+0:141      Branch: Return with expression
+0:141        Constant:
+0:141          0.000000
+0:142  Function Definition: TDSoftShadow(i1;vf3;i1;i1; ( global highp float)
+0:142    Function Parameters: 
+0:142      'lightIndex' ( in highp int)
+0:142      'worldSpacePos' ( in highp 3-component vector of float)
+0:142      'samples' ( in highp int)
+0:142      'steps' ( in highp int)
+0:143    Sequence
+0:143      Branch: Return with expression
+0:143        Constant:
+0:143          0.000000
+0:144  Function Definition: TDSoftShadow(i1;vf3; ( global highp float)
+0:144    Function Parameters: 
+0:144      'lightIndex' ( in highp int)
+0:144      'worldSpacePos' ( in highp 3-component vector of float)
+0:145    Sequence
+0:145      Branch: Return with expression
+0:145        Constant:
+0:145          0.000000
+0:146  Function Definition: TDShadow(i1;vf3; ( global highp float)
+0:146    Function Parameters: 
+0:146      'lightIndex' ( in highp int)
+0:146      'worldSpacePos' ( in highp 3-component vector of float)
+0:147    Sequence
+0:147      Branch: Return with expression
+0:147        Constant:
+0:147          0.000000
+0:152  Function Definition: iTDRadicalInverse_VdC(u1; ( global highp float)
+0:152    Function Parameters: 
+0:152      'bits' ( in highp uint)
+0:154    Sequence
+0:154      move second child to first child ( temp highp uint)
+0:154        'bits' ( in highp uint)
+0:154        inclusive-or ( temp highp uint)
+0:154          left-shift ( temp highp uint)
+0:154            'bits' ( in highp uint)
+0:154            Constant:
+0:154              16 (const uint)
+0:154          right-shift ( temp highp uint)
+0:154            'bits' ( in highp uint)
+0:154            Constant:
+0:154              16 (const uint)
+0:155      move second child to first child ( temp highp uint)
+0:155        'bits' ( in highp uint)
+0:155        inclusive-or ( temp highp uint)
+0:155          left-shift ( temp highp uint)
+0:155            bitwise and ( temp highp uint)
+0:155              'bits' ( in highp uint)
+0:155              Constant:
+0:155                1431655765 (const uint)
+0:155            Constant:
+0:155              1 (const uint)
+0:155          right-shift ( temp highp uint)
+0:155            bitwise and ( temp highp uint)
+0:155              'bits' ( in highp uint)
+0:155              Constant:
+0:155                2863311530 (const uint)
+0:155            Constant:
+0:155              1 (const uint)
+0:156      move second child to first child ( temp highp uint)
+0:156        'bits' ( in highp uint)
+0:156        inclusive-or ( temp highp uint)
+0:156          left-shift ( temp highp uint)
+0:156            bitwise and ( temp highp uint)
+0:156              'bits' ( in highp uint)
+0:156              Constant:
+0:156                858993459 (const uint)
+0:156            Constant:
+0:156              2 (const uint)
+0:156          right-shift ( temp highp uint)
+0:156            bitwise and ( temp highp uint)
+0:156              'bits' ( in highp uint)
+0:156              Constant:
+0:156                3435973836 (const uint)
+0:156            Constant:
+0:156              2 (const uint)
+0:157      move second child to first child ( temp highp uint)
+0:157        'bits' ( in highp uint)
+0:157        inclusive-or ( temp highp uint)
+0:157          left-shift ( temp highp uint)
+0:157            bitwise and ( temp highp uint)
+0:157              'bits' ( in highp uint)
+0:157              Constant:
+0:157                252645135 (const uint)
+0:157            Constant:
+0:157              4 (const uint)
+0:157          right-shift ( temp highp uint)
+0:157            bitwise and ( temp highp uint)
+0:157              'bits' ( in highp uint)
+0:157              Constant:
+0:157                4042322160 (const uint)
+0:157            Constant:
+0:157              4 (const uint)
+0:158      move second child to first child ( temp highp uint)
+0:158        'bits' ( in highp uint)
+0:158        inclusive-or ( temp highp uint)
+0:158          left-shift ( temp highp uint)
+0:158            bitwise and ( temp highp uint)
+0:158              'bits' ( in highp uint)
+0:158              Constant:
+0:158                16711935 (const uint)
+0:158            Constant:
+0:158              8 (const uint)
+0:158          right-shift ( temp highp uint)
+0:158            bitwise and ( temp highp uint)
+0:158              'bits' ( in highp uint)
+0:158              Constant:
+0:158                4278255360 (const uint)
+0:158            Constant:
+0:158              8 (const uint)
+0:159      Branch: Return with expression
+0:159        component-wise multiply ( temp highp float)
+0:159          Convert uint to float ( temp highp float)
+0:159            'bits' ( in highp uint)
+0:159          Constant:
+0:159            2.3283064365387e-10
+0:161  Function Definition: iTDHammersley(u1;u1; ( global highp 2-component vector of float)
+0:161    Function Parameters: 
+0:161      'i' ( in highp uint)
+0:161      'N' ( in highp uint)
+0:163    Sequence
+0:163      Branch: Return with expression
+0:163        Construct vec2 ( temp highp 2-component vector of float)
+0:163          divide ( temp highp float)
+0:163            Convert uint to float ( temp highp float)
+0:163              'i' ( in highp uint)
+0:163            Convert uint to float ( temp highp float)
+0:163              'N' ( in highp uint)
+0:163          Function Call: iTDRadicalInverse_VdC(u1; ( global highp float)
+0:163            'i' ( in highp uint)
+0:165  Function Definition: iTDImportanceSampleGGX(vf2;f1;vf3; ( global highp 3-component vector of float)
+0:165    Function Parameters: 
+0:165      'Xi' ( in highp 2-component vector of float)
+0:165      'roughness2' ( in highp float)
+0:165      'N' ( in highp 3-component vector of float)
+0:167    Sequence
+0:167      Sequence
+0:167        move second child to first child ( temp highp float)
+0:167          'a' ( temp highp float)
+0:167          'roughness2' ( in highp float)
+0:168      Sequence
+0:168        move second child to first child ( temp highp float)
+0:168          'phi' ( temp highp float)
+0:168          component-wise multiply ( temp highp float)
+0:168            Constant:
+0:168              6.283185
+0:168            direct index ( temp highp float)
+0:168              'Xi' ( in highp 2-component vector of float)
+0:168              Constant:
+0:168                0 (const int)
+0:169      Sequence
+0:169        move second child to first child ( temp highp float)
+0:169          'cosTheta' ( temp highp float)
+0:169          sqrt ( global highp float)
+0:169            divide ( temp highp float)
+0:169              subtract ( temp highp float)
+0:169                Constant:
+0:169                  1.000000
+0:169                direct index ( temp highp float)
+0:169                  'Xi' ( in highp 2-component vector of float)
+0:169                  Constant:
+0:169                    1 (const int)
+0:169              add ( temp highp float)
+0:169                Constant:
+0:169                  1.000000
+0:169                component-wise multiply ( temp highp float)
+0:169                  subtract ( temp highp float)
+0:169                    component-wise multiply ( temp highp float)
+0:169                      'a' ( temp highp float)
+0:169                      'a' ( temp highp float)
+0:169                    Constant:
+0:169                      1.000000
+0:169                  direct index ( temp highp float)
+0:169                    'Xi' ( in highp 2-component vector of float)
+0:169                    Constant:
+0:169                      1 (const int)
+0:170      Sequence
+0:170        move second child to first child ( temp highp float)
+0:170          'sinTheta' ( temp highp float)
+0:170          sqrt ( global highp float)
+0:170            subtract ( temp highp float)
+0:170              Constant:
+0:170                1.000000
+0:170              component-wise multiply ( temp highp float)
+0:170                'cosTheta' ( temp highp float)
+0:170                'cosTheta' ( temp highp float)
+0:173      move second child to first child ( temp highp float)
+0:173        direct index ( temp highp float)
+0:173          'H' ( temp highp 3-component vector of float)
+0:173          Constant:
+0:173            0 (const int)
+0:173        component-wise multiply ( temp highp float)
+0:173          'sinTheta' ( temp highp float)
+0:173          cosine ( global highp float)
+0:173            'phi' ( temp highp float)
+0:174      move second child to first child ( temp highp float)
+0:174        direct index ( temp highp float)
+0:174          'H' ( temp highp 3-component vector of float)
+0:174          Constant:
+0:174            1 (const int)
+0:174        component-wise multiply ( temp highp float)
+0:174          'sinTheta' ( temp highp float)
+0:174          sine ( global highp float)
+0:174            'phi' ( temp highp float)
+0:175      move second child to first child ( temp highp float)
+0:175        direct index ( temp highp float)
+0:175          'H' ( temp highp 3-component vector of float)
+0:175          Constant:
+0:175            2 (const int)
+0:175        'cosTheta' ( temp highp float)
+0:177      Sequence
+0:177        move second child to first child ( temp highp 3-component vector of float)
+0:177          'upVector' ( temp highp 3-component vector of float)
+0:177          Test condition and select ( temp highp 3-component vector of float)
+0:177            Condition
+0:177            Compare Less Than ( temp bool)
+0:177              Absolute value ( global highp float)
+0:177                direct index ( temp highp float)
+0:177                  'N' ( in highp 3-component vector of float)
+0:177                  Constant:
+0:177                    2 (const int)
+0:177              Constant:
+0:177                0.999000
+0:177            true case
+0:177            Constant:
+0:177              0.000000
+0:177              0.000000
+0:177              1.000000
+0:177            false case
+0:177            Constant:
+0:177              1.000000
+0:177              0.000000
+0:177              0.000000
+0:178      Sequence
+0:178        move second child to first child ( temp highp 3-component vector of float)
+0:178          'tangentX' ( temp highp 3-component vector of float)
+0:178          normalize ( global highp 3-component vector of float)
+0:178            cross-product ( global highp 3-component vector of float)
+0:178              'upVector' ( temp highp 3-component vector of float)
+0:178              'N' ( in highp 3-component vector of float)
+0:179      Sequence
+0:179        move second child to first child ( temp highp 3-component vector of float)
+0:179          'tangentY' ( temp highp 3-component vector of float)
+0:179          cross-product ( global highp 3-component vector of float)
+0:179            'N' ( in highp 3-component vector of float)
+0:179            'tangentX' ( temp highp 3-component vector of float)
+0:182      Sequence
+0:182        move second child to first child ( temp highp 3-component vector of float)
+0:182          'worldResult' ( temp highp 3-component vector of float)
+0:182          add ( temp highp 3-component vector of float)
+0:182            add ( temp highp 3-component vector of float)
+0:182              vector-scale ( temp highp 3-component vector of float)
+0:182                'tangentX' ( temp highp 3-component vector of float)
+0:182                direct index ( temp highp float)
+0:182                  'H' ( temp highp 3-component vector of float)
+0:182                  Constant:
+0:182                    0 (const int)
+0:182              vector-scale ( temp highp 3-component vector of float)
+0:182                'tangentY' ( temp highp 3-component vector of float)
+0:182                direct index ( temp highp float)
+0:182                  'H' ( temp highp 3-component vector of float)
+0:182                  Constant:
+0:182                    1 (const int)
+0:182            vector-scale ( temp highp 3-component vector of float)
+0:182              'N' ( in highp 3-component vector of float)
+0:182              direct index ( temp highp float)
+0:182                'H' ( temp highp 3-component vector of float)
+0:182                Constant:
+0:182                  2 (const int)
+0:183      Branch: Return with expression
+0:183        'worldResult' ( temp highp 3-component vector of float)
+0:185  Function Definition: iTDDistributionGGX(vf3;vf3;f1; ( global highp float)
+0:185    Function Parameters: 
+0:185      'normal' ( in highp 3-component vector of float)
+0:185      'half_vector' ( in highp 3-component vector of float)
+0:185      'roughness2' ( in highp float)
+0:?     Sequence
+0:189      Sequence
+0:189        move second child to first child ( temp highp float)
+0:189          'NdotH' ( temp highp float)
+0:189          clamp ( global highp float)
+0:189            dot-product ( global highp float)
+0:189              'normal' ( in highp 3-component vector of float)
+0:189              'half_vector' ( in highp 3-component vector of float)
+0:189            Constant:
+0:189              1.0000000000000e-06
+0:189            Constant:
+0:189              1.000000
+0:191      Sequence
+0:191        move second child to first child ( temp highp float)
+0:191          'alpha2' ( temp highp float)
+0:191          component-wise multiply ( temp highp float)
+0:191            'roughness2' ( in highp float)
+0:191            'roughness2' ( in highp float)
+0:193      Sequence
+0:193        move second child to first child ( temp highp float)
+0:193          'denom' ( temp highp float)
+0:193          add ( temp highp float)
+0:193            component-wise multiply ( temp highp float)
+0:193              component-wise multiply ( temp highp float)
+0:193                'NdotH' ( temp highp float)
+0:193                'NdotH' ( temp highp float)
+0:193              subtract ( temp highp float)
+0:193                'alpha2' ( temp highp float)
+0:193                Constant:
+0:193                  1.000000
+0:193            Constant:
+0:193              1.000000
+0:194      move second child to first child ( temp highp float)
+0:194        'denom' ( temp highp float)
+0:194        max ( global highp float)
+0:194          Constant:
+0:194            1.0000000000000e-08
+0:194          'denom' ( temp highp float)
+0:195      Branch: Return with expression
+0:195        divide ( temp highp float)
+0:195          'alpha2' ( temp highp float)
+0:195          component-wise multiply ( temp highp float)
+0:195            component-wise multiply ( temp highp float)
+0:195              Constant:
+0:195                3.141593
+0:195              'denom' ( temp highp float)
+0:195            'denom' ( temp highp float)
+0:197  Function Definition: iTDCalcF(vf3;f1; ( global highp 3-component vector of float)
+0:197    Function Parameters: 
+0:197      'F0' ( in highp 3-component vector of float)
+0:197      'VdotH' ( in highp float)
+0:198    Sequence
+0:198      Branch: Return with expression
+0:198        add ( temp highp 3-component vector of float)
+0:198          'F0' ( in highp 3-component vector of float)
+0:198          vector-scale ( temp highp 3-component vector of float)
+0:198            subtract ( temp highp 3-component vector of float)
+0:198              Constant:
+0:198                1.000000
+0:198                1.000000
+0:198                1.000000
+0:198              'F0' ( in highp 3-component vector of float)
+0:198            pow ( global highp float)
+0:198              Constant:
+0:198                2.000000
+0:198              component-wise multiply ( temp highp float)
+0:198                subtract ( temp highp float)
+0:198                  component-wise multiply ( temp highp float)
+0:198                    Constant:
+0:198                      -5.554730
+0:198                    'VdotH' ( in highp float)
+0:198                  Constant:
+0:198                    6.983160
+0:198                'VdotH' ( in highp float)
+0:201  Function Definition: iTDCalcG(f1;f1;f1; ( global highp float)
+0:201    Function Parameters: 
+0:201      'NdotL' ( in highp float)
+0:201      'NdotV' ( in highp float)
+0:201      'k' ( in highp float)
+0:202    Sequence
+0:202      Sequence
+0:202        move second child to first child ( temp highp float)
+0:202          'Gl' ( temp highp float)
+0:202          divide ( temp highp float)
+0:202            Constant:
+0:202              1.000000
+0:202            add ( temp highp float)
+0:202              component-wise multiply ( temp highp float)
+0:202                'NdotL' ( in highp float)
+0:202                subtract ( temp highp float)
+0:202                  Constant:
+0:202                    1.000000
+0:202                  'k' ( in highp float)
+0:202              'k' ( in highp float)
+0:203      Sequence
+0:203        move second child to first child ( temp highp float)
+0:203          'Gv' ( temp highp float)
+0:203          divide ( temp highp float)
+0:203            Constant:
+0:203              1.000000
+0:203            add ( temp highp float)
+0:203              component-wise multiply ( temp highp float)
+0:203                'NdotV' ( in highp float)
+0:203                subtract ( temp highp float)
+0:203                  Constant:
+0:203                    1.000000
+0:203                  'k' ( in highp float)
+0:203              'k' ( in highp float)
+0:204      Branch: Return with expression
+0:204        component-wise multiply ( temp highp float)
+0:204          'Gl' ( temp highp float)
+0:204          'Gv' ( temp highp float)
+0:207  Function Definition: TDLightingPBR(i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1; ( global structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:207    Function Parameters: 
+0:207      'index' ( in highp int)
+0:207      'diffuseColor' ( in highp 3-component vector of float)
+0:207      'specularColor' ( in highp 3-component vector of float)
+0:207      'worldSpacePos' ( in highp 3-component vector of float)
+0:207      'normal' ( in highp 3-component vector of float)
+0:207      'shadowStrength' ( in highp float)
+0:207      'shadowColor' ( in highp 3-component vector of float)
+0:207      'camVector' ( in highp 3-component vector of float)
+0:207      'roughness' ( in highp float)
+0:?     Sequence
+0:210      Branch: Return with expression
+0:210        'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:213  Function Definition: TDLightingPBR(vf3;vf3;f1;i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1; ( global void)
+0:213    Function Parameters: 
+0:213      'diffuseContrib' ( inout highp 3-component vector of float)
+0:213      'specularContrib' ( inout highp 3-component vector of float)
+0:213      'shadowStrengthOut' ( inout highp float)
+0:213      'index' ( in highp int)
+0:213      'diffuseColor' ( in highp 3-component vector of float)
+0:213      'specularColor' ( in highp 3-component vector of float)
+0:213      'worldSpacePos' ( in highp 3-component vector of float)
+0:213      'normal' ( in highp 3-component vector of float)
+0:213      'shadowStrength' ( in highp float)
+0:213      'shadowColor' ( in highp 3-component vector of float)
+0:213      'camVector' ( in highp 3-component vector of float)
+0:213      'roughness' ( in highp float)
+0:215    Sequence
+0:215      Sequence
+0:215        move second child to first child ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:215          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:215          Function Call: TDLightingPBR(i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1; ( global structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:215            'index' ( in highp int)
+0:215            'diffuseColor' ( in highp 3-component vector of float)
+0:215            'specularColor' ( in highp 3-component vector of float)
+0:215            'worldSpacePos' ( in highp 3-component vector of float)
+0:215            'normal' ( in highp 3-component vector of float)
+0:215            'shadowStrength' ( in highp float)
+0:215            'shadowColor' ( in highp 3-component vector of float)
+0:215            'camVector' ( in highp 3-component vector of float)
+0:215            'roughness' ( in highp float)
+0:215      move second child to first child ( temp highp 3-component vector of float)
+0:215        'diffuseContrib' ( inout highp 3-component vector of float)
+0:215        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:215          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:215          Constant:
+0:215            0 (const int)
+0:216      move second child to first child ( temp highp 3-component vector of float)
+0:216        'specularContrib' ( inout highp 3-component vector of float)
+0:216        specular: direct index for structure ( global highp 3-component vector of float)
+0:216          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:216          Constant:
+0:216            1 (const int)
+0:217      move second child to first child ( temp highp float)
+0:217        'shadowStrengthOut' ( inout highp float)
+0:217        shadowStrength: direct index for structure ( global highp float)
+0:217          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:217          Constant:
+0:217            2 (const int)
+0:220  Function Definition: TDLightingPBR(vf3;vf3;i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1; ( global void)
+0:220    Function Parameters: 
+0:220      'diffuseContrib' ( inout highp 3-component vector of float)
+0:220      'specularContrib' ( inout highp 3-component vector of float)
+0:220      'index' ( in highp int)
+0:220      'diffuseColor' ( in highp 3-component vector of float)
+0:220      'specularColor' ( in highp 3-component vector of float)
+0:220      'worldSpacePos' ( in highp 3-component vector of float)
+0:220      'normal' ( in highp 3-component vector of float)
+0:220      'shadowStrength' ( in highp float)
+0:220      'shadowColor' ( in highp 3-component vector of float)
+0:220      'camVector' ( in highp 3-component vector of float)
+0:220      'roughness' ( in highp float)
+0:222    Sequence
+0:222      Sequence
+0:222        move second child to first child ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:222          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:222          Function Call: TDLightingPBR(i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1; ( global structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:222            'index' ( in highp int)
+0:222            'diffuseColor' ( in highp 3-component vector of float)
+0:222            'specularColor' ( in highp 3-component vector of float)
+0:222            'worldSpacePos' ( in highp 3-component vector of float)
+0:222            'normal' ( in highp 3-component vector of float)
+0:222            'shadowStrength' ( in highp float)
+0:222            'shadowColor' ( in highp 3-component vector of float)
+0:222            'camVector' ( in highp 3-component vector of float)
+0:222            'roughness' ( in highp float)
+0:222      move second child to first child ( temp highp 3-component vector of float)
+0:222        'diffuseContrib' ( inout highp 3-component vector of float)
+0:222        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:222          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:222          Constant:
+0:222            0 (const int)
+0:223      move second child to first child ( temp highp 3-component vector of float)
+0:223        'specularContrib' ( inout highp 3-component vector of float)
+0:223        specular: direct index for structure ( global highp 3-component vector of float)
+0:223          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:223          Constant:
+0:223            1 (const int)
+0:226  Function Definition: TDEnvLightingPBR(i1;vf3;vf3;vf3;vf3;f1;f1; ( global structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:226    Function Parameters: 
+0:226      'index' ( in highp int)
+0:226      'diffuseColor' ( in highp 3-component vector of float)
+0:226      'specularColor' ( in highp 3-component vector of float)
+0:226      'normal' ( in highp 3-component vector of float)
+0:226      'camVector' ( in highp 3-component vector of float)
+0:226      'roughness' ( in highp float)
+0:226      'ambientOcclusion' ( in highp float)
+0:?     Sequence
+0:229      Branch: Return with expression
+0:229        'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:232  Function Definition: TDEnvLightingPBR(vf3;vf3;i1;vf3;vf3;vf3;vf3;f1;f1; ( global void)
+0:232    Function Parameters: 
+0:232      'diffuseContrib' ( inout highp 3-component vector of float)
+0:232      'specularContrib' ( inout highp 3-component vector of float)
+0:232      'index' ( in highp int)
+0:232      'diffuseColor' ( in highp 3-component vector of float)
+0:232      'specularColor' ( in highp 3-component vector of float)
+0:232      'normal' ( in highp 3-component vector of float)
+0:232      'camVector' ( in highp 3-component vector of float)
+0:232      'roughness' ( in highp float)
+0:232      'ambientOcclusion' ( in highp float)
+0:234    Sequence
+0:234      Sequence
+0:234        move second child to first child ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:234          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:234          Function Call: TDEnvLightingPBR(i1;vf3;vf3;vf3;vf3;f1;f1; ( global structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:234            'index' ( in highp int)
+0:234            'diffuseColor' ( in highp 3-component vector of float)
+0:234            'specularColor' ( in highp 3-component vector of float)
+0:234            'normal' ( in highp 3-component vector of float)
+0:234            'camVector' ( in highp 3-component vector of float)
+0:234            'roughness' ( in highp float)
+0:234            'ambientOcclusion' ( in highp float)
+0:235      move second child to first child ( temp highp 3-component vector of float)
+0:235        'diffuseContrib' ( inout highp 3-component vector of float)
+0:235        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:235          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:235          Constant:
+0:235            0 (const int)
+0:236      move second child to first child ( temp highp 3-component vector of float)
+0:236        'specularContrib' ( inout highp 3-component vector of float)
+0:236        specular: direct index for structure ( global highp 3-component vector of float)
+0:236          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:236          Constant:
+0:236            1 (const int)
+0:239  Function Definition: TDLighting(i1;vf3;vf3;f1;vf3;vf3;f1;f1; ( global structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:239    Function Parameters: 
+0:239      'index' ( in highp int)
+0:239      'worldSpacePos' ( in highp 3-component vector of float)
+0:239      'normal' ( in highp 3-component vector of float)
+0:239      'shadowStrength' ( in highp float)
+0:239      'shadowColor' ( in highp 3-component vector of float)
+0:239      'camVector' ( in highp 3-component vector of float)
+0:239      'shininess' ( in highp float)
+0:239      'shininess2' ( in highp float)
+0:?     Sequence
+0:242      switch
+0:242      condition
+0:242        'index' ( in highp int)
+0:242      body
+0:242        Sequence
+0:244          default: 
+0:?           Sequence
+0:245            move second child to first child ( temp highp 3-component vector of float)
+0:245              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:245                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:245                Constant:
+0:245                  0 (const int)
+0:245              Constant:
+0:245                0.000000
+0:245                0.000000
+0:245                0.000000
+0:246            move second child to first child ( temp highp 3-component vector of float)
+0:246              specular: direct index for structure ( global highp 3-component vector of float)
+0:246                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:246                Constant:
+0:246                  1 (const int)
+0:246              Constant:
+0:246                0.000000
+0:246                0.000000
+0:246                0.000000
+0:247            move second child to first child ( temp highp 3-component vector of float)
+0:247              specular2: direct index for structure ( global highp 3-component vector of float)
+0:247                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:247                Constant:
+0:247                  2 (const int)
+0:247              Constant:
+0:247                0.000000
+0:247                0.000000
+0:247                0.000000
+0:248            move second child to first child ( temp highp float)
+0:248              shadowStrength: direct index for structure ( global highp float)
+0:248                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:248                Constant:
+0:248                  3 (const int)
+0:248              Constant:
+0:248                0.000000
+0:249            Branch: Break
+0:251      Branch: Return with expression
+0:251        'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:254  Function Definition: TDLighting(vf3;vf3;vf3;f1;i1;vf3;vf3;f1;vf3;vf3;f1;f1; ( global void)
+0:254    Function Parameters: 
+0:254      'diffuseContrib' ( inout highp 3-component vector of float)
+0:254      'specularContrib' ( inout highp 3-component vector of float)
+0:254      'specularContrib2' ( inout highp 3-component vector of float)
+0:254      'shadowStrengthOut' ( inout highp float)
+0:254      'index' ( in highp int)
+0:254      'worldSpacePos' ( in highp 3-component vector of float)
+0:254      'normal' ( in highp 3-component vector of float)
+0:254      'shadowStrength' ( in highp float)
+0:254      'shadowColor' ( in highp 3-component vector of float)
+0:254      'camVector' ( in highp 3-component vector of float)
+0:254      'shininess' ( in highp float)
+0:254      'shininess2' ( in highp float)
+0:?     Sequence
+0:257      switch
+0:257      condition
+0:257        'index' ( in highp int)
+0:257      body
+0:257        Sequence
+0:259          default: 
+0:?           Sequence
+0:260            move second child to first child ( temp highp 3-component vector of float)
+0:260              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:260                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:260                Constant:
+0:260                  0 (const int)
+0:260              Constant:
+0:260                0.000000
+0:260                0.000000
+0:260                0.000000
+0:261            move second child to first child ( temp highp 3-component vector of float)
+0:261              specular: direct index for structure ( global highp 3-component vector of float)
+0:261                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:261                Constant:
+0:261                  1 (const int)
+0:261              Constant:
+0:261                0.000000
+0:261                0.000000
+0:261                0.000000
+0:262            move second child to first child ( temp highp 3-component vector of float)
+0:262              specular2: direct index for structure ( global highp 3-component vector of float)
+0:262                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:262                Constant:
+0:262                  2 (const int)
+0:262              Constant:
+0:262                0.000000
+0:262                0.000000
+0:262                0.000000
+0:263            move second child to first child ( temp highp float)
+0:263              shadowStrength: direct index for structure ( global highp float)
+0:263                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:263                Constant:
+0:263                  3 (const int)
+0:263              Constant:
+0:263                0.000000
+0:264            Branch: Break
+0:266      move second child to first child ( temp highp 3-component vector of float)
+0:266        'diffuseContrib' ( inout highp 3-component vector of float)
+0:266        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:266          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:266          Constant:
+0:266            0 (const int)
+0:267      move second child to first child ( temp highp 3-component vector of float)
+0:267        'specularContrib' ( inout highp 3-component vector of float)
+0:267        specular: direct index for structure ( global highp 3-component vector of float)
+0:267          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:267          Constant:
+0:267            1 (const int)
+0:268      move second child to first child ( temp highp 3-component vector of float)
+0:268        'specularContrib2' ( inout highp 3-component vector of float)
+0:268        specular2: direct index for structure ( global highp 3-component vector of float)
+0:268          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:268          Constant:
+0:268            2 (const int)
+0:269      move second child to first child ( temp highp float)
+0:269        'shadowStrengthOut' ( inout highp float)
+0:269        shadowStrength: direct index for structure ( global highp float)
+0:269          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:269          Constant:
+0:269            3 (const int)
+0:272  Function Definition: TDLighting(vf3;vf3;vf3;i1;vf3;vf3;f1;vf3;vf3;f1;f1; ( global void)
+0:272    Function Parameters: 
+0:272      'diffuseContrib' ( inout highp 3-component vector of float)
+0:272      'specularContrib' ( inout highp 3-component vector of float)
+0:272      'specularContrib2' ( inout highp 3-component vector of float)
+0:272      'index' ( in highp int)
+0:272      'worldSpacePos' ( in highp 3-component vector of float)
+0:272      'normal' ( in highp 3-component vector of float)
+0:272      'shadowStrength' ( in highp float)
+0:272      'shadowColor' ( in highp 3-component vector of float)
+0:272      'camVector' ( in highp 3-component vector of float)
+0:272      'shininess' ( in highp float)
+0:272      'shininess2' ( in highp float)
+0:?     Sequence
+0:275      switch
+0:275      condition
+0:275        'index' ( in highp int)
+0:275      body
+0:275        Sequence
+0:277          default: 
+0:?           Sequence
+0:278            move second child to first child ( temp highp 3-component vector of float)
+0:278              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:278                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:278                Constant:
+0:278                  0 (const int)
+0:278              Constant:
+0:278                0.000000
+0:278                0.000000
+0:278                0.000000
+0:279            move second child to first child ( temp highp 3-component vector of float)
+0:279              specular: direct index for structure ( global highp 3-component vector of float)
+0:279                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:279                Constant:
+0:279                  1 (const int)
+0:279              Constant:
+0:279                0.000000
+0:279                0.000000
+0:279                0.000000
+0:280            move second child to first child ( temp highp 3-component vector of float)
+0:280              specular2: direct index for structure ( global highp 3-component vector of float)
+0:280                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:280                Constant:
+0:280                  2 (const int)
+0:280              Constant:
+0:280                0.000000
+0:280                0.000000
+0:280                0.000000
+0:281            move second child to first child ( temp highp float)
+0:281              shadowStrength: direct index for structure ( global highp float)
+0:281                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:281                Constant:
+0:281                  3 (const int)
+0:281              Constant:
+0:281                0.000000
+0:282            Branch: Break
+0:284      move second child to first child ( temp highp 3-component vector of float)
+0:284        'diffuseContrib' ( inout highp 3-component vector of float)
+0:284        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:284          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:284          Constant:
+0:284            0 (const int)
+0:285      move second child to first child ( temp highp 3-component vector of float)
+0:285        'specularContrib' ( inout highp 3-component vector of float)
+0:285        specular: direct index for structure ( global highp 3-component vector of float)
+0:285          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:285          Constant:
+0:285            1 (const int)
+0:286      move second child to first child ( temp highp 3-component vector of float)
+0:286        'specularContrib2' ( inout highp 3-component vector of float)
+0:286        specular2: direct index for structure ( global highp 3-component vector of float)
+0:286          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:286          Constant:
+0:286            2 (const int)
+0:289  Function Definition: TDLighting(vf3;vf3;i1;vf3;vf3;f1;vf3;vf3;f1; ( global void)
+0:289    Function Parameters: 
+0:289      'diffuseContrib' ( inout highp 3-component vector of float)
+0:289      'specularContrib' ( inout highp 3-component vector of float)
+0:289      'index' ( in highp int)
+0:289      'worldSpacePos' ( in highp 3-component vector of float)
+0:289      'normal' ( in highp 3-component vector of float)
+0:289      'shadowStrength' ( in highp float)
+0:289      'shadowColor' ( in highp 3-component vector of float)
+0:289      'camVector' ( in highp 3-component vector of float)
+0:289      'shininess' ( in highp float)
+0:?     Sequence
+0:292      switch
+0:292      condition
+0:292        'index' ( in highp int)
+0:292      body
+0:292        Sequence
+0:294          default: 
+0:?           Sequence
+0:295            move second child to first child ( temp highp 3-component vector of float)
+0:295              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:295                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:295                Constant:
+0:295                  0 (const int)
+0:295              Constant:
+0:295                0.000000
+0:295                0.000000
+0:295                0.000000
+0:296            move second child to first child ( temp highp 3-component vector of float)
+0:296              specular: direct index for structure ( global highp 3-component vector of float)
+0:296                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:296                Constant:
+0:296                  1 (const int)
+0:296              Constant:
+0:296                0.000000
+0:296                0.000000
+0:296                0.000000
+0:297            move second child to first child ( temp highp 3-component vector of float)
+0:297              specular2: direct index for structure ( global highp 3-component vector of float)
+0:297                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:297                Constant:
+0:297                  2 (const int)
+0:297              Constant:
+0:297                0.000000
+0:297                0.000000
+0:297                0.000000
+0:298            move second child to first child ( temp highp float)
+0:298              shadowStrength: direct index for structure ( global highp float)
+0:298                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:298                Constant:
+0:298                  3 (const int)
+0:298              Constant:
+0:298                0.000000
+0:299            Branch: Break
+0:301      move second child to first child ( temp highp 3-component vector of float)
+0:301        'diffuseContrib' ( inout highp 3-component vector of float)
+0:301        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:301          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:301          Constant:
+0:301            0 (const int)
+0:302      move second child to first child ( temp highp 3-component vector of float)
+0:302        'specularContrib' ( inout highp 3-component vector of float)
+0:302        specular: direct index for structure ( global highp 3-component vector of float)
+0:302          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:302          Constant:
+0:302            1 (const int)
+0:305  Function Definition: TDLighting(vf3;vf3;vf3;i1;vf3;vf3;vf3;f1;f1; ( global void)
+0:305    Function Parameters: 
+0:305      'diffuseContrib' ( inout highp 3-component vector of float)
+0:305      'specularContrib' ( inout highp 3-component vector of float)
+0:305      'specularContrib2' ( inout highp 3-component vector of float)
+0:305      'index' ( in highp int)
+0:305      'worldSpacePos' ( in highp 3-component vector of float)
+0:305      'normal' ( in highp 3-component vector of float)
+0:305      'camVector' ( in highp 3-component vector of float)
+0:305      'shininess' ( in highp float)
+0:305      'shininess2' ( in highp float)
+0:?     Sequence
+0:308      switch
+0:308      condition
+0:308        'index' ( in highp int)
+0:308      body
+0:308        Sequence
+0:310          default: 
+0:?           Sequence
+0:311            move second child to first child ( temp highp 3-component vector of float)
+0:311              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:311                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:311                Constant:
+0:311                  0 (const int)
+0:311              Constant:
+0:311                0.000000
+0:311                0.000000
+0:311                0.000000
+0:312            move second child to first child ( temp highp 3-component vector of float)
+0:312              specular: direct index for structure ( global highp 3-component vector of float)
+0:312                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:312                Constant:
+0:312                  1 (const int)
+0:312              Constant:
+0:312                0.000000
+0:312                0.000000
+0:312                0.000000
+0:313            move second child to first child ( temp highp 3-component vector of float)
+0:313              specular2: direct index for structure ( global highp 3-component vector of float)
+0:313                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:313                Constant:
+0:313                  2 (const int)
+0:313              Constant:
+0:313                0.000000
+0:313                0.000000
+0:313                0.000000
+0:314            move second child to first child ( temp highp float)
+0:314              shadowStrength: direct index for structure ( global highp float)
+0:314                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:314                Constant:
+0:314                  3 (const int)
+0:314              Constant:
+0:314                0.000000
+0:315            Branch: Break
+0:317      move second child to first child ( temp highp 3-component vector of float)
+0:317        'diffuseContrib' ( inout highp 3-component vector of float)
+0:317        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:317          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:317          Constant:
+0:317            0 (const int)
+0:318      move second child to first child ( temp highp 3-component vector of float)
+0:318        'specularContrib' ( inout highp 3-component vector of float)
+0:318        specular: direct index for structure ( global highp 3-component vector of float)
+0:318          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:318          Constant:
+0:318            1 (const int)
+0:319      move second child to first child ( temp highp 3-component vector of float)
+0:319        'specularContrib2' ( inout highp 3-component vector of float)
+0:319        specular2: direct index for structure ( global highp 3-component vector of float)
+0:319          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:319          Constant:
+0:319            2 (const int)
+0:322  Function Definition: TDLighting(vf3;vf3;i1;vf3;vf3;vf3;f1; ( global void)
+0:322    Function Parameters: 
+0:322      'diffuseContrib' ( inout highp 3-component vector of float)
+0:322      'specularContrib' ( inout highp 3-component vector of float)
+0:322      'index' ( in highp int)
+0:322      'worldSpacePos' ( in highp 3-component vector of float)
+0:322      'normal' ( in highp 3-component vector of float)
+0:322      'camVector' ( in highp 3-component vector of float)
+0:322      'shininess' ( in highp float)
+0:?     Sequence
+0:325      switch
+0:325      condition
+0:325        'index' ( in highp int)
+0:325      body
+0:325        Sequence
+0:327          default: 
+0:?           Sequence
+0:328            move second child to first child ( temp highp 3-component vector of float)
+0:328              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:328                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:328                Constant:
+0:328                  0 (const int)
+0:328              Constant:
+0:328                0.000000
+0:328                0.000000
+0:328                0.000000
+0:329            move second child to first child ( temp highp 3-component vector of float)
+0:329              specular: direct index for structure ( global highp 3-component vector of float)
+0:329                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:329                Constant:
+0:329                  1 (const int)
+0:329              Constant:
+0:329                0.000000
+0:329                0.000000
+0:329                0.000000
+0:330            move second child to first child ( temp highp 3-component vector of float)
+0:330              specular2: direct index for structure ( global highp 3-component vector of float)
+0:330                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:330                Constant:
+0:330                  2 (const int)
+0:330              Constant:
+0:330                0.000000
+0:330                0.000000
+0:330                0.000000
+0:331            move second child to first child ( temp highp float)
+0:331              shadowStrength: direct index for structure ( global highp float)
+0:331                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:331                Constant:
+0:331                  3 (const int)
+0:331              Constant:
+0:331                0.000000
+0:332            Branch: Break
+0:334      move second child to first child ( temp highp 3-component vector of float)
+0:334        'diffuseContrib' ( inout highp 3-component vector of float)
+0:334        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:334          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:334          Constant:
+0:334            0 (const int)
+0:335      move second child to first child ( temp highp 3-component vector of float)
+0:335        'specularContrib' ( inout highp 3-component vector of float)
+0:335        specular: direct index for structure ( global highp 3-component vector of float)
+0:335          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:335          Constant:
+0:335            1 (const int)
+0:338  Function Definition: TDLighting(vf3;i1;vf3;vf3; ( global void)
+0:338    Function Parameters: 
+0:338      'diffuseContrib' ( inout highp 3-component vector of float)
+0:338      'index' ( in highp int)
+0:338      'worldSpacePos' ( in highp 3-component vector of float)
+0:338      'normal' ( in highp 3-component vector of float)
+0:?     Sequence
+0:341      switch
+0:341      condition
+0:341        'index' ( in highp int)
+0:341      body
+0:341        Sequence
+0:343          default: 
+0:?           Sequence
+0:344            move second child to first child ( temp highp 3-component vector of float)
+0:344              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:344                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:344                Constant:
+0:344                  0 (const int)
+0:344              Constant:
+0:344                0.000000
+0:344                0.000000
+0:344                0.000000
+0:345            move second child to first child ( temp highp 3-component vector of float)
+0:345              specular: direct index for structure ( global highp 3-component vector of float)
+0:345                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:345                Constant:
+0:345                  1 (const int)
+0:345              Constant:
+0:345                0.000000
+0:345                0.000000
+0:345                0.000000
+0:346            move second child to first child ( temp highp 3-component vector of float)
+0:346              specular2: direct index for structure ( global highp 3-component vector of float)
+0:346                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:346                Constant:
+0:346                  2 (const int)
+0:346              Constant:
+0:346                0.000000
+0:346                0.000000
+0:346                0.000000
+0:347            move second child to first child ( temp highp float)
+0:347              shadowStrength: direct index for structure ( global highp float)
+0:347                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:347                Constant:
+0:347                  3 (const int)
+0:347              Constant:
+0:347                0.000000
+0:348            Branch: Break
+0:350      move second child to first child ( temp highp 3-component vector of float)
+0:350        'diffuseContrib' ( inout highp 3-component vector of float)
+0:350        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:350          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:350          Constant:
+0:350            0 (const int)
+0:353  Function Definition: TDLighting(vf3;i1;vf3;vf3;f1;vf3; ( global void)
+0:353    Function Parameters: 
+0:353      'diffuseContrib' ( inout highp 3-component vector of float)
+0:353      'index' ( in highp int)
+0:353      'worldSpacePos' ( in highp 3-component vector of float)
+0:353      'normal' ( in highp 3-component vector of float)
+0:353      'shadowStrength' ( in highp float)
+0:353      'shadowColor' ( in highp 3-component vector of float)
+0:?     Sequence
+0:356      switch
+0:356      condition
+0:356        'index' ( in highp int)
+0:356      body
+0:356        Sequence
+0:358          default: 
+0:?           Sequence
+0:359            move second child to first child ( temp highp 3-component vector of float)
+0:359              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:359                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:359                Constant:
+0:359                  0 (const int)
+0:359              Constant:
+0:359                0.000000
+0:359                0.000000
+0:359                0.000000
+0:360            move second child to first child ( temp highp 3-component vector of float)
+0:360              specular: direct index for structure ( global highp 3-component vector of float)
+0:360                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:360                Constant:
+0:360                  1 (const int)
+0:360              Constant:
+0:360                0.000000
+0:360                0.000000
+0:360                0.000000
+0:361            move second child to first child ( temp highp 3-component vector of float)
+0:361              specular2: direct index for structure ( global highp 3-component vector of float)
+0:361                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:361                Constant:
+0:361                  2 (const int)
+0:361              Constant:
+0:361                0.000000
+0:361                0.000000
+0:361                0.000000
+0:362            move second child to first child ( temp highp float)
+0:362              shadowStrength: direct index for structure ( global highp float)
+0:362                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:362                Constant:
+0:362                  3 (const int)
+0:362              Constant:
+0:362                0.000000
+0:363            Branch: Break
+0:365      move second child to first child ( temp highp 3-component vector of float)
+0:365        'diffuseContrib' ( inout highp 3-component vector of float)
+0:365        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:365          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:365          Constant:
+0:365            0 (const int)
+0:367  Function Definition: TDProjMap(i1;vf3;vf4; ( global highp 4-component vector of float)
+0:367    Function Parameters: 
+0:367      'index' ( in highp int)
+0:367      'worldSpacePos' ( in highp 3-component vector of float)
+0:367      'defaultColor' ( in highp 4-component vector of float)
+0:368    Sequence
+0:368      switch
+0:368      condition
+0:368        'index' ( in highp int)
+0:368      body
+0:368        Sequence
+0:370          default: 
+0:?           Sequence
+0:370            Branch: Return with expression
+0:370              'defaultColor' ( in highp 4-component vector of float)
+0:373  Function Definition: TDFog(vf4;vf3;i1; ( global highp 4-component vector of float)
+0:373    Function Parameters: 
+0:373      'color' ( in highp 4-component vector of float)
+0:373      'lightingSpacePosition' ( in highp 3-component vector of float)
+0:373      'cameraIndex' ( in highp int)
+0:374    Sequence
+0:374      switch
+0:374      condition
+0:374        'cameraIndex' ( in highp int)
+0:374      body
+0:374        Sequence
+0:375          default: 
+0:376          case:  with expression
+0:376            Constant:
+0:376              0 (const int)
+0:?           Sequence
+0:378            Sequence
+0:378              Branch: Return with expression
+0:378                'color' ( in highp 4-component vector of float)
+0:382  Function Definition: TDFog(vf4;vf3; ( global highp 4-component vector of float)
+0:382    Function Parameters: 
+0:382      'color' ( in highp 4-component vector of float)
+0:382      'lightingSpacePosition' ( in highp 3-component vector of float)
+0:384    Sequence
+0:384      Branch: Return with expression
+0:384        Function Call: TDFog(vf4;vf3;i1; ( global highp 4-component vector of float)
+0:384          'color' ( in highp 4-component vector of float)
+0:384          'lightingSpacePosition' ( in highp 3-component vector of float)
+0:384          Constant:
+0:384            0 (const int)
+0:386  Function Definition: TDInstanceTexCoord(i1;vf3; ( global highp 3-component vector of float)
+0:386    Function Parameters: 
+0:386      'index' ( in highp int)
+0:386      't' ( in highp 3-component vector of float)
+0:?     Sequence
+0:388      Sequence
+0:388        move second child to first child ( temp highp int)
+0:388          'coord' ( temp highp int)
+0:388          'index' ( in highp int)
+0:389      Sequence
+0:389        move second child to first child ( temp highp 4-component vector of float)
+0:389          'samp' ( temp highp 4-component vector of float)
+0:389          textureFetch ( global highp 4-component vector of float)
+0:389            'sTDInstanceTexCoord' (layout( binding=16) uniform highp samplerBuffer)
+0:389            'coord' ( temp highp int)
+0:390      move second child to first child ( temp highp float)
+0:390        direct index ( temp highp float)
+0:390          'v' ( temp highp 3-component vector of float)
+0:390          Constant:
+0:390            0 (const int)
+0:390        direct index ( temp highp float)
+0:390          't' ( in highp 3-component vector of float)
+0:390          Constant:
+0:390            0 (const int)
+0:391      move second child to first child ( temp highp float)
+0:391        direct index ( temp highp float)
+0:391          'v' ( temp highp 3-component vector of float)
+0:391          Constant:
+0:391            1 (const int)
+0:391        direct index ( temp highp float)
+0:391          't' ( in highp 3-component vector of float)
+0:391          Constant:
+0:391            1 (const int)
+0:392      move second child to first child ( temp highp float)
+0:392        direct index ( temp highp float)
+0:392          'v' ( temp highp 3-component vector of float)
+0:392          Constant:
+0:392            2 (const int)
+0:392        direct index ( temp highp float)
+0:392          'samp' ( temp highp 4-component vector of float)
+0:392          Constant:
+0:392            0 (const int)
+0:393      move second child to first child ( temp highp 3-component vector of float)
+0:393        vector swizzle ( temp highp 3-component vector of float)
+0:393          't' ( in highp 3-component vector of float)
+0:393          Sequence
+0:393            Constant:
+0:393              0 (const int)
+0:393            Constant:
+0:393              1 (const int)
+0:393            Constant:
+0:393              2 (const int)
+0:393        vector swizzle ( temp highp 3-component vector of float)
+0:393          'v' ( temp highp 3-component vector of float)
+0:393          Sequence
+0:393            Constant:
+0:393              0 (const int)
+0:393            Constant:
+0:393              1 (const int)
+0:393            Constant:
+0:393              2 (const int)
+0:394      Branch: Return with expression
+0:394        't' ( in highp 3-component vector of float)
+0:396  Function Definition: TDInstanceActive(i1; ( global bool)
+0:396    Function Parameters: 
+0:396      'index' ( in highp int)
+0:397    Sequence
+0:397      subtract second child into first child ( temp highp int)
+0:397        'index' ( in highp int)
+0:397        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:397          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:397          Constant:
+0:397            0 (const uint)
+0:399      Sequence
+0:399        move second child to first child ( temp highp int)
+0:399          'coord' ( temp highp int)
+0:399          'index' ( in highp int)
+0:400      Sequence
+0:400        move second child to first child ( temp highp 4-component vector of float)
+0:400          'samp' ( temp highp 4-component vector of float)
+0:400          textureFetch ( global highp 4-component vector of float)
+0:400            'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:400            'coord' ( temp highp int)
+0:401      move second child to first child ( temp highp float)
+0:401        'v' ( temp highp float)
+0:401        direct index ( temp highp float)
+0:401          'samp' ( temp highp 4-component vector of float)
+0:401          Constant:
+0:401            0 (const int)
+0:402      Branch: Return with expression
+0:402        Compare Not Equal ( temp bool)
+0:402          'v' ( temp highp float)
+0:402          Constant:
+0:402            0.000000
+0:404  Function Definition: iTDInstanceTranslate(i1;b1; ( global highp 3-component vector of float)
+0:404    Function Parameters: 
+0:404      'index' ( in highp int)
+0:404      'instanceActive' ( out bool)
+0:405    Sequence
+0:405      Sequence
+0:405        move second child to first child ( temp highp int)
+0:405          'origIndex' ( temp highp int)
+0:405          'index' ( in highp int)
+0:406      subtract second child into first child ( temp highp int)
+0:406        'index' ( in highp int)
+0:406        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:406          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:406          Constant:
+0:406            0 (const uint)
+0:408      Sequence
+0:408        move second child to first child ( temp highp int)
+0:408          'coord' ( temp highp int)
+0:408          'index' ( in highp int)
+0:409      Sequence
+0:409        move second child to first child ( temp highp 4-component vector of float)
+0:409          'samp' ( temp highp 4-component vector of float)
+0:409          textureFetch ( global highp 4-component vector of float)
+0:409            'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:409            'coord' ( temp highp int)
+0:410      move second child to first child ( temp highp float)
+0:410        direct index ( temp highp float)
+0:410          'v' ( temp highp 3-component vector of float)
+0:410          Constant:
+0:410            0 (const int)
+0:410        direct index ( temp highp float)
+0:410          'samp' ( temp highp 4-component vector of float)
+0:410          Constant:
+0:410            1 (const int)
+0:411      move second child to first child ( temp highp float)
+0:411        direct index ( temp highp float)
+0:411          'v' ( temp highp 3-component vector of float)
+0:411          Constant:
+0:411            1 (const int)
+0:411        direct index ( temp highp float)
+0:411          'samp' ( temp highp 4-component vector of float)
+0:411          Constant:
+0:411            2 (const int)
+0:412      move second child to first child ( temp highp float)
+0:412        direct index ( temp highp float)
+0:412          'v' ( temp highp 3-component vector of float)
+0:412          Constant:
+0:412            2 (const int)
+0:412        direct index ( temp highp float)
+0:412          'samp' ( temp highp 4-component vector of float)
+0:412          Constant:
+0:412            3 (const int)
+0:413      move second child to first child ( temp bool)
+0:413        'instanceActive' ( out bool)
+0:413        Compare Not Equal ( temp bool)
+0:413          direct index ( temp highp float)
+0:413            'samp' ( temp highp 4-component vector of float)
+0:413            Constant:
+0:413              0 (const int)
+0:413          Constant:
+0:413            0.000000
+0:414      Branch: Return with expression
+0:414        'v' ( temp highp 3-component vector of float)
+0:416  Function Definition: TDInstanceTranslate(i1; ( global highp 3-component vector of float)
+0:416    Function Parameters: 
+0:416      'index' ( in highp int)
+0:417    Sequence
+0:417      subtract second child into first child ( temp highp int)
+0:417        'index' ( in highp int)
+0:417        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:417          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:417          Constant:
+0:417            0 (const uint)
+0:419      Sequence
+0:419        move second child to first child ( temp highp int)
+0:419          'coord' ( temp highp int)
+0:419          'index' ( in highp int)
+0:420      Sequence
+0:420        move second child to first child ( temp highp 4-component vector of float)
+0:420          'samp' ( temp highp 4-component vector of float)
+0:420          textureFetch ( global highp 4-component vector of float)
+0:420            'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:420            'coord' ( temp highp int)
+0:421      move second child to first child ( temp highp float)
+0:421        direct index ( temp highp float)
+0:421          'v' ( temp highp 3-component vector of float)
+0:421          Constant:
+0:421            0 (const int)
+0:421        direct index ( temp highp float)
+0:421          'samp' ( temp highp 4-component vector of float)
+0:421          Constant:
+0:421            1 (const int)
+0:422      move second child to first child ( temp highp float)
+0:422        direct index ( temp highp float)
+0:422          'v' ( temp highp 3-component vector of float)
+0:422          Constant:
+0:422            1 (const int)
+0:422        direct index ( temp highp float)
+0:422          'samp' ( temp highp 4-component vector of float)
+0:422          Constant:
+0:422            2 (const int)
+0:423      move second child to first child ( temp highp float)
+0:423        direct index ( temp highp float)
+0:423          'v' ( temp highp 3-component vector of float)
+0:423          Constant:
+0:423            2 (const int)
+0:423        direct index ( temp highp float)
+0:423          'samp' ( temp highp 4-component vector of float)
+0:423          Constant:
+0:423            3 (const int)
+0:424      Branch: Return with expression
+0:424        'v' ( temp highp 3-component vector of float)
+0:426  Function Definition: TDInstanceRotateMat(i1; ( global highp 3X3 matrix of float)
+0:426    Function Parameters: 
+0:426      'index' ( in highp int)
+0:427    Sequence
+0:427      subtract second child into first child ( temp highp int)
+0:427        'index' ( in highp int)
+0:427        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:427          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:427          Constant:
+0:427            0 (const uint)
+0:428      Sequence
+0:428        move second child to first child ( temp highp 3-component vector of float)
+0:428          'v' ( temp highp 3-component vector of float)
+0:428          Constant:
+0:428            0.000000
+0:428            0.000000
+0:428            0.000000
+0:429      Sequence
+0:429        move second child to first child ( temp highp 3X3 matrix of float)
+0:429          'm' ( temp highp 3X3 matrix of float)
+0:429          Constant:
+0:429            1.000000
+0:429            0.000000
+0:429            0.000000
+0:429            0.000000
+0:429            1.000000
+0:429            0.000000
+0:429            0.000000
+0:429            0.000000
+0:429            1.000000
+0:433      Branch: Return with expression
+0:433        'm' ( temp highp 3X3 matrix of float)
+0:435  Function Definition: TDInstanceScale(i1; ( global highp 3-component vector of float)
+0:435    Function Parameters: 
+0:435      'index' ( in highp int)
+0:436    Sequence
+0:436      subtract second child into first child ( temp highp int)
+0:436        'index' ( in highp int)
+0:436        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:436          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:436          Constant:
+0:436            0 (const uint)
+0:437      Sequence
+0:437        move second child to first child ( temp highp 3-component vector of float)
+0:437          'v' ( temp highp 3-component vector of float)
+0:437          Constant:
+0:437            1.000000
+0:437            1.000000
+0:437            1.000000
+0:438      Branch: Return with expression
+0:438        'v' ( temp highp 3-component vector of float)
+0:440  Function Definition: TDInstancePivot(i1; ( global highp 3-component vector of float)
+0:440    Function Parameters: 
+0:440      'index' ( in highp int)
+0:441    Sequence
+0:441      subtract second child into first child ( temp highp int)
+0:441        'index' ( in highp int)
+0:441        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:441          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:441          Constant:
+0:441            0 (const uint)
+0:442      Sequence
+0:442        move second child to first child ( temp highp 3-component vector of float)
+0:442          'v' ( temp highp 3-component vector of float)
+0:442          Constant:
+0:442            0.000000
+0:442            0.000000
+0:442            0.000000
+0:443      Branch: Return with expression
+0:443        'v' ( temp highp 3-component vector of float)
+0:445  Function Definition: TDInstanceRotTo(i1; ( global highp 3-component vector of float)
+0:445    Function Parameters: 
+0:445      'index' ( in highp int)
+0:446    Sequence
+0:446      subtract second child into first child ( temp highp int)
+0:446        'index' ( in highp int)
+0:446        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:446          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:446          Constant:
+0:446            0 (const uint)
+0:447      Sequence
+0:447        move second child to first child ( temp highp 3-component vector of float)
+0:447          'v' ( temp highp 3-component vector of float)
+0:447          Constant:
+0:447            0.000000
+0:447            0.000000
+0:447            1.000000
+0:448      Branch: Return with expression
+0:448        'v' ( temp highp 3-component vector of float)
+0:450  Function Definition: TDInstanceRotUp(i1; ( global highp 3-component vector of float)
+0:450    Function Parameters: 
+0:450      'index' ( in highp int)
+0:451    Sequence
+0:451      subtract second child into first child ( temp highp int)
+0:451        'index' ( in highp int)
+0:451        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:451          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:451          Constant:
+0:451            0 (const uint)
+0:452      Sequence
+0:452        move second child to first child ( temp highp 3-component vector of float)
+0:452          'v' ( temp highp 3-component vector of float)
+0:452          Constant:
+0:452            0.000000
+0:452            1.000000
+0:452            0.000000
+0:453      Branch: Return with expression
+0:453        'v' ( temp highp 3-component vector of float)
+0:455  Function Definition: TDInstanceMat(i1; ( global highp 4X4 matrix of float)
+0:455    Function Parameters: 
+0:455      'id' ( in highp int)
+0:456    Sequence
+0:456      Sequence
+0:456        move second child to first child ( temp bool)
+0:456          'instanceActive' ( temp bool)
+0:456          Constant:
+0:456            true (const bool)
+0:457      Sequence
+0:457        move second child to first child ( temp highp 3-component vector of float)
+0:457          't' ( temp highp 3-component vector of float)
+0:457          Function Call: iTDInstanceTranslate(i1;b1; ( global highp 3-component vector of float)
+0:457            'id' ( in highp int)
+0:457            'instanceActive' ( temp bool)
+0:458      Test condition and select ( temp void)
+0:458        Condition
+0:458        Negate conditional ( temp bool)
+0:458          'instanceActive' ( temp bool)
+0:458        true case
+0:460        Sequence
+0:460          Branch: Return with expression
+0:460            Constant:
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:462      Sequence
+0:462        move second child to first child ( temp highp 4X4 matrix of float)
+0:462          'm' ( temp highp 4X4 matrix of float)
+0:462          Constant:
+0:462            1.000000
+0:462            0.000000
+0:462            0.000000
+0:462            0.000000
+0:462            0.000000
+0:462            1.000000
+0:462            0.000000
+0:462            0.000000
+0:462            0.000000
+0:462            0.000000
+0:462            1.000000
+0:462            0.000000
+0:462            0.000000
+0:462            0.000000
+0:462            0.000000
+0:462            1.000000
+0:464      Sequence
+0:464        Sequence
+0:464          move second child to first child ( temp highp 3-component vector of float)
+0:464            'tt' ( temp highp 3-component vector of float)
+0:464            't' ( temp highp 3-component vector of float)
+0:465        add second child into first child ( temp highp float)
+0:465          direct index ( temp highp float)
+0:465            direct index ( temp highp 4-component vector of float)
+0:465              'm' ( temp highp 4X4 matrix of float)
+0:465              Constant:
+0:465                3 (const int)
+0:465            Constant:
+0:465              0 (const int)
+0:465          component-wise multiply ( temp highp float)
+0:465            direct index ( temp highp float)
+0:465              direct index ( temp highp 4-component vector of float)
+0:465                'm' ( temp highp 4X4 matrix of float)
+0:465                Constant:
+0:465                  0 (const int)
+0:465              Constant:
+0:465                0 (const int)
+0:465            direct index ( temp highp float)
+0:465              'tt' ( temp highp 3-component vector of float)
+0:465              Constant:
+0:465                0 (const int)
+0:466        add second child into first child ( temp highp float)
+0:466          direct index ( temp highp float)
+0:466            direct index ( temp highp 4-component vector of float)
+0:466              'm' ( temp highp 4X4 matrix of float)
+0:466              Constant:
+0:466                3 (const int)
+0:466            Constant:
+0:466              1 (const int)
+0:466          component-wise multiply ( temp highp float)
+0:466            direct index ( temp highp float)
+0:466              direct index ( temp highp 4-component vector of float)
+0:466                'm' ( temp highp 4X4 matrix of float)
+0:466                Constant:
+0:466                  0 (const int)
+0:466              Constant:
+0:466                1 (const int)
+0:466            direct index ( temp highp float)
+0:466              'tt' ( temp highp 3-component vector of float)
+0:466              Constant:
+0:466                0 (const int)
+0:467        add second child into first child ( temp highp float)
+0:467          direct index ( temp highp float)
+0:467            direct index ( temp highp 4-component vector of float)
+0:467              'm' ( temp highp 4X4 matrix of float)
+0:467              Constant:
+0:467                3 (const int)
+0:467            Constant:
+0:467              2 (const int)
+0:467          component-wise multiply ( temp highp float)
+0:467            direct index ( temp highp float)
+0:467              direct index ( temp highp 4-component vector of float)
+0:467                'm' ( temp highp 4X4 matrix of float)
+0:467                Constant:
+0:467                  0 (const int)
+0:467              Constant:
+0:467                2 (const int)
+0:467            direct index ( temp highp float)
+0:467              'tt' ( temp highp 3-component vector of float)
+0:467              Constant:
+0:467                0 (const int)
+0:468        add second child into first child ( temp highp float)
+0:468          direct index ( temp highp float)
+0:468            direct index ( temp highp 4-component vector of float)
+0:468              'm' ( temp highp 4X4 matrix of float)
+0:468              Constant:
+0:468                3 (const int)
+0:468            Constant:
+0:468              3 (const int)
+0:468          component-wise multiply ( temp highp float)
+0:468            direct index ( temp highp float)
+0:468              direct index ( temp highp 4-component vector of float)
+0:468                'm' ( temp highp 4X4 matrix of float)
+0:468                Constant:
+0:468                  0 (const int)
+0:468              Constant:
+0:468                3 (const int)
+0:468            direct index ( temp highp float)
+0:468              'tt' ( temp highp 3-component vector of float)
+0:468              Constant:
+0:468                0 (const int)
+0:469        add second child into first child ( temp highp float)
+0:469          direct index ( temp highp float)
+0:469            direct index ( temp highp 4-component vector of float)
+0:469              'm' ( temp highp 4X4 matrix of float)
+0:469              Constant:
+0:469                3 (const int)
+0:469            Constant:
+0:469              0 (const int)
+0:469          component-wise multiply ( temp highp float)
+0:469            direct index ( temp highp float)
+0:469              direct index ( temp highp 4-component vector of float)
+0:469                'm' ( temp highp 4X4 matrix of float)
+0:469                Constant:
+0:469                  1 (const int)
+0:469              Constant:
+0:469                0 (const int)
+0:469            direct index ( temp highp float)
+0:469              'tt' ( temp highp 3-component vector of float)
+0:469              Constant:
+0:469                1 (const int)
+0:470        add second child into first child ( temp highp float)
+0:470          direct index ( temp highp float)
+0:470            direct index ( temp highp 4-component vector of float)
+0:470              'm' ( temp highp 4X4 matrix of float)
+0:470              Constant:
+0:470                3 (const int)
+0:470            Constant:
+0:470              1 (const int)
+0:470          component-wise multiply ( temp highp float)
+0:470            direct index ( temp highp float)
+0:470              direct index ( temp highp 4-component vector of float)
+0:470                'm' ( temp highp 4X4 matrix of float)
+0:470                Constant:
+0:470                  1 (const int)
+0:470              Constant:
+0:470                1 (const int)
+0:470            direct index ( temp highp float)
+0:470              'tt' ( temp highp 3-component vector of float)
+0:470              Constant:
+0:470                1 (const int)
+0:471        add second child into first child ( temp highp float)
+0:471          direct index ( temp highp float)
+0:471            direct index ( temp highp 4-component vector of float)
+0:471              'm' ( temp highp 4X4 matrix of float)
+0:471              Constant:
+0:471                3 (const int)
+0:471            Constant:
+0:471              2 (const int)
+0:471          component-wise multiply ( temp highp float)
+0:471            direct index ( temp highp float)
+0:471              direct index ( temp highp 4-component vector of float)
+0:471                'm' ( temp highp 4X4 matrix of float)
+0:471                Constant:
+0:471                  1 (const int)
+0:471              Constant:
+0:471                2 (const int)
+0:471            direct index ( temp highp float)
+0:471              'tt' ( temp highp 3-component vector of float)
+0:471              Constant:
+0:471                1 (const int)
+0:472        add second child into first child ( temp highp float)
+0:472          direct index ( temp highp float)
+0:472            direct index ( temp highp 4-component vector of float)
+0:472              'm' ( temp highp 4X4 matrix of float)
+0:472              Constant:
+0:472                3 (const int)
+0:472            Constant:
+0:472              3 (const int)
+0:472          component-wise multiply ( temp highp float)
+0:472            direct index ( temp highp float)
+0:472              direct index ( temp highp 4-component vector of float)
+0:472                'm' ( temp highp 4X4 matrix of float)
+0:472                Constant:
+0:472                  1 (const int)
+0:472              Constant:
+0:472                3 (const int)
+0:472            direct index ( temp highp float)
+0:472              'tt' ( temp highp 3-component vector of float)
+0:472              Constant:
+0:472                1 (const int)
+0:473        add second child into first child ( temp highp float)
+0:473          direct index ( temp highp float)
+0:473            direct index ( temp highp 4-component vector of float)
+0:473              'm' ( temp highp 4X4 matrix of float)
+0:473              Constant:
+0:473                3 (const int)
+0:473            Constant:
+0:473              0 (const int)
+0:473          component-wise multiply ( temp highp float)
+0:473            direct index ( temp highp float)
+0:473              direct index ( temp highp 4-component vector of float)
+0:473                'm' ( temp highp 4X4 matrix of float)
+0:473                Constant:
+0:473                  2 (const int)
+0:473              Constant:
+0:473                0 (const int)
+0:473            direct index ( temp highp float)
+0:473              'tt' ( temp highp 3-component vector of float)
+0:473              Constant:
+0:473                2 (const int)
+0:474        add second child into first child ( temp highp float)
+0:474          direct index ( temp highp float)
+0:474            direct index ( temp highp 4-component vector of float)
+0:474              'm' ( temp highp 4X4 matrix of float)
+0:474              Constant:
+0:474                3 (const int)
+0:474            Constant:
+0:474              1 (const int)
+0:474          component-wise multiply ( temp highp float)
+0:474            direct index ( temp highp float)
+0:474              direct index ( temp highp 4-component vector of float)
+0:474                'm' ( temp highp 4X4 matrix of float)
+0:474                Constant:
+0:474                  2 (const int)
+0:474              Constant:
+0:474                1 (const int)
+0:474            direct index ( temp highp float)
+0:474              'tt' ( temp highp 3-component vector of float)
+0:474              Constant:
+0:474                2 (const int)
+0:475        add second child into first child ( temp highp float)
+0:475          direct index ( temp highp float)
+0:475            direct index ( temp highp 4-component vector of float)
+0:475              'm' ( temp highp 4X4 matrix of float)
+0:475              Constant:
+0:475                3 (const int)
+0:475            Constant:
+0:475              2 (const int)
+0:475          component-wise multiply ( temp highp float)
+0:475            direct index ( temp highp float)
+0:475              direct index ( temp highp 4-component vector of float)
+0:475                'm' ( temp highp 4X4 matrix of float)
+0:475                Constant:
+0:475                  2 (const int)
+0:475              Constant:
+0:475                2 (const int)
+0:475            direct index ( temp highp float)
+0:475              'tt' ( temp highp 3-component vector of float)
+0:475              Constant:
+0:475                2 (const int)
+0:476        add second child into first child ( temp highp float)
+0:476          direct index ( temp highp float)
+0:476            direct index ( temp highp 4-component vector of float)
+0:476              'm' ( temp highp 4X4 matrix of float)
+0:476              Constant:
+0:476                3 (const int)
+0:476            Constant:
+0:476              3 (const int)
+0:476          component-wise multiply ( temp highp float)
+0:476            direct index ( temp highp float)
+0:476              direct index ( temp highp 4-component vector of float)
+0:476                'm' ( temp highp 4X4 matrix of float)
+0:476                Constant:
+0:476                  2 (const int)
+0:476              Constant:
+0:476                3 (const int)
+0:476            direct index ( temp highp float)
+0:476              'tt' ( temp highp 3-component vector of float)
+0:476              Constant:
+0:476                2 (const int)
+0:478      Branch: Return with expression
+0:478        'm' ( temp highp 4X4 matrix of float)
+0:480  Function Definition: TDInstanceMat3(i1; ( global highp 3X3 matrix of float)
+0:480    Function Parameters: 
+0:480      'id' ( in highp int)
+0:481    Sequence
+0:481      Sequence
+0:481        move second child to first child ( temp highp 3X3 matrix of float)
+0:481          'm' ( temp highp 3X3 matrix of float)
+0:481          Constant:
+0:481            1.000000
+0:481            0.000000
+0:481            0.000000
+0:481            0.000000
+0:481            1.000000
+0:481            0.000000
+0:481            0.000000
+0:481            0.000000
+0:481            1.000000
+0:482      Branch: Return with expression
+0:482        'm' ( temp highp 3X3 matrix of float)
+0:484  Function Definition: TDInstanceMat3ForNorm(i1; ( global highp 3X3 matrix of float)
+0:484    Function Parameters: 
+0:484      'id' ( in highp int)
+0:485    Sequence
+0:485      Sequence
+0:485        move second child to first child ( temp highp 3X3 matrix of float)
+0:485          'm' ( temp highp 3X3 matrix of float)
+0:485          Function Call: TDInstanceMat3(i1; ( global highp 3X3 matrix of float)
+0:485            'id' ( in highp int)
+0:486      Branch: Return with expression
+0:486        'm' ( temp highp 3X3 matrix of float)
+0:488  Function Definition: TDInstanceColor(i1;vf4; ( global highp 4-component vector of float)
+0:488    Function Parameters: 
+0:488      'index' ( in highp int)
+0:488      'curColor' ( in highp 4-component vector of float)
+0:489    Sequence
+0:489      subtract second child into first child ( temp highp int)
+0:489        'index' ( in highp int)
+0:489        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:489          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:489          Constant:
+0:489            0 (const uint)
+0:491      Sequence
+0:491        move second child to first child ( temp highp int)
+0:491          'coord' ( temp highp int)
+0:491          'index' ( in highp int)
+0:492      Sequence
+0:492        move second child to first child ( temp highp 4-component vector of float)
+0:492          'samp' ( temp highp 4-component vector of float)
+0:492          textureFetch ( global highp 4-component vector of float)
+0:492            'sTDInstanceColor' (layout( binding=17) uniform highp samplerBuffer)
+0:492            'coord' ( temp highp int)
+0:493      move second child to first child ( temp highp float)
+0:493        direct index ( temp highp float)
+0:493          'v' ( temp highp 4-component vector of float)
+0:493          Constant:
+0:493            0 (const int)
+0:493        direct index ( temp highp float)
+0:493          'samp' ( temp highp 4-component vector of float)
+0:493          Constant:
+0:493            0 (const int)
+0:494      move second child to first child ( temp highp float)
+0:494        direct index ( temp highp float)
+0:494          'v' ( temp highp 4-component vector of float)
+0:494          Constant:
+0:494            1 (const int)
+0:494        direct index ( temp highp float)
+0:494          'samp' ( temp highp 4-component vector of float)
+0:494          Constant:
+0:494            1 (const int)
+0:495      move second child to first child ( temp highp float)
+0:495        direct index ( temp highp float)
+0:495          'v' ( temp highp 4-component vector of float)
+0:495          Constant:
+0:495            2 (const int)
+0:495        direct index ( temp highp float)
+0:495          'samp' ( temp highp 4-component vector of float)
+0:495          Constant:
+0:495            2 (const int)
+0:496      move second child to first child ( temp highp float)
+0:496        direct index ( temp highp float)
+0:496          'v' ( temp highp 4-component vector of float)
+0:496          Constant:
+0:496            3 (const int)
+0:496        Constant:
+0:496          1.000000
+0:497      move second child to first child ( temp highp float)
+0:497        direct index ( temp highp float)
+0:497          'curColor' ( in highp 4-component vector of float)
+0:497          Constant:
+0:497            0 (const int)
+0:497        direct index ( temp highp float)
+0:497          'v' ( temp highp 4-component vector of float)
+0:497          Constant:
+0:497            0 (const int)
+0:499      move second child to first child ( temp highp float)
+0:499        direct index ( temp highp float)
+0:499          'curColor' ( in highp 4-component vector of float)
+0:499          Constant:
+0:499            1 (const int)
+0:499        direct index ( temp highp float)
+0:499          'v' ( temp highp 4-component vector of float)
+0:499          Constant:
+0:499            1 (const int)
+0:501      move second child to first child ( temp highp float)
+0:501        direct index ( temp highp float)
+0:501          'curColor' ( in highp 4-component vector of float)
+0:501          Constant:
+0:501            2 (const int)
+0:501        direct index ( temp highp float)
+0:501          'v' ( temp highp 4-component vector of float)
+0:501          Constant:
+0:501            2 (const int)
+0:503      Branch: Return with expression
+0:503        'curColor' ( in highp 4-component vector of float)
+0:?   Linker Objects
+0:?     'sTDNoiseMap' ( uniform highp sampler2D)
+0:?     'sTDSineLookup' ( uniform highp sampler1D)
+0:?     'sTDWhite2D' ( uniform highp sampler2D)
+0:?     'sTDWhite3D' ( uniform highp sampler3D)
+0:?     'sTDWhite2DArray' ( uniform highp sampler2DArray)
+0:?     'sTDWhiteCube' ( uniform highp samplerCube)
+0:?     'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:?     'anon@1' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 4-component vector of float position,  global highp 3-component vector of float direction,  global highp 3-component vector of float diffuse,  global highp 4-component vector of float nearFar,  global highp 4-component vector of float lightSize,  global highp 4-component vector of float misc,  global highp 4-component vector of float coneLookupScaleBias,  global highp 4-component vector of float attenScaleBiasRoll, layout( column_major std140) global highp 4X4 matrix of float shadowMapMatrix, layout( column_major std140) global highp 4X4 matrix of float shadowMapCamMatrix,  global highp 4-component vector of float shadowMapRes, layout( column_major std140) global highp 4X4 matrix of float projMapMatrix} uTDLights})
+0:?     'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 3-component vector of float color, layout( column_major std140) global highp 3X3 matrix of float rotate} uTDEnvLights})
+0:?     'uTDEnvLightBuffers' (layout( column_major std430) restrict readonly buffer 1-element array of block{layout( column_major std430 offset=0) restrict readonly buffer 9-element array of highp 3-component vector of float shCoeffs})
+0:?     'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:?     'anon@4' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 4-component vector of float nearFar,  global highp 4-component vector of float fog,  global highp 4-component vector of float fogColor,  global highp int renderTOPCameraIndex} uTDCamInfos})
+0:?     'anon@5' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform structure{ global highp 4-component vector of float ambientColor,  global highp 4-component vector of float nearFar,  global highp 4-component vector of float viewport,  global highp 4-component vector of float viewportRes,  global highp 4-component vector of float fog,  global highp 4-component vector of float fogColor} uTDGeneral})
+0:?     'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:?     'sTDInstanceTexCoord' (layout( binding=16) uniform highp samplerBuffer)
+0:?     'sTDInstanceColor' (layout( binding=17) uniform highp samplerBuffer)
+
+vk.relaxed.stagelink.0.2.frag
+Shader version: 460
+gl_FragCoord origin is upper left
+0:? Sequence
+0:2  Function Definition: TDOutputSwizzle(vf4; ( global highp 4-component vector of float)
+0:2    Function Parameters: 
+0:2      'c' ( in highp 4-component vector of float)
+0:4    Sequence
+0:4      Branch: Return with expression
+0:4        vector swizzle ( temp highp 4-component vector of float)
+0:4          'c' ( in highp 4-component vector of float)
+0:4          Sequence
+0:4            Constant:
+0:4              0 (const int)
+0:4            Constant:
+0:4              1 (const int)
+0:4            Constant:
+0:4              2 (const int)
+0:4            Constant:
+0:4              3 (const int)
+0:6  Function Definition: TDOutputSwizzle(vu4; ( global highp 4-component vector of uint)
+0:6    Function Parameters: 
+0:6      'c' ( in highp 4-component vector of uint)
+0:8    Sequence
+0:8      Branch: Return with expression
+0:8        vector swizzle ( temp highp 4-component vector of uint)
+0:8          'c' ( in highp 4-component vector of uint)
+0:8          Sequence
+0:8            Constant:
+0:8              0 (const int)
+0:8            Constant:
+0:8              1 (const int)
+0:8            Constant:
+0:8              2 (const int)
+0:8            Constant:
+0:8              3 (const int)
+0:?   Linker Objects
+
+
+Linked vertex stage:
+
+
+Linked fragment stage:
+
+
+Shader version: 460
+0:? Sequence
+0:11  Function Definition: main( ( global void)
+0:11    Function Parameters: 
+0:15    Sequence
+0:15      Sequence
+0:15        Sequence
+0:15          move second child to first child ( temp highp 3-component vector of float)
+0:15            'texcoord' ( temp highp 3-component vector of float)
+0:15            Function Call: TDInstanceTexCoord(vf3; ( global highp 3-component vector of float)
+0:15              direct index (layout( location=3) temp highp 3-component vector of float)
+0:15                'uv' (layout( location=3) in 8-element array of highp 3-component vector of float)
+0:15                Constant:
+0:15                  0 (const int)
+0:16        move second child to first child ( temp highp 3-component vector of float)
+0:16          vector swizzle ( temp highp 3-component vector of float)
+0:16            texCoord0: direct index for structure ( out highp 3-component vector of float)
+0:16              'oVert' ( out block{ out highp 4-component vector of float color,  out highp 3-component vector of float worldSpacePos,  out highp 3-component vector of float texCoord0,  flat out highp int cameraIndex,  flat out highp int instance})
+0:16              Constant:
+0:16                2 (const int)
+0:16            Sequence
+0:16              Constant:
+0:16                0 (const int)
+0:16              Constant:
+0:16                1 (const int)
+0:16              Constant:
+0:16                2 (const int)
+0:16          vector swizzle ( temp highp 3-component vector of float)
+0:16            'texcoord' ( temp highp 3-component vector of float)
+0:16            Sequence
+0:16              Constant:
+0:16                0 (const int)
+0:16              Constant:
+0:16                1 (const int)
+0:16              Constant:
+0:16                2 (const int)
+0:20      move second child to first child ( temp highp int)
+0:20        instance: direct index for structure ( flat out highp int)
+0:20          'oVert' ( out block{ out highp 4-component vector of float color,  out highp 3-component vector of float worldSpacePos,  out highp 3-component vector of float texCoord0,  flat out highp int cameraIndex,  flat out highp int instance})
+0:20          Constant:
+0:20            4 (const int)
+0:20        Function Call: TDInstanceID( ( global highp int)
+0:21      Sequence
+0:21        move second child to first child ( temp highp 4-component vector of float)
+0:21          'worldSpacePos' ( temp highp 4-component vector of float)
+0:21          Function Call: TDDeform(vf3; ( global highp 4-component vector of float)
+0:21            'P' (layout( location=0) in highp 3-component vector of float)
+0:22      Sequence
+0:22        move second child to first child ( temp highp 3-component vector of float)
+0:22          'uvUnwrapCoord' ( temp highp 3-component vector of float)
+0:22          Function Call: TDInstanceTexCoord(vf3; ( global highp 3-component vector of float)
+0:22            Function Call: TDUVUnwrapCoord( ( global highp 3-component vector of float)
+0:23      move second child to first child ( temp highp 4-component vector of float)
+0:23        gl_Position: direct index for structure ( gl_Position highp 4-component vector of float Position)
+0:23          'anon@4' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  out 1-element array of float CullDistance gl_CullDistance})
+0:23          Constant:
+0:23            0 (const uint)
+0:23        Function Call: TDWorldToProj(vf4;vf3; ( global highp 4-component vector of float)
+0:23          'worldSpacePos' ( temp highp 4-component vector of float)
+0:23          'uvUnwrapCoord' ( temp highp 3-component vector of float)
+0:32      Sequence
+0:32        move second child to first child ( temp highp int)
+0:32          'cameraIndex' ( temp highp int)
+0:32          Function Call: TDCameraIndex( ( global highp int)
+0:33      move second child to first child ( temp highp int)
+0:33        cameraIndex: direct index for structure ( flat out highp int)
+0:33          'oVert' ( out block{ out highp 4-component vector of float color,  out highp 3-component vector of float worldSpacePos,  out highp 3-component vector of float texCoord0,  flat out highp int cameraIndex,  flat out highp int instance})
+0:33          Constant:
+0:33            3 (const int)
+0:33        'cameraIndex' ( temp highp int)
+0:34      move second child to first child ( temp highp 3-component vector of float)
+0:34        vector swizzle ( temp highp 3-component vector of float)
+0:34          worldSpacePos: direct index for structure ( out highp 3-component vector of float)
+0:34            'oVert' ( out block{ out highp 4-component vector of float color,  out highp 3-component vector of float worldSpacePos,  out highp 3-component vector of float texCoord0,  flat out highp int cameraIndex,  flat out highp int instance})
+0:34            Constant:
+0:34              1 (const int)
+0:34          Sequence
+0:34            Constant:
+0:34              0 (const int)
+0:34            Constant:
+0:34              1 (const int)
+0:34            Constant:
+0:34              2 (const int)
+0:34        vector swizzle ( temp highp 3-component vector of float)
+0:34          'worldSpacePos' ( temp highp 4-component vector of float)
+0:34          Sequence
+0:34            Constant:
+0:34              0 (const int)
+0:34            Constant:
+0:34              1 (const int)
+0:34            Constant:
+0:34              2 (const int)
+0:35      move second child to first child ( temp highp 4-component vector of float)
+0:35        color: direct index for structure ( out highp 4-component vector of float)
+0:35          'oVert' ( out block{ out highp 4-component vector of float color,  out highp 3-component vector of float worldSpacePos,  out highp 3-component vector of float texCoord0,  flat out highp int cameraIndex,  flat out highp int instance})
+0:35          Constant:
+0:35            0 (const int)
+0:35        Function Call: TDInstanceColor(vf4; ( global highp 4-component vector of float)
+0:35          'Cd' (layout( location=2) in highp 4-component vector of float)
+0:176  Function Definition: iTDCamToProj(vf4;vf3;i1;b1; ( global highp 4-component vector of float)
+0:176    Function Parameters: 
+0:176      'v' ( in highp 4-component vector of float)
+0:176      'uv' ( in highp 3-component vector of float)
+0:176      'cameraIndex' ( in highp int)
+0:176      'applyPickMod' ( in bool)
+0:178    Sequence
+0:178      Test condition and select ( temp void)
+0:178        Condition
+0:178        Negate conditional ( temp bool)
+0:178          Function Call: TDInstanceActive( ( global bool)
+0:178        true case
+0:179        Branch: Return with expression
+0:179          Constant:
+0:179            2.000000
+0:179            2.000000
+0:179            2.000000
+0:179            0.000000
+0:180      move second child to first child ( temp highp 4-component vector of float)
+0:180        'v' ( in highp 4-component vector of float)
+0:180        matrix-times-vector ( temp highp 4-component vector of float)
+0:180          proj: direct index for structure (layout( column_major std140) global highp 4X4 matrix of float)
+0:180            direct index (layout( column_major std140 offset=0) temp structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:180              uTDMats: direct index for structure (layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:180                'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:180                Constant:
+0:180                  0 (const uint)
+0:180              Constant:
+0:180                0 (const int)
+0:180            Constant:
+0:180              8 (const int)
+0:180          'v' ( in highp 4-component vector of float)
+0:181      Branch: Return with expression
+0:181        'v' ( in highp 4-component vector of float)
+0:183  Function Definition: iTDWorldToProj(vf4;vf3;i1;b1; ( global highp 4-component vector of float)
+0:183    Function Parameters: 
+0:183      'v' ( in highp 4-component vector of float)
+0:183      'uv' ( in highp 3-component vector of float)
+0:183      'cameraIndex' ( in highp int)
+0:183      'applyPickMod' ( in bool)
+0:184    Sequence
+0:184      Test condition and select ( temp void)
+0:184        Condition
+0:184        Negate conditional ( temp bool)
+0:184          Function Call: TDInstanceActive( ( global bool)
+0:184        true case
+0:185        Branch: Return with expression
+0:185          Constant:
+0:185            2.000000
+0:185            2.000000
+0:185            2.000000
+0:185            0.000000
+0:186      move second child to first child ( temp highp 4-component vector of float)
+0:186        'v' ( in highp 4-component vector of float)
+0:186        matrix-times-vector ( temp highp 4-component vector of float)
+0:186          camProj: direct index for structure (layout( column_major std140) global highp 4X4 matrix of float)
+0:186            direct index (layout( column_major std140 offset=0) temp structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:186              uTDMats: direct index for structure (layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:186                'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:186                Constant:
+0:186                  0 (const uint)
+0:186              Constant:
+0:186                0 (const int)
+0:186            Constant:
+0:186              6 (const int)
+0:186          'v' ( in highp 4-component vector of float)
+0:187      Branch: Return with expression
+0:187        'v' ( in highp 4-component vector of float)
+0:193  Function Definition: TDInstanceID( ( global highp int)
+0:193    Function Parameters: 
+0:194    Sequence
+0:194      Branch: Return with expression
+0:194        add ( temp highp int)
+0:194          'gl_InstanceIndex' ( in highp int InstanceIndex)
+0:194          uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:194            'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:194            Constant:
+0:194              0 (const uint)
+0:196  Function Definition: TDCameraIndex( ( global highp int)
+0:196    Function Parameters: 
+0:197    Sequence
+0:197      Branch: Return with expression
+0:197        Constant:
+0:197          0 (const int)
+0:199  Function Definition: TDUVUnwrapCoord( ( global highp 3-component vector of float)
+0:199    Function Parameters: 
+0:200    Sequence
+0:200      Branch: Return with expression
+0:200        direct index (layout( location=3) temp highp 3-component vector of float)
+0:200          'uv' (layout( location=3) in 8-element array of highp 3-component vector of float)
+0:200          Constant:
+0:200            0 (const int)
+0:205  Function Definition: TDPickID( ( global highp int)
+0:205    Function Parameters: 
+0:209    Sequence
+0:209      Branch: Return with expression
+0:209        Constant:
+0:209          0 (const int)
+0:212  Function Definition: iTDConvertPickId(i1; ( global highp float)
+0:212    Function Parameters: 
+0:212      'id' ( in highp int)
+0:213    Sequence
+0:213      or second child into first child ( temp highp int)
+0:213        'id' ( in highp int)
+0:213        Constant:
+0:213          1073741824 (const int)
+0:214      Branch: Return with expression
+0:214        intBitsToFloat ( global highp float)
+0:214          'id' ( in highp int)
+0:217  Function Definition: TDWritePickingValues( ( global void)
+0:217    Function Parameters: 
+0:224  Function Definition: TDWorldToProj(vf4;vf3; ( global highp 4-component vector of float)
+0:224    Function Parameters: 
+0:224      'v' ( in highp 4-component vector of float)
+0:224      'uv' ( in highp 3-component vector of float)
+0:226    Sequence
+0:226      Branch: Return with expression
+0:226        Function Call: iTDWorldToProj(vf4;vf3;i1;b1; ( global highp 4-component vector of float)
+0:226          'v' ( in highp 4-component vector of float)
+0:226          'uv' ( in highp 3-component vector of float)
+0:226          Function Call: TDCameraIndex( ( global highp int)
+0:226          Constant:
+0:226            true (const bool)
+0:228  Function Definition: TDWorldToProj(vf3;vf3; ( global highp 4-component vector of float)
+0:228    Function Parameters: 
+0:228      'v' ( in highp 3-component vector of float)
+0:228      'uv' ( in highp 3-component vector of float)
+0:230    Sequence
+0:230      Branch: Return with expression
+0:230        Function Call: TDWorldToProj(vf4;vf3; ( global highp 4-component vector of float)
+0:230          Construct vec4 ( temp highp 4-component vector of float)
+0:230            'v' ( in highp 3-component vector of float)
+0:230            Constant:
+0:230              1.000000
+0:230          'uv' ( in highp 3-component vector of float)
+0:232  Function Definition: TDWorldToProj(vf4; ( global highp 4-component vector of float)
+0:232    Function Parameters: 
+0:232      'v' ( in highp 4-component vector of float)
+0:234    Sequence
+0:234      Branch: Return with expression
+0:234        Function Call: TDWorldToProj(vf4;vf3; ( global highp 4-component vector of float)
+0:234          'v' ( in highp 4-component vector of float)
+0:234          Constant:
+0:234            0.000000
+0:234            0.000000
+0:234            0.000000
+0:236  Function Definition: TDWorldToProj(vf3; ( global highp 4-component vector of float)
+0:236    Function Parameters: 
+0:236      'v' ( in highp 3-component vector of float)
+0:238    Sequence
+0:238      Branch: Return with expression
+0:238        Function Call: TDWorldToProj(vf4; ( global highp 4-component vector of float)
+0:238          Construct vec4 ( temp highp 4-component vector of float)
+0:238            'v' ( in highp 3-component vector of float)
+0:238            Constant:
+0:238              1.000000
+0:240  Function Definition: TDPointColor( ( global highp 4-component vector of float)
+0:240    Function Parameters: 
+0:241    Sequence
+0:241      Branch: Return with expression
+0:241        'Cd' (layout( location=2) in highp 4-component vector of float)
+0:114  Function Definition: TDInstanceTexCoord(i1;vf3; ( global highp 3-component vector of float)
+0:114    Function Parameters: 
+0:114      'index' ( in highp int)
+0:114      't' ( in highp 3-component vector of float)
+0:?     Sequence
+0:116      Sequence
+0:116        move second child to first child ( temp highp int)
+0:116          'coord' ( temp highp int)
+0:116          'index' ( in highp int)
+0:117      Sequence
+0:117        move second child to first child ( temp highp 4-component vector of float)
+0:117          'samp' ( temp highp 4-component vector of float)
+0:117          textureFetch ( global highp 4-component vector of float)
+0:117            'sTDInstanceTexCoord' (layout( binding=16) uniform highp samplerBuffer)
+0:117            'coord' ( temp highp int)
+0:118      move second child to first child ( temp highp float)
+0:118        direct index ( temp highp float)
+0:118          'v' ( temp highp 3-component vector of float)
+0:118          Constant:
+0:118            0 (const int)
+0:118        direct index ( temp highp float)
+0:118          't' ( in highp 3-component vector of float)
+0:118          Constant:
+0:118            0 (const int)
+0:119      move second child to first child ( temp highp float)
+0:119        direct index ( temp highp float)
+0:119          'v' ( temp highp 3-component vector of float)
+0:119          Constant:
+0:119            1 (const int)
+0:119        direct index ( temp highp float)
+0:119          't' ( in highp 3-component vector of float)
+0:119          Constant:
+0:119            1 (const int)
+0:120      move second child to first child ( temp highp float)
+0:120        direct index ( temp highp float)
+0:120          'v' ( temp highp 3-component vector of float)
+0:120          Constant:
+0:120            2 (const int)
+0:120        direct index ( temp highp float)
+0:120          'samp' ( temp highp 4-component vector of float)
+0:120          Constant:
+0:120            0 (const int)
+0:121      move second child to first child ( temp highp 3-component vector of float)
+0:121        vector swizzle ( temp highp 3-component vector of float)
+0:121          't' ( in highp 3-component vector of float)
+0:121          Sequence
+0:121            Constant:
+0:121              0 (const int)
+0:121            Constant:
+0:121              1 (const int)
+0:121            Constant:
+0:121              2 (const int)
+0:121        vector swizzle ( temp highp 3-component vector of float)
+0:121          'v' ( temp highp 3-component vector of float)
+0:121          Sequence
+0:121            Constant:
+0:121              0 (const int)
+0:121            Constant:
+0:121              1 (const int)
+0:121            Constant:
+0:121              2 (const int)
+0:122      Branch: Return with expression
+0:122        't' ( in highp 3-component vector of float)
+0:124  Function Definition: TDInstanceActive(i1; ( global bool)
+0:124    Function Parameters: 
+0:124      'index' ( in highp int)
+0:125    Sequence
+0:125      subtract second child into first child ( temp highp int)
+0:125        'index' ( in highp int)
+0:125        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:125          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:125          Constant:
+0:125            0 (const uint)
+0:127      Sequence
+0:127        move second child to first child ( temp highp int)
+0:127          'coord' ( temp highp int)
+0:127          'index' ( in highp int)
+0:128      Sequence
+0:128        move second child to first child ( temp highp 4-component vector of float)
+0:128          'samp' ( temp highp 4-component vector of float)
+0:128          textureFetch ( global highp 4-component vector of float)
+0:128            'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:128            'coord' ( temp highp int)
+0:129      move second child to first child ( temp highp float)
+0:129        'v' ( temp highp float)
+0:129        direct index ( temp highp float)
+0:129          'samp' ( temp highp 4-component vector of float)
+0:129          Constant:
+0:129            0 (const int)
+0:130      Branch: Return with expression
+0:130        Compare Not Equal ( temp bool)
+0:130          'v' ( temp highp float)
+0:130          Constant:
+0:130            0.000000
+0:132  Function Definition: iTDInstanceTranslate(i1;b1; ( global highp 3-component vector of float)
+0:132    Function Parameters: 
+0:132      'index' ( in highp int)
+0:132      'instanceActive' ( out bool)
+0:133    Sequence
+0:133      Sequence
+0:133        move second child to first child ( temp highp int)
+0:133          'origIndex' ( temp highp int)
+0:133          'index' ( in highp int)
+0:134      subtract second child into first child ( temp highp int)
+0:134        'index' ( in highp int)
+0:134        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:134          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:134          Constant:
+0:134            0 (const uint)
+0:136      Sequence
+0:136        move second child to first child ( temp highp int)
+0:136          'coord' ( temp highp int)
+0:136          'index' ( in highp int)
+0:137      Sequence
+0:137        move second child to first child ( temp highp 4-component vector of float)
+0:137          'samp' ( temp highp 4-component vector of float)
+0:137          textureFetch ( global highp 4-component vector of float)
+0:137            'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:137            'coord' ( temp highp int)
+0:138      move second child to first child ( temp highp float)
+0:138        direct index ( temp highp float)
+0:138          'v' ( temp highp 3-component vector of float)
+0:138          Constant:
+0:138            0 (const int)
+0:138        direct index ( temp highp float)
+0:138          'samp' ( temp highp 4-component vector of float)
+0:138          Constant:
+0:138            1 (const int)
+0:139      move second child to first child ( temp highp float)
+0:139        direct index ( temp highp float)
+0:139          'v' ( temp highp 3-component vector of float)
+0:139          Constant:
+0:139            1 (const int)
+0:139        direct index ( temp highp float)
+0:139          'samp' ( temp highp 4-component vector of float)
+0:139          Constant:
+0:139            2 (const int)
+0:140      move second child to first child ( temp highp float)
+0:140        direct index ( temp highp float)
+0:140          'v' ( temp highp 3-component vector of float)
+0:140          Constant:
+0:140            2 (const int)
+0:140        direct index ( temp highp float)
+0:140          'samp' ( temp highp 4-component vector of float)
+0:140          Constant:
+0:140            3 (const int)
+0:141      move second child to first child ( temp bool)
+0:141        'instanceActive' ( out bool)
+0:141        Compare Not Equal ( temp bool)
+0:141          direct index ( temp highp float)
+0:141            'samp' ( temp highp 4-component vector of float)
+0:141            Constant:
+0:141              0 (const int)
+0:141          Constant:
+0:141            0.000000
+0:142      Branch: Return with expression
+0:142        'v' ( temp highp 3-component vector of float)
+0:144  Function Definition: TDInstanceTranslate(i1; ( global highp 3-component vector of float)
+0:144    Function Parameters: 
+0:144      'index' ( in highp int)
+0:145    Sequence
+0:145      subtract second child into first child ( temp highp int)
+0:145        'index' ( in highp int)
+0:145        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:145          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:145          Constant:
+0:145            0 (const uint)
+0:147      Sequence
+0:147        move second child to first child ( temp highp int)
+0:147          'coord' ( temp highp int)
+0:147          'index' ( in highp int)
+0:148      Sequence
+0:148        move second child to first child ( temp highp 4-component vector of float)
+0:148          'samp' ( temp highp 4-component vector of float)
+0:148          textureFetch ( global highp 4-component vector of float)
+0:148            'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:148            'coord' ( temp highp int)
+0:149      move second child to first child ( temp highp float)
+0:149        direct index ( temp highp float)
+0:149          'v' ( temp highp 3-component vector of float)
+0:149          Constant:
+0:149            0 (const int)
+0:149        direct index ( temp highp float)
+0:149          'samp' ( temp highp 4-component vector of float)
+0:149          Constant:
+0:149            1 (const int)
+0:150      move second child to first child ( temp highp float)
+0:150        direct index ( temp highp float)
+0:150          'v' ( temp highp 3-component vector of float)
+0:150          Constant:
+0:150            1 (const int)
+0:150        direct index ( temp highp float)
+0:150          'samp' ( temp highp 4-component vector of float)
+0:150          Constant:
+0:150            2 (const int)
+0:151      move second child to first child ( temp highp float)
+0:151        direct index ( temp highp float)
+0:151          'v' ( temp highp 3-component vector of float)
+0:151          Constant:
+0:151            2 (const int)
+0:151        direct index ( temp highp float)
+0:151          'samp' ( temp highp 4-component vector of float)
+0:151          Constant:
+0:151            3 (const int)
+0:152      Branch: Return with expression
+0:152        'v' ( temp highp 3-component vector of float)
+0:154  Function Definition: TDInstanceRotateMat(i1; ( global highp 3X3 matrix of float)
+0:154    Function Parameters: 
+0:154      'index' ( in highp int)
+0:155    Sequence
+0:155      subtract second child into first child ( temp highp int)
+0:155        'index' ( in highp int)
+0:155        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:155          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:155          Constant:
+0:155            0 (const uint)
+0:156      Sequence
+0:156        move second child to first child ( temp highp 3-component vector of float)
+0:156          'v' ( temp highp 3-component vector of float)
+0:156          Constant:
+0:156            0.000000
+0:156            0.000000
+0:156            0.000000
+0:157      Sequence
+0:157        move second child to first child ( temp highp 3X3 matrix of float)
+0:157          'm' ( temp highp 3X3 matrix of float)
+0:157          Constant:
+0:157            1.000000
+0:157            0.000000
+0:157            0.000000
+0:157            0.000000
+0:157            1.000000
+0:157            0.000000
+0:157            0.000000
+0:157            0.000000
+0:157            1.000000
+0:161      Branch: Return with expression
+0:161        'm' ( temp highp 3X3 matrix of float)
+0:163  Function Definition: TDInstanceScale(i1; ( global highp 3-component vector of float)
+0:163    Function Parameters: 
+0:163      'index' ( in highp int)
+0:164    Sequence
+0:164      subtract second child into first child ( temp highp int)
+0:164        'index' ( in highp int)
+0:164        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:164          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:164          Constant:
+0:164            0 (const uint)
+0:165      Sequence
+0:165        move second child to first child ( temp highp 3-component vector of float)
+0:165          'v' ( temp highp 3-component vector of float)
+0:165          Constant:
+0:165            1.000000
+0:165            1.000000
+0:165            1.000000
+0:166      Branch: Return with expression
+0:166        'v' ( temp highp 3-component vector of float)
+0:168  Function Definition: TDInstancePivot(i1; ( global highp 3-component vector of float)
+0:168    Function Parameters: 
+0:168      'index' ( in highp int)
+0:169    Sequence
+0:169      subtract second child into first child ( temp highp int)
+0:169        'index' ( in highp int)
+0:169        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:169          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:169          Constant:
+0:169            0 (const uint)
+0:170      Sequence
+0:170        move second child to first child ( temp highp 3-component vector of float)
+0:170          'v' ( temp highp 3-component vector of float)
+0:170          Constant:
+0:170            0.000000
+0:170            0.000000
+0:170            0.000000
+0:171      Branch: Return with expression
+0:171        'v' ( temp highp 3-component vector of float)
+0:173  Function Definition: TDInstanceRotTo(i1; ( global highp 3-component vector of float)
+0:173    Function Parameters: 
+0:173      'index' ( in highp int)
+0:174    Sequence
+0:174      subtract second child into first child ( temp highp int)
+0:174        'index' ( in highp int)
+0:174        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:174          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:174          Constant:
+0:174            0 (const uint)
+0:175      Sequence
+0:175        move second child to first child ( temp highp 3-component vector of float)
+0:175          'v' ( temp highp 3-component vector of float)
+0:175          Constant:
+0:175            0.000000
+0:175            0.000000
+0:175            1.000000
+0:176      Branch: Return with expression
+0:176        'v' ( temp highp 3-component vector of float)
+0:178  Function Definition: TDInstanceRotUp(i1; ( global highp 3-component vector of float)
+0:178    Function Parameters: 
+0:178      'index' ( in highp int)
+0:179    Sequence
+0:179      subtract second child into first child ( temp highp int)
+0:179        'index' ( in highp int)
+0:179        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:179          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:179          Constant:
+0:179            0 (const uint)
+0:180      Sequence
+0:180        move second child to first child ( temp highp 3-component vector of float)
+0:180          'v' ( temp highp 3-component vector of float)
+0:180          Constant:
+0:180            0.000000
+0:180            1.000000
+0:180            0.000000
+0:181      Branch: Return with expression
+0:181        'v' ( temp highp 3-component vector of float)
+0:183  Function Definition: TDInstanceMat(i1; ( global highp 4X4 matrix of float)
+0:183    Function Parameters: 
+0:183      'id' ( in highp int)
+0:184    Sequence
+0:184      Sequence
+0:184        move second child to first child ( temp bool)
+0:184          'instanceActive' ( temp bool)
+0:184          Constant:
+0:184            true (const bool)
+0:185      Sequence
+0:185        move second child to first child ( temp highp 3-component vector of float)
+0:185          't' ( temp highp 3-component vector of float)
+0:185          Function Call: iTDInstanceTranslate(i1;b1; ( global highp 3-component vector of float)
+0:185            'id' ( in highp int)
+0:185            'instanceActive' ( temp bool)
+0:186      Test condition and select ( temp void)
+0:186        Condition
+0:186        Negate conditional ( temp bool)
+0:186          'instanceActive' ( temp bool)
+0:186        true case
+0:188        Sequence
+0:188          Branch: Return with expression
+0:188            Constant:
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:188              0.000000
+0:190      Sequence
+0:190        move second child to first child ( temp highp 4X4 matrix of float)
+0:190          'm' ( temp highp 4X4 matrix of float)
+0:190          Constant:
+0:190            1.000000
+0:190            0.000000
+0:190            0.000000
+0:190            0.000000
+0:190            0.000000
+0:190            1.000000
+0:190            0.000000
+0:190            0.000000
+0:190            0.000000
+0:190            0.000000
+0:190            1.000000
+0:190            0.000000
+0:190            0.000000
+0:190            0.000000
+0:190            0.000000
+0:190            1.000000
+0:192      Sequence
+0:192        Sequence
+0:192          move second child to first child ( temp highp 3-component vector of float)
+0:192            'tt' ( temp highp 3-component vector of float)
+0:192            't' ( temp highp 3-component vector of float)
+0:193        add second child into first child ( temp highp float)
+0:193          direct index ( temp highp float)
+0:193            direct index ( temp highp 4-component vector of float)
+0:193              'm' ( temp highp 4X4 matrix of float)
+0:193              Constant:
+0:193                3 (const int)
+0:193            Constant:
+0:193              0 (const int)
+0:193          component-wise multiply ( temp highp float)
+0:193            direct index ( temp highp float)
+0:193              direct index ( temp highp 4-component vector of float)
+0:193                'm' ( temp highp 4X4 matrix of float)
+0:193                Constant:
+0:193                  0 (const int)
+0:193              Constant:
+0:193                0 (const int)
+0:193            direct index ( temp highp float)
+0:193              'tt' ( temp highp 3-component vector of float)
+0:193              Constant:
+0:193                0 (const int)
+0:194        add second child into first child ( temp highp float)
+0:194          direct index ( temp highp float)
+0:194            direct index ( temp highp 4-component vector of float)
+0:194              'm' ( temp highp 4X4 matrix of float)
+0:194              Constant:
+0:194                3 (const int)
+0:194            Constant:
+0:194              1 (const int)
+0:194          component-wise multiply ( temp highp float)
+0:194            direct index ( temp highp float)
+0:194              direct index ( temp highp 4-component vector of float)
+0:194                'm' ( temp highp 4X4 matrix of float)
+0:194                Constant:
+0:194                  0 (const int)
+0:194              Constant:
+0:194                1 (const int)
+0:194            direct index ( temp highp float)
+0:194              'tt' ( temp highp 3-component vector of float)
+0:194              Constant:
+0:194                0 (const int)
+0:195        add second child into first child ( temp highp float)
+0:195          direct index ( temp highp float)
+0:195            direct index ( temp highp 4-component vector of float)
+0:195              'm' ( temp highp 4X4 matrix of float)
+0:195              Constant:
+0:195                3 (const int)
+0:195            Constant:
+0:195              2 (const int)
+0:195          component-wise multiply ( temp highp float)
+0:195            direct index ( temp highp float)
+0:195              direct index ( temp highp 4-component vector of float)
+0:195                'm' ( temp highp 4X4 matrix of float)
+0:195                Constant:
+0:195                  0 (const int)
+0:195              Constant:
+0:195                2 (const int)
+0:195            direct index ( temp highp float)
+0:195              'tt' ( temp highp 3-component vector of float)
+0:195              Constant:
+0:195                0 (const int)
+0:196        add second child into first child ( temp highp float)
+0:196          direct index ( temp highp float)
+0:196            direct index ( temp highp 4-component vector of float)
+0:196              'm' ( temp highp 4X4 matrix of float)
+0:196              Constant:
+0:196                3 (const int)
+0:196            Constant:
+0:196              3 (const int)
+0:196          component-wise multiply ( temp highp float)
+0:196            direct index ( temp highp float)
+0:196              direct index ( temp highp 4-component vector of float)
+0:196                'm' ( temp highp 4X4 matrix of float)
+0:196                Constant:
+0:196                  0 (const int)
+0:196              Constant:
+0:196                3 (const int)
+0:196            direct index ( temp highp float)
+0:196              'tt' ( temp highp 3-component vector of float)
+0:196              Constant:
+0:196                0 (const int)
+0:197        add second child into first child ( temp highp float)
+0:197          direct index ( temp highp float)
+0:197            direct index ( temp highp 4-component vector of float)
+0:197              'm' ( temp highp 4X4 matrix of float)
+0:197              Constant:
+0:197                3 (const int)
+0:197            Constant:
+0:197              0 (const int)
+0:197          component-wise multiply ( temp highp float)
+0:197            direct index ( temp highp float)
+0:197              direct index ( temp highp 4-component vector of float)
+0:197                'm' ( temp highp 4X4 matrix of float)
+0:197                Constant:
+0:197                  1 (const int)
+0:197              Constant:
+0:197                0 (const int)
+0:197            direct index ( temp highp float)
+0:197              'tt' ( temp highp 3-component vector of float)
+0:197              Constant:
+0:197                1 (const int)
+0:198        add second child into first child ( temp highp float)
+0:198          direct index ( temp highp float)
+0:198            direct index ( temp highp 4-component vector of float)
+0:198              'm' ( temp highp 4X4 matrix of float)
+0:198              Constant:
+0:198                3 (const int)
+0:198            Constant:
+0:198              1 (const int)
+0:198          component-wise multiply ( temp highp float)
+0:198            direct index ( temp highp float)
+0:198              direct index ( temp highp 4-component vector of float)
+0:198                'm' ( temp highp 4X4 matrix of float)
+0:198                Constant:
+0:198                  1 (const int)
+0:198              Constant:
+0:198                1 (const int)
+0:198            direct index ( temp highp float)
+0:198              'tt' ( temp highp 3-component vector of float)
+0:198              Constant:
+0:198                1 (const int)
+0:199        add second child into first child ( temp highp float)
+0:199          direct index ( temp highp float)
+0:199            direct index ( temp highp 4-component vector of float)
+0:199              'm' ( temp highp 4X4 matrix of float)
+0:199              Constant:
+0:199                3 (const int)
+0:199            Constant:
+0:199              2 (const int)
+0:199          component-wise multiply ( temp highp float)
+0:199            direct index ( temp highp float)
+0:199              direct index ( temp highp 4-component vector of float)
+0:199                'm' ( temp highp 4X4 matrix of float)
+0:199                Constant:
+0:199                  1 (const int)
+0:199              Constant:
+0:199                2 (const int)
+0:199            direct index ( temp highp float)
+0:199              'tt' ( temp highp 3-component vector of float)
+0:199              Constant:
+0:199                1 (const int)
+0:200        add second child into first child ( temp highp float)
+0:200          direct index ( temp highp float)
+0:200            direct index ( temp highp 4-component vector of float)
+0:200              'm' ( temp highp 4X4 matrix of float)
+0:200              Constant:
+0:200                3 (const int)
+0:200            Constant:
+0:200              3 (const int)
+0:200          component-wise multiply ( temp highp float)
+0:200            direct index ( temp highp float)
+0:200              direct index ( temp highp 4-component vector of float)
+0:200                'm' ( temp highp 4X4 matrix of float)
+0:200                Constant:
+0:200                  1 (const int)
+0:200              Constant:
+0:200                3 (const int)
+0:200            direct index ( temp highp float)
+0:200              'tt' ( temp highp 3-component vector of float)
+0:200              Constant:
+0:200                1 (const int)
+0:201        add second child into first child ( temp highp float)
+0:201          direct index ( temp highp float)
+0:201            direct index ( temp highp 4-component vector of float)
+0:201              'm' ( temp highp 4X4 matrix of float)
+0:201              Constant:
+0:201                3 (const int)
+0:201            Constant:
+0:201              0 (const int)
+0:201          component-wise multiply ( temp highp float)
+0:201            direct index ( temp highp float)
+0:201              direct index ( temp highp 4-component vector of float)
+0:201                'm' ( temp highp 4X4 matrix of float)
+0:201                Constant:
+0:201                  2 (const int)
+0:201              Constant:
+0:201                0 (const int)
+0:201            direct index ( temp highp float)
+0:201              'tt' ( temp highp 3-component vector of float)
+0:201              Constant:
+0:201                2 (const int)
+0:202        add second child into first child ( temp highp float)
+0:202          direct index ( temp highp float)
+0:202            direct index ( temp highp 4-component vector of float)
+0:202              'm' ( temp highp 4X4 matrix of float)
+0:202              Constant:
+0:202                3 (const int)
+0:202            Constant:
+0:202              1 (const int)
+0:202          component-wise multiply ( temp highp float)
+0:202            direct index ( temp highp float)
+0:202              direct index ( temp highp 4-component vector of float)
+0:202                'm' ( temp highp 4X4 matrix of float)
+0:202                Constant:
+0:202                  2 (const int)
+0:202              Constant:
+0:202                1 (const int)
+0:202            direct index ( temp highp float)
+0:202              'tt' ( temp highp 3-component vector of float)
+0:202              Constant:
+0:202                2 (const int)
+0:203        add second child into first child ( temp highp float)
+0:203          direct index ( temp highp float)
+0:203            direct index ( temp highp 4-component vector of float)
+0:203              'm' ( temp highp 4X4 matrix of float)
+0:203              Constant:
+0:203                3 (const int)
+0:203            Constant:
+0:203              2 (const int)
+0:203          component-wise multiply ( temp highp float)
+0:203            direct index ( temp highp float)
+0:203              direct index ( temp highp 4-component vector of float)
+0:203                'm' ( temp highp 4X4 matrix of float)
+0:203                Constant:
+0:203                  2 (const int)
+0:203              Constant:
+0:203                2 (const int)
+0:203            direct index ( temp highp float)
+0:203              'tt' ( temp highp 3-component vector of float)
+0:203              Constant:
+0:203                2 (const int)
+0:204        add second child into first child ( temp highp float)
+0:204          direct index ( temp highp float)
+0:204            direct index ( temp highp 4-component vector of float)
+0:204              'm' ( temp highp 4X4 matrix of float)
+0:204              Constant:
+0:204                3 (const int)
+0:204            Constant:
+0:204              3 (const int)
+0:204          component-wise multiply ( temp highp float)
+0:204            direct index ( temp highp float)
+0:204              direct index ( temp highp 4-component vector of float)
+0:204                'm' ( temp highp 4X4 matrix of float)
+0:204                Constant:
+0:204                  2 (const int)
+0:204              Constant:
+0:204                3 (const int)
+0:204            direct index ( temp highp float)
+0:204              'tt' ( temp highp 3-component vector of float)
+0:204              Constant:
+0:204                2 (const int)
+0:206      Branch: Return with expression
+0:206        'm' ( temp highp 4X4 matrix of float)
+0:208  Function Definition: TDInstanceMat3(i1; ( global highp 3X3 matrix of float)
+0:208    Function Parameters: 
+0:208      'id' ( in highp int)
+0:209    Sequence
+0:209      Sequence
+0:209        move second child to first child ( temp highp 3X3 matrix of float)
+0:209          'm' ( temp highp 3X3 matrix of float)
+0:209          Constant:
+0:209            1.000000
+0:209            0.000000
+0:209            0.000000
+0:209            0.000000
+0:209            1.000000
+0:209            0.000000
+0:209            0.000000
+0:209            0.000000
+0:209            1.000000
+0:210      Branch: Return with expression
+0:210        'm' ( temp highp 3X3 matrix of float)
+0:212  Function Definition: TDInstanceMat3ForNorm(i1; ( global highp 3X3 matrix of float)
+0:212    Function Parameters: 
+0:212      'id' ( in highp int)
+0:213    Sequence
+0:213      Sequence
+0:213        move second child to first child ( temp highp 3X3 matrix of float)
+0:213          'm' ( temp highp 3X3 matrix of float)
+0:213          Function Call: TDInstanceMat3(i1; ( global highp 3X3 matrix of float)
+0:213            'id' ( in highp int)
+0:214      Branch: Return with expression
+0:214        'm' ( temp highp 3X3 matrix of float)
+0:216  Function Definition: TDInstanceColor(i1;vf4; ( global highp 4-component vector of float)
+0:216    Function Parameters: 
+0:216      'index' ( in highp int)
+0:216      'curColor' ( in highp 4-component vector of float)
+0:217    Sequence
+0:217      subtract second child into first child ( temp highp int)
+0:217        'index' ( in highp int)
+0:217        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:217          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:217          Constant:
+0:217            0 (const uint)
+0:219      Sequence
+0:219        move second child to first child ( temp highp int)
+0:219          'coord' ( temp highp int)
+0:219          'index' ( in highp int)
+0:220      Sequence
+0:220        move second child to first child ( temp highp 4-component vector of float)
+0:220          'samp' ( temp highp 4-component vector of float)
+0:220          textureFetch ( global highp 4-component vector of float)
+0:220            'sTDInstanceColor' (layout( binding=17) uniform highp samplerBuffer)
+0:220            'coord' ( temp highp int)
+0:221      move second child to first child ( temp highp float)
+0:221        direct index ( temp highp float)
+0:221          'v' ( temp highp 4-component vector of float)
+0:221          Constant:
+0:221            0 (const int)
+0:221        direct index ( temp highp float)
+0:221          'samp' ( temp highp 4-component vector of float)
+0:221          Constant:
+0:221            0 (const int)
+0:222      move second child to first child ( temp highp float)
+0:222        direct index ( temp highp float)
+0:222          'v' ( temp highp 4-component vector of float)
+0:222          Constant:
+0:222            1 (const int)
+0:222        direct index ( temp highp float)
+0:222          'samp' ( temp highp 4-component vector of float)
+0:222          Constant:
+0:222            1 (const int)
+0:223      move second child to first child ( temp highp float)
+0:223        direct index ( temp highp float)
+0:223          'v' ( temp highp 4-component vector of float)
+0:223          Constant:
+0:223            2 (const int)
+0:223        direct index ( temp highp float)
+0:223          'samp' ( temp highp 4-component vector of float)
+0:223          Constant:
+0:223            2 (const int)
+0:224      move second child to first child ( temp highp float)
+0:224        direct index ( temp highp float)
+0:224          'v' ( temp highp 4-component vector of float)
+0:224          Constant:
+0:224            3 (const int)
+0:224        Constant:
+0:224          1.000000
+0:225      move second child to first child ( temp highp float)
+0:225        direct index ( temp highp float)
+0:225          'curColor' ( in highp 4-component vector of float)
+0:225          Constant:
+0:225            0 (const int)
+0:225        direct index ( temp highp float)
+0:225          'v' ( temp highp 4-component vector of float)
+0:225          Constant:
+0:225            0 (const int)
+0:227      move second child to first child ( temp highp float)
+0:227        direct index ( temp highp float)
+0:227          'curColor' ( in highp 4-component vector of float)
+0:227          Constant:
+0:227            1 (const int)
+0:227        direct index ( temp highp float)
+0:227          'v' ( temp highp 4-component vector of float)
+0:227          Constant:
+0:227            1 (const int)
+0:229      move second child to first child ( temp highp float)
+0:229        direct index ( temp highp float)
+0:229          'curColor' ( in highp 4-component vector of float)
+0:229          Constant:
+0:229            2 (const int)
+0:229        direct index ( temp highp float)
+0:229          'v' ( temp highp 4-component vector of float)
+0:229          Constant:
+0:229            2 (const int)
+0:231      Branch: Return with expression
+0:231        'curColor' ( in highp 4-component vector of float)
+0:233  Function Definition: TDInstanceDeform(i1;vf4; ( global highp 4-component vector of float)
+0:233    Function Parameters: 
+0:233      'id' ( in highp int)
+0:233      'pos' ( in highp 4-component vector of float)
+0:234    Sequence
+0:234      move second child to first child ( temp highp 4-component vector of float)
+0:234        'pos' ( in highp 4-component vector of float)
+0:234        matrix-times-vector ( temp highp 4-component vector of float)
+0:234          Function Call: TDInstanceMat(i1; ( global highp 4X4 matrix of float)
+0:234            'id' ( in highp int)
+0:234          'pos' ( in highp 4-component vector of float)
+0:235      Branch: Return with expression
+0:235        matrix-times-vector ( temp highp 4-component vector of float)
+0:235          world: direct index for structure (layout( column_major std140) global highp 4X4 matrix of float)
+0:235            indirect index (layout( column_major std140 offset=0) temp structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:235              uTDMats: direct index for structure (layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:235                'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:235                Constant:
+0:235                  0 (const uint)
+0:235              Function Call: TDCameraIndex( ( global highp int)
+0:235            Constant:
+0:235              0 (const int)
+0:235          'pos' ( in highp 4-component vector of float)
+0:238  Function Definition: TDInstanceDeformVec(i1;vf3; ( global highp 3-component vector of float)
+0:238    Function Parameters: 
+0:238      'id' ( in highp int)
+0:238      'vec' ( in highp 3-component vector of float)
+0:240    Sequence
+0:240      Sequence
+0:240        move second child to first child ( temp highp 3X3 matrix of float)
+0:240          'm' ( temp highp 3X3 matrix of float)
+0:240          Function Call: TDInstanceMat3(i1; ( global highp 3X3 matrix of float)
+0:240            'id' ( in highp int)
+0:241      Branch: Return with expression
+0:241        matrix-times-vector ( temp highp 3-component vector of float)
+0:241          Construct mat3 ( temp highp 3X3 matrix of float)
+0:241            world: direct index for structure (layout( column_major std140) global highp 4X4 matrix of float)
+0:241              indirect index (layout( column_major std140 offset=0) temp structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:241                uTDMats: direct index for structure (layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:241                  'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:241                  Constant:
+0:241                    0 (const uint)
+0:241                Function Call: TDCameraIndex( ( global highp int)
+0:241              Constant:
+0:241                0 (const int)
+0:241          matrix-times-vector ( temp highp 3-component vector of float)
+0:241            'm' ( temp highp 3X3 matrix of float)
+0:241            'vec' ( in highp 3-component vector of float)
+0:243  Function Definition: TDInstanceDeformNorm(i1;vf3; ( global highp 3-component vector of float)
+0:243    Function Parameters: 
+0:243      'id' ( in highp int)
+0:243      'vec' ( in highp 3-component vector of float)
+0:245    Sequence
+0:245      Sequence
+0:245        move second child to first child ( temp highp 3X3 matrix of float)
+0:245          'm' ( temp highp 3X3 matrix of float)
+0:245          Function Call: TDInstanceMat3ForNorm(i1; ( global highp 3X3 matrix of float)
+0:245            'id' ( in highp int)
+0:246      Branch: Return with expression
+0:246        matrix-times-vector ( temp highp 3-component vector of float)
+0:246          Construct mat3 ( temp highp 3X3 matrix of float)
+0:246            worldForNormals: direct index for structure (layout( column_major std140) global highp 3X3 matrix of float)
+0:246              indirect index (layout( column_major std140 offset=0) temp structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:246                uTDMats: direct index for structure (layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals})
+0:246                  'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:246                  Constant:
+0:246                    0 (const uint)
+0:246                Function Call: TDCameraIndex( ( global highp int)
+0:246              Constant:
+0:246                13 (const int)
+0:246          matrix-times-vector ( temp highp 3-component vector of float)
+0:246            'm' ( temp highp 3X3 matrix of float)
+0:246            'vec' ( in highp 3-component vector of float)
+0:248  Function Definition: TDInstanceDeform(vf4; ( global highp 4-component vector of float)
+0:248    Function Parameters: 
+0:248      'pos' ( in highp 4-component vector of float)
+0:249    Sequence
+0:249      Branch: Return with expression
+0:249        Function Call: TDInstanceDeform(i1;vf4; ( global highp 4-component vector of float)
+0:249          Function Call: TDInstanceID( ( global highp int)
+0:249          'pos' ( in highp 4-component vector of float)
+0:251  Function Definition: TDInstanceDeformVec(vf3; ( global highp 3-component vector of float)
+0:251    Function Parameters: 
+0:251      'vec' ( in highp 3-component vector of float)
+0:252    Sequence
+0:252      Branch: Return with expression
+0:252        Function Call: TDInstanceDeformVec(i1;vf3; ( global highp 3-component vector of float)
+0:252          Function Call: TDInstanceID( ( global highp int)
+0:252          'vec' ( in highp 3-component vector of float)
+0:254  Function Definition: TDInstanceDeformNorm(vf3; ( global highp 3-component vector of float)
+0:254    Function Parameters: 
+0:254      'vec' ( in highp 3-component vector of float)
+0:255    Sequence
+0:255      Branch: Return with expression
+0:255        Function Call: TDInstanceDeformNorm(i1;vf3; ( global highp 3-component vector of float)
+0:255          Function Call: TDInstanceID( ( global highp int)
+0:255          'vec' ( in highp 3-component vector of float)
+0:257  Function Definition: TDInstanceActive( ( global bool)
+0:257    Function Parameters: 
+0:257    Sequence
+0:257      Branch: Return with expression
+0:257        Function Call: TDInstanceActive(i1; ( global bool)
+0:257          Function Call: TDInstanceID( ( global highp int)
+0:258  Function Definition: TDInstanceTranslate( ( global highp 3-component vector of float)
+0:258    Function Parameters: 
+0:258    Sequence
+0:258      Branch: Return with expression
+0:258        Function Call: TDInstanceTranslate(i1; ( global highp 3-component vector of float)
+0:258          Function Call: TDInstanceID( ( global highp int)
+0:259  Function Definition: TDInstanceRotateMat( ( global highp 3X3 matrix of float)
+0:259    Function Parameters: 
+0:259    Sequence
+0:259      Branch: Return with expression
+0:259        Function Call: TDInstanceRotateMat(i1; ( global highp 3X3 matrix of float)
+0:259          Function Call: TDInstanceID( ( global highp int)
+0:260  Function Definition: TDInstanceScale( ( global highp 3-component vector of float)
+0:260    Function Parameters: 
+0:260    Sequence
+0:260      Branch: Return with expression
+0:260        Function Call: TDInstanceScale(i1; ( global highp 3-component vector of float)
+0:260          Function Call: TDInstanceID( ( global highp int)
+0:261  Function Definition: TDInstanceMat( ( global highp 4X4 matrix of float)
+0:261    Function Parameters: 
+0:261    Sequence
+0:261      Branch: Return with expression
+0:261        Function Call: TDInstanceMat(i1; ( global highp 4X4 matrix of float)
+0:261          Function Call: TDInstanceID( ( global highp int)
+0:263  Function Definition: TDInstanceMat3( ( global highp 3X3 matrix of float)
+0:263    Function Parameters: 
+0:263    Sequence
+0:263      Branch: Return with expression
+0:263        Function Call: TDInstanceMat3(i1; ( global highp 3X3 matrix of float)
+0:263          Function Call: TDInstanceID( ( global highp int)
+0:265  Function Definition: TDInstanceTexCoord(vf3; ( global highp 3-component vector of float)
+0:265    Function Parameters: 
+0:265      't' ( in highp 3-component vector of float)
+0:266    Sequence
+0:266      Branch: Return with expression
+0:266        Function Call: TDInstanceTexCoord(i1;vf3; ( global highp 3-component vector of float)
+0:266          Function Call: TDInstanceID( ( global highp int)
+0:266          't' ( in highp 3-component vector of float)
+0:268  Function Definition: TDInstanceColor(vf4; ( global highp 4-component vector of float)
+0:268    Function Parameters: 
+0:268      'curColor' ( in highp 4-component vector of float)
+0:269    Sequence
+0:269      Branch: Return with expression
+0:269        Function Call: TDInstanceColor(i1;vf4; ( global highp 4-component vector of float)
+0:269          Function Call: TDInstanceID( ( global highp int)
+0:269          'curColor' ( in highp 4-component vector of float)
+0:271  Function Definition: TDSkinnedDeform(vf4; ( global highp 4-component vector of float)
+0:271    Function Parameters: 
+0:271      'pos' ( in highp 4-component vector of float)
+0:271    Sequence
+0:271      Branch: Return with expression
+0:271        'pos' ( in highp 4-component vector of float)
+0:273  Function Definition: TDSkinnedDeformVec(vf3; ( global highp 3-component vector of float)
+0:273    Function Parameters: 
+0:273      'vec' ( in highp 3-component vector of float)
+0:273    Sequence
+0:273      Branch: Return with expression
+0:273        'vec' ( in highp 3-component vector of float)
+0:275  Function Definition: TDFastDeformTangent(vf3;vf4;vf3; ( global highp 3-component vector of float)
+0:275    Function Parameters: 
+0:275      'oldNorm' ( in highp 3-component vector of float)
+0:275      'oldTangent' ( in highp 4-component vector of float)
+0:275      'deformedNorm' ( in highp 3-component vector of float)
+0:276    Sequence
+0:276      Branch: Return with expression
+0:276        vector swizzle ( temp highp 3-component vector of float)
+0:276          'oldTangent' ( in highp 4-component vector of float)
+0:276          Sequence
+0:276            Constant:
+0:276              0 (const int)
+0:276            Constant:
+0:276              1 (const int)
+0:276            Constant:
+0:276              2 (const int)
+0:277  Function Definition: TDBoneMat(i1; ( global highp 4X4 matrix of float)
+0:277    Function Parameters: 
+0:277      'index' ( in highp int)
+0:278    Sequence
+0:278      Branch: Return with expression
+0:278        Constant:
+0:278          1.000000
+0:278          0.000000
+0:278          0.000000
+0:278          0.000000
+0:278          0.000000
+0:278          1.000000
+0:278          0.000000
+0:278          0.000000
+0:278          0.000000
+0:278          0.000000
+0:278          1.000000
+0:278          0.000000
+0:278          0.000000
+0:278          0.000000
+0:278          0.000000
+0:278          1.000000
+0:280  Function Definition: TDDeform(vf4; ( global highp 4-component vector of float)
+0:280    Function Parameters: 
+0:280      'pos' ( in highp 4-component vector of float)
+0:281    Sequence
+0:281      move second child to first child ( temp highp 4-component vector of float)
+0:281        'pos' ( in highp 4-component vector of float)
+0:281        Function Call: TDSkinnedDeform(vf4; ( global highp 4-component vector of float)
+0:281          'pos' ( in highp 4-component vector of float)
+0:282      move second child to first child ( temp highp 4-component vector of float)
+0:282        'pos' ( in highp 4-component vector of float)
+0:282        Function Call: TDInstanceDeform(vf4; ( global highp 4-component vector of float)
+0:282          'pos' ( in highp 4-component vector of float)
+0:283      Branch: Return with expression
+0:283        'pos' ( in highp 4-component vector of float)
+0:286  Function Definition: TDDeform(i1;vf3; ( global highp 4-component vector of float)
+0:286    Function Parameters: 
+0:286      'instanceID' ( in highp int)
+0:286      'p' ( in highp 3-component vector of float)
+0:287    Sequence
+0:287      Sequence
+0:287        move second child to first child ( temp highp 4-component vector of float)
+0:287          'pos' ( temp highp 4-component vector of float)
+0:287          Construct vec4 ( temp highp 4-component vector of float)
+0:287            'p' ( in highp 3-component vector of float)
+0:287            Constant:
+0:287              1.000000
+0:288      move second child to first child ( temp highp 4-component vector of float)
+0:288        'pos' ( temp highp 4-component vector of float)
+0:288        Function Call: TDSkinnedDeform(vf4; ( global highp 4-component vector of float)
+0:288          'pos' ( temp highp 4-component vector of float)
+0:289      move second child to first child ( temp highp 4-component vector of float)
+0:289        'pos' ( temp highp 4-component vector of float)
+0:289        Function Call: TDInstanceDeform(i1;vf4; ( global highp 4-component vector of float)
+0:289          'instanceID' ( in highp int)
+0:289          'pos' ( temp highp 4-component vector of float)
+0:290      Branch: Return with expression
+0:290        'pos' ( temp highp 4-component vector of float)
+0:293  Function Definition: TDDeform(vf3; ( global highp 4-component vector of float)
+0:293    Function Parameters: 
+0:293      'pos' ( in highp 3-component vector of float)
+0:294    Sequence
+0:294      Branch: Return with expression
+0:294        Function Call: TDDeform(i1;vf3; ( global highp 4-component vector of float)
+0:294          Function Call: TDInstanceID( ( global highp int)
+0:294          'pos' ( in highp 3-component vector of float)
+0:297  Function Definition: TDDeformVec(i1;vf3; ( global highp 3-component vector of float)
+0:297    Function Parameters: 
+0:297      'instanceID' ( in highp int)
+0:297      'vec' ( in highp 3-component vector of float)
+0:298    Sequence
+0:298      move second child to first child ( temp highp 3-component vector of float)
+0:298        'vec' ( in highp 3-component vector of float)
+0:298        Function Call: TDSkinnedDeformVec(vf3; ( global highp 3-component vector of float)
+0:298          'vec' ( in highp 3-component vector of float)
+0:299      move second child to first child ( temp highp 3-component vector of float)
+0:299        'vec' ( in highp 3-component vector of float)
+0:299        Function Call: TDInstanceDeformVec(i1;vf3; ( global highp 3-component vector of float)
+0:299          'instanceID' ( in highp int)
+0:299          'vec' ( in highp 3-component vector of float)
+0:300      Branch: Return with expression
+0:300        'vec' ( in highp 3-component vector of float)
+0:303  Function Definition: TDDeformVec(vf3; ( global highp 3-component vector of float)
+0:303    Function Parameters: 
+0:303      'vec' ( in highp 3-component vector of float)
+0:304    Sequence
+0:304      Branch: Return with expression
+0:304        Function Call: TDDeformVec(i1;vf3; ( global highp 3-component vector of float)
+0:304          Function Call: TDInstanceID( ( global highp int)
+0:304          'vec' ( in highp 3-component vector of float)
+0:307  Function Definition: TDDeformNorm(i1;vf3; ( global highp 3-component vector of float)
+0:307    Function Parameters: 
+0:307      'instanceID' ( in highp int)
+0:307      'vec' ( in highp 3-component vector of float)
+0:308    Sequence
+0:308      move second child to first child ( temp highp 3-component vector of float)
+0:308        'vec' ( in highp 3-component vector of float)
+0:308        Function Call: TDSkinnedDeformVec(vf3; ( global highp 3-component vector of float)
+0:308          'vec' ( in highp 3-component vector of float)
+0:309      move second child to first child ( temp highp 3-component vector of float)
+0:309        'vec' ( in highp 3-component vector of float)
+0:309        Function Call: TDInstanceDeformNorm(i1;vf3; ( global highp 3-component vector of float)
+0:309          'instanceID' ( in highp int)
+0:309          'vec' ( in highp 3-component vector of float)
+0:310      Branch: Return with expression
+0:310        'vec' ( in highp 3-component vector of float)
+0:313  Function Definition: TDDeformNorm(vf3; ( global highp 3-component vector of float)
+0:313    Function Parameters: 
+0:313      'vec' ( in highp 3-component vector of float)
+0:314    Sequence
+0:314      Branch: Return with expression
+0:314        Function Call: TDDeformNorm(i1;vf3; ( global highp 3-component vector of float)
+0:314          Function Call: TDInstanceID( ( global highp int)
+0:314          'vec' ( in highp 3-component vector of float)
+0:317  Function Definition: TDSkinnedDeformNorm(vf3; ( global highp 3-component vector of float)
+0:317    Function Parameters: 
+0:317      'vec' ( in highp 3-component vector of float)
+0:318    Sequence
+0:318      move second child to first child ( temp highp 3-component vector of float)
+0:318        'vec' ( in highp 3-component vector of float)
+0:318        Function Call: TDSkinnedDeformVec(vf3; ( global highp 3-component vector of float)
+0:318          'vec' ( in highp 3-component vector of float)
+0:319      Branch: Return with expression
+0:319        'vec' ( in highp 3-component vector of float)
+0:?   Linker Objects
+0:?     'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal})
+0:?     'anon@1' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:?     'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 4-component vector of float nearFar,  global highp 4-component vector of float fog,  global highp 4-component vector of float fogColor,  global highp int renderTOPCameraIndex} uTDCamInfos})
+0:?     'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform structure{ global highp 4-component vector of float ambientColor,  global highp 4-component vector of float nearFar,  global highp 4-component vector of float viewport,  global highp 4-component vector of float viewportRes,  global highp 4-component vector of float fog,  global highp 4-component vector of float fogColor} uTDGeneral})
+0:?     'P' (layout( location=0) in highp 3-component vector of float)
+0:?     'N' (layout( location=1) in highp 3-component vector of float)
+0:?     'Cd' (layout( location=2) in highp 4-component vector of float)
+0:?     'uv' (layout( location=3) in 8-element array of highp 3-component vector of float)
+0:?     'oVert' ( out block{ out highp 4-component vector of float color,  out highp 3-component vector of float worldSpacePos,  out highp 3-component vector of float texCoord0,  flat out highp int cameraIndex,  flat out highp int instance})
+0:?     'anon@4' ( out block{ gl_Position 4-component vector of float Position gl_Position,  gl_PointSize float PointSize gl_PointSize,  out 1-element array of float ClipDistance gl_ClipDistance,  out 1-element array of float CullDistance gl_CullDistance})
+0:?     'gl_VertexIndex' ( in int VertexIndex)
+0:?     'gl_InstanceIndex' ( in int InstanceIndex)
+0:?     'anon@1' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 4-component vector of float position,  global highp 3-component vector of float direction,  global highp 3-component vector of float diffuse,  global highp 4-component vector of float nearFar,  global highp 4-component vector of float lightSize,  global highp 4-component vector of float misc,  global highp 4-component vector of float coneLookupScaleBias,  global highp 4-component vector of float attenScaleBiasRoll, layout( column_major std140) global highp 4X4 matrix of float shadowMapMatrix, layout( column_major std140) global highp 4X4 matrix of float shadowMapCamMatrix,  global highp 4-component vector of float shadowMapRes, layout( column_major std140) global highp 4X4 matrix of float projMapMatrix} uTDLights})
+0:?     'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 3-component vector of float color, layout( column_major std140) global highp 3X3 matrix of float rotate} uTDEnvLights})
+0:?     'uTDEnvLightBuffers' (layout( column_major std430) restrict readonly buffer 1-element array of block{layout( column_major std430 offset=0) restrict readonly buffer 9-element array of highp 3-component vector of float shCoeffs})
+0:?     'mTD2DImageOutputs' (layout( rgba8) uniform 1-element array of highp image2D)
+0:?     'mTD2DArrayImageOutputs' (layout( rgba8) uniform 1-element array of highp image2DArray)
+0:?     'mTD3DImageOutputs' (layout( rgba8) uniform 1-element array of highp image3D)
+0:?     'mTDCubeImageOutputs' (layout( rgba8) uniform 1-element array of highp imageCube)
+0:?     'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:?     'sTDInstanceTexCoord' (layout( binding=16) uniform highp samplerBuffer)
+0:?     'sTDInstanceColor' (layout( binding=17) uniform highp samplerBuffer)
+Shader version: 460
+gl_FragCoord origin is upper left
+0:? Sequence
+0:95  Function Definition: main( ( global void)
+0:95    Function Parameters: 
+0:99    Sequence
+0:99      Function Call: TDCheckDiscard( ( global void)
+0:101      Sequence
+0:101        move second child to first child ( temp highp 4-component vector of float)
+0:101          'outcol' ( temp highp 4-component vector of float)
+0:101          Constant:
+0:101            0.000000
+0:101            0.000000
+0:101            0.000000
+0:101            0.000000
+0:103      Sequence
+0:103        move second child to first child ( temp highp 3-component vector of float)
+0:103          'texCoord0' ( temp highp 3-component vector of float)
+0:103          vector swizzle ( temp highp 3-component vector of float)
+0:103            texCoord0: direct index for structure ( in highp 3-component vector of float)
+0:103              'iVert' ( in block{ in highp 4-component vector of float color,  in highp 3-component vector of float worldSpacePos,  in highp 3-component vector of float texCoord0,  flat in highp int cameraIndex,  flat in highp int instance})
+0:103              Constant:
+0:103                2 (const int)
+0:103            Sequence
+0:103              Constant:
+0:103                0 (const int)
+0:103              Constant:
+0:103                1 (const int)
+0:103              Constant:
+0:103                2 (const int)
+0:104      Sequence
+0:104        move second child to first child ( temp highp float)
+0:104          'actualTexZ' ( temp highp float)
+0:104          mod ( global highp float)
+0:104            Convert int to float ( temp highp float)
+0:104              Convert float to int ( temp highp int)
+0:104                direct index ( temp highp float)
+0:104                  'texCoord0' ( temp highp 3-component vector of float)
+0:104                  Constant:
+0:104                    2 (const int)
+0:104            Constant:
+0:104              2048.000000
+0:105      Sequence
+0:105        move second child to first child ( temp highp float)
+0:105          'instanceLoop' ( temp highp float)
+0:105          Floor ( global highp float)
+0:105            Convert int to float ( temp highp float)
+0:105              divide ( temp highp int)
+0:105                Convert float to int ( temp highp int)
+0:105                  direct index ( temp highp float)
+0:105                    'texCoord0' ( temp highp 3-component vector of float)
+0:105                    Constant:
+0:105                      2 (const int)
+0:105                Constant:
+0:105                  2048 (const int)
+0:106      move second child to first child ( temp highp float)
+0:106        direct index ( temp highp float)
+0:106          'texCoord0' ( temp highp 3-component vector of float)
+0:106          Constant:
+0:106            2 (const int)
+0:106        'actualTexZ' ( temp highp float)
+0:107      Sequence
+0:107        move second child to first child ( temp highp 4-component vector of float)
+0:107          'colorMapColor' ( temp highp 4-component vector of float)
+0:107          texture ( global highp 4-component vector of float)
+0:107            'sColorMap' ( uniform highp sampler2DArray)
+0:107            vector swizzle ( temp highp 3-component vector of float)
+0:107              'texCoord0' ( temp highp 3-component vector of float)
+0:107              Sequence
+0:107                Constant:
+0:107                  0 (const int)
+0:107                Constant:
+0:107                  1 (const int)
+0:107                Constant:
+0:107                  2 (const int)
+0:109      Sequence
+0:109        move second child to first child ( temp highp float)
+0:109          'red' ( temp highp float)
+0:109          indirect index ( temp highp float)
+0:109            'colorMapColor' ( temp highp 4-component vector of float)
+0:109            Convert float to int ( temp highp int)
+0:109              'instanceLoop' ( temp highp float)
+0:110      move second child to first child ( temp highp 4-component vector of float)
+0:110        'colorMapColor' ( temp highp 4-component vector of float)
+0:110        Construct vec4 ( temp highp 4-component vector of float)
+0:110          'red' ( temp highp float)
+0:112      add second child into first child ( temp highp 3-component vector of float)
+0:112        vector swizzle ( temp highp 3-component vector of float)
+0:112          'outcol' ( temp highp 4-component vector of float)
+0:112          Sequence
+0:112            Constant:
+0:112              0 (const int)
+0:112            Constant:
+0:112              1 (const int)
+0:112            Constant:
+0:112              2 (const int)
+0:112        component-wise multiply ( temp highp 3-component vector of float)
+0:112          uConstant: direct index for structure ( uniform highp 3-component vector of float)
+0:112            'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal,  uniform highp 3-component vector of float uConstant,  uniform highp float uShadowStrength,  uniform highp 3-component vector of float uShadowColor,  uniform highp 4-component vector of float uDiffuseColor,  uniform highp 4-component vector of float uAmbientColor})
+0:112            Constant:
+0:112              3 (const uint)
+0:112          vector swizzle ( temp highp 3-component vector of float)
+0:112            color: direct index for structure ( in highp 4-component vector of float)
+0:112              'iVert' ( in block{ in highp 4-component vector of float color,  in highp 3-component vector of float worldSpacePos,  in highp 3-component vector of float texCoord0,  flat in highp int cameraIndex,  flat in highp int instance})
+0:112              Constant:
+0:112                0 (const int)
+0:112            Sequence
+0:112              Constant:
+0:112                0 (const int)
+0:112              Constant:
+0:112                1 (const int)
+0:112              Constant:
+0:112                2 (const int)
+0:114      multiply second child into first child ( temp highp 4-component vector of float)
+0:114        'outcol' ( temp highp 4-component vector of float)
+0:114        'colorMapColor' ( temp highp 4-component vector of float)
+0:117      Sequence
+0:117        move second child to first child ( temp highp float)
+0:117          'alpha' ( temp highp float)
+0:117          component-wise multiply ( temp highp float)
+0:117            direct index ( temp highp float)
+0:117              color: direct index for structure ( in highp 4-component vector of float)
+0:117                'iVert' ( in block{ in highp 4-component vector of float color,  in highp 3-component vector of float worldSpacePos,  in highp 3-component vector of float texCoord0,  flat in highp int cameraIndex,  flat in highp int instance})
+0:117                Constant:
+0:117                  0 (const int)
+0:117              Constant:
+0:117                3 (const int)
+0:117            direct index ( temp highp float)
+0:117              'colorMapColor' ( temp highp 4-component vector of float)
+0:117              Constant:
+0:117                3 (const int)
+0:120      move second child to first child ( temp highp 4-component vector of float)
+0:120        'outcol' ( temp highp 4-component vector of float)
+0:120        Function Call: TDDither(vf4; ( global highp 4-component vector of float)
+0:120          'outcol' ( temp highp 4-component vector of float)
+0:122      vector scale second child into first child ( temp highp 3-component vector of float)
+0:122        vector swizzle ( temp highp 3-component vector of float)
+0:122          'outcol' ( temp highp 4-component vector of float)
+0:122          Sequence
+0:122            Constant:
+0:122              0 (const int)
+0:122            Constant:
+0:122              1 (const int)
+0:122            Constant:
+0:122              2 (const int)
+0:122        'alpha' ( temp highp float)
+0:126      Function Call: TDAlphaTest(f1; ( global void)
+0:126        'alpha' ( temp highp float)
+0:128      move second child to first child ( temp highp float)
+0:128        direct index ( temp highp float)
+0:128          'outcol' ( temp highp 4-component vector of float)
+0:128          Constant:
+0:128            3 (const int)
+0:128        'alpha' ( temp highp float)
+0:129      move second child to first child ( temp highp 4-component vector of float)
+0:129        direct index (layout( location=0) temp highp 4-component vector of float)
+0:129          'oFragColor' (layout( location=0) out 1-element array of highp 4-component vector of float)
+0:129          Constant:
+0:129            0 (const int)
+0:129        Function Call: TDOutputSwizzle(vf4; ( global highp 4-component vector of float)
+0:129          'outcol' ( temp highp 4-component vector of float)
+0:135      Sequence
+0:135        Sequence
+0:135          move second child to first child ( temp highp int)
+0:135            'i' ( temp highp int)
+0:135            Constant:
+0:135              1 (const int)
+0:135        Loop with condition tested first
+0:135          Loop Condition
+0:135          Compare Less Than ( temp bool)
+0:135            'i' ( temp highp int)
+0:135            Constant:
+0:135              1 (const int)
+0:135          Loop Body
+0:137          Sequence
+0:137            move second child to first child ( temp highp 4-component vector of float)
+0:137              indirect index (layout( location=0) temp highp 4-component vector of float)
+0:137                'oFragColor' (layout( location=0) out 1-element array of highp 4-component vector of float)
+0:137                'i' ( temp highp int)
+0:137              Constant:
+0:137                0.000000
+0:137                0.000000
+0:137                0.000000
+0:137                0.000000
+0:135          Loop Terminal Expression
+0:135          Post-Increment ( temp highp int)
+0:135            'i' ( temp highp int)
+0:116  Function Definition: TDColor(vf4; ( global highp 4-component vector of float)
+0:116    Function Parameters: 
+0:116      'color' ( in highp 4-component vector of float)
+0:116    Sequence
+0:116      Branch: Return with expression
+0:116        'color' ( in highp 4-component vector of float)
+0:117  Function Definition: TDCheckOrderIndTrans( ( global void)
+0:117    Function Parameters: 
+0:119  Function Definition: TDCheckDiscard( ( global void)
+0:119    Function Parameters: 
+0:120    Sequence
+0:120      Function Call: TDCheckOrderIndTrans( ( global void)
+0:122  Function Definition: TDDither(vf4; ( global highp 4-component vector of float)
+0:122    Function Parameters: 
+0:122      'color' ( in highp 4-component vector of float)
+0:124    Sequence
+0:124      Sequence
+0:124        move second child to first child ( temp highp float)
+0:124          'd' ( temp highp float)
+0:125          direct index ( temp highp float)
+0:125            texture ( global highp 4-component vector of float)
+0:124              'sTDNoiseMap' ( uniform highp sampler2D)
+0:125              divide ( temp highp 2-component vector of float)
+0:125                vector swizzle ( temp highp 2-component vector of float)
+0:125                  'gl_FragCoord' ( gl_FragCoord highp 4-component vector of float FragCoord)
+0:125                  Sequence
+0:125                    Constant:
+0:125                      0 (const int)
+0:125                    Constant:
+0:125                      1 (const int)
+0:125                Constant:
+0:125                  256.000000
+0:125            Constant:
+0:125              0 (const int)
+0:126      subtract second child into first child ( temp highp float)
+0:126        'd' ( temp highp float)
+0:126        Constant:
+0:126          0.500000
+0:127      divide second child into first child ( temp highp float)
+0:127        'd' ( temp highp float)
+0:127        Constant:
+0:127          256.000000
+0:128      Branch: Return with expression
+0:128        Construct vec4 ( temp highp 4-component vector of float)
+0:128          add ( temp highp 3-component vector of float)
+0:128            vector swizzle ( temp highp 3-component vector of float)
+0:128              'color' ( in highp 4-component vector of float)
+0:128              Sequence
+0:128                Constant:
+0:128                  0 (const int)
+0:128                Constant:
+0:128                  1 (const int)
+0:128                Constant:
+0:128                  2 (const int)
+0:128            'd' ( temp highp float)
+0:128          direct index ( temp highp float)
+0:128            'color' ( in highp 4-component vector of float)
+0:128            Constant:
+0:128              3 (const int)
+0:130  Function Definition: TDFrontFacing(vf3;vf3; ( global bool)
+0:130    Function Parameters: 
+0:130      'pos' ( in highp 3-component vector of float)
+0:130      'normal' ( in highp 3-component vector of float)
+0:132    Sequence
+0:132      Branch: Return with expression
+0:132        'gl_FrontFacing' ( gl_FrontFacing bool Face)
+0:134  Function Definition: TDAttenuateLight(i1;f1; ( global highp float)
+0:134    Function Parameters: 
+0:134      'index' ( in highp int)
+0:134      'lightDist' ( in highp float)
+0:136    Sequence
+0:136      Branch: Return with expression
+0:136        Constant:
+0:136          1.000000
+0:138  Function Definition: TDAlphaTest(f1; ( global void)
+0:138    Function Parameters: 
+0:138      'alpha' ( in highp float)
+0:140  Function Definition: TDHardShadow(i1;vf3; ( global highp float)
+0:140    Function Parameters: 
+0:140      'lightIndex' ( in highp int)
+0:140      'worldSpacePos' ( in highp 3-component vector of float)
+0:141    Sequence
+0:141      Branch: Return with expression
+0:141        Constant:
+0:141          0.000000
+0:142  Function Definition: TDSoftShadow(i1;vf3;i1;i1; ( global highp float)
+0:142    Function Parameters: 
+0:142      'lightIndex' ( in highp int)
+0:142      'worldSpacePos' ( in highp 3-component vector of float)
+0:142      'samples' ( in highp int)
+0:142      'steps' ( in highp int)
+0:143    Sequence
+0:143      Branch: Return with expression
+0:143        Constant:
+0:143          0.000000
+0:144  Function Definition: TDSoftShadow(i1;vf3; ( global highp float)
+0:144    Function Parameters: 
+0:144      'lightIndex' ( in highp int)
+0:144      'worldSpacePos' ( in highp 3-component vector of float)
+0:145    Sequence
+0:145      Branch: Return with expression
+0:145        Constant:
+0:145          0.000000
+0:146  Function Definition: TDShadow(i1;vf3; ( global highp float)
+0:146    Function Parameters: 
+0:146      'lightIndex' ( in highp int)
+0:146      'worldSpacePos' ( in highp 3-component vector of float)
+0:147    Sequence
+0:147      Branch: Return with expression
+0:147        Constant:
+0:147          0.000000
+0:152  Function Definition: iTDRadicalInverse_VdC(u1; ( global highp float)
+0:152    Function Parameters: 
+0:152      'bits' ( in highp uint)
+0:154    Sequence
+0:154      move second child to first child ( temp highp uint)
+0:154        'bits' ( in highp uint)
+0:154        inclusive-or ( temp highp uint)
+0:154          left-shift ( temp highp uint)
+0:154            'bits' ( in highp uint)
+0:154            Constant:
+0:154              16 (const uint)
+0:154          right-shift ( temp highp uint)
+0:154            'bits' ( in highp uint)
+0:154            Constant:
+0:154              16 (const uint)
+0:155      move second child to first child ( temp highp uint)
+0:155        'bits' ( in highp uint)
+0:155        inclusive-or ( temp highp uint)
+0:155          left-shift ( temp highp uint)
+0:155            bitwise and ( temp highp uint)
+0:155              'bits' ( in highp uint)
+0:155              Constant:
+0:155                1431655765 (const uint)
+0:155            Constant:
+0:155              1 (const uint)
+0:155          right-shift ( temp highp uint)
+0:155            bitwise and ( temp highp uint)
+0:155              'bits' ( in highp uint)
+0:155              Constant:
+0:155                2863311530 (const uint)
+0:155            Constant:
+0:155              1 (const uint)
+0:156      move second child to first child ( temp highp uint)
+0:156        'bits' ( in highp uint)
+0:156        inclusive-or ( temp highp uint)
+0:156          left-shift ( temp highp uint)
+0:156            bitwise and ( temp highp uint)
+0:156              'bits' ( in highp uint)
+0:156              Constant:
+0:156                858993459 (const uint)
+0:156            Constant:
+0:156              2 (const uint)
+0:156          right-shift ( temp highp uint)
+0:156            bitwise and ( temp highp uint)
+0:156              'bits' ( in highp uint)
+0:156              Constant:
+0:156                3435973836 (const uint)
+0:156            Constant:
+0:156              2 (const uint)
+0:157      move second child to first child ( temp highp uint)
+0:157        'bits' ( in highp uint)
+0:157        inclusive-or ( temp highp uint)
+0:157          left-shift ( temp highp uint)
+0:157            bitwise and ( temp highp uint)
+0:157              'bits' ( in highp uint)
+0:157              Constant:
+0:157                252645135 (const uint)
+0:157            Constant:
+0:157              4 (const uint)
+0:157          right-shift ( temp highp uint)
+0:157            bitwise and ( temp highp uint)
+0:157              'bits' ( in highp uint)
+0:157              Constant:
+0:157                4042322160 (const uint)
+0:157            Constant:
+0:157              4 (const uint)
+0:158      move second child to first child ( temp highp uint)
+0:158        'bits' ( in highp uint)
+0:158        inclusive-or ( temp highp uint)
+0:158          left-shift ( temp highp uint)
+0:158            bitwise and ( temp highp uint)
+0:158              'bits' ( in highp uint)
+0:158              Constant:
+0:158                16711935 (const uint)
+0:158            Constant:
+0:158              8 (const uint)
+0:158          right-shift ( temp highp uint)
+0:158            bitwise and ( temp highp uint)
+0:158              'bits' ( in highp uint)
+0:158              Constant:
+0:158                4278255360 (const uint)
+0:158            Constant:
+0:158              8 (const uint)
+0:159      Branch: Return with expression
+0:159        component-wise multiply ( temp highp float)
+0:159          Convert uint to float ( temp highp float)
+0:159            'bits' ( in highp uint)
+0:159          Constant:
+0:159            2.3283064365387e-10
+0:161  Function Definition: iTDHammersley(u1;u1; ( global highp 2-component vector of float)
+0:161    Function Parameters: 
+0:161      'i' ( in highp uint)
+0:161      'N' ( in highp uint)
+0:163    Sequence
+0:163      Branch: Return with expression
+0:163        Construct vec2 ( temp highp 2-component vector of float)
+0:163          divide ( temp highp float)
+0:163            Convert uint to float ( temp highp float)
+0:163              'i' ( in highp uint)
+0:163            Convert uint to float ( temp highp float)
+0:163              'N' ( in highp uint)
+0:163          Function Call: iTDRadicalInverse_VdC(u1; ( global highp float)
+0:163            'i' ( in highp uint)
+0:165  Function Definition: iTDImportanceSampleGGX(vf2;f1;vf3; ( global highp 3-component vector of float)
+0:165    Function Parameters: 
+0:165      'Xi' ( in highp 2-component vector of float)
+0:165      'roughness2' ( in highp float)
+0:165      'N' ( in highp 3-component vector of float)
+0:167    Sequence
+0:167      Sequence
+0:167        move second child to first child ( temp highp float)
+0:167          'a' ( temp highp float)
+0:167          'roughness2' ( in highp float)
+0:168      Sequence
+0:168        move second child to first child ( temp highp float)
+0:168          'phi' ( temp highp float)
+0:168          component-wise multiply ( temp highp float)
+0:168            Constant:
+0:168              6.283185
+0:168            direct index ( temp highp float)
+0:168              'Xi' ( in highp 2-component vector of float)
+0:168              Constant:
+0:168                0 (const int)
+0:169      Sequence
+0:169        move second child to first child ( temp highp float)
+0:169          'cosTheta' ( temp highp float)
+0:169          sqrt ( global highp float)
+0:169            divide ( temp highp float)
+0:169              subtract ( temp highp float)
+0:169                Constant:
+0:169                  1.000000
+0:169                direct index ( temp highp float)
+0:169                  'Xi' ( in highp 2-component vector of float)
+0:169                  Constant:
+0:169                    1 (const int)
+0:169              add ( temp highp float)
+0:169                Constant:
+0:169                  1.000000
+0:169                component-wise multiply ( temp highp float)
+0:169                  subtract ( temp highp float)
+0:169                    component-wise multiply ( temp highp float)
+0:169                      'a' ( temp highp float)
+0:169                      'a' ( temp highp float)
+0:169                    Constant:
+0:169                      1.000000
+0:169                  direct index ( temp highp float)
+0:169                    'Xi' ( in highp 2-component vector of float)
+0:169                    Constant:
+0:169                      1 (const int)
+0:170      Sequence
+0:170        move second child to first child ( temp highp float)
+0:170          'sinTheta' ( temp highp float)
+0:170          sqrt ( global highp float)
+0:170            subtract ( temp highp float)
+0:170              Constant:
+0:170                1.000000
+0:170              component-wise multiply ( temp highp float)
+0:170                'cosTheta' ( temp highp float)
+0:170                'cosTheta' ( temp highp float)
+0:173      move second child to first child ( temp highp float)
+0:173        direct index ( temp highp float)
+0:173          'H' ( temp highp 3-component vector of float)
+0:173          Constant:
+0:173            0 (const int)
+0:173        component-wise multiply ( temp highp float)
+0:173          'sinTheta' ( temp highp float)
+0:173          cosine ( global highp float)
+0:173            'phi' ( temp highp float)
+0:174      move second child to first child ( temp highp float)
+0:174        direct index ( temp highp float)
+0:174          'H' ( temp highp 3-component vector of float)
+0:174          Constant:
+0:174            1 (const int)
+0:174        component-wise multiply ( temp highp float)
+0:174          'sinTheta' ( temp highp float)
+0:174          sine ( global highp float)
+0:174            'phi' ( temp highp float)
+0:175      move second child to first child ( temp highp float)
+0:175        direct index ( temp highp float)
+0:175          'H' ( temp highp 3-component vector of float)
+0:175          Constant:
+0:175            2 (const int)
+0:175        'cosTheta' ( temp highp float)
+0:177      Sequence
+0:177        move second child to first child ( temp highp 3-component vector of float)
+0:177          'upVector' ( temp highp 3-component vector of float)
+0:177          Test condition and select ( temp highp 3-component vector of float)
+0:177            Condition
+0:177            Compare Less Than ( temp bool)
+0:177              Absolute value ( global highp float)
+0:177                direct index ( temp highp float)
+0:177                  'N' ( in highp 3-component vector of float)
+0:177                  Constant:
+0:177                    2 (const int)
+0:177              Constant:
+0:177                0.999000
+0:177            true case
+0:177            Constant:
+0:177              0.000000
+0:177              0.000000
+0:177              1.000000
+0:177            false case
+0:177            Constant:
+0:177              1.000000
+0:177              0.000000
+0:177              0.000000
+0:178      Sequence
+0:178        move second child to first child ( temp highp 3-component vector of float)
+0:178          'tangentX' ( temp highp 3-component vector of float)
+0:178          normalize ( global highp 3-component vector of float)
+0:178            cross-product ( global highp 3-component vector of float)
+0:178              'upVector' ( temp highp 3-component vector of float)
+0:178              'N' ( in highp 3-component vector of float)
+0:179      Sequence
+0:179        move second child to first child ( temp highp 3-component vector of float)
+0:179          'tangentY' ( temp highp 3-component vector of float)
+0:179          cross-product ( global highp 3-component vector of float)
+0:179            'N' ( in highp 3-component vector of float)
+0:179            'tangentX' ( temp highp 3-component vector of float)
+0:182      Sequence
+0:182        move second child to first child ( temp highp 3-component vector of float)
+0:182          'worldResult' ( temp highp 3-component vector of float)
+0:182          add ( temp highp 3-component vector of float)
+0:182            add ( temp highp 3-component vector of float)
+0:182              vector-scale ( temp highp 3-component vector of float)
+0:182                'tangentX' ( temp highp 3-component vector of float)
+0:182                direct index ( temp highp float)
+0:182                  'H' ( temp highp 3-component vector of float)
+0:182                  Constant:
+0:182                    0 (const int)
+0:182              vector-scale ( temp highp 3-component vector of float)
+0:182                'tangentY' ( temp highp 3-component vector of float)
+0:182                direct index ( temp highp float)
+0:182                  'H' ( temp highp 3-component vector of float)
+0:182                  Constant:
+0:182                    1 (const int)
+0:182            vector-scale ( temp highp 3-component vector of float)
+0:182              'N' ( in highp 3-component vector of float)
+0:182              direct index ( temp highp float)
+0:182                'H' ( temp highp 3-component vector of float)
+0:182                Constant:
+0:182                  2 (const int)
+0:183      Branch: Return with expression
+0:183        'worldResult' ( temp highp 3-component vector of float)
+0:185  Function Definition: iTDDistributionGGX(vf3;vf3;f1; ( global highp float)
+0:185    Function Parameters: 
+0:185      'normal' ( in highp 3-component vector of float)
+0:185      'half_vector' ( in highp 3-component vector of float)
+0:185      'roughness2' ( in highp float)
+0:?     Sequence
+0:189      Sequence
+0:189        move second child to first child ( temp highp float)
+0:189          'NdotH' ( temp highp float)
+0:189          clamp ( global highp float)
+0:189            dot-product ( global highp float)
+0:189              'normal' ( in highp 3-component vector of float)
+0:189              'half_vector' ( in highp 3-component vector of float)
+0:189            Constant:
+0:189              1.0000000000000e-06
+0:189            Constant:
+0:189              1.000000
+0:191      Sequence
+0:191        move second child to first child ( temp highp float)
+0:191          'alpha2' ( temp highp float)
+0:191          component-wise multiply ( temp highp float)
+0:191            'roughness2' ( in highp float)
+0:191            'roughness2' ( in highp float)
+0:193      Sequence
+0:193        move second child to first child ( temp highp float)
+0:193          'denom' ( temp highp float)
+0:193          add ( temp highp float)
+0:193            component-wise multiply ( temp highp float)
+0:193              component-wise multiply ( temp highp float)
+0:193                'NdotH' ( temp highp float)
+0:193                'NdotH' ( temp highp float)
+0:193              subtract ( temp highp float)
+0:193                'alpha2' ( temp highp float)
+0:193                Constant:
+0:193                  1.000000
+0:193            Constant:
+0:193              1.000000
+0:194      move second child to first child ( temp highp float)
+0:194        'denom' ( temp highp float)
+0:194        max ( global highp float)
+0:194          Constant:
+0:194            1.0000000000000e-08
+0:194          'denom' ( temp highp float)
+0:195      Branch: Return with expression
+0:195        divide ( temp highp float)
+0:195          'alpha2' ( temp highp float)
+0:195          component-wise multiply ( temp highp float)
+0:195            component-wise multiply ( temp highp float)
+0:195              Constant:
+0:195                3.141593
+0:195              'denom' ( temp highp float)
+0:195            'denom' ( temp highp float)
+0:197  Function Definition: iTDCalcF(vf3;f1; ( global highp 3-component vector of float)
+0:197    Function Parameters: 
+0:197      'F0' ( in highp 3-component vector of float)
+0:197      'VdotH' ( in highp float)
+0:198    Sequence
+0:198      Branch: Return with expression
+0:198        add ( temp highp 3-component vector of float)
+0:198          'F0' ( in highp 3-component vector of float)
+0:198          vector-scale ( temp highp 3-component vector of float)
+0:198            subtract ( temp highp 3-component vector of float)
+0:198              Constant:
+0:198                1.000000
+0:198                1.000000
+0:198                1.000000
+0:198              'F0' ( in highp 3-component vector of float)
+0:198            pow ( global highp float)
+0:198              Constant:
+0:198                2.000000
+0:198              component-wise multiply ( temp highp float)
+0:198                subtract ( temp highp float)
+0:198                  component-wise multiply ( temp highp float)
+0:198                    Constant:
+0:198                      -5.554730
+0:198                    'VdotH' ( in highp float)
+0:198                  Constant:
+0:198                    6.983160
+0:198                'VdotH' ( in highp float)
+0:201  Function Definition: iTDCalcG(f1;f1;f1; ( global highp float)
+0:201    Function Parameters: 
+0:201      'NdotL' ( in highp float)
+0:201      'NdotV' ( in highp float)
+0:201      'k' ( in highp float)
+0:202    Sequence
+0:202      Sequence
+0:202        move second child to first child ( temp highp float)
+0:202          'Gl' ( temp highp float)
+0:202          divide ( temp highp float)
+0:202            Constant:
+0:202              1.000000
+0:202            add ( temp highp float)
+0:202              component-wise multiply ( temp highp float)
+0:202                'NdotL' ( in highp float)
+0:202                subtract ( temp highp float)
+0:202                  Constant:
+0:202                    1.000000
+0:202                  'k' ( in highp float)
+0:202              'k' ( in highp float)
+0:203      Sequence
+0:203        move second child to first child ( temp highp float)
+0:203          'Gv' ( temp highp float)
+0:203          divide ( temp highp float)
+0:203            Constant:
+0:203              1.000000
+0:203            add ( temp highp float)
+0:203              component-wise multiply ( temp highp float)
+0:203                'NdotV' ( in highp float)
+0:203                subtract ( temp highp float)
+0:203                  Constant:
+0:203                    1.000000
+0:203                  'k' ( in highp float)
+0:203              'k' ( in highp float)
+0:204      Branch: Return with expression
+0:204        component-wise multiply ( temp highp float)
+0:204          'Gl' ( temp highp float)
+0:204          'Gv' ( temp highp float)
+0:207  Function Definition: TDLightingPBR(i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1; ( global structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:207    Function Parameters: 
+0:207      'index' ( in highp int)
+0:207      'diffuseColor' ( in highp 3-component vector of float)
+0:207      'specularColor' ( in highp 3-component vector of float)
+0:207      'worldSpacePos' ( in highp 3-component vector of float)
+0:207      'normal' ( in highp 3-component vector of float)
+0:207      'shadowStrength' ( in highp float)
+0:207      'shadowColor' ( in highp 3-component vector of float)
+0:207      'camVector' ( in highp 3-component vector of float)
+0:207      'roughness' ( in highp float)
+0:?     Sequence
+0:210      Branch: Return with expression
+0:210        'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:213  Function Definition: TDLightingPBR(vf3;vf3;f1;i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1; ( global void)
+0:213    Function Parameters: 
+0:213      'diffuseContrib' ( inout highp 3-component vector of float)
+0:213      'specularContrib' ( inout highp 3-component vector of float)
+0:213      'shadowStrengthOut' ( inout highp float)
+0:213      'index' ( in highp int)
+0:213      'diffuseColor' ( in highp 3-component vector of float)
+0:213      'specularColor' ( in highp 3-component vector of float)
+0:213      'worldSpacePos' ( in highp 3-component vector of float)
+0:213      'normal' ( in highp 3-component vector of float)
+0:213      'shadowStrength' ( in highp float)
+0:213      'shadowColor' ( in highp 3-component vector of float)
+0:213      'camVector' ( in highp 3-component vector of float)
+0:213      'roughness' ( in highp float)
+0:215    Sequence
+0:215      Sequence
+0:215        move second child to first child ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:215          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:215          Function Call: TDLightingPBR(i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1; ( global structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:215            'index' ( in highp int)
+0:215            'diffuseColor' ( in highp 3-component vector of float)
+0:215            'specularColor' ( in highp 3-component vector of float)
+0:215            'worldSpacePos' ( in highp 3-component vector of float)
+0:215            'normal' ( in highp 3-component vector of float)
+0:215            'shadowStrength' ( in highp float)
+0:215            'shadowColor' ( in highp 3-component vector of float)
+0:215            'camVector' ( in highp 3-component vector of float)
+0:215            'roughness' ( in highp float)
+0:215      move second child to first child ( temp highp 3-component vector of float)
+0:215        'diffuseContrib' ( inout highp 3-component vector of float)
+0:215        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:215          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:215          Constant:
+0:215            0 (const int)
+0:216      move second child to first child ( temp highp 3-component vector of float)
+0:216        'specularContrib' ( inout highp 3-component vector of float)
+0:216        specular: direct index for structure ( global highp 3-component vector of float)
+0:216          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:216          Constant:
+0:216            1 (const int)
+0:217      move second child to first child ( temp highp float)
+0:217        'shadowStrengthOut' ( inout highp float)
+0:217        shadowStrength: direct index for structure ( global highp float)
+0:217          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:217          Constant:
+0:217            2 (const int)
+0:220  Function Definition: TDLightingPBR(vf3;vf3;i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1; ( global void)
+0:220    Function Parameters: 
+0:220      'diffuseContrib' ( inout highp 3-component vector of float)
+0:220      'specularContrib' ( inout highp 3-component vector of float)
+0:220      'index' ( in highp int)
+0:220      'diffuseColor' ( in highp 3-component vector of float)
+0:220      'specularColor' ( in highp 3-component vector of float)
+0:220      'worldSpacePos' ( in highp 3-component vector of float)
+0:220      'normal' ( in highp 3-component vector of float)
+0:220      'shadowStrength' ( in highp float)
+0:220      'shadowColor' ( in highp 3-component vector of float)
+0:220      'camVector' ( in highp 3-component vector of float)
+0:220      'roughness' ( in highp float)
+0:222    Sequence
+0:222      Sequence
+0:222        move second child to first child ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:222          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:222          Function Call: TDLightingPBR(i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1; ( global structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:222            'index' ( in highp int)
+0:222            'diffuseColor' ( in highp 3-component vector of float)
+0:222            'specularColor' ( in highp 3-component vector of float)
+0:222            'worldSpacePos' ( in highp 3-component vector of float)
+0:222            'normal' ( in highp 3-component vector of float)
+0:222            'shadowStrength' ( in highp float)
+0:222            'shadowColor' ( in highp 3-component vector of float)
+0:222            'camVector' ( in highp 3-component vector of float)
+0:222            'roughness' ( in highp float)
+0:222      move second child to first child ( temp highp 3-component vector of float)
+0:222        'diffuseContrib' ( inout highp 3-component vector of float)
+0:222        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:222          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:222          Constant:
+0:222            0 (const int)
+0:223      move second child to first child ( temp highp 3-component vector of float)
+0:223        'specularContrib' ( inout highp 3-component vector of float)
+0:223        specular: direct index for structure ( global highp 3-component vector of float)
+0:223          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:223          Constant:
+0:223            1 (const int)
+0:226  Function Definition: TDEnvLightingPBR(i1;vf3;vf3;vf3;vf3;f1;f1; ( global structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:226    Function Parameters: 
+0:226      'index' ( in highp int)
+0:226      'diffuseColor' ( in highp 3-component vector of float)
+0:226      'specularColor' ( in highp 3-component vector of float)
+0:226      'normal' ( in highp 3-component vector of float)
+0:226      'camVector' ( in highp 3-component vector of float)
+0:226      'roughness' ( in highp float)
+0:226      'ambientOcclusion' ( in highp float)
+0:?     Sequence
+0:229      Branch: Return with expression
+0:229        'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:232  Function Definition: TDEnvLightingPBR(vf3;vf3;i1;vf3;vf3;vf3;vf3;f1;f1; ( global void)
+0:232    Function Parameters: 
+0:232      'diffuseContrib' ( inout highp 3-component vector of float)
+0:232      'specularContrib' ( inout highp 3-component vector of float)
+0:232      'index' ( in highp int)
+0:232      'diffuseColor' ( in highp 3-component vector of float)
+0:232      'specularColor' ( in highp 3-component vector of float)
+0:232      'normal' ( in highp 3-component vector of float)
+0:232      'camVector' ( in highp 3-component vector of float)
+0:232      'roughness' ( in highp float)
+0:232      'ambientOcclusion' ( in highp float)
+0:234    Sequence
+0:234      Sequence
+0:234        move second child to first child ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:234          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:234          Function Call: TDEnvLightingPBR(i1;vf3;vf3;vf3;vf3;f1;f1; ( global structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:234            'index' ( in highp int)
+0:234            'diffuseColor' ( in highp 3-component vector of float)
+0:234            'specularColor' ( in highp 3-component vector of float)
+0:234            'normal' ( in highp 3-component vector of float)
+0:234            'camVector' ( in highp 3-component vector of float)
+0:234            'roughness' ( in highp float)
+0:234            'ambientOcclusion' ( in highp float)
+0:235      move second child to first child ( temp highp 3-component vector of float)
+0:235        'diffuseContrib' ( inout highp 3-component vector of float)
+0:235        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:235          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:235          Constant:
+0:235            0 (const int)
+0:236      move second child to first child ( temp highp 3-component vector of float)
+0:236        'specularContrib' ( inout highp 3-component vector of float)
+0:236        specular: direct index for structure ( global highp 3-component vector of float)
+0:236          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp float shadowStrength})
+0:236          Constant:
+0:236            1 (const int)
+0:239  Function Definition: TDLighting(i1;vf3;vf3;f1;vf3;vf3;f1;f1; ( global structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:239    Function Parameters: 
+0:239      'index' ( in highp int)
+0:239      'worldSpacePos' ( in highp 3-component vector of float)
+0:239      'normal' ( in highp 3-component vector of float)
+0:239      'shadowStrength' ( in highp float)
+0:239      'shadowColor' ( in highp 3-component vector of float)
+0:239      'camVector' ( in highp 3-component vector of float)
+0:239      'shininess' ( in highp float)
+0:239      'shininess2' ( in highp float)
+0:?     Sequence
+0:242      switch
+0:242      condition
+0:242        'index' ( in highp int)
+0:242      body
+0:242        Sequence
+0:244          default: 
+0:?           Sequence
+0:245            move second child to first child ( temp highp 3-component vector of float)
+0:245              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:245                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:245                Constant:
+0:245                  0 (const int)
+0:245              Constant:
+0:245                0.000000
+0:245                0.000000
+0:245                0.000000
+0:246            move second child to first child ( temp highp 3-component vector of float)
+0:246              specular: direct index for structure ( global highp 3-component vector of float)
+0:246                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:246                Constant:
+0:246                  1 (const int)
+0:246              Constant:
+0:246                0.000000
+0:246                0.000000
+0:246                0.000000
+0:247            move second child to first child ( temp highp 3-component vector of float)
+0:247              specular2: direct index for structure ( global highp 3-component vector of float)
+0:247                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:247                Constant:
+0:247                  2 (const int)
+0:247              Constant:
+0:247                0.000000
+0:247                0.000000
+0:247                0.000000
+0:248            move second child to first child ( temp highp float)
+0:248              shadowStrength: direct index for structure ( global highp float)
+0:248                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:248                Constant:
+0:248                  3 (const int)
+0:248              Constant:
+0:248                0.000000
+0:249            Branch: Break
+0:251      Branch: Return with expression
+0:251        'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:254  Function Definition: TDLighting(vf3;vf3;vf3;f1;i1;vf3;vf3;f1;vf3;vf3;f1;f1; ( global void)
+0:254    Function Parameters: 
+0:254      'diffuseContrib' ( inout highp 3-component vector of float)
+0:254      'specularContrib' ( inout highp 3-component vector of float)
+0:254      'specularContrib2' ( inout highp 3-component vector of float)
+0:254      'shadowStrengthOut' ( inout highp float)
+0:254      'index' ( in highp int)
+0:254      'worldSpacePos' ( in highp 3-component vector of float)
+0:254      'normal' ( in highp 3-component vector of float)
+0:254      'shadowStrength' ( in highp float)
+0:254      'shadowColor' ( in highp 3-component vector of float)
+0:254      'camVector' ( in highp 3-component vector of float)
+0:254      'shininess' ( in highp float)
+0:254      'shininess2' ( in highp float)
+0:?     Sequence
+0:257      switch
+0:257      condition
+0:257        'index' ( in highp int)
+0:257      body
+0:257        Sequence
+0:259          default: 
+0:?           Sequence
+0:260            move second child to first child ( temp highp 3-component vector of float)
+0:260              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:260                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:260                Constant:
+0:260                  0 (const int)
+0:260              Constant:
+0:260                0.000000
+0:260                0.000000
+0:260                0.000000
+0:261            move second child to first child ( temp highp 3-component vector of float)
+0:261              specular: direct index for structure ( global highp 3-component vector of float)
+0:261                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:261                Constant:
+0:261                  1 (const int)
+0:261              Constant:
+0:261                0.000000
+0:261                0.000000
+0:261                0.000000
+0:262            move second child to first child ( temp highp 3-component vector of float)
+0:262              specular2: direct index for structure ( global highp 3-component vector of float)
+0:262                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:262                Constant:
+0:262                  2 (const int)
+0:262              Constant:
+0:262                0.000000
+0:262                0.000000
+0:262                0.000000
+0:263            move second child to first child ( temp highp float)
+0:263              shadowStrength: direct index for structure ( global highp float)
+0:263                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:263                Constant:
+0:263                  3 (const int)
+0:263              Constant:
+0:263                0.000000
+0:264            Branch: Break
+0:266      move second child to first child ( temp highp 3-component vector of float)
+0:266        'diffuseContrib' ( inout highp 3-component vector of float)
+0:266        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:266          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:266          Constant:
+0:266            0 (const int)
+0:267      move second child to first child ( temp highp 3-component vector of float)
+0:267        'specularContrib' ( inout highp 3-component vector of float)
+0:267        specular: direct index for structure ( global highp 3-component vector of float)
+0:267          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:267          Constant:
+0:267            1 (const int)
+0:268      move second child to first child ( temp highp 3-component vector of float)
+0:268        'specularContrib2' ( inout highp 3-component vector of float)
+0:268        specular2: direct index for structure ( global highp 3-component vector of float)
+0:268          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:268          Constant:
+0:268            2 (const int)
+0:269      move second child to first child ( temp highp float)
+0:269        'shadowStrengthOut' ( inout highp float)
+0:269        shadowStrength: direct index for structure ( global highp float)
+0:269          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:269          Constant:
+0:269            3 (const int)
+0:272  Function Definition: TDLighting(vf3;vf3;vf3;i1;vf3;vf3;f1;vf3;vf3;f1;f1; ( global void)
+0:272    Function Parameters: 
+0:272      'diffuseContrib' ( inout highp 3-component vector of float)
+0:272      'specularContrib' ( inout highp 3-component vector of float)
+0:272      'specularContrib2' ( inout highp 3-component vector of float)
+0:272      'index' ( in highp int)
+0:272      'worldSpacePos' ( in highp 3-component vector of float)
+0:272      'normal' ( in highp 3-component vector of float)
+0:272      'shadowStrength' ( in highp float)
+0:272      'shadowColor' ( in highp 3-component vector of float)
+0:272      'camVector' ( in highp 3-component vector of float)
+0:272      'shininess' ( in highp float)
+0:272      'shininess2' ( in highp float)
+0:?     Sequence
+0:275      switch
+0:275      condition
+0:275        'index' ( in highp int)
+0:275      body
+0:275        Sequence
+0:277          default: 
+0:?           Sequence
+0:278            move second child to first child ( temp highp 3-component vector of float)
+0:278              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:278                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:278                Constant:
+0:278                  0 (const int)
+0:278              Constant:
+0:278                0.000000
+0:278                0.000000
+0:278                0.000000
+0:279            move second child to first child ( temp highp 3-component vector of float)
+0:279              specular: direct index for structure ( global highp 3-component vector of float)
+0:279                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:279                Constant:
+0:279                  1 (const int)
+0:279              Constant:
+0:279                0.000000
+0:279                0.000000
+0:279                0.000000
+0:280            move second child to first child ( temp highp 3-component vector of float)
+0:280              specular2: direct index for structure ( global highp 3-component vector of float)
+0:280                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:280                Constant:
+0:280                  2 (const int)
+0:280              Constant:
+0:280                0.000000
+0:280                0.000000
+0:280                0.000000
+0:281            move second child to first child ( temp highp float)
+0:281              shadowStrength: direct index for structure ( global highp float)
+0:281                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:281                Constant:
+0:281                  3 (const int)
+0:281              Constant:
+0:281                0.000000
+0:282            Branch: Break
+0:284      move second child to first child ( temp highp 3-component vector of float)
+0:284        'diffuseContrib' ( inout highp 3-component vector of float)
+0:284        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:284          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:284          Constant:
+0:284            0 (const int)
+0:285      move second child to first child ( temp highp 3-component vector of float)
+0:285        'specularContrib' ( inout highp 3-component vector of float)
+0:285        specular: direct index for structure ( global highp 3-component vector of float)
+0:285          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:285          Constant:
+0:285            1 (const int)
+0:286      move second child to first child ( temp highp 3-component vector of float)
+0:286        'specularContrib2' ( inout highp 3-component vector of float)
+0:286        specular2: direct index for structure ( global highp 3-component vector of float)
+0:286          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:286          Constant:
+0:286            2 (const int)
+0:289  Function Definition: TDLighting(vf3;vf3;i1;vf3;vf3;f1;vf3;vf3;f1; ( global void)
+0:289    Function Parameters: 
+0:289      'diffuseContrib' ( inout highp 3-component vector of float)
+0:289      'specularContrib' ( inout highp 3-component vector of float)
+0:289      'index' ( in highp int)
+0:289      'worldSpacePos' ( in highp 3-component vector of float)
+0:289      'normal' ( in highp 3-component vector of float)
+0:289      'shadowStrength' ( in highp float)
+0:289      'shadowColor' ( in highp 3-component vector of float)
+0:289      'camVector' ( in highp 3-component vector of float)
+0:289      'shininess' ( in highp float)
+0:?     Sequence
+0:292      switch
+0:292      condition
+0:292        'index' ( in highp int)
+0:292      body
+0:292        Sequence
+0:294          default: 
+0:?           Sequence
+0:295            move second child to first child ( temp highp 3-component vector of float)
+0:295              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:295                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:295                Constant:
+0:295                  0 (const int)
+0:295              Constant:
+0:295                0.000000
+0:295                0.000000
+0:295                0.000000
+0:296            move second child to first child ( temp highp 3-component vector of float)
+0:296              specular: direct index for structure ( global highp 3-component vector of float)
+0:296                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:296                Constant:
+0:296                  1 (const int)
+0:296              Constant:
+0:296                0.000000
+0:296                0.000000
+0:296                0.000000
+0:297            move second child to first child ( temp highp 3-component vector of float)
+0:297              specular2: direct index for structure ( global highp 3-component vector of float)
+0:297                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:297                Constant:
+0:297                  2 (const int)
+0:297              Constant:
+0:297                0.000000
+0:297                0.000000
+0:297                0.000000
+0:298            move second child to first child ( temp highp float)
+0:298              shadowStrength: direct index for structure ( global highp float)
+0:298                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:298                Constant:
+0:298                  3 (const int)
+0:298              Constant:
+0:298                0.000000
+0:299            Branch: Break
+0:301      move second child to first child ( temp highp 3-component vector of float)
+0:301        'diffuseContrib' ( inout highp 3-component vector of float)
+0:301        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:301          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:301          Constant:
+0:301            0 (const int)
+0:302      move second child to first child ( temp highp 3-component vector of float)
+0:302        'specularContrib' ( inout highp 3-component vector of float)
+0:302        specular: direct index for structure ( global highp 3-component vector of float)
+0:302          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:302          Constant:
+0:302            1 (const int)
+0:305  Function Definition: TDLighting(vf3;vf3;vf3;i1;vf3;vf3;vf3;f1;f1; ( global void)
+0:305    Function Parameters: 
+0:305      'diffuseContrib' ( inout highp 3-component vector of float)
+0:305      'specularContrib' ( inout highp 3-component vector of float)
+0:305      'specularContrib2' ( inout highp 3-component vector of float)
+0:305      'index' ( in highp int)
+0:305      'worldSpacePos' ( in highp 3-component vector of float)
+0:305      'normal' ( in highp 3-component vector of float)
+0:305      'camVector' ( in highp 3-component vector of float)
+0:305      'shininess' ( in highp float)
+0:305      'shininess2' ( in highp float)
+0:?     Sequence
+0:308      switch
+0:308      condition
+0:308        'index' ( in highp int)
+0:308      body
+0:308        Sequence
+0:310          default: 
+0:?           Sequence
+0:311            move second child to first child ( temp highp 3-component vector of float)
+0:311              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:311                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:311                Constant:
+0:311                  0 (const int)
+0:311              Constant:
+0:311                0.000000
+0:311                0.000000
+0:311                0.000000
+0:312            move second child to first child ( temp highp 3-component vector of float)
+0:312              specular: direct index for structure ( global highp 3-component vector of float)
+0:312                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:312                Constant:
+0:312                  1 (const int)
+0:312              Constant:
+0:312                0.000000
+0:312                0.000000
+0:312                0.000000
+0:313            move second child to first child ( temp highp 3-component vector of float)
+0:313              specular2: direct index for structure ( global highp 3-component vector of float)
+0:313                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:313                Constant:
+0:313                  2 (const int)
+0:313              Constant:
+0:313                0.000000
+0:313                0.000000
+0:313                0.000000
+0:314            move second child to first child ( temp highp float)
+0:314              shadowStrength: direct index for structure ( global highp float)
+0:314                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:314                Constant:
+0:314                  3 (const int)
+0:314              Constant:
+0:314                0.000000
+0:315            Branch: Break
+0:317      move second child to first child ( temp highp 3-component vector of float)
+0:317        'diffuseContrib' ( inout highp 3-component vector of float)
+0:317        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:317          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:317          Constant:
+0:317            0 (const int)
+0:318      move second child to first child ( temp highp 3-component vector of float)
+0:318        'specularContrib' ( inout highp 3-component vector of float)
+0:318        specular: direct index for structure ( global highp 3-component vector of float)
+0:318          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:318          Constant:
+0:318            1 (const int)
+0:319      move second child to first child ( temp highp 3-component vector of float)
+0:319        'specularContrib2' ( inout highp 3-component vector of float)
+0:319        specular2: direct index for structure ( global highp 3-component vector of float)
+0:319          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:319          Constant:
+0:319            2 (const int)
+0:322  Function Definition: TDLighting(vf3;vf3;i1;vf3;vf3;vf3;f1; ( global void)
+0:322    Function Parameters: 
+0:322      'diffuseContrib' ( inout highp 3-component vector of float)
+0:322      'specularContrib' ( inout highp 3-component vector of float)
+0:322      'index' ( in highp int)
+0:322      'worldSpacePos' ( in highp 3-component vector of float)
+0:322      'normal' ( in highp 3-component vector of float)
+0:322      'camVector' ( in highp 3-component vector of float)
+0:322      'shininess' ( in highp float)
+0:?     Sequence
+0:325      switch
+0:325      condition
+0:325        'index' ( in highp int)
+0:325      body
+0:325        Sequence
+0:327          default: 
+0:?           Sequence
+0:328            move second child to first child ( temp highp 3-component vector of float)
+0:328              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:328                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:328                Constant:
+0:328                  0 (const int)
+0:328              Constant:
+0:328                0.000000
+0:328                0.000000
+0:328                0.000000
+0:329            move second child to first child ( temp highp 3-component vector of float)
+0:329              specular: direct index for structure ( global highp 3-component vector of float)
+0:329                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:329                Constant:
+0:329                  1 (const int)
+0:329              Constant:
+0:329                0.000000
+0:329                0.000000
+0:329                0.000000
+0:330            move second child to first child ( temp highp 3-component vector of float)
+0:330              specular2: direct index for structure ( global highp 3-component vector of float)
+0:330                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:330                Constant:
+0:330                  2 (const int)
+0:330              Constant:
+0:330                0.000000
+0:330                0.000000
+0:330                0.000000
+0:331            move second child to first child ( temp highp float)
+0:331              shadowStrength: direct index for structure ( global highp float)
+0:331                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:331                Constant:
+0:331                  3 (const int)
+0:331              Constant:
+0:331                0.000000
+0:332            Branch: Break
+0:334      move second child to first child ( temp highp 3-component vector of float)
+0:334        'diffuseContrib' ( inout highp 3-component vector of float)
+0:334        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:334          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:334          Constant:
+0:334            0 (const int)
+0:335      move second child to first child ( temp highp 3-component vector of float)
+0:335        'specularContrib' ( inout highp 3-component vector of float)
+0:335        specular: direct index for structure ( global highp 3-component vector of float)
+0:335          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:335          Constant:
+0:335            1 (const int)
+0:338  Function Definition: TDLighting(vf3;i1;vf3;vf3; ( global void)
+0:338    Function Parameters: 
+0:338      'diffuseContrib' ( inout highp 3-component vector of float)
+0:338      'index' ( in highp int)
+0:338      'worldSpacePos' ( in highp 3-component vector of float)
+0:338      'normal' ( in highp 3-component vector of float)
+0:?     Sequence
+0:341      switch
+0:341      condition
+0:341        'index' ( in highp int)
+0:341      body
+0:341        Sequence
+0:343          default: 
+0:?           Sequence
+0:344            move second child to first child ( temp highp 3-component vector of float)
+0:344              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:344                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:344                Constant:
+0:344                  0 (const int)
+0:344              Constant:
+0:344                0.000000
+0:344                0.000000
+0:344                0.000000
+0:345            move second child to first child ( temp highp 3-component vector of float)
+0:345              specular: direct index for structure ( global highp 3-component vector of float)
+0:345                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:345                Constant:
+0:345                  1 (const int)
+0:345              Constant:
+0:345                0.000000
+0:345                0.000000
+0:345                0.000000
+0:346            move second child to first child ( temp highp 3-component vector of float)
+0:346              specular2: direct index for structure ( global highp 3-component vector of float)
+0:346                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:346                Constant:
+0:346                  2 (const int)
+0:346              Constant:
+0:346                0.000000
+0:346                0.000000
+0:346                0.000000
+0:347            move second child to first child ( temp highp float)
+0:347              shadowStrength: direct index for structure ( global highp float)
+0:347                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:347                Constant:
+0:347                  3 (const int)
+0:347              Constant:
+0:347                0.000000
+0:348            Branch: Break
+0:350      move second child to first child ( temp highp 3-component vector of float)
+0:350        'diffuseContrib' ( inout highp 3-component vector of float)
+0:350        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:350          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:350          Constant:
+0:350            0 (const int)
+0:353  Function Definition: TDLighting(vf3;i1;vf3;vf3;f1;vf3; ( global void)
+0:353    Function Parameters: 
+0:353      'diffuseContrib' ( inout highp 3-component vector of float)
+0:353      'index' ( in highp int)
+0:353      'worldSpacePos' ( in highp 3-component vector of float)
+0:353      'normal' ( in highp 3-component vector of float)
+0:353      'shadowStrength' ( in highp float)
+0:353      'shadowColor' ( in highp 3-component vector of float)
+0:?     Sequence
+0:356      switch
+0:356      condition
+0:356        'index' ( in highp int)
+0:356      body
+0:356        Sequence
+0:358          default: 
+0:?           Sequence
+0:359            move second child to first child ( temp highp 3-component vector of float)
+0:359              diffuse: direct index for structure ( global highp 3-component vector of float)
+0:359                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:359                Constant:
+0:359                  0 (const int)
+0:359              Constant:
+0:359                0.000000
+0:359                0.000000
+0:359                0.000000
+0:360            move second child to first child ( temp highp 3-component vector of float)
+0:360              specular: direct index for structure ( global highp 3-component vector of float)
+0:360                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:360                Constant:
+0:360                  1 (const int)
+0:360              Constant:
+0:360                0.000000
+0:360                0.000000
+0:360                0.000000
+0:361            move second child to first child ( temp highp 3-component vector of float)
+0:361              specular2: direct index for structure ( global highp 3-component vector of float)
+0:361                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:361                Constant:
+0:361                  2 (const int)
+0:361              Constant:
+0:361                0.000000
+0:361                0.000000
+0:361                0.000000
+0:362            move second child to first child ( temp highp float)
+0:362              shadowStrength: direct index for structure ( global highp float)
+0:362                'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:362                Constant:
+0:362                  3 (const int)
+0:362              Constant:
+0:362                0.000000
+0:363            Branch: Break
+0:365      move second child to first child ( temp highp 3-component vector of float)
+0:365        'diffuseContrib' ( inout highp 3-component vector of float)
+0:365        diffuse: direct index for structure ( global highp 3-component vector of float)
+0:365          'res' ( temp structure{ global highp 3-component vector of float diffuse,  global highp 3-component vector of float specular,  global highp 3-component vector of float specular2,  global highp float shadowStrength})
+0:365          Constant:
+0:365            0 (const int)
+0:367  Function Definition: TDProjMap(i1;vf3;vf4; ( global highp 4-component vector of float)
+0:367    Function Parameters: 
+0:367      'index' ( in highp int)
+0:367      'worldSpacePos' ( in highp 3-component vector of float)
+0:367      'defaultColor' ( in highp 4-component vector of float)
+0:368    Sequence
+0:368      switch
+0:368      condition
+0:368        'index' ( in highp int)
+0:368      body
+0:368        Sequence
+0:370          default: 
+0:?           Sequence
+0:370            Branch: Return with expression
+0:370              'defaultColor' ( in highp 4-component vector of float)
+0:373  Function Definition: TDFog(vf4;vf3;i1; ( global highp 4-component vector of float)
+0:373    Function Parameters: 
+0:373      'color' ( in highp 4-component vector of float)
+0:373      'lightingSpacePosition' ( in highp 3-component vector of float)
+0:373      'cameraIndex' ( in highp int)
+0:374    Sequence
+0:374      switch
+0:374      condition
+0:374        'cameraIndex' ( in highp int)
+0:374      body
+0:374        Sequence
+0:375          default: 
+0:376          case:  with expression
+0:376            Constant:
+0:376              0 (const int)
+0:?           Sequence
+0:378            Sequence
+0:378              Branch: Return with expression
+0:378                'color' ( in highp 4-component vector of float)
+0:382  Function Definition: TDFog(vf4;vf3; ( global highp 4-component vector of float)
+0:382    Function Parameters: 
+0:382      'color' ( in highp 4-component vector of float)
+0:382      'lightingSpacePosition' ( in highp 3-component vector of float)
+0:384    Sequence
+0:384      Branch: Return with expression
+0:384        Function Call: TDFog(vf4;vf3;i1; ( global highp 4-component vector of float)
+0:384          'color' ( in highp 4-component vector of float)
+0:384          'lightingSpacePosition' ( in highp 3-component vector of float)
+0:384          Constant:
+0:384            0 (const int)
+0:386  Function Definition: TDInstanceTexCoord(i1;vf3; ( global highp 3-component vector of float)
+0:386    Function Parameters: 
+0:386      'index' ( in highp int)
+0:386      't' ( in highp 3-component vector of float)
+0:?     Sequence
+0:388      Sequence
+0:388        move second child to first child ( temp highp int)
+0:388          'coord' ( temp highp int)
+0:388          'index' ( in highp int)
+0:389      Sequence
+0:389        move second child to first child ( temp highp 4-component vector of float)
+0:389          'samp' ( temp highp 4-component vector of float)
+0:389          textureFetch ( global highp 4-component vector of float)
+0:389            'sTDInstanceTexCoord' (layout( binding=16) uniform highp samplerBuffer)
+0:389            'coord' ( temp highp int)
+0:390      move second child to first child ( temp highp float)
+0:390        direct index ( temp highp float)
+0:390          'v' ( temp highp 3-component vector of float)
+0:390          Constant:
+0:390            0 (const int)
+0:390        direct index ( temp highp float)
+0:390          't' ( in highp 3-component vector of float)
+0:390          Constant:
+0:390            0 (const int)
+0:391      move second child to first child ( temp highp float)
+0:391        direct index ( temp highp float)
+0:391          'v' ( temp highp 3-component vector of float)
+0:391          Constant:
+0:391            1 (const int)
+0:391        direct index ( temp highp float)
+0:391          't' ( in highp 3-component vector of float)
+0:391          Constant:
+0:391            1 (const int)
+0:392      move second child to first child ( temp highp float)
+0:392        direct index ( temp highp float)
+0:392          'v' ( temp highp 3-component vector of float)
+0:392          Constant:
+0:392            2 (const int)
+0:392        direct index ( temp highp float)
+0:392          'samp' ( temp highp 4-component vector of float)
+0:392          Constant:
+0:392            0 (const int)
+0:393      move second child to first child ( temp highp 3-component vector of float)
+0:393        vector swizzle ( temp highp 3-component vector of float)
+0:393          't' ( in highp 3-component vector of float)
+0:393          Sequence
+0:393            Constant:
+0:393              0 (const int)
+0:393            Constant:
+0:393              1 (const int)
+0:393            Constant:
+0:393              2 (const int)
+0:393        vector swizzle ( temp highp 3-component vector of float)
+0:393          'v' ( temp highp 3-component vector of float)
+0:393          Sequence
+0:393            Constant:
+0:393              0 (const int)
+0:393            Constant:
+0:393              1 (const int)
+0:393            Constant:
+0:393              2 (const int)
+0:394      Branch: Return with expression
+0:394        't' ( in highp 3-component vector of float)
+0:396  Function Definition: TDInstanceActive(i1; ( global bool)
+0:396    Function Parameters: 
+0:396      'index' ( in highp int)
+0:397    Sequence
+0:397      subtract second child into first child ( temp highp int)
+0:397        'index' ( in highp int)
+0:397        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:397          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal,  uniform highp 3-component vector of float uConstant,  uniform highp float uShadowStrength,  uniform highp 3-component vector of float uShadowColor,  uniform highp 4-component vector of float uDiffuseColor,  uniform highp 4-component vector of float uAmbientColor})
+0:397          Constant:
+0:397            0 (const uint)
+0:399      Sequence
+0:399        move second child to first child ( temp highp int)
+0:399          'coord' ( temp highp int)
+0:399          'index' ( in highp int)
+0:400      Sequence
+0:400        move second child to first child ( temp highp 4-component vector of float)
+0:400          'samp' ( temp highp 4-component vector of float)
+0:400          textureFetch ( global highp 4-component vector of float)
+0:400            'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:400            'coord' ( temp highp int)
+0:401      move second child to first child ( temp highp float)
+0:401        'v' ( temp highp float)
+0:401        direct index ( temp highp float)
+0:401          'samp' ( temp highp 4-component vector of float)
+0:401          Constant:
+0:401            0 (const int)
+0:402      Branch: Return with expression
+0:402        Compare Not Equal ( temp bool)
+0:402          'v' ( temp highp float)
+0:402          Constant:
+0:402            0.000000
+0:404  Function Definition: iTDInstanceTranslate(i1;b1; ( global highp 3-component vector of float)
+0:404    Function Parameters: 
+0:404      'index' ( in highp int)
+0:404      'instanceActive' ( out bool)
+0:405    Sequence
+0:405      Sequence
+0:405        move second child to first child ( temp highp int)
+0:405          'origIndex' ( temp highp int)
+0:405          'index' ( in highp int)
+0:406      subtract second child into first child ( temp highp int)
+0:406        'index' ( in highp int)
+0:406        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:406          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal,  uniform highp 3-component vector of float uConstant,  uniform highp float uShadowStrength,  uniform highp 3-component vector of float uShadowColor,  uniform highp 4-component vector of float uDiffuseColor,  uniform highp 4-component vector of float uAmbientColor})
+0:406          Constant:
+0:406            0 (const uint)
+0:408      Sequence
+0:408        move second child to first child ( temp highp int)
+0:408          'coord' ( temp highp int)
+0:408          'index' ( in highp int)
+0:409      Sequence
+0:409        move second child to first child ( temp highp 4-component vector of float)
+0:409          'samp' ( temp highp 4-component vector of float)
+0:409          textureFetch ( global highp 4-component vector of float)
+0:409            'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:409            'coord' ( temp highp int)
+0:410      move second child to first child ( temp highp float)
+0:410        direct index ( temp highp float)
+0:410          'v' ( temp highp 3-component vector of float)
+0:410          Constant:
+0:410            0 (const int)
+0:410        direct index ( temp highp float)
+0:410          'samp' ( temp highp 4-component vector of float)
+0:410          Constant:
+0:410            1 (const int)
+0:411      move second child to first child ( temp highp float)
+0:411        direct index ( temp highp float)
+0:411          'v' ( temp highp 3-component vector of float)
+0:411          Constant:
+0:411            1 (const int)
+0:411        direct index ( temp highp float)
+0:411          'samp' ( temp highp 4-component vector of float)
+0:411          Constant:
+0:411            2 (const int)
+0:412      move second child to first child ( temp highp float)
+0:412        direct index ( temp highp float)
+0:412          'v' ( temp highp 3-component vector of float)
+0:412          Constant:
+0:412            2 (const int)
+0:412        direct index ( temp highp float)
+0:412          'samp' ( temp highp 4-component vector of float)
+0:412          Constant:
+0:412            3 (const int)
+0:413      move second child to first child ( temp bool)
+0:413        'instanceActive' ( out bool)
+0:413        Compare Not Equal ( temp bool)
+0:413          direct index ( temp highp float)
+0:413            'samp' ( temp highp 4-component vector of float)
+0:413            Constant:
+0:413              0 (const int)
+0:413          Constant:
+0:413            0.000000
+0:414      Branch: Return with expression
+0:414        'v' ( temp highp 3-component vector of float)
+0:416  Function Definition: TDInstanceTranslate(i1; ( global highp 3-component vector of float)
+0:416    Function Parameters: 
+0:416      'index' ( in highp int)
+0:417    Sequence
+0:417      subtract second child into first child ( temp highp int)
+0:417        'index' ( in highp int)
+0:417        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:417          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal,  uniform highp 3-component vector of float uConstant,  uniform highp float uShadowStrength,  uniform highp 3-component vector of float uShadowColor,  uniform highp 4-component vector of float uDiffuseColor,  uniform highp 4-component vector of float uAmbientColor})
+0:417          Constant:
+0:417            0 (const uint)
+0:419      Sequence
+0:419        move second child to first child ( temp highp int)
+0:419          'coord' ( temp highp int)
+0:419          'index' ( in highp int)
+0:420      Sequence
+0:420        move second child to first child ( temp highp 4-component vector of float)
+0:420          'samp' ( temp highp 4-component vector of float)
+0:420          textureFetch ( global highp 4-component vector of float)
+0:420            'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:420            'coord' ( temp highp int)
+0:421      move second child to first child ( temp highp float)
+0:421        direct index ( temp highp float)
+0:421          'v' ( temp highp 3-component vector of float)
+0:421          Constant:
+0:421            0 (const int)
+0:421        direct index ( temp highp float)
+0:421          'samp' ( temp highp 4-component vector of float)
+0:421          Constant:
+0:421            1 (const int)
+0:422      move second child to first child ( temp highp float)
+0:422        direct index ( temp highp float)
+0:422          'v' ( temp highp 3-component vector of float)
+0:422          Constant:
+0:422            1 (const int)
+0:422        direct index ( temp highp float)
+0:422          'samp' ( temp highp 4-component vector of float)
+0:422          Constant:
+0:422            2 (const int)
+0:423      move second child to first child ( temp highp float)
+0:423        direct index ( temp highp float)
+0:423          'v' ( temp highp 3-component vector of float)
+0:423          Constant:
+0:423            2 (const int)
+0:423        direct index ( temp highp float)
+0:423          'samp' ( temp highp 4-component vector of float)
+0:423          Constant:
+0:423            3 (const int)
+0:424      Branch: Return with expression
+0:424        'v' ( temp highp 3-component vector of float)
+0:426  Function Definition: TDInstanceRotateMat(i1; ( global highp 3X3 matrix of float)
+0:426    Function Parameters: 
+0:426      'index' ( in highp int)
+0:427    Sequence
+0:427      subtract second child into first child ( temp highp int)
+0:427        'index' ( in highp int)
+0:427        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:427          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal,  uniform highp 3-component vector of float uConstant,  uniform highp float uShadowStrength,  uniform highp 3-component vector of float uShadowColor,  uniform highp 4-component vector of float uDiffuseColor,  uniform highp 4-component vector of float uAmbientColor})
+0:427          Constant:
+0:427            0 (const uint)
+0:428      Sequence
+0:428        move second child to first child ( temp highp 3-component vector of float)
+0:428          'v' ( temp highp 3-component vector of float)
+0:428          Constant:
+0:428            0.000000
+0:428            0.000000
+0:428            0.000000
+0:429      Sequence
+0:429        move second child to first child ( temp highp 3X3 matrix of float)
+0:429          'm' ( temp highp 3X3 matrix of float)
+0:429          Constant:
+0:429            1.000000
+0:429            0.000000
+0:429            0.000000
+0:429            0.000000
+0:429            1.000000
+0:429            0.000000
+0:429            0.000000
+0:429            0.000000
+0:429            1.000000
+0:433      Branch: Return with expression
+0:433        'm' ( temp highp 3X3 matrix of float)
+0:435  Function Definition: TDInstanceScale(i1; ( global highp 3-component vector of float)
+0:435    Function Parameters: 
+0:435      'index' ( in highp int)
+0:436    Sequence
+0:436      subtract second child into first child ( temp highp int)
+0:436        'index' ( in highp int)
+0:436        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:436          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal,  uniform highp 3-component vector of float uConstant,  uniform highp float uShadowStrength,  uniform highp 3-component vector of float uShadowColor,  uniform highp 4-component vector of float uDiffuseColor,  uniform highp 4-component vector of float uAmbientColor})
+0:436          Constant:
+0:436            0 (const uint)
+0:437      Sequence
+0:437        move second child to first child ( temp highp 3-component vector of float)
+0:437          'v' ( temp highp 3-component vector of float)
+0:437          Constant:
+0:437            1.000000
+0:437            1.000000
+0:437            1.000000
+0:438      Branch: Return with expression
+0:438        'v' ( temp highp 3-component vector of float)
+0:440  Function Definition: TDInstancePivot(i1; ( global highp 3-component vector of float)
+0:440    Function Parameters: 
+0:440      'index' ( in highp int)
+0:441    Sequence
+0:441      subtract second child into first child ( temp highp int)
+0:441        'index' ( in highp int)
+0:441        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:441          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal,  uniform highp 3-component vector of float uConstant,  uniform highp float uShadowStrength,  uniform highp 3-component vector of float uShadowColor,  uniform highp 4-component vector of float uDiffuseColor,  uniform highp 4-component vector of float uAmbientColor})
+0:441          Constant:
+0:441            0 (const uint)
+0:442      Sequence
+0:442        move second child to first child ( temp highp 3-component vector of float)
+0:442          'v' ( temp highp 3-component vector of float)
+0:442          Constant:
+0:442            0.000000
+0:442            0.000000
+0:442            0.000000
+0:443      Branch: Return with expression
+0:443        'v' ( temp highp 3-component vector of float)
+0:445  Function Definition: TDInstanceRotTo(i1; ( global highp 3-component vector of float)
+0:445    Function Parameters: 
+0:445      'index' ( in highp int)
+0:446    Sequence
+0:446      subtract second child into first child ( temp highp int)
+0:446        'index' ( in highp int)
+0:446        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:446          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal,  uniform highp 3-component vector of float uConstant,  uniform highp float uShadowStrength,  uniform highp 3-component vector of float uShadowColor,  uniform highp 4-component vector of float uDiffuseColor,  uniform highp 4-component vector of float uAmbientColor})
+0:446          Constant:
+0:446            0 (const uint)
+0:447      Sequence
+0:447        move second child to first child ( temp highp 3-component vector of float)
+0:447          'v' ( temp highp 3-component vector of float)
+0:447          Constant:
+0:447            0.000000
+0:447            0.000000
+0:447            1.000000
+0:448      Branch: Return with expression
+0:448        'v' ( temp highp 3-component vector of float)
+0:450  Function Definition: TDInstanceRotUp(i1; ( global highp 3-component vector of float)
+0:450    Function Parameters: 
+0:450      'index' ( in highp int)
+0:451    Sequence
+0:451      subtract second child into first child ( temp highp int)
+0:451        'index' ( in highp int)
+0:451        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:451          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal,  uniform highp 3-component vector of float uConstant,  uniform highp float uShadowStrength,  uniform highp 3-component vector of float uShadowColor,  uniform highp 4-component vector of float uDiffuseColor,  uniform highp 4-component vector of float uAmbientColor})
+0:451          Constant:
+0:451            0 (const uint)
+0:452      Sequence
+0:452        move second child to first child ( temp highp 3-component vector of float)
+0:452          'v' ( temp highp 3-component vector of float)
+0:452          Constant:
+0:452            0.000000
+0:452            1.000000
+0:452            0.000000
+0:453      Branch: Return with expression
+0:453        'v' ( temp highp 3-component vector of float)
+0:455  Function Definition: TDInstanceMat(i1; ( global highp 4X4 matrix of float)
+0:455    Function Parameters: 
+0:455      'id' ( in highp int)
+0:456    Sequence
+0:456      Sequence
+0:456        move second child to first child ( temp bool)
+0:456          'instanceActive' ( temp bool)
+0:456          Constant:
+0:456            true (const bool)
+0:457      Sequence
+0:457        move second child to first child ( temp highp 3-component vector of float)
+0:457          't' ( temp highp 3-component vector of float)
+0:457          Function Call: iTDInstanceTranslate(i1;b1; ( global highp 3-component vector of float)
+0:457            'id' ( in highp int)
+0:457            'instanceActive' ( temp bool)
+0:458      Test condition and select ( temp void)
+0:458        Condition
+0:458        Negate conditional ( temp bool)
+0:458          'instanceActive' ( temp bool)
+0:458        true case
+0:460        Sequence
+0:460          Branch: Return with expression
+0:460            Constant:
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:460              0.000000
+0:462      Sequence
+0:462        move second child to first child ( temp highp 4X4 matrix of float)
+0:462          'm' ( temp highp 4X4 matrix of float)
+0:462          Constant:
+0:462            1.000000
+0:462            0.000000
+0:462            0.000000
+0:462            0.000000
+0:462            0.000000
+0:462            1.000000
+0:462            0.000000
+0:462            0.000000
+0:462            0.000000
+0:462            0.000000
+0:462            1.000000
+0:462            0.000000
+0:462            0.000000
+0:462            0.000000
+0:462            0.000000
+0:462            1.000000
+0:464      Sequence
+0:464        Sequence
+0:464          move second child to first child ( temp highp 3-component vector of float)
+0:464            'tt' ( temp highp 3-component vector of float)
+0:464            't' ( temp highp 3-component vector of float)
+0:465        add second child into first child ( temp highp float)
+0:465          direct index ( temp highp float)
+0:465            direct index ( temp highp 4-component vector of float)
+0:465              'm' ( temp highp 4X4 matrix of float)
+0:465              Constant:
+0:465                3 (const int)
+0:465            Constant:
+0:465              0 (const int)
+0:465          component-wise multiply ( temp highp float)
+0:465            direct index ( temp highp float)
+0:465              direct index ( temp highp 4-component vector of float)
+0:465                'm' ( temp highp 4X4 matrix of float)
+0:465                Constant:
+0:465                  0 (const int)
+0:465              Constant:
+0:465                0 (const int)
+0:465            direct index ( temp highp float)
+0:465              'tt' ( temp highp 3-component vector of float)
+0:465              Constant:
+0:465                0 (const int)
+0:466        add second child into first child ( temp highp float)
+0:466          direct index ( temp highp float)
+0:466            direct index ( temp highp 4-component vector of float)
+0:466              'm' ( temp highp 4X4 matrix of float)
+0:466              Constant:
+0:466                3 (const int)
+0:466            Constant:
+0:466              1 (const int)
+0:466          component-wise multiply ( temp highp float)
+0:466            direct index ( temp highp float)
+0:466              direct index ( temp highp 4-component vector of float)
+0:466                'm' ( temp highp 4X4 matrix of float)
+0:466                Constant:
+0:466                  0 (const int)
+0:466              Constant:
+0:466                1 (const int)
+0:466            direct index ( temp highp float)
+0:466              'tt' ( temp highp 3-component vector of float)
+0:466              Constant:
+0:466                0 (const int)
+0:467        add second child into first child ( temp highp float)
+0:467          direct index ( temp highp float)
+0:467            direct index ( temp highp 4-component vector of float)
+0:467              'm' ( temp highp 4X4 matrix of float)
+0:467              Constant:
+0:467                3 (const int)
+0:467            Constant:
+0:467              2 (const int)
+0:467          component-wise multiply ( temp highp float)
+0:467            direct index ( temp highp float)
+0:467              direct index ( temp highp 4-component vector of float)
+0:467                'm' ( temp highp 4X4 matrix of float)
+0:467                Constant:
+0:467                  0 (const int)
+0:467              Constant:
+0:467                2 (const int)
+0:467            direct index ( temp highp float)
+0:467              'tt' ( temp highp 3-component vector of float)
+0:467              Constant:
+0:467                0 (const int)
+0:468        add second child into first child ( temp highp float)
+0:468          direct index ( temp highp float)
+0:468            direct index ( temp highp 4-component vector of float)
+0:468              'm' ( temp highp 4X4 matrix of float)
+0:468              Constant:
+0:468                3 (const int)
+0:468            Constant:
+0:468              3 (const int)
+0:468          component-wise multiply ( temp highp float)
+0:468            direct index ( temp highp float)
+0:468              direct index ( temp highp 4-component vector of float)
+0:468                'm' ( temp highp 4X4 matrix of float)
+0:468                Constant:
+0:468                  0 (const int)
+0:468              Constant:
+0:468                3 (const int)
+0:468            direct index ( temp highp float)
+0:468              'tt' ( temp highp 3-component vector of float)
+0:468              Constant:
+0:468                0 (const int)
+0:469        add second child into first child ( temp highp float)
+0:469          direct index ( temp highp float)
+0:469            direct index ( temp highp 4-component vector of float)
+0:469              'm' ( temp highp 4X4 matrix of float)
+0:469              Constant:
+0:469                3 (const int)
+0:469            Constant:
+0:469              0 (const int)
+0:469          component-wise multiply ( temp highp float)
+0:469            direct index ( temp highp float)
+0:469              direct index ( temp highp 4-component vector of float)
+0:469                'm' ( temp highp 4X4 matrix of float)
+0:469                Constant:
+0:469                  1 (const int)
+0:469              Constant:
+0:469                0 (const int)
+0:469            direct index ( temp highp float)
+0:469              'tt' ( temp highp 3-component vector of float)
+0:469              Constant:
+0:469                1 (const int)
+0:470        add second child into first child ( temp highp float)
+0:470          direct index ( temp highp float)
+0:470            direct index ( temp highp 4-component vector of float)
+0:470              'm' ( temp highp 4X4 matrix of float)
+0:470              Constant:
+0:470                3 (const int)
+0:470            Constant:
+0:470              1 (const int)
+0:470          component-wise multiply ( temp highp float)
+0:470            direct index ( temp highp float)
+0:470              direct index ( temp highp 4-component vector of float)
+0:470                'm' ( temp highp 4X4 matrix of float)
+0:470                Constant:
+0:470                  1 (const int)
+0:470              Constant:
+0:470                1 (const int)
+0:470            direct index ( temp highp float)
+0:470              'tt' ( temp highp 3-component vector of float)
+0:470              Constant:
+0:470                1 (const int)
+0:471        add second child into first child ( temp highp float)
+0:471          direct index ( temp highp float)
+0:471            direct index ( temp highp 4-component vector of float)
+0:471              'm' ( temp highp 4X4 matrix of float)
+0:471              Constant:
+0:471                3 (const int)
+0:471            Constant:
+0:471              2 (const int)
+0:471          component-wise multiply ( temp highp float)
+0:471            direct index ( temp highp float)
+0:471              direct index ( temp highp 4-component vector of float)
+0:471                'm' ( temp highp 4X4 matrix of float)
+0:471                Constant:
+0:471                  1 (const int)
+0:471              Constant:
+0:471                2 (const int)
+0:471            direct index ( temp highp float)
+0:471              'tt' ( temp highp 3-component vector of float)
+0:471              Constant:
+0:471                1 (const int)
+0:472        add second child into first child ( temp highp float)
+0:472          direct index ( temp highp float)
+0:472            direct index ( temp highp 4-component vector of float)
+0:472              'm' ( temp highp 4X4 matrix of float)
+0:472              Constant:
+0:472                3 (const int)
+0:472            Constant:
+0:472              3 (const int)
+0:472          component-wise multiply ( temp highp float)
+0:472            direct index ( temp highp float)
+0:472              direct index ( temp highp 4-component vector of float)
+0:472                'm' ( temp highp 4X4 matrix of float)
+0:472                Constant:
+0:472                  1 (const int)
+0:472              Constant:
+0:472                3 (const int)
+0:472            direct index ( temp highp float)
+0:472              'tt' ( temp highp 3-component vector of float)
+0:472              Constant:
+0:472                1 (const int)
+0:473        add second child into first child ( temp highp float)
+0:473          direct index ( temp highp float)
+0:473            direct index ( temp highp 4-component vector of float)
+0:473              'm' ( temp highp 4X4 matrix of float)
+0:473              Constant:
+0:473                3 (const int)
+0:473            Constant:
+0:473              0 (const int)
+0:473          component-wise multiply ( temp highp float)
+0:473            direct index ( temp highp float)
+0:473              direct index ( temp highp 4-component vector of float)
+0:473                'm' ( temp highp 4X4 matrix of float)
+0:473                Constant:
+0:473                  2 (const int)
+0:473              Constant:
+0:473                0 (const int)
+0:473            direct index ( temp highp float)
+0:473              'tt' ( temp highp 3-component vector of float)
+0:473              Constant:
+0:473                2 (const int)
+0:474        add second child into first child ( temp highp float)
+0:474          direct index ( temp highp float)
+0:474            direct index ( temp highp 4-component vector of float)
+0:474              'm' ( temp highp 4X4 matrix of float)
+0:474              Constant:
+0:474                3 (const int)
+0:474            Constant:
+0:474              1 (const int)
+0:474          component-wise multiply ( temp highp float)
+0:474            direct index ( temp highp float)
+0:474              direct index ( temp highp 4-component vector of float)
+0:474                'm' ( temp highp 4X4 matrix of float)
+0:474                Constant:
+0:474                  2 (const int)
+0:474              Constant:
+0:474                1 (const int)
+0:474            direct index ( temp highp float)
+0:474              'tt' ( temp highp 3-component vector of float)
+0:474              Constant:
+0:474                2 (const int)
+0:475        add second child into first child ( temp highp float)
+0:475          direct index ( temp highp float)
+0:475            direct index ( temp highp 4-component vector of float)
+0:475              'm' ( temp highp 4X4 matrix of float)
+0:475              Constant:
+0:475                3 (const int)
+0:475            Constant:
+0:475              2 (const int)
+0:475          component-wise multiply ( temp highp float)
+0:475            direct index ( temp highp float)
+0:475              direct index ( temp highp 4-component vector of float)
+0:475                'm' ( temp highp 4X4 matrix of float)
+0:475                Constant:
+0:475                  2 (const int)
+0:475              Constant:
+0:475                2 (const int)
+0:475            direct index ( temp highp float)
+0:475              'tt' ( temp highp 3-component vector of float)
+0:475              Constant:
+0:475                2 (const int)
+0:476        add second child into first child ( temp highp float)
+0:476          direct index ( temp highp float)
+0:476            direct index ( temp highp 4-component vector of float)
+0:476              'm' ( temp highp 4X4 matrix of float)
+0:476              Constant:
+0:476                3 (const int)
+0:476            Constant:
+0:476              3 (const int)
+0:476          component-wise multiply ( temp highp float)
+0:476            direct index ( temp highp float)
+0:476              direct index ( temp highp 4-component vector of float)
+0:476                'm' ( temp highp 4X4 matrix of float)
+0:476                Constant:
+0:476                  2 (const int)
+0:476              Constant:
+0:476                3 (const int)
+0:476            direct index ( temp highp float)
+0:476              'tt' ( temp highp 3-component vector of float)
+0:476              Constant:
+0:476                2 (const int)
+0:478      Branch: Return with expression
+0:478        'm' ( temp highp 4X4 matrix of float)
+0:480  Function Definition: TDInstanceMat3(i1; ( global highp 3X3 matrix of float)
+0:480    Function Parameters: 
+0:480      'id' ( in highp int)
+0:481    Sequence
+0:481      Sequence
+0:481        move second child to first child ( temp highp 3X3 matrix of float)
+0:481          'm' ( temp highp 3X3 matrix of float)
+0:481          Constant:
+0:481            1.000000
+0:481            0.000000
+0:481            0.000000
+0:481            0.000000
+0:481            1.000000
+0:481            0.000000
+0:481            0.000000
+0:481            0.000000
+0:481            1.000000
+0:482      Branch: Return with expression
+0:482        'm' ( temp highp 3X3 matrix of float)
+0:484  Function Definition: TDInstanceMat3ForNorm(i1; ( global highp 3X3 matrix of float)
+0:484    Function Parameters: 
+0:484      'id' ( in highp int)
+0:485    Sequence
+0:485      Sequence
+0:485        move second child to first child ( temp highp 3X3 matrix of float)
+0:485          'm' ( temp highp 3X3 matrix of float)
+0:485          Function Call: TDInstanceMat3(i1; ( global highp 3X3 matrix of float)
+0:485            'id' ( in highp int)
+0:486      Branch: Return with expression
+0:486        'm' ( temp highp 3X3 matrix of float)
+0:488  Function Definition: TDInstanceColor(i1;vf4; ( global highp 4-component vector of float)
+0:488    Function Parameters: 
+0:488      'index' ( in highp int)
+0:488      'curColor' ( in highp 4-component vector of float)
+0:489    Sequence
+0:489      subtract second child into first child ( temp highp int)
+0:489        'index' ( in highp int)
+0:489        uTDInstanceIDOffset: direct index for structure ( uniform highp int)
+0:489          'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal,  uniform highp 3-component vector of float uConstant,  uniform highp float uShadowStrength,  uniform highp 3-component vector of float uShadowColor,  uniform highp 4-component vector of float uDiffuseColor,  uniform highp 4-component vector of float uAmbientColor})
+0:489          Constant:
+0:489            0 (const uint)
+0:491      Sequence
+0:491        move second child to first child ( temp highp int)
+0:491          'coord' ( temp highp int)
+0:491          'index' ( in highp int)
+0:492      Sequence
+0:492        move second child to first child ( temp highp 4-component vector of float)
+0:492          'samp' ( temp highp 4-component vector of float)
+0:492          textureFetch ( global highp 4-component vector of float)
+0:492            'sTDInstanceColor' (layout( binding=17) uniform highp samplerBuffer)
+0:492            'coord' ( temp highp int)
+0:493      move second child to first child ( temp highp float)
+0:493        direct index ( temp highp float)
+0:493          'v' ( temp highp 4-component vector of float)
+0:493          Constant:
+0:493            0 (const int)
+0:493        direct index ( temp highp float)
+0:493          'samp' ( temp highp 4-component vector of float)
+0:493          Constant:
+0:493            0 (const int)
+0:494      move second child to first child ( temp highp float)
+0:494        direct index ( temp highp float)
+0:494          'v' ( temp highp 4-component vector of float)
+0:494          Constant:
+0:494            1 (const int)
+0:494        direct index ( temp highp float)
+0:494          'samp' ( temp highp 4-component vector of float)
+0:494          Constant:
+0:494            1 (const int)
+0:495      move second child to first child ( temp highp float)
+0:495        direct index ( temp highp float)
+0:495          'v' ( temp highp 4-component vector of float)
+0:495          Constant:
+0:495            2 (const int)
+0:495        direct index ( temp highp float)
+0:495          'samp' ( temp highp 4-component vector of float)
+0:495          Constant:
+0:495            2 (const int)
+0:496      move second child to first child ( temp highp float)
+0:496        direct index ( temp highp float)
+0:496          'v' ( temp highp 4-component vector of float)
+0:496          Constant:
+0:496            3 (const int)
+0:496        Constant:
+0:496          1.000000
+0:497      move second child to first child ( temp highp float)
+0:497        direct index ( temp highp float)
+0:497          'curColor' ( in highp 4-component vector of float)
+0:497          Constant:
+0:497            0 (const int)
+0:497        direct index ( temp highp float)
+0:497          'v' ( temp highp 4-component vector of float)
+0:497          Constant:
+0:497            0 (const int)
+0:499      move second child to first child ( temp highp float)
+0:499        direct index ( temp highp float)
+0:499          'curColor' ( in highp 4-component vector of float)
+0:499          Constant:
+0:499            1 (const int)
+0:499        direct index ( temp highp float)
+0:499          'v' ( temp highp 4-component vector of float)
+0:499          Constant:
+0:499            1 (const int)
+0:501      move second child to first child ( temp highp float)
+0:501        direct index ( temp highp float)
+0:501          'curColor' ( in highp 4-component vector of float)
+0:501          Constant:
+0:501            2 (const int)
+0:501        direct index ( temp highp float)
+0:501          'v' ( temp highp 4-component vector of float)
+0:501          Constant:
+0:501            2 (const int)
+0:503      Branch: Return with expression
+0:503        'curColor' ( in highp 4-component vector of float)
+0:2  Function Definition: TDOutputSwizzle(vf4; ( global highp 4-component vector of float)
+0:2    Function Parameters: 
+0:2      'c' ( in highp 4-component vector of float)
+0:4    Sequence
+0:4      Branch: Return with expression
+0:4        vector swizzle ( temp highp 4-component vector of float)
+0:4          'c' ( in highp 4-component vector of float)
+0:4          Sequence
+0:4            Constant:
+0:4              0 (const int)
+0:4            Constant:
+0:4              1 (const int)
+0:4            Constant:
+0:4              2 (const int)
+0:4            Constant:
+0:4              3 (const int)
+0:6  Function Definition: TDOutputSwizzle(vu4; ( global highp 4-component vector of uint)
+0:6    Function Parameters: 
+0:6      'c' ( in highp 4-component vector of uint)
+0:8    Sequence
+0:8      Branch: Return with expression
+0:8        vector swizzle ( temp highp 4-component vector of uint)
+0:8          'c' ( in highp 4-component vector of uint)
+0:8          Sequence
+0:8            Constant:
+0:8              0 (const int)
+0:8            Constant:
+0:8              1 (const int)
+0:8            Constant:
+0:8              2 (const int)
+0:8            Constant:
+0:8              3 (const int)
+0:?   Linker Objects
+0:?     'anon@0' (layout( column_major std140) uniform block{ uniform highp int uTDInstanceIDOffset,  uniform highp int uTDNumInstances,  uniform highp float uTDAlphaTestVal,  uniform highp 3-component vector of float uConstant,  uniform highp float uShadowStrength,  uniform highp 3-component vector of float uShadowColor,  uniform highp 4-component vector of float uDiffuseColor,  uniform highp 4-component vector of float uAmbientColor})
+0:?     'anon@1' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{layout( column_major std140) global highp 4X4 matrix of float world, layout( column_major std140) global highp 4X4 matrix of float worldInverse, layout( column_major std140) global highp 4X4 matrix of float worldCam, layout( column_major std140) global highp 4X4 matrix of float worldCamInverse, layout( column_major std140) global highp 4X4 matrix of float cam, layout( column_major std140) global highp 4X4 matrix of float camInverse, layout( column_major std140) global highp 4X4 matrix of float camProj, layout( column_major std140) global highp 4X4 matrix of float camProjInverse, layout( column_major std140) global highp 4X4 matrix of float proj, layout( column_major std140) global highp 4X4 matrix of float projInverse, layout( column_major std140) global highp 4X4 matrix of float worldCamProj, layout( column_major std140) global highp 4X4 matrix of float worldCamProjInverse, layout( column_major std140) global highp 4X4 matrix of float quadReproject, layout( column_major std140) global highp 3X3 matrix of float worldForNormals, layout( column_major std140) global highp 3X3 matrix of float camForNormals, layout( column_major std140) global highp 3X3 matrix of float worldCamForNormals} uTDMats})
+0:?     'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 4-component vector of float nearFar,  global highp 4-component vector of float fog,  global highp 4-component vector of float fogColor,  global highp int renderTOPCameraIndex} uTDCamInfos})
+0:?     'anon@3' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform structure{ global highp 4-component vector of float ambientColor,  global highp 4-component vector of float nearFar,  global highp 4-component vector of float viewport,  global highp 4-component vector of float viewportRes,  global highp 4-component vector of float fog,  global highp 4-component vector of float fogColor} uTDGeneral})
+0:?     'sColorMap' ( uniform highp sampler2DArray)
+0:?     'iVert' ( in block{ in highp 4-component vector of float color,  in highp 3-component vector of float worldSpacePos,  in highp 3-component vector of float texCoord0,  flat in highp int cameraIndex,  flat in highp int instance})
+0:?     'oFragColor' (layout( location=0) out 1-element array of highp 4-component vector of float)
+0:?     'sTDNoiseMap' ( uniform highp sampler2D)
+0:?     'sTDSineLookup' ( uniform highp sampler1D)
+0:?     'sTDWhite2D' ( uniform highp sampler2D)
+0:?     'sTDWhite3D' ( uniform highp sampler3D)
+0:?     'sTDWhite2DArray' ( uniform highp sampler2DArray)
+0:?     'sTDWhiteCube' ( uniform highp samplerCube)
+0:?     'anon@1' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 4-component vector of float position,  global highp 3-component vector of float direction,  global highp 3-component vector of float diffuse,  global highp 4-component vector of float nearFar,  global highp 4-component vector of float lightSize,  global highp 4-component vector of float misc,  global highp 4-component vector of float coneLookupScaleBias,  global highp 4-component vector of float attenScaleBiasRoll, layout( column_major std140) global highp 4X4 matrix of float shadowMapMatrix, layout( column_major std140) global highp 4X4 matrix of float shadowMapCamMatrix,  global highp 4-component vector of float shadowMapRes, layout( column_major std140) global highp 4X4 matrix of float projMapMatrix} uTDLights})
+0:?     'anon@2' (layout( column_major std140) uniform block{layout( column_major std140 offset=0) uniform 1-element array of structure{ global highp 3-component vector of float color, layout( column_major std140) global highp 3X3 matrix of float rotate} uTDEnvLights})
+0:?     'uTDEnvLightBuffers' (layout( column_major std430) restrict readonly buffer 1-element array of block{layout( column_major std430 offset=0) restrict readonly buffer 9-element array of highp 3-component vector of float shCoeffs})
+0:?     'sTDInstanceT' (layout( binding=15) uniform highp samplerBuffer)
+0:?     'sTDInstanceTexCoord' (layout( binding=16) uniform highp samplerBuffer)
+0:?     'sTDInstanceColor' (layout( binding=17) uniform highp samplerBuffer)
+
+// Module Version 10000
+// Generated by (magic number): 8000a
+// Id's are bound by 939
+
+                              Capability Shader
+                              Capability SampledBuffer
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Vertex 4  "main" 207 216 226 238 256 297 905 906
+                              Source GLSL 460
+                              Name 4  "main"
+                              Name 20  "iTDCamToProj(vf4;vf3;i1;b1;"
+                              Name 16  "v"
+                              Name 17  "uv"
+                              Name 18  "cameraIndex"
+                              Name 19  "applyPickMod"
+                              Name 26  "iTDWorldToProj(vf4;vf3;i1;b1;"
+                              Name 22  "v"
+                              Name 23  "uv"
+                              Name 24  "cameraIndex"
+                              Name 25  "applyPickMod"
+                              Name 29  "TDInstanceID("
+                              Name 31  "TDCameraIndex("
+                              Name 34  "TDUVUnwrapCoord("
+                              Name 36  "TDPickID("
+                              Name 40  "iTDConvertPickId(i1;"
+                              Name 39  "id"
+                              Name 42  "TDWritePickingValues("
+                              Name 47  "TDWorldToProj(vf4;vf3;"
+                              Name 45  "v"
+                              Name 46  "uv"
+                              Name 52  "TDWorldToProj(vf3;vf3;"
+                              Name 50  "v"
+                              Name 51  "uv"
+                              Name 56  "TDWorldToProj(vf4;"
+                              Name 55  "v"
+                              Name 60  "TDWorldToProj(vf3;"
+                              Name 59  "v"
+                              Name 63  "TDPointColor("
+                              Name 68  "TDInstanceTexCoord(i1;vf3;"
+                              Name 66  "index"
+                              Name 67  "t"
+                              Name 72  "TDInstanceActive(i1;"
+                              Name 71  "index"
+                              Name 77  "iTDInstanceTranslate(i1;b1;"
+                              Name 75  "index"
+                              Name 76  "instanceActive"
+                              Name 81  "TDInstanceTranslate(i1;"
+                              Name 80  "index"
+                              Name 86  "TDInstanceRotateMat(i1;"
+                              Name 85  "index"
+                              Name 89  "TDInstanceScale(i1;"
+                              Name 88  "index"
+                              Name 92  "TDInstancePivot(i1;"
+                              Name 91  "index"
+                              Name 95  "TDInstanceRotTo(i1;"
+                              Name 94  "index"
+                              Name 98  "TDInstanceRotUp(i1;"
+                              Name 97  "index"
+                              Name 103  "TDInstanceMat(i1;"
+                              Name 102  "id"
+                              Name 106  "TDInstanceMat3(i1;"
+                              Name 105  "id"
+                              Name 109  "TDInstanceMat3ForNorm(i1;"
+                              Name 108  "id"
+                              Name 114  "TDInstanceColor(i1;vf4;"
+                              Name 112  "index"
+                              Name 113  "curColor"
+                              Name 118  "TDInstanceDeform(i1;vf4;"
+                              Name 116  "id"
+                              Name 117  "pos"
+                              Name 122  "TDInstanceDeformVec(i1;vf3;"
+                              Name 120  "id"
+                              Name 121  "vec"
+                              Name 126  "TDInstanceDeformNorm(i1;vf3;"
+                              Name 124  "id"
+                              Name 125  "vec"
+                              Name 129  "TDInstanceDeform(vf4;"
+                              Name 128  "pos"
+                              Name 133  "TDInstanceDeformVec(vf3;"
+                              Name 132  "vec"
+                              Name 136  "TDInstanceDeformNorm(vf3;"
+                              Name 135  "vec"
+                              Name 139  "TDInstanceActive("
+                              Name 141  "TDInstanceTranslate("
+                              Name 144  "TDInstanceRotateMat("
+                              Name 146  "TDInstanceScale("
+                              Name 149  "TDInstanceMat("
+                              Name 151  "TDInstanceMat3("
+                              Name 154  "TDInstanceTexCoord(vf3;"
+                              Name 153  "t"
+                              Name 157  "TDInstanceColor(vf4;"
+                              Name 156  "curColor"
+                              Name 160  "TDSkinnedDeform(vf4;"
+                              Name 159  "pos"
+                              Name 163  "TDSkinnedDeformVec(vf3;"
+                              Name 162  "vec"
+                              Name 169  "TDFastDeformTangent(vf3;vf4;vf3;"
+                              Name 166  "oldNorm"
+                              Name 167  "oldTangent"
+                              Name 168  "deformedNorm"
+                              Name 172  "TDBoneMat(i1;"
+                              Name 171  "index"
+                              Name 175  "TDDeform(vf4;"
+                              Name 174  "pos"
+                              Name 180  "TDDeform(i1;vf3;"
+                              Name 178  "instanceID"
+                              Name 179  "p"
+                              Name 183  "TDDeform(vf3;"
+                              Name 182  "pos"
+                              Name 187  "TDDeformVec(i1;vf3;"
+                              Name 185  "instanceID"
+                              Name 186  "vec"
+                              Name 190  "TDDeformVec(vf3;"
+                              Name 189  "vec"
+                              Name 194  "TDDeformNorm(i1;vf3;"
+                              Name 192  "instanceID"
+                              Name 193  "vec"
+                              Name 197  "TDDeformNorm(vf3;"
+                              Name 196  "vec"
+                              Name 200  "TDSkinnedDeformNorm(vf3;"
+                              Name 199  "vec"
+                              Name 202  "texcoord"
+                              Name 207  "uv"
+                              Name 209  "param"
+                              Name 214  "Vertex"
+                              MemberName 214(Vertex) 0  "color"
+                              MemberName 214(Vertex) 1  "worldSpacePos"
+                              MemberName 214(Vertex) 2  "texCoord0"
+                              MemberName 214(Vertex) 3  "cameraIndex"
+                              MemberName 214(Vertex) 4  "instance"
+                              Name 216  "oVert"
+                              Name 225  "worldSpacePos"
+                              Name 226  "P"
+                              Name 227  "param"
+                              Name 230  "uvUnwrapCoord"
+                              Name 232  "param"
+                              Name 236  "gl_PerVertex"
+                              MemberName 236(gl_PerVertex) 0  "gl_Position"
+                              MemberName 236(gl_PerVertex) 1  "gl_PointSize"
+                              MemberName 236(gl_PerVertex) 2  "gl_ClipDistance"
+                              MemberName 236(gl_PerVertex) 3  "gl_CullDistance"
+                              Name 238  ""
+                              Name 239  "param"
+                              Name 241  "param"
+                              Name 246  "cameraIndex"
+                              Name 256  "Cd"
+                              Name 257  "param"
+                              Name 269  "TDMatrix"
+                              MemberName 269(TDMatrix) 0  "world"
+                              MemberName 269(TDMatrix) 1  "worldInverse"
+                              MemberName 269(TDMatrix) 2  "worldCam"
+                              MemberName 269(TDMatrix) 3  "worldCamInverse"
+                              MemberName 269(TDMatrix) 4  "cam"
+                              MemberName 269(TDMatrix) 5  "camInverse"
+                              MemberName 269(TDMatrix) 6  "camProj"
+                              MemberName 269(TDMatrix) 7  "camProjInverse"
+                              MemberName 269(TDMatrix) 8  "proj"
+                              MemberName 269(TDMatrix) 9  "projInverse"
+                              MemberName 269(TDMatrix) 10  "worldCamProj"
+                              MemberName 269(TDMatrix) 11  "worldCamProjInverse"
+                              MemberName 269(TDMatrix) 12  "quadReproject"
+                              MemberName 269(TDMatrix) 13  "worldForNormals"
+                              MemberName 269(TDMatrix) 14  "camForNormals"
+                              MemberName 269(TDMatrix) 15  "worldCamForNormals"
+                              Name 271  "TDMatricesBlock"
+                              MemberName 271(TDMatricesBlock) 0  "uTDMats"
+                              Name 273  ""
+                              Name 297  "gl_InstanceIndex"
+                              Name 299  "gl_DefaultUniformBlock"
+                              MemberName 299(gl_DefaultUniformBlock) 0  "uTDInstanceIDOffset"
+                              MemberName 299(gl_DefaultUniformBlock) 1  "uTDNumInstances"
+                              MemberName 299(gl_DefaultUniformBlock) 2  "uTDAlphaTestVal"
+                              MemberName 299(gl_DefaultUniformBlock) 3  "uConstant"
+                              MemberName 299(gl_DefaultUniformBlock) 4  "uShadowStrength"
+                              MemberName 299(gl_DefaultUniformBlock) 5  "uShadowColor"
+                              MemberName 299(gl_DefaultUniformBlock) 6  "uDiffuseColor"
+                              MemberName 299(gl_DefaultUniformBlock) 7  "uAmbientColor"
+                              Name 301  ""
+                              Name 325  "param"
+                              Name 327  "param"
+                              Name 329  "param"
+                              Name 330  "param"
+                              Name 340  "param"
+                              Name 341  "param"
+                              Name 347  "param"
+                              Name 349  "param"
+                              Name 358  "param"
+                              Name 365  "coord"
+                              Name 367  "samp"
+                              Name 371  "sTDInstanceTexCoord"
+                              Name 376  "v"
+                              Name 397  "coord"
+                              Name 399  "samp"
+                              Name 400  "sTDInstanceT"
+                              Name 405  "v"
+                              Name 412  "origIndex"
+                              Name 418  "coord"
+                              Name 420  "samp"
+                              Name 425  "v"
+                              Name 446  "coord"
+                              Name 448  "samp"
+                              Name 453  "v"
+                              Name 470  "v"
+                              Name 472  "m"
+                              Name 484  "v"
+                              Name 493  "v"
+                              Name 501  "v"
+                              Name 509  "v"
+                              Name 513  "instanceActive"
+                              Name 514  "t"
+                              Name 515  "param"
+                              Name 517  "param"
+                              Name 528  "m"
+                              Name 534  "tt"
+                              Name 647  "m"
+                              Name 651  "m"
+                              Name 652  "param"
+                              Name 662  "coord"
+                              Name 664  "samp"
+                              Name 665  "sTDInstanceColor"
+                              Name 670  "v"
+                              Name 693  "param"
+                              Name 705  "m"
+                              Name 706  "param"
+                              Name 725  "m"
+                              Name 726  "param"
+                              Name 745  "param"
+                              Name 746  "param"
+                              Name 752  "param"
+                              Name 753  "param"
+                              Name 759  "param"
+                              Name 760  "param"
+                              Name 766  "param"
+                              Name 771  "param"
+                              Name 776  "param"
+                              Name 781  "param"
+                              Name 786  "param"
+                              Name 791  "param"
+                              Name 796  "param"
+                              Name 797  "param"
+                              Name 803  "param"
+                              Name 804  "param"
+                              Name 821  "param"
+                              Name 824  "param"
+                              Name 830  "pos"
+                              Name 836  "param"
+                              Name 839  "param"
+                              Name 841  "param"
+                              Name 848  "param"
+                              Name 849  "param"
+                              Name 854  "param"
+                              Name 857  "param"
+                              Name 859  "param"
+                              Name 866  "param"
+                              Name 867  "param"
+                              Name 872  "param"
+                              Name 875  "param"
+                              Name 877  "param"
+                              Name 884  "param"
+                              Name 885  "param"
+                              Name 890  "param"
+                              Name 896  "TDCameraInfo"
+                              MemberName 896(TDCameraInfo) 0  "nearFar"
+                              MemberName 896(TDCameraInfo) 1  "fog"
+                              MemberName 896(TDCameraInfo) 2  "fogColor"
+                              MemberName 896(TDCameraInfo) 3  "renderTOPCameraIndex"
+                              Name 898  "TDCameraInfoBlock"
+                              MemberName 898(TDCameraInfoBlock) 0  "uTDCamInfos"
+                              Name 900  ""
+                              Name 901  "TDGeneral"
+                              MemberName 901(TDGeneral) 0  "ambientColor"
+                              MemberName 901(TDGeneral) 1  "nearFar"
+                              MemberName 901(TDGeneral) 2  "viewport"
+                              MemberName 901(TDGeneral) 3  "viewportRes"
+                              MemberName 901(TDGeneral) 4  "fog"
+                              MemberName 901(TDGeneral) 5  "fogColor"
+                              Name 902  "TDGeneralBlock"
+                              MemberName 902(TDGeneralBlock) 0  "uTDGeneral"
+                              Name 904  ""
+                              Name 905  "N"
+                              Name 906  "gl_VertexIndex"
+                              Name 907  "TDLight"
+                              MemberName 907(TDLight) 0  "position"
+                              MemberName 907(TDLight) 1  "direction"
+                              MemberName 907(TDLight) 2  "diffuse"
+                              MemberName 907(TDLight) 3  "nearFar"
+                              MemberName 907(TDLight) 4  "lightSize"
+                              MemberName 907(TDLight) 5  "misc"
+                              MemberName 907(TDLight) 6  "coneLookupScaleBias"
+                              MemberName 907(TDLight) 7  "attenScaleBiasRoll"
+                              MemberName 907(TDLight) 8  "shadowMapMatrix"
+                              MemberName 907(TDLight) 9  "shadowMapCamMatrix"
+                              MemberName 907(TDLight) 10  "shadowMapRes"
+                              MemberName 907(TDLight) 11  "projMapMatrix"
+                              Name 909  "TDLightBlock"
+                              MemberName 909(TDLightBlock) 0  "uTDLights"
+                              Name 911  ""
+                              Name 912  "TDEnvLight"
+                              MemberName 912(TDEnvLight) 0  "color"
+                              MemberName 912(TDEnvLight) 1  "rotate"
+                              Name 914  "TDEnvLightBlock"
+                              MemberName 914(TDEnvLightBlock) 0  "uTDEnvLights"
+                              Name 916  ""
+                              Name 919  "TDEnvLightBuffer"
+                              MemberName 919(TDEnvLightBuffer) 0  "shCoeffs"
+                              Name 922  "uTDEnvLightBuffers"
+                              Name 926  "mTD2DImageOutputs"
+                              Name 930  "mTD2DArrayImageOutputs"
+                              Name 934  "mTD3DImageOutputs"
+                              Name 938  "mTDCubeImageOutputs"
+                              Decorate 207(uv) Location 3
+                              MemberDecorate 214(Vertex) 3 Flat
+                              MemberDecorate 214(Vertex) 4 Flat
+                              Decorate 214(Vertex) Block
+                              Decorate 216(oVert) Location 0
+                              Decorate 226(P) Location 0
+                              MemberDecorate 236(gl_PerVertex) 0 BuiltIn Position
+                              MemberDecorate 236(gl_PerVertex) 1 BuiltIn PointSize
+                              MemberDecorate 236(gl_PerVertex) 2 BuiltIn ClipDistance
+                              MemberDecorate 236(gl_PerVertex) 3 BuiltIn CullDistance
+                              Decorate 236(gl_PerVertex) Block
+                              Decorate 256(Cd) Location 2
+                              MemberDecorate 269(TDMatrix) 0 ColMajor
+                              MemberDecorate 269(TDMatrix) 0 Offset 0
+                              MemberDecorate 269(TDMatrix) 0 MatrixStride 16
+                              MemberDecorate 269(TDMatrix) 1 ColMajor
+                              MemberDecorate 269(TDMatrix) 1 Offset 64
+                              MemberDecorate 269(TDMatrix) 1 MatrixStride 16
+                              MemberDecorate 269(TDMatrix) 2 ColMajor
+                              MemberDecorate 269(TDMatrix) 2 Offset 128
+                              MemberDecorate 269(TDMatrix) 2 MatrixStride 16
+                              MemberDecorate 269(TDMatrix) 3 ColMajor
+                              MemberDecorate 269(TDMatrix) 3 Offset 192
+                              MemberDecorate 269(TDMatrix) 3 MatrixStride 16
+                              MemberDecorate 269(TDMatrix) 4 ColMajor
+                              MemberDecorate 269(TDMatrix) 4 Offset 256
+                              MemberDecorate 269(TDMatrix) 4 MatrixStride 16
+                              MemberDecorate 269(TDMatrix) 5 ColMajor
+                              MemberDecorate 269(TDMatrix) 5 Offset 320
+                              MemberDecorate 269(TDMatrix) 5 MatrixStride 16
+                              MemberDecorate 269(TDMatrix) 6 ColMajor
+                              MemberDecorate 269(TDMatrix) 6 Offset 384
+                              MemberDecorate 269(TDMatrix) 6 MatrixStride 16
+                              MemberDecorate 269(TDMatrix) 7 ColMajor
+                              MemberDecorate 269(TDMatrix) 7 Offset 448
+                              MemberDecorate 269(TDMatrix) 7 MatrixStride 16
+                              MemberDecorate 269(TDMatrix) 8 ColMajor
+                              MemberDecorate 269(TDMatrix) 8 Offset 512
+                              MemberDecorate 269(TDMatrix) 8 MatrixStride 16
+                              MemberDecorate 269(TDMatrix) 9 ColMajor
+                              MemberDecorate 269(TDMatrix) 9 Offset 576
+                              MemberDecorate 269(TDMatrix) 9 MatrixStride 16
+                              MemberDecorate 269(TDMatrix) 10 ColMajor
+                              MemberDecorate 269(TDMatrix) 10 Offset 640
+                              MemberDecorate 269(TDMatrix) 10 MatrixStride 16
+                              MemberDecorate 269(TDMatrix) 11 ColMajor
+                              MemberDecorate 269(TDMatrix) 11 Offset 704
+                              MemberDecorate 269(TDMatrix) 11 MatrixStride 16
+                              MemberDecorate 269(TDMatrix) 12 ColMajor
+                              MemberDecorate 269(TDMatrix) 12 Offset 768
+                              MemberDecorate 269(TDMatrix) 12 MatrixStride 16
+                              MemberDecorate 269(TDMatrix) 13 ColMajor
+                              MemberDecorate 269(TDMatrix) 13 Offset 832
+                              MemberDecorate 269(TDMatrix) 13 MatrixStride 16
+                              MemberDecorate 269(TDMatrix) 14 ColMajor
+                              MemberDecorate 269(TDMatrix) 14 Offset 880
+                              MemberDecorate 269(TDMatrix) 14 MatrixStride 16
+                              MemberDecorate 269(TDMatrix) 15 ColMajor
+                              MemberDecorate 269(TDMatrix) 15 Offset 928
+                              MemberDecorate 269(TDMatrix) 15 MatrixStride 16
+                              Decorate 270 ArrayStride 976
+                              MemberDecorate 271(TDMatricesBlock) 0 Offset 0
+                              Decorate 271(TDMatricesBlock) Block
+                              Decorate 273 DescriptorSet 0
+                              Decorate 273 Binding 1
+                              Decorate 297(gl_InstanceIndex) BuiltIn InstanceIndex
+                              MemberDecorate 299(gl_DefaultUniformBlock) 0 Offset 0
+                              MemberDecorate 299(gl_DefaultUniformBlock) 1 Offset 4
+                              MemberDecorate 299(gl_DefaultUniformBlock) 2 Offset 8
+                              MemberDecorate 299(gl_DefaultUniformBlock) 3 Offset 16
+                              MemberDecorate 299(gl_DefaultUniformBlock) 4 Offset 28
+                              MemberDecorate 299(gl_DefaultUniformBlock) 5 Offset 32
+                              MemberDecorate 299(gl_DefaultUniformBlock) 6 Offset 48
+                              MemberDecorate 299(gl_DefaultUniformBlock) 7 Offset 64
+                              Decorate 299(gl_DefaultUniformBlock) Block
+                              Decorate 301 DescriptorSet 0
+                              Decorate 301 Binding 0
+                              Decorate 371(sTDInstanceTexCoord) DescriptorSet 0
+                              Decorate 371(sTDInstanceTexCoord) Binding 16
+                              Decorate 400(sTDInstanceT) DescriptorSet 0
+                              Decorate 400(sTDInstanceT) Binding 15
+                              Decorate 665(sTDInstanceColor) DescriptorSet 0
+                              Decorate 665(sTDInstanceColor) Binding 17
+                              MemberDecorate 896(TDCameraInfo) 0 Offset 0
+                              MemberDecorate 896(TDCameraInfo) 1 Offset 16
+                              MemberDecorate 896(TDCameraInfo) 2 Offset 32
+                              MemberDecorate 896(TDCameraInfo) 3 Offset 48
+                              Decorate 897 ArrayStride 64
+                              MemberDecorate 898(TDCameraInfoBlock) 0 Offset 0
+                              Decorate 898(TDCameraInfoBlock) Block
+                              Decorate 900 DescriptorSet 0
+                              Decorate 900 Binding 0
+                              MemberDecorate 901(TDGeneral) 0 Offset 0
+                              MemberDecorate 901(TDGeneral) 1 Offset 16
+                              MemberDecorate 901(TDGeneral) 2 Offset 32
+                              MemberDecorate 901(TDGeneral) 3 Offset 48
+                              MemberDecorate 901(TDGeneral) 4 Offset 64
+                              MemberDecorate 901(TDGeneral) 5 Offset 80
+                              MemberDecorate 902(TDGeneralBlock) 0 Offset 0
+                              Decorate 902(TDGeneralBlock) Block
+                              Decorate 904 DescriptorSet 0
+                              Decorate 904 Binding 0
+                              Decorate 905(N) Location 1
+                              Decorate 906(gl_VertexIndex) BuiltIn VertexIndex
+                              MemberDecorate 907(TDLight) 0 Offset 0
+                              MemberDecorate 907(TDLight) 1 Offset 16
+                              MemberDecorate 907(TDLight) 2 Offset 32
+                              MemberDecorate 907(TDLight) 3 Offset 48
+                              MemberDecorate 907(TDLight) 4 Offset 64
+                              MemberDecorate 907(TDLight) 5 Offset 80
+                              MemberDecorate 907(TDLight) 6 Offset 96
+                              MemberDecorate 907(TDLight) 7 Offset 112
+                              MemberDecorate 907(TDLight) 8 ColMajor
+                              MemberDecorate 907(TDLight) 8 Offset 128
+                              MemberDecorate 907(TDLight) 8 MatrixStride 16
+                              MemberDecorate 907(TDLight) 9 ColMajor
+                              MemberDecorate 907(TDLight) 9 Offset 192
+                              MemberDecorate 907(TDLight) 9 MatrixStride 16
+                              MemberDecorate 907(TDLight) 10 Offset 256
+                              MemberDecorate 907(TDLight) 11 ColMajor
+                              MemberDecorate 907(TDLight) 11 Offset 272
+                              MemberDecorate 907(TDLight) 11 MatrixStride 16
+                              Decorate 908 ArrayStride 336
+                              MemberDecorate 909(TDLightBlock) 0 Offset 0
+                              Decorate 909(TDLightBlock) Block
+                              Decorate 911 DescriptorSet 0
+                              Decorate 911 Binding 0
+                              MemberDecorate 912(TDEnvLight) 0 Offset 0
+                              MemberDecorate 912(TDEnvLight) 1 ColMajor
+                              MemberDecorate 912(TDEnvLight) 1 Offset 16
+                              MemberDecorate 912(TDEnvLight) 1 MatrixStride 16
+                              Decorate 913 ArrayStride 64
+                              MemberDecorate 914(TDEnvLightBlock) 0 Offset 0
+                              Decorate 914(TDEnvLightBlock) Block
+                              Decorate 916 DescriptorSet 0
+                              Decorate 916 Binding 0
+                              Decorate 918 ArrayStride 16
+                              MemberDecorate 919(TDEnvLightBuffer) 0 Restrict
+                              MemberDecorate 919(TDEnvLightBuffer) 0 NonWritable
+                              MemberDecorate 919(TDEnvLightBuffer) 0 Offset 0
+                              Decorate 919(TDEnvLightBuffer) BufferBlock
+                              Decorate 922(uTDEnvLightBuffers) DescriptorSet 0
+                              Decorate 922(uTDEnvLightBuffers) Binding 0
+                              Decorate 926(mTD2DImageOutputs) DescriptorSet 0
+                              Decorate 926(mTD2DImageOutputs) Binding 0
+                              Decorate 930(mTD2DArrayImageOutputs) DescriptorSet 0
+                              Decorate 930(mTD2DArrayImageOutputs) Binding 0
+                              Decorate 934(mTD3DImageOutputs) DescriptorSet 0
+                              Decorate 934(mTD3DImageOutputs) Binding 0
+                              Decorate 938(mTDCubeImageOutputs) DescriptorSet 0
+                              Decorate 938(mTDCubeImageOutputs) Binding 0
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeFloat 32
+               7:             TypeVector 6(float) 4
+               8:             TypePointer Function 7(fvec4)
+               9:             TypeVector 6(float) 3
+              10:             TypePointer Function 9(fvec3)
+              11:             TypeInt 32 1
+              12:             TypePointer Function 11(int)
+              13:             TypeBool
+              14:             TypePointer Function 13(bool)
+              15:             TypeFunction 7(fvec4) 8(ptr) 10(ptr) 12(ptr) 14(ptr)
+              28:             TypeFunction 11(int)
+              33:             TypeFunction 9(fvec3)
+              38:             TypeFunction 6(float) 12(ptr)
+              44:             TypeFunction 7(fvec4) 8(ptr) 10(ptr)
+              49:             TypeFunction 7(fvec4) 10(ptr) 10(ptr)
+              54:             TypeFunction 7(fvec4) 8(ptr)
+              58:             TypeFunction 7(fvec4) 10(ptr)
+              62:             TypeFunction 7(fvec4)
+              65:             TypeFunction 9(fvec3) 12(ptr) 10(ptr)
+              70:             TypeFunction 13(bool) 12(ptr)
+              74:             TypeFunction 9(fvec3) 12(ptr) 14(ptr)
+              79:             TypeFunction 9(fvec3) 12(ptr)
+              83:             TypeMatrix 9(fvec3) 3
+              84:             TypeFunction 83 12(ptr)
+             100:             TypeMatrix 7(fvec4) 4
+             101:             TypeFunction 100 12(ptr)
+             111:             TypeFunction 7(fvec4) 12(ptr) 8(ptr)
+             131:             TypeFunction 9(fvec3) 10(ptr)
+             138:             TypeFunction 13(bool)
+             143:             TypeFunction 83
+             148:             TypeFunction 100
+             165:             TypeFunction 9(fvec3) 10(ptr) 8(ptr) 10(ptr)
+             177:             TypeFunction 7(fvec4) 12(ptr) 10(ptr)
+             203:             TypeInt 32 0
+             204:    203(int) Constant 8
+             205:             TypeArray 9(fvec3) 204
+             206:             TypePointer Input 205
+         207(uv):    206(ptr) Variable Input
+             208:     11(int) Constant 0
+             210:             TypePointer Input 9(fvec3)
+     214(Vertex):             TypeStruct 7(fvec4) 9(fvec3) 9(fvec3) 11(int) 11(int)
+             215:             TypePointer Output 214(Vertex)
+      216(oVert):    215(ptr) Variable Output
+             217:     11(int) Constant 2
+             219:             TypePointer Output 9(fvec3)
+             221:     11(int) Constant 4
+             223:             TypePointer Output 11(int)
+          226(P):    210(ptr) Variable Input
+             234:    203(int) Constant 1
+             235:             TypeArray 6(float) 234
+236(gl_PerVertex):             TypeStruct 7(fvec4) 6(float) 235 235
+             237:             TypePointer Output 236(gl_PerVertex)
+             238:    237(ptr) Variable Output
+             244:             TypePointer Output 7(fvec4)
+             248:     11(int) Constant 3
+             251:     11(int) Constant 1
+             255:             TypePointer Input 7(fvec4)
+         256(Cd):    255(ptr) Variable Input
+             265:    6(float) Constant 1073741824
+             266:    6(float) Constant 0
+             267:    7(fvec4) ConstantComposite 265 265 265 266
+   269(TDMatrix):             TypeStruct 100 100 100 100 100 100 100 100 100 100 100 100 100 83 83 83
+             270:             TypeArray 269(TDMatrix) 234
+271(TDMatricesBlock):             TypeStruct 270
+             272:             TypePointer Uniform 271(TDMatricesBlock)
+             273:    272(ptr) Variable Uniform
+             274:     11(int) Constant 8
+             275:             TypePointer Uniform 100
+             288:     11(int) Constant 6
+             296:             TypePointer Input 11(int)
+297(gl_InstanceIndex):    296(ptr) Variable Input
+299(gl_DefaultUniformBlock):             TypeStruct 11(int) 11(int) 6(float) 9(fvec3) 6(float) 9(fvec3) 7(fvec4) 7(fvec4)
+             300:             TypePointer Uniform 299(gl_DefaultUniformBlock)
+             301:    300(ptr) Variable Uniform
+             302:             TypePointer Uniform 11(int)
+             316:     11(int) Constant 1073741824
+             324:    13(bool) ConstantTrue
+             335:    6(float) Constant 1065353216
+             346:    9(fvec3) ConstantComposite 266 266 266
+             368:             TypeImage 6(float) Buffer sampled format:Unknown
+             369:             TypeSampledImage 368
+             370:             TypePointer UniformConstant 369
+371(sTDInstanceTexCoord):    370(ptr) Variable UniformConstant
+             377:    203(int) Constant 0
+             378:             TypePointer Function 6(float)
+             387:    203(int) Constant 2
+400(sTDInstanceT):    370(ptr) Variable UniformConstant
+             432:    203(int) Constant 3
+             471:             TypePointer Function 83
+             473:    9(fvec3) ConstantComposite 335 266 266
+             474:    9(fvec3) ConstantComposite 266 335 266
+             475:    9(fvec3) ConstantComposite 266 266 335
+             476:          83 ConstantComposite 473 474 475
+             485:    9(fvec3) ConstantComposite 335 335 335
+             524:    7(fvec4) ConstantComposite 266 266 266 266
+             525:         100 ConstantComposite 524 524 524 524
+             527:             TypePointer Function 100
+             529:    7(fvec4) ConstantComposite 335 266 266 266
+             530:    7(fvec4) ConstantComposite 266 335 266 266
+             531:    7(fvec4) ConstantComposite 266 266 335 266
+             532:    7(fvec4) ConstantComposite 266 266 266 335
+             533:         100 ConstantComposite 529 530 531 532
+665(sTDInstanceColor):    370(ptr) Variable UniformConstant
+             730:     11(int) Constant 13
+             731:             TypePointer Uniform 83
+896(TDCameraInfo):             TypeStruct 7(fvec4) 7(fvec4) 7(fvec4) 11(int)
+             897:             TypeArray 896(TDCameraInfo) 234
+898(TDCameraInfoBlock):             TypeStruct 897
+             899:             TypePointer Uniform 898(TDCameraInfoBlock)
+             900:    899(ptr) Variable Uniform
+  901(TDGeneral):             TypeStruct 7(fvec4) 7(fvec4) 7(fvec4) 7(fvec4) 7(fvec4) 7(fvec4)
+902(TDGeneralBlock):             TypeStruct 901(TDGeneral)
+             903:             TypePointer Uniform 902(TDGeneralBlock)
+             904:    903(ptr) Variable Uniform
+          905(N):    210(ptr) Variable Input
+906(gl_VertexIndex):    296(ptr) Variable Input
+    907(TDLight):             TypeStruct 7(fvec4) 9(fvec3) 9(fvec3) 7(fvec4) 7(fvec4) 7(fvec4) 7(fvec4) 7(fvec4) 100 100 7(fvec4) 100
+             908:             TypeArray 907(TDLight) 234
+909(TDLightBlock):             TypeStruct 908
+             910:             TypePointer Uniform 909(TDLightBlock)
+             911:    910(ptr) Variable Uniform
+ 912(TDEnvLight):             TypeStruct 9(fvec3) 83
+             913:             TypeArray 912(TDEnvLight) 234
+914(TDEnvLightBlock):             TypeStruct 913
+             915:             TypePointer Uniform 914(TDEnvLightBlock)
+             916:    915(ptr) Variable Uniform
+             917:    203(int) Constant 9
+             918:             TypeArray 9(fvec3) 917
+919(TDEnvLightBuffer):             TypeStruct 918
+             920:             TypeArray 919(TDEnvLightBuffer) 234
+             921:             TypePointer Uniform 920
+922(uTDEnvLightBuffers):    921(ptr) Variable Uniform
+             923:             TypeImage 6(float) 2D nonsampled format:Rgba8
+             924:             TypeArray 923 234
+             925:             TypePointer UniformConstant 924
+926(mTD2DImageOutputs):    925(ptr) Variable UniformConstant
+             927:             TypeImage 6(float) 2D array nonsampled format:Rgba8
+             928:             TypeArray 927 234
+             929:             TypePointer UniformConstant 928
+930(mTD2DArrayImageOutputs):    929(ptr) Variable UniformConstant
+             931:             TypeImage 6(float) 3D nonsampled format:Rgba8
+             932:             TypeArray 931 234
+             933:             TypePointer UniformConstant 932
+934(mTD3DImageOutputs):    933(ptr) Variable UniformConstant
+             935:             TypeImage 6(float) Cube nonsampled format:Rgba8
+             936:             TypeArray 935 234
+             937:             TypePointer UniformConstant 936
+938(mTDCubeImageOutputs):    937(ptr) Variable UniformConstant
+         4(main):           2 Function None 3
+               5:             Label
+   202(texcoord):     10(ptr) Variable Function
+      209(param):     10(ptr) Variable Function
+225(worldSpacePos):      8(ptr) Variable Function
+      227(param):     10(ptr) Variable Function
+230(uvUnwrapCoord):     10(ptr) Variable Function
+      232(param):     10(ptr) Variable Function
+      239(param):      8(ptr) Variable Function
+      241(param):     10(ptr) Variable Function
+246(cameraIndex):     12(ptr) Variable Function
+      257(param):      8(ptr) Variable Function
+             211:    210(ptr) AccessChain 207(uv) 208
+             212:    9(fvec3) Load 211
+                              Store 209(param) 212
+             213:    9(fvec3) FunctionCall 154(TDInstanceTexCoord(vf3;) 209(param)
+                              Store 202(texcoord) 213
+             218:    9(fvec3) Load 202(texcoord)
+             220:    219(ptr) AccessChain 216(oVert) 217
+                              Store 220 218
+             222:     11(int) FunctionCall 29(TDInstanceID()
+             224:    223(ptr) AccessChain 216(oVert) 221
+                              Store 224 222
+             228:    9(fvec3) Load 226(P)
+                              Store 227(param) 228
+             229:    7(fvec4) FunctionCall 183(TDDeform(vf3;) 227(param)
+                              Store 225(worldSpacePos) 229
+             231:    9(fvec3) FunctionCall 34(TDUVUnwrapCoord()
+                              Store 232(param) 231
+             233:    9(fvec3) FunctionCall 154(TDInstanceTexCoord(vf3;) 232(param)
+                              Store 230(uvUnwrapCoord) 233
+             240:    7(fvec4) Load 225(worldSpacePos)
+                              Store 239(param) 240
+             242:    9(fvec3) Load 230(uvUnwrapCoord)
+                              Store 241(param) 242
+             243:    7(fvec4) FunctionCall 47(TDWorldToProj(vf4;vf3;) 239(param) 241(param)
+             245:    244(ptr) AccessChain 238 208
+                              Store 245 243
+             247:     11(int) FunctionCall 31(TDCameraIndex()
+                              Store 246(cameraIndex) 247
+             249:     11(int) Load 246(cameraIndex)
+             250:    223(ptr) AccessChain 216(oVert) 248
+                              Store 250 249
+             252:    7(fvec4) Load 225(worldSpacePos)
+             253:    9(fvec3) VectorShuffle 252 252 0 1 2
+             254:    219(ptr) AccessChain 216(oVert) 251
+                              Store 254 253
+             258:    7(fvec4) Load 256(Cd)
+                              Store 257(param) 258
+             259:    7(fvec4) FunctionCall 157(TDInstanceColor(vf4;) 257(param)
+             260:    244(ptr) AccessChain 216(oVert) 208
+                              Store 260 259
+                              Return
+                              FunctionEnd
+20(iTDCamToProj(vf4;vf3;i1;b1;):    7(fvec4) Function None 15
+           16(v):      8(ptr) FunctionParameter
+          17(uv):     10(ptr) FunctionParameter
+ 18(cameraIndex):     12(ptr) FunctionParameter
+19(applyPickMod):     14(ptr) FunctionParameter
+              21:             Label
+             261:    13(bool) FunctionCall 139(TDInstanceActive()
+             262:    13(bool) LogicalNot 261
+                              SelectionMerge 264 None
+                              BranchConditional 262 263 264
+             263:               Label
+                                ReturnValue 267
+             264:             Label
+             276:    275(ptr) AccessChain 273 208 208 274
+             277:         100 Load 276
+             278:    7(fvec4) Load 16(v)
+             279:    7(fvec4) MatrixTimesVector 277 278
+                              Store 16(v) 279
+             280:    7(fvec4) Load 16(v)
+                              ReturnValue 280
+                              FunctionEnd
+26(iTDWorldToProj(vf4;vf3;i1;b1;):    7(fvec4) Function None 15
+           22(v):      8(ptr) FunctionParameter
+          23(uv):     10(ptr) FunctionParameter
+ 24(cameraIndex):     12(ptr) FunctionParameter
+25(applyPickMod):     14(ptr) FunctionParameter
+              27:             Label
+             283:    13(bool) FunctionCall 139(TDInstanceActive()
+             284:    13(bool) LogicalNot 283
+                              SelectionMerge 286 None
+                              BranchConditional 284 285 286
+             285:               Label
+                                ReturnValue 267
+             286:             Label
+             289:    275(ptr) AccessChain 273 208 208 288
+             290:         100 Load 289
+             291:    7(fvec4) Load 22(v)
+             292:    7(fvec4) MatrixTimesVector 290 291
+                              Store 22(v) 292
+             293:    7(fvec4) Load 22(v)
+                              ReturnValue 293
+                              FunctionEnd
+29(TDInstanceID():     11(int) Function None 28
+              30:             Label
+             298:     11(int) Load 297(gl_InstanceIndex)
+             303:    302(ptr) AccessChain 301 208
+             304:     11(int) Load 303
+             305:     11(int) IAdd 298 304
+                              ReturnValue 305
+                              FunctionEnd
+31(TDCameraIndex():     11(int) Function None 28
+              32:             Label
+                              ReturnValue 208
+                              FunctionEnd
+34(TDUVUnwrapCoord():    9(fvec3) Function None 33
+              35:             Label
+             310:    210(ptr) AccessChain 207(uv) 208
+             311:    9(fvec3) Load 310
+                              ReturnValue 311
+                              FunctionEnd
+   36(TDPickID():     11(int) Function None 28
+              37:             Label
+                              ReturnValue 208
+                              FunctionEnd
+40(iTDConvertPickId(i1;):    6(float) Function None 38
+          39(id):     12(ptr) FunctionParameter
+              41:             Label
+             317:     11(int) Load 39(id)
+             318:     11(int) BitwiseOr 317 316
+                              Store 39(id) 318
+             319:     11(int) Load 39(id)
+             320:    6(float) Bitcast 319
+                              ReturnValue 320
+                              FunctionEnd
+42(TDWritePickingValues():           2 Function None 3
+              43:             Label
+                              Return
+                              FunctionEnd
+47(TDWorldToProj(vf4;vf3;):    7(fvec4) Function None 44
+           45(v):      8(ptr) FunctionParameter
+          46(uv):     10(ptr) FunctionParameter
+              48:             Label
+      325(param):      8(ptr) Variable Function
+      327(param):     10(ptr) Variable Function
+      329(param):     12(ptr) Variable Function
+      330(param):     14(ptr) Variable Function
+             323:     11(int) FunctionCall 31(TDCameraIndex()
+             326:    7(fvec4) Load 45(v)
+                              Store 325(param) 326
+             328:    9(fvec3) Load 46(uv)
+                              Store 327(param) 328
+                              Store 329(param) 323
+                              Store 330(param) 324
+             331:    7(fvec4) FunctionCall 26(iTDWorldToProj(vf4;vf3;i1;b1;) 325(param) 327(param) 329(param) 330(param)
+                              ReturnValue 331
+                              FunctionEnd
+52(TDWorldToProj(vf3;vf3;):    7(fvec4) Function None 49
+           50(v):     10(ptr) FunctionParameter
+          51(uv):     10(ptr) FunctionParameter
+              53:             Label
+      340(param):      8(ptr) Variable Function
+      341(param):     10(ptr) Variable Function
+             334:    9(fvec3) Load 50(v)
+             336:    6(float) CompositeExtract 334 0
+             337:    6(float) CompositeExtract 334 1
+             338:    6(float) CompositeExtract 334 2
+             339:    7(fvec4) CompositeConstruct 336 337 338 335
+                              Store 340(param) 339
+             342:    9(fvec3) Load 51(uv)
+                              Store 341(param) 342
+             343:    7(fvec4) FunctionCall 47(TDWorldToProj(vf4;vf3;) 340(param) 341(param)
+                              ReturnValue 343
+                              FunctionEnd
+56(TDWorldToProj(vf4;):    7(fvec4) Function None 54
+           55(v):      8(ptr) FunctionParameter
+              57:             Label
+      347(param):      8(ptr) Variable Function
+      349(param):     10(ptr) Variable Function
+             348:    7(fvec4) Load 55(v)
+                              Store 347(param) 348
+                              Store 349(param) 346
+             350:    7(fvec4) FunctionCall 47(TDWorldToProj(vf4;vf3;) 347(param) 349(param)
+                              ReturnValue 350
+                              FunctionEnd
+60(TDWorldToProj(vf3;):    7(fvec4) Function None 58
+           59(v):     10(ptr) FunctionParameter
+              61:             Label
+      358(param):      8(ptr) Variable Function
+             353:    9(fvec3) Load 59(v)
+             354:    6(float) CompositeExtract 353 0
+             355:    6(float) CompositeExtract 353 1
+             356:    6(float) CompositeExtract 353 2
+             357:    7(fvec4) CompositeConstruct 354 355 356 335
+                              Store 358(param) 357
+             359:    7(fvec4) FunctionCall 56(TDWorldToProj(vf4;) 358(param)
+                              ReturnValue 359
+                              FunctionEnd
+63(TDPointColor():    7(fvec4) Function None 62
+              64:             Label
+             362:    7(fvec4) Load 256(Cd)
+                              ReturnValue 362
+                              FunctionEnd
+68(TDInstanceTexCoord(i1;vf3;):    9(fvec3) Function None 65
+       66(index):     12(ptr) FunctionParameter
+           67(t):     10(ptr) FunctionParameter
+              69:             Label
+      365(coord):     12(ptr) Variable Function
+       367(samp):      8(ptr) Variable Function
+          376(v):     10(ptr) Variable Function
+             366:     11(int) Load 66(index)
+                              Store 365(coord) 366
+             372:         369 Load 371(sTDInstanceTexCoord)
+             373:     11(int) Load 365(coord)
+             374:         368 Image 372
+             375:    7(fvec4) ImageFetch 374 373
+                              Store 367(samp) 375
+             379:    378(ptr) AccessChain 67(t) 377
+             380:    6(float) Load 379
+             381:    378(ptr) AccessChain 376(v) 377
+                              Store 381 380
+             382:    378(ptr) AccessChain 67(t) 234
+             383:    6(float) Load 382
+             384:    378(ptr) AccessChain 376(v) 234
+                              Store 384 383
+             385:    378(ptr) AccessChain 367(samp) 377
+             386:    6(float) Load 385
+             388:    378(ptr) AccessChain 376(v) 387
+                              Store 388 386
+             389:    9(fvec3) Load 376(v)
+                              Store 67(t) 389
+             390:    9(fvec3) Load 67(t)
+                              ReturnValue 390
+                              FunctionEnd
+72(TDInstanceActive(i1;):    13(bool) Function None 70
+       71(index):     12(ptr) FunctionParameter
+              73:             Label
+      397(coord):     12(ptr) Variable Function
+       399(samp):      8(ptr) Variable Function
+          405(v):    378(ptr) Variable Function
+             393:    302(ptr) AccessChain 301 208
+             394:     11(int) Load 393
+             395:     11(int) Load 71(index)
+             396:     11(int) ISub 395 394
+                              Store 71(index) 396
+             398:     11(int) Load 71(index)
+                              Store 397(coord) 398
+             401:         369 Load 400(sTDInstanceT)
+             402:     11(int) Load 397(coord)
+             403:         368 Image 401
+             404:    7(fvec4) ImageFetch 403 402
+                              Store 399(samp) 404
+             406:    378(ptr) AccessChain 399(samp) 377
+             407:    6(float) Load 406
+                              Store 405(v) 407
+             408:    6(float) Load 405(v)
+             409:    13(bool) FUnordNotEqual 408 266
+                              ReturnValue 409
+                              FunctionEnd
+77(iTDInstanceTranslate(i1;b1;):    9(fvec3) Function None 74
+       75(index):     12(ptr) FunctionParameter
+76(instanceActive):     14(ptr) FunctionParameter
+              78:             Label
+  412(origIndex):     12(ptr) Variable Function
+      418(coord):     12(ptr) Variable Function
+       420(samp):      8(ptr) Variable Function
+          425(v):     10(ptr) Variable Function
+             413:     11(int) Load 75(index)
+                              Store 412(origIndex) 413
+             414:    302(ptr) AccessChain 301 208
+             415:     11(int) Load 414
+             416:     11(int) Load 75(index)
+             417:     11(int) ISub 416 415
+                              Store 75(index) 417
+             419:     11(int) Load 75(index)
+                              Store 418(coord) 419
+             421:         369 Load 400(sTDInstanceT)
+             422:     11(int) Load 418(coord)
+             423:         368 Image 421
+             424:    7(fvec4) ImageFetch 423 422
+                              Store 420(samp) 424
+             426:    378(ptr) AccessChain 420(samp) 234
+             427:    6(float) Load 426
+             428:    378(ptr) AccessChain 425(v) 377
+                              Store 428 427
+             429:    378(ptr) AccessChain 420(samp) 387
+             430:    6(float) Load 429
+             431:    378(ptr) AccessChain 425(v) 234
+                              Store 431 430
+             433:    378(ptr) AccessChain 420(samp) 432
+             434:    6(float) Load 433
+             435:    378(ptr) AccessChain 425(v) 387
+                              Store 435 434
+             436:    378(ptr) AccessChain 420(samp) 377
+             437:    6(float) Load 436
+             438:    13(bool) FUnordNotEqual 437 266
+                              Store 76(instanceActive) 438
+             439:    9(fvec3) Load 425(v)
+                              ReturnValue 439
+                              FunctionEnd
+81(TDInstanceTranslate(i1;):    9(fvec3) Function None 79
+       80(index):     12(ptr) FunctionParameter
+              82:             Label
+      446(coord):     12(ptr) Variable Function
+       448(samp):      8(ptr) Variable Function
+          453(v):     10(ptr) Variable Function
+             442:    302(ptr) AccessChain 301 208
+             443:     11(int) Load 442
+             444:     11(int) Load 80(index)
+             445:     11(int) ISub 444 443
+                              Store 80(index) 445
+             447:     11(int) Load 80(index)
+                              Store 446(coord) 447
+             449:         369 Load 400(sTDInstanceT)
+             450:     11(int) Load 446(coord)
+             451:         368 Image 449
+             452:    7(fvec4) ImageFetch 451 450
+                              Store 448(samp) 452
+             454:    378(ptr) AccessChain 448(samp) 234
+             455:    6(float) Load 454
+             456:    378(ptr) AccessChain 453(v) 377
+                              Store 456 455
+             457:    378(ptr) AccessChain 448(samp) 387
+             458:    6(float) Load 457
+             459:    378(ptr) AccessChain 453(v) 234
+                              Store 459 458
+             460:    378(ptr) AccessChain 448(samp) 432
+             461:    6(float) Load 460
+             462:    378(ptr) AccessChain 453(v) 387
+                              Store 462 461
+             463:    9(fvec3) Load 453(v)
+                              ReturnValue 463
+                              FunctionEnd
+86(TDInstanceRotateMat(i1;):          83 Function None 84
+       85(index):     12(ptr) FunctionParameter
+              87:             Label
+          470(v):     10(ptr) Variable Function
+          472(m):    471(ptr) Variable Function
+             466:    302(ptr) AccessChain 301 208
+             467:     11(int) Load 466
+             468:     11(int) Load 85(index)
+             469:     11(int) ISub 468 467
+                              Store 85(index) 469
+                              Store 470(v) 346
+                              Store 472(m) 476
+             477:          83 Load 472(m)
+                              ReturnValue 477
+                              FunctionEnd
+89(TDInstanceScale(i1;):    9(fvec3) Function None 79
+       88(index):     12(ptr) FunctionParameter
+              90:             Label
+          484(v):     10(ptr) Variable Function
+             480:    302(ptr) AccessChain 301 208
+             481:     11(int) Load 480
+             482:     11(int) Load 88(index)
+             483:     11(int) ISub 482 481
+                              Store 88(index) 483
+                              Store 484(v) 485
+             486:    9(fvec3) Load 484(v)
+                              ReturnValue 486
+                              FunctionEnd
+92(TDInstancePivot(i1;):    9(fvec3) Function None 79
+       91(index):     12(ptr) FunctionParameter
+              93:             Label
+          493(v):     10(ptr) Variable Function
+             489:    302(ptr) AccessChain 301 208
+             490:     11(int) Load 489
+             491:     11(int) Load 91(index)
+             492:     11(int) ISub 491 490
+                              Store 91(index) 492
+                              Store 493(v) 346
+             494:    9(fvec3) Load 493(v)
+                              ReturnValue 494
+                              FunctionEnd
+95(TDInstanceRotTo(i1;):    9(fvec3) Function None 79
+       94(index):     12(ptr) FunctionParameter
+              96:             Label
+          501(v):     10(ptr) Variable Function
+             497:    302(ptr) AccessChain 301 208
+             498:     11(int) Load 497
+             499:     11(int) Load 94(index)
+             500:     11(int) ISub 499 498
+                              Store 94(index) 500
+                              Store 501(v) 475
+             502:    9(fvec3) Load 501(v)
+                              ReturnValue 502
+                              FunctionEnd
+98(TDInstanceRotUp(i1;):    9(fvec3) Function None 79
+       97(index):     12(ptr) FunctionParameter
+              99:             Label
+          509(v):     10(ptr) Variable Function
+             505:    302(ptr) AccessChain 301 208
+             506:     11(int) Load 505
+             507:     11(int) Load 97(index)
+             508:     11(int) ISub 507 506
+                              Store 97(index) 508
+                              Store 509(v) 474
+             510:    9(fvec3) Load 509(v)
+                              ReturnValue 510
+                              FunctionEnd
+103(TDInstanceMat(i1;):         100 Function None 101
+         102(id):     12(ptr) FunctionParameter
+             104:             Label
+513(instanceActive):     14(ptr) Variable Function
+          514(t):     10(ptr) Variable Function
+      515(param):     12(ptr) Variable Function
+      517(param):     14(ptr) Variable Function
+          528(m):    527(ptr) Variable Function
+         534(tt):     10(ptr) Variable Function
+                              Store 513(instanceActive) 324
+             516:     11(int) Load 102(id)
+                              Store 515(param) 516
+             518:    9(fvec3) FunctionCall 77(iTDInstanceTranslate(i1;b1;) 515(param) 517(param)
+             519:    13(bool) Load 517(param)
+                              Store 513(instanceActive) 519
+                              Store 514(t) 518
+             520:    13(bool) Load 513(instanceActive)
+             521:    13(bool) LogicalNot 520
+                              SelectionMerge 523 None
+                              BranchConditional 521 522 523
+             522:               Label
+                                ReturnValue 525
+             523:             Label
+                              Store 528(m) 533
+             535:    9(fvec3) Load 514(t)
+                              Store 534(tt) 535
+             536:    378(ptr) AccessChain 528(m) 208 377
+             537:    6(float) Load 536
+             538:    378(ptr) AccessChain 534(tt) 377
+             539:    6(float) Load 538
+             540:    6(float) FMul 537 539
+             541:    378(ptr) AccessChain 528(m) 248 377
+             542:    6(float) Load 541
+             543:    6(float) FAdd 542 540
+             544:    378(ptr) AccessChain 528(m) 248 377
+                              Store 544 543
+             545:    378(ptr) AccessChain 528(m) 208 234
+             546:    6(float) Load 545
+             547:    378(ptr) AccessChain 534(tt) 377
+             548:    6(float) Load 547
+             549:    6(float) FMul 546 548
+             550:    378(ptr) AccessChain 528(m) 248 234
+             551:    6(float) Load 550
+             552:    6(float) FAdd 551 549
+             553:    378(ptr) AccessChain 528(m) 248 234
+                              Store 553 552
+             554:    378(ptr) AccessChain 528(m) 208 387
+             555:    6(float) Load 554
+             556:    378(ptr) AccessChain 534(tt) 377
+             557:    6(float) Load 556
+             558:    6(float) FMul 555 557
+             559:    378(ptr) AccessChain 528(m) 248 387
+             560:    6(float) Load 559
+             561:    6(float) FAdd 560 558
+             562:    378(ptr) AccessChain 528(m) 248 387
+                              Store 562 561
+             563:    378(ptr) AccessChain 528(m) 208 432
+             564:    6(float) Load 563
+             565:    378(ptr) AccessChain 534(tt) 377
+             566:    6(float) Load 565
+             567:    6(float) FMul 564 566
+             568:    378(ptr) AccessChain 528(m) 248 432
+             569:    6(float) Load 568
+             570:    6(float) FAdd 569 567
+             571:    378(ptr) AccessChain 528(m) 248 432
+                              Store 571 570
+             572:    378(ptr) AccessChain 528(m) 251 377
+             573:    6(float) Load 572
+             574:    378(ptr) AccessChain 534(tt) 234
+             575:    6(float) Load 574
+             576:    6(float) FMul 573 575
+             577:    378(ptr) AccessChain 528(m) 248 377
+             578:    6(float) Load 577
+             579:    6(float) FAdd 578 576
+             580:    378(ptr) AccessChain 528(m) 248 377
+                              Store 580 579
+             581:    378(ptr) AccessChain 528(m) 251 234
+             582:    6(float) Load 581
+             583:    378(ptr) AccessChain 534(tt) 234
+             584:    6(float) Load 583
+             585:    6(float) FMul 582 584
+             586:    378(ptr) AccessChain 528(m) 248 234
+             587:    6(float) Load 586
+             588:    6(float) FAdd 587 585
+             589:    378(ptr) AccessChain 528(m) 248 234
+                              Store 589 588
+             590:    378(ptr) AccessChain 528(m) 251 387
+             591:    6(float) Load 590
+             592:    378(ptr) AccessChain 534(tt) 234
+             593:    6(float) Load 592
+             594:    6(float) FMul 591 593
+             595:    378(ptr) AccessChain 528(m) 248 387
+             596:    6(float) Load 595
+             597:    6(float) FAdd 596 594
+             598:    378(ptr) AccessChain 528(m) 248 387
+                              Store 598 597
+             599:    378(ptr) AccessChain 528(m) 251 432
+             600:    6(float) Load 599
+             601:    378(ptr) AccessChain 534(tt) 234
+             602:    6(float) Load 601
+             603:    6(float) FMul 600 602
+             604:    378(ptr) AccessChain 528(m) 248 432
+             605:    6(float) Load 604
+             606:    6(float) FAdd 605 603
+             607:    378(ptr) AccessChain 528(m) 248 432
+                              Store 607 606
+             608:    378(ptr) AccessChain 528(m) 217 377
+             609:    6(float) Load 608
+             610:    378(ptr) AccessChain 534(tt) 387
+             611:    6(float) Load 610
+             612:    6(float) FMul 609 611
+             613:    378(ptr) AccessChain 528(m) 248 377
+             614:    6(float) Load 613
+             615:    6(float) FAdd 614 612
+             616:    378(ptr) AccessChain 528(m) 248 377
+                              Store 616 615
+             617:    378(ptr) AccessChain 528(m) 217 234
+             618:    6(float) Load 617
+             619:    378(ptr) AccessChain 534(tt) 387
+             620:    6(float) Load 619
+             621:    6(float) FMul 618 620
+             622:    378(ptr) AccessChain 528(m) 248 234
+             623:    6(float) Load 622
+             624:    6(float) FAdd 623 621
+             625:    378(ptr) AccessChain 528(m) 248 234
+                              Store 625 624
+             626:    378(ptr) AccessChain 528(m) 217 387
+             627:    6(float) Load 626
+             628:    378(ptr) AccessChain 534(tt) 387
+             629:    6(float) Load 628
+             630:    6(float) FMul 627 629
+             631:    378(ptr) AccessChain 528(m) 248 387
+             632:    6(float) Load 631
+             633:    6(float) FAdd 632 630
+             634:    378(ptr) AccessChain 528(m) 248 387
+                              Store 634 633
+             635:    378(ptr) AccessChain 528(m) 217 432
+             636:    6(float) Load 635
+             637:    378(ptr) AccessChain 534(tt) 387
+             638:    6(float) Load 637
+             639:    6(float) FMul 636 638
+             640:    378(ptr) AccessChain 528(m) 248 432
+             641:    6(float) Load 640
+             642:    6(float) FAdd 641 639
+             643:    378(ptr) AccessChain 528(m) 248 432
+                              Store 643 642
+             644:         100 Load 528(m)
+                              ReturnValue 644
+                              FunctionEnd
+106(TDInstanceMat3(i1;):          83 Function None 84
+         105(id):     12(ptr) FunctionParameter
+             107:             Label
+          647(m):    471(ptr) Variable Function
+                              Store 647(m) 476
+             648:          83 Load 647(m)
+                              ReturnValue 648
+                              FunctionEnd
+109(TDInstanceMat3ForNorm(i1;):          83 Function None 84
+         108(id):     12(ptr) FunctionParameter
+             110:             Label
+          651(m):    471(ptr) Variable Function
+      652(param):     12(ptr) Variable Function
+             653:     11(int) Load 108(id)
+                              Store 652(param) 653
+             654:          83 FunctionCall 106(TDInstanceMat3(i1;) 652(param)
+                              Store 651(m) 654
+             655:          83 Load 651(m)
+                              ReturnValue 655
+                              FunctionEnd
+114(TDInstanceColor(i1;vf4;):    7(fvec4) Function None 111
+      112(index):     12(ptr) FunctionParameter
+   113(curColor):      8(ptr) FunctionParameter
+             115:             Label
+      662(coord):     12(ptr) Variable Function
+       664(samp):      8(ptr) Variable Function
+          670(v):      8(ptr) Variable Function
+             658:    302(ptr) AccessChain 301 208
+             659:     11(int) Load 658
+             660:     11(int) Load 112(index)
+             661:     11(int) ISub 660 659
+                              Store 112(index) 661
+             663:     11(int) Load 112(index)
+                              Store 662(coord) 663
+             666:         369 Load 665(sTDInstanceColor)
+             667:     11(int) Load 662(coord)
+             668:         368 Image 666
+             669:    7(fvec4) ImageFetch 668 667
+                              Store 664(samp) 669
+             671:    378(ptr) AccessChain 664(samp) 377
+             672:    6(float) Load 671
+             673:    378(ptr) AccessChain 670(v) 377
+                              Store 673 672
+             674:    378(ptr) AccessChain 664(samp) 234
+             675:    6(float) Load 674
+             676:    378(ptr) AccessChain 670(v) 234
+                              Store 676 675
+             677:    378(ptr) AccessChain 664(samp) 387
+             678:    6(float) Load 677
+             679:    378(ptr) AccessChain 670(v) 387
+                              Store 679 678
+             680:    378(ptr) AccessChain 670(v) 432
+                              Store 680 335
+             681:    378(ptr) AccessChain 670(v) 377
+             682:    6(float) Load 681
+             683:    378(ptr) AccessChain 113(curColor) 377
+                              Store 683 682
+             684:    378(ptr) AccessChain 670(v) 234
+             685:    6(float) Load 684
+             686:    378(ptr) AccessChain 113(curColor) 234
+                              Store 686 685
+             687:    378(ptr) AccessChain 670(v) 387
+             688:    6(float) Load 687
+             689:    378(ptr) AccessChain 113(curColor) 387
+                              Store 689 688
+             690:    7(fvec4) Load 113(curColor)
+                              ReturnValue 690
+                              FunctionEnd
+118(TDInstanceDeform(i1;vf4;):    7(fvec4) Function None 111
+         116(id):     12(ptr) FunctionParameter
+        117(pos):      8(ptr) FunctionParameter
+             119:             Label
+      693(param):     12(ptr) Variable Function
+             694:     11(int) Load 116(id)
+                              Store 693(param) 694
+             695:         100 FunctionCall 103(TDInstanceMat(i1;) 693(param)
+             696:    7(fvec4) Load 117(pos)
+             697:    7(fvec4) MatrixTimesVector 695 696
+                              Store 117(pos) 697
+             698:     11(int) FunctionCall 31(TDCameraIndex()
+             699:    275(ptr) AccessChain 273 208 698 208
+             700:         100 Load 699
+             701:    7(fvec4) Load 117(pos)
+             702:    7(fvec4) MatrixTimesVector 700 701
+                              ReturnValue 702
+                              FunctionEnd
+122(TDInstanceDeformVec(i1;vf3;):    9(fvec3) Function None 65
+         120(id):     12(ptr) FunctionParameter
+        121(vec):     10(ptr) FunctionParameter
+             123:             Label
+          705(m):    471(ptr) Variable Function
+      706(param):     12(ptr) Variable Function
+             707:     11(int) Load 120(id)
+                              Store 706(param) 707
+             708:          83 FunctionCall 106(TDInstanceMat3(i1;) 706(param)
+                              Store 705(m) 708
+             709:     11(int) FunctionCall 31(TDCameraIndex()
+             710:    275(ptr) AccessChain 273 208 709 208
+             711:         100 Load 710
+             712:    7(fvec4) CompositeExtract 711 0
+             713:    9(fvec3) VectorShuffle 712 712 0 1 2
+             714:    7(fvec4) CompositeExtract 711 1
+             715:    9(fvec3) VectorShuffle 714 714 0 1 2
+             716:    7(fvec4) CompositeExtract 711 2
+             717:    9(fvec3) VectorShuffle 716 716 0 1 2
+             718:          83 CompositeConstruct 713 715 717
+             719:          83 Load 705(m)
+             720:    9(fvec3) Load 121(vec)
+             721:    9(fvec3) MatrixTimesVector 719 720
+             722:    9(fvec3) MatrixTimesVector 718 721
+                              ReturnValue 722
+                              FunctionEnd
+126(TDInstanceDeformNorm(i1;vf3;):    9(fvec3) Function None 65
+         124(id):     12(ptr) FunctionParameter
+        125(vec):     10(ptr) FunctionParameter
+             127:             Label
+          725(m):    471(ptr) Variable Function
+      726(param):     12(ptr) Variable Function
+             727:     11(int) Load 124(id)
+                              Store 726(param) 727
+             728:          83 FunctionCall 109(TDInstanceMat3ForNorm(i1;) 726(param)
+                              Store 725(m) 728
+             729:     11(int) FunctionCall 31(TDCameraIndex()
+             732:    731(ptr) AccessChain 273 208 729 730
+             733:          83 Load 732
+             734:    9(fvec3) CompositeExtract 733 0
+             735:    9(fvec3) CompositeExtract 733 1
+             736:    9(fvec3) CompositeExtract 733 2
+             737:          83 CompositeConstruct 734 735 736
+             738:          83 Load 725(m)
+             739:    9(fvec3) Load 125(vec)
+             740:    9(fvec3) MatrixTimesVector 738 739
+             741:    9(fvec3) MatrixTimesVector 737 740
+                              ReturnValue 741
+                              FunctionEnd
+129(TDInstanceDeform(vf4;):    7(fvec4) Function None 54
+        128(pos):      8(ptr) FunctionParameter
+             130:             Label
+      745(param):     12(ptr) Variable Function
+      746(param):      8(ptr) Variable Function
+             744:     11(int) FunctionCall 29(TDInstanceID()
+                              Store 745(param) 744
+             747:    7(fvec4) Load 128(pos)
+                              Store 746(param) 747
+             748:    7(fvec4) FunctionCall 118(TDInstanceDeform(i1;vf4;) 745(param) 746(param)
+                              ReturnValue 748
+                              FunctionEnd
+133(TDInstanceDeformVec(vf3;):    9(fvec3) Function None 131
+        132(vec):     10(ptr) FunctionParameter
+             134:             Label
+      752(param):     12(ptr) Variable Function
+      753(param):     10(ptr) Variable Function
+             751:     11(int) FunctionCall 29(TDInstanceID()
+                              Store 752(param) 751
+             754:    9(fvec3) Load 132(vec)
+                              Store 753(param) 754
+             755:    9(fvec3) FunctionCall 122(TDInstanceDeformVec(i1;vf3;) 752(param) 753(param)
+                              ReturnValue 755
+                              FunctionEnd
+136(TDInstanceDeformNorm(vf3;):    9(fvec3) Function None 131
+        135(vec):     10(ptr) FunctionParameter
+             137:             Label
+      759(param):     12(ptr) Variable Function
+      760(param):     10(ptr) Variable Function
+             758:     11(int) FunctionCall 29(TDInstanceID()
+                              Store 759(param) 758
+             761:    9(fvec3) Load 135(vec)
+                              Store 760(param) 761
+             762:    9(fvec3) FunctionCall 126(TDInstanceDeformNorm(i1;vf3;) 759(param) 760(param)
+                              ReturnValue 762
+                              FunctionEnd
+139(TDInstanceActive():    13(bool) Function None 138
+             140:             Label
+      766(param):     12(ptr) Variable Function
+             765:     11(int) FunctionCall 29(TDInstanceID()
+                              Store 766(param) 765
+             767:    13(bool) FunctionCall 72(TDInstanceActive(i1;) 766(param)
+                              ReturnValue 767
+                              FunctionEnd
+141(TDInstanceTranslate():    9(fvec3) Function None 33
+             142:             Label
+      771(param):     12(ptr) Variable Function
+             770:     11(int) FunctionCall 29(TDInstanceID()
+                              Store 771(param) 770
+             772:    9(fvec3) FunctionCall 81(TDInstanceTranslate(i1;) 771(param)
+                              ReturnValue 772
+                              FunctionEnd
+144(TDInstanceRotateMat():          83 Function None 143
+             145:             Label
+      776(param):     12(ptr) Variable Function
+             775:     11(int) FunctionCall 29(TDInstanceID()
+                              Store 776(param) 775
+             777:          83 FunctionCall 86(TDInstanceRotateMat(i1;) 776(param)
+                              ReturnValue 777
+                              FunctionEnd
+146(TDInstanceScale():    9(fvec3) Function None 33
+             147:             Label
+      781(param):     12(ptr) Variable Function
+             780:     11(int) FunctionCall 29(TDInstanceID()
+                              Store 781(param) 780
+             782:    9(fvec3) FunctionCall 89(TDInstanceScale(i1;) 781(param)
+                              ReturnValue 782
+                              FunctionEnd
+149(TDInstanceMat():         100 Function None 148
+             150:             Label
+      786(param):     12(ptr) Variable Function
+             785:     11(int) FunctionCall 29(TDInstanceID()
+                              Store 786(param) 785
+             787:         100 FunctionCall 103(TDInstanceMat(i1;) 786(param)
+                              ReturnValue 787
+                              FunctionEnd
+151(TDInstanceMat3():          83 Function None 143
+             152:             Label
+      791(param):     12(ptr) Variable Function
+             790:     11(int) FunctionCall 29(TDInstanceID()
+                              Store 791(param) 790
+             792:          83 FunctionCall 106(TDInstanceMat3(i1;) 791(param)
+                              ReturnValue 792
+                              FunctionEnd
+154(TDInstanceTexCoord(vf3;):    9(fvec3) Function None 131
+          153(t):     10(ptr) FunctionParameter
+             155:             Label
+      796(param):     12(ptr) Variable Function
+      797(param):     10(ptr) Variable Function
+             795:     11(int) FunctionCall 29(TDInstanceID()
+                              Store 796(param) 795
+             798:    9(fvec3) Load 153(t)
+                              Store 797(param) 798
+             799:    9(fvec3) FunctionCall 68(TDInstanceTexCoord(i1;vf3;) 796(param) 797(param)
+                              ReturnValue 799
+                              FunctionEnd
+157(TDInstanceColor(vf4;):    7(fvec4) Function None 54
+   156(curColor):      8(ptr) FunctionParameter
+             158:             Label
+      803(param):     12(ptr) Variable Function
+      804(param):      8(ptr) Variable Function
+             802:     11(int) FunctionCall 29(TDInstanceID()
+                              Store 803(param) 802
+             805:    7(fvec4) Load 156(curColor)
+                              Store 804(param) 805
+             806:    7(fvec4) FunctionCall 114(TDInstanceColor(i1;vf4;) 803(param) 804(param)
+                              ReturnValue 806
+                              FunctionEnd
+160(TDSkinnedDeform(vf4;):    7(fvec4) Function None 54
+        159(pos):      8(ptr) FunctionParameter
+             161:             Label
+             809:    7(fvec4) Load 159(pos)
+                              ReturnValue 809
+                              FunctionEnd
+163(TDSkinnedDeformVec(vf3;):    9(fvec3) Function None 131
+        162(vec):     10(ptr) FunctionParameter
+             164:             Label
+             812:    9(fvec3) Load 162(vec)
+                              ReturnValue 812
+                              FunctionEnd
+169(TDFastDeformTangent(vf3;vf4;vf3;):    9(fvec3) Function None 165
+    166(oldNorm):     10(ptr) FunctionParameter
+ 167(oldTangent):      8(ptr) FunctionParameter
+168(deformedNorm):     10(ptr) FunctionParameter
+             170:             Label
+             815:    7(fvec4) Load 167(oldTangent)
+             816:    9(fvec3) VectorShuffle 815 815 0 1 2
+                              ReturnValue 816
+                              FunctionEnd
+172(TDBoneMat(i1;):         100 Function None 101
+      171(index):     12(ptr) FunctionParameter
+             173:             Label
+                              ReturnValue 533
+                              FunctionEnd
+175(TDDeform(vf4;):    7(fvec4) Function None 54
+        174(pos):      8(ptr) FunctionParameter
+             176:             Label
+      821(param):      8(ptr) Variable Function
+      824(param):      8(ptr) Variable Function
+             822:    7(fvec4) Load 174(pos)
+                              Store 821(param) 822
+             823:    7(fvec4) FunctionCall 160(TDSkinnedDeform(vf4;) 821(param)
+                              Store 174(pos) 823
+             825:    7(fvec4) Load 174(pos)
+                              Store 824(param) 825
+             826:    7(fvec4) FunctionCall 129(TDInstanceDeform(vf4;) 824(param)
+                              Store 174(pos) 826
+             827:    7(fvec4) Load 174(pos)
+                              ReturnValue 827
+                              FunctionEnd
+180(TDDeform(i1;vf3;):    7(fvec4) Function None 177
+ 178(instanceID):     12(ptr) FunctionParameter
+          179(p):     10(ptr) FunctionParameter
+             181:             Label
+        830(pos):      8(ptr) Variable Function
+      836(param):      8(ptr) Variable Function
+      839(param):     12(ptr) Variable Function
+      841(param):      8(ptr) Variable Function
+             831:    9(fvec3) Load 179(p)
+             832:    6(float) CompositeExtract 831 0
+             833:    6(float) CompositeExtract 831 1
+             834:    6(float) CompositeExtract 831 2
+             835:    7(fvec4) CompositeConstruct 832 833 834 335
+                              Store 830(pos) 835
+             837:    7(fvec4) Load 830(pos)
+                              Store 836(param) 837
+             838:    7(fvec4) FunctionCall 160(TDSkinnedDeform(vf4;) 836(param)
+                              Store 830(pos) 838
+             840:     11(int) Load 178(instanceID)
+                              Store 839(param) 840
+             842:    7(fvec4) Load 830(pos)
+                              Store 841(param) 842
+             843:    7(fvec4) FunctionCall 118(TDInstanceDeform(i1;vf4;) 839(param) 841(param)
+                              Store 830(pos) 843
+             844:    7(fvec4) Load 830(pos)
+                              ReturnValue 844
+                              FunctionEnd
+183(TDDeform(vf3;):    7(fvec4) Function None 58
+        182(pos):     10(ptr) FunctionParameter
+             184:             Label
+      848(param):     12(ptr) Variable Function
+      849(param):     10(ptr) Variable Function
+             847:     11(int) FunctionCall 29(TDInstanceID()
+                              Store 848(param) 847
+             850:    9(fvec3) Load 182(pos)
+                              Store 849(param) 850
+             851:    7(fvec4) FunctionCall 180(TDDeform(i1;vf3;) 848(param) 849(param)
+                              ReturnValue 851
+                              FunctionEnd
+187(TDDeformVec(i1;vf3;):    9(fvec3) Function None 65
+ 185(instanceID):     12(ptr) FunctionParameter
+        186(vec):     10(ptr) FunctionParameter
+             188:             Label
+      854(param):     10(ptr) Variable Function
+      857(param):     12(ptr) Variable Function
+      859(param):     10(ptr) Variable Function
+             855:    9(fvec3) Load 186(vec)
+                              Store 854(param) 855
+             856:    9(fvec3) FunctionCall 163(TDSkinnedDeformVec(vf3;) 854(param)
+                              Store 186(vec) 856
+             858:     11(int) Load 185(instanceID)
+                              Store 857(param) 858
+             860:    9(fvec3) Load 186(vec)
+                              Store 859(param) 860
+             861:    9(fvec3) FunctionCall 122(TDInstanceDeformVec(i1;vf3;) 857(param) 859(param)
+                              Store 186(vec) 861
+             862:    9(fvec3) Load 186(vec)
+                              ReturnValue 862
+                              FunctionEnd
+190(TDDeformVec(vf3;):    9(fvec3) Function None 131
+        189(vec):     10(ptr) FunctionParameter
+             191:             Label
+      866(param):     12(ptr) Variable Function
+      867(param):     10(ptr) Variable Function
+             865:     11(int) FunctionCall 29(TDInstanceID()
+                              Store 866(param) 865
+             868:    9(fvec3) Load 189(vec)
+                              Store 867(param) 868
+             869:    9(fvec3) FunctionCall 187(TDDeformVec(i1;vf3;) 866(param) 867(param)
+                              ReturnValue 869
+                              FunctionEnd
+194(TDDeformNorm(i1;vf3;):    9(fvec3) Function None 65
+ 192(instanceID):     12(ptr) FunctionParameter
+        193(vec):     10(ptr) FunctionParameter
+             195:             Label
+      872(param):     10(ptr) Variable Function
+      875(param):     12(ptr) Variable Function
+      877(param):     10(ptr) Variable Function
+             873:    9(fvec3) Load 193(vec)
+                              Store 872(param) 873
+             874:    9(fvec3) FunctionCall 163(TDSkinnedDeformVec(vf3;) 872(param)
+                              Store 193(vec) 874
+             876:     11(int) Load 192(instanceID)
+                              Store 875(param) 876
+             878:    9(fvec3) Load 193(vec)
+                              Store 877(param) 878
+             879:    9(fvec3) FunctionCall 126(TDInstanceDeformNorm(i1;vf3;) 875(param) 877(param)
+                              Store 193(vec) 879
+             880:    9(fvec3) Load 193(vec)
+                              ReturnValue 880
+                              FunctionEnd
+197(TDDeformNorm(vf3;):    9(fvec3) Function None 131
+        196(vec):     10(ptr) FunctionParameter
+             198:             Label
+      884(param):     12(ptr) Variable Function
+      885(param):     10(ptr) Variable Function
+             883:     11(int) FunctionCall 29(TDInstanceID()
+                              Store 884(param) 883
+             886:    9(fvec3) Load 196(vec)
+                              Store 885(param) 886
+             887:    9(fvec3) FunctionCall 194(TDDeformNorm(i1;vf3;) 884(param) 885(param)
+                              ReturnValue 887
+                              FunctionEnd
+200(TDSkinnedDeformNorm(vf3;):    9(fvec3) Function None 131
+        199(vec):     10(ptr) FunctionParameter
+             201:             Label
+      890(param):     10(ptr) Variable Function
+             891:    9(fvec3) Load 199(vec)
+                              Store 890(param) 891
+             892:    9(fvec3) FunctionCall 163(TDSkinnedDeformVec(vf3;) 890(param)
+                              Store 199(vec) 892
+             893:    9(fvec3) Load 199(vec)
+                              ReturnValue 893
+                              FunctionEnd
+// Module Version 10000
+// Generated by (magic number): 8000a
+// Id's are bound by 1297
+
+                              Capability Shader
+                              Capability Sampled1D
+                              Capability SampledBuffer
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint Fragment 4  "main" 336 429 458 485
+                              ExecutionMode 4 OriginUpperLeft
+                              Source GLSL 460
+                              Name 4  "main"
+                              Name 11  "TDColor(vf4;"
+                              Name 10  "color"
+                              Name 13  "TDCheckOrderIndTrans("
+                              Name 15  "TDCheckDiscard("
+                              Name 18  "TDDither(vf4;"
+                              Name 17  "color"
+                              Name 26  "TDFrontFacing(vf3;vf3;"
+                              Name 24  "pos"
+                              Name 25  "normal"
+                              Name 34  "TDAttenuateLight(i1;f1;"
+                              Name 32  "index"
+                              Name 33  "lightDist"
+                              Name 38  "TDAlphaTest(f1;"
+                              Name 37  "alpha"
+                              Name 43  "TDHardShadow(i1;vf3;"
+                              Name 41  "lightIndex"
+                              Name 42  "worldSpacePos"
+                              Name 50  "TDSoftShadow(i1;vf3;i1;i1;"
+                              Name 46  "lightIndex"
+                              Name 47  "worldSpacePos"
+                              Name 48  "samples"
+                              Name 49  "steps"
+                              Name 54  "TDSoftShadow(i1;vf3;"
+                              Name 52  "lightIndex"
+                              Name 53  "worldSpacePos"
+                              Name 58  "TDShadow(i1;vf3;"
+                              Name 56  "lightIndex"
+                              Name 57  "worldSpacePos"
+                              Name 64  "iTDRadicalInverse_VdC(u1;"
+                              Name 63  "bits"
+                              Name 70  "iTDHammersley(u1;u1;"
+                              Name 68  "i"
+                              Name 69  "N"
+                              Name 77  "iTDImportanceSampleGGX(vf2;f1;vf3;"
+                              Name 74  "Xi"
+                              Name 75  "roughness2"
+                              Name 76  "N"
+                              Name 83  "iTDDistributionGGX(vf3;vf3;f1;"
+                              Name 80  "normal"
+                              Name 81  "half_vector"
+                              Name 82  "roughness2"
+                              Name 88  "iTDCalcF(vf3;f1;"
+                              Name 86  "F0"
+                              Name 87  "VdotH"
+                              Name 94  "iTDCalcG(f1;f1;f1;"
+                              Name 91  "NdotL"
+                              Name 92  "NdotV"
+                              Name 93  "k"
+                              Name 96  "TDPBRResult"
+                              MemberName 96(TDPBRResult) 0  "diffuse"
+                              MemberName 96(TDPBRResult) 1  "specular"
+                              MemberName 96(TDPBRResult) 2  "shadowStrength"
+                              Name 107  "TDLightingPBR(i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1;"
+                              Name 98  "index"
+                              Name 99  "diffuseColor"
+                              Name 100  "specularColor"
+                              Name 101  "worldSpacePos"
+                              Name 102  "normal"
+                              Name 103  "shadowStrength"
+                              Name 104  "shadowColor"
+                              Name 105  "camVector"
+                              Name 106  "roughness"
+                              Name 122  "TDLightingPBR(vf3;vf3;f1;i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1;"
+                              Name 110  "diffuseContrib"
+                              Name 111  "specularContrib"
+                              Name 112  "shadowStrengthOut"
+                              Name 113  "index"
+                              Name 114  "diffuseColor"
+                              Name 115  "specularColor"
+                              Name 116  "worldSpacePos"
+                              Name 117  "normal"
+                              Name 118  "shadowStrength"
+                              Name 119  "shadowColor"
+                              Name 120  "camVector"
+                              Name 121  "roughness"
+                              Name 136  "TDLightingPBR(vf3;vf3;i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1;"
+                              Name 125  "diffuseContrib"
+                              Name 126  "specularContrib"
+                              Name 127  "index"
+                              Name 128  "diffuseColor"
+                              Name 129  "specularColor"
+                              Name 130  "worldSpacePos"
+                              Name 131  "normal"
+                              Name 132  "shadowStrength"
+                              Name 133  "shadowColor"
+                              Name 134  "camVector"
+                              Name 135  "roughness"
+                              Name 146  "TDEnvLightingPBR(i1;vf3;vf3;vf3;vf3;f1;f1;"
+                              Name 139  "index"
+                              Name 140  "diffuseColor"
+                              Name 141  "specularColor"
+                              Name 142  "normal"
+                              Name 143  "camVector"
+                              Name 144  "roughness"
+                              Name 145  "ambientOcclusion"
+                              Name 158  "TDEnvLightingPBR(vf3;vf3;i1;vf3;vf3;vf3;vf3;f1;f1;"
+                              Name 149  "diffuseContrib"
+                              Name 150  "specularContrib"
+                              Name 151  "index"
+                              Name 152  "diffuseColor"
+                              Name 153  "specularColor"
+                              Name 154  "normal"
+                              Name 155  "camVector"
+                              Name 156  "roughness"
+                              Name 157  "ambientOcclusion"
+                              Name 160  "TDPhongResult"
+                              MemberName 160(TDPhongResult) 0  "diffuse"
+                              MemberName 160(TDPhongResult) 1  "specular"
+                              MemberName 160(TDPhongResult) 2  "specular2"
+                              MemberName 160(TDPhongResult) 3  "shadowStrength"
+                              Name 170  "TDLighting(i1;vf3;vf3;f1;vf3;vf3;f1;f1;"
+                              Name 162  "index"
+                              Name 163  "worldSpacePos"
+                              Name 164  "normal"
+                              Name 165  "shadowStrength"
+                              Name 166  "shadowColor"
+                              Name 167  "camVector"
+                              Name 168  "shininess"
+                              Name 169  "shininess2"
+                              Name 185  "TDLighting(vf3;vf3;vf3;f1;i1;vf3;vf3;f1;vf3;vf3;f1;f1;"
+                              Name 173  "diffuseContrib"
+                              Name 174  "specularContrib"
+                              Name 175  "specularContrib2"
+                              Name 176  "shadowStrengthOut"
+                              Name 177  "index"
+                              Name 178  "worldSpacePos"
+                              Name 179  "normal"
+                              Name 180  "shadowStrength"
+                              Name 181  "shadowColor"
+                              Name 182  "camVector"
+                              Name 183  "shininess"
+                              Name 184  "shininess2"
+                              Name 199  "TDLighting(vf3;vf3;vf3;i1;vf3;vf3;f1;vf3;vf3;f1;f1;"
+                              Name 188  "diffuseContrib"
+                              Name 189  "specularContrib"
+                              Name 190  "specularContrib2"
+                              Name 191  "index"
+                              Name 192  "worldSpacePos"
+                              Name 193  "normal"
+                              Name 194  "shadowStrength"
+                              Name 195  "shadowColor"
+                              Name 196  "camVector"
+                              Name 197  "shininess"
+                              Name 198  "shininess2"
+                              Name 211  "TDLighting(vf3;vf3;i1;vf3;vf3;f1;vf3;vf3;f1;"
+                              Name 202  "diffuseContrib"
+                              Name 203  "specularContrib"
+                              Name 204  "index"
+                              Name 205  "worldSpacePos"
+                              Name 206  "normal"
+                              Name 207  "shadowStrength"
+                              Name 208  "shadowColor"
+                              Name 209  "camVector"
+                              Name 210  "shininess"
+                              Name 223  "TDLighting(vf3;vf3;vf3;i1;vf3;vf3;vf3;f1;f1;"
+                              Name 214  "diffuseContrib"
+                              Name 215  "specularContrib"
+                              Name 216  "specularContrib2"
+                              Name 217  "index"
+                              Name 218  "worldSpacePos"
+                              Name 219  "normal"
+                              Name 220  "camVector"
+                              Name 221  "shininess"
+                              Name 222  "shininess2"
+                              Name 233  "TDLighting(vf3;vf3;i1;vf3;vf3;vf3;f1;"
+                              Name 226  "diffuseContrib"
+                              Name 227  "specularContrib"
+                              Name 228  "index"
+                              Name 229  "worldSpacePos"
+                              Name 230  "normal"
+                              Name 231  "camVector"
+                              Name 232  "shininess"
+                              Name 240  "TDLighting(vf3;i1;vf3;vf3;"
+                              Name 236  "diffuseContrib"
+                              Name 237  "index"
+                              Name 238  "worldSpacePos"
+                              Name 239  "normal"
+                              Name 249  "TDLighting(vf3;i1;vf3;vf3;f1;vf3;"
+                              Name 243  "diffuseContrib"
+                              Name 244  "index"
+                              Name 245  "worldSpacePos"
+                              Name 246  "normal"
+                              Name 247  "shadowStrength"
+                              Name 248  "shadowColor"
+                              Name 255  "TDProjMap(i1;vf3;vf4;"
+                              Name 252  "index"
+                              Name 253  "worldSpacePos"
+                              Name 254  "defaultColor"
+                              Name 261  "TDFog(vf4;vf3;i1;"
+                              Name 258  "color"
+                              Name 259  "lightingSpacePosition"
+                              Name 260  "cameraIndex"
+                              Name 266  "TDFog(vf4;vf3;"
+                              Name 264  "color"
+                              Name 265  "lightingSpacePosition"
+                              Name 271  "TDInstanceTexCoord(i1;vf3;"
+                              Name 269  "index"
+                              Name 270  "t"
+                              Name 275  "TDInstanceActive(i1;"
+                              Name 274  "index"
+                              Name 281  "iTDInstanceTranslate(i1;b1;"
+                              Name 279  "index"
+                              Name 280  "instanceActive"
+                              Name 285  "TDInstanceTranslate(i1;"
+                              Name 284  "index"
+                              Name 290  "TDInstanceRotateMat(i1;"
+                              Name 289  "index"
+                              Name 293  "TDInstanceScale(i1;"
+                              Name 292  "index"
+                              Name 296  "TDInstancePivot(i1;"
+                              Name 295  "index"
+                              Name 299  "TDInstanceRotTo(i1;"
+                              Name 298  "index"
+                              Name 302  "TDInstanceRotUp(i1;"
+                              Name 301  "index"
+                              Name 307  "TDInstanceMat(i1;"
+                              Name 306  "id"
+                              Name 310  "TDInstanceMat3(i1;"
+                              Name 309  "id"
+                              Name 313  "TDInstanceMat3ForNorm(i1;"
+                              Name 312  "id"
+                              Name 318  "TDInstanceColor(i1;vf4;"
+                              Name 316  "index"
+                              Name 317  "curColor"
+                              Name 321  "TDOutputSwizzle(vf4;"
+                              Name 320  "c"
+                              Name 327  "TDOutputSwizzle(vu4;"
+                              Name 326  "c"
+                              Name 330  "outcol"
+                              Name 333  "texCoord0"
+                              Name 334  "Vertex"
+                              MemberName 334(Vertex) 0  "color"
+                              MemberName 334(Vertex) 1  "worldSpacePos"
+                              MemberName 334(Vertex) 2  "texCoord0"
+                              MemberName 334(Vertex) 3  "cameraIndex"
+                              MemberName 334(Vertex) 4  "instance"
+                              Name 336  "iVert"
+                              Name 341  "actualTexZ"
+                              Name 349  "instanceLoop"
+                              Name 359  "colorMapColor"
+                              Name 363  "sColorMap"
+                              Name 367  "red"
+                              Name 374  "gl_DefaultUniformBlock"
+                              MemberName 374(gl_DefaultUniformBlock) 0  "uTDInstanceIDOffset"
+                              MemberName 374(gl_DefaultUniformBlock) 1  "uTDNumInstances"
+                              MemberName 374(gl_DefaultUniformBlock) 2  "uTDAlphaTestVal"
+                              MemberName 374(gl_DefaultUniformBlock) 3  "uConstant"
+                              MemberName 374(gl_DefaultUniformBlock) 4  "uShadowStrength"
+                              MemberName 374(gl_DefaultUniformBlock) 5  "uShadowColor"
+                              MemberName 374(gl_DefaultUniformBlock) 6  "uDiffuseColor"
+                              MemberName 374(gl_DefaultUniformBlock) 7  "uAmbientColor"
+                              Name 376  ""
+                              Name 401  "alpha"
+                              Name 409  "param"
+                              Name 422  "param"
+                              Name 429  "oFragColor"
+                              Name 430  "param"
+                              Name 435  "i"
+                              Name 452  "d"
+                              Name 456  "sTDNoiseMap"
+                              Name 458  "gl_FragCoord"
+                              Name 485  "gl_FrontFacing"
+                              Name 555  "param"
+                              Name 561  "a"
+                              Name 563  "phi"
+                              Name 568  "cosTheta"
+                              Name 582  "sinTheta"
+                              Name 588  "H"
+                              Name 601  "upVector"
+                              Name 612  "tangentX"
+                              Name 617  "tangentY"
+                              Name 621  "worldResult"
+                              Name 639  "NdotH"
+                              Name 645  "alpha2"
+                              Name 649  "denom"
+                              Name 686  "Gl"
+                              Name 694  "Gv"
+                              Name 708  "res"
+                              Name 712  "res"
+                              Name 713  "param"
+                              Name 715  "param"
+                              Name 717  "param"
+                              Name 719  "param"
+                              Name 721  "param"
+                              Name 723  "param"
+                              Name 725  "param"
+                              Name 727  "param"
+                              Name 729  "param"
+                              Name 738  "res"
+                              Name 739  "param"
+                              Name 741  "param"
+                              Name 743  "param"
+                              Name 745  "param"
+                              Name 747  "param"
+                              Name 749  "param"
+                              Name 751  "param"
+                              Name 753  "param"
+                              Name 755  "param"
+                              Name 762  "res"
+                              Name 766  "res"
+                              Name 767  "param"
+                              Name 769  "param"
+                              Name 771  "param"
+                              Name 773  "param"
+                              Name 775  "param"
+                              Name 777  "param"
+                              Name 779  "param"
+                              Name 790  "res"
+                              Name 804  "res"
+                              Name 822  "res"
+                              Name 838  "res"
+                              Name 852  "res"
+                              Name 868  "res"
+                              Name 882  "res"
+                              Name 894  "res"
+                              Name 917  "param"
+                              Name 919  "param"
+                              Name 921  "param"
+                              Name 925  "coord"
+                              Name 927  "samp"
+                              Name 931  "sTDInstanceTexCoord"
+                              Name 936  "v"
+                              Name 955  "coord"
+                              Name 957  "samp"
+                              Name 958  "sTDInstanceT"
+                              Name 963  "v"
+                              Name 970  "origIndex"
+                              Name 976  "coord"
+                              Name 978  "samp"
+                              Name 983  "v"
+                              Name 1003  "coord"
+                              Name 1005  "samp"
+                              Name 1010  "v"
+                              Name 1027  "v"
+                              Name 1029  "m"
+                              Name 1039  "v"
+                              Name 1047  "v"
+                              Name 1055  "v"
+                              Name 1063  "v"
+                              Name 1067  "instanceActive"
+                              Name 1069  "t"
+                              Name 1070  "param"
+                              Name 1072  "param"
+                              Name 1082  "m"
+                              Name 1088  "tt"
+                              Name 1201  "m"
+                              Name 1205  "m"
+                              Name 1206  "param"
+                              Name 1216  "coord"
+                              Name 1218  "samp"
+                              Name 1219  "sTDInstanceColor"
+                              Name 1224  "v"
+                              Name 1253  "TDMatrix"
+                              MemberName 1253(TDMatrix) 0  "world"
+                              MemberName 1253(TDMatrix) 1  "worldInverse"
+                              MemberName 1253(TDMatrix) 2  "worldCam"
+                              MemberName 1253(TDMatrix) 3  "worldCamInverse"
+                              MemberName 1253(TDMatrix) 4  "cam"
+                              MemberName 1253(TDMatrix) 5  "camInverse"
+                              MemberName 1253(TDMatrix) 6  "camProj"
+                              MemberName 1253(TDMatrix) 7  "camProjInverse"
+                              MemberName 1253(TDMatrix) 8  "proj"
+                              MemberName 1253(TDMatrix) 9  "projInverse"
+                              MemberName 1253(TDMatrix) 10  "worldCamProj"
+                              MemberName 1253(TDMatrix) 11  "worldCamProjInverse"
+                              MemberName 1253(TDMatrix) 12  "quadReproject"
+                              MemberName 1253(TDMatrix) 13  "worldForNormals"
+                              MemberName 1253(TDMatrix) 14  "camForNormals"
+                              MemberName 1253(TDMatrix) 15  "worldCamForNormals"
+                              Name 1255  "TDMatricesBlock"
+                              MemberName 1255(TDMatricesBlock) 0  "uTDMats"
+                              Name 1257  ""
+                              Name 1258  "TDCameraInfo"
+                              MemberName 1258(TDCameraInfo) 0  "nearFar"
+                              MemberName 1258(TDCameraInfo) 1  "fog"
+                              MemberName 1258(TDCameraInfo) 2  "fogColor"
+                              MemberName 1258(TDCameraInfo) 3  "renderTOPCameraIndex"
+                              Name 1260  "TDCameraInfoBlock"
+                              MemberName 1260(TDCameraInfoBlock) 0  "uTDCamInfos"
+                              Name 1262  ""
+                              Name 1263  "TDGeneral"
+                              MemberName 1263(TDGeneral) 0  "ambientColor"
+                              MemberName 1263(TDGeneral) 1  "nearFar"
+                              MemberName 1263(TDGeneral) 2  "viewport"
+                              MemberName 1263(TDGeneral) 3  "viewportRes"
+                              MemberName 1263(TDGeneral) 4  "fog"
+                              MemberName 1263(TDGeneral) 5  "fogColor"
+                              Name 1264  "TDGeneralBlock"
+                              MemberName 1264(TDGeneralBlock) 0  "uTDGeneral"
+                              Name 1266  ""
+                              Name 1270  "sTDSineLookup"
+                              Name 1271  "sTDWhite2D"
+                              Name 1275  "sTDWhite3D"
+                              Name 1276  "sTDWhite2DArray"
+                              Name 1280  "sTDWhiteCube"
+                              Name 1281  "TDLight"
+                              MemberName 1281(TDLight) 0  "position"
+                              MemberName 1281(TDLight) 1  "direction"
+                              MemberName 1281(TDLight) 2  "diffuse"
+                              MemberName 1281(TDLight) 3  "nearFar"
+                              MemberName 1281(TDLight) 4  "lightSize"
+                              MemberName 1281(TDLight) 5  "misc"
+                              MemberName 1281(TDLight) 6  "coneLookupScaleBias"
+                              MemberName 1281(TDLight) 7  "attenScaleBiasRoll"
+                              MemberName 1281(TDLight) 8  "shadowMapMatrix"
+                              MemberName 1281(TDLight) 9  "shadowMapCamMatrix"
+                              MemberName 1281(TDLight) 10  "shadowMapRes"
+                              MemberName 1281(TDLight) 11  "projMapMatrix"
+                              Name 1283  "TDLightBlock"
+                              MemberName 1283(TDLightBlock) 0  "uTDLights"
+                              Name 1285  ""
+                              Name 1286  "TDEnvLight"
+                              MemberName 1286(TDEnvLight) 0  "color"
+                              MemberName 1286(TDEnvLight) 1  "rotate"
+                              Name 1288  "TDEnvLightBlock"
+                              MemberName 1288(TDEnvLightBlock) 0  "uTDEnvLights"
+                              Name 1290  ""
+                              Name 1293  "TDEnvLightBuffer"
+                              MemberName 1293(TDEnvLightBuffer) 0  "shCoeffs"
+                              Name 1296  "uTDEnvLightBuffers"
+                              MemberDecorate 334(Vertex) 3 Flat
+                              MemberDecorate 334(Vertex) 4 Flat
+                              Decorate 334(Vertex) Block
+                              Decorate 336(iVert) Location 0
+                              Decorate 363(sColorMap) DescriptorSet 0
+                              Decorate 363(sColorMap) Binding 2
+                              MemberDecorate 374(gl_DefaultUniformBlock) 0 Offset 0
+                              MemberDecorate 374(gl_DefaultUniformBlock) 1 Offset 4
+                              MemberDecorate 374(gl_DefaultUniformBlock) 2 Offset 8
+                              MemberDecorate 374(gl_DefaultUniformBlock) 3 Offset 16
+                              MemberDecorate 374(gl_DefaultUniformBlock) 4 Offset 28
+                              MemberDecorate 374(gl_DefaultUniformBlock) 5 Offset 32
+                              MemberDecorate 374(gl_DefaultUniformBlock) 6 Offset 48
+                              MemberDecorate 374(gl_DefaultUniformBlock) 7 Offset 64
+                              Decorate 374(gl_DefaultUniformBlock) Block
+                              Decorate 376 DescriptorSet 0
+                              Decorate 376 Binding 0
+                              Decorate 429(oFragColor) Location 0
+                              Decorate 456(sTDNoiseMap) DescriptorSet 0
+                              Decorate 456(sTDNoiseMap) Binding 3
+                              Decorate 458(gl_FragCoord) BuiltIn FragCoord
+                              Decorate 485(gl_FrontFacing) BuiltIn FrontFacing
+                              Decorate 931(sTDInstanceTexCoord) DescriptorSet 0
+                              Decorate 931(sTDInstanceTexCoord) Binding 16
+                              Decorate 958(sTDInstanceT) DescriptorSet 0
+                              Decorate 958(sTDInstanceT) Binding 15
+                              Decorate 1219(sTDInstanceColor) DescriptorSet 0
+                              Decorate 1219(sTDInstanceColor) Binding 17
+                              MemberDecorate 1253(TDMatrix) 0 ColMajor
+                              MemberDecorate 1253(TDMatrix) 0 Offset 0
+                              MemberDecorate 1253(TDMatrix) 0 MatrixStride 16
+                              MemberDecorate 1253(TDMatrix) 1 ColMajor
+                              MemberDecorate 1253(TDMatrix) 1 Offset 64
+                              MemberDecorate 1253(TDMatrix) 1 MatrixStride 16
+                              MemberDecorate 1253(TDMatrix) 2 ColMajor
+                              MemberDecorate 1253(TDMatrix) 2 Offset 128
+                              MemberDecorate 1253(TDMatrix) 2 MatrixStride 16
+                              MemberDecorate 1253(TDMatrix) 3 ColMajor
+                              MemberDecorate 1253(TDMatrix) 3 Offset 192
+                              MemberDecorate 1253(TDMatrix) 3 MatrixStride 16
+                              MemberDecorate 1253(TDMatrix) 4 ColMajor
+                              MemberDecorate 1253(TDMatrix) 4 Offset 256
+                              MemberDecorate 1253(TDMatrix) 4 MatrixStride 16
+                              MemberDecorate 1253(TDMatrix) 5 ColMajor
+                              MemberDecorate 1253(TDMatrix) 5 Offset 320
+                              MemberDecorate 1253(TDMatrix) 5 MatrixStride 16
+                              MemberDecorate 1253(TDMatrix) 6 ColMajor
+                              MemberDecorate 1253(TDMatrix) 6 Offset 384
+                              MemberDecorate 1253(TDMatrix) 6 MatrixStride 16
+                              MemberDecorate 1253(TDMatrix) 7 ColMajor
+                              MemberDecorate 1253(TDMatrix) 7 Offset 448
+                              MemberDecorate 1253(TDMatrix) 7 MatrixStride 16
+                              MemberDecorate 1253(TDMatrix) 8 ColMajor
+                              MemberDecorate 1253(TDMatrix) 8 Offset 512
+                              MemberDecorate 1253(TDMatrix) 8 MatrixStride 16
+                              MemberDecorate 1253(TDMatrix) 9 ColMajor
+                              MemberDecorate 1253(TDMatrix) 9 Offset 576
+                              MemberDecorate 1253(TDMatrix) 9 MatrixStride 16
+                              MemberDecorate 1253(TDMatrix) 10 ColMajor
+                              MemberDecorate 1253(TDMatrix) 10 Offset 640
+                              MemberDecorate 1253(TDMatrix) 10 MatrixStride 16
+                              MemberDecorate 1253(TDMatrix) 11 ColMajor
+                              MemberDecorate 1253(TDMatrix) 11 Offset 704
+                              MemberDecorate 1253(TDMatrix) 11 MatrixStride 16
+                              MemberDecorate 1253(TDMatrix) 12 ColMajor
+                              MemberDecorate 1253(TDMatrix) 12 Offset 768
+                              MemberDecorate 1253(TDMatrix) 12 MatrixStride 16
+                              MemberDecorate 1253(TDMatrix) 13 ColMajor
+                              MemberDecorate 1253(TDMatrix) 13 Offset 832
+                              MemberDecorate 1253(TDMatrix) 13 MatrixStride 16
+                              MemberDecorate 1253(TDMatrix) 14 ColMajor
+                              MemberDecorate 1253(TDMatrix) 14 Offset 880
+                              MemberDecorate 1253(TDMatrix) 14 MatrixStride 16
+                              MemberDecorate 1253(TDMatrix) 15 ColMajor
+                              MemberDecorate 1253(TDMatrix) 15 Offset 928
+                              MemberDecorate 1253(TDMatrix) 15 MatrixStride 16
+                              Decorate 1254 ArrayStride 976
+                              MemberDecorate 1255(TDMatricesBlock) 0 Offset 0
+                              Decorate 1255(TDMatricesBlock) Block
+                              Decorate 1257 DescriptorSet 0
+                              Decorate 1257 Binding 1
+                              MemberDecorate 1258(TDCameraInfo) 0 Offset 0
+                              MemberDecorate 1258(TDCameraInfo) 1 Offset 16
+                              MemberDecorate 1258(TDCameraInfo) 2 Offset 32
+                              MemberDecorate 1258(TDCameraInfo) 3 Offset 48
+                              Decorate 1259 ArrayStride 64
+                              MemberDecorate 1260(TDCameraInfoBlock) 0 Offset 0
+                              Decorate 1260(TDCameraInfoBlock) Block
+                              Decorate 1262 DescriptorSet 0
+                              Decorate 1262 Binding 0
+                              MemberDecorate 1263(TDGeneral) 0 Offset 0
+                              MemberDecorate 1263(TDGeneral) 1 Offset 16
+                              MemberDecorate 1263(TDGeneral) 2 Offset 32
+                              MemberDecorate 1263(TDGeneral) 3 Offset 48
+                              MemberDecorate 1263(TDGeneral) 4 Offset 64
+                              MemberDecorate 1263(TDGeneral) 5 Offset 80
+                              MemberDecorate 1264(TDGeneralBlock) 0 Offset 0
+                              Decorate 1264(TDGeneralBlock) Block
+                              Decorate 1266 DescriptorSet 0
+                              Decorate 1266 Binding 0
+                              Decorate 1270(sTDSineLookup) DescriptorSet 0
+                              Decorate 1270(sTDSineLookup) Binding 0
+                              Decorate 1271(sTDWhite2D) DescriptorSet 0
+                              Decorate 1271(sTDWhite2D) Binding 0
+                              Decorate 1275(sTDWhite3D) DescriptorSet 0
+                              Decorate 1275(sTDWhite3D) Binding 0
+                              Decorate 1276(sTDWhite2DArray) DescriptorSet 0
+                              Decorate 1276(sTDWhite2DArray) Binding 0
+                              Decorate 1280(sTDWhiteCube) DescriptorSet 0
+                              Decorate 1280(sTDWhiteCube) Binding 0
+                              MemberDecorate 1281(TDLight) 0 Offset 0
+                              MemberDecorate 1281(TDLight) 1 Offset 16
+                              MemberDecorate 1281(TDLight) 2 Offset 32
+                              MemberDecorate 1281(TDLight) 3 Offset 48
+                              MemberDecorate 1281(TDLight) 4 Offset 64
+                              MemberDecorate 1281(TDLight) 5 Offset 80
+                              MemberDecorate 1281(TDLight) 6 Offset 96
+                              MemberDecorate 1281(TDLight) 7 Offset 112
+                              MemberDecorate 1281(TDLight) 8 ColMajor
+                              MemberDecorate 1281(TDLight) 8 Offset 128
+                              MemberDecorate 1281(TDLight) 8 MatrixStride 16
+                              MemberDecorate 1281(TDLight) 9 ColMajor
+                              MemberDecorate 1281(TDLight) 9 Offset 192
+                              MemberDecorate 1281(TDLight) 9 MatrixStride 16
+                              MemberDecorate 1281(TDLight) 10 Offset 256
+                              MemberDecorate 1281(TDLight) 11 ColMajor
+                              MemberDecorate 1281(TDLight) 11 Offset 272
+                              MemberDecorate 1281(TDLight) 11 MatrixStride 16
+                              Decorate 1282 ArrayStride 336
+                              MemberDecorate 1283(TDLightBlock) 0 Offset 0
+                              Decorate 1283(TDLightBlock) Block
+                              Decorate 1285 DescriptorSet 0
+                              Decorate 1285 Binding 0
+                              MemberDecorate 1286(TDEnvLight) 0 Offset 0
+                              MemberDecorate 1286(TDEnvLight) 1 ColMajor
+                              MemberDecorate 1286(TDEnvLight) 1 Offset 16
+                              MemberDecorate 1286(TDEnvLight) 1 MatrixStride 16
+                              Decorate 1287 ArrayStride 64
+                              MemberDecorate 1288(TDEnvLightBlock) 0 Offset 0
+                              Decorate 1288(TDEnvLightBlock) Block
+                              Decorate 1290 DescriptorSet 0
+                              Decorate 1290 Binding 0
+                              Decorate 1292 ArrayStride 16
+                              MemberDecorate 1293(TDEnvLightBuffer) 0 Restrict
+                              MemberDecorate 1293(TDEnvLightBuffer) 0 NonWritable
+                              MemberDecorate 1293(TDEnvLightBuffer) 0 Offset 0
+                              Decorate 1293(TDEnvLightBuffer) BufferBlock
+                              Decorate 1296(uTDEnvLightBuffers) DescriptorSet 0
+                              Decorate 1296(uTDEnvLightBuffers) Binding 0
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeFloat 32
+               7:             TypeVector 6(float) 4
+               8:             TypePointer Function 7(fvec4)
+               9:             TypeFunction 7(fvec4) 8(ptr)
+              20:             TypeVector 6(float) 3
+              21:             TypePointer Function 20(fvec3)
+              22:             TypeBool
+              23:             TypeFunction 22(bool) 21(ptr) 21(ptr)
+              28:             TypeInt 32 1
+              29:             TypePointer Function 28(int)
+              30:             TypePointer Function 6(float)
+              31:             TypeFunction 6(float) 29(ptr) 30(ptr)
+              36:             TypeFunction 2 30(ptr)
+              40:             TypeFunction 6(float) 29(ptr) 21(ptr)
+              45:             TypeFunction 6(float) 29(ptr) 21(ptr) 29(ptr) 29(ptr)
+              60:             TypeInt 32 0
+              61:             TypePointer Function 60(int)
+              62:             TypeFunction 6(float) 61(ptr)
+              66:             TypeVector 6(float) 2
+              67:             TypeFunction 66(fvec2) 61(ptr) 61(ptr)
+              72:             TypePointer Function 66(fvec2)
+              73:             TypeFunction 20(fvec3) 72(ptr) 30(ptr) 21(ptr)
+              79:             TypeFunction 6(float) 21(ptr) 21(ptr) 30(ptr)
+              85:             TypeFunction 20(fvec3) 21(ptr) 30(ptr)
+              90:             TypeFunction 6(float) 30(ptr) 30(ptr) 30(ptr)
+ 96(TDPBRResult):             TypeStruct 20(fvec3) 20(fvec3) 6(float)
+              97:             TypeFunction 96(TDPBRResult) 29(ptr) 21(ptr) 21(ptr) 21(ptr) 21(ptr) 30(ptr) 21(ptr) 21(ptr) 30(ptr)
+             109:             TypeFunction 2 21(ptr) 21(ptr) 30(ptr) 29(ptr) 21(ptr) 21(ptr) 21(ptr) 21(ptr) 30(ptr) 21(ptr) 21(ptr) 30(ptr)
+             124:             TypeFunction 2 21(ptr) 21(ptr) 29(ptr) 21(ptr) 21(ptr) 21(ptr) 21(ptr) 30(ptr) 21(ptr) 21(ptr) 30(ptr)
+             138:             TypeFunction 96(TDPBRResult) 29(ptr) 21(ptr) 21(ptr) 21(ptr) 21(ptr) 30(ptr) 30(ptr)
+             148:             TypeFunction 2 21(ptr) 21(ptr) 29(ptr) 21(ptr) 21(ptr) 21(ptr) 21(ptr) 30(ptr) 30(ptr)
+160(TDPhongResult):             TypeStruct 20(fvec3) 20(fvec3) 20(fvec3) 6(float)
+             161:             TypeFunction 160(TDPhongResult) 29(ptr) 21(ptr) 21(ptr) 30(ptr) 21(ptr) 21(ptr) 30(ptr) 30(ptr)
+             172:             TypeFunction 2 21(ptr) 21(ptr) 21(ptr) 30(ptr) 29(ptr) 21(ptr) 21(ptr) 30(ptr) 21(ptr) 21(ptr) 30(ptr) 30(ptr)
+             187:             TypeFunction 2 21(ptr) 21(ptr) 21(ptr) 29(ptr) 21(ptr) 21(ptr) 30(ptr) 21(ptr) 21(ptr) 30(ptr) 30(ptr)
+             201:             TypeFunction 2 21(ptr) 21(ptr) 29(ptr) 21(ptr) 21(ptr) 30(ptr) 21(ptr) 21(ptr) 30(ptr)
+             213:             TypeFunction 2 21(ptr) 21(ptr) 21(ptr) 29(ptr) 21(ptr) 21(ptr) 21(ptr) 30(ptr) 30(ptr)
+             225:             TypeFunction 2 21(ptr) 21(ptr) 29(ptr) 21(ptr) 21(ptr) 21(ptr) 30(ptr)
+             235:             TypeFunction 2 21(ptr) 29(ptr) 21(ptr) 21(ptr)
+             242:             TypeFunction 2 21(ptr) 29(ptr) 21(ptr) 21(ptr) 30(ptr) 21(ptr)
+             251:             TypeFunction 7(fvec4) 29(ptr) 21(ptr) 8(ptr)
+             257:             TypeFunction 7(fvec4) 8(ptr) 21(ptr) 29(ptr)
+             263:             TypeFunction 7(fvec4) 8(ptr) 21(ptr)
+             268:             TypeFunction 20(fvec3) 29(ptr) 21(ptr)
+             273:             TypeFunction 22(bool) 29(ptr)
+             277:             TypePointer Function 22(bool)
+             278:             TypeFunction 20(fvec3) 29(ptr) 277(ptr)
+             283:             TypeFunction 20(fvec3) 29(ptr)
+             287:             TypeMatrix 20(fvec3) 3
+             288:             TypeFunction 287 29(ptr)
+             304:             TypeMatrix 7(fvec4) 4
+             305:             TypeFunction 304 29(ptr)
+             315:             TypeFunction 7(fvec4) 29(ptr) 8(ptr)
+             323:             TypeVector 60(int) 4
+             324:             TypePointer Function 323(ivec4)
+             325:             TypeFunction 323(ivec4) 324(ptr)
+             331:    6(float) Constant 0
+             332:    7(fvec4) ConstantComposite 331 331 331 331
+     334(Vertex):             TypeStruct 7(fvec4) 20(fvec3) 20(fvec3) 28(int) 28(int)
+             335:             TypePointer Input 334(Vertex)
+      336(iVert):    335(ptr) Variable Input
+             337:     28(int) Constant 2
+             338:             TypePointer Input 20(fvec3)
+             342:     60(int) Constant 2
+             347:    6(float) Constant 1157627904
+             353:     28(int) Constant 2048
+             360:             TypeImage 6(float) 2D array sampled format:Unknown
+             361:             TypeSampledImage 360
+             362:             TypePointer UniformConstant 361
+  363(sColorMap):    362(ptr) Variable UniformConstant
+374(gl_DefaultUniformBlock):             TypeStruct 28(int) 28(int) 6(float) 20(fvec3) 6(float) 20(fvec3) 7(fvec4) 7(fvec4)
+             375:             TypePointer Uniform 374(gl_DefaultUniformBlock)
+             376:    375(ptr) Variable Uniform
+             377:     28(int) Constant 3
+             378:             TypePointer Uniform 20(fvec3)
+             381:     28(int) Constant 0
+             382:             TypePointer Input 7(fvec4)
+             390:     60(int) Constant 0
+             393:     60(int) Constant 1
+             402:     60(int) Constant 3
+             403:             TypePointer Input 6(float)
+             427:             TypeArray 7(fvec4) 393
+             428:             TypePointer Output 427
+ 429(oFragColor):    428(ptr) Variable Output
+             433:             TypePointer Output 7(fvec4)
+             436:     28(int) Constant 1
+             453:             TypeImage 6(float) 2D sampled format:Unknown
+             454:             TypeSampledImage 453
+             455:             TypePointer UniformConstant 454
+456(sTDNoiseMap):    455(ptr) Variable UniformConstant
+458(gl_FragCoord):    382(ptr) Variable Input
+             461:    6(float) Constant 1132462080
+             466:    6(float) Constant 1056964608
+             484:             TypePointer Input 22(bool)
+485(gl_FrontFacing):    484(ptr) Variable Input
+             489:    6(float) Constant 1065353216
+             501:     60(int) Constant 16
+             507:     60(int) Constant 1431655765
+             511:     60(int) Constant 2863311530
+             516:     60(int) Constant 858993459
+             520:     60(int) Constant 3435973836
+             525:     60(int) Constant 252645135
+             527:     60(int) Constant 4
+             530:     60(int) Constant 4042322160
+             535:     60(int) Constant 16711935
+             537:     60(int) Constant 8
+             540:     60(int) Constant 4278255360
+             546:    6(float) Constant 796917760
+             564:    6(float) Constant 1086918619
+             605:    6(float) Constant 1065336439
+             607:   20(fvec3) ConstantComposite 331 331 489
+             608:   20(fvec3) ConstantComposite 489 331 331
+             609:             TypeVector 22(bool) 3
+             643:    6(float) Constant 897988541
+             657:    6(float) Constant 841731191
+             661:    6(float) Constant 1078530011
+             670:   20(fvec3) ConstantComposite 489 489 489
+             673:    6(float) Constant 1073741824
+             674:    6(float) Constant 3232874585
+             677:    6(float) Constant 1088386572
+             707:             TypePointer Function 96(TDPBRResult)
+             789:             TypePointer Function 160(TDPhongResult)
+             791:   20(fvec3) ConstantComposite 331 331 331
+             928:             TypeImage 6(float) Buffer sampled format:Unknown
+             929:             TypeSampledImage 928
+             930:             TypePointer UniformConstant 929
+931(sTDInstanceTexCoord):    930(ptr) Variable UniformConstant
+             950:             TypePointer Uniform 28(int)
+958(sTDInstanceT):    930(ptr) Variable UniformConstant
+            1028:             TypePointer Function 287
+            1030:   20(fvec3) ConstantComposite 331 489 331
+            1031:         287 ConstantComposite 608 1030 607
+            1068:    22(bool) ConstantTrue
+            1079:         304 ConstantComposite 332 332 332 332
+            1081:             TypePointer Function 304
+            1083:    7(fvec4) ConstantComposite 489 331 331 331
+            1084:    7(fvec4) ConstantComposite 331 489 331 331
+            1085:    7(fvec4) ConstantComposite 331 331 489 331
+            1086:    7(fvec4) ConstantComposite 331 331 331 489
+            1087:         304 ConstantComposite 1083 1084 1085 1086
+1219(sTDInstanceColor):    930(ptr) Variable UniformConstant
+  1253(TDMatrix):             TypeStruct 304 304 304 304 304 304 304 304 304 304 304 304 304 287 287 287
+            1254:             TypeArray 1253(TDMatrix) 393
+1255(TDMatricesBlock):             TypeStruct 1254
+            1256:             TypePointer Uniform 1255(TDMatricesBlock)
+            1257:   1256(ptr) Variable Uniform
+1258(TDCameraInfo):             TypeStruct 7(fvec4) 7(fvec4) 7(fvec4) 28(int)
+            1259:             TypeArray 1258(TDCameraInfo) 393
+1260(TDCameraInfoBlock):             TypeStruct 1259
+            1261:             TypePointer Uniform 1260(TDCameraInfoBlock)
+            1262:   1261(ptr) Variable Uniform
+ 1263(TDGeneral):             TypeStruct 7(fvec4) 7(fvec4) 7(fvec4) 7(fvec4) 7(fvec4) 7(fvec4)
+1264(TDGeneralBlock):             TypeStruct 1263(TDGeneral)
+            1265:             TypePointer Uniform 1264(TDGeneralBlock)
+            1266:   1265(ptr) Variable Uniform
+            1267:             TypeImage 6(float) 1D sampled format:Unknown
+            1268:             TypeSampledImage 1267
+            1269:             TypePointer UniformConstant 1268
+1270(sTDSineLookup):   1269(ptr) Variable UniformConstant
+1271(sTDWhite2D):    455(ptr) Variable UniformConstant
+            1272:             TypeImage 6(float) 3D sampled format:Unknown
+            1273:             TypeSampledImage 1272
+            1274:             TypePointer UniformConstant 1273
+1275(sTDWhite3D):   1274(ptr) Variable UniformConstant
+1276(sTDWhite2DArray):    362(ptr) Variable UniformConstant
+            1277:             TypeImage 6(float) Cube sampled format:Unknown
+            1278:             TypeSampledImage 1277
+            1279:             TypePointer UniformConstant 1278
+1280(sTDWhiteCube):   1279(ptr) Variable UniformConstant
+   1281(TDLight):             TypeStruct 7(fvec4) 20(fvec3) 20(fvec3) 7(fvec4) 7(fvec4) 7(fvec4) 7(fvec4) 7(fvec4) 304 304 7(fvec4) 304
+            1282:             TypeArray 1281(TDLight) 393
+1283(TDLightBlock):             TypeStruct 1282
+            1284:             TypePointer Uniform 1283(TDLightBlock)
+            1285:   1284(ptr) Variable Uniform
+1286(TDEnvLight):             TypeStruct 20(fvec3) 287
+            1287:             TypeArray 1286(TDEnvLight) 393
+1288(TDEnvLightBlock):             TypeStruct 1287
+            1289:             TypePointer Uniform 1288(TDEnvLightBlock)
+            1290:   1289(ptr) Variable Uniform
+            1291:     60(int) Constant 9
+            1292:             TypeArray 20(fvec3) 1291
+1293(TDEnvLightBuffer):             TypeStruct 1292
+            1294:             TypeArray 1293(TDEnvLightBuffer) 393
+            1295:             TypePointer Uniform 1294
+1296(uTDEnvLightBuffers):   1295(ptr) Variable Uniform
+         4(main):           2 Function None 3
+               5:             Label
+     330(outcol):      8(ptr) Variable Function
+  333(texCoord0):     21(ptr) Variable Function
+ 341(actualTexZ):     30(ptr) Variable Function
+349(instanceLoop):     30(ptr) Variable Function
+359(colorMapColor):      8(ptr) Variable Function
+        367(red):     30(ptr) Variable Function
+      401(alpha):     30(ptr) Variable Function
+      409(param):      8(ptr) Variable Function
+      422(param):     30(ptr) Variable Function
+      430(param):      8(ptr) Variable Function
+          435(i):     29(ptr) Variable Function
+             329:           2 FunctionCall 15(TDCheckDiscard()
+                              Store 330(outcol) 332
+             339:    338(ptr) AccessChain 336(iVert) 337
+             340:   20(fvec3) Load 339
+                              Store 333(texCoord0) 340
+             343:     30(ptr) AccessChain 333(texCoord0) 342
+             344:    6(float) Load 343
+             345:     28(int) ConvertFToS 344
+             346:    6(float) ConvertSToF 345
+             348:    6(float) FMod 346 347
+                              Store 341(actualTexZ) 348
+             350:     30(ptr) AccessChain 333(texCoord0) 342
+             351:    6(float) Load 350
+             352:     28(int) ConvertFToS 351
+             354:     28(int) SDiv 352 353
+             355:    6(float) ConvertSToF 354
+             356:    6(float) ExtInst 1(GLSL.std.450) 8(Floor) 355
+                              Store 349(instanceLoop) 356
+             357:    6(float) Load 341(actualTexZ)
+             358:     30(ptr) AccessChain 333(texCoord0) 342
+                              Store 358 357
+             364:         361 Load 363(sColorMap)
+             365:   20(fvec3) Load 333(texCoord0)
+             366:    7(fvec4) ImageSampleImplicitLod 364 365
+                              Store 359(colorMapColor) 366
+             368:    6(float) Load 349(instanceLoop)
+             369:     28(int) ConvertFToS 368
+             370:     30(ptr) AccessChain 359(colorMapColor) 369
+             371:    6(float) Load 370
+                              Store 367(red) 371
+             372:    6(float) Load 367(red)
+             373:    7(fvec4) CompositeConstruct 372 372 372 372
+                              Store 359(colorMapColor) 373
+             379:    378(ptr) AccessChain 376 377
+             380:   20(fvec3) Load 379
+             383:    382(ptr) AccessChain 336(iVert) 381
+             384:    7(fvec4) Load 383
+             385:   20(fvec3) VectorShuffle 384 384 0 1 2
+             386:   20(fvec3) FMul 380 385
+             387:    7(fvec4) Load 330(outcol)
+             388:   20(fvec3) VectorShuffle 387 387 0 1 2
+             389:   20(fvec3) FAdd 388 386
+             391:     30(ptr) AccessChain 330(outcol) 390
+             392:    6(float) CompositeExtract 389 0
+                              Store 391 392
+             394:     30(ptr) AccessChain 330(outcol) 393
+             395:    6(float) CompositeExtract 389 1
+                              Store 394 395
+             396:     30(ptr) AccessChain 330(outcol) 342
+             397:    6(float) CompositeExtract 389 2
+                              Store 396 397
+             398:    7(fvec4) Load 359(colorMapColor)
+             399:    7(fvec4) Load 330(outcol)
+             400:    7(fvec4) FMul 399 398
+                              Store 330(outcol) 400
+             404:    403(ptr) AccessChain 336(iVert) 381 402
+             405:    6(float) Load 404
+             406:     30(ptr) AccessChain 359(colorMapColor) 402
+             407:    6(float) Load 406
+             408:    6(float) FMul 405 407
+                              Store 401(alpha) 408
+             410:    7(fvec4) Load 330(outcol)
+                              Store 409(param) 410
+             411:    7(fvec4) FunctionCall 18(TDDither(vf4;) 409(param)
+                              Store 330(outcol) 411
+             412:    6(float) Load 401(alpha)
+             413:    7(fvec4) Load 330(outcol)
+             414:   20(fvec3) VectorShuffle 413 413 0 1 2
+             415:   20(fvec3) VectorTimesScalar 414 412
+             416:     30(ptr) AccessChain 330(outcol) 390
+             417:    6(float) CompositeExtract 415 0
+                              Store 416 417
+             418:     30(ptr) AccessChain 330(outcol) 393
+             419:    6(float) CompositeExtract 415 1
+                              Store 418 419
+             420:     30(ptr) AccessChain 330(outcol) 342
+             421:    6(float) CompositeExtract 415 2
+                              Store 420 421
+             423:    6(float) Load 401(alpha)
+                              Store 422(param) 423
+             424:           2 FunctionCall 38(TDAlphaTest(f1;) 422(param)
+             425:    6(float) Load 401(alpha)
+             426:     30(ptr) AccessChain 330(outcol) 402
+                              Store 426 425
+             431:    7(fvec4) Load 330(outcol)
+                              Store 430(param) 431
+             432:    7(fvec4) FunctionCall 321(TDOutputSwizzle(vf4;) 430(param)
+             434:    433(ptr) AccessChain 429(oFragColor) 381
+                              Store 434 432
+                              Store 435(i) 436
+                              Branch 437
+             437:             Label
+                              LoopMerge 439 440 None
+                              Branch 441
+             441:             Label
+             442:     28(int) Load 435(i)
+             443:    22(bool) SLessThan 442 436
+                              BranchConditional 443 438 439
+             438:               Label
+             444:     28(int)   Load 435(i)
+             445:    433(ptr)   AccessChain 429(oFragColor) 444
+                                Store 445 332
+                                Branch 440
+             440:               Label
+             446:     28(int)   Load 435(i)
+             447:     28(int)   IAdd 446 436
+                                Store 435(i) 447
+                                Branch 437
+             439:             Label
+                              Return
+                              FunctionEnd
+11(TDColor(vf4;):    7(fvec4) Function None 9
+       10(color):      8(ptr) FunctionParameter
+              12:             Label
+             448:    7(fvec4) Load 10(color)
+                              ReturnValue 448
+                              FunctionEnd
+13(TDCheckOrderIndTrans():           2 Function None 3
+              14:             Label
+                              Return
+                              FunctionEnd
+15(TDCheckDiscard():           2 Function None 3
+              16:             Label
+             451:           2 FunctionCall 13(TDCheckOrderIndTrans()
+                              Return
+                              FunctionEnd
+18(TDDither(vf4;):    7(fvec4) Function None 9
+       17(color):      8(ptr) FunctionParameter
+              19:             Label
+          452(d):     30(ptr) Variable Function
+             457:         454 Load 456(sTDNoiseMap)
+             459:    7(fvec4) Load 458(gl_FragCoord)
+             460:   66(fvec2) VectorShuffle 459 459 0 1
+             462:   66(fvec2) CompositeConstruct 461 461
+             463:   66(fvec2) FDiv 460 462
+             464:    7(fvec4) ImageSampleImplicitLod 457 463
+             465:    6(float) CompositeExtract 464 0
+                              Store 452(d) 465
+             467:    6(float) Load 452(d)
+             468:    6(float) FSub 467 466
+                              Store 452(d) 468
+             469:    6(float) Load 452(d)
+             470:    6(float) FDiv 469 461
+                              Store 452(d) 470
+             471:    7(fvec4) Load 17(color)
+             472:   20(fvec3) VectorShuffle 471 471 0 1 2
+             473:    6(float) Load 452(d)
+             474:   20(fvec3) CompositeConstruct 473 473 473
+             475:   20(fvec3) FAdd 472 474
+             476:     30(ptr) AccessChain 17(color) 402
+             477:    6(float) Load 476
+             478:    6(float) CompositeExtract 475 0
+             479:    6(float) CompositeExtract 475 1
+             480:    6(float) CompositeExtract 475 2
+             481:    7(fvec4) CompositeConstruct 478 479 480 477
+                              ReturnValue 481
+                              FunctionEnd
+26(TDFrontFacing(vf3;vf3;):    22(bool) Function None 23
+         24(pos):     21(ptr) FunctionParameter
+      25(normal):     21(ptr) FunctionParameter
+              27:             Label
+             486:    22(bool) Load 485(gl_FrontFacing)
+                              ReturnValue 486
+                              FunctionEnd
+34(TDAttenuateLight(i1;f1;):    6(float) Function None 31
+       32(index):     29(ptr) FunctionParameter
+   33(lightDist):     30(ptr) FunctionParameter
+              35:             Label
+                              ReturnValue 489
+                              FunctionEnd
+38(TDAlphaTest(f1;):           2 Function None 36
+       37(alpha):     30(ptr) FunctionParameter
+              39:             Label
+                              Return
+                              FunctionEnd
+43(TDHardShadow(i1;vf3;):    6(float) Function None 40
+  41(lightIndex):     29(ptr) FunctionParameter
+42(worldSpacePos):     21(ptr) FunctionParameter
+              44:             Label
+                              ReturnValue 331
+                              FunctionEnd
+50(TDSoftShadow(i1;vf3;i1;i1;):    6(float) Function None 45
+  46(lightIndex):     29(ptr) FunctionParameter
+47(worldSpacePos):     21(ptr) FunctionParameter
+     48(samples):     29(ptr) FunctionParameter
+       49(steps):     29(ptr) FunctionParameter
+              51:             Label
+                              ReturnValue 331
+                              FunctionEnd
+54(TDSoftShadow(i1;vf3;):    6(float) Function None 40
+  52(lightIndex):     29(ptr) FunctionParameter
+53(worldSpacePos):     21(ptr) FunctionParameter
+              55:             Label
+                              ReturnValue 331
+                              FunctionEnd
+58(TDShadow(i1;vf3;):    6(float) Function None 40
+  56(lightIndex):     29(ptr) FunctionParameter
+57(worldSpacePos):     21(ptr) FunctionParameter
+              59:             Label
+                              ReturnValue 331
+                              FunctionEnd
+64(iTDRadicalInverse_VdC(u1;):    6(float) Function None 62
+        63(bits):     61(ptr) FunctionParameter
+              65:             Label
+             500:     60(int) Load 63(bits)
+             502:     60(int) ShiftLeftLogical 500 501
+             503:     60(int) Load 63(bits)
+             504:     60(int) ShiftRightLogical 503 501
+             505:     60(int) BitwiseOr 502 504
+                              Store 63(bits) 505
+             506:     60(int) Load 63(bits)
+             508:     60(int) BitwiseAnd 506 507
+             509:     60(int) ShiftLeftLogical 508 393
+             510:     60(int) Load 63(bits)
+             512:     60(int) BitwiseAnd 510 511
+             513:     60(int) ShiftRightLogical 512 393
+             514:     60(int) BitwiseOr 509 513
+                              Store 63(bits) 514
+             515:     60(int) Load 63(bits)
+             517:     60(int) BitwiseAnd 515 516
+             518:     60(int) ShiftLeftLogical 517 342
+             519:     60(int) Load 63(bits)
+             521:     60(int) BitwiseAnd 519 520
+             522:     60(int) ShiftRightLogical 521 342
+             523:     60(int) BitwiseOr 518 522
+                              Store 63(bits) 523
+             524:     60(int) Load 63(bits)
+             526:     60(int) BitwiseAnd 524 525
+             528:     60(int) ShiftLeftLogical 526 527
+             529:     60(int) Load 63(bits)
+             531:     60(int) BitwiseAnd 529 530
+             532:     60(int) ShiftRightLogical 531 527
+             533:     60(int) BitwiseOr 528 532
+                              Store 63(bits) 533
+             534:     60(int) Load 63(bits)
+             536:     60(int) BitwiseAnd 534 535
+             538:     60(int) ShiftLeftLogical 536 537
+             539:     60(int) Load 63(bits)
+             541:     60(int) BitwiseAnd 539 540
+             542:     60(int) ShiftRightLogical 541 537
+             543:     60(int) BitwiseOr 538 542
+                              Store 63(bits) 543
+             544:     60(int) Load 63(bits)
+             545:    6(float) ConvertUToF 544
+             547:    6(float) FMul 545 546
+                              ReturnValue 547
+                              FunctionEnd
+70(iTDHammersley(u1;u1;):   66(fvec2) Function None 67
+           68(i):     61(ptr) FunctionParameter
+           69(N):     61(ptr) FunctionParameter
+              71:             Label
+      555(param):     61(ptr) Variable Function
+             550:     60(int) Load 68(i)
+             551:    6(float) ConvertUToF 550
+             552:     60(int) Load 69(N)
+             553:    6(float) ConvertUToF 552
+             554:    6(float) FDiv 551 553
+             556:     60(int) Load 68(i)
+                              Store 555(param) 556
+             557:    6(float) FunctionCall 64(iTDRadicalInverse_VdC(u1;) 555(param)
+             558:   66(fvec2) CompositeConstruct 554 557
+                              ReturnValue 558
+                              FunctionEnd
+77(iTDImportanceSampleGGX(vf2;f1;vf3;):   20(fvec3) Function None 73
+          74(Xi):     72(ptr) FunctionParameter
+  75(roughness2):     30(ptr) FunctionParameter
+           76(N):     21(ptr) FunctionParameter
+              78:             Label
+          561(a):     30(ptr) Variable Function
+        563(phi):     30(ptr) Variable Function
+   568(cosTheta):     30(ptr) Variable Function
+   582(sinTheta):     30(ptr) Variable Function
+          588(H):     21(ptr) Variable Function
+   601(upVector):     21(ptr) Variable Function
+   612(tangentX):     21(ptr) Variable Function
+   617(tangentY):     21(ptr) Variable Function
+621(worldResult):     21(ptr) Variable Function
+             562:    6(float) Load 75(roughness2)
+                              Store 561(a) 562
+             565:     30(ptr) AccessChain 74(Xi) 390
+             566:    6(float) Load 565
+             567:    6(float) FMul 564 566
+                              Store 563(phi) 567
+             569:     30(ptr) AccessChain 74(Xi) 393
+             570:    6(float) Load 569
+             571:    6(float) FSub 489 570
+             572:    6(float) Load 561(a)
+             573:    6(float) Load 561(a)
+             574:    6(float) FMul 572 573
+             575:    6(float) FSub 574 489
+             576:     30(ptr) AccessChain 74(Xi) 393
+             577:    6(float) Load 576
+             578:    6(float) FMul 575 577
+             579:    6(float) FAdd 489 578
+             580:    6(float) FDiv 571 579
+             581:    6(float) ExtInst 1(GLSL.std.450) 31(Sqrt) 580
+                              Store 568(cosTheta) 581
+             583:    6(float) Load 568(cosTheta)
+             584:    6(float) Load 568(cosTheta)
+             585:    6(float) FMul 583 584
+             586:    6(float) FSub 489 585
+             587:    6(float) ExtInst 1(GLSL.std.450) 31(Sqrt) 586
+                              Store 582(sinTheta) 587
+             589:    6(float) Load 582(sinTheta)
+             590:    6(float) Load 563(phi)
+             591:    6(float) ExtInst 1(GLSL.std.450) 14(Cos) 590
+             592:    6(float) FMul 589 591
+             593:     30(ptr) AccessChain 588(H) 390
+                              Store 593 592
+             594:    6(float) Load 582(sinTheta)
+             595:    6(float) Load 563(phi)
+             596:    6(float) ExtInst 1(GLSL.std.450) 13(Sin) 595
+             597:    6(float) FMul 594 596
+             598:     30(ptr) AccessChain 588(H) 393
+                              Store 598 597
+             599:    6(float) Load 568(cosTheta)
+             600:     30(ptr) AccessChain 588(H) 342
+                              Store 600 599
+             602:     30(ptr) AccessChain 76(N) 342
+             603:    6(float) Load 602
+             604:    6(float) ExtInst 1(GLSL.std.450) 4(FAbs) 603
+             606:    22(bool) FOrdLessThan 604 605
+             610:  609(bvec3) CompositeConstruct 606 606 606
+             611:   20(fvec3) Select 610 607 608
+                              Store 601(upVector) 611
+             613:   20(fvec3) Load 601(upVector)
+             614:   20(fvec3) Load 76(N)
+             615:   20(fvec3) ExtInst 1(GLSL.std.450) 68(Cross) 613 614
+             616:   20(fvec3) ExtInst 1(GLSL.std.450) 69(Normalize) 615
+                              Store 612(tangentX) 616
+             618:   20(fvec3) Load 76(N)
+             619:   20(fvec3) Load 612(tangentX)
+             620:   20(fvec3) ExtInst 1(GLSL.std.450) 68(Cross) 618 619
+                              Store 617(tangentY) 620
+             622:   20(fvec3) Load 612(tangentX)
+             623:     30(ptr) AccessChain 588(H) 390
+             624:    6(float) Load 623
+             625:   20(fvec3) VectorTimesScalar 622 624
+             626:   20(fvec3) Load 617(tangentY)
+             627:     30(ptr) AccessChain 588(H) 393
+             628:    6(float) Load 627
+             629:   20(fvec3) VectorTimesScalar 626 628
+             630:   20(fvec3) FAdd 625 629
+             631:   20(fvec3) Load 76(N)
+             632:     30(ptr) AccessChain 588(H) 342
+             633:    6(float) Load 632
+             634:   20(fvec3) VectorTimesScalar 631 633
+             635:   20(fvec3) FAdd 630 634
+                              Store 621(worldResult) 635
+             636:   20(fvec3) Load 621(worldResult)
+                              ReturnValue 636
+                              FunctionEnd
+83(iTDDistributionGGX(vf3;vf3;f1;):    6(float) Function None 79
+      80(normal):     21(ptr) FunctionParameter
+ 81(half_vector):     21(ptr) FunctionParameter
+  82(roughness2):     30(ptr) FunctionParameter
+              84:             Label
+      639(NdotH):     30(ptr) Variable Function
+     645(alpha2):     30(ptr) Variable Function
+      649(denom):     30(ptr) Variable Function
+             640:   20(fvec3) Load 80(normal)
+             641:   20(fvec3) Load 81(half_vector)
+             642:    6(float) Dot 640 641
+             644:    6(float) ExtInst 1(GLSL.std.450) 43(FClamp) 642 643 489
+                              Store 639(NdotH) 644
+             646:    6(float) Load 82(roughness2)
+             647:    6(float) Load 82(roughness2)
+             648:    6(float) FMul 646 647
+                              Store 645(alpha2) 648
+             650:    6(float) Load 639(NdotH)
+             651:    6(float) Load 639(NdotH)
+             652:    6(float) FMul 650 651
+             653:    6(float) Load 645(alpha2)
+             654:    6(float) FSub 653 489
+             655:    6(float) FMul 652 654
+             656:    6(float) FAdd 655 489
+                              Store 649(denom) 656
+             658:    6(float) Load 649(denom)
+             659:    6(float) ExtInst 1(GLSL.std.450) 40(FMax) 657 658
+                              Store 649(denom) 659
+             660:    6(float) Load 645(alpha2)
+             662:    6(float) Load 649(denom)
+             663:    6(float) FMul 661 662
+             664:    6(float) Load 649(denom)
+             665:    6(float) FMul 663 664
+             666:    6(float) FDiv 660 665
+                              ReturnValue 666
+                              FunctionEnd
+88(iTDCalcF(vf3;f1;):   20(fvec3) Function None 85
+          86(F0):     21(ptr) FunctionParameter
+       87(VdotH):     30(ptr) FunctionParameter
+              89:             Label
+             669:   20(fvec3) Load 86(F0)
+             671:   20(fvec3) Load 86(F0)
+             672:   20(fvec3) FSub 670 671
+             675:    6(float) Load 87(VdotH)
+             676:    6(float) FMul 674 675
+             678:    6(float) FSub 676 677
+             679:    6(float) Load 87(VdotH)
+             680:    6(float) FMul 678 679
+             681:    6(float) ExtInst 1(GLSL.std.450) 26(Pow) 673 680
+             682:   20(fvec3) VectorTimesScalar 672 681
+             683:   20(fvec3) FAdd 669 682
+                              ReturnValue 683
+                              FunctionEnd
+94(iTDCalcG(f1;f1;f1;):    6(float) Function None 90
+       91(NdotL):     30(ptr) FunctionParameter
+       92(NdotV):     30(ptr) FunctionParameter
+           93(k):     30(ptr) FunctionParameter
+              95:             Label
+         686(Gl):     30(ptr) Variable Function
+         694(Gv):     30(ptr) Variable Function
+             687:    6(float) Load 91(NdotL)
+             688:    6(float) Load 93(k)
+             689:    6(float) FSub 489 688
+             690:    6(float) FMul 687 689
+             691:    6(float) Load 93(k)
+             692:    6(float) FAdd 690 691
+             693:    6(float) FDiv 489 692
+                              Store 686(Gl) 693
+             695:    6(float) Load 92(NdotV)
+             696:    6(float) Load 93(k)
+             697:    6(float) FSub 489 696
+             698:    6(float) FMul 695 697
+             699:    6(float) Load 93(k)
+             700:    6(float) FAdd 698 699
+             701:    6(float) FDiv 489 700
+                              Store 694(Gv) 701
+             702:    6(float) Load 686(Gl)
+             703:    6(float) Load 694(Gv)
+             704:    6(float) FMul 702 703
+                              ReturnValue 704
+                              FunctionEnd
+107(TDLightingPBR(i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1;):96(TDPBRResult) Function None 97
+       98(index):     29(ptr) FunctionParameter
+99(diffuseColor):     21(ptr) FunctionParameter
+100(specularColor):     21(ptr) FunctionParameter
+101(worldSpacePos):     21(ptr) FunctionParameter
+     102(normal):     21(ptr) FunctionParameter
+103(shadowStrength):     30(ptr) FunctionParameter
+104(shadowColor):     21(ptr) FunctionParameter
+  105(camVector):     21(ptr) FunctionParameter
+  106(roughness):     30(ptr) FunctionParameter
+             108:             Label
+        708(res):    707(ptr) Variable Function
+             709:96(TDPBRResult) Load 708(res)
+                              ReturnValue 709
+                              FunctionEnd
+122(TDLightingPBR(vf3;vf3;f1;i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1;):           2 Function None 109
+110(diffuseContrib):     21(ptr) FunctionParameter
+111(specularContrib):     21(ptr) FunctionParameter
+112(shadowStrengthOut):     30(ptr) FunctionParameter
+      113(index):     29(ptr) FunctionParameter
+114(diffuseColor):     21(ptr) FunctionParameter
+115(specularColor):     21(ptr) FunctionParameter
+116(worldSpacePos):     21(ptr) FunctionParameter
+     117(normal):     21(ptr) FunctionParameter
+118(shadowStrength):     30(ptr) FunctionParameter
+119(shadowColor):     21(ptr) FunctionParameter
+  120(camVector):     21(ptr) FunctionParameter
+  121(roughness):     30(ptr) FunctionParameter
+             123:             Label
+        712(res):    707(ptr) Variable Function
+      713(param):     29(ptr) Variable Function
+      715(param):     21(ptr) Variable Function
+      717(param):     21(ptr) Variable Function
+      719(param):     21(ptr) Variable Function
+      721(param):     21(ptr) Variable Function
+      723(param):     30(ptr) Variable Function
+      725(param):     21(ptr) Variable Function
+      727(param):     21(ptr) Variable Function
+      729(param):     30(ptr) Variable Function
+             714:     28(int) Load 113(index)
+                              Store 713(param) 714
+             716:   20(fvec3) Load 114(diffuseColor)
+                              Store 715(param) 716
+             718:   20(fvec3) Load 115(specularColor)
+                              Store 717(param) 718
+             720:   20(fvec3) Load 116(worldSpacePos)
+                              Store 719(param) 720
+             722:   20(fvec3) Load 117(normal)
+                              Store 721(param) 722
+             724:    6(float) Load 118(shadowStrength)
+                              Store 723(param) 724
+             726:   20(fvec3) Load 119(shadowColor)
+                              Store 725(param) 726
+             728:   20(fvec3) Load 120(camVector)
+                              Store 727(param) 728
+             730:    6(float) Load 121(roughness)
+                              Store 729(param) 730
+             731:96(TDPBRResult) FunctionCall 107(TDLightingPBR(i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1;) 713(param) 715(param) 717(param) 719(param) 721(param) 723(param) 725(param) 727(param) 729(param)
+                              Store 712(res) 731
+             732:     21(ptr) AccessChain 712(res) 381
+             733:   20(fvec3) Load 732
+                              Store 110(diffuseContrib) 733
+             734:     21(ptr) AccessChain 712(res) 436
+             735:   20(fvec3) Load 734
+                              Store 111(specularContrib) 735
+             736:     30(ptr) AccessChain 712(res) 337
+             737:    6(float) Load 736
+                              Store 112(shadowStrengthOut) 737
+                              Return
+                              FunctionEnd
+136(TDLightingPBR(vf3;vf3;i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1;):           2 Function None 124
+125(diffuseContrib):     21(ptr) FunctionParameter
+126(specularContrib):     21(ptr) FunctionParameter
+      127(index):     29(ptr) FunctionParameter
+128(diffuseColor):     21(ptr) FunctionParameter
+129(specularColor):     21(ptr) FunctionParameter
+130(worldSpacePos):     21(ptr) FunctionParameter
+     131(normal):     21(ptr) FunctionParameter
+132(shadowStrength):     30(ptr) FunctionParameter
+133(shadowColor):     21(ptr) FunctionParameter
+  134(camVector):     21(ptr) FunctionParameter
+  135(roughness):     30(ptr) FunctionParameter
+             137:             Label
+        738(res):    707(ptr) Variable Function
+      739(param):     29(ptr) Variable Function
+      741(param):     21(ptr) Variable Function
+      743(param):     21(ptr) Variable Function
+      745(param):     21(ptr) Variable Function
+      747(param):     21(ptr) Variable Function
+      749(param):     30(ptr) Variable Function
+      751(param):     21(ptr) Variable Function
+      753(param):     21(ptr) Variable Function
+      755(param):     30(ptr) Variable Function
+             740:     28(int) Load 127(index)
+                              Store 739(param) 740
+             742:   20(fvec3) Load 128(diffuseColor)
+                              Store 741(param) 742
+             744:   20(fvec3) Load 129(specularColor)
+                              Store 743(param) 744
+             746:   20(fvec3) Load 130(worldSpacePos)
+                              Store 745(param) 746
+             748:   20(fvec3) Load 131(normal)
+                              Store 747(param) 748
+             750:    6(float) Load 132(shadowStrength)
+                              Store 749(param) 750
+             752:   20(fvec3) Load 133(shadowColor)
+                              Store 751(param) 752
+             754:   20(fvec3) Load 134(camVector)
+                              Store 753(param) 754
+             756:    6(float) Load 135(roughness)
+                              Store 755(param) 756
+             757:96(TDPBRResult) FunctionCall 107(TDLightingPBR(i1;vf3;vf3;vf3;vf3;f1;vf3;vf3;f1;) 739(param) 741(param) 743(param) 745(param) 747(param) 749(param) 751(param) 753(param) 755(param)
+                              Store 738(res) 757
+             758:     21(ptr) AccessChain 738(res) 381
+             759:   20(fvec3) Load 758
+                              Store 125(diffuseContrib) 759
+             760:     21(ptr) AccessChain 738(res) 436
+             761:   20(fvec3) Load 760
+                              Store 126(specularContrib) 761
+                              Return
+                              FunctionEnd
+146(TDEnvLightingPBR(i1;vf3;vf3;vf3;vf3;f1;f1;):96(TDPBRResult) Function None 138
+      139(index):     29(ptr) FunctionParameter
+140(diffuseColor):     21(ptr) FunctionParameter
+141(specularColor):     21(ptr) FunctionParameter
+     142(normal):     21(ptr) FunctionParameter
+  143(camVector):     21(ptr) FunctionParameter
+  144(roughness):     30(ptr) FunctionParameter
+145(ambientOcclusion):     30(ptr) FunctionParameter
+             147:             Label
+        762(res):    707(ptr) Variable Function
+             763:96(TDPBRResult) Load 762(res)
+                              ReturnValue 763
+                              FunctionEnd
+158(TDEnvLightingPBR(vf3;vf3;i1;vf3;vf3;vf3;vf3;f1;f1;):           2 Function None 148
+149(diffuseContrib):     21(ptr) FunctionParameter
+150(specularContrib):     21(ptr) FunctionParameter
+      151(index):     29(ptr) FunctionParameter
+152(diffuseColor):     21(ptr) FunctionParameter
+153(specularColor):     21(ptr) FunctionParameter
+     154(normal):     21(ptr) FunctionParameter
+  155(camVector):     21(ptr) FunctionParameter
+  156(roughness):     30(ptr) FunctionParameter
+157(ambientOcclusion):     30(ptr) FunctionParameter
+             159:             Label
+        766(res):    707(ptr) Variable Function
+      767(param):     29(ptr) Variable Function
+      769(param):     21(ptr) Variable Function
+      771(param):     21(ptr) Variable Function
+      773(param):     21(ptr) Variable Function
+      775(param):     21(ptr) Variable Function
+      777(param):     30(ptr) Variable Function
+      779(param):     30(ptr) Variable Function
+             768:     28(int) Load 151(index)
+                              Store 767(param) 768
+             770:   20(fvec3) Load 152(diffuseColor)
+                              Store 769(param) 770
+             772:   20(fvec3) Load 153(specularColor)
+                              Store 771(param) 772
+             774:   20(fvec3) Load 154(normal)
+                              Store 773(param) 774
+             776:   20(fvec3) Load 155(camVector)
+                              Store 775(param) 776
+             778:    6(float) Load 156(roughness)
+                              Store 777(param) 778
+             780:    6(float) Load 157(ambientOcclusion)
+                              Store 779(param) 780
+             781:96(TDPBRResult) FunctionCall 146(TDEnvLightingPBR(i1;vf3;vf3;vf3;vf3;f1;f1;) 767(param) 769(param) 771(param) 773(param) 775(param) 777(param) 779(param)
+                              Store 766(res) 781
+             782:     21(ptr) AccessChain 766(res) 381
+             783:   20(fvec3) Load 782
+                              Store 149(diffuseContrib) 783
+             784:     21(ptr) AccessChain 766(res) 436
+             785:   20(fvec3) Load 784
+                              Store 150(specularContrib) 785
+                              Return
+                              FunctionEnd
+170(TDLighting(i1;vf3;vf3;f1;vf3;vf3;f1;f1;):160(TDPhongResult) Function None 161
+      162(index):     29(ptr) FunctionParameter
+163(worldSpacePos):     21(ptr) FunctionParameter
+     164(normal):     21(ptr) FunctionParameter
+165(shadowStrength):     30(ptr) FunctionParameter
+166(shadowColor):     21(ptr) FunctionParameter
+  167(camVector):     21(ptr) FunctionParameter
+  168(shininess):     30(ptr) FunctionParameter
+ 169(shininess2):     30(ptr) FunctionParameter
+             171:             Label
+        790(res):    789(ptr) Variable Function
+             786:     28(int) Load 162(index)
+                              SelectionMerge 788 None
+                              Switch 786 787
+             787:               Label
+             792:     21(ptr)   AccessChain 790(res) 381
+                                Store 792 791
+             793:     21(ptr)   AccessChain 790(res) 436
+                                Store 793 791
+             794:     21(ptr)   AccessChain 790(res) 337
+                                Store 794 791
+             795:     30(ptr)   AccessChain 790(res) 377
+                                Store 795 331
+                                Branch 788
+             788:             Label
+             798:160(TDPhongResult) Load 790(res)
+                              ReturnValue 798
+                              FunctionEnd
+185(TDLighting(vf3;vf3;vf3;f1;i1;vf3;vf3;f1;vf3;vf3;f1;f1;):           2 Function None 172
+173(diffuseContrib):     21(ptr) FunctionParameter
+174(specularContrib):     21(ptr) FunctionParameter
+175(specularContrib2):     21(ptr) FunctionParameter
+176(shadowStrengthOut):     30(ptr) FunctionParameter
+      177(index):     29(ptr) FunctionParameter
+178(worldSpacePos):     21(ptr) FunctionParameter
+     179(normal):     21(ptr) FunctionParameter
+180(shadowStrength):     30(ptr) FunctionParameter
+181(shadowColor):     21(ptr) FunctionParameter
+  182(camVector):     21(ptr) FunctionParameter
+  183(shininess):     30(ptr) FunctionParameter
+ 184(shininess2):     30(ptr) FunctionParameter
+             186:             Label
+        804(res):    789(ptr) Variable Function
+             801:     28(int) Load 177(index)
+                              SelectionMerge 803 None
+                              Switch 801 802
+             802:               Label
+             805:     21(ptr)   AccessChain 804(res) 381
+                                Store 805 791
+             806:     21(ptr)   AccessChain 804(res) 436
+                                Store 806 791
+             807:     21(ptr)   AccessChain 804(res) 337
+                                Store 807 791
+             808:     30(ptr)   AccessChain 804(res) 377
+                                Store 808 331
+                                Branch 803
+             803:             Label
+             811:     21(ptr) AccessChain 804(res) 381
+             812:   20(fvec3) Load 811
+                              Store 173(diffuseContrib) 812
+             813:     21(ptr) AccessChain 804(res) 436
+             814:   20(fvec3) Load 813
+                              Store 174(specularContrib) 814
+             815:     21(ptr) AccessChain 804(res) 337
+             816:   20(fvec3) Load 815
+                              Store 175(specularContrib2) 816
+             817:     30(ptr) AccessChain 804(res) 377
+             818:    6(float) Load 817
+                              Store 176(shadowStrengthOut) 818
+                              Return
+                              FunctionEnd
+199(TDLighting(vf3;vf3;vf3;i1;vf3;vf3;f1;vf3;vf3;f1;f1;):           2 Function None 187
+188(diffuseContrib):     21(ptr) FunctionParameter
+189(specularContrib):     21(ptr) FunctionParameter
+190(specularContrib2):     21(ptr) FunctionParameter
+      191(index):     29(ptr) FunctionParameter
+192(worldSpacePos):     21(ptr) FunctionParameter
+     193(normal):     21(ptr) FunctionParameter
+194(shadowStrength):     30(ptr) FunctionParameter
+195(shadowColor):     21(ptr) FunctionParameter
+  196(camVector):     21(ptr) FunctionParameter
+  197(shininess):     30(ptr) FunctionParameter
+ 198(shininess2):     30(ptr) FunctionParameter
+             200:             Label
+        822(res):    789(ptr) Variable Function
+             819:     28(int) Load 191(index)
+                              SelectionMerge 821 None
+                              Switch 819 820
+             820:               Label
+             823:     21(ptr)   AccessChain 822(res) 381
+                                Store 823 791
+             824:     21(ptr)   AccessChain 822(res) 436
+                                Store 824 791
+             825:     21(ptr)   AccessChain 822(res) 337
+                                Store 825 791
+             826:     30(ptr)   AccessChain 822(res) 377
+                                Store 826 331
+                                Branch 821
+             821:             Label
+             829:     21(ptr) AccessChain 822(res) 381
+             830:   20(fvec3) Load 829
+                              Store 188(diffuseContrib) 830
+             831:     21(ptr) AccessChain 822(res) 436
+             832:   20(fvec3) Load 831
+                              Store 189(specularContrib) 832
+             833:     21(ptr) AccessChain 822(res) 337
+             834:   20(fvec3) Load 833
+                              Store 190(specularContrib2) 834
+                              Return
+                              FunctionEnd
+211(TDLighting(vf3;vf3;i1;vf3;vf3;f1;vf3;vf3;f1;):           2 Function None 201
+202(diffuseContrib):     21(ptr) FunctionParameter
+203(specularContrib):     21(ptr) FunctionParameter
+      204(index):     29(ptr) FunctionParameter
+205(worldSpacePos):     21(ptr) FunctionParameter
+     206(normal):     21(ptr) FunctionParameter
+207(shadowStrength):     30(ptr) FunctionParameter
+208(shadowColor):     21(ptr) FunctionParameter
+  209(camVector):     21(ptr) FunctionParameter
+  210(shininess):     30(ptr) FunctionParameter
+             212:             Label
+        838(res):    789(ptr) Variable Function
+             835:     28(int) Load 204(index)
+                              SelectionMerge 837 None
+                              Switch 835 836
+             836:               Label
+             839:     21(ptr)   AccessChain 838(res) 381
+                                Store 839 791
+             840:     21(ptr)   AccessChain 838(res) 436
+                                Store 840 791
+             841:     21(ptr)   AccessChain 838(res) 337
+                                Store 841 791
+             842:     30(ptr)   AccessChain 838(res) 377
+                                Store 842 331
+                                Branch 837
+             837:             Label
+             845:     21(ptr) AccessChain 838(res) 381
+             846:   20(fvec3) Load 845
+                              Store 202(diffuseContrib) 846
+             847:     21(ptr) AccessChain 838(res) 436
+             848:   20(fvec3) Load 847
+                              Store 203(specularContrib) 848
+                              Return
+                              FunctionEnd
+223(TDLighting(vf3;vf3;vf3;i1;vf3;vf3;vf3;f1;f1;):           2 Function None 213
+214(diffuseContrib):     21(ptr) FunctionParameter
+215(specularContrib):     21(ptr) FunctionParameter
+216(specularContrib2):     21(ptr) FunctionParameter
+      217(index):     29(ptr) FunctionParameter
+218(worldSpacePos):     21(ptr) FunctionParameter
+     219(normal):     21(ptr) FunctionParameter
+  220(camVector):     21(ptr) FunctionParameter
+  221(shininess):     30(ptr) FunctionParameter
+ 222(shininess2):     30(ptr) FunctionParameter
+             224:             Label
+        852(res):    789(ptr) Variable Function
+             849:     28(int) Load 217(index)
+                              SelectionMerge 851 None
+                              Switch 849 850
+             850:               Label
+             853:     21(ptr)   AccessChain 852(res) 381
+                                Store 853 791
+             854:     21(ptr)   AccessChain 852(res) 436
+                                Store 854 791
+             855:     21(ptr)   AccessChain 852(res) 337
+                                Store 855 791
+             856:     30(ptr)   AccessChain 852(res) 377
+                                Store 856 331
+                                Branch 851
+             851:             Label
+             859:     21(ptr) AccessChain 852(res) 381
+             860:   20(fvec3) Load 859
+                              Store 214(diffuseContrib) 860
+             861:     21(ptr) AccessChain 852(res) 436
+             862:   20(fvec3) Load 861
+                              Store 215(specularContrib) 862
+             863:     21(ptr) AccessChain 852(res) 337
+             864:   20(fvec3) Load 863
+                              Store 216(specularContrib2) 864
+                              Return
+                              FunctionEnd
+233(TDLighting(vf3;vf3;i1;vf3;vf3;vf3;f1;):           2 Function None 225
+226(diffuseContrib):     21(ptr) FunctionParameter
+227(specularContrib):     21(ptr) FunctionParameter
+      228(index):     29(ptr) FunctionParameter
+229(worldSpacePos):     21(ptr) FunctionParameter
+     230(normal):     21(ptr) FunctionParameter
+  231(camVector):     21(ptr) FunctionParameter
+  232(shininess):     30(ptr) FunctionParameter
+             234:             Label
+        868(res):    789(ptr) Variable Function
+             865:     28(int) Load 228(index)
+                              SelectionMerge 867 None
+                              Switch 865 866
+             866:               Label
+             869:     21(ptr)   AccessChain 868(res) 381
+                                Store 869 791
+             870:     21(ptr)   AccessChain 868(res) 436
+                                Store 870 791
+             871:     21(ptr)   AccessChain 868(res) 337
+                                Store 871 791
+             872:     30(ptr)   AccessChain 868(res) 377
+                                Store 872 331
+                                Branch 867
+             867:             Label
+             875:     21(ptr) AccessChain 868(res) 381
+             876:   20(fvec3) Load 875
+                              Store 226(diffuseContrib) 876
+             877:     21(ptr) AccessChain 868(res) 436
+             878:   20(fvec3) Load 877
+                              Store 227(specularContrib) 878
+                              Return
+                              FunctionEnd
+240(TDLighting(vf3;i1;vf3;vf3;):           2 Function None 235
+236(diffuseContrib):     21(ptr) FunctionParameter
+      237(index):     29(ptr) FunctionParameter
+238(worldSpacePos):     21(ptr) FunctionParameter
+     239(normal):     21(ptr) FunctionParameter
+             241:             Label
+        882(res):    789(ptr) Variable Function
+             879:     28(int) Load 237(index)
+                              SelectionMerge 881 None
+                              Switch 879 880
+             880:               Label
+             883:     21(ptr)   AccessChain 882(res) 381
+                                Store 883 791
+             884:     21(ptr)   AccessChain 882(res) 436
+                                Store 884 791
+             885:     21(ptr)   AccessChain 882(res) 337
+                                Store 885 791
+             886:     30(ptr)   AccessChain 882(res) 377
+                                Store 886 331
+                                Branch 881
+             881:             Label
+             889:     21(ptr) AccessChain 882(res) 381
+             890:   20(fvec3) Load 889
+                              Store 236(diffuseContrib) 890
+                              Return
+                              FunctionEnd
+249(TDLighting(vf3;i1;vf3;vf3;f1;vf3;):           2 Function None 242
+243(diffuseContrib):     21(ptr) FunctionParameter
+      244(index):     29(ptr) FunctionParameter
+245(worldSpacePos):     21(ptr) FunctionParameter
+     246(normal):     21(ptr) FunctionParameter
+247(shadowStrength):     30(ptr) FunctionParameter
+248(shadowColor):     21(ptr) FunctionParameter
+             250:             Label
+        894(res):    789(ptr) Variable Function
+             891:     28(int) Load 244(index)
+                              SelectionMerge 893 None
+                              Switch 891 892
+             892:               Label
+             895:     21(ptr)   AccessChain 894(res) 381
+                                Store 895 791
+             896:     21(ptr)   AccessChain 894(res) 436
+                                Store 896 791
+             897:     21(ptr)   AccessChain 894(res) 337
+                                Store 897 791
+             898:     30(ptr)   AccessChain 894(res) 377
+                                Store 898 331
+                                Branch 893
+             893:             Label
+             901:     21(ptr) AccessChain 894(res) 381
+             902:   20(fvec3) Load 901
+                              Store 243(diffuseContrib) 902
+                              Return
+                              FunctionEnd
+255(TDProjMap(i1;vf3;vf4;):    7(fvec4) Function None 251
+      252(index):     29(ptr) FunctionParameter
+253(worldSpacePos):     21(ptr) FunctionParameter
+254(defaultColor):      8(ptr) FunctionParameter
+             256:             Label
+             903:     28(int) Load 252(index)
+                              SelectionMerge 905 None
+                              Switch 903 904
+             904:               Label
+             906:    7(fvec4)   Load 254(defaultColor)
+                                ReturnValue 906
+             905:             Label
+                              Unreachable
+                              FunctionEnd
+261(TDFog(vf4;vf3;i1;):    7(fvec4) Function None 257
+      258(color):      8(ptr) FunctionParameter
+259(lightingSpacePosition):     21(ptr) FunctionParameter
+260(cameraIndex):     29(ptr) FunctionParameter
+             262:             Label
+             910:     28(int) Load 260(cameraIndex)
+                              SelectionMerge 912 None
+                              Switch 910 911 
+                                     case 0: 911
+             911:               Label
+             913:    7(fvec4)   Load 258(color)
+                                ReturnValue 913
+             912:             Label
+                              Unreachable
+                              FunctionEnd
+266(TDFog(vf4;vf3;):    7(fvec4) Function None 263
+      264(color):      8(ptr) FunctionParameter
+265(lightingSpacePosition):     21(ptr) FunctionParameter
+             267:             Label
+      917(param):      8(ptr) Variable Function
+      919(param):     21(ptr) Variable Function
+      921(param):     29(ptr) Variable Function
+             918:    7(fvec4) Load 264(color)
+                              Store 917(param) 918
+             920:   20(fvec3) Load 265(lightingSpacePosition)
+                              Store 919(param) 920
+                              Store 921(param) 381
+             922:    7(fvec4) FunctionCall 261(TDFog(vf4;vf3;i1;) 917(param) 919(param) 921(param)
+                              ReturnValue 922
+                              FunctionEnd
+271(TDInstanceTexCoord(i1;vf3;):   20(fvec3) Function None 268
+      269(index):     29(ptr) FunctionParameter
+          270(t):     21(ptr) FunctionParameter
+             272:             Label
+      925(coord):     29(ptr) Variable Function
+       927(samp):      8(ptr) Variable Function
+          936(v):     21(ptr) Variable Function
+             926:     28(int) Load 269(index)
+                              Store 925(coord) 926
+             932:         929 Load 931(sTDInstanceTexCoord)
+             933:     28(int) Load 925(coord)
+             934:         928 Image 932
+             935:    7(fvec4) ImageFetch 934 933
+                              Store 927(samp) 935
+             937:     30(ptr) AccessChain 270(t) 390
+             938:    6(float) Load 937
+             939:     30(ptr) AccessChain 936(v) 390
+                              Store 939 938
+             940:     30(ptr) AccessChain 270(t) 393
+             941:    6(float) Load 940
+             942:     30(ptr) AccessChain 936(v) 393
+                              Store 942 941
+             943:     30(ptr) AccessChain 927(samp) 390
+             944:    6(float) Load 943
+             945:     30(ptr) AccessChain 936(v) 342
+                              Store 945 944
+             946:   20(fvec3) Load 936(v)
+                              Store 270(t) 946
+             947:   20(fvec3) Load 270(t)
+                              ReturnValue 947
+                              FunctionEnd
+275(TDInstanceActive(i1;):    22(bool) Function None 273
+      274(index):     29(ptr) FunctionParameter
+             276:             Label
+      955(coord):     29(ptr) Variable Function
+       957(samp):      8(ptr) Variable Function
+          963(v):     30(ptr) Variable Function
+             951:    950(ptr) AccessChain 376 381
+             952:     28(int) Load 951
+             953:     28(int) Load 274(index)
+             954:     28(int) ISub 953 952
+                              Store 274(index) 954
+             956:     28(int) Load 274(index)
+                              Store 955(coord) 956
+             959:         929 Load 958(sTDInstanceT)
+             960:     28(int) Load 955(coord)
+             961:         928 Image 959
+             962:    7(fvec4) ImageFetch 961 960
+                              Store 957(samp) 962
+             964:     30(ptr) AccessChain 957(samp) 390
+             965:    6(float) Load 964
+                              Store 963(v) 965
+             966:    6(float) Load 963(v)
+             967:    22(bool) FUnordNotEqual 966 331
+                              ReturnValue 967
+                              FunctionEnd
+281(iTDInstanceTranslate(i1;b1;):   20(fvec3) Function None 278
+      279(index):     29(ptr) FunctionParameter
+280(instanceActive):    277(ptr) FunctionParameter
+             282:             Label
+  970(origIndex):     29(ptr) Variable Function
+      976(coord):     29(ptr) Variable Function
+       978(samp):      8(ptr) Variable Function
+          983(v):     21(ptr) Variable Function
+             971:     28(int) Load 279(index)
+                              Store 970(origIndex) 971
+             972:    950(ptr) AccessChain 376 381
+             973:     28(int) Load 972
+             974:     28(int) Load 279(index)
+             975:     28(int) ISub 974 973
+                              Store 279(index) 975
+             977:     28(int) Load 279(index)
+                              Store 976(coord) 977
+             979:         929 Load 958(sTDInstanceT)
+             980:     28(int) Load 976(coord)
+             981:         928 Image 979
+             982:    7(fvec4) ImageFetch 981 980
+                              Store 978(samp) 982
+             984:     30(ptr) AccessChain 978(samp) 393
+             985:    6(float) Load 984
+             986:     30(ptr) AccessChain 983(v) 390
+                              Store 986 985
+             987:     30(ptr) AccessChain 978(samp) 342
+             988:    6(float) Load 987
+             989:     30(ptr) AccessChain 983(v) 393
+                              Store 989 988
+             990:     30(ptr) AccessChain 978(samp) 402
+             991:    6(float) Load 990
+             992:     30(ptr) AccessChain 983(v) 342
+                              Store 992 991
+             993:     30(ptr) AccessChain 978(samp) 390
+             994:    6(float) Load 993
+             995:    22(bool) FUnordNotEqual 994 331
+                              Store 280(instanceActive) 995
+             996:   20(fvec3) Load 983(v)
+                              ReturnValue 996
+                              FunctionEnd
+285(TDInstanceTranslate(i1;):   20(fvec3) Function None 283
+      284(index):     29(ptr) FunctionParameter
+             286:             Label
+     1003(coord):     29(ptr) Variable Function
+      1005(samp):      8(ptr) Variable Function
+         1010(v):     21(ptr) Variable Function
+             999:    950(ptr) AccessChain 376 381
+            1000:     28(int) Load 999
+            1001:     28(int) Load 284(index)
+            1002:     28(int) ISub 1001 1000
+                              Store 284(index) 1002
+            1004:     28(int) Load 284(index)
+                              Store 1003(coord) 1004
+            1006:         929 Load 958(sTDInstanceT)
+            1007:     28(int) Load 1003(coord)
+            1008:         928 Image 1006
+            1009:    7(fvec4) ImageFetch 1008 1007
+                              Store 1005(samp) 1009
+            1011:     30(ptr) AccessChain 1005(samp) 393
+            1012:    6(float) Load 1011
+            1013:     30(ptr) AccessChain 1010(v) 390
+                              Store 1013 1012
+            1014:     30(ptr) AccessChain 1005(samp) 342
+            1015:    6(float) Load 1014
+            1016:     30(ptr) AccessChain 1010(v) 393
+                              Store 1016 1015
+            1017:     30(ptr) AccessChain 1005(samp) 402
+            1018:    6(float) Load 1017
+            1019:     30(ptr) AccessChain 1010(v) 342
+                              Store 1019 1018
+            1020:   20(fvec3) Load 1010(v)
+                              ReturnValue 1020
+                              FunctionEnd
+290(TDInstanceRotateMat(i1;):         287 Function None 288
+      289(index):     29(ptr) FunctionParameter
+             291:             Label
+         1027(v):     21(ptr) Variable Function
+         1029(m):   1028(ptr) Variable Function
+            1023:    950(ptr) AccessChain 376 381
+            1024:     28(int) Load 1023
+            1025:     28(int) Load 289(index)
+            1026:     28(int) ISub 1025 1024
+                              Store 289(index) 1026
+                              Store 1027(v) 791
+                              Store 1029(m) 1031
+            1032:         287 Load 1029(m)
+                              ReturnValue 1032
+                              FunctionEnd
+293(TDInstanceScale(i1;):   20(fvec3) Function None 283
+      292(index):     29(ptr) FunctionParameter
+             294:             Label
+         1039(v):     21(ptr) Variable Function
+            1035:    950(ptr) AccessChain 376 381
+            1036:     28(int) Load 1035
+            1037:     28(int) Load 292(index)
+            1038:     28(int) ISub 1037 1036
+                              Store 292(index) 1038
+                              Store 1039(v) 670
+            1040:   20(fvec3) Load 1039(v)
+                              ReturnValue 1040
+                              FunctionEnd
+296(TDInstancePivot(i1;):   20(fvec3) Function None 283
+      295(index):     29(ptr) FunctionParameter
+             297:             Label
+         1047(v):     21(ptr) Variable Function
+            1043:    950(ptr) AccessChain 376 381
+            1044:     28(int) Load 1043
+            1045:     28(int) Load 295(index)
+            1046:     28(int) ISub 1045 1044
+                              Store 295(index) 1046
+                              Store 1047(v) 791
+            1048:   20(fvec3) Load 1047(v)
+                              ReturnValue 1048
+                              FunctionEnd
+299(TDInstanceRotTo(i1;):   20(fvec3) Function None 283
+      298(index):     29(ptr) FunctionParameter
+             300:             Label
+         1055(v):     21(ptr) Variable Function
+            1051:    950(ptr) AccessChain 376 381
+            1052:     28(int) Load 1051
+            1053:     28(int) Load 298(index)
+            1054:     28(int) ISub 1053 1052
+                              Store 298(index) 1054
+                              Store 1055(v) 607
+            1056:   20(fvec3) Load 1055(v)
+                              ReturnValue 1056
+                              FunctionEnd
+302(TDInstanceRotUp(i1;):   20(fvec3) Function None 283
+      301(index):     29(ptr) FunctionParameter
+             303:             Label
+         1063(v):     21(ptr) Variable Function
+            1059:    950(ptr) AccessChain 376 381
+            1060:     28(int) Load 1059
+            1061:     28(int) Load 301(index)
+            1062:     28(int) ISub 1061 1060
+                              Store 301(index) 1062
+                              Store 1063(v) 1030
+            1064:   20(fvec3) Load 1063(v)
+                              ReturnValue 1064
+                              FunctionEnd
+307(TDInstanceMat(i1;):         304 Function None 305
+         306(id):     29(ptr) FunctionParameter
+             308:             Label
+1067(instanceActive):    277(ptr) Variable Function
+         1069(t):     21(ptr) Variable Function
+     1070(param):     29(ptr) Variable Function
+     1072(param):    277(ptr) Variable Function
+         1082(m):   1081(ptr) Variable Function
+        1088(tt):     21(ptr) Variable Function
+                              Store 1067(instanceActive) 1068
+            1071:     28(int) Load 306(id)
+                              Store 1070(param) 1071
+            1073:   20(fvec3) FunctionCall 281(iTDInstanceTranslate(i1;b1;) 1070(param) 1072(param)
+            1074:    22(bool) Load 1072(param)
+                              Store 1067(instanceActive) 1074
+                              Store 1069(t) 1073
+            1075:    22(bool) Load 1067(instanceActive)
+            1076:    22(bool) LogicalNot 1075
+                              SelectionMerge 1078 None
+                              BranchConditional 1076 1077 1078
+            1077:               Label
+                                ReturnValue 1079
+            1078:             Label
+                              Store 1082(m) 1087
+            1089:   20(fvec3) Load 1069(t)
+                              Store 1088(tt) 1089
+            1090:     30(ptr) AccessChain 1082(m) 381 390
+            1091:    6(float) Load 1090
+            1092:     30(ptr) AccessChain 1088(tt) 390
+            1093:    6(float) Load 1092
+            1094:    6(float) FMul 1091 1093
+            1095:     30(ptr) AccessChain 1082(m) 377 390
+            1096:    6(float) Load 1095
+            1097:    6(float) FAdd 1096 1094
+            1098:     30(ptr) AccessChain 1082(m) 377 390
+                              Store 1098 1097
+            1099:     30(ptr) AccessChain 1082(m) 381 393
+            1100:    6(float) Load 1099
+            1101:     30(ptr) AccessChain 1088(tt) 390
+            1102:    6(float) Load 1101
+            1103:    6(float) FMul 1100 1102
+            1104:     30(ptr) AccessChain 1082(m) 377 393
+            1105:    6(float) Load 1104
+            1106:    6(float) FAdd 1105 1103
+            1107:     30(ptr) AccessChain 1082(m) 377 393
+                              Store 1107 1106
+            1108:     30(ptr) AccessChain 1082(m) 381 342
+            1109:    6(float) Load 1108
+            1110:     30(ptr) AccessChain 1088(tt) 390
+            1111:    6(float) Load 1110
+            1112:    6(float) FMul 1109 1111
+            1113:     30(ptr) AccessChain 1082(m) 377 342
+            1114:    6(float) Load 1113
+            1115:    6(float) FAdd 1114 1112
+            1116:     30(ptr) AccessChain 1082(m) 377 342
+                              Store 1116 1115
+            1117:     30(ptr) AccessChain 1082(m) 381 402
+            1118:    6(float) Load 1117
+            1119:     30(ptr) AccessChain 1088(tt) 390
+            1120:    6(float) Load 1119
+            1121:    6(float) FMul 1118 1120
+            1122:     30(ptr) AccessChain 1082(m) 377 402
+            1123:    6(float) Load 1122
+            1124:    6(float) FAdd 1123 1121
+            1125:     30(ptr) AccessChain 1082(m) 377 402
+                              Store 1125 1124
+            1126:     30(ptr) AccessChain 1082(m) 436 390
+            1127:    6(float) Load 1126
+            1128:     30(ptr) AccessChain 1088(tt) 393
+            1129:    6(float) Load 1128
+            1130:    6(float) FMul 1127 1129
+            1131:     30(ptr) AccessChain 1082(m) 377 390
+            1132:    6(float) Load 1131
+            1133:    6(float) FAdd 1132 1130
+            1134:     30(ptr) AccessChain 1082(m) 377 390
+                              Store 1134 1133
+            1135:     30(ptr) AccessChain 1082(m) 436 393
+            1136:    6(float) Load 1135
+            1137:     30(ptr) AccessChain 1088(tt) 393
+            1138:    6(float) Load 1137
+            1139:    6(float) FMul 1136 1138
+            1140:     30(ptr) AccessChain 1082(m) 377 393
+            1141:    6(float) Load 1140
+            1142:    6(float) FAdd 1141 1139
+            1143:     30(ptr) AccessChain 1082(m) 377 393
+                              Store 1143 1142
+            1144:     30(ptr) AccessChain 1082(m) 436 342
+            1145:    6(float) Load 1144
+            1146:     30(ptr) AccessChain 1088(tt) 393
+            1147:    6(float) Load 1146
+            1148:    6(float) FMul 1145 1147
+            1149:     30(ptr) AccessChain 1082(m) 377 342
+            1150:    6(float) Load 1149
+            1151:    6(float) FAdd 1150 1148
+            1152:     30(ptr) AccessChain 1082(m) 377 342
+                              Store 1152 1151
+            1153:     30(ptr) AccessChain 1082(m) 436 402
+            1154:    6(float) Load 1153
+            1155:     30(ptr) AccessChain 1088(tt) 393
+            1156:    6(float) Load 1155
+            1157:    6(float) FMul 1154 1156
+            1158:     30(ptr) AccessChain 1082(m) 377 402
+            1159:    6(float) Load 1158
+            1160:    6(float) FAdd 1159 1157
+            1161:     30(ptr) AccessChain 1082(m) 377 402
+                              Store 1161 1160
+            1162:     30(ptr) AccessChain 1082(m) 337 390
+            1163:    6(float) Load 1162
+            1164:     30(ptr) AccessChain 1088(tt) 342
+            1165:    6(float) Load 1164
+            1166:    6(float) FMul 1163 1165
+            1167:     30(ptr) AccessChain 1082(m) 377 390
+            1168:    6(float) Load 1167
+            1169:    6(float) FAdd 1168 1166
+            1170:     30(ptr) AccessChain 1082(m) 377 390
+                              Store 1170 1169
+            1171:     30(ptr) AccessChain 1082(m) 337 393
+            1172:    6(float) Load 1171
+            1173:     30(ptr) AccessChain 1088(tt) 342
+            1174:    6(float) Load 1173
+            1175:    6(float) FMul 1172 1174
+            1176:     30(ptr) AccessChain 1082(m) 377 393
+            1177:    6(float) Load 1176
+            1178:    6(float) FAdd 1177 1175
+            1179:     30(ptr) AccessChain 1082(m) 377 393
+                              Store 1179 1178
+            1180:     30(ptr) AccessChain 1082(m) 337 342
+            1181:    6(float) Load 1180
+            1182:     30(ptr) AccessChain 1088(tt) 342
+            1183:    6(float) Load 1182
+            1184:    6(float) FMul 1181 1183
+            1185:     30(ptr) AccessChain 1082(m) 377 342
+            1186:    6(float) Load 1185
+            1187:    6(float) FAdd 1186 1184
+            1188:     30(ptr) AccessChain 1082(m) 377 342
+                              Store 1188 1187
+            1189:     30(ptr) AccessChain 1082(m) 337 402
+            1190:    6(float) Load 1189
+            1191:     30(ptr) AccessChain 1088(tt) 342
+            1192:    6(float) Load 1191
+            1193:    6(float) FMul 1190 1192
+            1194:     30(ptr) AccessChain 1082(m) 377 402
+            1195:    6(float) Load 1194
+            1196:    6(float) FAdd 1195 1193
+            1197:     30(ptr) AccessChain 1082(m) 377 402
+                              Store 1197 1196
+            1198:         304 Load 1082(m)
+                              ReturnValue 1198
+                              FunctionEnd
+310(TDInstanceMat3(i1;):         287 Function None 288
+         309(id):     29(ptr) FunctionParameter
+             311:             Label
+         1201(m):   1028(ptr) Variable Function
+                              Store 1201(m) 1031
+            1202:         287 Load 1201(m)
+                              ReturnValue 1202
+                              FunctionEnd
+313(TDInstanceMat3ForNorm(i1;):         287 Function None 288
+         312(id):     29(ptr) FunctionParameter
+             314:             Label
+         1205(m):   1028(ptr) Variable Function
+     1206(param):     29(ptr) Variable Function
+            1207:     28(int) Load 312(id)
+                              Store 1206(param) 1207
+            1208:         287 FunctionCall 310(TDInstanceMat3(i1;) 1206(param)
+                              Store 1205(m) 1208
+            1209:         287 Load 1205(m)
+                              ReturnValue 1209
+                              FunctionEnd
+318(TDInstanceColor(i1;vf4;):    7(fvec4) Function None 315
+      316(index):     29(ptr) FunctionParameter
+   317(curColor):      8(ptr) FunctionParameter
+             319:             Label
+     1216(coord):     29(ptr) Variable Function
+      1218(samp):      8(ptr) Variable Function
+         1224(v):      8(ptr) Variable Function
+            1212:    950(ptr) AccessChain 376 381
+            1213:     28(int) Load 1212
+            1214:     28(int) Load 316(index)
+            1215:     28(int) ISub 1214 1213
+                              Store 316(index) 1215
+            1217:     28(int) Load 316(index)
+                              Store 1216(coord) 1217
+            1220:         929 Load 1219(sTDInstanceColor)
+            1221:     28(int) Load 1216(coord)
+            1222:         928 Image 1220
+            1223:    7(fvec4) ImageFetch 1222 1221
+                              Store 1218(samp) 1223
+            1225:     30(ptr) AccessChain 1218(samp) 390
+            1226:    6(float) Load 1225
+            1227:     30(ptr) AccessChain 1224(v) 390
+                              Store 1227 1226
+            1228:     30(ptr) AccessChain 1218(samp) 393
+            1229:    6(float) Load 1228
+            1230:     30(ptr) AccessChain 1224(v) 393
+                              Store 1230 1229
+            1231:     30(ptr) AccessChain 1218(samp) 342
+            1232:    6(float) Load 1231
+            1233:     30(ptr) AccessChain 1224(v) 342
+                              Store 1233 1232
+            1234:     30(ptr) AccessChain 1224(v) 402
+                              Store 1234 489
+            1235:     30(ptr) AccessChain 1224(v) 390
+            1236:    6(float) Load 1235
+            1237:     30(ptr) AccessChain 317(curColor) 390
+                              Store 1237 1236
+            1238:     30(ptr) AccessChain 1224(v) 393
+            1239:    6(float) Load 1238
+            1240:     30(ptr) AccessChain 317(curColor) 393
+                              Store 1240 1239
+            1241:     30(ptr) AccessChain 1224(v) 342
+            1242:    6(float) Load 1241
+            1243:     30(ptr) AccessChain 317(curColor) 342
+                              Store 1243 1242
+            1244:    7(fvec4) Load 317(curColor)
+                              ReturnValue 1244
+                              FunctionEnd
+321(TDOutputSwizzle(vf4;):    7(fvec4) Function None 9
+          320(c):      8(ptr) FunctionParameter
+             322:             Label
+            1247:    7(fvec4) Load 320(c)
+                              ReturnValue 1247
+                              FunctionEnd
+327(TDOutputSwizzle(vu4;):  323(ivec4) Function None 325
+          326(c):    324(ptr) FunctionParameter
+             328:             Label
+            1250:  323(ivec4) Load 326(c)
+                              ReturnValue 1250
+                              FunctionEnd

--- a/Test/vk.relaxed.stagelink.0.0.frag
+++ b/Test/vk.relaxed.stagelink.0.0.frag
@@ -1,0 +1,139 @@
+#version 460
+uniform int uTDInstanceIDOffset;
+uniform int uTDNumInstances;
+uniform float uTDAlphaTestVal;
+#define TD_NUM_COLOR_BUFFERS 1
+#define TD_NUM_LIGHTS 0
+#define TD_NUM_SHADOWED_LIGHTS 0
+#define TD_NUM_ENV_LIGHTS 0
+#define TD_LIGHTS_ARRAY_SIZE 1
+#define TD_ENV_LIGHTS_ARRAY_SIZE 1
+#define TD_NUM_CAMERAS 1
+struct TDPhongResult
+{
+	vec3 diffuse;
+	vec3 specular;
+	vec3 specular2;
+	float shadowStrength;
+};
+struct TDPBRResult
+{
+	vec3 diffuse;
+	vec3 specular;
+	float shadowStrength;
+};
+struct TDMatrix
+{
+	mat4 world;
+	mat4 worldInverse;
+	mat4 worldCam;
+	mat4 worldCamInverse;
+	mat4 cam;
+	mat4 camInverse;
+	mat4 camProj;
+	mat4 camProjInverse;
+	mat4 proj;
+	mat4 projInverse;
+	mat4 worldCamProj;
+	mat4 worldCamProjInverse;
+	mat4 quadReproject;
+	mat3 worldForNormals;
+	mat3 camForNormals;
+	mat3 worldCamForNormals;
+};
+layout(std140) uniform TDMatricesBlock {
+	TDMatrix uTDMats[TD_NUM_CAMERAS];
+};
+struct TDCameraInfo
+{
+	vec4 nearFar;
+	vec4 fog;
+	vec4 fogColor;
+	int renderTOPCameraIndex;
+};
+layout(std140) uniform TDCameraInfoBlock {
+	TDCameraInfo uTDCamInfos[TD_NUM_CAMERAS];
+};
+struct TDGeneral
+{
+	vec4 ambientColor;
+	vec4 nearFar;
+	vec4 viewport;
+	vec4 viewportRes;
+	vec4 fog;
+	vec4 fogColor;
+};
+layout(std140) uniform TDGeneralBlock {
+	TDGeneral uTDGeneral;
+};
+
+void TDAlphaTest(float alpha);
+vec4 TDDither(vec4 color);
+vec4 TDOutputSwizzle(vec4 v);
+uvec4 TDOutputSwizzle(uvec4 v);
+void TDCheckOrderIndTrans();
+void TDCheckDiscard();
+uniform vec3 uConstant;
+uniform float uShadowStrength;
+uniform vec3 uShadowColor;
+uniform vec4 uDiffuseColor;
+uniform vec4 uAmbientColor;
+
+uniform sampler2DArray sColorMap;
+
+in Vertex
+{
+	vec4 color;
+	vec3 worldSpacePos;
+	vec3 texCoord0;
+	flat int cameraIndex;
+	flat int instance;
+} iVert;
+
+// Output variable for the color
+layout(location = 0) out vec4 oFragColor[TD_NUM_COLOR_BUFFERS];
+void main()
+{
+	// This allows things such as order independent transparency
+	// and Dual-Paraboloid rendering to work properly
+	TDCheckDiscard();
+
+	vec4 outcol = vec4(0.0, 0.0, 0.0, 0.0);
+
+	vec3 texCoord0 = iVert.texCoord0.stp;
+	float actualTexZ = mod(int(texCoord0.z),2048);
+	float instanceLoop = floor(int(texCoord0.z)/2048);
+	texCoord0.z = actualTexZ;
+	vec4 colorMapColor = texture(sColorMap, texCoord0.stp);
+
+	float red = colorMapColor[int(instanceLoop)];
+	colorMapColor = vec4(red);
+	// Constant Light Contribution
+	outcol.rgb += uConstant * iVert.color.rgb;
+
+	outcol *= colorMapColor;
+
+	// Alpha Calculation
+	float alpha = iVert.color.a * colorMapColor.a ;
+
+	// Dithering, does nothing if dithering is disabled
+	outcol = TDDither(outcol);
+
+	outcol.rgb *= alpha;
+
+	// Modern GL removed the implicit alpha test, so we need to apply
+	// it manually here. This function does nothing if alpha test is disabled.
+	TDAlphaTest(alpha);
+
+	outcol.a = alpha;
+	oFragColor[0] = TDOutputSwizzle(outcol);
+
+
+	// TD_NUM_COLOR_BUFFERS will be set to the number of color buffers
+	// active in the render. By default we want to output zero to every
+	// buffer except the first one.
+	for (int i = 1; i < TD_NUM_COLOR_BUFFERS; i++)
+	{
+		oFragColor[i] = vec4(0.0);
+	}
+}

--- a/Test/vk.relaxed.stagelink.0.0.vert
+++ b/Test/vk.relaxed.stagelink.0.0.vert
@@ -1,0 +1,126 @@
+#version 460
+uniform int uTDInstanceIDOffset;
+uniform int uTDNumInstances;
+uniform float uTDAlphaTestVal;
+#define TD_NUM_COLOR_BUFFERS 1
+#define TD_NUM_LIGHTS 0
+#define TD_NUM_SHADOWED_LIGHTS 0
+#define TD_NUM_ENV_LIGHTS 0
+#define TD_LIGHTS_ARRAY_SIZE 1
+#define TD_ENV_LIGHTS_ARRAY_SIZE 1
+#define TD_NUM_CAMERAS 1
+struct TDPhongResult
+{
+	vec3 diffuse;
+	vec3 specular;
+	vec3 specular2;
+	float shadowStrength;
+};
+struct TDPBRResult
+{
+	vec3 diffuse;
+	vec3 specular;
+	float shadowStrength;
+};
+struct TDMatrix
+{
+	mat4 world;
+	mat4 worldInverse;
+	mat4 worldCam;
+	mat4 worldCamInverse;
+	mat4 cam;
+	mat4 camInverse;
+	mat4 camProj;
+	mat4 camProjInverse;
+	mat4 proj;
+	mat4 projInverse;
+	mat4 worldCamProj;
+	mat4 worldCamProjInverse;
+	mat4 quadReproject;
+	mat3 worldForNormals;
+	mat3 camForNormals;
+	mat3 worldCamForNormals;
+};
+layout(std140) uniform TDMatricesBlock {
+	TDMatrix uTDMats[TD_NUM_CAMERAS];
+};
+struct TDCameraInfo
+{
+	vec4 nearFar;
+	vec4 fog;
+	vec4 fogColor;
+	int renderTOPCameraIndex;
+};
+layout(std140) uniform TDCameraInfoBlock {
+	TDCameraInfo uTDCamInfos[TD_NUM_CAMERAS];
+};
+struct TDGeneral
+{
+	vec4 ambientColor;
+	vec4 nearFar;
+	vec4 viewport;
+	vec4 viewportRes;
+	vec4 fog;
+	vec4 fogColor;
+};
+layout(std140) uniform TDGeneralBlock {
+	TDGeneral uTDGeneral;
+};
+layout(location = 0) in vec3 P;
+layout(location = 1) in vec3 N;
+layout(location = 2) in vec4 Cd;
+layout(location = 3) in vec3 uv[8];
+vec4 TDWorldToProj(vec4 v);
+vec4 TDWorldToProj(vec3 v);
+vec4 TDWorldToProj(vec4 v, vec3 uv);
+vec4 TDWorldToProj(vec3 v, vec3 uv);
+int TDInstanceID();
+int TDCameraIndex();
+vec3 TDUVUnwrapCoord();
+/*********TOUCHDEFORMPREFIX**********/
+#define TD_NUM_BONES 0
+
+vec3 TDInstanceTexCoord(int instanceID, vec3 t);
+vec4 TDInstanceColor(int instanceID, vec4 curColor);
+
+vec4 TDDeform(vec4 pos);
+vec4 TDDeform(vec3 pos);
+vec3 TDInstanceTexCoord(vec3 t);
+vec4 TDInstanceColor(vec4 curColor);
+#line 1
+
+out Vertex
+{
+	vec4 color;
+	vec3 worldSpacePos;
+	vec3 texCoord0;
+	flat int cameraIndex;
+	flat int instance;
+} oVert;
+
+void main()
+{
+
+	{ // Avoid duplicate variable defs
+		vec3 texcoord = TDInstanceTexCoord(uv[0]);
+		oVert.texCoord0.stp = texcoord.stp;
+	}
+	// First deform the vertex and normal
+	// TDDeform always returns values in world space
+	oVert.instance = TDInstanceID();
+	vec4 worldSpacePos = TDDeform(P);
+	vec3 uvUnwrapCoord = TDInstanceTexCoord(TDUVUnwrapCoord());
+	gl_Position = TDWorldToProj(worldSpacePos, uvUnwrapCoord);
+
+
+	// This is here to ensure we only execute lighting etc. code
+	// when we need it. If picking is active we don't need lighting, so
+	// this entire block of code will be ommited from the compile.
+	// The TD_PICKING_ACTIVE define will be set automatically when
+	// picking is active.
+
+	int cameraIndex = TDCameraIndex();
+	oVert.cameraIndex = cameraIndex;
+	oVert.worldSpacePos.xyz = worldSpacePos.xyz;
+	oVert.color = TDInstanceColor(Cd);
+}

--- a/Test/vk.relaxed.stagelink.0.1.frag
+++ b/Test/vk.relaxed.stagelink.0.1.frag
@@ -1,0 +1,504 @@
+#version 460
+uniform sampler2D sTDNoiseMap;
+uniform sampler1D sTDSineLookup;
+uniform sampler2D sTDWhite2D;
+uniform sampler3D sTDWhite3D;
+uniform sampler2DArray sTDWhite2DArray;
+uniform samplerCube sTDWhiteCube;
+uniform int uTDInstanceIDOffset;
+uniform int uTDNumInstances;
+uniform float uTDAlphaTestVal;
+#define TD_NUM_COLOR_BUFFERS 1
+#define TD_NUM_LIGHTS 0
+#define TD_NUM_SHADOWED_LIGHTS 0
+#define TD_NUM_ENV_LIGHTS 0
+#define TD_LIGHTS_ARRAY_SIZE 1
+#define TD_ENV_LIGHTS_ARRAY_SIZE 1
+#define TD_NUM_CAMERAS 1
+struct TDLight
+{
+	vec4 position;
+	vec3 direction;
+	vec3 diffuse;
+	vec4 nearFar;
+	vec4 lightSize;
+	vec4 misc;
+	vec4 coneLookupScaleBias;
+	vec4 attenScaleBiasRoll;
+	mat4 shadowMapMatrix;
+	mat4 shadowMapCamMatrix;
+	vec4 shadowMapRes;
+	mat4 projMapMatrix;
+};
+struct TDEnvLight
+{
+	vec3 color;
+	mat3 rotate;
+};
+layout(std140) uniform TDLightBlock
+{
+	TDLight	uTDLights[TD_LIGHTS_ARRAY_SIZE];
+};
+layout(std140) uniform TDEnvLightBlock
+{
+	TDEnvLight	uTDEnvLights[TD_ENV_LIGHTS_ARRAY_SIZE];
+};
+layout(std430) readonly restrict buffer TDEnvLightBuffer
+{
+	vec3 shCoeffs[9];
+} uTDEnvLightBuffers[TD_ENV_LIGHTS_ARRAY_SIZE];
+struct TDPhongResult
+{
+	vec3 diffuse;
+	vec3 specular;
+	vec3 specular2;
+	float shadowStrength;
+};
+struct TDPBRResult
+{
+	vec3 diffuse;
+	vec3 specular;
+	float shadowStrength;
+};
+struct TDMatrix
+{
+	mat4 world;
+	mat4 worldInverse;
+	mat4 worldCam;
+	mat4 worldCamInverse;
+	mat4 cam;
+	mat4 camInverse;
+	mat4 camProj;
+	mat4 camProjInverse;
+	mat4 proj;
+	mat4 projInverse;
+	mat4 worldCamProj;
+	mat4 worldCamProjInverse;
+	mat4 quadReproject;
+	mat3 worldForNormals;
+	mat3 camForNormals;
+	mat3 worldCamForNormals;
+};
+layout(std140) uniform TDMatricesBlock {
+	TDMatrix uTDMats[TD_NUM_CAMERAS];
+};
+struct TDCameraInfo
+{
+	vec4 nearFar;
+	vec4 fog;
+	vec4 fogColor;
+	int renderTOPCameraIndex;
+};
+layout(std140) uniform TDCameraInfoBlock {
+	TDCameraInfo uTDCamInfos[TD_NUM_CAMERAS];
+};
+struct TDGeneral
+{
+	vec4 ambientColor;
+	vec4 nearFar;
+	vec4 viewport;
+	vec4 viewportRes;
+	vec4 fog;
+	vec4 fogColor;
+};
+layout(std140) uniform TDGeneralBlock {
+	TDGeneral uTDGeneral;
+};
+
+layout(binding = 15) uniform samplerBuffer sTDInstanceT;
+layout(binding = 16) uniform samplerBuffer sTDInstanceTexCoord;
+layout(binding = 17) uniform samplerBuffer sTDInstanceColor;
+vec4 TDDither(vec4 color);
+vec3 TDHSVToRGB(vec3 c);
+vec3 TDRGBToHSV(vec3 c);
+#define PI 3.14159265
+
+vec4 TDColor(vec4 color) { return color; }
+void TDCheckOrderIndTrans() {
+}
+void TDCheckDiscard() {
+	TDCheckOrderIndTrans();
+}
+vec4 TDDither(vec4 color)
+{
+   float d = texture(sTDNoiseMap, 
+                gl_FragCoord.xy / 256.0).r;
+   d -= 0.5;
+   d /= 256.0;
+   return vec4(color.rgb + d, color.a);
+}
+bool TDFrontFacing(vec3 pos, vec3 normal)
+{
+	return gl_FrontFacing;
+}
+float TDAttenuateLight(int index, float lightDist)
+{
+	return 1.0;
+}
+void TDAlphaTest(float alpha) {
+}
+float TDHardShadow(int lightIndex, vec3 worldSpacePos)
+{ return 0.0; }
+float TDSoftShadow(int lightIndex, vec3 worldSpacePos, int samples, int steps)
+{ return 0.0; }
+float TDSoftShadow(int lightIndex, vec3 worldSpacePos)
+{ return 0.0; }
+float TDShadow(int lightIndex, vec3 worldSpacePos)
+{ return 0.0; }
+vec3 TDEquirectangularToCubeMap(vec2 mapCoord);
+vec2 TDCubeMapToEquirectangular(vec3 envMapCoord);
+vec2 TDCubeMapToEquirectangular(vec3 envMapCoord, out float mipMapBias);
+vec2 TDTexGenSphere(vec3 envMapCoord);
+float iTDRadicalInverse_VdC(uint bits) 
+{
+	bits = (bits << 16u) | (bits >> 16u);
+    bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+    bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+    bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+    bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+    return float(bits) * 2.3283064365386963e-10; // / 0x100000000
+}
+vec2 iTDHammersley(uint i, uint N) 
+{
+    return vec2(float(i) / float(N), iTDRadicalInverse_VdC(i));
+}
+vec3 iTDImportanceSampleGGX(vec2 Xi, float roughness2, vec3 N)
+{	
+	float a = roughness2;
+	float phi = 2 * 3.14159265 * Xi.x;
+	float cosTheta = sqrt( (1 - Xi.y) / (1 + (a*a - 1) * Xi.y) );
+	float sinTheta = sqrt( 1 - cosTheta * cosTheta );
+	
+	vec3 H;
+	H.x = sinTheta * cos(phi);
+	H.y = sinTheta * sin(phi);
+	H.z = cosTheta;
+	
+	vec3 upVector = abs(N.z) < 0.999 ? vec3(0, 0, 1) : vec3(1, 0, 0);
+	vec3 tangentX = normalize(cross(upVector, N));
+	vec3 tangentY = cross(N, tangentX);
+	
+	// Tangent to world space
+	vec3 worldResult = tangentX * H.x + tangentY * H.y + N * H.z;
+	return worldResult;
+}
+float iTDDistributionGGX(vec3 normal, vec3 half_vector, float roughness2)
+{
+	const float Epsilon = 0.000001;
+
+    float NdotH = clamp(dot(normal, half_vector), Epsilon, 1.0);
+    
+    float alpha2 = roughness2 * roughness2;
+    
+    float denom = NdotH * NdotH * (alpha2 - 1.0) + 1.0;
+	denom = max(1e-8, denom);
+    return alpha2 / (PI * denom * denom);
+}
+vec3 iTDCalcF(vec3 F0, float VdotH) {
+    return F0 + (vec3(1.0) - F0) * pow(2.0, (-5.55473*VdotH - 6.98316) * VdotH);
+}
+
+float iTDCalcG(float NdotL, float NdotV, float k) {
+    float Gl = 1.0 / (NdotL * (1.0 - k) + k);
+    float Gv = 1.0 / (NdotV * (1.0 - k) + k);
+    return Gl * Gv;
+}
+// 0 - All options
+TDPBRResult TDLightingPBR(int index,vec3 diffuseColor,vec3 specularColor,vec3 worldSpacePos,vec3 normal,float shadowStrength,vec3 shadowColor,vec3 camVector,float roughness)
+{
+	TDPBRResult res;
+	return res;
+}
+// 0 - All options
+void TDLightingPBR(inout vec3 diffuseContrib,inout vec3 specularContrib,inout float shadowStrengthOut,int index,vec3 diffuseColor,vec3 specularColor,vec3 worldSpacePos,vec3 normal,float shadowStrength,vec3 shadowColor,vec3 camVector,float roughness)
+{
+	TDPBRResult res = TDLightingPBR(index,diffuseColor,specularColor,worldSpacePos,normal,shadowStrength,shadowColor,camVector,roughness);	diffuseContrib = res.diffuse;
+	specularContrib = res.specular;
+	shadowStrengthOut = res.shadowStrength;
+}
+// 0 - All options
+void TDLightingPBR(inout vec3 diffuseContrib,inout vec3 specularContrib,int index,vec3 diffuseColor,vec3 specularColor,vec3 worldSpacePos,vec3 normal,float shadowStrength,vec3 shadowColor,vec3 camVector,float roughness)
+{
+	TDPBRResult res = TDLightingPBR(index,diffuseColor,specularColor,worldSpacePos,normal,shadowStrength,shadowColor,camVector,roughness);	diffuseContrib = res.diffuse;
+	specularContrib = res.specular;
+}
+// 0 - All options
+TDPBRResult TDEnvLightingPBR(int index,vec3 diffuseColor,vec3 specularColor,vec3 normal,vec3 camVector,float roughness,float ambientOcclusion)
+{
+	TDPBRResult res;
+	return res;
+}
+// 0 - All options
+void TDEnvLightingPBR(inout vec3 diffuseContrib,inout vec3 specularContrib,int index,vec3 diffuseColor,vec3 specularColor,vec3 normal,vec3 camVector,float roughness,float ambientOcclusion)
+{
+	TDPBRResult res = TDEnvLightingPBR(index, diffuseColor, specularColor,										normal, camVector, roughness, ambientOcclusion);
+	diffuseContrib = res.diffuse;
+	specularContrib = res.specular;
+}
+// 0 - All options
+TDPhongResult TDLighting(int index,vec3 worldSpacePos,vec3 normal,float shadowStrength,vec3 shadowColor,vec3 camVector,float shininess,float shininess2)
+{
+	TDPhongResult res;
+	switch (index)
+	{
+		default:
+			res.diffuse = vec3(0.0);
+			res.specular = vec3(0.0);
+			res.specular2 = vec3(0.0);
+			res.shadowStrength = 0.0;
+			break;
+	}
+		return res;
+}
+// 0 - Legacy
+void TDLighting(inout vec3 diffuseContrib,inout vec3 specularContrib,inout vec3 specularContrib2,inout float shadowStrengthOut,int index,vec3 worldSpacePos,vec3 normal,float shadowStrength,vec3 shadowColor,vec3 camVector,float shininess,float shininess2)
+{
+	TDPhongResult res;
+	switch (index)
+	{
+		default:
+			res.diffuse = vec3(0.0);
+			res.specular = vec3(0.0);
+			res.specular2 = vec3(0.0);
+			res.shadowStrength = 0.0;
+			break;
+	}
+	diffuseContrib = res.diffuse;
+	specularContrib = res.specular;
+	specularContrib2 = res.specular2;
+	shadowStrengthOut = res.shadowStrength;
+}
+// 0 - Legacy
+void TDLighting(inout vec3 diffuseContrib,inout vec3 specularContrib,inout vec3 specularContrib2,int index,vec3 worldSpacePos,vec3 normal,float shadowStrength,vec3 shadowColor,vec3 camVector,float shininess,float shininess2)
+{
+	TDPhongResult res;
+	switch (index)
+	{
+		default:
+			res.diffuse = vec3(0.0);
+			res.specular = vec3(0.0);
+			res.specular2 = vec3(0.0);
+			res.shadowStrength = 0.0;
+			break;
+	}
+	diffuseContrib = res.diffuse;
+	specularContrib = res.specular;
+	specularContrib2 = res.specular2;
+}
+// 1 - Without specular2
+void TDLighting(inout vec3 diffuseContrib,inout vec3 specularContrib,int index,vec3 worldSpacePos,vec3 normal,float shadowStrength,vec3 shadowColor,vec3 camVector,float shininess)
+{
+	TDPhongResult res;
+	switch (index)
+	{
+		default:
+			res.diffuse = vec3(0.0);
+			res.specular = vec3(0.0);
+			res.specular2 = vec3(0.0);
+			res.shadowStrength = 0.0;
+			break;
+	}
+	diffuseContrib = res.diffuse;
+	specularContrib = res.specular;
+}
+// 2 - Without shadows
+void TDLighting(inout vec3 diffuseContrib,inout vec3 specularContrib,inout vec3 specularContrib2,int index,vec3 worldSpacePos,vec3 normal,vec3 camVector,float shininess,float shininess2)
+{
+	TDPhongResult res;
+	switch (index)
+	{
+		default:
+			res.diffuse = vec3(0.0);
+			res.specular = vec3(0.0);
+			res.specular2 = vec3(0.0);
+			res.shadowStrength = 0.0;
+			break;
+	}
+	diffuseContrib = res.diffuse;
+	specularContrib = res.specular;
+	specularContrib2 = res.specular2;
+}
+// 3 - diffuse and specular only
+void TDLighting(inout vec3 diffuseContrib,inout vec3 specularContrib,int index,vec3 worldSpacePos,vec3 normal,vec3 camVector,float shininess)
+{
+	TDPhongResult res;
+	switch (index)
+	{
+		default:
+			res.diffuse = vec3(0.0);
+			res.specular = vec3(0.0);
+			res.specular2 = vec3(0.0);
+			res.shadowStrength = 0.0;
+			break;
+	}
+	diffuseContrib = res.diffuse;
+	specularContrib = res.specular;
+}
+// 4 - Diffuse only
+void TDLighting(inout vec3 diffuseContrib,int index, vec3 worldSpacePos, vec3 normal)
+{
+	TDPhongResult res;
+	switch (index)
+	{
+		default:
+			res.diffuse = vec3(0.0);
+			res.specular = vec3(0.0);
+			res.specular2 = vec3(0.0);
+			res.shadowStrength = 0.0;
+			break;
+	}
+	diffuseContrib = res.diffuse;
+}
+// 5 - diffuse only with shadows
+void TDLighting(inout vec3 diffuseContrib,int index,vec3 worldSpacePos,vec3 normal,float shadowStrength,vec3 shadowColor)
+{
+	TDPhongResult res;
+	switch (index)
+	{
+		default:
+			res.diffuse = vec3(0.0);
+			res.specular = vec3(0.0);
+			res.specular2 = vec3(0.0);
+			res.shadowStrength = 0.0;
+			break;
+	}
+	diffuseContrib = res.diffuse;
+}
+vec4 TDProjMap(int index, vec3 worldSpacePos, vec4 defaultColor) {
+	switch (index)
+	{
+		default: return defaultColor;
+	}
+}
+vec4 TDFog(vec4 color, vec3 lightingSpacePosition, int cameraIndex) {
+	switch (cameraIndex) {
+			default:
+		case 0:
+		{
+	return color;
+		}
+	}
+}
+vec4 TDFog(vec4 color, vec3 lightingSpacePosition)
+{
+	return TDFog(color, lightingSpacePosition, 0);
+}
+vec3 TDInstanceTexCoord(int index, vec3 t) {
+	vec3 v;
+	int coord = index;
+	vec4 samp = texelFetch(sTDInstanceTexCoord, coord);
+	v[0] = t.s;
+	v[1] = t.t;
+	v[2] = samp[0];
+    t.stp = v.stp;
+	return t;
+}
+bool TDInstanceActive(int index) {
+	index -= uTDInstanceIDOffset;
+	float v;
+	int coord = index;
+	vec4 samp = texelFetch(sTDInstanceT, coord);
+	v = samp[0];
+	return v != 0.0;
+}
+vec3 iTDInstanceTranslate(int index, out bool instanceActive) {
+	int origIndex = index;
+	index -= uTDInstanceIDOffset;
+	vec3 v;
+	int coord = index;
+	vec4 samp = texelFetch(sTDInstanceT, coord);
+	v[0] = samp[1];
+	v[1] = samp[2];
+	v[2] = samp[3];
+	instanceActive = samp[0] != 0.0;
+	return v;
+}
+vec3 TDInstanceTranslate(int index) {
+	index -= uTDInstanceIDOffset;
+	vec3 v;
+	int coord = index;
+	vec4 samp = texelFetch(sTDInstanceT, coord);
+	v[0] = samp[1];
+	v[1] = samp[2];
+	v[2] = samp[3];
+	return v;
+}
+mat3 TDInstanceRotateMat(int index) {
+	index -= uTDInstanceIDOffset;
+	vec3 v = vec3(0.0, 0.0, 0.0);
+	mat3 m = mat3(1.0);
+{
+	mat3 r;
+}
+	return m;
+}
+vec3 TDInstanceScale(int index) {
+	index -= uTDInstanceIDOffset;
+	vec3 v = vec3(1.0, 1.0, 1.0);
+	return v;
+}
+vec3 TDInstancePivot(int index) {
+	index -= uTDInstanceIDOffset;
+	vec3 v = vec3(0.0, 0.0, 0.0);
+	return v;
+}
+vec3 TDInstanceRotTo(int index) {
+	index -= uTDInstanceIDOffset;
+	vec3 v = vec3(0.0, 0.0, 1.0);
+	return v;
+}
+vec3 TDInstanceRotUp(int index) {
+	index -= uTDInstanceIDOffset;
+	vec3 v = vec3(0.0, 1.0, 0.0);
+	return v;
+}
+mat4 TDInstanceMat(int id) {
+	bool instanceActive = true;
+	vec3 t = iTDInstanceTranslate(id, instanceActive);
+	if (!instanceActive)
+	{
+		return mat4(0.0);
+	}
+	mat4 m = mat4(1.0);
+	{
+		vec3 tt = t;
+		m[3][0] += m[0][0]*tt.x;
+		m[3][1] += m[0][1]*tt.x;
+		m[3][2] += m[0][2]*tt.x;
+		m[3][3] += m[0][3]*tt.x;
+		m[3][0] += m[1][0]*tt.y;
+		m[3][1] += m[1][1]*tt.y;
+		m[3][2] += m[1][2]*tt.y;
+		m[3][3] += m[1][3]*tt.y;
+		m[3][0] += m[2][0]*tt.z;
+		m[3][1] += m[2][1]*tt.z;
+		m[3][2] += m[2][2]*tt.z;
+		m[3][3] += m[2][3]*tt.z;
+	}
+	return m;
+}
+mat3 TDInstanceMat3(int id) {
+	mat3 m = mat3(1.0);
+	return m;
+}
+mat3 TDInstanceMat3ForNorm(int id) {
+	mat3 m = TDInstanceMat3(id);
+	return m;
+}
+vec4 TDInstanceColor(int index, vec4 curColor) {
+	index -= uTDInstanceIDOffset;
+	vec4 v;
+	int coord = index;
+	vec4 samp = texelFetch(sTDInstanceColor, coord);
+	v[0] = samp[0];
+	v[1] = samp[1];
+	v[2] = samp[2];
+	v[3] = 1.0;
+	curColor[0] = v[0];
+;
+	curColor[1] = v[1];
+;
+	curColor[2] = v[2];
+;
+	return curColor;
+}

--- a/Test/vk.relaxed.stagelink.0.1.vert
+++ b/Test/vk.relaxed.stagelink.0.1.vert
@@ -1,0 +1,242 @@
+#version 460
+layout(location = 0) in vec3 P;
+layout(location = 1) in vec3 N;
+layout(location = 2) in vec4 Cd;
+layout(location = 3) in vec3 uv[8];
+uniform int uTDInstanceIDOffset;
+uniform int uTDNumInstances;
+uniform float uTDAlphaTestVal;
+#define TD_NUM_COLOR_BUFFERS 1
+#define TD_NUM_LIGHTS 0
+#define TD_NUM_SHADOWED_LIGHTS 0
+#define TD_NUM_ENV_LIGHTS 0
+#define TD_LIGHTS_ARRAY_SIZE 1
+#define TD_ENV_LIGHTS_ARRAY_SIZE 1
+#define TD_NUM_CAMERAS 1
+struct TDLight
+{
+	vec4 position;
+	vec3 direction;
+	vec3 diffuse;
+	vec4 nearFar;
+	vec4 lightSize;
+	vec4 misc;
+	vec4 coneLookupScaleBias;
+	vec4 attenScaleBiasRoll;
+	mat4 shadowMapMatrix;
+	mat4 shadowMapCamMatrix;
+	vec4 shadowMapRes;
+	mat4 projMapMatrix;
+};
+struct TDEnvLight
+{
+	vec3 color;
+	mat3 rotate;
+};
+layout(std140) uniform TDLightBlock
+{
+	TDLight	uTDLights[TD_LIGHTS_ARRAY_SIZE];
+};
+layout(std140) uniform TDEnvLightBlock
+{
+	TDEnvLight	uTDEnvLights[TD_ENV_LIGHTS_ARRAY_SIZE];
+};
+layout(std430) readonly restrict buffer TDEnvLightBuffer
+{
+	vec3 shCoeffs[9];
+} uTDEnvLightBuffers[TD_ENV_LIGHTS_ARRAY_SIZE];
+struct TDPhongResult
+{
+	vec3 diffuse;
+	vec3 specular;
+	vec3 specular2;
+	float shadowStrength;
+};
+struct TDPBRResult
+{
+	vec3 diffuse;
+	vec3 specular;
+	float shadowStrength;
+};
+struct TDMatrix
+{
+	mat4 world;
+	mat4 worldInverse;
+	mat4 worldCam;
+	mat4 worldCamInverse;
+	mat4 cam;
+	mat4 camInverse;
+	mat4 camProj;
+	mat4 camProjInverse;
+	mat4 proj;
+	mat4 projInverse;
+	mat4 worldCamProj;
+	mat4 worldCamProjInverse;
+	mat4 quadReproject;
+	mat3 worldForNormals;
+	mat3 camForNormals;
+	mat3 worldCamForNormals;
+};
+layout(std140) uniform TDMatricesBlock {
+	TDMatrix uTDMats[TD_NUM_CAMERAS];
+};
+struct TDCameraInfo
+{
+	vec4 nearFar;
+	vec4 fog;
+	vec4 fogColor;
+	int renderTOPCameraIndex;
+};
+layout(std140) uniform TDCameraInfoBlock {
+	TDCameraInfo uTDCamInfos[TD_NUM_CAMERAS];
+};
+struct TDGeneral
+{
+	vec4 ambientColor;
+	vec4 nearFar;
+	vec4 viewport;
+	vec4 viewportRes;
+	vec4 fog;
+	vec4 fogColor;
+};
+layout(std140) uniform TDGeneralBlock {
+	TDGeneral uTDGeneral;
+};
+layout (rgba8) uniform image2D mTD2DImageOutputs[1];
+layout (rgba8) uniform image2DArray mTD2DArrayImageOutputs[1];
+layout (rgba8) uniform image3D mTD3DImageOutputs[1];
+layout (rgba8) uniform imageCube mTDCubeImageOutputs[1];
+
+mat4 TDInstanceMat(int instanceID);
+mat3 TDInstanceMat3(int instanceID);
+vec3 TDInstanceTranslate(int instanceID);
+bool TDInstanceActive(int instanceID);
+mat3 TDInstanceRotateMat(int instanceID);
+vec3 TDInstanceScale(int instanceID);
+vec3 TDInstanceTexCoord(int instanceID, vec3 t);
+vec4 TDInstanceColor(int instanceID, vec4 curColor);
+vec4 TDInstanceCustomAttrib0(int instanceID);
+vec4 TDInstanceCustomAttrib1(int instanceID);
+vec4 TDInstanceCustomAttrib2(int instanceID);
+vec4 TDInstanceCustomAttrib3(int instanceID);
+vec4 TDInstanceCustomAttrib4(int instanceID);
+vec4 TDInstanceCustomAttrib5(int instanceID);
+vec4 TDInstanceCustomAttrib6(int instanceID);
+vec4 TDInstanceCustomAttrib7(int instanceID);
+vec4 TDInstanceCustomAttrib8(int instanceID);
+vec4 TDInstanceCustomAttrib9(int instanceID);
+vec4 TDInstanceCustomAttrib10(int instanceID);
+vec4 TDInstanceCustomAttrib11(int instanceID);
+uint TDInstanceTextureIndex(int instanceIndex);
+vec4 TDInstanceTexture(uint texIndex, vec3 uv);
+vec4 TDInstanceTexture(uint texIndex, vec2 uv);
+
+vec4 TDDeform(vec4 pos);
+vec4 TDDeform(vec3 pos);
+vec4 TDDeform(int instanceID, vec3 pos);
+vec3 TDDeformVec(vec3 v); 
+vec3 TDDeformVec(int instanceID, vec3 v); 
+vec3 TDDeformNorm(vec3 v); 
+vec3 TDDeformNorm(int instanceID, vec3 v); 
+vec4 TDSkinnedDeform(vec4 pos);
+vec3 TDSkinnedDeformVec(vec3 vec);
+vec3 TDSkinnedDeformNorm(vec3 vec);
+vec4 TDInstanceDeform(vec4 pos);
+vec3 TDInstanceDeformVec(vec3 vec);
+vec3 TDInstanceDeformNorm(vec3 vec);
+vec4 TDInstanceDeform(int instanceID, vec4 pos);
+vec3 TDInstanceDeformVec(int instanceID, vec3 vec);
+vec3 TDInstanceDeformNorm(int instanceID, vec3 vec);
+vec3 TDFastDeformTangent(vec3 oldNorm, vec4 oldTangent, vec3 deformedNorm);
+mat4 TDBoneMat(int boneIndex);
+mat4 TDInstanceMat();
+mat3 TDInstanceMat3();
+vec3 TDInstanceTranslate();
+bool TDInstanceActive();
+mat3 TDInstanceRotateMat();
+vec3 TDInstanceScale();
+vec3 TDInstanceTexCoord(vec3 t);
+vec4 TDInstanceColor(vec4 curColor);
+vec4 TDPointColor();
+#ifdef TD_PICKING_ACTIVE
+out TDPickVertex {
+	vec3 sopSpacePosition;
+	vec3 camSpacePosition;
+	vec3 worldSpacePosition;
+	vec3 sopSpaceNormal;
+	vec3 camSpaceNormal;
+	vec3 worldSpaceNormal;
+	vec3 uv[1];
+	flat int pickId;
+	flat int instanceId;
+	vec4 color;
+} oTDPickVert;
+#define vTDPickVert oTDPickVert
+#endif
+vec4 iTDCamToProj(vec4 v, vec3 uv, int cameraIndex, bool applyPickMod)
+{
+	if (!TDInstanceActive())
+		return vec4(2, 2, 2, 0);
+	v = uTDMats[0].proj * v;
+	return v;
+}
+vec4 iTDWorldToProj(vec4 v, vec3 uv, int cameraIndex, bool applyPickMod) {
+	if (!TDInstanceActive())
+		return vec4(2, 2, 2, 0);
+	v = uTDMats[0].camProj * v;
+	return v;
+}
+vec4 TDDeform(vec4 pos);
+vec4 TDDeform(vec3 pos);
+vec4 TDInstanceColor(vec4 curColor);
+vec3 TDInstanceTexCoord(vec3 t);
+int TDInstanceID() {
+	return gl_InstanceID + uTDInstanceIDOffset;
+}
+int TDCameraIndex() {
+	return 0;
+}
+vec3 TDUVUnwrapCoord() {
+	return uv[0];
+}
+#ifdef TD_PICKING_ACTIVE
+uniform int uTDPickId;
+#endif
+int TDPickID() {
+#ifdef TD_PICKING_ACTIVE
+	return uTDPickId;
+#else
+	return 0;
+#endif
+}
+float iTDConvertPickId(int id) {
+	id |= 1073741824;
+	return intBitsToFloat(id);
+}
+
+	void TDWritePickingValues() {
+#ifdef TD_PICKING_ACTIVE
+   vec4 worldPos = TDDeform(P);
+   vec4 camPos = uTDMats[TDCameraIndex()].cam * worldPos;
+	oTDPickVert.pickId = TDPickID();
+#endif
+}
+vec4 TDWorldToProj(vec4 v, vec3 uv)
+{
+	return iTDWorldToProj(v, uv, TDCameraIndex(), true);
+}
+vec4 TDWorldToProj(vec3 v, vec3 uv)
+{
+	return TDWorldToProj(vec4(v, 1.0), uv);
+}
+vec4 TDWorldToProj(vec4 v)
+{
+	return TDWorldToProj(v, vec3(0.0));
+}
+vec4 TDWorldToProj(vec3 v)
+{
+	return TDWorldToProj(vec4(v, 1.0));
+}
+vec4 TDPointColor() {
+	return Cd;
+}

--- a/Test/vk.relaxed.stagelink.0.2.frag
+++ b/Test/vk.relaxed.stagelink.0.2.frag
@@ -1,0 +1,9 @@
+#version 460
+vec4 TDOutputSwizzle(vec4 c)
+{
+	return c.rgba;
+}
+uvec4 TDOutputSwizzle(uvec4 c)
+{
+	return c.rgba;
+}

--- a/Test/vk.relaxed.stagelink.0.2.vert
+++ b/Test/vk.relaxed.stagelink.0.2.vert
@@ -1,0 +1,320 @@
+#version 460
+uniform int uTDInstanceIDOffset;
+uniform int uTDNumInstances;
+uniform float uTDAlphaTestVal;
+#define TD_NUM_COLOR_BUFFERS 1
+#define TD_NUM_LIGHTS 0
+#define TD_NUM_SHADOWED_LIGHTS 0
+#define TD_NUM_ENV_LIGHTS 0
+#define TD_LIGHTS_ARRAY_SIZE 1
+#define TD_ENV_LIGHTS_ARRAY_SIZE 1
+#define TD_NUM_CAMERAS 1
+struct TDLight
+{
+	vec4 position;
+	vec3 direction;
+	vec3 diffuse;
+	vec4 nearFar;
+	vec4 lightSize;
+	vec4 misc;
+	vec4 coneLookupScaleBias;
+	vec4 attenScaleBiasRoll;
+	mat4 shadowMapMatrix;
+	mat4 shadowMapCamMatrix;
+	vec4 shadowMapRes;
+	mat4 projMapMatrix;
+};
+struct TDEnvLight
+{
+	vec3 color;
+	mat3 rotate;
+};
+layout(std140) uniform TDLightBlock
+{
+	TDLight	uTDLights[TD_LIGHTS_ARRAY_SIZE];
+};
+layout(std140) uniform TDEnvLightBlock
+{
+	TDEnvLight	uTDEnvLights[TD_ENV_LIGHTS_ARRAY_SIZE];
+};
+layout(std430) readonly restrict buffer TDEnvLightBuffer
+{
+	vec3 shCoeffs[9];
+} uTDEnvLightBuffers[TD_ENV_LIGHTS_ARRAY_SIZE];
+struct TDPhongResult
+{
+	vec3 diffuse;
+	vec3 specular;
+	vec3 specular2;
+	float shadowStrength;
+};
+struct TDPBRResult
+{
+	vec3 diffuse;
+	vec3 specular;
+	float shadowStrength;
+};
+struct TDMatrix
+{
+	mat4 world;
+	mat4 worldInverse;
+	mat4 worldCam;
+	mat4 worldCamInverse;
+	mat4 cam;
+	mat4 camInverse;
+	mat4 camProj;
+	mat4 camProjInverse;
+	mat4 proj;
+	mat4 projInverse;
+	mat4 worldCamProj;
+	mat4 worldCamProjInverse;
+	mat4 quadReproject;
+	mat3 worldForNormals;
+	mat3 camForNormals;
+	mat3 worldCamForNormals;
+};
+layout(std140) uniform TDMatricesBlock {
+	TDMatrix uTDMats[TD_NUM_CAMERAS];
+};
+struct TDCameraInfo
+{
+	vec4 nearFar;
+	vec4 fog;
+	vec4 fogColor;
+	int renderTOPCameraIndex;
+};
+layout(std140) uniform TDCameraInfoBlock {
+	TDCameraInfo uTDCamInfos[TD_NUM_CAMERAS];
+};
+struct TDGeneral
+{
+	vec4 ambientColor;
+	vec4 nearFar;
+	vec4 viewport;
+	vec4 viewportRes;
+	vec4 fog;
+	vec4 fogColor;
+};
+layout(std140) uniform TDGeneralBlock {
+	TDGeneral uTDGeneral;
+};
+
+layout(binding = 15) uniform samplerBuffer sTDInstanceT;
+layout(binding = 16) uniform samplerBuffer sTDInstanceTexCoord;
+layout(binding = 17) uniform samplerBuffer sTDInstanceColor;
+#define TD_NUM_BONES 0
+vec4 TDWorldToProj(vec4 v);
+vec4 TDWorldToProj(vec3 v);
+vec4 TDWorldToProj(vec4 v, vec3 uv);
+vec4 TDWorldToProj(vec3 v, vec3 uv);
+int TDPickID();
+int TDInstanceID();
+int TDCameraIndex();
+vec3 TDUVUnwrapCoord();
+vec3 TDInstanceTexCoord(int index, vec3 t) {
+	vec3 v;
+	int coord = index;
+	vec4 samp = texelFetch(sTDInstanceTexCoord, coord);
+	v[0] = t.s;
+	v[1] = t.t;
+	v[2] = samp[0];
+    t.stp = v.stp;
+	return t;
+}
+bool TDInstanceActive(int index) {
+	index -= uTDInstanceIDOffset;
+	float v;
+	int coord = index;
+	vec4 samp = texelFetch(sTDInstanceT, coord);
+	v = samp[0];
+	return v != 0.0;
+}
+vec3 iTDInstanceTranslate(int index, out bool instanceActive) {
+	int origIndex = index;
+	index -= uTDInstanceIDOffset;
+	vec3 v;
+	int coord = index;
+	vec4 samp = texelFetch(sTDInstanceT, coord);
+	v[0] = samp[1];
+	v[1] = samp[2];
+	v[2] = samp[3];
+	instanceActive = samp[0] != 0.0;
+	return v;
+}
+vec3 TDInstanceTranslate(int index) {
+	index -= uTDInstanceIDOffset;
+	vec3 v;
+	int coord = index;
+	vec4 samp = texelFetch(sTDInstanceT, coord);
+	v[0] = samp[1];
+	v[1] = samp[2];
+	v[2] = samp[3];
+	return v;
+}
+mat3 TDInstanceRotateMat(int index) {
+	index -= uTDInstanceIDOffset;
+	vec3 v = vec3(0.0, 0.0, 0.0);
+	mat3 m = mat3(1.0);
+{
+	mat3 r;
+}
+	return m;
+}
+vec3 TDInstanceScale(int index) {
+	index -= uTDInstanceIDOffset;
+	vec3 v = vec3(1.0, 1.0, 1.0);
+	return v;
+}
+vec3 TDInstancePivot(int index) {
+	index -= uTDInstanceIDOffset;
+	vec3 v = vec3(0.0, 0.0, 0.0);
+	return v;
+}
+vec3 TDInstanceRotTo(int index) {
+	index -= uTDInstanceIDOffset;
+	vec3 v = vec3(0.0, 0.0, 1.0);
+	return v;
+}
+vec3 TDInstanceRotUp(int index) {
+	index -= uTDInstanceIDOffset;
+	vec3 v = vec3(0.0, 1.0, 0.0);
+	return v;
+}
+mat4 TDInstanceMat(int id) {
+	bool instanceActive = true;
+	vec3 t = iTDInstanceTranslate(id, instanceActive);
+	if (!instanceActive)
+	{
+		return mat4(0.0);
+	}
+	mat4 m = mat4(1.0);
+	{
+		vec3 tt = t;
+		m[3][0] += m[0][0]*tt.x;
+		m[3][1] += m[0][1]*tt.x;
+		m[3][2] += m[0][2]*tt.x;
+		m[3][3] += m[0][3]*tt.x;
+		m[3][0] += m[1][0]*tt.y;
+		m[3][1] += m[1][1]*tt.y;
+		m[3][2] += m[1][2]*tt.y;
+		m[3][3] += m[1][3]*tt.y;
+		m[3][0] += m[2][0]*tt.z;
+		m[3][1] += m[2][1]*tt.z;
+		m[3][2] += m[2][2]*tt.z;
+		m[3][3] += m[2][3]*tt.z;
+	}
+	return m;
+}
+mat3 TDInstanceMat3(int id) {
+	mat3 m = mat3(1.0);
+	return m;
+}
+mat3 TDInstanceMat3ForNorm(int id) {
+	mat3 m = TDInstanceMat3(id);
+	return m;
+}
+vec4 TDInstanceColor(int index, vec4 curColor) {
+	index -= uTDInstanceIDOffset;
+	vec4 v;
+	int coord = index;
+	vec4 samp = texelFetch(sTDInstanceColor, coord);
+	v[0] = samp[0];
+	v[1] = samp[1];
+	v[2] = samp[2];
+	v[3] = 1.0;
+	curColor[0] = v[0];
+;
+	curColor[1] = v[1];
+;
+	curColor[2] = v[2];
+;
+	return curColor;
+}
+vec4 TDInstanceDeform(int id, vec4 pos) {
+	pos = TDInstanceMat(id) * pos;
+	return uTDMats[TDCameraIndex()].world * pos;
+}
+
+vec3 TDInstanceDeformVec(int id, vec3 vec)
+{
+	mat3 m = TDInstanceMat3(id);
+	return mat3(uTDMats[TDCameraIndex()].world) * (m * vec);
+}
+vec3 TDInstanceDeformNorm(int id, vec3 vec)
+{
+	mat3 m = TDInstanceMat3ForNorm(id);
+	return mat3(uTDMats[TDCameraIndex()].worldForNormals) * (m * vec);
+}
+vec4 TDInstanceDeform(vec4 pos) {
+	return TDInstanceDeform(TDInstanceID(), pos);
+}
+vec3 TDInstanceDeformVec(vec3 vec) {
+	return TDInstanceDeformVec(TDInstanceID(), vec);
+}
+vec3 TDInstanceDeformNorm(vec3 vec) {
+	return TDInstanceDeformNorm(TDInstanceID(), vec);
+}
+bool TDInstanceActive() { return TDInstanceActive(TDInstanceID()); }
+vec3 TDInstanceTranslate() { return TDInstanceTranslate(TDInstanceID()); }
+mat3 TDInstanceRotateMat() { return TDInstanceRotateMat(TDInstanceID()); }
+vec3 TDInstanceScale() { return TDInstanceScale(TDInstanceID()); }
+mat4 TDInstanceMat() { return TDInstanceMat(TDInstanceID());
+ }
+mat3 TDInstanceMat3() { return TDInstanceMat3(TDInstanceID());
+}
+vec3 TDInstanceTexCoord(vec3 t) {
+	return TDInstanceTexCoord(TDInstanceID(), t);
+}
+vec4 TDInstanceColor(vec4 curColor) {
+	return TDInstanceColor(TDInstanceID(), curColor);
+}
+vec4 TDSkinnedDeform(vec4 pos) { return pos; }
+
+vec3 TDSkinnedDeformVec(vec3 vec) { return vec; }
+
+vec3 TDFastDeformTangent(vec3 oldNorm, vec4 oldTangent, vec3 deformedNorm)
+{   return oldTangent.xyz;   }
+mat4 TDBoneMat(int index) {
+   return mat4(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1);
+}
+vec4 TDDeform(vec4 pos) {
+    pos = TDSkinnedDeform(pos);
+    pos = TDInstanceDeform(pos);
+    return pos;
+}
+
+vec4 TDDeform(int instanceID, vec3 p) {
+	vec4 pos = vec4(p, 1.0);
+    pos = TDSkinnedDeform(pos);
+    pos = TDInstanceDeform(instanceID, pos);
+    return pos;
+}
+
+vec4 TDDeform(vec3 pos) {
+	return TDDeform(TDInstanceID(), pos);
+}
+
+vec3 TDDeformVec(int instanceID, vec3 vec) {
+    vec = TDSkinnedDeformVec(vec);
+    vec = TDInstanceDeformVec(instanceID, vec);
+    return vec;
+}
+
+vec3 TDDeformVec(vec3 vec) {
+	return TDDeformVec(TDInstanceID(), vec);
+}
+
+vec3 TDDeformNorm(int instanceID, vec3 vec) {
+    vec = TDSkinnedDeformVec(vec);
+    vec = TDInstanceDeformNorm(instanceID, vec);
+    return vec;
+}
+
+vec3 TDDeformNorm(vec3 vec) {
+	return TDDeformNorm(TDInstanceID(), vec);
+}
+
+vec3 TDSkinnedDeformNorm(vec3 vec) {
+    vec = TDSkinnedDeformVec(vec);
+	return vec;
+}

--- a/gtests/VkRelaxed.FromFile.cpp
+++ b/gtests/VkRelaxed.FromFile.cpp
@@ -107,8 +107,8 @@ bool verifyIOMapping(std::string& linkingError, glslang::TProgram& program) {
                 auto inQualifier = in.getType()->getQualifier();
                 auto outQualifier = out->second->getType()->getQualifier();
                 success &= outQualifier.layoutLocation == inQualifier.layoutLocation;
-            }
-            else {
+            // These are not part of a matched interface. Other cases still need to be added.
+            } else if (name != "gl_FrontFacing" && name != "gl_FragCoord") {
                 success &= false;
             }
         }
@@ -293,6 +293,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::ValuesIn(std::vector<vkRelaxedData>({
         {{"vk.relaxed.frag"}},
         {{"vk.relaxed.link1.frag", "vk.relaxed.link2.frag"}},
+        {{"vk.relaxed.stagelink.0.0.vert", "vk.relaxed.stagelink.0.1.vert", "vk.relaxed.stagelink.0.2.vert", "vk.relaxed.stagelink.0.0.frag", "vk.relaxed.stagelink.0.1.frag", "vk.relaxed.stagelink.0.2.frag"}},
         {{"vk.relaxed.stagelink.vert", "vk.relaxed.stagelink.frag"}},
         {{"vk.relaxed.errorcheck.vert", "vk.relaxed.errorcheck.frag"}},
         {{"vk.relaxed.changeSet.vert", "vk.relaxed.changeSet.frag" }, { {"0"}, {"1"} } },


### PR DESCRIPTION
For GL_EXT_vulkan_glsl_relaxed. When merging the default uniform block,
there were cases where symbols in the tree wern't updated to match the
new block structure after merging blocks together.

This change traverses the symbol tree and updates any references to the
merged block.