### PR TITLE
Fix CMake for OSDependent install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,10 +356,18 @@ endif()
 if(ENABLE_GLSLANG_INSTALL)
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake.in" [=[
         @PACKAGE_INIT@
+        @INSTALL_CONFIG_UNIX@
         include("@PACKAGE_PATH_EXPORT_TARGETS@")
     ]=])
-    
+
     set(PATH_EXPORT_TARGETS "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake")
+    if(UNIX OR "${CMAKE_SYSTEM_NAME}" STREQUAL "Fuchsia")
+        set(INSTALL_CONFIG_UNIX [=[
+            include(CMakeFindDependencyMacro)
+            set(THREADS_PREFER_PTHREAD_FLAG ON)
+            find_dependency(Threads REQUIRED)
+        ]=])
+    endif()
     configure_package_config_file(
         "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake.in"
         "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake"

--- a/glslang/OSDependent/Unix/CMakeLists.txt
+++ b/glslang/OSDependent/Unix/CMakeLists.txt
@@ -36,21 +36,9 @@ set_property(TARGET OSDependent PROPERTY FOLDER glslang)
 set_property(TARGET OSDependent PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # Link pthread
-set(CMAKE_THREAD_PREFER_PTHREAD ON)
-if(${CMAKE_VERSION} VERSION_LESS "3.1.0" OR CMAKE_CROSSCOMPILING)
-    # Needed as long as we support CMake 2.8 for Ubuntu 14.04,
-    # which does not support the recommended Threads::Threads target.
-    # https://cmake.org/cmake/help/v2.8.12/cmake.html#module:FindThreads
-    # Also needed when cross-compiling to work around
-    # https://gitlab.kitware.com/cmake/cmake/issues/16920
-    find_package(Threads)
-    target_link_libraries(OSDependent ${CMAKE_THREAD_LIBS_INIT})
-else()
-    # This is the recommended way, so we use it for 3.1+.
-    set(THREADS_PREFER_PTHREAD_FLAG ON)
-    find_package(Threads)
-    target_link_libraries(OSDependent Threads::Threads)
-endif()
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+target_link_libraries(OSDependent Threads::Threads)
 
 if(ENABLE_GLSLANG_INSTALL AND NOT BUILD_SHARED_LIBS)
     install(TARGETS OSDependent EXPORT glslang-targets)


### PR DESCRIPTION
Fix #3125 (also reported in vcpkg: https://github.com/microsoft/vcpkg/issues/27121).

The CMake target `OSDependent` requires `Threads::Threads` on Unix, but the requirement of Threads is not exported in the installed Config.cmake file. This PR adds the necessary `find_dependency(Threads REQUIRED)` to the installed Config.cmake file.

Further the OSDependent CMake includes workarounds with seem outdated with the currently required minimum version of 3.14.0. The check if( < 3.1) could be just removed. The second mentioned issue about cross compiling was closed upstream over 5 years ago and I verified that the mentioned fix commit is contained in CMake 3.10.0. So I assume should be also save to remove if CMake 3.14 is required anyway, but I do not have a cross compilation toolchain to actually test it.