### PR TITLE
Update README.md with ray tracing shader stages filename extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,15 @@ The applied stage-specific rules are based on the file extension:
 * `.frag` for a fragment shader
 * `.comp` for a compute shader
 
-There is also a non-shader extension
+For ray tracing pipeline shaders:
+* `.rgen` for a ray generation shader
+* `.rint` for a ray intersection shader
+* `.rahit` for a ray any-hit shader
+* `.rchit` for a ray closest-hit shader
+* `.rmiss` for a ray miss shader
+* `.rcall` for a callable shader
+
+There is also a non-shader extension:
 * `.conf` for a configuration file of limits, see usage statement for example
 
 ## Building (CMake)


### PR DESCRIPTION
While looking for the ray tracing shaders file extensions I had to look inside the source code to find them
https://github.com/KhronosGroup/glslang/blob/2c7c84c8ac996b16b2645046dd1757043669ed52/gtests/TestFixture.cpp#L49

Since the rasterization filename extensions are already listed why not include the ray tracing ones?