### PR TITLE
Improve error message of alignment offset

### DIFF
--- a/Test/baseResults/440.frag.out
+++ b/Test/baseResults/440.frag.out
@@ -43,11 +43,11 @@ ERROR: 0:62: 'layout' : offset/align can only be used on a uniform or buffer
 ERROR: 0:63: 'layout' : offset/align can only be used on a uniform or buffer 
 ERROR: 0:84: 'align' : must be a power of 2 
 ERROR: 0:83: 'offset' : cannot lie in previous members 
-ERROR: 0:85: 'offset' : must be a multiple of the member's alignment 
+ERROR: 0:85: 'offset' : must be a multiple of the member's alignment (layout offset = 68 | member alignment = 8)
 ERROR: 0:103: 'align' : must be a power of 2 
 ERROR: 0:105: 'align' : must be a power of 2 
 ERROR: 0:102: 'offset' : cannot lie in previous members 
-ERROR: 0:104: 'offset' : must be a multiple of the member's alignment 
+ERROR: 0:104: 'offset' : must be a multiple of the member's alignment (layout offset = 68 | member alignment = 8)
 ERROR: 49 compilation errors.  No code generated.
 
 

--- a/glslang/HLSL/hlslParseHelper.cpp
+++ b/glslang/HLSL/hlslParseHelper.cpp
@@ -9045,7 +9045,8 @@ void HlslParseContext::fixBlockUniformOffsets(const TQualifier& qualifier, TType
             // "The specified offset must be a multiple
             // of the base alignment of the type of the block member it qualifies, or a compile-time error results."
             if (! IsMultipleOfPow2(memberQualifier.layoutOffset, memberAlignment))
-                error(memberLoc, "must be a multiple of the member's alignment", "offset", "");
+                error(memberLoc, "must be a multiple of the member's alignment", "offset",
+                    "(layout offset = %d | member alignment = %d)", memberQualifier.layoutOffset, memberAlignment);
 
             // "The offset qualifier forces the qualified member to start at or after the specified
             // integral-constant expression, which will be its byte offset from the beginning of the buffer.

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -9029,7 +9029,8 @@ void TParseContext::fixBlockUniformOffsets(TQualifier& qualifier, TTypeList& typ
             // "The specified offset must be a multiple
             // of the base alignment of the type of the block member it qualifies, or a compile-time error results."
             if (! IsMultipleOfPow2(memberQualifier.layoutOffset, memberAlignment))
-                error(memberLoc, "must be a multiple of the member's alignment", "offset", "");
+                error(memberLoc, "must be a multiple of the member's alignment", "offset",
+                    "(layout offset = %d | member alignment = %d)", memberQualifier.layoutOffset, memberAlignment);
 
             // GLSL: "It is a compile-time error to specify an offset that is smaller than the offset of the previous
             // member in the block or that lies within the previous member of the block"


### PR DESCRIPTION
The I thought there was a bug in GLSL but once I printed the values in the error message it made sense it was my shader

error message diff

```patch
- ERROR: struct.vert:16: 'offset' : must be a multiple of the member's alignment
+ ERROR: struct.vert:16: 'offset' : must be a multiple of the member's alignment (layout offset = 8 | member alignment = 16)
```