### PR TITLE
build: install glslang-config.cmake to libdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,13 +375,13 @@ if(ENABLE_GLSLANG_INSTALL)
         include("@PACKAGE_PATH_EXPORT_TARGETS@")
     ]=])
     
-    set(PATH_EXPORT_TARGETS "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/glslang-targets.cmake")
+    set(PATH_EXPORT_TARGETS "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/glslang-targets.cmake")
     configure_package_config_file(
         "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake.in"
         "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake"
         PATH_VARS
             PATH_EXPORT_TARGETS
-        INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}
     )
     
     write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/glslang-config-version.cmake"
@@ -392,7 +392,7 @@ if(ENABLE_GLSLANG_INSTALL)
     install(
         EXPORT      glslang-targets
         NAMESPACE   "glslang::"
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}"
     )
     
     install(
@@ -400,6 +400,6 @@ if(ENABLE_GLSLANG_INSTALL)
             "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake"
             "${CMAKE_CURRENT_BINARY_DIR}/glslang-config-version.cmake"
         DESTINATION
-            "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}"
+            "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}"
     )
 endif()

--- a/OGLCompilersDLL/CMakeLists.txt
+++ b/OGLCompilersDLL/CMakeLists.txt
@@ -49,7 +49,7 @@ if(ENABLE_GLSLANG_INSTALL)
         message(WARNING \"Using `OGLCompilerTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
 
         if (NOT TARGET glslang::OGLCompiler)
-            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/glslang-targets.cmake\")
+            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/glslang-targets.cmake\")
         endif()
 
         add_library(OGLCompiler ALIAS glslang::OGLCompiler)

--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -121,7 +121,7 @@ if(ENABLE_GLSLANG_INSTALL)
             message(WARNING \"Using `SPVRemapperTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
 
             if (NOT TARGET glslang::SPVRemapper)
-                include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/glslang-targets.cmake\")
+                include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/glslang-targets.cmake\")
             endif()
 
             add_library(SPVRemapper ALIAS glslang::SPVRemapper)
@@ -133,7 +133,7 @@ if(ENABLE_GLSLANG_INSTALL)
         message(WARNING \"Using `SPIRVTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
 
         if (NOT TARGET glslang::SPIRV)
-            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/glslang-targets.cmake\")
+            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/glslang-targets.cmake\")
         endif()
 
         add_library(SPIRV ALIAS glslang::SPIRV)

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -111,7 +111,7 @@ if(ENABLE_GLSLANG_INSTALL)
         message(WARNING \"Using `glslangValidatorTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
 
         if (NOT TARGET glslang::glslangValidator)
-            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/glslang-targets.cmake\")
+            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/glslang-targets.cmake\")
         endif()
 
         add_library(glslangValidator ALIAS glslang::glslangValidator)
@@ -126,7 +126,7 @@ if(ENABLE_GLSLANG_INSTALL)
             message(WARNING \"Using `spirv-remapTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
 
             if (NOT TARGET glslang::spirv-remap)
-                include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/glslang-targets.cmake\")
+                include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/glslang-targets.cmake\")
             endif()
 
             add_library(spirv-remap ALIAS glslang::spirv-remap)
@@ -141,7 +141,7 @@ if(ENABLE_GLSLANG_INSTALL)
         message(WARNING \"Using `glslang-default-resource-limitsTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
 
         if (NOT TARGET glslang::glslang-default-resource-limits)
-            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/glslang-targets.cmake\")
+            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/glslang-targets.cmake\")
         endif()
 
         add_library(glslang-default-resource-limits ALIAS glslang::glslang-default-resource-limits)

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -209,7 +209,7 @@ if(ENABLE_GLSLANG_INSTALL)
         message(WARNING \"Using `glslangTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
 
         if (NOT TARGET glslang::glslang)
-            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/glslang-targets.cmake\")
+            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/glslang-targets.cmake\")
         endif()
 
         if(${BUILD_SHARED_LIBS})

--- a/glslang/OSDependent/Unix/CMakeLists.txt
+++ b/glslang/OSDependent/Unix/CMakeLists.txt
@@ -60,7 +60,7 @@ if(ENABLE_GLSLANG_INSTALL)
         message(WARNING \"Using `OSDependentTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
 
         if (NOT TARGET glslang::OSDependent)
-            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/glslang-targets.cmake\")
+            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/glslang-targets.cmake\")
         endif()
 
         add_library(OSDependent ALIAS glslang::OSDependent)

--- a/glslang/OSDependent/Windows/CMakeLists.txt
+++ b/glslang/OSDependent/Windows/CMakeLists.txt
@@ -55,7 +55,7 @@ if(ENABLE_GLSLANG_INSTALL)
         message(WARNING \"Using `OSDependentTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
 
         if (NOT TARGET glslang::OSDependent)
-            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/glslang-targets.cmake\")
+            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/glslang-targets.cmake\")
         endif()
 
         add_library(OSDependent ALIAS glslang::OSDependent)

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -76,7 +76,7 @@ if(BUILD_TESTING)
                 message(WARNING \"Using `glslangtestsTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
 
                 if (NOT TARGET glslang::glslangtests)
-                    include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/glslang-targets.cmake\")
+                    include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/glslang-targets.cmake\")
                 endif()
 
                 add_library(glslangtests ALIAS glslang::glslangtests)

--- a/hlsl/CMakeLists.txt
+++ b/hlsl/CMakeLists.txt
@@ -52,7 +52,7 @@ if(ENABLE_GLSLANG_INSTALL)
         message(WARNING \"Using `HLSLTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
 
         if (NOT TARGET glslang::HLSL)
-            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/glslang-targets.cmake\")
+            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/glslang-targets.cmake\")
         endif()
 
         add_library(HLSL ALIAS glslang::HLSL)


### PR DESCRIPTION
As glslang ships architecture dependant files, the Config file should be installed to `libdir`, not `datadir`. See https://github.com/KhronosGroup/glslang/pull/2989#discussion_r955367103 for more details.

Here's the diff between the install tree before and after this patch:

    $ diff <(tree install-datadir) <(tree install)
    1c1
    < install-datadir
    ---
    > install
    74,99c74,98
    <         ├── lib
    <         │   ├── cmake
    <         │   │   ├── glslang-default-resource-limitsTargets.cmake
    <         │   │   ├── glslangTargets.cmake
    <         │   │   ├── glslangValidatorTargets.cmake
    <         │   │   ├── HLSLTargets.cmake
    <         │   │   ├── OGLCompilerTargets.cmake
    <         │   │   ├── OSDependentTargets.cmake
    <         │   │   ├── spirv-remapTargets.cmake
    <         │   │   ├── SPIRVTargets.cmake
    <         │   │   └── SPVRemapperTargets.cmake
    <         │   ├── libGenericCodeGen.a
    <         │   ├── libglslang.a
    <         │   ├── libglslang-default-resource-limits.a
    <         │   ├── libHLSL.a
    <         │   ├── libMachineIndependent.a
    <         │   ├── libOGLCompiler.a
    <         │   ├── libOSDependent.a
    <         │   ├── libSPIRV.a
    <         │   └── libSPVRemapper.a
    <         └── share
    <             └── glslang
    <                 ├── glslang-config.cmake
    <                 ├── glslang-config-version.cmake
    <                 ├── glslang-targets.cmake
    <                 └── glslang-targets-debug.cmake
    ---
    >         └── lib
    >             ├── cmake
    >             │   ├── glslang-default-resource-limitsTargets.cmake
    >             │   ├── glslangTargets.cmake
    >             │   ├── glslangValidatorTargets.cmake
    >             │   ├── HLSLTargets.cmake
    >             │   ├── OGLCompilerTargets.cmake
    >             │   ├── OSDependentTargets.cmake
    >             │   ├── spirv-remapTargets.cmake
    >             │   ├── SPIRVTargets.cmake
    >             │   └── SPVRemapperTargets.cmake
    >             ├── glslang
    >             │   ├── glslang-config.cmake
    >             │   ├── glslang-config-version.cmake
    >             │   ├── glslang-targets.cmake
    >             │   └── glslang-targets-debug.cmake
    >             ├── libGenericCodeGen.a
    >             ├── libglslang.a
    >             ├── libglslang-default-resource-limits.a
    >             ├── libHLSL.a
    >             ├── libMachineIndependent.a
    >             ├── libOGLCompiler.a
    >             ├── libOSDependent.a
    >             ├── libSPIRV.a
    >             └── libSPVRemapper.a
    101c100
    < 15 directories, 83 files
    ---
    > 14 directories, 83 files