### PR TITLE
C interface symbol export

### DIFF
--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -76,6 +76,7 @@ target_include_directories(SPIRV PUBLIC
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 glslang_add_build_info_dependency(SPIRV)
+glslang_only_export_explicit_symbols(SPIRV)
 
 if (ENABLE_SPVREMAPPER)
     add_library(SPVRemapper ${LIB_TYPE} ${SPVREMAP_SOURCES} ${SPVREMAP_HEADERS})

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -57,6 +57,8 @@ target_include_directories(glslang-default-resource-limits
                            PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
 
+glslang_only_export_explicit_symbols(glslang-default-resource-limits)
+
 set(SOURCES StandAlone.cpp DirStackFileIncluder.h  ${GLSLANG_INTRINSIC_H})
 
 add_executable(glslangValidator ${SOURCES})

--- a/StandAlone/resource_limits_c.cpp
+++ b/StandAlone/resource_limits_c.cpp
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <string>
 
-const glslang_resource_t* glslang_default_resource(void)
+GLSLANG_EXPORT const glslang_resource_t* glslang_default_resource(void)
 {
     return reinterpret_cast<const glslang_resource_t*>(&glslang::DefaultTBuiltInResource);
 }
@@ -45,7 +45,7 @@ const glslang_resource_t* glslang_default_resource(void)
 #pragma warning(disable : 4996)
 #endif
 
-const char* glslang_default_resource_string()
+GLSLANG_EXPORT const char* glslang_default_resource_string()
 {
     std::string cpp_str = glslang::GetDefaultTBuiltInResourceString();
     char* c_str = (char*)malloc(cpp_str.length() + 1);
@@ -59,7 +59,7 @@ const char* glslang_default_resource_string()
 #pragma warning(pop)
 #endif
 
-void glslang_decode_resource_limits(glslang_resource_t* resources, char* config)
+GLSLANG_EXPORT void glslang_decode_resource_limits(glslang_resource_t* resources, char* config)
 {
     glslang::DecodeResourceLimits(reinterpret_cast<TBuiltInResource*>(resources), config);
 }

--- a/StandAlone/resource_limits_c.h
+++ b/StandAlone/resource_limits_c.h
@@ -38,14 +38,14 @@ extern "C" {
 // These are the default resources for TBuiltInResources, used for both
 //  - parsing this string for the case where the user didn't supply one,
 //  - dumping out a template for user construction of a config file.
-const glslang_resource_t* glslang_default_resource(void);
+GLSLANG_EXPORT const glslang_resource_t* glslang_default_resource(void);
 
 // Returns the DefaultTBuiltInResource as a human-readable string.
 // NOTE: User is responsible for freeing this string.
-const char* glslang_default_resource_string();
+GLSLANG_EXPORT const char* glslang_default_resource_string();
 
 // Decodes the resource limits from |config| to |resources|.
-void glslang_decode_resource_limits(glslang_resource_t* resources, char* config);
+GLSLANG_EXPORT void glslang_decode_resource_limits(glslang_resource_t* resources, char* config);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes this issue: https://github.com/KhronosGroup/glslang/issues/3001

An issue remains with the .lib for SPVRemapper not being generated when shared library build is enabled.

I don't know if anything should be exported there so I left as is.