### PR TITLE
Fix sameElementShape test of sampler

### DIFF
--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -2703,7 +2703,7 @@ public:
             *lpidx = -1;
             *rpidx = -1;
         }
-        return    sampler == right.sampler    &&
+        return ((basicType != EbtSampler && right.basicType != EbtSampler) || sampler == right.sampler) &&
                vectorSize == right.vectorSize &&
                matrixCols == right.matrixCols &&
                matrixRows == right.matrixRows &&


### PR DESCRIPTION
There is apparently a hole in the initialization of sampler in TType
so that a simple comparison which should pass might fail. Until the
hole is found, also test that both types are samplers before comparing
the sampler field for equality.

Fixes #2875