### PR TITLE
only use dead input elimination on vertex shaders

### DIFF
--- a/SPIRV/SpvTools.cpp
+++ b/SPIRV/SpvTools.cpp
@@ -212,7 +212,8 @@ void SpirvToolsTransform(const glslang::TIntermediate& intermediate, std::vector
     optimizer.RegisterPass(spvtools::CreateInterpolateFixupPass());
     if (options->optimizeSize) {
         optimizer.RegisterPass(spvtools::CreateRedundancyEliminationPass());
-        optimizer.RegisterPass(spvtools::CreateEliminateDeadInputComponentsPass());
+        if (intermediate.getStage() == EShLanguage::EShLangVertex)
+            optimizer.RegisterPass(spvtools::CreateEliminateDeadInputComponentsPass());
     }
     optimizer.RegisterPass(spvtools::CreateAggressiveDCEPass());
     optimizer.RegisterPass(spvtools::CreateCFGCleanupPass());


### PR DESCRIPTION
It can't be safely used unilaterally on other stages, since that will result in output/input mismatches between stages. They arn't having their output variables eliminated accordingly.