### PR TITLE
cmake: Do not install static libraries in shared build mode

### DIFF
--- a/OGLCompilersDLL/CMakeLists.txt
+++ b/OGLCompilersDLL/CMakeLists.txt
@@ -41,7 +41,7 @@ if(WIN32)
     source_group("Source" FILES ${SOURCES})
 endif(WIN32)
 
-if(ENABLE_GLSLANG_INSTALL)
+if(ENABLE_GLSLANG_INSTALL AND NOT BUILD_SHARED_LIBS)
     install(TARGETS OGLCompiler EXPORT glslang-targets)
 
     # Backward compatibility
@@ -56,4 +56,4 @@ if(ENABLE_GLSLANG_INSTALL)
     ")
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/OGLCompilerTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 
-endif(ENABLE_GLSLANG_INSTALL)
+endif()

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -201,26 +201,28 @@ endif()
 ################################################################################
 if(ENABLE_GLSLANG_INSTALL)
     install(TARGETS glslang EXPORT glslang-targets)
-    install(TARGETS MachineIndependent EXPORT glslang-targets)
-    install(TARGETS GenericCodeGen EXPORT glslang-targets)
+    if(NOT BUILD_SHARED_LIBS)
+        install(TARGETS MachineIndependent EXPORT glslang-targets)
+        install(TARGETS GenericCodeGen EXPORT glslang-targets)
 
-    # Backward compatibility
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/glslangTargets.cmake" "
-        message(WARNING \"Using `glslangTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
+        # Backward compatibility
+        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/glslangTargets.cmake" "
+            message(WARNING \"Using `glslangTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
 
-        if (NOT TARGET glslang::glslang)
-            include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/glslang-targets.cmake\")
-        endif()
+            if (NOT TARGET glslang::glslang)
+                include(\"\${CMAKE_CURRENT_LIST_DIR}/../../${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/glslang-targets.cmake\")
+            endif()
 
-        if(${BUILD_SHARED_LIBS})
-            add_library(glslang ALIAS glslang::glslang)
-        else()
-            add_library(glslang ALIAS glslang::glslang)
-            add_library(MachineIndependent ALIAS glslang::MachineIndependent)
-            add_library(GenericCodeGen ALIAS glslang::GenericCodeGen)
-        endif()
-    ")
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/glslangTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+            if(${BUILD_SHARED_LIBS})
+                add_library(glslang ALIAS glslang::glslang)
+            else()
+                add_library(glslang ALIAS glslang::glslang)
+                add_library(MachineIndependent ALIAS glslang::MachineIndependent)
+                add_library(GenericCodeGen ALIAS glslang::GenericCodeGen)
+            endif()
+        ")
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/glslangTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+    endif()
 
     set(ALL_HEADERS
         ${GLSLANG_HEADERS}

--- a/glslang/OSDependent/Unix/CMakeLists.txt
+++ b/glslang/OSDependent/Unix/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
     target_link_libraries(OSDependent Threads::Threads)
 endif()
 
-if(ENABLE_GLSLANG_INSTALL)
+if(ENABLE_GLSLANG_INSTALL AND NOT BUILD_SHARED_LIBS)
     install(TARGETS OSDependent EXPORT glslang-targets)
 
     # Backward compatibility


### PR DESCRIPTION
The glslang cmake build system installs static libraries in addition to the dynamic glslang library, which are required when used in a package that uses glslang when calling find_package().

Distributions such as openSUSE (and perhaps others) use a "shared only" strategy, which conflicts with the current state of the glslang build system.
The static libraries mentioned are already all included in glslang and thus not needed. With this commit, these will no longer install the associated cmake support files when glslang is built shared.

See https://build.opensuse.org/request/show/1001407 for a related issue description.