### PR TITLE
Rename master to main and update news

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ configuration:
 
 branches:
   only:
-    - master
+    - main
 
 # changes to these files don't need to trigger testing
 skip_commits:
@@ -31,9 +31,9 @@ skip_commits:
     - Android.mk
     - _config.yml
 
-# Travis advances the master-tot tag to current top of the tree after
-# each push into the master branch, because it relies on that tag to
-# upload build artifacts to the master-tot release. This will cause
+# Travis advances the main-tot tag to current top of the tree after
+# each push into the main branch, because it relies on that tag to
+# upload build artifacts to the main-tot release. This will cause
 # double testing for each push on Appveyor: one for the push, one for
 # the tag advance. Disable testing tags.
 skip_tags: true
@@ -73,7 +73,7 @@ after_test:
       }
   - cd install
   # Zip all glslang artifacts for uploading and deploying
-  - 7z a glslang-master-windows-"%PLATFORM%"-"%CONFIGURATION%".zip
+  - 7z a glslang-main-windows-"%PLATFORM%"-"%CONFIGURATION%".zip
     bin\glslangValidator.exe
     bin\spirv-remap.exe
     include\glslang\*
@@ -97,12 +97,12 @@ deploy:
   - provider: GitHub
     auth_token:
       secure: YglcSYdl0TylEa59H4K6lylBEDr586NAt2EMgZquSo+iuPrwgZQuJLPCoihSm9y6
-    release: master-tot
-    description: "Continuous build of the latest master branch by Appveyor and Github"
+    release: main-tot
+    description: "Continuous build of the latest main branch by Appveyor and Github"
     artifact: artifacts-zip
     draft: false
     prerelease: false
     force_update: true
     on:
-      branch: master
+      branch: main
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015

--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -20,7 +20,7 @@ on:
     workflow_dispatch:
     push:
         branches:
-            - master
+            - main
 
 jobs:
     linux:
@@ -71,7 +71,7 @@ jobs:
             - name: Zip
               if: ${{ matrix.compiler.cc == 'clang' }}
               env:
-                  ARCHIVE: glslang-master-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
+                  ARCHIVE: glslang-main-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
               run: |
                   cd build/install
                   zip ${ARCHIVE} \
@@ -92,7 +92,7 @@ jobs:
             - name: Deploy
               if: ${{ matrix.compiler.cc == 'clang' }}
               env:
-                  ARCHIVE: glslang-master-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
+                  ARCHIVE: glslang-main-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
               uses: actions/github-script@v5
               with:
                   script: |
@@ -142,7 +142,7 @@ jobs:
                   cd ../Test && ./runtests
             - name: Zip
               env:
-                  ARCHIVE: glslang-master-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
+                  ARCHIVE: glslang-main-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
               run: |
                   cd build/install
                   zip ${ARCHIVE} \
@@ -162,7 +162,7 @@ jobs:
                       lib/libSPIRV-Tools-opt.a
             - name: Deploy
               env:
-                  ARCHIVE: glslang-master-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
+                  ARCHIVE: glslang-main-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
               uses: actions/github-script@v5
               with:
                   script: |

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -10,7 +10,7 @@ on:
     workflow_dispatch:
     pull_request:
         branches:
-            - master
+            - main
 
 jobs:
     linux:

--- a/.github/workflows/deploy.js
+++ b/.github/workflows/deploy.js
@@ -3,11 +3,11 @@ module.exports = async ({github, context, core}) => {
         await github.rest.git.updateRef({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            ref: 'tags/master-tot',
+            ref: 'tags/main-tot',
             sha: context.sha
         })
     } catch (error) {
-        core.setFailed(`upload master-tot tag; ${error.name}; ${error.message}`)
+        core.setFailed(`upload main-tot tag; ${error.name}; ${error.message}`)
     }
 
     let release
@@ -15,10 +15,10 @@ module.exports = async ({github, context, core}) => {
         release = await github.rest.repos.getReleaseByTag({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            tag: 'master-tot'
+            tag: 'main-tot'
         })
     } catch (error) {
-        core.setFailed(`get the master release; ${error.name}; ${error.message}`)
+        core.setFailed(`get the main release; ${error.name}; ${error.message}`)
     }
 
     try {
@@ -28,7 +28,7 @@ module.exports = async ({github, context, core}) => {
             release_id: release.data.id
         })
     } catch (error) {
-        core.setFailed(`update the master release; ${error.name}; ${error.message}`)
+        core.setFailed(`update the main release; ${error.name}; ${error.message}`)
     }
 
     let release_assets

--- a/README.md
+++ b/README.md
@@ -1,27 +1,17 @@
 # News
 
-1. Default branch will be renamed from 'master' to 'main' [as requested by Khronos](https://github.com/KhronosGroup/glslang/issues/3107) on 01/30/2023.
+1. [As discussed in #3107](https://github.com/KhronosGroup/glslang/issues/3107), the default branch of this repository is now 'main'. This change should be transparent to repository users, since github rewrites many references to the old 'master' branch to 'main'. However, if you have a checked-out local clone, you may wish to take the following steps as recommended by github:
 
-2. Visual Studio 2013 is no longer supported
+```sh
+git branch -m master main
+git fetch origin
+git branch -u origin/main main
+git remote set-head origin -a
+```
 
-   [As scheduled](https://github.com/KhronosGroup/glslang/blob/9eef54b2513ca6b40b47b07d24f453848b65c0df/README.md#planned-deprecationsremovals),
-Microsoft Visual Studio 2013 is no longer officially supported. \
-   Please upgrade to at least Visual Studio 2015.
+2. Visual Studio 2019 is now the minimum supported compiler for windows. This change was driven by the external dependency on SPIRV-Tools.
 
-3. The versioning scheme is being improved, and you might notice some differences.  This is currently WIP, but will be coming soon.  See, for example, PR #2277.
-
-4. If you get a new **compilation error due to a missing header**, it might be caused by this planned removal:
-
-**SPIRV Folder, 1-May, 2020.** Glslang, when installed through CMake,
-will install a `SPIRV` folder into `${CMAKE_INSTALL_INCLUDEDIR}`.
-This `SPIRV` folder is being moved to `glslang/SPIRV`.
-During the transition the `SPIRV` folder will be installed into both locations.
-The old install of `SPIRV/` will be removed as a CMake install target no sooner than May 1, 2020.
-See issue #1964.
-
-If people are only using this location to get spirv.hpp, I recommend they get that from [SPIRV-Headers](https://github.com/KhronosGroup/SPIRV-Headers) instead.
-
-[![appveyor status](https://ci.appveyor.com/api/projects/status/q6fi9cb0qnhkla68/branch/master?svg=true)](https://ci.appveyor.com/project/Khronoswebmaster/glslang/branch/master)
+[![appveyor status](https://ci.appveyor.com/api/projects/status/q6fi9cb0qnhkla68/branch/main?svg=true)](https://ci.appveyor.com/project/Khronoswebmaster/glslang/branch/main)
 ![Continuous Deployment](https://github.com/KhronosGroup/glslang/actions/workflows/continuous_deployment.yml/badge.svg)
 
 # Glslang Components and Status
@@ -101,9 +91,9 @@ There is also a non-shader extension:
 ## Building (CMake)
 
 Instead of building manually, you can also download the binaries for your
-platform directly from the [master-tot release][master-tot-release] on GitHub.
+platform directly from the [main-tot release][main-tot-release] on GitHub.
 Those binaries are automatically uploaded by the buildbots after successful
-testing and they always reflect the current top of the tree of the master
+testing and they always reflect the current top of the tree of the main
 branch.
 
 ### Dependencies
@@ -557,4 +547,4 @@ std::vector<uint32_t> compileShaderToSPIRV_Vulkan(glslang_stage_t stage, const c
 [bison]: https://www.gnu.org/software/bison/
 [googletest]: https://github.com/google/googletest
 [bison-gnu-win32]: http://gnuwin32.sourceforge.net/packages/bison.htm
-[master-tot-release]: https://github.com/KhronosGroup/glslang/releases/tag/master-tot
+[main-tot-release]: https://github.com/KhronosGroup/glslang/releases/tag/main-tot


### PR DESCRIPTION
Update CI and README to reflect rename.
Update News:
    * Notify users of rename.
    * Update minimum required VS compiler to 2019.
    * Remove notice about versioning. This has been completed.
    * Remove notice about SPIRV folder relocation. It has been 2.5 years
    since this occured.

Fix #3107