### PR TITLE
Improve error message for image/sampler functions under enhanced-msgs

### DIFF
--- a/Test/baseResults/spv.textureError.frag.out
+++ b/Test/baseResults/spv.textureError.frag.out
@@ -1,0 +1,6 @@
+spv.textureError.frag
+ERROR: spv.textureError.frag:8: 'texture*D*' : function not supported in this version; use texture() instead 
+ERROR: 1 compilation errors.  No code generated.
+
+
+SPIR-V is not generated for failed compile or link

--- a/Test/runtests
+++ b/Test/runtests
@@ -319,6 +319,8 @@ run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.6.vert enhanc
 diff -b $BASEDIR/enhanced.6.link.out $TARGETDIR/enhanced.6.link.out || HASERROR=1
 run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.7.vert enhanced.7.frag > $TARGETDIR/enhanced.7.link.out
 diff -b $BASEDIR/enhanced.7.link.out $TARGETDIR/enhanced.7.link.out || HASERROR=1
+run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml spv.textureError.frag > $TARGETDIR/spv.textureError.frag.out
+diff -b $BASEDIR/spv.textureError.frag.out $TARGETDIR/spv.textureError.frag.out || HASERROR=1
 
 #
 # Final checking

--- a/Test/spv.textureError.frag
+++ b/Test/spv.textureError.frag
@@ -1,0 +1,10 @@
+#version 140
+
+uniform sampler2D s2D;
+centroid vec2 centTexCoord;
+
+void main()
+{
+    gl_FragColor = texture2D(s2D, centTexCoord);
+}
+

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -2799,7 +2799,10 @@ TFunction* TParseContext::handleConstructorCall(const TSourceLoc& loc, const TPu
     TOperator op = intermediate.mapTypeToConstructorOp(type);
 
     if (op == EOpNull) {
-        error(loc, "cannot construct this type", type.getBasicString(), "");
+      if (intermediate.getEnhancedMsgs() && type.getBasicType() == EbtSampler)
+            error(loc, "function not supported in this version; use texture() instead", "texture*D*", "");
+        else
+            error(loc, "cannot construct this type", type.getBasicString(), "");
         op = EOpConstructFloat;
         TType errorType(EbtFloat);
         type.shallowCopy(errorType);


### PR DESCRIPTION
For recent GLSL versions, if texture2D function call appears, the error
message reports an unsupported type constructor. Change message to
unsupported function. Likewise for other removed texture* function calls.