### PR TITLE
kokoro: avoid git permissions issue that GN fails on

### DIFF
--- a/kokoro/linux-clang-gn/build-docker.sh
+++ b/kokoro/linux-clang-gn/build-docker.sh
@@ -34,7 +34,12 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 set -e # Fail on any error.
+
+. /bin/using.sh # Declare the bash `using` function for configuring toolchains.
+
 set -x # Display commands being run.
+
+using ninja-1.10.0
 
 # Disable git's "detected dubious ownership" error - kokoro checks out the repo
 # with a different user, and we don't care about this warning.

--- a/kokoro/linux-clang-gn/build-docker.sh
+++ b/kokoro/linux-clang-gn/build-docker.sh
@@ -36,6 +36,10 @@
 set -e # Fail on any error.
 set -x # Display commands being run.
 
+# Disable git's "detected dubious ownership" error - kokoro checks out the repo
+# with a different user, and we don't care about this warning.
+git config --global --add safe.directory '*'
+
 echo "Fetching external projects..."
 ./update_glslang_sources.py
 


### PR DESCRIPTION
In the docker build script that Kokoro runs, the directories are owned by a different user.  Git complains about that and in the GN flow GN will error out.
In this docker flow we don't care about that warning, so within the docker config set a git global option to ignore the issue.