### PR TITLE
Explicitly use Python 3 for scripts

### DIFF
--- a/build_info.py
+++ b/build_info.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2020 Google Inc.
 #

--- a/gen_extension_headers.py
+++ b/gen_extension_headers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2020 Google Inc.
 #

--- a/update_glslang_sources.py
+++ b/update_glslang_sources.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2017 The Glslang Authors. All rights reserved.
 #


### PR DESCRIPTION
This fixes `update_glslang_sources.py` and the other Python scripts on macOS 12.3, which no longer includes Python 2 or any `/usr/bin/python`.