### PR TITLE
Update appveyor environment

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@
 # build version format
 version: "{build}"
 
-os: Visual Studio 2015
+os: Visual Studio 2019
 
 platform:
   - x64
@@ -55,7 +55,7 @@ build:
 
 build_script:
   - mkdir build && cd build
-  - cmake -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=install ..
+  - cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=install ..
   - cmake --build . --config %CONFIGURATION% --target install
 
 test_script:


### PR DESCRIPTION
SPIRV-Tools now requires 3.17.2 or higher. The version provided by Visual Studio 2015 is 3.16.2.