### PR TITLE
Fix the issue for GL_ARB_fragment_coord_conventions extension.

### DIFF
--- a/Test/baseResults/coord_conventions.frag.out
+++ b/Test/baseResults/coord_conventions.frag.out
@@ -1,0 +1,255 @@
+coord_conventions.frag
+Shader version: 140
+Requested GL_ARB_explicit_attrib_location
+Requested GL_ARB_fragment_coord_conventions
+gl_FragCoord pixel center is integer
+gl_FragCoord origin is upper left
+0:? Sequence
+0:17  Function Definition: main( ( global void)
+0:17    Function Parameters: 
+0:19    Sequence
+0:19      move second child to first child ( temp 4-component vector of float)
+0:19        'myColor' (layout( location=0) out 4-component vector of float)
+0:19        Constant:
+0:19          0.200000
+0:19          0.200000
+0:19          0.200000
+0:19          0.200000
+0:20      Test condition and select ( temp void)
+0:20        Condition
+0:20        Compare Greater Than or Equal ( temp bool)
+0:20          direct index ( temp float)
+0:20            'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:20            Constant:
+0:20              1 (const int)
+0:20          Constant:
+0:20            10.000000
+0:20        true case
+0:21        Sequence
+0:21          move second child to first child ( temp float)
+0:21            direct index ( temp float)
+0:21              'myColor' (layout( location=0) out 4-component vector of float)
+0:21              Constant:
+0:21                2 (const int)
+0:21            Constant:
+0:21              0.800000
+0:23      Test condition and select ( temp void)
+0:23        Condition
+0:23        Compare Equal ( temp bool)
+0:23          direct index ( temp float)
+0:23            'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:23            Constant:
+0:23              1 (const int)
+0:23          trunc ( global float)
+0:23            direct index ( temp float)
+0:23              'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:23              Constant:
+0:23                1 (const int)
+0:23        true case
+0:24        Sequence
+0:24          move second child to first child ( temp float)
+0:24            direct index ( temp float)
+0:24              'myColor' (layout( location=0) out 4-component vector of float)
+0:24              Constant:
+0:24                1 (const int)
+0:24            Constant:
+0:24              0.800000
+0:26      Test condition and select ( temp void)
+0:26        Condition
+0:26        Compare Equal ( temp bool)
+0:26          direct index ( temp float)
+0:26            'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:26            Constant:
+0:26              0 (const int)
+0:26          trunc ( global float)
+0:26            direct index ( temp float)
+0:26              'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:26              Constant:
+0:26                0 (const int)
+0:26        true case
+0:27        Sequence
+0:27          move second child to first child ( temp float)
+0:27            direct index ( temp float)
+0:27              'myColor' (layout( location=0) out 4-component vector of float)
+0:27              Constant:
+0:27                0 (const int)
+0:27            Constant:
+0:27              0.800000
+0:30      Sequence
+0:30        move second child to first child ( temp 4-component vector of float)
+0:30          'diff' ( temp 4-component vector of float)
+0:30          subtract ( temp 4-component vector of float)
+0:30            'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:30            'i' ( smooth in 4-component vector of float)
+0:31      Test condition and select ( temp void)
+0:31        Condition
+0:31        Compare Greater Than ( temp bool)
+0:31          Absolute value ( global float)
+0:31            direct index ( temp float)
+0:31              'diff' ( temp 4-component vector of float)
+0:31              Constant:
+0:31                2 (const int)
+0:31          Constant:
+0:31            0.001000
+0:31        true case
+0:32        move second child to first child ( temp float)
+0:32          direct index ( temp float)
+0:32            'myColor' (layout( location=0) out 4-component vector of float)
+0:32            Constant:
+0:32              2 (const int)
+0:32          Constant:
+0:32            0.500000
+0:33      Test condition and select ( temp void)
+0:33        Condition
+0:33        Compare Greater Than ( temp bool)
+0:33          Absolute value ( global float)
+0:33            direct index ( temp float)
+0:33              'diff' ( temp 4-component vector of float)
+0:33              Constant:
+0:33                3 (const int)
+0:33          Constant:
+0:33            0.001000
+0:33        true case
+0:34        move second child to first child ( temp float)
+0:34          direct index ( temp float)
+0:34            'myColor' (layout( location=0) out 4-component vector of float)
+0:34            Constant:
+0:34              3 (const int)
+0:34          Constant:
+0:34            0.500000
+0:?   Linker Objects
+0:?     'i' ( smooth in 4-component vector of float)
+0:?     'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:?     'myColor' (layout( location=0) out 4-component vector of float)
+0:?     'eps' ( const float)
+0:?       0.001000
+
+
+Linked fragment stage:
+
+
+Shader version: 140
+Requested GL_ARB_explicit_attrib_location
+Requested GL_ARB_fragment_coord_conventions
+gl_FragCoord pixel center is integer
+gl_FragCoord origin is upper left
+0:? Sequence
+0:17  Function Definition: main( ( global void)
+0:17    Function Parameters: 
+0:19    Sequence
+0:19      move second child to first child ( temp 4-component vector of float)
+0:19        'myColor' (layout( location=0) out 4-component vector of float)
+0:19        Constant:
+0:19          0.200000
+0:19          0.200000
+0:19          0.200000
+0:19          0.200000
+0:20      Test condition and select ( temp void)
+0:20        Condition
+0:20        Compare Greater Than or Equal ( temp bool)
+0:20          direct index ( temp float)
+0:20            'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:20            Constant:
+0:20              1 (const int)
+0:20          Constant:
+0:20            10.000000
+0:20        true case
+0:21        Sequence
+0:21          move second child to first child ( temp float)
+0:21            direct index ( temp float)
+0:21              'myColor' (layout( location=0) out 4-component vector of float)
+0:21              Constant:
+0:21                2 (const int)
+0:21            Constant:
+0:21              0.800000
+0:23      Test condition and select ( temp void)
+0:23        Condition
+0:23        Compare Equal ( temp bool)
+0:23          direct index ( temp float)
+0:23            'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:23            Constant:
+0:23              1 (const int)
+0:23          trunc ( global float)
+0:23            direct index ( temp float)
+0:23              'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:23              Constant:
+0:23                1 (const int)
+0:23        true case
+0:24        Sequence
+0:24          move second child to first child ( temp float)
+0:24            direct index ( temp float)
+0:24              'myColor' (layout( location=0) out 4-component vector of float)
+0:24              Constant:
+0:24                1 (const int)
+0:24            Constant:
+0:24              0.800000
+0:26      Test condition and select ( temp void)
+0:26        Condition
+0:26        Compare Equal ( temp bool)
+0:26          direct index ( temp float)
+0:26            'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:26            Constant:
+0:26              0 (const int)
+0:26          trunc ( global float)
+0:26            direct index ( temp float)
+0:26              'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:26              Constant:
+0:26                0 (const int)
+0:26        true case
+0:27        Sequence
+0:27          move second child to first child ( temp float)
+0:27            direct index ( temp float)
+0:27              'myColor' (layout( location=0) out 4-component vector of float)
+0:27              Constant:
+0:27                0 (const int)
+0:27            Constant:
+0:27              0.800000
+0:30      Sequence
+0:30        move second child to first child ( temp 4-component vector of float)
+0:30          'diff' ( temp 4-component vector of float)
+0:30          subtract ( temp 4-component vector of float)
+0:30            'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:30            'i' ( smooth in 4-component vector of float)
+0:31      Test condition and select ( temp void)
+0:31        Condition
+0:31        Compare Greater Than ( temp bool)
+0:31          Absolute value ( global float)
+0:31            direct index ( temp float)
+0:31              'diff' ( temp 4-component vector of float)
+0:31              Constant:
+0:31                2 (const int)
+0:31          Constant:
+0:31            0.001000
+0:31        true case
+0:32        move second child to first child ( temp float)
+0:32          direct index ( temp float)
+0:32            'myColor' (layout( location=0) out 4-component vector of float)
+0:32            Constant:
+0:32              2 (const int)
+0:32          Constant:
+0:32            0.500000
+0:33      Test condition and select ( temp void)
+0:33        Condition
+0:33        Compare Greater Than ( temp bool)
+0:33          Absolute value ( global float)
+0:33            direct index ( temp float)
+0:33              'diff' ( temp 4-component vector of float)
+0:33              Constant:
+0:33                3 (const int)
+0:33          Constant:
+0:33            0.001000
+0:33        true case
+0:34        move second child to first child ( temp float)
+0:34          direct index ( temp float)
+0:34            'myColor' (layout( location=0) out 4-component vector of float)
+0:34            Constant:
+0:34              3 (const int)
+0:34          Constant:
+0:34            0.500000
+0:?   Linker Objects
+0:?     'i' ( smooth in 4-component vector of float)
+0:?     'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:?     'myColor' (layout( location=0) out 4-component vector of float)
+0:?     'eps' ( const float)
+0:?       0.001000
+

--- a/Test/coord_conventions.frag
+++ b/Test/coord_conventions.frag
@@ -1,0 +1,36 @@
+#version 140
+
+#extension GL_ARB_fragment_coord_conventions: require
+#extension GL_ARB_explicit_attrib_location : enable
+
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+in vec4 i;
+
+layout (origin_upper_left,pixel_center_integer) in vec4 gl_FragCoord;
+layout (location = 0) out vec4 myColor;
+
+const float eps=0.001;
+
+void main() 
+{
+    myColor = vec4(0.2);
+    if (gl_FragCoord.y >= 10) {
+        myColor.b = 0.8;
+    }
+    if (gl_FragCoord.y == trunc(gl_FragCoord.y)) {
+        myColor.g = 0.8;
+    }
+    if (gl_FragCoord.x == trunc(gl_FragCoord.x)) {
+        myColor.r = 0.8;
+    }
+
+    vec4 diff = gl_FragCoord - i;
+    if (abs(diff.z)>eps) 
+        myColor.b = 0.5;
+    if (abs(diff.w)>eps) 
+        myColor.a = 0.5;
+
+}

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -4611,7 +4611,7 @@ TSymbol* TParseContext::redeclareBuiltinVariable(const TSourceLoc& loc, const TS
 
     if (ssoPre150 ||
         (identifier == "gl_FragDepth"           && ((nonEsRedecls && version >= 420) || esRedecls)) ||
-        (identifier == "gl_FragCoord"           && ((nonEsRedecls && version >= 150) || esRedecls)) ||
+        (identifier == "gl_FragCoord"           && ((nonEsRedecls && version >= 140) || esRedecls)) ||
          identifier == "gl_ClipDistance"                                                            ||
          identifier == "gl_CullDistance"                                                            ||
          identifier == "gl_ShadingRateEXT"                                                          ||
@@ -5521,12 +5521,19 @@ void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publi
     }
     if (language == EShLangFragment) {
         if (id == "origin_upper_left") {
-            requireProfile(loc, ECoreProfile | ECompatibilityProfile, "origin_upper_left");
+            requireProfile(loc, ECoreProfile | ECompatibilityProfile | ENoProfile, "origin_upper_left");
+            if (profile == ENoProfile) {
+                profileRequires(loc,ECoreProfile | ECompatibilityProfile, 140, E_GL_ARB_fragment_coord_conventions, "origin_upper_left");
+            }
+
             publicType.shaderQualifiers.originUpperLeft = true;
             return;
         }
         if (id == "pixel_center_integer") {
-            requireProfile(loc, ECoreProfile | ECompatibilityProfile, "pixel_center_integer");
+            requireProfile(loc, ECoreProfile | ECompatibilityProfile | ENoProfile, "pixel_center_integer");
+            if (profile == ENoProfile) {
+                profileRequires(loc,ECoreProfile | ECompatibilityProfile, 140, E_GL_ARB_fragment_coord_conventions, "pixel_center_integer");
+            }
             publicType.shaderQualifiers.pixelCenterInteger = true;
             return;
         }

--- a/gtests/AST.FromFile.cpp
+++ b/gtests/AST.FromFile.cpp
@@ -294,6 +294,7 @@ INSTANTIATE_TEST_SUITE_P(
         "BestMatchFunction.vert",
         "EndStreamPrimitive.geom",
         "floatBitsToInt.vert",
+        "coord_conventions.frag",
     })),
     FileNameAsCustomTestSuffix
 );


### PR DESCRIPTION
1. refine the check for "origin_upper_left" and "pixel_center_integer"
2. gl_FragCoord can be used at ogl140 with extension "GL_ARB_fragment_coord_conventions".




Signed-off-by: ZhiqianXia <xzq0528@outlook.com>