### PR TITLE
Fix GL_NV_shader_invocation_reorder #define typo

### DIFF
--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -556,7 +556,7 @@ void TParseVersions::getPreamble(std::string& preamble)
             "#define GL_NV_mesh_shader 1\n"
             "#define GL_NV_cooperative_matrix 1\n"
             "#define GL_NV_integer_cooperative_matrix 1\n"
-            "#define GL_NV_shader_execution_reorder 1\n"
+            "#define GL_NV_shader_invocation_reorder 1\n"
 
             "#define GL_EXT_shader_explicit_arithmetic_types 1\n"
             "#define GL_EXT_shader_explicit_arithmetic_types_int8 1\n"


### PR DESCRIPTION
As per spec, the extension defines [GL_NV_shader_invocation_reorder](https://github.com/KhronosGroup/GLSL/blob/f7f0724d62b701c4f13b03999f81c02315407f7b/extensions/nv/GLSL_NV_shader_invocation_reorder.txt#L136) as 1. There is no GL_NV_shader_execution_reorder.