### PR TITLE
Fix: Build arm64 binaries for macOS

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -106,6 +106,7 @@ jobs:
             matrix:
                 os: [{genus: macos-11, family: osx}]
                 compiler: [{cc: clang, cxx: clang++}]
+                arch: [x86_64, arm64]
                 cmake_build_type: [Debug, Release]
         steps:
             - uses: actions/checkout@v2
@@ -133,7 +134,7 @@ jobs:
                   CXX: ${{matrix.compiler.cxx}}
               run: |
                   mkdir build && cd build
-                  cmake -DCMAKE_BUILD_TYPE=${{matrix.cmake_build_type}} -DCMAKE_INSTALL_PREFIX=`pwd`/install ..
+                  cmake -DCMAKE_BUILD_TYPE=${{matrix.cmake_build_type}} -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCMAKE_OSX_ARCHITECTURES=${{matrix.arch}} ..
                   make -j4 install
             - name: Test
               run: |
@@ -142,7 +143,7 @@ jobs:
                   cd ../Test && ./runtests
             - name: Zip
               env:
-                  ARCHIVE: glslang-master-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
+                  ARCHIVE: glslang-master-${{matrix.os.family}}-${{matrix.arch}}-${{matrix.cmake_build_type}}.zip
               run: |
                   cd build/install
                   zip ${ARCHIVE} \
@@ -162,7 +163,7 @@ jobs:
                       lib/libSPIRV-Tools-opt.a
             - name: Deploy
               env:
-                  ARCHIVE: glslang-master-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
+                  ARCHIVE: glslang-master-${{matrix.os.family}}-${{matrix.arch}}-${{matrix.cmake_build_type}}.zip
               uses: actions/github-script@v5
               with:
                   script: |


### PR DESCRIPTION
x86_64 binaries cannot be linked when building solely for arm64. This uses the matrix to build separately for x86_64 and arm64. I specifically opted for this instead of building a universal binary as there seems to be no guarantee that universal binary 2 files can be read and understood by older linkers, and the fact that a universal binary will effectively have two copies of the library/executable wasting a considerable amount of space. Also, upgrading the runner to `macOS-11` in 457d11ebd86c089f00a934e579f9c4dc76921e71 was required for this to work.