### PR TITLE
Fix version check macros

### DIFF
--- a/build_info.h.tmpl
+++ b/build_info.h.tmpl
@@ -40,23 +40,23 @@
 #define GLSLANG_VERSION_FLAVOR "@flavor@"
 
 #define GLSLANG_VERSION_GREATER_THAN(major, minor, patch) \
-    (((major) > GLSLANG_VERSION_MAJOR) || ((major) == GLSLANG_VERSION_MAJOR && \
-    (((minor) > GLSLANG_VERSION_MINOR) || ((minor) == GLSLANG_VERSION_MINOR && \
-     ((patch) > GLSLANG_VERSION_PATCH)))))
+    ((GLSLANG_VERSION_MAJOR) > (major) || ((major) == GLSLANG_VERSION_MAJOR && \
+    ((GLSLANG_VERSION_MINOR) > (minor) || ((minor) == GLSLANG_VERSION_MINOR && \
+     (GLSLANG_VERSION_PATCH) > (patch)))))
 
 #define GLSLANG_VERSION_GREATER_OR_EQUAL_TO(major, minor, patch) \
-    (((major) > GLSLANG_VERSION_MAJOR) || ((major) == GLSLANG_VERSION_MAJOR && \
-    (((minor) > GLSLANG_VERSION_MINOR) || ((minor) == GLSLANG_VERSION_MINOR && \
-     ((patch) >= GLSLANG_VERSION_PATCH)))))
+    ((GLSLANG_VERSION_MAJOR) > (major) || ((major) == GLSLANG_VERSION_MAJOR && \
+    ((GLSLANG_VERSION_MINOR) > (minor) || ((minor) == GLSLANG_VERSION_MINOR && \
+     (GLSLANG_VERSION_PATCH >= (patch))))))
 
 #define GLSLANG_VERSION_LESS_THAN(major, minor, patch) \
-    (((major) < GLSLANG_VERSION_MAJOR) || ((major) == GLSLANG_VERSION_MAJOR && \
-    (((minor) < GLSLANG_VERSION_MINOR) || ((minor) == GLSLANG_VERSION_MINOR && \
-     ((patch) < GLSLANG_VERSION_PATCH)))))
+    ((GLSLANG_VERSION_MAJOR) < (major) || ((major) == GLSLANG_VERSION_MAJOR && \
+    ((GLSLANG_VERSION_MINOR) < (minor) || ((minor) == GLSLANG_VERSION_MINOR && \
+     (GLSLANG_VERSION_PATCH) < (patch)))))
 
 #define GLSLANG_VERSION_LESS_OR_EQUAL_TO(major, minor, patch) \
-    (((major) < GLSLANG_VERSION_MAJOR) || ((major) == GLSLANG_VERSION_MAJOR && \
-    (((minor) < GLSLANG_VERSION_MINOR) || ((minor) == GLSLANG_VERSION_MINOR && \
-     ((patch) <= GLSLANG_VERSION_PATCH)))))
+    ((GLSLANG_VERSION_MAJOR) < (major) || ((major) == GLSLANG_VERSION_MAJOR && \
+    ((GLSLANG_VERSION_MINOR) < (minor) || ((minor) == GLSLANG_VERSION_MINOR && \
+     (GLSLANG_VERSION_PATCH <= (patch))))))
 
 #endif // GLSLANG_BUILD_INFO


### PR DESCRIPTION
These were defined backwards to the usual convention.

 #if GLSLANG_VERSION_GREATER_THAN(11, 10, 0)

This reads as "if glslang version is greater than 11.10.0" to any
reasonable sane programmer, and should therefore expand to
"glslang_version > macro_argument".

Yet the check it references was actually written as "macro_argument >
glslang_version", thus expressing the completely opposite condition of
"if glslang version is *less than* 11.10.0". This is definitely
backwards and extremely, dangerously surprising behavior to any
programmer familiar with such version macros.

I'm not sure if anybody actually ever used them. I certainly didn't, on
account of them being backwards. I could not find a single reference to
them on GitHub (other than in copies of this header) - every project I
found just used the GLSLANG_VERSION_MAJOR etc. macros directly.