### PR TITLE
Add CInterface files and documentation

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -96,6 +96,7 @@ LOCAL_MODULE:=glslang
 LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti $(GLSLANG_DEFINES)
 LOCAL_EXPORT_C_INCLUDES:=$(LOCAL_PATH)
 LOCAL_SRC_FILES:= \
+		glslang/CInterface/glslang_c_interface.cpp \
 		glslang/GenericCodeGen/CodeGen.cpp \
 		glslang/GenericCodeGen/Link.cpp \
 		glslang/HLSL/hlslAttributes.cpp \
@@ -149,6 +150,7 @@ $(LOCAL_PATH)/SPIRV/GlslangToSpv.cpp: \
 LOCAL_MODULE:=SPIRV
 LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti -Werror $(GLSLANG_DEFINES)
 LOCAL_SRC_FILES:= \
+	SPIRV/CInterface/spirv_c_interface.cpp \
 	SPIRV/GlslangToSpv.cpp \
 	SPIRV/InReadableOrder.cpp \
 	SPIRV/Logger.cpp \


### PR DESCRIPTION
Both `glslang/CInterface` and `SPIRV/CInterface` files are missing from `Android.mk`.

Added missing documentation.