### PR TITLE
[SPIRV] Implement debugBreak in glslangValidator.

### DIFF
--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -64,6 +64,7 @@ set(HEADERS
     GLSL.ext.NV.h
     GLSL.ext.ARM.h
     NonSemanticDebugPrintf.h
+    NonSemanticDebugBreak.h
     NonSemanticShaderDebugInfo100.h)
 
 set(SPVREMAP_HEADERS

--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -1601,6 +1601,8 @@ TGlslangToSpvTraverser::TGlslangToSpvTraverser(unsigned int spvVersion,
 
     builder.setEmitNonSemanticShaderDebugInfo(options.emitNonSemanticShaderDebugInfo);
     builder.setEmitNonSemanticShaderDebugSource(options.emitNonSemanticShaderDebugSource);
+    builder.setEmitNonSemanticShaderDebugBreak(options.emitNonSemanticShaderDebugBreak);
+    builder.setEmitNonSemanticShaderDebugBreakSource(options.NonSemanticShaderDebugBreakLine, options.NonSemanticShaderDebugBreakFile);
 
     stdBuiltins = builder.import("GLSL.std.450");
 

--- a/SPIRV/NonSemanticDebugBreak.h
+++ b/SPIRV/NonSemanticDebugBreak.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2020 The Khronos Group Inc.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+// 
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+// 
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+// 
+
+#ifndef SPIRV_UNIFIED1_NonSemanticDebugBreak_H_
+#define SPIRV_UNIFIED1_NonSemanticDebugBreak_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum NonSemanticDebugBreakInstructions {
+    NonSemanticDebugBreak = 1,
+    NonSemanticDebugBreakInstructionsMax = 0x7fffffff
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SPIRV_UNIFIED1_NonSemanticDebugBreak_H_

--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -53,6 +53,7 @@
 namespace spv {
     #include "GLSL.ext.KHR.h"
     #include "NonSemanticShaderDebugInfo100.h"
+    #include "NonSemanticDebugBreak.h"
 }
 
 #include <algorithm>
@@ -129,6 +130,20 @@ public:
     {
         emitNonSemanticShaderDebugSource = src;
     }
+    void setEmitNonSemanticShaderDebugBreak(bool const emit)
+    {
+        emitNonSemanticShaderDebugBreak = emit;
+
+        if (emit)
+        {
+            importNonSemanticShaderDebugBreakInstructions();
+        }
+    }
+    void setEmitNonSemanticShaderDebugBreakSource(int lineNo, const char* fileName)
+    {
+        dbgBreakLine = lineNo;
+        dbgBreakFile = fileName;
+    }
     void addExtension(const char* ext) { extensions.insert(ext); }
     void removeExtension(const char* ext)
     {
@@ -179,6 +194,7 @@ public:
     // than the last one, issue a new OpLine using the new line and file
     // name.
     void setLine(int line, const char* filename);
+    void addDebugBreak();
     // Low-level OpLine. See setLine() for a layered helper.
     void addLine(Id fileName, int line, int column);
     void addDebugScopeAndLine(Id fileName, int line, int column);
@@ -376,6 +392,7 @@ public:
     Id makeFpConstant(Id type, double d, bool specConstant = false);
 
     Id importNonSemanticShaderDebugInfoInstructions();
+    Id importNonSemanticShaderDebugBreakInstructions();
 
     // Turn the array of constants into a proper spv constant of the requested type.
     Id makeCompositeConstant(Id type, const std::vector<Id>& comps, bool specConst = false);
@@ -884,11 +901,14 @@ public:
     spv::Id sourceFileStringId;
     spv::Id nonSemanticShaderCompilationUnitId {0};
     spv::Id nonSemanticShaderDebugInfo {0};
+    spv::Id nonSemanticShaderDebugBreak {0};
     spv::Id debugInfoNone {0};
     spv::Id debugExpression {0}; // Debug expression with zero operations.
     std::string sourceText;
     int currentLine;
+    int dbgBreakLine;
     const char* currentFile;
+    const char* dbgBreakFile;
     spv::Id currentFileId;
     std::stack<spv::Id> currentDebugScopeId;
     spv::Id lastDebugScopeId;
@@ -896,6 +916,7 @@ public:
     bool emitNonSemanticShaderDebugInfo;
     bool restoreNonSemanticShaderDebugInfo;
     bool emitNonSemanticShaderDebugSource;
+    bool emitNonSemanticShaderDebugBreak;
     std::set<std::string> extensions;
     std::vector<const char*> sourceExtensions;
     std::vector<const char*> moduleProcesses;

--- a/SPIRV/SpvTools.h
+++ b/SPIRV/SpvTools.h
@@ -61,6 +61,9 @@ struct SpvOptions {
     bool validate {false};
     bool emitNonSemanticShaderDebugInfo {false};
     bool emitNonSemanticShaderDebugSource{ false };
+    bool emitNonSemanticShaderDebugBreak { false };
+    int NonSemanticShaderDebugBreakLine { -1 };
+    const char* NonSemanticShaderDebugBreakFile { nullptr };
 };
 
 #if ENABLE_OPT

--- a/SPIRV/disassemble.cpp
+++ b/SPIRV/disassemble.cpp
@@ -79,6 +79,7 @@ enum ExtInstSet {
     GLSLextNVInst,
     OpenCLExtInst,
     NonSemanticDebugPrintfExtInst,
+    NonSemanticDebugBreakExtInst,
     NonSemanticShaderDebugInfo100
 };
 
@@ -505,6 +506,8 @@ void SpirvStream::disassembleInstruction(Id resultId, Id /*typeId*/, Op opCode, 
                     extInstSet = OpenCLExtInst;
                 } else if (strcmp("NonSemantic.DebugPrintf", name) == 0) {
                     extInstSet = NonSemanticDebugPrintfExtInst;
+                } else if (strcmp("NonSemantic.DebugBreak", name) == 0) {
+                    extInstSet = NonSemanticDebugBreakExtInst;
                 } else if (strcmp("NonSemantic.Shader.DebugInfo.100", name) == 0) {
                     extInstSet = NonSemanticShaderDebugInfo100;
                 } else if (strcmp(spv::E_SPV_AMD_shader_ballot, name) == 0 ||
@@ -532,6 +535,8 @@ void SpirvStream::disassembleInstruction(Id resultId, Id /*typeId*/, Op opCode, 
                     out << "(" << GLSLextNVGetDebugNames(name, entrypoint) << ")";
                 } else if (extInstSet == NonSemanticDebugPrintfExtInst) {
                     out << "(DebugPrintf)";
+                } else if (extInstSet == NonSemanticDebugBreakExtInst) {
+                    out << "(DebugBreak)";
                 } else if (extInstSet == NonSemanticShaderDebugInfo100) {
                     out << "(" << NonSemanticShaderDebugInfo100GetDebugNames(entrypoint) << ")";
                 }


### PR DESCRIPTION
An implementation for issue #3157.

Debug Break op would be inserted before specified line, only within a function declaration body block.

If this <line> is set outside a function body block, it would be ignored (for example, behind a global variable declaration statement).

Command line would be like:

`glslangValidator.exe --breakPoint 15 --breakFile vertexShader.vert -G vertexShader.vert`

The spirv would looks like:

```
%1 = OpExtInstImport "NonSemantic.DebugBreak"
%2 = OpExtInst %void %1
```

Ref: https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.DebugBreak.asciidoc