### PR TITLE
Generate OpLine Before OpFunction

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -2783,6 +2783,10 @@ bool TGlslangToSpvTraverser::visitAggregate(glslang::TVisit visit, glslang::TInt
             } else {
                 handleFunctionEntry(node);
             }
+            if (options.generateDebugInfo) {
+                const auto& loc = node->getLoc();
+                currentFunction->setDebugLineInfo(builder.getSourceFile(), loc.line, loc.column);
+            }
         } else {
             if (inEntryPoint)
                 entryPointTerminated = true;

--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -99,6 +99,10 @@ public:
         stringIds[file_c_str] = strId;
         return strId;
     }
+    spv::Id getSourceFile() const 
+    {
+        return sourceFileStringId;
+    }
     void setSourceFile(const std::string& file)
     {
         sourceFileStringId = getStringId(file);

--- a/SPIRV/spvIR.h
+++ b/SPIRV/spvIR.h
@@ -357,6 +357,14 @@ public:
     Decoration getReturnPrecision() const
         { return reducedPrecisionReturn ? DecorationRelaxedPrecision : NoPrecision; }
 
+    void setDebugLineInfo(Id fileName, int line, int column) {
+        lineInstruction = Instruction(OpLine);
+        lineInstruction.addIdOperand(fileName);
+        lineInstruction.addImmediateOperand(line);
+        lineInstruction.addImmediateOperand(column);
+    }
+    bool hasDebugLineInfo() const { return lineInstruction.getOpCode() == OpLine; }
+
     void setImplicitThis() { implicitThis = true; }
     bool hasImplicitThis() const { return implicitThis; }
 
@@ -373,6 +381,11 @@ public:
 
     void dump(std::vector<unsigned int>& out) const
     {
+        // OpLine
+        if (hasDebugLineInfo()) {
+            lineInstruction.dump(out);
+        }
+        
         // OpFunction
         functionInstruction.dump(out);
 
@@ -391,6 +404,7 @@ protected:
     Function& operator=(Function&);
 
     Module& parent;
+    Instruction lineInstruction;
     Instruction functionInstruction;
     std::vector<Instruction*> parameterInstructions;
     std::vector<Block*> blocks;
@@ -457,7 +471,8 @@ protected:
 // - the OpFunction instruction
 // - all the OpFunctionParameter instructions
 __inline Function::Function(Id id, Id resultType, Id functionType, Id firstParamId, Module& parent)
-    : parent(parent), functionInstruction(id, resultType, OpFunction), implicitThis(false),
+    : parent(parent), lineInstruction(OpNop),
+      functionInstruction(id, resultType, OpFunction), implicitThis(false),
       reducedPrecisionReturn(false)
 {
     // OpFunction

--- a/Test/baseResults/hlsl.pp.line2.frag.out
+++ b/Test/baseResults/hlsl.pp.line2.frag.out
@@ -129,6 +129,7 @@ PS_OUTPUT MainPs ( PS_INPUT i )
 71(i.vTextureCoords):     70(ptr) Variable Input
               74:             TypePointer Output 11(fvec4)
 75(@entryPointOutput.vColor):     74(ptr) Variable Output
+                              Line 1 23 1
        5(MainPs):           3 Function None 4
                6:             Label
            69(i):     10(ptr) Variable Function
@@ -144,6 +145,7 @@ PS_OUTPUT MainPs ( PS_INPUT i )
                               Store 75(@entryPointOutput.vColor) 79
                               Return
                               FunctionEnd
+                              Line 1 23 1
 15(@MainPs(struct-PS_INPUT-vf21;):12(PS_OUTPUT) Function None 13
            14(i):     10(ptr) FunctionParameter
               16:             Label

--- a/Test/baseResults/hlsl.pp.line3.frag.out
+++ b/Test/baseResults/hlsl.pp.line3.frag.out
@@ -120,6 +120,7 @@ PS_OUTPUT MainPs ( PS_INPUT i )
 69(i.vTextureCoords):     68(ptr) Variable Input
               72:             TypePointer Output 12(fvec4)
 73(@entryPointOutput.vColor):     72(ptr) Variable Output
+                              Line 1 23 1
        6(MainPs):           4 Function None 5
                7:             Label
            67(i):     11(ptr) Variable Function
@@ -135,6 +136,7 @@ PS_OUTPUT MainPs ( PS_INPUT i )
                               Store 73(@entryPointOutput.vColor) 77
                               Return
                               FunctionEnd
+                              Line 1 23 1
 16(@MainPs(struct-PS_INPUT-vf21;):13(PS_OUTPUT) Function None 14
            15(i):     11(ptr) FunctionParameter
               17:             Label

--- a/Test/baseResults/hlsl.pp.line4.frag.out
+++ b/Test/baseResults/hlsl.pp.line4.frag.out
@@ -112,7 +112,9 @@ PS_OUTPUT MainPs ( PS_INPUT i )
 70(i.vTextureCoords):     69(ptr) Variable Input
               73:             TypePointer Output 11(fvec4)
 74(@entryPointOutput.vColor):     73(ptr) Variable Output
+                              Line 1 25 1
        5(MainPs):           3 Function None 4
+                              NoLine
                6:             Label
                               Line 17 25 0
               71:    8(fvec2) Load 70(i.vTextureCoords)

--- a/Test/baseResults/hlsl.round.dx9.frag.out
+++ b/Test/baseResults/hlsl.round.dx9.frag.out
@@ -60,6 +60,7 @@ gl_FragCoord origin is upper left
                6:             Label
                               Return
                               FunctionEnd
+                              Line 1 2 1
 12(PixelShaderFunction(vf4;):    8(fvec4) Function None 10
        11(input):      9(ptr) FunctionParameter
               13:             Label

--- a/Test/baseResults/hlsl.sample.dx9.frag.out
+++ b/Test/baseResults/hlsl.sample.dx9.frag.out
@@ -477,6 +477,7 @@ using depth_any
 128(@entryPointOutput.Color):    127(ptr) Variable Output
              131:             TypePointer Output 7(float)
 132(@entryPointOutput.Depth):    131(ptr) Variable Output
+                              Line 1 15 1
          5(main):           3 Function None 4
                6:             Label
 125(flattenTemp):    109(ptr) Variable Function
@@ -491,6 +492,7 @@ using depth_any
                               Store 132(@entryPointOutput.Depth) 134
                               Return
                               FunctionEnd
+                              Line 1 15 1
       11(@main():9(PS_OUTPUT) Function None 10
               12:             Label
     14(ColorOut):     13(ptr) Variable Function

--- a/Test/baseResults/hlsl.sample.dx9.vert.out
+++ b/Test/baseResults/hlsl.sample.dx9.vert.out
@@ -215,6 +215,7 @@ Shader version: 500
               53:    7(float) Constant 1073741824
               60:             TypePointer Output 8(fvec4)
 61(@entryPointOutput.Pos):     60(ptr) Variable Output
+                              Line 1 11 1
          5(main):           3 Function None 4
                6:             Label
                               Line 1 11 0
@@ -223,6 +224,7 @@ Shader version: 500
                               Store 61(@entryPointOutput.Pos) 63
                               Return
                               FunctionEnd
+                              Line 1 11 1
       11(@main():9(VS_OUTPUT) Function None 10
               12:             Label
       14(PosOut):     13(ptr) Variable Function

--- a/Test/baseResults/spv.debugInfo.1.1.frag.out
+++ b/Test/baseResults/spv.debugInfo.1.1.frag.out
@@ -136,6 +136,7 @@ void main()
              109:      7(int) Constant 1
              111:             TypePointer Output 10(float)
              114:   10(float) Constant 1092616192
+                              Line 1 28 11
          5(main):           3 Function None 4
                6:             Label
        57(param):      9(ptr) Variable Function
@@ -237,6 +238,7 @@ void main()
              118:             Label
                               Return
                               FunctionEnd
+                              Line 1 16 13
 14(foo(struct-S-i11;):   11(fvec4) Function None 12
            13(s):      9(ptr) FunctionParameter
               15:             Label

--- a/Test/baseResults/spv.debugInfo.frag.out
+++ b/Test/baseResults/spv.debugInfo.frag.out
@@ -137,6 +137,7 @@ void main()
              109:      7(int) Constant 1
              111:             TypePointer Output 10(float)
              114:   10(float) Constant 1092616192
+                              Line 1 28 11
          5(main):           3 Function None 4
                6:             Label
        57(param):      9(ptr) Variable Function
@@ -238,6 +239,7 @@ void main()
              118:             Label
                               Return
                               FunctionEnd
+                              Line 1 16 13
 14(foo(struct-S-i11;):   11(fvec4) Function None 12
            13(s):      9(ptr) FunctionParameter
               15:             Label

--- a/Test/baseResults/spv.hlslDebugInfo.frag.out
+++ b/Test/baseResults/spv.hlslDebugInfo.frag.out
@@ -44,6 +44,7 @@ float4 origMain() : SV_Position
               13:    8(fvec4) ConstantComposite 12 12 12 12
               16:             TypePointer Output 8(fvec4)
 17(@entryPointOutput):     16(ptr) Variable Output
+                              Line 1 2 1
       5(newMain):           3 Function None 4
                6:             Label
                               Line 1 2 0
@@ -51,6 +52,7 @@ float4 origMain() : SV_Position
                               Store 17(@entryPointOutput) 18
                               Return
                               FunctionEnd
+                              Line 1 2 1
    10(@newMain():    8(fvec4) Function None 9
               11:             Label
                               Line 1 3 0

--- a/Test/baseResults/spv.pp.line.frag.out
+++ b/Test/baseResults/spv.pp.line.frag.out
@@ -92,6 +92,7 @@ void main()
            56(u):     55(ptr) Variable Input
               58:             TypePointer Input 7(float)
        59(blend):     58(ptr) Variable Input
+                              Line 1 11 11
          5(main):           3 Function None 4
                6:             Label
    9(blendscale):      8(ptr) Variable Function


### PR DESCRIPTION
This is a PR succeeding https://github.com/KhronosGroup/glslang/pull/2321 as the author of the original PR doesn't have time to finalize it. The goal is to emit OpLine before OpFunction so that downstream user of spir-v module could have a more accurate debug line information.

There's following design decisions might need to be discussed:
1. Due to different parsing behavior, for a function "void foo() { ... }", glsl sets the OpLine to the location of '(' while hlsl sets it to '{'
2. Sometimes, compiling hlsl will generate a dummy main function. Currently, the dummy function will have the same line info with the original main function. But this could be removed if wanted.