### PR TITLE
Fix #2658: Properly include all headers in deployments

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -77,17 +77,18 @@ jobs:
                   zip ${ARCHIVE} \
                       bin/glslangValidator \
                       include/glslang/* \
-                      lib/libGenericCodeGen${SUFFIX}.a \
-                      lib/libglslang${SUFFIX}.a \
-                      lib/libglslang-default-resource-limits${SUFFIX}.a \
-                      lib/libHLSL${SUFFIX}.a \
-                      lib/libMachineIndependent${SUFFIX}.a \
-                      lib/libOGLCompiler${SUFFIX}.a \
-                      lib/libOSDependent${SUFFIX}.a \
-                      lib/libSPIRV${SUFFIX}.a \
-                      lib/libSPVRemapper${SUFFIX}.a \
-                      lib/libSPIRV-Tools${SUFFIX}.a \
-                      lib/libSPIRV-Tools-opt${SUFFIX}.a
+                      include/glslang/**/* \
+                      lib/libGenericCodeGen.a \
+                      lib/libglslang.a \
+                      lib/libglslang-default-resource-limits.a \
+                      lib/libHLSL.a \
+                      lib/libMachineIndependent.a \
+                      lib/libOGLCompiler.a \
+                      lib/libOSDependent.a \
+                      lib/libSPIRV.a \
+                      lib/libSPVRemapper.a \
+                      lib/libSPIRV-Tools.a \
+                      lib/libSPIRV-Tools-opt.a
             - name: Deploy
               if: ${{ matrix.compiler.cc == 'clang' }}
               env:
@@ -147,17 +148,18 @@ jobs:
                   zip ${ARCHIVE} \
                       bin/glslangValidator \
                       include/glslang/* \
-                      lib/libGenericCodeGen${SUFFIX}.a \
-                      lib/libglslang${SUFFIX}.a \
-                      lib/libglslang-default-resource-limits${SUFFIX}.a \
-                      lib/libHLSL${SUFFIX}.a \
-                      lib/libMachineIndependent${SUFFIX}.a \
-                      lib/libOGLCompiler${SUFFIX}.a \
-                      lib/libOSDependent${SUFFIX}.a \
-                      lib/libSPIRV${SUFFIX}.a \
-                      lib/libSPVRemapper${SUFFIX}.a \
-                      lib/libSPIRV-Tools${SUFFIX}.a \
-                      lib/libSPIRV-Tools-opt${SUFFIX}.a
+                      include/glslang/**/* \
+                      lib/libGenericCodeGen.a \
+                      lib/libglslang.a \
+                      lib/libglslang-default-resource-limits.a \
+                      lib/libHLSL.a \
+                      lib/libMachineIndependent.a \
+                      lib/libOGLCompiler.a \
+                      lib/libOSDependent.a \
+                      lib/libSPIRV.a \
+                      lib/libSPVRemapper.a \
+                      lib/libSPIRV-Tools.a \
+                      lib/libSPIRV-Tools-opt.a
             - name: Deploy
               env:
                   ARCHIVE: glslang-master-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip


### PR DESCRIPTION
The workflow used to only zip files in `include/glslang/*`, which does not respect subdirectories. Also including `include/glslang/**/*` fixes this issue. If you look at the current builds, you can precisely observe this behaviour as `build_info.h` in the root directory is actually zipped. The `${SUFFIX}` seems to also have been blindly copied from the old CI which has no usage anymore. This workflow never worked. I fully tested this on Ubuntu 20.04 in WSL and on my macOS 13 Mac.

Also, I've rewritten the GitHub workflow to also build for Windows, but is there any reason why VS 2015 is strictly *required*? GitHub workflow only offers VS Enterprise 2017, VS Enterprise 2019, or VS Enterprise 2022.

Fixes #2658.