### PR TITLE
Move check if useStorageBuffer needs to be set

### DIFF
--- a/Test/baseResults/hlsl.wavebroadcast.comp.out
+++ b/Test/baseResults/hlsl.wavebroadcast.comp.out
@@ -2331,7 +2331,7 @@ local_size = (32, 16, 1)
                               MemberDecorate 20(Types) 3 Offset 64
                               Decorate 21 ArrayStride 96
                               MemberDecorate 22(data) 0 Offset 0
-                              Decorate 22(data) BufferBlock
+                              Decorate 22(data) Block
                               Decorate 24(data) DescriptorSet 0
                               Decorate 24(data) Binding 0
                               Decorate 388(dti) BuiltIn GlobalInvocationId
@@ -2351,31 +2351,31 @@ local_size = (32, 16, 1)
        20(Types):             TypeStruct 13(ivec4) 15(ivec4) 17(fvec4) 19(f64vec4)
               21:             TypeRuntimeArray 20(Types)
         22(data):             TypeStruct 21
-              23:             TypePointer Uniform 22(data)
-        24(data):     23(ptr) Variable Uniform
+              23:             TypePointer StorageBuffer 22(data)
+        24(data):     23(ptr) Variable StorageBuffer
               25:     14(int) Constant 0
               26:      6(int) Constant 0
               27:             TypePointer Function 6(int)
-              32:             TypePointer Uniform 13(ivec4)
+              32:             TypePointer StorageBuffer 13(ivec4)
               35:      6(int) Constant 13
               36:      6(int) Constant 3
-              43:             TypePointer Uniform 6(int)
+              43:             TypePointer StorageBuffer 6(int)
               52:             TypeVector 6(int) 2
               59:      6(int) Constant 1
               74:      6(int) Constant 2
               79:     14(int) Constant 1
-              82:             TypePointer Uniform 15(ivec4)
-              91:             TypePointer Uniform 14(int)
+              82:             TypePointer StorageBuffer 15(ivec4)
+              91:             TypePointer StorageBuffer 14(int)
              100:             TypeVector 14(int) 2
              113:             TypeVector 14(int) 3
              126:     14(int) Constant 2
-             129:             TypePointer Uniform 17(fvec4)
-             138:             TypePointer Uniform 16(float)
+             129:             TypePointer StorageBuffer 17(fvec4)
+             138:             TypePointer StorageBuffer 16(float)
              147:             TypeVector 16(float) 2
              160:             TypeVector 16(float) 3
              173:     14(int) Constant 3
-             176:             TypePointer Uniform 19(f64vec4)
-             185:             TypePointer Uniform 18(float64_t)
+             176:             TypePointer StorageBuffer 19(f64vec4)
+             185:             TypePointer StorageBuffer 18(float64_t)
              194:             TypeVector 18(float64_t) 2
              207:             TypeVector 18(float64_t) 3
              387:             TypePointer Input 7(ivec3)

--- a/Test/baseResults/hlsl.waveprefix.comp.out
+++ b/Test/baseResults/hlsl.waveprefix.comp.out
@@ -2355,7 +2355,7 @@ local_size = (32, 16, 1)
                               MemberDecorate 20(Types) 3 Offset 64
                               Decorate 21 ArrayStride 96
                               MemberDecorate 22(data) 0 Offset 0
-                              Decorate 22(data) BufferBlock
+                              Decorate 22(data) Block
                               Decorate 24(data) DescriptorSet 0
                               Decorate 24(data) Binding 0
                               Decorate 398(dti) BuiltIn GlobalInvocationId
@@ -2375,30 +2375,30 @@ local_size = (32, 16, 1)
        20(Types):             TypeStruct 13(ivec4) 15(ivec4) 17(fvec4) 19(f64vec4)
               21:             TypeRuntimeArray 20(Types)
         22(data):             TypeStruct 21
-              23:             TypePointer Uniform 22(data)
-        24(data):     23(ptr) Variable Uniform
+              23:             TypePointer StorageBuffer 22(data)
+        24(data):     23(ptr) Variable StorageBuffer
               25:     14(int) Constant 0
               26:      6(int) Constant 0
               27:             TypePointer Function 6(int)
-              32:             TypePointer Uniform 13(ivec4)
+              32:             TypePointer StorageBuffer 13(ivec4)
               35:      6(int) Constant 3
-              42:             TypePointer Uniform 6(int)
+              42:             TypePointer StorageBuffer 6(int)
               51:             TypeVector 6(int) 2
               58:      6(int) Constant 1
               73:      6(int) Constant 2
               78:     14(int) Constant 1
-              81:             TypePointer Uniform 15(ivec4)
-              90:             TypePointer Uniform 14(int)
+              81:             TypePointer StorageBuffer 15(ivec4)
+              90:             TypePointer StorageBuffer 14(int)
               99:             TypeVector 14(int) 2
              112:             TypeVector 14(int) 3
              125:     14(int) Constant 2
-             128:             TypePointer Uniform 17(fvec4)
-             137:             TypePointer Uniform 16(float)
+             128:             TypePointer StorageBuffer 17(fvec4)
+             137:             TypePointer StorageBuffer 16(float)
              146:             TypeVector 16(float) 2
              159:             TypeVector 16(float) 3
              172:     14(int) Constant 3
-             175:             TypePointer Uniform 19(f64vec4)
-             184:             TypePointer Uniform 18(float64_t)
+             175:             TypePointer StorageBuffer 19(f64vec4)
+             184:             TypePointer StorageBuffer 18(float64_t)
              193:             TypeVector 18(float64_t) 2
              206:             TypeVector 18(float64_t) 3
              391:             TypeBool

--- a/Test/baseResults/hlsl.wavequad.comp.out
+++ b/Test/baseResults/hlsl.wavequad.comp.out
@@ -8058,7 +8058,7 @@ local_size = (32, 16, 1)
                               MemberDecorate 20(Types) 3 Offset 64
                               Decorate 21 ArrayStride 96
                               MemberDecorate 22(data) 0 Offset 0
-                              Decorate 22(data) BufferBlock
+                              Decorate 22(data) Block
                               Decorate 24(data) DescriptorSet 0
                               Decorate 24(data) Binding 0
                               Decorate 1227(dti) BuiltIn GlobalInvocationId
@@ -8078,30 +8078,30 @@ local_size = (32, 16, 1)
        20(Types):             TypeStruct 13(ivec4) 15(ivec4) 17(fvec4) 19(f64vec4)
               21:             TypeRuntimeArray 20(Types)
         22(data):             TypeStruct 21
-              23:             TypePointer Uniform 22(data)
-        24(data):     23(ptr) Variable Uniform
+              23:             TypePointer StorageBuffer 22(data)
+        24(data):     23(ptr) Variable StorageBuffer
               25:     14(int) Constant 0
               26:      6(int) Constant 0
               27:             TypePointer Function 6(int)
-              32:             TypePointer Uniform 13(ivec4)
+              32:             TypePointer StorageBuffer 13(ivec4)
               35:      6(int) Constant 3
-              42:             TypePointer Uniform 6(int)
+              42:             TypePointer StorageBuffer 6(int)
               51:             TypeVector 6(int) 2
               58:      6(int) Constant 1
               73:      6(int) Constant 2
               78:     14(int) Constant 1
-              81:             TypePointer Uniform 15(ivec4)
-              90:             TypePointer Uniform 14(int)
+              81:             TypePointer StorageBuffer 15(ivec4)
+              90:             TypePointer StorageBuffer 14(int)
               99:             TypeVector 14(int) 2
              112:             TypeVector 14(int) 3
              125:     14(int) Constant 2
-             128:             TypePointer Uniform 17(fvec4)
-             137:             TypePointer Uniform 16(float)
+             128:             TypePointer StorageBuffer 17(fvec4)
+             137:             TypePointer StorageBuffer 16(float)
              146:             TypeVector 16(float) 2
              159:             TypeVector 16(float) 3
              172:     14(int) Constant 3
-             175:             TypePointer Uniform 19(f64vec4)
-             184:             TypePointer Uniform 18(float64_t)
+             175:             TypePointer StorageBuffer 19(f64vec4)
+             184:             TypePointer StorageBuffer 18(float64_t)
              193:             TypeVector 18(float64_t) 2
              206:             TypeVector 18(float64_t) 3
             1226:             TypePointer Input 7(ivec3)

--- a/Test/baseResults/hlsl.wavequery.comp.out
+++ b/Test/baseResults/hlsl.wavequery.comp.out
@@ -79,7 +79,7 @@ local_size = (32, 16, 1)
                               Name 21  "@gl_SubgroupSize"
                               Decorate 9 ArrayStride 4
                               MemberDecorate 10(data) 0 Offset 0
-                              Decorate 10(data) BufferBlock
+                              Decorate 10(data) Block
                               Decorate 12(data) DescriptorSet 0
                               Decorate 12(data) Binding 0
                               Decorate 16(@gl_SubgroupInvocationID) BuiltIn SubgroupLocalInvocationId
@@ -89,8 +89,8 @@ local_size = (32, 16, 1)
                8:             TypeInt 32 0
                9:             TypeRuntimeArray 8(int)
         10(data):             TypeStruct 9
-              11:             TypePointer Uniform 10(data)
-        12(data):     11(ptr) Variable Uniform
+              11:             TypePointer StorageBuffer 10(data)
+        12(data):     11(ptr) Variable StorageBuffer
               13:             TypeInt 32 1
               14:     13(int) Constant 0
               15:             TypePointer Input 8(int)
@@ -99,7 +99,7 @@ local_size = (32, 16, 1)
               19:      8(int) Constant 3
 21(@gl_SubgroupSize):     15(ptr) Variable Input
               23:      8(int) Constant 0
-              25:             TypePointer Uniform 8(int)
+              25:             TypePointer StorageBuffer 8(int)
        4(CSMain):           2 Function None 3
                5:             Label
               27:           2 FunctionCall 6(@CSMain()

--- a/Test/baseResults/hlsl.wavereduction.comp.out
+++ b/Test/baseResults/hlsl.wavereduction.comp.out
@@ -6219,7 +6219,7 @@ local_size = (32, 16, 1)
                               MemberDecorate 20(Types) 3 Offset 64
                               Decorate 21 ArrayStride 96
                               MemberDecorate 22(data) 0 Offset 0
-                              Decorate 22(data) BufferBlock
+                              Decorate 22(data) Block
                               Decorate 24(data) DescriptorSet 0
                               Decorate 24(data) Binding 0
                               Decorate 986(dti) BuiltIn GlobalInvocationId
@@ -6239,30 +6239,30 @@ local_size = (32, 16, 1)
        20(Types):             TypeStruct 13(ivec4) 15(ivec4) 17(fvec4) 19(f64vec4)
               21:             TypeRuntimeArray 20(Types)
         22(data):             TypeStruct 21
-              23:             TypePointer Uniform 22(data)
-        24(data):     23(ptr) Variable Uniform
+              23:             TypePointer StorageBuffer 22(data)
+        24(data):     23(ptr) Variable StorageBuffer
               25:     14(int) Constant 0
               26:      6(int) Constant 0
               27:             TypePointer Function 6(int)
-              32:             TypePointer Uniform 13(ivec4)
+              32:             TypePointer StorageBuffer 13(ivec4)
               35:      6(int) Constant 3
-              42:             TypePointer Uniform 6(int)
+              42:             TypePointer StorageBuffer 6(int)
               51:             TypeVector 6(int) 2
               58:      6(int) Constant 1
               73:      6(int) Constant 2
               78:     14(int) Constant 1
-              81:             TypePointer Uniform 15(ivec4)
-              90:             TypePointer Uniform 14(int)
+              81:             TypePointer StorageBuffer 15(ivec4)
+              90:             TypePointer StorageBuffer 14(int)
               99:             TypeVector 14(int) 2
              112:             TypeVector 14(int) 3
              125:     14(int) Constant 2
-             128:             TypePointer Uniform 17(fvec4)
-             137:             TypePointer Uniform 16(float)
+             128:             TypePointer StorageBuffer 17(fvec4)
+             137:             TypePointer StorageBuffer 16(float)
              146:             TypeVector 16(float) 2
              159:             TypeVector 16(float) 3
              172:     14(int) Constant 3
-             175:             TypePointer Uniform 19(f64vec4)
-             184:             TypePointer Uniform 18(float64_t)
+             175:             TypePointer StorageBuffer 19(f64vec4)
+             184:             TypePointer StorageBuffer 18(float64_t)
              193:             TypeVector 18(float64_t) 2
              206:             TypeVector 18(float64_t) 3
              979:             TypeBool

--- a/Test/baseResults/hlsl.wavevote.comp.out
+++ b/Test/baseResults/hlsl.wavevote.comp.out
@@ -228,7 +228,7 @@ local_size = (32, 16, 1)
                               Name 72  "param"
                               Decorate 14 ArrayStride 8
                               MemberDecorate 15(data) 0 Offset 0
-                              Decorate 15(data) BufferBlock
+                              Decorate 15(data) Block
                               Decorate 17(data) DescriptorSet 0
                               Decorate 17(data) Binding 0
                               Decorate 70(dti) BuiltIn GlobalInvocationId
@@ -241,8 +241,8 @@ local_size = (32, 16, 1)
               13:             TypeInt 64 0
               14:             TypeRuntimeArray 13(int64_t)
         15(data):             TypeStruct 14
-              16:             TypePointer Uniform 15(data)
-        17(data):     16(ptr) Variable Uniform
+              16:             TypePointer StorageBuffer 15(data)
+        17(data):     16(ptr) Variable StorageBuffer
               18:             TypeInt 32 1
               19:     18(int) Constant 0
               20:      6(int) Constant 0
@@ -251,7 +251,7 @@ local_size = (32, 16, 1)
               28:      6(int) Constant 3
               30:             TypeVector 6(int) 4
               32:             TypeVector 13(int64_t) 4
-              35:             TypePointer Uniform 13(int64_t)
+              35:             TypePointer StorageBuffer 13(int64_t)
               37:      6(int) Constant 1
               48:      6(int) Constant 2
               69:             TypePointer Input 7(ivec3)

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -80,10 +80,6 @@ TParseContext::TParseContext(TSymbolTable& symbolTable, TIntermediate& interm, b
     globalBufferDefaults.layoutMatrix = ElmColumnMajor;
     globalBufferDefaults.layoutPacking = spvVersion.spv != 0 ? ElpStd430 : ElpShared;
 
-    // use storage buffer on SPIR-V 1.3 and up
-    if (spvVersion.spv >= EShTargetSpv_1_3)
-        intermediate.setUseStorageBuffer();
-
     globalInputDefaults.clear();
     globalOutputDefaults.clear();
 

--- a/glslang/MachineIndependent/ParseHelper.h
+++ b/glslang/MachineIndependent/ParseHelper.h
@@ -95,6 +95,10 @@ public:
             globalUniformSet(TQualifier::layoutSetEnd),
             atomicCounterBlockSet(TQualifier::layoutSetEnd)
     {
+        // use storage buffer on SPIR-V 1.3 and up
+        if (spvVersion.spv >= EShTargetSpv_1_3)
+            intermediate.setUseStorageBuffer();
+
         if (entryPoint != nullptr)
             sourceEntryPointName = *entryPoint;
     }


### PR DESCRIPTION
...From TParseContext used only by GLSL, to TParseContextBase inherited by both GLSL and HLSL paths. It caused compilations from HLSL to SPIR-V 1.3+ to use BufferBlock decoration which is no longer valid.