### PR TITLE
Add OpSource support to the C interface.

### DIFF
--- a/glslang/CInterface/glslang_c_interface.cpp
+++ b/glslang/CInterface/glslang_c_interface.cpp
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "glslang/Include/ResourceLimits.h"
 #include "glslang/MachineIndependent/Versions.h"
+#include "glslang/MachineIndependent/localintermediate.h"
 
 static_assert(int(GLSLANG_STAGE_COUNT) == EShLangCount, "");
 static_assert(int(GLSLANG_STAGE_MASK_COUNT) == EShLanguageMaskCount, "");
@@ -453,6 +454,16 @@ GLSLANG_EXPORT void glslang_program_add_shader(glslang_program_t* program, glsla
 GLSLANG_EXPORT int glslang_program_link(glslang_program_t* program, int messages)
 {
     return (int)program->program->link((EShMessages)messages);
+}
+
+GLSLANG_EXPORT void glslang_program_add_source_text(glslang_program_t* program, glslang_stage_t stage, const char* text, size_t len) {
+    glslang::TIntermediate* intermediate = program->program->getIntermediate(c_shader_stage(stage));
+    intermediate->addSourceText(text, len);
+}
+
+GLSLANG_EXPORT void glslang_program_set_source_file(glslang_program_t* program, glslang_stage_t stage, const char* file) {
+    glslang::TIntermediate* intermediate = program->program->getIntermediate(c_shader_stage(stage));
+    intermediate->setSourceFile(file);
 }
 
 GLSLANG_EXPORT int glslang_program_map_io(glslang_program_t* program)

--- a/glslang/Include/glslang_c_interface.h
+++ b/glslang/Include/glslang_c_interface.h
@@ -199,6 +199,16 @@ typedef struct glsl_include_callbacks_s {
     glsl_free_include_result_func free_include_result;
 } glsl_include_callbacks_t;
 
+/* SpvOptions counterpart */
+typedef struct glslang_spv_options_s {
+    bool generate_debug_info;
+    bool strip_debug_info;
+    bool disable_optimizer;
+    bool optimize_size;
+    bool disassemble;
+    bool validate;
+} glslang_spv_options_t;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -238,8 +248,11 @@ GLSLANG_EXPORT glslang_program_t* glslang_program_create();
 GLSLANG_EXPORT void glslang_program_delete(glslang_program_t* program);
 GLSLANG_EXPORT void glslang_program_add_shader(glslang_program_t* program, glslang_shader_t* shader);
 GLSLANG_EXPORT int glslang_program_link(glslang_program_t* program, int messages); // glslang_messages_t
+GLSLANG_EXPORT void glslang_program_add_source_text(glslang_program_t* program, glslang_stage_t stage, const char* text, size_t len);
+GLSLANG_EXPORT void glslang_program_set_source_file(glslang_program_t* program, glslang_stage_t stage, const char* file);
 GLSLANG_EXPORT int glslang_program_map_io(glslang_program_t* program);
 GLSLANG_EXPORT void glslang_program_SPIRV_generate(glslang_program_t* program, glslang_stage_t stage);
+GLSLANG_EXPORT void glslang_program_SPIRV_generate_with_options(glslang_program_t* program, glslang_stage_t stage, glslang_spv_options_t* spv_options);
 GLSLANG_EXPORT size_t glslang_program_SPIRV_get_size(glslang_program_t* program);
 GLSLANG_EXPORT void glslang_program_SPIRV_get(glslang_program_t* program, unsigned int*);
 GLSLANG_EXPORT unsigned int* glslang_program_SPIRV_get_ptr(glslang_program_t* program);


### PR DESCRIPTION
The C interface was lacking support for adding `OpSource` source code information instruction to the resulting SPIR-V.

This PR adds C interface counterparts of `TIntermediate::addSourceText`, `TIntermediate::setSourceFile` and `SpvOptions`.

I opted not to change the signature of `glslang_program_SPIRV_generate` so as not to break existing code,
instead adding a variant `glslang_program_SPIRV_generate_with_options` which additionally takes the `SpvOptions` counterpart,
and restructured `glslang_program_SPIRV_generate` to be implemented in terms of the latter to avoid code duplication.