### PR TITLE
Remove workarounds for older MSVC versions

### DIFF
--- a/SPIRV/SPVRemapper.cpp
+++ b/SPIRV/SPVRemapper.cpp
@@ -36,10 +36,6 @@
 #include "SPVRemapper.h"
 #include "doc.h"
 
-#if !defined (use_cpp11)
-// ... not supported before C++11
-#else // defined (use_cpp11)
-
 #include <algorithm>
 #include <cassert>
 #include "../glslang/Include/Common.h"
@@ -1527,6 +1523,4 @@ namespace spv {
     }
 
 } // namespace SPV
-
-#endif // defined (use_cpp11)
 

--- a/SPIRV/SPVRemapper.h
+++ b/SPIRV/SPVRemapper.h
@@ -43,12 +43,6 @@
 
 namespace spv {
 
-// MSVC defines __cplusplus as an older value, even when it supports almost all of 11.
-// We handle that here by making our own symbol.
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1700)
-#   define use_cpp11 1
-#endif
-
 class spirvbin_base_t
 {
 public:
@@ -73,27 +67,6 @@ public:
 };
 
 } // namespace SPV
-
-#if !defined (use_cpp11)
-#include <cstdio>
-#include <cstdint>
-
-namespace spv {
-class spirvbin_t : public spirvbin_base_t
-{
-public:
-    spirvbin_t(int /*verbose = 0*/) { }
-
-    void remap(std::vector<std::uint32_t>& /*spv*/, unsigned int /*opts = 0*/)
-    {
-        printf("Tool not compiled for C++11, which is required for SPIR-V remapping.\n");
-        exit(5);
-    }
-};
-
-} // namespace SPV
-
-#else // defined (use_cpp11)
 
 #include <functional>
 #include <cstdint>
@@ -308,5 +281,4 @@ private:
 
 } // namespace SPV
 
-#endif // defined (use_cpp11)
 #endif // SPIRVREMAPPER_H

--- a/SPIRV/hex_float.h
+++ b/SPIRV/hex_float.h
@@ -23,19 +23,6 @@
 #include <limits>
 #include <sstream>
 
-#if defined(_MSC_VER) && _MSC_VER < 1800
-namespace std {
-bool isnan(double f)
-{
-  return ::_isnan(f) != 0;
-}
-bool isinf(double f)
-{
-  return ::_finite(f) == 0;
-}
-}
-#endif
-
 #include "bitutils.h"
 
 namespace spvutils {

--- a/StandAlone/spirv-remap.cpp
+++ b/StandAlone/spirv-remap.cpp
@@ -352,13 +352,11 @@ int main(int argc, char** argv)
     int                      opts;
     int                      verbosity;
 
-#ifdef use_cpp11
     // handle errors by exiting
     spv::spirvbin_t::registerErrorHandler(errHandler);
 
     // Log messages to std::cout
     spv::spirvbin_t::registerLogHandler(logHandler);
-#endif
 
     if (argc < 2)
         usage(argv[0]);

--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -54,7 +54,7 @@
 #include <unordered_set>
 #include <vector>
 
-#if defined(__ANDROID__) || (defined(_MSC_VER) && _MSC_VER < 1700)
+#if defined(__ANDROID__)
 #include <sstream>
 namespace std {
 template<typename T>

--- a/glslang/MachineIndependent/preprocessor/PpTokens.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpTokens.cpp
@@ -85,9 +85,6 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
 #endif
-#if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/)
-#define snprintf sprintf_s
-#endif
 
 #include <cassert>
 #include <cstdlib>


### PR DESCRIPTION
Since https://github.com/KhronosGroup/glslang/commit/58d302cfa28d04efafab64025d7b7ad5e5029ba7, the minimum VS version was raised to VS2019. Adjust the README, and remove some workarounds for older VS versions.