### PR TITLE
ndk-build: test Android API 24

### DIFF
--- a/kokoro/android-ndk-build/build-docker.sh
+++ b/kokoro/android-ndk-build/build-docker.sh
@@ -43,6 +43,7 @@ using ndk-r21d
 
 export NDK_PROJECT_PATH="${ROOT_DIR}/ndk_test"
 export APP_BUILD_SCRIPT="${ROOT_DIR}/ndk_test/Android.mk"
+export APP_PLATFORM=android-24 # Vulkan introduced in API 24
 
 echo "Building..."
 ndk-build -j

--- a/ndk_test/jni/Application.mk
+++ b/ndk_test/jni/Application.mk
@@ -34,5 +34,5 @@
 APP_ABI := all
 APP_BUILD_SCRIPT := Android.mk
 APP_STL := c++_static
-APP_PLATFORM := android-9
+APP_PLATFORM := android-24
 NDK_TOOLCHAIN_VERSION := 4.9


### PR DESCRIPTION
Vulkan was introduced in Android API 24.
Test against that API level.
NDKs drop support for older APIs

Google-internal BUG=285134453