### PR TITLE
cmake: Use common installation directory for cmake support files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,13 +375,13 @@ if(ENABLE_GLSLANG_INSTALL)
         include("@PACKAGE_PATH_EXPORT_TARGETS@")
     ]=])
     
-    set(PATH_EXPORT_TARGETS "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/glslang-targets.cmake")
+    set(PATH_EXPORT_TARGETS "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake")
     configure_package_config_file(
         "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake.in"
         "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake"
         PATH_VARS
             PATH_EXPORT_TARGETS
-        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
     )
     
     write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/glslang-config-version.cmake"
@@ -392,7 +392,7 @@ if(ENABLE_GLSLANG_INSTALL)
     install(
         EXPORT      glslang-targets
         NAMESPACE   "glslang::"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
     )
     
     install(
@@ -400,6 +400,6 @@ if(ENABLE_GLSLANG_INSTALL)
             "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake"
             "${CMAKE_CURRENT_BINARY_DIR}/glslang-config-version.cmake"
         DESTINATION
-            "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}"
+            "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
     )
 endif()


### PR DESCRIPTION
At least on openSUSE, the usual installation location for cmake support files is ${CMAKE_INSTALL_LIBDIR}/cmake/<name>

   $ find /usr/lib64 -name '*.cmake' | grep /cmake/ | wc -l
   834
   $ find /usr/lib64 -name '*.cmake' | grep -v /cmake/ | wc -l
   8

which is also used by glslang with these changes.