### PR TITLE
Add whitelist filtering for debug comments in SPIRV-Remap.

### DIFF
--- a/SPIRV/SPVRemapper.cpp
+++ b/SPIRV/SPVRemapper.cpp
@@ -160,15 +160,30 @@ namespace spv {
     }
 
     // Is this an opcode we should remove when using --strip?
-    bool spirvbin_t::isStripOp(spv::Op opCode) const
+    bool spirvbin_t::isStripOp(spv::Op opCode, unsigned start) const
     {
         switch (opCode) {
         case spv::OpSource:
         case spv::OpSourceExtension:
         case spv::OpName:
         case spv::OpMemberName:
-        case spv::OpLine:           return true;
-        default:                    return false;
+        case spv::OpLine :
+        {
+            const spv::Id target = asId(start + 1);
+            const std::string name = literalString(start + 2);
+
+            std::vector<std::string>::const_iterator it;
+            for (it = stripWhiteList.begin(); it < stripWhiteList.end(); it++)
+            {
+                if (name.find(*it) != std::string::npos) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        default :
+            return false;
         }
     }
 
@@ -372,7 +387,7 @@ namespace spv {
         process(
             [&](spv::Op opCode, unsigned start) {
                 // remember opcodes we want to strip later
-                if (isStripOp(opCode))
+                if (isStripOp(opCode, start))
                     stripInst(start);
                 return true;
             },
@@ -1494,8 +1509,10 @@ namespace spv {
     }
 
     // remap from a memory image
-    void spirvbin_t::remap(std::vector<std::uint32_t>& in_spv, std::uint32_t opts)
+    void spirvbin_t::remap(std::vector<std::uint32_t>& in_spv, const std::vector<std::string>& whiteListStrings,
+                           std::uint32_t opts)
     {
+        stripWhiteList = whiteListStrings;
         spv.swap(in_spv);
         remap(opts);
         spv.swap(in_spv);

--- a/SPIRV/SPVRemapper.h
+++ b/SPIRV/SPVRemapper.h
@@ -118,7 +118,8 @@ public:
    virtual ~spirvbin_t() { }
 
    // remap on an existing binary in memory
-   void remap(std::vector<std::uint32_t>& spv, std::uint32_t opts = DO_EVERYTHING);
+   void remap(std::vector<std::uint32_t>& spv, const std::vector<std::string>& whiteListStrings,
+              std::uint32_t opts = DO_EVERYTHING);
 
    // Type for error/log handler functions
    typedef std::function<void(const std::string&)> errorfn_t;
@@ -179,6 +180,8 @@ private:
    range_t  constRange(spv::Op opCode)     const;
    unsigned typeSizeInWords(spv::Id id)    const;
    unsigned idTypeSizeInWords(spv::Id id)  const;
+
+   bool isStripOp(spv::Op opCode, unsigned start) const;
 
    spv::Id&        asId(unsigned word)                { return spv[word]; }
    const spv::Id&  asId(unsigned word)          const { return spv[word]; }
@@ -248,6 +251,8 @@ private:
    void        strip();               // remove debug symbols
 
    std::vector<spirword_t> spv;      // SPIR words
+
+   std::vector<std::string> stripWhiteList;
 
    namemap_t               nameMap;  // ID names from OpName
 

--- a/gtests/TestFixture.h
+++ b/gtests/TestFixture.h
@@ -367,11 +367,12 @@ public:
 
         if (success && (controls & EShMsgSpvRules)) {
         spv::SpvBuildLogger logger;
+            std::vector<std::string> whiteListStrings;
             std::vector<uint32_t> spirv_binary;
             glslang::GlslangToSpv(*program.getIntermediate(stage),
                                   spirv_binary, &logger, &options());
 
-            spv::spirvbin_t(0 /*verbosity*/).remap(spirv_binary, remapOptions);
+            spv::spirvbin_t(0 /*verbosity*/).remap(spirv_binary, whiteListStrings, remapOptions);
 
             std::ostringstream disassembly_stream;
             spv::Parameterize();
@@ -394,9 +395,9 @@ public:
     {
         if ((controls & EShMsgSpvRules)) {
             std::vector<uint32_t> spirv_binary(code); // scratch copy
+            std::vector<std::string> whiteListStrings;
+            spv::spirvbin_t(0 /*verbosity*/).remap(spirv_binary, whiteListStrings, remapOptions);
 
-            spv::spirvbin_t(0 /*verbosity*/).remap(spirv_binary, remapOptions);
-            
             std::ostringstream disassembly_stream;
             spv::Parameterize();
             spv::Disassemble(disassembly_stream, spirv_binary);


### PR DESCRIPTION
We are currently using glslang and spirv-remap for a project we would like to open source and as part of the compilation step, we need the ability to not strip out some "unused" functions in the SPIRV. We currently do this by passing in a whitelist file to the remapper. It would greatly simplify things if we could get this also added to the glslang codebase.
