### PR TITLE
Fixed barycentric coords support

### DIFF
--- a/glslang/HLSL/hlslParseHelper.cpp
+++ b/glslang/HLSL/hlslParseHelper.cpp
@@ -9527,6 +9527,8 @@ bool HlslParseContext::isInputBuiltIn(const TQualifier& qualifier) const
     case EbvSampleMask:
     case EbvSamplePosition:
     case EbvViewportIndex:
+    case EbvBaryCoordEXT:
+    case EbvBaryCoordNoPerspEXT:
         return language == EShLangFragment;
     case EbvGlobalInvocationId:
     case EbvLocalInvocationIndex:

--- a/glslang/HLSL/hlslScanContext.cpp
+++ b/glslang/HLSL/hlslScanContext.cpp
@@ -525,6 +525,8 @@ void HlslScanContext::fillInKeywordMap()
     (*SemanticMap)["SV_DEPTHGREATEREQUAL"] =      EbvFragDepthGreater;
     (*SemanticMap)["SV_DEPTHLESSEQUAL"] =         EbvFragDepthLesser;
     (*SemanticMap)["SV_STENCILREF"] =             EbvFragStencilRef;
+    (*SemanticMap)["SV_BARYCENTRICS"] =           EbvBaryCoordEXT;
+    (*SemanticMap)["SV_BARYCENTRICS1"] =          EbvBaryCoordNoPerspEXT;
 }
 
 void HlslScanContext::deleteKeywordMap()


### PR DESCRIPTION
Fix for fragment shader barycentric coords support following this spec: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_fragment_shader_barycentric.html