### PR TITLE
Reject non-float inputs/outputs with version < 120

### DIFF
--- a/Test/baseResults/120.vert.out
+++ b/Test/baseResults/120.vert.out
@@ -46,6 +46,7 @@ ERROR: 0:108: 'overloadE' : no matching overloaded function found
 ERROR: 0:111: 'overloadE' : no matching overloaded function found 
 ERROR: 0:117: 'overloadF' : no matching overloaded function found 
 ERROR: 0:121: 'gl_TexCoord array size' : must be less than or equal to gl_MaxTextureCoords (32)
+ERROR: 0:154: 'non-float shader input/output' : not supported for this version or the enabled extensions 
 ERROR: 0:165: 'switch' : Reserved word. 
 ERROR: 0:171: 'default' : Reserved word. 
 ERROR: 0:165: 'switch statements' : not supported for this version or the enabled extensions 
@@ -80,7 +81,7 @@ ERROR: 0:195: 'gl_ModelViewMatrix' : identifiers starting with "gl_" are reserve
 ERROR: 0:200: 'token pasting (##)' : not supported for this version or the enabled extensions 
 ERROR: 0:203: 'token pasting (##)' : not supported for this version or the enabled extensions 
 ERROR: 0:205: '' :  syntax error, unexpected IDENTIFIER
-ERROR: 81 compilation errors.  No code generated.
+ERROR: 82 compilation errors.  No code generated.
 
 
 Shader version: 120

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -3983,8 +3983,10 @@ void TParseContext::globalQualifierTypeCheck(const TSourceLoc& loc, const TQuali
         return;
     }
 
-    if (isTypeInt(publicType.basicType) || publicType.basicType == EbtDouble)
-        profileRequires(loc, EEsProfile, 300, nullptr, "shader input/output");
+    if (isTypeInt(publicType.basicType) || publicType.basicType == EbtDouble) {
+        profileRequires(loc, EEsProfile, 300, nullptr, "non-float shader input/output");
+        profileRequires(loc, ~EEsProfile, 130, nullptr, "non-float shader input/output");
+    }
 
     if (!qualifier.flat && !qualifier.isExplicitInterpolation() && !qualifier.isPervertexNV() && !qualifier.isPervertexEXT()) {
         if (isTypeInt(publicType.basicType) ||


### PR DESCRIPTION
GLSL 1.20 and prior stated that "the attribute qualifier can be used only with float, floating-point vectors, and matrices" and likewise for varying.

Fixes: #3111