### PR TITLE
GLSL: Fix integer overflow warnings in Constant.cpp

### DIFF
--- a/glslang/MachineIndependent/Constant.cpp
+++ b/glslang/MachineIndependent/Constant.cpp
@@ -212,9 +212,9 @@ TIntermTyped* TIntermConstantUnion::fold(TOperator op, const TIntermTyped* right
 
             case EbtInt64:
                 if (rightUnionArray[i] == 0ll)
-                    newConstArray[i].setI64Const(0x7FFFFFFFFFFFFFFFll);
-                else if (rightUnionArray[i].getI64Const() == -1 && leftUnionArray[i].getI64Const() == (long long)-0x8000000000000000ll)
-                    newConstArray[i].setI64Const((long long)-0x8000000000000000ll);
+                    newConstArray[i].setI64Const(LLONG_MAX);
+                else if (rightUnionArray[i].getI64Const() == -1 && leftUnionArray[i].getI64Const() == LLONG_MIN)
+                    newConstArray[i].setI64Const(LLONG_MIN);
                 else
                     newConstArray[i].setI64Const(leftUnionArray[i].getI64Const() / rightUnionArray[i].getI64Const());
                 break;


### PR DESCRIPTION
New versions of Clang warn:

```
glslang/MachineIndependent/Constant.cpp(216,114):
error: overflow in expression; result is -9223372036854775808 with type 'long long' [-Werror,-Winteger-overflow]
                else if (rightUnionArray[i].getI64Const() == -1 && leftUnionArray[i].getI64Const() == (long long)-0x8000000000000000ll)
                                                                                                                 ^
glslang/MachineIndependent/Constant.cpp(217,61):
error: overflow in expression; result is -9223372036854775808 with type 'long long' [-Werror,-Winteger-overflow]
                    newConstArray[i].setI64Const((long long)-0x8000000000000000ll);
                                                            ^
2 errors generated.
```

Using LLONG_MIN instead avoids the problem. I think it's also more clear, and the code for EOpMod further down already does this.