### PR TITLE
Include <cstdint> header in Common.h

### DIFF
--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -44,6 +44,7 @@
 #else
 #include <cmath>
 #endif
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <list>
@@ -80,22 +81,6 @@ std::string to_string(const T& val) {
     #define safe_vsprintf(buf,max,format,args) vsnprintf((buf), (max), (format), (args))
     #include <stdint.h>
     #define UINT_PTR uintptr_t
-#endif
-
-#if defined(_MSC_VER) && _MSC_VER < 1800
-    #include <stdlib.h>
-    inline long long int strtoll (const char* str, char** endptr, int base)
-    {
-        return _strtoi64(str, endptr, base);
-    }
-    inline unsigned long long int strtoull (const char* str, char** endptr, int base)
-    {
-        return _strtoui64(str, endptr, base);
-    }
-    inline long long int atoll (const char* str)
-    {
-        return strtoll(str, NULL, 10);
-    }
 #endif
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
This change also cleans up some ifdef'd code for no longer supported versions of MSVC.

Fixes: #3139