### PR TITLE
cmake: Remove USE_CCACHE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 The Khronos Group Inc.
+# Copyright (C) 2020-2023 The Khronos Group Inc.
 #
 # All rights reserved.
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,14 +111,6 @@ if(ENABLE_GLSLANG_INSTALL AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND WI
     set(CMAKE_INSTALL_PREFIX "install" CACHE STRING "..." FORCE)
 endif()
 
-option(USE_CCACHE "Use ccache" OFF)
-if(USE_CCACHE)
-    find_program(CCACHE_FOUND ccache)
-    if(CCACHE_FOUND)
-        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-    endif()
-endif()
-
 if(ENABLE_CTEST)
     include(CTest)
 endif()


### PR DESCRIPTION
This is no longer needed with modern CMake.

I've already removed this from several Khronos repos.

See this stackoverflow for modern approaches to setting ccache via cmake:
https://stackoverflow.com/a/74120112/19739129