### PR TITLE
Add option to glslangValidator to inject preamble

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -258,6 +258,17 @@ public:
         text.append("\n");
     }
 
+    void addText(std::string preambleText)
+    {
+        fixLine(preambleText);
+
+        Processes.push_back("preamble-text");
+        Processes.back().append(preambleText);
+
+        text.append(preambleText);
+        text.append("\n");
+    }
+
 protected:
     void fixLine(std::string& line)
     {
@@ -727,6 +738,13 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
                     } else if (lowerword == "no-storage-format" || // synonyms
                                lowerword == "nsf") {
                         Options |= EOptionNoStorageFormat;
+                    } else if (lowerword == "preamble-text" ||
+                               lowerword == "p") {
+                        if (argc > 1)
+                            UserPreamble.addText(argv[1]);
+                        else
+                            Error("expects <text>", argv[0]);
+                        bumpArg();
                     } else if (lowerword == "relaxed-errors") {
                         Options |= EOptionRelaxedErrors;
                     } else if (lowerword == "reflect-strict-array-suffix") {
@@ -925,6 +943,9 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
 #endif
                 else
                     Error("unknown -O option");
+                break;
+            case 'P':
+                UserPreamble.addText(getStringOperand("-P<text>"));
                 break;
             case 'R':
                 VulkanRulesRelaxed = true;
@@ -1832,7 +1853,7 @@ void CompileFile(const char* fileName, ShHandle compiler)
     SetMessageOptions(messages);
 
     if (UserPreamble.isSet())
-        Error("-D and -U options require -l (linking)\n");
+        Error("-D, -U and -P options require -l (linking)\n");
 
     for (int i = 0; i < ((Options & EOptionMemoryLeakMode) ? 100 : 1); ++i) {
         for (int j = 0; j < ((Options & EOptionMemoryLeakMode) ? 100 : 1); ++j) {
@@ -1902,6 +1923,8 @@ void usage()
            "              is searched first, followed by left-to-right order of -I\n"
            "  -Od         disables optimization; may cause illegal SPIR-V for HLSL\n"
            "  -Os         optimizes SPIR-V to minimize size\n"
+           "  -P<text> | --preamble-text <text> | --P <text>\n"
+           "              inject custom preamble text\n"
            "  -R          use relaxed verification rules for generating Vulkan SPIR-V,\n"
            "              allowing the use of default uniforms, atomic_uints, and\n"
            "              gl_VertexID and gl_InstanceID keywords.\n"

--- a/Test/baseResults/glsl.-P.frag.out
+++ b/Test/baseResults/glsl.-P.frag.out
@@ -1,0 +1,35 @@
+glsl.-P.frag
+Shader version: 450
+0:? Sequence
+0:5  Function Definition: main( ( global void)
+0:5    Function Parameters: 
+0:19    Sequence
+0:19      move second child to first child ( temp 4-component vector of float)
+0:19        'color' (layout( location=0) out 4-component vector of float)
+0:19        Constant:
+0:19          1.000000
+0:19          1.000000
+0:19          1.000000
+0:19          1.000000
+0:?   Linker Objects
+0:?     'color' (layout( location=0) out 4-component vector of float)
+
+
+Linked fragment stage:
+
+
+Shader version: 450
+0:? Sequence
+0:5  Function Definition: main( ( global void)
+0:5    Function Parameters: 
+0:19    Sequence
+0:19      move second child to first child ( temp 4-component vector of float)
+0:19        'color' (layout( location=0) out 4-component vector of float)
+0:19        Constant:
+0:19          1.000000
+0:19          1.000000
+0:19          1.000000
+0:19          1.000000
+0:?   Linker Objects
+0:?     'color' (layout( location=0) out 4-component vector of float)
+

--- a/Test/glsl.-P.frag
+++ b/Test/glsl.-P.frag
@@ -1,0 +1,20 @@
+#version 450
+
+layout(location=0) out vec4 color;
+
+void main()
+{
+    #ifndef TEST1
+    #error TEST1 is not defined
+    #endif
+
+    #ifndef TEST2
+    #error TEST2 is not defined
+    #endif
+
+    #ifndef TEST3
+    #error TEST3 is not defined
+    #endif
+
+    color = vec4(1.0);
+}

--- a/Test/runtests
+++ b/Test/runtests
@@ -18,7 +18,7 @@ if [ -d "${LIBPATH}" ]; then
 fi
 
 function run {
-    $EXE $@
+    $EXE "$@"
     result=$?
     case "$result" in
     [0-6]) # Valid success and error codes
@@ -201,13 +201,15 @@ run -D -Od -e main -H --depfile $TARGETDIR/hlsl.dashI.vert.d.out -Od -Iinc1/path
 diff -b $BASEDIR/hlsl.dashI.vert.d.out $TARGETDIR/hlsl.dashI.vert.d.out || HASERROR=1
 
 #
-# Testing -D and -U
+# Testing -D, -U and -P
 #
-echo "Testing -D and -U"
+echo "Testing -D, -U and -P"
 run -DUNDEFED -UIN_SHADER -DFOO=200 -i -l --U UNDEFED --define-macro MUL=FOO*2 glsl.-D-U.frag > $TARGETDIR/glsl.-D-U.frag.out
 diff -b $BASEDIR/glsl.-D-U.frag.out $TARGETDIR/glsl.-D-U.frag.out || HASERROR=1
 run -D -Od -e main -V -i -DUNDEFED -UIN_SHADER --D FOO=200 --undef-macro UNDEFED -Od hlsl.-D-U.frag > $TARGETDIR/hlsl.-D-U.frag.out
 diff -b $BASEDIR/hlsl.-D-U.frag.out $TARGETDIR/hlsl.-D-U.frag.out || HASERROR=1
+run -P"#define TEST1" -i -l --preamble-text "#define TEST2" --p "#define TEST3" glsl.-P.frag > $TARGETDIR/glsl.-P.frag.out
+diff -b $BASEDIR/glsl.-P.frag.out $TARGETDIR/glsl.-P.frag.out || HASERROR=1
 
 #
 # Test --client and --target-env


### PR DESCRIPTION
Add option `-P` / `--preamble-text` / `--p` to glslangValidator to add custom text to the preamble. There are already the parameters `-D` and `-U` allowing to set #define and #undef, but this options makes it possible to inject fully customizable preamble text via a command line parameter.

My intended usecase is to allow enabling of extensions, but might be useful for other things as well to have the flexibility of setting arbitrary preambles.