### PR TITLE
Fix strict aliasing violation

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -1338,7 +1338,9 @@ void TGlslangToSpvTraverser::TranslateLiterals(const glslang::TVector<const glsl
     for (auto constant : constants) {
         if (constant->getBasicType() == glslang::EbtFloat) {
             float floatValue = static_cast<float>(constant->getConstArray()[0].getDConst());
-            unsigned literal = *reinterpret_cast<unsigned*>(&floatValue);
+            unsigned literal;
+            static_assert(sizeof(literal) == sizeof(floatValue), "sizeof(unsigned) != sizeof(float)");
+            memcpy(&literal, &floatValue, sizeof(literal));
             literals.push_back(literal);
         } else if (constant->getBasicType() == glslang::EbtInt) {
             unsigned literal = constant->getConstArray()[0].getIConst();
@@ -4247,7 +4249,9 @@ spv::Id TGlslangToSpvTraverser::convertGlslangToSpvType(const glslang::TType& ty
             if (typeParam.constant->isLiteral()) {
                 if (typeParam.constant->getBasicType() == glslang::EbtFloat) {
                     float floatValue = static_cast<float>(typeParam.constant->getConstArray()[0].getDConst());
-                    unsigned literal = *reinterpret_cast<unsigned*>(&floatValue);
+                    unsigned literal;
+                    static_assert(sizeof(literal) == sizeof(floatValue), "sizeof(unsigned) != sizeof(float)");
+                    memcpy(&literal, &floatValue, sizeof(literal));
                     operands.push_back({false, literal});
                 } else if (typeParam.constant->getBasicType() == glslang::EbtInt) {
                     unsigned literal = typeParam.constant->getConstArray()[0].getIConst();


### PR DESCRIPTION
Dereferencing a type-punned pointer breaks type aliasing rules, leading to undefined behavior as in this statement:
```
unsigned literal = *reinterpret_cast<unsigned*>(&floatValue);
```
This can be fixed with `std::bit_cast`, but I use `memcpy` for compatibility with C++11 (and `static_assert` for safety):
```
unsigned literal;
static_assert(sizeof(literal) == sizeof(floatValue), "sizeof(unsigned) != sizeof(float)");
memcpy(&literal, &floatValue, sizeof(literal));
```