### PR TITLE
CMake: fix MinGW build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ option(ENABLE_RTTI "Enables RTTI" OFF)
 option(ENABLE_EXCEPTIONS "Enables Exceptions" OFF)
 option(ENABLE_OPT "Enables spirv-opt capability if present" ON)
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+if(MINGW OR (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU"))
     # Workaround for CMake behavior on Mac OS with gcc, cmake generates -Xarch_* arguments
     # which gcc rejects
     option(ENABLE_PCH "Enables Precompiled header" OFF)


### PR DESCRIPTION
Pre compiled headers lead to `internal error in mingw32_gt_pch_use_address, at config/i386/host-mingw32.c:192: MapViewOfFileEx: Attempt to access invalid address`.

closes https://github.com/KhronosGroup/glslang/issues/2922