### PR TITLE
Fix outdated cmake conditional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,16 +227,10 @@ if(ENABLE_GLSLANG_JS)
     endif()
 endif()
 
-# Request C++11
-if(${CMAKE_VERSION} VERSION_LESS 3.1)
-    # CMake versions before 3.1 do not understand CMAKE_CXX_STANDARD
-    # remove this block once CMake >=3.1 has fixated in the ecosystem
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-else()
-    set(CMAKE_CXX_STANDARD 17)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-    set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
+# Request C++17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 function(glslang_set_link_args TARGET)
     # For MinGW compiles, statically link against the GCC and C++ runtimes.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ git branch -u origin/main main
 git remote set-head origin -a
 ```
 
-2. Visual Studio 2019 is now the minimum supported compiler for windows. This change was driven by the external dependency on SPIRV-Tools.
+2. C++17 (all platforms) and Visual Studio 2019 (Windows) are now required. This change was driven by the external dependency on SPIRV-Tools.
 
 [![appveyor status](https://ci.appveyor.com/api/projects/status/q6fi9cb0qnhkla68/branch/main?svg=true)](https://ci.appveyor.com/project/Khronoswebmaster/glslang/branch/main)
 ![Continuous Deployment](https://github.com/KhronosGroup/glslang/actions/workflows/continuous_deployment.yml/badge.svg)
@@ -98,8 +98,8 @@ branch.
 
 ### Dependencies
 
-* A C++11 compiler.
-  (For MSVS: use 2015 or later.)
+* A C++17 compiler.
+  (For MSVS: use 2019 or later.)
 * [CMake][cmake]: for generating compilation targets.
 * make: _Linux_, ninja is an alternative, if configured.
 * [Python 3.x][python]: for executing SPIRV-Tools scripts. (Optional if not using SPIRV-Tools and the 'External' subdirectory does not exist.)


### PR DESCRIPTION
Remove cmake condition. The minimum is 3.14. The condition is no longer required.

C++17 is now required. Update the landing page.