### PR TITLE
Fix -Wmaybe-uninitialized warnings

### DIFF
--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -1788,14 +1788,15 @@ public:
                             }
     // for block reference (first parameter must be EbtReference)
     explicit TType(TBasicType t, const TType &p, const TString& n) :
-                            basicType(t), vectorSize(1), matrixCols(0), matrixRows(0), vector1(false),
-                            arraySizes(nullptr), structure(nullptr), fieldName(nullptr), typeName(nullptr)
+                            basicType(t), vectorSize(1), matrixCols(0), matrixRows(0), vector1(false), coopmat(false),
+                            arraySizes(nullptr), structure(nullptr), fieldName(nullptr), typeName(nullptr), typeParameters(nullptr)
 #ifndef GLSLANG_WEB
                             , spirvType(nullptr)
 #endif
                             {
                                 assert(t == EbtReference);
                                 typeName = NewPoolTString(n.c_str());
+                                sampler.clear();
                                 qualifier.clear();
                                 qualifier.storage = p.qualifier.storage;
                                 referentType = p.clone();

--- a/glslang/MachineIndependent/SymbolTable.cpp
+++ b/glslang/MachineIndependent/SymbolTable.cpp
@@ -382,7 +382,7 @@ TVariable* TVariable::clone() const
 TFunction::TFunction(const TFunction& copyOf) : TSymbol(copyOf)
 {
     for (unsigned int i = 0; i < copyOf.parameters.size(); ++i) {
-        TParameter param;
+        TParameter param{};
         parameters.push_back(param);
         (void)parameters.back().copyParam(copyOf.parameters[i]);
     }


### PR DESCRIPTION
Fix some potentially uninitialized uses that are reported by GCC 13 with `-O3`.