### PR TITLE
fix crash in HLSL frontend

### DIFF
--- a/Test/baseResults/hlsl.emptystructreturn.tesc.out
+++ b/Test/baseResults/hlsl.emptystructreturn.tesc.out
@@ -1,0 +1,606 @@
+hlsl.emptystructreturn.tesc
+Shader version: 500
+vertices = 3
+vertex spacing = equal_spacing
+triangle order = cw
+0:? Sequence
+0:16  Function Definition: blob(struct-HullInputType-vf41[3]; ( temp void)
+0:16    Function Parameters: 
+0:16      'patch' ( in 3-element array of structure{ temp 4-component vector of float position})
+0:20  Function Definition: ColorPatchConstantFunction(struct-HullInputType-vf41[3];u1; ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:20    Function Parameters: 
+0:20      'inputPatch' ( in 3-element array of structure{ temp 4-component vector of float position})
+0:20      'patchId' ( in uint)
+0:?     Sequence
+0:24      move second child to first child ( temp float)
+0:24        direct index ( temp float)
+0:24          edges: direct index for structure ( temp 3-element array of float)
+0:24            'output' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:24            Constant:
+0:24              0 (const int)
+0:24          Constant:
+0:24            0 (const int)
+0:24        Constant:
+0:24          2.000000
+0:25      move second child to first child ( temp float)
+0:25        direct index ( temp float)
+0:25          edges: direct index for structure ( temp 3-element array of float)
+0:25            'output' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:25            Constant:
+0:25              0 (const int)
+0:25          Constant:
+0:25            1 (const int)
+0:25        Constant:
+0:25          2.000000
+0:26      move second child to first child ( temp float)
+0:26        direct index ( temp float)
+0:26          edges: direct index for structure ( temp 3-element array of float)
+0:26            'output' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:26            Constant:
+0:26              0 (const int)
+0:26          Constant:
+0:26            2 (const int)
+0:26        Constant:
+0:26          2.000000
+0:29      move second child to first child ( temp float)
+0:29        inside: direct index for structure ( temp float)
+0:29          'output' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:29          Constant:
+0:29            1 (const int)
+0:29        Constant:
+0:29          2.000000
+0:31      Branch: Return with expression
+0:31        'output' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:42  Function Definition: @main(struct-EmptyStruct1;struct-HullInputType-vf41[3];u1;u1; ( temp structure{})
+0:42    Function Parameters: 
+0:42      'stage_input' ( in structure{})
+0:42      'patch' ( in 3-element array of structure{ temp 4-component vector of float position})
+0:42      'pointId' ( in uint)
+0:42      'patchId' ( in uint)
+0:?     Sequence
+0:44      Function Call: blob(struct-HullInputType-vf41[3]; ( temp void)
+0:44        'patch' ( in 3-element array of structure{ temp 4-component vector of float position})
+0:46      Branch: Return with expression
+0:46        'output' ( temp structure{})
+0:42  Function Definition: main( ( temp void)
+0:42    Function Parameters: 
+0:?     Sequence
+0:42      Sequence
+0:42        move second child to first child ( temp structure{})
+0:?           'stage_input' ( temp structure{})
+0:?           'stage_input' ( in structure{})
+0:42      Sequence
+0:42        move second child to first child ( temp 4-component vector of float)
+0:42          position: direct index for structure ( temp 4-component vector of float)
+0:42            direct index ( temp structure{ temp 4-component vector of float position})
+0:?               'patch' ( temp 3-element array of structure{ temp 4-component vector of float position})
+0:42              Constant:
+0:42                0 (const int)
+0:42            Constant:
+0:42              0 (const int)
+0:42          direct index ( in 4-component vector of float Position)
+0:?             'patch.position' ( in 3-element array of 4-component vector of float Position)
+0:42            Constant:
+0:42              0 (const int)
+0:42        move second child to first child ( temp 4-component vector of float)
+0:42          position: direct index for structure ( temp 4-component vector of float)
+0:42            direct index ( temp structure{ temp 4-component vector of float position})
+0:?               'patch' ( temp 3-element array of structure{ temp 4-component vector of float position})
+0:42              Constant:
+0:42                1 (const int)
+0:42            Constant:
+0:42              0 (const int)
+0:42          direct index ( in 4-component vector of float Position)
+0:?             'patch.position' ( in 3-element array of 4-component vector of float Position)
+0:42            Constant:
+0:42              1 (const int)
+0:42        move second child to first child ( temp 4-component vector of float)
+0:42          position: direct index for structure ( temp 4-component vector of float)
+0:42            direct index ( temp structure{ temp 4-component vector of float position})
+0:?               'patch' ( temp 3-element array of structure{ temp 4-component vector of float position})
+0:42              Constant:
+0:42                2 (const int)
+0:42            Constant:
+0:42              0 (const int)
+0:42          direct index ( in 4-component vector of float Position)
+0:?             'patch.position' ( in 3-element array of 4-component vector of float Position)
+0:42            Constant:
+0:42              2 (const int)
+0:42      move second child to first child ( temp uint)
+0:?         'pointId' ( temp uint)
+0:?         'pointId' ( in uint InvocationID)
+0:42      move second child to first child ( temp uint)
+0:?         'patchId' ( temp uint)
+0:?         'patchId' ( in uint PrimitiveID)
+0:42      Sequence
+0:42        move second child to first child ( temp structure{})
+0:42          indirect index ( out structure{})
+0:?             '@entryPointOutput' ( out 3-element array of structure{})
+0:?             'pointId' ( in uint InvocationID)
+0:42          Function Call: @main(struct-EmptyStruct1;struct-HullInputType-vf41[3];u1;u1; ( temp structure{})
+0:?             'stage_input' ( temp structure{})
+0:?             'patch' ( temp 3-element array of structure{ temp 4-component vector of float position})
+0:?             'pointId' ( temp uint)
+0:?             'patchId' ( temp uint)
+0:?       Barrier ( temp void)
+0:?       Test condition and select ( temp void)
+0:?         Condition
+0:?         Compare Equal ( temp bool)
+0:?           'pointId' ( in uint InvocationID)
+0:?           Constant:
+0:?             0 (const int)
+0:?         true case
+0:?         Sequence
+0:?           move second child to first child ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:?             '@patchConstantResult' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:?             Function Call: ColorPatchConstantFunction(struct-HullInputType-vf41[3];u1; ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:?               'patch' ( temp 3-element array of structure{ temp 4-component vector of float position})
+0:?               'patchId' ( in uint PrimitiveID)
+0:?           Sequence
+0:?             move second child to first child ( temp float)
+0:?               direct index ( patch out float TessLevelOuter)
+0:?                 '@patchConstantOutput.edges' ( patch out 4-element array of float TessLevelOuter)
+0:?                 Constant:
+0:?                   0 (const int)
+0:?               direct index ( temp float)
+0:?                 edges: direct index for structure ( temp 3-element array of float)
+0:?                   '@patchConstantResult' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:?                   Constant:
+0:?                     0 (const int)
+0:?                 Constant:
+0:?                   0 (const int)
+0:?             move second child to first child ( temp float)
+0:?               direct index ( patch out float TessLevelOuter)
+0:?                 '@patchConstantOutput.edges' ( patch out 4-element array of float TessLevelOuter)
+0:?                 Constant:
+0:?                   1 (const int)
+0:?               direct index ( temp float)
+0:?                 edges: direct index for structure ( temp 3-element array of float)
+0:?                   '@patchConstantResult' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:?                   Constant:
+0:?                     0 (const int)
+0:?                 Constant:
+0:?                   1 (const int)
+0:?             move second child to first child ( temp float)
+0:?               direct index ( patch out float TessLevelOuter)
+0:?                 '@patchConstantOutput.edges' ( patch out 4-element array of float TessLevelOuter)
+0:?                 Constant:
+0:?                   2 (const int)
+0:?               direct index ( temp float)
+0:?                 edges: direct index for structure ( temp 3-element array of float)
+0:?                   '@patchConstantResult' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:?                   Constant:
+0:?                     0 (const int)
+0:?                 Constant:
+0:?                   2 (const int)
+0:?             move second child to first child ( temp float)
+0:?               direct index ( patch out float TessLevelInner)
+0:?                 '@patchConstantOutput.inside' ( patch out 2-element array of float TessLevelInner)
+0:?                 Constant:
+0:?                   0 (const int)
+0:?               inside: direct index for structure ( temp float)
+0:?                 '@patchConstantResult' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:?                 Constant:
+0:?                   1 (const int)
+0:?   Linker Objects
+0:?     'patch.position' ( in 3-element array of 4-component vector of float Position)
+0:?     'pointId' ( in uint InvocationID)
+0:?     'patchId' ( in uint PrimitiveID)
+0:?     '@patchConstantOutput.edges' ( patch out 4-element array of float TessLevelOuter)
+0:?     '@patchConstantOutput.inside' ( patch out 2-element array of float TessLevelInner)
+
+
+Linked tessellation control stage:
+
+
+Shader version: 500
+vertices = 3
+vertex spacing = equal_spacing
+triangle order = cw
+0:? Sequence
+0:16  Function Definition: blob(struct-HullInputType-vf41[3]; ( temp void)
+0:16    Function Parameters: 
+0:16      'patch' ( in 3-element array of structure{ temp 4-component vector of float position})
+0:20  Function Definition: ColorPatchConstantFunction(struct-HullInputType-vf41[3];u1; ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:20    Function Parameters: 
+0:20      'inputPatch' ( in 3-element array of structure{ temp 4-component vector of float position})
+0:20      'patchId' ( in uint)
+0:?     Sequence
+0:24      move second child to first child ( temp float)
+0:24        direct index ( temp float)
+0:24          edges: direct index for structure ( temp 3-element array of float)
+0:24            'output' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:24            Constant:
+0:24              0 (const int)
+0:24          Constant:
+0:24            0 (const int)
+0:24        Constant:
+0:24          2.000000
+0:25      move second child to first child ( temp float)
+0:25        direct index ( temp float)
+0:25          edges: direct index for structure ( temp 3-element array of float)
+0:25            'output' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:25            Constant:
+0:25              0 (const int)
+0:25          Constant:
+0:25            1 (const int)
+0:25        Constant:
+0:25          2.000000
+0:26      move second child to first child ( temp float)
+0:26        direct index ( temp float)
+0:26          edges: direct index for structure ( temp 3-element array of float)
+0:26            'output' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:26            Constant:
+0:26              0 (const int)
+0:26          Constant:
+0:26            2 (const int)
+0:26        Constant:
+0:26          2.000000
+0:29      move second child to first child ( temp float)
+0:29        inside: direct index for structure ( temp float)
+0:29          'output' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:29          Constant:
+0:29            1 (const int)
+0:29        Constant:
+0:29          2.000000
+0:31      Branch: Return with expression
+0:31        'output' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:42  Function Definition: @main(struct-EmptyStruct1;struct-HullInputType-vf41[3];u1;u1; ( temp structure{})
+0:42    Function Parameters: 
+0:42      'stage_input' ( in structure{})
+0:42      'patch' ( in 3-element array of structure{ temp 4-component vector of float position})
+0:42      'pointId' ( in uint)
+0:42      'patchId' ( in uint)
+0:?     Sequence
+0:44      Function Call: blob(struct-HullInputType-vf41[3]; ( temp void)
+0:44        'patch' ( in 3-element array of structure{ temp 4-component vector of float position})
+0:46      Branch: Return with expression
+0:46        'output' ( temp structure{})
+0:42  Function Definition: main( ( temp void)
+0:42    Function Parameters: 
+0:?     Sequence
+0:42      Sequence
+0:42        move second child to first child ( temp structure{})
+0:?           'stage_input' ( temp structure{})
+0:?           'stage_input' ( in structure{})
+0:42      Sequence
+0:42        move second child to first child ( temp 4-component vector of float)
+0:42          position: direct index for structure ( temp 4-component vector of float)
+0:42            direct index ( temp structure{ temp 4-component vector of float position})
+0:?               'patch' ( temp 3-element array of structure{ temp 4-component vector of float position})
+0:42              Constant:
+0:42                0 (const int)
+0:42            Constant:
+0:42              0 (const int)
+0:42          direct index ( in 4-component vector of float Position)
+0:?             'patch.position' ( in 3-element array of 4-component vector of float Position)
+0:42            Constant:
+0:42              0 (const int)
+0:42        move second child to first child ( temp 4-component vector of float)
+0:42          position: direct index for structure ( temp 4-component vector of float)
+0:42            direct index ( temp structure{ temp 4-component vector of float position})
+0:?               'patch' ( temp 3-element array of structure{ temp 4-component vector of float position})
+0:42              Constant:
+0:42                1 (const int)
+0:42            Constant:
+0:42              0 (const int)
+0:42          direct index ( in 4-component vector of float Position)
+0:?             'patch.position' ( in 3-element array of 4-component vector of float Position)
+0:42            Constant:
+0:42              1 (const int)
+0:42        move second child to first child ( temp 4-component vector of float)
+0:42          position: direct index for structure ( temp 4-component vector of float)
+0:42            direct index ( temp structure{ temp 4-component vector of float position})
+0:?               'patch' ( temp 3-element array of structure{ temp 4-component vector of float position})
+0:42              Constant:
+0:42                2 (const int)
+0:42            Constant:
+0:42              0 (const int)
+0:42          direct index ( in 4-component vector of float Position)
+0:?             'patch.position' ( in 3-element array of 4-component vector of float Position)
+0:42            Constant:
+0:42              2 (const int)
+0:42      move second child to first child ( temp uint)
+0:?         'pointId' ( temp uint)
+0:?         'pointId' ( in uint InvocationID)
+0:42      move second child to first child ( temp uint)
+0:?         'patchId' ( temp uint)
+0:?         'patchId' ( in uint PrimitiveID)
+0:42      Sequence
+0:42        move second child to first child ( temp structure{})
+0:42          indirect index ( out structure{})
+0:?             '@entryPointOutput' ( out 3-element array of structure{})
+0:?             'pointId' ( in uint InvocationID)
+0:42          Function Call: @main(struct-EmptyStruct1;struct-HullInputType-vf41[3];u1;u1; ( temp structure{})
+0:?             'stage_input' ( temp structure{})
+0:?             'patch' ( temp 3-element array of structure{ temp 4-component vector of float position})
+0:?             'pointId' ( temp uint)
+0:?             'patchId' ( temp uint)
+0:?       Barrier ( temp void)
+0:?       Test condition and select ( temp void)
+0:?         Condition
+0:?         Compare Equal ( temp bool)
+0:?           'pointId' ( in uint InvocationID)
+0:?           Constant:
+0:?             0 (const int)
+0:?         true case
+0:?         Sequence
+0:?           move second child to first child ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:?             '@patchConstantResult' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:?             Function Call: ColorPatchConstantFunction(struct-HullInputType-vf41[3];u1; ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:?               'patch' ( temp 3-element array of structure{ temp 4-component vector of float position})
+0:?               'patchId' ( in uint PrimitiveID)
+0:?           Sequence
+0:?             move second child to first child ( temp float)
+0:?               direct index ( patch out float TessLevelOuter)
+0:?                 '@patchConstantOutput.edges' ( patch out 4-element array of float TessLevelOuter)
+0:?                 Constant:
+0:?                   0 (const int)
+0:?               direct index ( temp float)
+0:?                 edges: direct index for structure ( temp 3-element array of float)
+0:?                   '@patchConstantResult' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:?                   Constant:
+0:?                     0 (const int)
+0:?                 Constant:
+0:?                   0 (const int)
+0:?             move second child to first child ( temp float)
+0:?               direct index ( patch out float TessLevelOuter)
+0:?                 '@patchConstantOutput.edges' ( patch out 4-element array of float TessLevelOuter)
+0:?                 Constant:
+0:?                   1 (const int)
+0:?               direct index ( temp float)
+0:?                 edges: direct index for structure ( temp 3-element array of float)
+0:?                   '@patchConstantResult' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:?                   Constant:
+0:?                     0 (const int)
+0:?                 Constant:
+0:?                   1 (const int)
+0:?             move second child to first child ( temp float)
+0:?               direct index ( patch out float TessLevelOuter)
+0:?                 '@patchConstantOutput.edges' ( patch out 4-element array of float TessLevelOuter)
+0:?                 Constant:
+0:?                   2 (const int)
+0:?               direct index ( temp float)
+0:?                 edges: direct index for structure ( temp 3-element array of float)
+0:?                   '@patchConstantResult' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:?                   Constant:
+0:?                     0 (const int)
+0:?                 Constant:
+0:?                   2 (const int)
+0:?             move second child to first child ( temp float)
+0:?               direct index ( patch out float TessLevelInner)
+0:?                 '@patchConstantOutput.inside' ( patch out 2-element array of float TessLevelInner)
+0:?                 Constant:
+0:?                   0 (const int)
+0:?               inside: direct index for structure ( temp float)
+0:?                 '@patchConstantResult' ( temp structure{ temp 3-element array of float edges,  temp float inside})
+0:?                 Constant:
+0:?                   1 (const int)
+0:?   Linker Objects
+0:?     'patch.position' ( in 3-element array of 4-component vector of float Position)
+0:?     'pointId' ( in uint InvocationID)
+0:?     'patchId' ( in uint PrimitiveID)
+0:?     '@patchConstantOutput.edges' ( patch out 4-element array of float TessLevelOuter)
+0:?     '@patchConstantOutput.inside' ( patch out 2-element array of float TessLevelInner)
+
+Validation failed
+// Module Version 10000
+// Generated by (magic number): 8000b
+// Id's are bound by 132
+
+                              Capability Tessellation
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint TessellationControl 4  "main" 65 79 82 115 128
+                              ExecutionMode 4 OutputVertices 3
+                              ExecutionMode 4 Triangles
+                              ExecutionMode 4 SpacingEqual
+                              ExecutionMode 4 VertexOrderCw
+                              Source HLSL 500
+                              Name 4  "main"
+                              Name 8  "HullInputType"
+                              MemberName 8(HullInputType) 0  "position"
+                              Name 15  "blob(struct-HullInputType-vf41[3];"
+                              Name 14  "patch"
+                              Name 19  "ConstantOutputType"
+                              MemberName 19(ConstantOutputType) 0  "edges"
+                              MemberName 19(ConstantOutputType) 1  "inside"
+                              Name 23  "ColorPatchConstantFunction(struct-HullInputType-vf41[3];u1;"
+                              Name 21  "inputPatch"
+                              Name 22  "patchId"
+                              Name 25  "EmptyStruct"
+                              Name 27  "HullOutputType"
+                              Name 33  "@main(struct-EmptyStruct1;struct-HullInputType-vf41[3];u1;u1;"
+                              Name 29  "stage_input"
+                              Name 30  "patch"
+                              Name 31  "pointId"
+                              Name 32  "patchId"
+                              Name 36  "output"
+                              Name 50  "param"
+                              Name 54  "output"
+                              Name 58  "stage_input"
+                              Name 60  "stage_input"
+                              Name 62  "patch"
+                              Name 65  "patch.position"
+                              Name 77  "pointId"
+                              Name 79  "pointId"
+                              Name 81  "patchId"
+                              Name 82  "patchId"
+                              Name 86  "@entryPointOutput"
+                              Name 88  "param"
+                              Name 90  "param"
+                              Name 92  "param"
+                              Name 94  "param"
+                              Name 107  "@patchConstantResult"
+                              Name 108  "param"
+                              Name 110  "param"
+                              Name 115  "@patchConstantOutput.edges"
+                              Name 128  "@patchConstantOutput.inside"
+                              Decorate 65(patch.position) BuiltIn Position
+                              Decorate 79(pointId) BuiltIn InvocationId
+                              Decorate 82(patchId) BuiltIn PrimitiveId
+                              Decorate 115(@patchConstantOutput.edges) Patch
+                              Decorate 115(@patchConstantOutput.edges) BuiltIn TessLevelOuter
+                              Decorate 128(@patchConstantOutput.inside) Patch
+                              Decorate 128(@patchConstantOutput.inside) BuiltIn TessLevelInner
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeFloat 32
+               7:             TypeVector 6(float) 4
+8(HullInputType):             TypeStruct 7(fvec4)
+               9:             TypeInt 32 0
+              10:      9(int) Constant 3
+              11:             TypeArray 8(HullInputType) 10
+              12:             TypePointer Function 11
+              13:             TypeFunction 2 12(ptr)
+              17:             TypePointer Function 9(int)
+              18:             TypeArray 6(float) 10
+19(ConstantOutputType):             TypeStruct 18 6(float)
+              20:             TypeFunction 19(ConstantOutputType) 12(ptr) 17(ptr)
+ 25(EmptyStruct):             TypeStruct
+              26:             TypePointer Function 25(EmptyStruct)
+27(HullOutputType):             TypeStruct
+              28:             TypeFunction 27(HullOutputType) 26(ptr) 12(ptr) 17(ptr) 17(ptr)
+              35:             TypePointer Function 19(ConstantOutputType)
+              37:             TypeInt 32 1
+              38:     37(int) Constant 0
+              39:    6(float) Constant 1073741824
+              40:             TypePointer Function 6(float)
+              42:     37(int) Constant 1
+              44:     37(int) Constant 2
+              53:             TypePointer Function 27(HullOutputType)
+              59:             TypePointer Input 25(EmptyStruct)
+ 60(stage_input):     59(ptr) Variable Input
+              63:             TypeArray 7(fvec4) 10
+              64:             TypePointer Input 63
+65(patch.position):     64(ptr) Variable Input
+              66:             TypePointer Input 7(fvec4)
+              69:             TypePointer Function 7(fvec4)
+              78:             TypePointer Input 9(int)
+     79(pointId):     78(ptr) Variable Input
+     82(patchId):     78(ptr) Variable Input
+              84:             TypeArray 27(HullOutputType) 10
+              85:             TypePointer Output 84
+86(@entryPointOutput):     85(ptr) Variable Output
+              97:             TypePointer Output 27(HullOutputType)
+              99:      9(int) Constant 2
+             100:      9(int) Constant 4
+             101:      9(int) Constant 0
+             103:             TypeBool
+             113:             TypeArray 6(float) 100
+             114:             TypePointer Output 113
+115(@patchConstantOutput.edges):    114(ptr) Variable Output
+             118:             TypePointer Output 6(float)
+             126:             TypeArray 6(float) 99
+             127:             TypePointer Output 126
+128(@patchConstantOutput.inside):    127(ptr) Variable Output
+         4(main):           2 Function None 3
+               5:             Label
+ 58(stage_input):     26(ptr) Variable Function
+       62(patch):     12(ptr) Variable Function
+     77(pointId):     17(ptr) Variable Function
+     81(patchId):     17(ptr) Variable Function
+       88(param):     26(ptr) Variable Function
+       90(param):     12(ptr) Variable Function
+       92(param):     17(ptr) Variable Function
+       94(param):     17(ptr) Variable Function
+107(@patchConstantResult):     35(ptr) Variable Function
+      108(param):     12(ptr) Variable Function
+      110(param):     17(ptr) Variable Function
+              61:25(EmptyStruct) Load 60(stage_input)
+                              Store 58(stage_input) 61
+              67:     66(ptr) AccessChain 65(patch.position) 38
+              68:    7(fvec4) Load 67
+              70:     69(ptr) AccessChain 62(patch) 38 38
+                              Store 70 68
+              71:     66(ptr) AccessChain 65(patch.position) 42
+              72:    7(fvec4) Load 71
+              73:     69(ptr) AccessChain 62(patch) 42 38
+                              Store 73 72
+              74:     66(ptr) AccessChain 65(patch.position) 44
+              75:    7(fvec4) Load 74
+              76:     69(ptr) AccessChain 62(patch) 44 38
+                              Store 76 75
+              80:      9(int) Load 79(pointId)
+                              Store 77(pointId) 80
+              83:      9(int) Load 82(patchId)
+                              Store 81(patchId) 83
+              87:      9(int) Load 79(pointId)
+              89:25(EmptyStruct) Load 58(stage_input)
+                              Store 88(param) 89
+              91:          11 Load 62(patch)
+                              Store 90(param) 91
+              93:      9(int) Load 77(pointId)
+                              Store 92(param) 93
+              95:      9(int) Load 81(patchId)
+                              Store 94(param) 95
+              96:27(HullOutputType) FunctionCall 33(@main(struct-EmptyStruct1;struct-HullInputType-vf41[3];u1;u1;) 88(param) 90(param) 92(param) 94(param)
+              98:     97(ptr) AccessChain 86(@entryPointOutput) 87
+                              Store 98 96
+                              ControlBarrier 99 100 101
+             102:      9(int) Load 79(pointId)
+             104:   103(bool) IEqual 102 38
+                              SelectionMerge 106 None
+                              BranchConditional 104 105 106
+             105:               Label
+             109:          11   Load 62(patch)
+                                Store 108(param) 109
+             111:      9(int)   Load 82(patchId)
+                                Store 110(param) 111
+             112:19(ConstantOutputType)   FunctionCall 23(ColorPatchConstantFunction(struct-HullInputType-vf41[3];u1;) 108(param) 110(param)
+                                Store 107(@patchConstantResult) 112
+             116:     40(ptr)   AccessChain 107(@patchConstantResult) 38 38
+             117:    6(float)   Load 116
+             119:    118(ptr)   AccessChain 115(@patchConstantOutput.edges) 38
+                                Store 119 117
+             120:     40(ptr)   AccessChain 107(@patchConstantResult) 38 42
+             121:    6(float)   Load 120
+             122:    118(ptr)   AccessChain 115(@patchConstantOutput.edges) 42
+                                Store 122 121
+             123:     40(ptr)   AccessChain 107(@patchConstantResult) 38 44
+             124:    6(float)   Load 123
+             125:    118(ptr)   AccessChain 115(@patchConstantOutput.edges) 44
+                                Store 125 124
+             129:     40(ptr)   AccessChain 107(@patchConstantResult) 42
+             130:    6(float)   Load 129
+             131:    118(ptr)   AccessChain 128(@patchConstantOutput.inside) 38
+                                Store 131 130
+                                Branch 106
+             106:             Label
+                              Return
+                              FunctionEnd
+15(blob(struct-HullInputType-vf41[3];):           2 Function None 13
+       14(patch):     12(ptr) FunctionParameter
+              16:             Label
+                              Return
+                              FunctionEnd
+23(ColorPatchConstantFunction(struct-HullInputType-vf41[3];u1;):19(ConstantOutputType) Function None 20
+  21(inputPatch):     12(ptr) FunctionParameter
+     22(patchId):     17(ptr) FunctionParameter
+              24:             Label
+      36(output):     35(ptr) Variable Function
+              41:     40(ptr) AccessChain 36(output) 38 38
+                              Store 41 39
+              43:     40(ptr) AccessChain 36(output) 38 42
+                              Store 43 39
+              45:     40(ptr) AccessChain 36(output) 38 44
+                              Store 45 39
+              46:     40(ptr) AccessChain 36(output) 42
+                              Store 46 39
+              47:19(ConstantOutputType) Load 36(output)
+                              ReturnValue 47
+                              FunctionEnd
+33(@main(struct-EmptyStruct1;struct-HullInputType-vf41[3];u1;u1;):27(HullOutputType) Function None 28
+ 29(stage_input):     26(ptr) FunctionParameter
+       30(patch):     12(ptr) FunctionParameter
+     31(pointId):     17(ptr) FunctionParameter
+     32(patchId):     17(ptr) FunctionParameter
+              34:             Label
+       50(param):     12(ptr) Variable Function
+      54(output):     53(ptr) Variable Function
+              51:          11 Load 30(patch)
+                              Store 50(param) 51
+              52:           2 FunctionCall 15(blob(struct-HullInputType-vf41[3];) 50(param)
+              55:27(HullOutputType) Load 54(output)
+                              ReturnValue 55
+                              FunctionEnd

--- a/Test/hlsl.emptystructreturn.tesc
+++ b/Test/hlsl.emptystructreturn.tesc
@@ -1,0 +1,48 @@
+struct HullInputType
+{
+    float4 position : SV_Position;
+};
+
+struct ConstantOutputType
+{
+    float edges[3] : SV_TessFactor;
+    float inside : SV_InsideTessFactor;
+};
+struct EmptyStruct {};
+
+struct HullOutputType {};
+
+void blob(InputPatch<HullInputType, 3> patch)
+{
+}
+
+ConstantOutputType ColorPatchConstantFunction(InputPatch<HullInputType, 3> inputPatch, uint patchId : SV_PrimitiveID)
+{
+    ConstantOutputType output;
+
+	// Set the tessellation factors for the three edges of the triangle.
+    output.edges[0] = 2;
+    output.edges[1] = 2;
+    output.edges[2] = 2;
+
+	// Set the tessellation factor for tessallating inside the triangle.
+    output.inside = 2;
+
+    return output;
+}
+
+
+// Hull Shader
+[domain("tri")]
+[partitioning("integer")]
+[outputtopology("triangle_cw")]
+[outputcontrolpoints(3)]
+[patchconstantfunc("ColorPatchConstantFunction")]
+HullOutputType main(EmptyStruct stage_input, InputPatch<HullInputType, 3> patch, uint pointId : SV_OutputControlPointID, uint patchId : SV_PrimitiveID)
+{
+    HullOutputType output;
+    blob(patch);
+
+    return output;
+}
+

--- a/glslang/HLSL/hlslParseHelper.cpp
+++ b/glslang/HLSL/hlslParseHelper.cpp
@@ -1177,10 +1177,13 @@ void HlslParseContext::flatten(const TVariable& variable, bool linkage, bool arr
     if (type.isBuiltIn() && !type.isStruct())
         return;
 
+
     auto entry = flattenMap.insert(std::make_pair(variable.getUniqueId(),
                                                   TFlattenData(type.getQualifier().layoutBinding,
                                                                type.getQualifier().layoutLocation)));
 
+    if (type.isStruct() && type.getStruct()->size()==0)
+        return;
     // if flattening arrayed io struct, array each member of dereferenced type
     if (arrayed) {
         const TType dereferencedType(type, 0);

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -205,6 +205,7 @@ INSTANTIATE_TEST_SUITE_P(
         {"hlsl.earlydepthstencil.frag", "main"},
         {"hlsl.emptystructreturn.frag", "main"},
         {"hlsl.emptystructreturn.vert", "main"},
+        {"hlsl.emptystructreturn.tesc", "main"},
         {"hlsl.emptystruct.init.vert", "main"},
         {"hlsl.entry-in.frag", "PixelShaderFunction"},
         {"hlsl.entry-out.frag", "PixelShaderFunction"},


### PR DESCRIPTION
fix crash, when converting HLSL return of hull shader into spirv/glsl like arrayed output.

#fixed 2914