### PR TITLE
Include: PoolAlloc: do not rely on CMake define

### DIFF
--- a/glslang/Include/PoolAlloc.h
+++ b/glslang/Include/PoolAlloc.h
@@ -37,7 +37,7 @@
 #ifndef _POOLALLOC_INCLUDED_
 #define _POOLALLOC_INCLUDED_
 
-#ifdef _DEBUG
+#ifndef NDEBUG
 #  define GUARD_BLOCKS  // define to enable guard block sanity checking
 #endif
 


### PR DESCRIPTION
On Windows, _DEBUG is defined by CMake if CMAKE_BUILD_TYPE is Debug. But on other platforms, this is not the case and thus in debug mode, the guard checks are not enabled.

Instead, rely on the NDEBUG define, which is always defined in release mode (Release, RelWithDebInfo and MinSizeRel). This works reliably on all platforms: It is also used to enable or disable assertions.