### PR TITLE
Create a Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,5 @@
 
 To report a security issue, please disclose it at [security advisory](https://github.com/KhronosGroup/glslang/security/advisories/new).
 
-We will respond within 7 working days of your submission. If the issue is confirmed as a vulnerability, we will open a Security Advisory and acknowledge your contributions as part of it. This project follows a 90 day disclosure timeline.
+This project is maintained by a team of volunteers on a reasonable-effort basis. As
+such, please give us at least 90 days to work on a fix before public exposure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+To report a security issue, please disclose it at [security advisory](https://github.com/KhronosGroup/glslang/security/advisories/new).
+
+We will respond within 7 working days of your submission. If the issue is confirmed as a vulnerability, we will open a Security Advisory and acknowledge your contributions as part of it. This project follows a 90 day disclosure timeline.


### PR DESCRIPTION
Closes #3168 

I’ve created the SECURITY.md file considering the [report vulnerability through security advisory](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability), which is a new github feature still in beta and that has to be enabled.

If you rather not enabling it there is also the possibility to receive the vulnerability report through an email, in this case just let me know which email it would be and I’ll submit the change.

Besides, I've followed a standard timeline of 7 working days to respond and 90 days to a [public disclosure](https://www.techtarget.com/searchsecurity/definition/vulnerability-disclosure), but this can be easily changed to different timelines or no timeline at all (best effort base for example).

Besides that feel free to edit or suggest any changes to this document, it is supposed to reflect the amount of effort the team can offer to handle vulnerabilities.
