### PR TITLE
Restore legacy interface for remap()

### DIFF
--- a/SPIRV/SPVRemapper.cpp
+++ b/SPIRV/SPVRemapper.cpp
@@ -1517,6 +1517,15 @@ namespace spv {
         spv.swap(in_spv);
     }
 
+    // remap from a memory image - legacy interface without white list
+    void spirvbin_t::remap(std::vector<std::uint32_t>& in_spv, std::uint32_t opts)
+    {
+      stripWhiteList.clear();
+      spv.swap(in_spv);
+      remap(opts);
+      spv.swap(in_spv);
+    }
+
 } // namespace SPV
 
 #endif // defined (use_cpp11)

--- a/SPIRV/SPVRemapper.h
+++ b/SPIRV/SPVRemapper.h
@@ -121,6 +121,9 @@ public:
    void remap(std::vector<std::uint32_t>& spv, const std::vector<std::string>& whiteListStrings,
               std::uint32_t opts = DO_EVERYTHING);
 
+   // remap on an existing binary in memory - legacy interface without white list
+   void remap(std::vector<std::uint32_t>& spv, std::uint32_t opts = DO_EVERYTHING);
+
    // Type for error/log handler functions
    typedef std::function<void(const std::string&)> errorfn_t;
    typedef std::function<void(const std::string&)> logfn_t;


### PR DESCRIPTION
Fixes ABI breakage caused by #2933