### PR TITLE
Fix issues with MaxDualSourceDrawBuffersEXT

### DIFF
--- a/StandAlone/ResourceLimits.cpp
+++ b/StandAlone/ResourceLimits.cpp
@@ -505,6 +505,8 @@ void DecodeResourceLimits(TBuiltInResource* resources, char* config)
             resources->maxTaskWorkGroupSizeZ_EXT = value;
         else if (tokenStr == "MaxMeshViewCountEXT")
             resources->maxMeshViewCountEXT = value;
+        else if (tokenStr == "MaxDualSourceDrawBuffersEXT")
+            resources->maxDualSourceDrawBuffersEXT = value;
         else if (tokenStr == "nonInductiveForLoops")
             resources->limits.nonInductiveForLoops = (value != 0);
         else if (tokenStr == "whileLoops")

--- a/glslang/Include/glslang_c_interface.h
+++ b/glslang/Include/glslang_c_interface.h
@@ -157,7 +157,13 @@ typedef struct glslang_resource_s {
     int max_task_work_group_size_y_ext;
     int max_task_work_group_size_z_ext;
     int max_mesh_view_count_ext;
-    int maxDualSourceDrawBuffersEXT;
+    union
+    {
+        int max_dual_source_draw_buffers_ext;
+
+        /* Incorrectly capitalized name retained for backward compatibility */
+        int maxDualSourceDrawBuffersEXT;
+    };
 
     glslang_limits_t limits;
 } glslang_resource_t;

--- a/gtests/BuiltInResource.FromFile.cpp
+++ b/gtests/BuiltInResource.FromFile.cpp
@@ -53,5 +53,15 @@ TEST_F(DefaultResourceTest, FromFile)
     ASSERT_EQ(expectedConfig, realConfig);
 }
 
+TEST_F(DefaultResourceTest, UnrecognizedLimit)
+{
+    const std::string defaultConfig = GetDefaultTBuiltInResourceString();
+    testing::internal::CaptureStdout();
+    TBuiltInResource resources;
+    DecodeResourceLimits(&resources, const_cast<char*>(defaultConfig.c_str()));
+    std::string output = testing::internal::GetCapturedStdout();
+    ASSERT_EQ(output.find("unrecognized limit"), std::string::npos);
+}
+
 }  // anonymous namespace
 }  // namespace glslangtest


### PR DESCRIPTION
This PR fixes two issues introduced with the addition of support for MaxDualSourceDrawBuffersEXT.

First, glslangValidator's ResourceLimits.cpp was never updated to support the newly defined MaxDualSourceDrawBuffersEXT limit, causing the following warning to be output whenever glslangValidator is invoked with a default configuration file generated by glslangValidator's -c argument:

> Warning: unrecognized limit (MaxDualSourceDrawBuffersEXT) in configuration file.

This PR adds the appropriate check to recognize and apply this limit.

Second, the option for MaxDualSourceDrawBuffersEXT was added to the glslang_resource_s struct with inconsistent capitalization compared to all other members of the same struct (and indeed the entire C interface). This PR updates the struct definition with a union of the old name and the new name in order to maintain backward compatibility. The next time the major version of glslang is incremented this union could be replaced with just the new (consistent) name. Alternatively, it could be permanently left as a union.