### PR TITLE
[glslang][extension] GL_ARB_geometry_shader4.

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.h
+++ b/glslang/MachineIndependent/ParseHelper.h
@@ -335,6 +335,7 @@ public:
     void fixIoArraySize(const TSourceLoc&, TType&);
     void handleIoResizeArrayAccess(const TSourceLoc&, TIntermTyped* base);
     void checkIoArraysConsistency(const TSourceLoc&, bool tailOnly = false);
+    void fixBuiltinConstantVerticesIn();
     int getIoArrayImplicitSize(const TQualifier&, TString* featureString = nullptr) const;
     void checkIoArrayConsistency(const TSourceLoc&, int requiredSize, const char* feature, TType&, const TString&);
 
@@ -403,7 +404,7 @@ public:
     void precisionQualifierCheck(const TSourceLoc&, TBasicType, TQualifier&);
     void parameterTypeCheck(const TSourceLoc&, TStorageQualifier qualifier, const TType& type);
     bool containsFieldWithBasicType(const TType& type ,TBasicType basicType);
-    TSymbol* redeclareBuiltinVariable(const TSourceLoc&, const TString&, const TQualifier&, const TShaderQualifiers&);
+    TSymbol* redeclareBuiltinVariable(const TSourceLoc&, const TString&, const TType& type, const TShaderQualifiers&);
     void redeclareBuiltinBlock(const TSourceLoc&, TTypeList& typeList, const TString& blockName, const TString* instanceName, TArraySizes* arraySizes);
     void paramCheckFixStorage(const TSourceLoc&, const TStorageQualifier&, TType& type);
     void paramCheckFix(const TSourceLoc&, const TQualifier&, TType& type);

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -354,7 +354,7 @@ bool InitializeSymbolTables(TInfoSink& infoSink, TSymbolTable** commonTable,  TS
     }
 
     // check for geometry
-    if ((profile != EEsProfile && version >= 150) ||
+    if ((profile != EEsProfile && version >= 110) ||
         (profile == EEsProfile && version >= 310))
         InitializeStageSymbolTable(*builtInParseables, version, profile, spvVersion, EShLangGeometry, source,
                                    infoSink, commonTable, symbolTables);
@@ -605,8 +605,8 @@ bool DeduceVersionProfile(TInfoSink& infoSink, EShLanguage stage, bool versionNo
         if ((profile == EEsProfile && version < 310) ||
             (profile != EEsProfile && version < 150)) {
             correct = false;
-            infoSink.info.message(EPrefixError, "#version: geometry shaders require es profile with version 310 or non-es profile with version 150 or above");
-            version = (profile == EEsProfile) ? 310 : 150;
+            infoSink.info.message(EPrefixError, "#version: geometry shaders require es profile with version 310 or non-es profile with version 110 or above");
+            version = (profile == EEsProfile) ? 310 : 110; // OpenGL 1.1 is required for ARB_geometry_shader4 extension
             if (profile == EEsProfile || profile == ENoProfile)
                 profile = ECoreProfile;
         }
@@ -1013,6 +1013,10 @@ bool ProcessDeferred(
                                      versionWillBeError, *symbolTable,
                                      intermediate, optLevel, messages);
     intermediate.setUniqueId(symbolTable->getMaxSymbolId());
+
+    // A local change here. May not be upstreamed.
+    intermediate.setGeometryShader4(parseContext->extensionsTurnedOn(Num_ARB_geometry_shader4, ARB_geometry_shader4));
+
     return success;
 }
 

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -227,6 +227,8 @@ void TParseVersions::initializeExtensionBehavior()
     extensionBehavior[E_GL_ARB_texture_query_lod]            = EBhDisable;
     extensionBehavior[E_GL_ARB_vertex_attrib_64bit]          = EBhDisable;
     extensionBehavior[E_GL_ARB_draw_instanced]               = EBhDisable;
+    extensionBehavior[E_GL_GL_ARB_arrays_of_arrays]          = EBhDisable;
+    extensionBehavior[E_GL_ARB_geometry_shader4]             = EBhDisable;
     extensionBehavior[E_GL_ARB_fragment_coord_conventions]   = EBhDisable;
 
 
@@ -255,6 +257,7 @@ void TParseVersions::initializeExtensionBehavior()
     extensionBehavior[E_GL_EXT_buffer_reference_uvec2]                  = EBhDisable;
     extensionBehavior[E_GL_EXT_demote_to_helper_invocation]             = EBhDisable;
     extensionBehavior[E_GL_EXT_debug_printf]                            = EBhDisable;
+    extensionBehavior[E_GL_EXT_geometry_shader4]                        = EBhDisable;
 
     extensionBehavior[E_GL_EXT_shader_16bit_storage]                    = EBhDisable;
     extensionBehavior[E_GL_EXT_shader_8bit_storage]                     = EBhDisable;
@@ -444,6 +447,7 @@ void TParseVersions::getPreamble(std::string& preamble)
             "#define GL_ARB_gpu_shader5 1\n"
             "#define GL_ARB_separate_shader_objects 1\n"
             "#define GL_ARB_compute_shader 1\n"
+            "#define GL_ARB_geometry_shader4 1\n"
             "#define GL_ARB_tessellation_shader 1\n"
             "#define GL_ARB_enhanced_layouts 1\n"
             "#define GL_ARB_texture_cube_map_array 1\n"
@@ -476,6 +480,7 @@ void TParseVersions::getPreamble(std::string& preamble)
             "#define GL_ARB_texture_query_lod 1\n"
             "#define GL_ARB_vertex_attrib_64bit 1\n"
             "#define GL_ARB_draw_instanced 1\n"
+            "#define GL_ARB_arrays_of_arrays 1 \n"
             "#define GL_ARB_fragment_coord_conventions 1\n"
             "#define GL_EXT_shader_non_constant_global_initializers 1\n"
             "#define GL_EXT_shader_image_load_formatted 1\n"
@@ -494,6 +499,7 @@ void TParseVersions::getPreamble(std::string& preamble)
             "#define GL_EXT_debug_printf 1\n"
             "#define GL_EXT_fragment_shading_rate 1\n"
             "#define GL_EXT_shared_memory_block 1\n"
+            "#define GL_EXT_geometry_shader4 1\n"
             "#define GL_EXT_shader_integer_mix 1\n"
 
             // GL_KHR_shader_subgroup

--- a/glslang/MachineIndependent/Versions.h
+++ b/glslang/MachineIndependent/Versions.h
@@ -162,7 +162,9 @@ const char* const E_GL_ARB_shading_language_packing     = "GL_ARB_shading_langua
 const char* const E_GL_ARB_texture_query_lod            = "GL_ARB_texture_query_lod";
 const char* const E_GL_ARB_vertex_attrib_64bit          = "GL_ARB_vertex_attrib_64bit";
 const char* const E_GL_ARB_draw_instanced               = "GL_ARB_draw_instanced";
+const char* const E_GL_GL_ARB_arrays_of_arrays          = "GL_ARB_arrays_of_arrays";
 const char* const E_GL_ARB_fragment_coord_conventions   = "GL_ARB_fragment_coord_conventions";
+const char* const E_GL_ARB_geometry_shader4             = "GL_ARB_geometry_shader4";
 
 const char* const E_GL_KHR_shader_subgroup_basic            = "GL_KHR_shader_subgroup_basic";
 const char* const E_GL_KHR_shader_subgroup_vote             = "GL_KHR_shader_subgroup_vote";
@@ -206,6 +208,8 @@ const char* const E_GL_EXT_blend_func_extended              = "GL_EXT_blend_func
 const char* const E_GL_EXT_shader_implicit_conversions      = "GL_EXT_shader_implicit_conversions";
 const char* const E_GL_EXT_fragment_shading_rate            = "GL_EXT_fragment_shading_rate";
 const char* const E_GL_EXT_shader_image_int64               = "GL_EXT_shader_image_int64";
+const char* const E_GL_EXT_geometry_shader4                 = "GL_EXT_geometry_shader4";
+
 const char* const E_GL_EXT_null_initializer                 = "GL_EXT_null_initializer";
 const char* const E_GL_EXT_shared_memory_block              = "GL_EXT_shared_memory_block";
 const char* const E_GL_EXT_subgroup_uniform_control_flow    = "GL_EXT_subgroup_uniform_control_flow";
@@ -351,6 +355,11 @@ const int Num_AEP_texture_buffer = sizeof(AEP_texture_buffer)/sizeof(AEP_texture
 const char* const AEP_texture_cube_map_array[] = { E_GL_EXT_texture_cube_map_array, E_GL_OES_texture_cube_map_array };
 const int Num_AEP_texture_cube_map_array = sizeof(AEP_texture_cube_map_array)/sizeof(AEP_texture_cube_map_array[0]);
 
+const char* const ARB_geometry_arrays_of_arrays[] = { E_GL_GL_ARB_arrays_of_arrays , E_GL_ARB_geometry_shader4 };
+const int Num_ARB_geometry_arrays_of_arrays = sizeof(ARB_geometry_arrays_of_arrays) / sizeof(ARB_geometry_arrays_of_arrays[0]);
+
+const char* const ARB_geometry_shader4[] = { E_GL_EXT_geometry_shader4 , E_GL_ARB_geometry_shader4 };
+const int Num_ARB_geometry_shader4 = sizeof(ARB_geometry_shader4) / sizeof(ARB_geometry_shader4[0]);
 const char* const AEP_mesh_shader[] = { E_GL_NV_mesh_shader, E_GL_EXT_mesh_shader };
 const int Num_AEP_mesh_shader = sizeof(AEP_mesh_shader)/sizeof(AEP_mesh_shader[0]);
 

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -297,6 +297,7 @@ public:
         depthReplacing(false),
         stencilReplacing(false),
         uniqueId(0),
+        useGeometryShader4(false),
         globalUniformBlockName(""),
         atomicCounterBlockName(""),
         globalUniformBlockSet(TQualifier::layoutSetEnd),
@@ -308,6 +309,7 @@ public:
         source(EShSourceNone),
         useVulkanMemoryModel(false),
         invocations(TQualifier::layoutNotSet), vertices(TQualifier::layoutNotSet),
+        inputPrimitiveSetOutside(false), outputPrimitiveSetOutside(false), maxGSVerticesSetOutside(false),
         inputPrimitive(ElgNone), outputPrimitive(ElgNone),
         pixelCenterInteger(false), originUpperLeft(false),texCoordBuiltinRedeclared(false),
         vertexSpacing(EvsNone), vertexOrder(EvoNone), interlockOrdering(EioNone), pointMode(false), earlyFragmentTests(false),
@@ -771,7 +773,8 @@ public:
     int getInvocations() const { return invocations; }
     bool setVertices(int m)
     {
-        if (vertices != TQualifier::layoutNotSet)
+        if (vertices != TQualifier::layoutNotSet &&
+            getMaxGSVerticesSetOutside() == false)
             return vertices == m;
         vertices = m;
         return true;
@@ -779,12 +782,19 @@ public:
     int getVertices() const { return vertices; }
     bool setInputPrimitive(TLayoutGeometry p)
     {
-        if (inputPrimitive != ElgNone)
+        if (inputPrimitive != ElgNone &&
+            getInputPrimitiveSetOutside() == false)
             return inputPrimitive == p;
         inputPrimitive = p;
         return true;
     }
     TLayoutGeometry getInputPrimitive() const { return inputPrimitive; }
+    bool setInputPrimitiveSetOutside(bool p)
+    {
+        inputPrimitiveSetOutside = p;
+        return true;
+    }
+    bool getInputPrimitiveSetOutside() const { return inputPrimitiveSetOutside; }
     bool setVertexSpacing(TVertexSpacing s)
     {
         if (vertexSpacing != EvsNone)
@@ -819,12 +829,25 @@ public:
     bool isMultiStream() const { return multiStream; }
     bool setOutputPrimitive(TLayoutGeometry p)
     {
-        if (outputPrimitive != ElgNone)
+        if (outputPrimitive != ElgNone &&
+            getOutputPrimitiveSetOutside() == false)
             return outputPrimitive == p;
         outputPrimitive = p;
         return true;
     }
     TLayoutGeometry getOutputPrimitive() const { return outputPrimitive; }
+    bool setOutputPrimitiveSetOutside(bool p)
+    {
+        outputPrimitiveSetOutside = p;
+        return true;
+    }
+    bool getOutputPrimitiveSetOutside() const { return outputPrimitiveSetOutside; }
+    bool setMaxGSVerticesSetOutside(bool p)
+    {
+        maxGSVerticesSetOutside = p;
+        return true;
+    }
+    bool getMaxGSVerticesSetOutside() const { return maxGSVerticesSetOutside; }
     void setPostDepthCoverage() { postDepthCoverage = true; }
     bool getPostDepthCoverage() const { return postDepthCoverage; }
     void setEarlyFragmentTests() { earlyFragmentTests = true; }
@@ -1028,6 +1051,8 @@ public:
     const std::vector<std::string>& getProcesses() const { return processes.getProcesses(); }
     unsigned long long getUniqueId() const { return uniqueId; }
     void setUniqueId(unsigned long long id) { uniqueId = id; }
+    bool getGeometryShader4() const { return useGeometryShader4; }
+    void setGeometryShader4(bool enable) { useGeometryShader4 = enable; }
 
     // Certain explicit conversions are allowed conditionally
 #ifdef GLSLANG_WEB
@@ -1118,6 +1143,7 @@ protected:
     bool localSizeNotDefault[3];
     int localSizeSpecId[3];
     unsigned long long uniqueId;
+    bool useGeometryShader4;
 
     std::string globalUniformBlockName;
     std::string atomicCounterBlockName;
@@ -1134,6 +1160,9 @@ protected:
     bool useVulkanMemoryModel;
     int invocations;
     int vertices;
+    bool inputPrimitiveSetOutside;     // input primitive set from outside.
+    bool outputPrimitiveSetOutside;    // output primitive set from outside.
+    bool maxGSVerticesSetOutside;      // max_vertices set from outside.
     TLayoutGeometry inputPrimitive;
     TLayoutGeometry outputPrimitive;
     bool pixelCenterInteger;


### PR DESCRIPTION
Support extension GL_ARB_geometry_shader4.
1. primitive type and vertices number would be determined in link time, hence set flags.
2. Two changes in ParseHelper have dependency on implicit array size set.
3. For some special var like gl_VerticesIn, recompute would be later than first-time compile. Would be depend on api set topology and extra info across stages.