### PR TITLE
Prevent Push Constant blocks being an array

### DIFF
--- a/Test/baseResults/vulkan.frag.out
+++ b/Test/baseResults/vulkan.frag.out
@@ -25,37 +25,38 @@ ERROR: 0:43: 'non-opaque uniforms outside a block' : not allowed when using GLSL
 ERROR: 0:43: 'push_constant' : can only be used with a block 
 ERROR: 0:45: 'push_constant' : cannot declare a default, can only be used on a block 
 ERROR: 0:46: 'binding' : cannot be used with push_constant 
-ERROR: 0:54: 'binding' : sampler/texture/image requires layout(binding=X) 
-ERROR: 0:55: 'binding' : sampler/texture/image requires layout(binding=X) 
-ERROR: 0:55: 'input_attachment_index' : can only be used with a subpass 
-ERROR: 0:56: 'binding' : sampler/texture/image requires layout(binding=X) 
-ERROR: 0:56: 'input_attachment_index' : can only be used with a subpass 
+ERROR: 0:49: 'push_constant' : Push constants blocks can't be an array 
 ERROR: 0:57: 'binding' : sampler/texture/image requires layout(binding=X) 
-ERROR: 0:57: 'subpass' : requires an input_attachment_index layout qualifier 
 ERROR: 0:58: 'binding' : sampler/texture/image requires layout(binding=X) 
-ERROR: 0:63: 'subpassLoadMS' : no matching overloaded function found 
-ERROR: 0:64: 'subpassLoad' : no matching overloaded function found 
+ERROR: 0:58: 'input_attachment_index' : can only be used with a subpass 
+ERROR: 0:59: 'binding' : sampler/texture/image requires layout(binding=X) 
+ERROR: 0:59: 'input_attachment_index' : can only be used with a subpass 
+ERROR: 0:60: 'binding' : sampler/texture/image requires layout(binding=X) 
+ERROR: 0:60: 'subpass' : requires an input_attachment_index layout qualifier 
+ERROR: 0:61: 'binding' : sampler/texture/image requires layout(binding=X) 
 ERROR: 0:66: 'subpassLoadMS' : no matching overloaded function found 
-ERROR: 0:69: 'subroutine' : not allowed when generating SPIR-V 
-ERROR: 0:69: 'subroutine' : feature not yet implemented 
-ERROR: 0:70: 'subroutine' : not allowed when generating SPIR-V 
-ERROR: 0:70: 'subroutine' : feature not yet implemented 
-ERROR: 0:72: 'non-opaque uniforms outside a block' : not allowed when using GLSL for Vulkan 
-ERROR: 0:76: 'texture' : no matching overloaded function found 
-ERROR: 0:77: 'imageStore' : no matching overloaded function found 
-WARNING: 0:85: '' : all default precisions are highp; use precision statements to quiet warning, e.g.:
+ERROR: 0:67: 'subpassLoad' : no matching overloaded function found 
+ERROR: 0:69: 'subpassLoadMS' : no matching overloaded function found 
+ERROR: 0:72: 'subroutine' : not allowed when generating SPIR-V 
+ERROR: 0:72: 'subroutine' : feature not yet implemented 
+ERROR: 0:73: 'subroutine' : not allowed when generating SPIR-V 
+ERROR: 0:73: 'subroutine' : feature not yet implemented 
+ERROR: 0:75: 'non-opaque uniforms outside a block' : not allowed when using GLSL for Vulkan 
+ERROR: 0:79: 'texture' : no matching overloaded function found 
+ERROR: 0:80: 'imageStore' : no matching overloaded function found 
+WARNING: 0:88: '' : all default precisions are highp; use precision statements to quiet warning, e.g.:
          "precision mediump int; precision highp float;" 
-ERROR: 0:94: 'call argument' : sampler constructor must appear at point of use 
-ERROR: 0:95: 'call argument' : sampler constructor must appear at point of use 
-ERROR: 0:96: ',' : sampler constructor must appear at point of use 
-ERROR: 0:97: ':' :  wrong operand types: no operation ':' exists that takes a left-hand operand of type ' temp sampler2D' and a right operand of type ' temp sampler2D' (or there is no acceptable conversion)
 ERROR: 0:97: 'call argument' : sampler constructor must appear at point of use 
-ERROR: 0:99: 'gl_NumSamples' : undeclared identifier 
-ERROR: 0:104: 'noise1' : no matching overloaded function found 
-ERROR: 0:105: 'noise2' : no matching overloaded function found 
-ERROR: 0:106: 'noise3' : no matching overloaded function found 
-ERROR: 0:107: 'noise4' : no matching overloaded function found 
-ERROR: 54 compilation errors.  No code generated.
+ERROR: 0:98: 'call argument' : sampler constructor must appear at point of use 
+ERROR: 0:99: ',' : sampler constructor must appear at point of use 
+ERROR: 0:100: ':' :  wrong operand types: no operation ':' exists that takes a left-hand operand of type ' temp sampler2D' and a right operand of type ' temp sampler2D' (or there is no acceptable conversion)
+ERROR: 0:100: 'call argument' : sampler constructor must appear at point of use 
+ERROR: 0:102: 'gl_NumSamples' : undeclared identifier 
+ERROR: 0:107: 'noise1' : no matching overloaded function found 
+ERROR: 0:108: 'noise2' : no matching overloaded function found 
+ERROR: 0:109: 'noise3' : no matching overloaded function found 
+ERROR: 0:110: 'noise4' : no matching overloaded function found 
+ERROR: 55 compilation errors.  No code generated.
 
 
 ERROR: Linking fragment stage: Only one push_constant block is allowed per stage

--- a/Test/vulkan.frag
+++ b/Test/vulkan.frag
@@ -46,6 +46,9 @@ layout(push_constant) uniform;                // ERROR, needs an object
 layout(binding=2, push_constant) uniform pcbnd1 {  // ERROR, can't have binding
     int a;
 } pcbnd1inst;
+layout(push_constant) uniform pcbnd2 {  // ERROR, can't be array
+    float a;
+} pcbnd2inst[2];
 layout(std430, push_constant) uniform pcb1 { int a; } pcb1inst;
 layout(push_constant) uniform pcb2 {
     int a;

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -6365,8 +6365,12 @@ void TParseContext::layoutTypeCheck(const TSourceLoc& loc, const TType& type)
         profileRequires(loc, ECoreProfile | ECompatibilityProfile, 0, E_GL_EXT_shader_image_load_formatted, explanation);
     }
 
-    if (qualifier.isPushConstant() && type.getBasicType() != EbtBlock)
-        error(loc, "can only be used with a block", "push_constant", "");
+    if (qualifier.isPushConstant()) {
+        if (type.getBasicType() != EbtBlock)
+            error(loc, "can only be used with a block", "push_constant", "");
+        if (type.isArray())
+            error(loc, "Push constants blocks can't be an array", "push_constant", "");
+    }
 
     if (qualifier.hasBufferReference() && type.getBasicType() != EbtBlock)
         error(loc, "can only be used with a block", "buffer_reference", "");


### PR DESCRIPTION
The [WG agreed](https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/5080) that the following shader makes no sense

```glsl
layout(push_constant) uniform PushData {
  float a;
} data[2];

void main() {
  float x = data[1].a;
}
```

So I have a [spirv-val](https://github.com/KhronosGroup/SPIRV-Tools/pull/4742) patch ready as well when the VUID appears in a future release. The Vulkan spec change is just waiting on deciding how to best word this restriction