### PR TITLE
Fix: Migrate Windows CI to GitHub Actions

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -21,6 +21,17 @@ on:
     push:
         branches:
             - main
+        paths-ignore:
+            - 'README.md'
+            - 'README-spirv-remap.txt'
+            - 'LICENSE.txt'
+            - 'CODE_OF_CONDUCT.md'
+            - 'BUILD.*'
+            - 'WORKSPACE'
+            - 'kokoro/*'
+            - 'make-revision'
+            - 'Android.mk'
+            - '_config.yml'
 
 permissions: read-all
 
@@ -36,8 +47,8 @@ jobs:
                 compiler: [{cc: clang, cxx: clang++}, {cc: gcc, cxx: g++}]
                 cmake_build_type: [Debug, Release]
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-python@v2
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
               with:
                   python-version: '3.7'
             - name: Install Ubuntu Package Dependencies
@@ -97,7 +108,7 @@ jobs:
               if: ${{ matrix.compiler.cc == 'clang' }}
               env:
                   ARCHIVE: glslang-main-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
-              uses: actions/github-script@v5
+              uses: actions/github-script@v6
               with:
                   script: |
                       const script = require('.github/workflows/deploy.js')
@@ -114,8 +125,8 @@ jobs:
                 compiler: [{cc: clang, cxx: clang++}]
                 cmake_build_type: [Debug, Release]
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-python@v2
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
               with:
                   python-version: '3.7'
             - name: Install GoogleTest
@@ -169,7 +180,96 @@ jobs:
             - name: Deploy
               env:
                   ARCHIVE: glslang-main-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
-              uses: actions/github-script@v5
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const script = require('.github/workflows/deploy.js')
+                      await script({github, context, core})
+
+    windows:
+        runs-on: ${{matrix.os.genus}}
+        permissions:
+            contents: write
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [{genus: windows-2019, family: windows}]
+                cmake_build_type: [Debug, Release]
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: '3.7'
+            - name: Install GoogleTest
+              run: |
+                  # check out pre-breakage version of googletest; can be deleted when
+                  # issue 3128 is fixed
+                  # git clone --depth=1 https://github.com/google/googletest.git External/googletest
+                  mkdir -p External/googletest
+                  cd External/googletest
+                  git init
+                  git remote add origin https://github.com/google/googletest.git
+                  git fetch --depth 1 origin 0c400f67fcf305869c5fb113dd296eca266c9725
+                  git reset --hard FETCH_HEAD
+                  cd ../..
+            - name: Update Glslang Sources
+              run: |
+                  python update_glslang_sources.py
+            - name: Build
+              run: |
+                  cmake -S. -Bbuild -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="$PWD/build/install"
+                  cmake --build build --config ${{matrix.cmake_build_type}} --target install
+            - name: Test
+              run: |
+                  cd build
+                  ctest -C ${{matrix.cmake_build_type}} --output-on-failure
+                  cd ../Test && bash runtests
+            - name: Zip
+              if: ${{ matrix.cmake_build_type == 'Debug' }}
+              env:
+                  ARCHIVE: glslang-master-${{matrix.os.family}}-Debug.zip
+              run: |
+                  cd build/install
+                  7z a ${{env.ARCHIVE}} `
+                      bin/glslangValidator.exe `
+                      bin/spirv-remap.exe `
+                      include/glslang/* `
+                      lib/GenericCodeGend.lib `
+                      lib/glslangd.lib `
+                      lib/glslang-default-resource-limitsd.lib `
+                      lib/HLSLd.lib `
+                      lib/MachineIndependentd.lib `
+                      lib/OGLCompilerd.lib `
+                      lib/OSDependentd.lib `
+                      lib/SPIRVd.lib `
+                      lib/SPVRemapperd.lib `
+                      lib/SPIRV-Toolsd.lib `
+                      lib/SPIRV-Tools-optd.lib
+            - name: Zip
+              if: ${{ matrix.cmake_build_type == 'Release' }}
+              env:
+                  ARCHIVE: glslang-master-${{matrix.os.family}}-Release.zip
+              run: |
+                  cd build/install
+                  7z a ${{env.ARCHIVE}} `
+                      bin/glslangValidator.exe `
+                      bin/spirv-remap.exe `
+                      include/glslang/* `
+                      lib/GenericCodeGen.lib `
+                      lib/glslang.lib `
+                      lib/glslang-default-resource-limits.lib `
+                      lib/HLSL.lib `
+                      lib/MachineIndependent.lib `
+                      lib/OGLCompiler.lib `
+                      lib/OSDependent.lib `
+                      lib/SPIRV.lib `
+                      lib/SPVRemapper.lib `
+                      lib/SPIRV-Tools.lib `
+                      lib/SPIRV-Tools-opt.lib
+            - name: Deploy
+              env:
+                  ARCHIVE: glslang-master-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
+              uses: actions/github-script@v6
               with:
                   script: |
                       const script = require('.github/workflows/deploy.js')

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -103,6 +103,45 @@ jobs:
                   ctest --output-on-failure &&
                   cd ../Test && ./runtests
 
+    windows:
+        runs-on: ${{matrix.os.genus}}
+        permissions:
+            contents: write
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [{genus: windows-2019, family: windows}]
+                cmake_build_type: [Debug, Release]
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: '3.7'
+            - name: Install GoogleTest
+              run: |
+                  # check out pre-breakage version of googletest; can be deleted when
+                  # issue 3128 is fixed
+                  # git clone --depth=1 https://github.com/google/googletest.git External/googletest
+                  mkdir -p External/googletest
+                  cd External/googletest
+                  git init
+                  git remote add origin https://github.com/google/googletest.git
+                  git fetch --depth 1 origin 0c400f67fcf305869c5fb113dd296eca266c9725
+                  git reset --hard FETCH_HEAD
+                  cd ../..
+            - name: Update Glslang Sources
+              run: |
+                  python update_glslang_sources.py
+            - name: Build
+              run: |
+                  cmake -S. -Bbuild -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="$PWD/build/install"
+                  cmake --build build --config ${{matrix.cmake_build_type}} --target install
+            - name: Test
+              run: |
+                  cd build
+                  ctest -C ${{matrix.cmake_build_type}} --output-on-failure
+                  cd ../Test && bash runtests
+
     android:
         runs-on: ${{matrix.os}}
         strategy:


### PR DESCRIPTION
This removes the need for AppVeyor in this repository. This workflow however runs on windows-2016, meaning that by default these are being built with Visual Studio Enterprise 2017. If that's not acceptable, this can wait until VS 2015 is deprecated by you. Also includes some nice things that weren't ported in the original migration.

Also, note that the AppVeyor auth token was always public in the .appveyor.yml config :) https://github.com/KhronosGroup/glslang/blob/607771c3622dc5c01e2e2ec088324383db1964fc/.appveyor.yml#L99