### PR TITLE
cmake: Fix CMake 3.27 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,7 @@ else()
 endif()
 
 if(BUILD_EXTERNAL AND IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/External)
-    find_host_package(PythonInterp 3 REQUIRED)
+    find_host_package(Python3 REQUIRED)
 
     # We depend on these for later projects, so they should come first.
     add_subdirectory(External)

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -31,7 +31,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-find_host_package(PythonInterp 3 REQUIRED)
+find_host_package(Python3 REQUIRED)
 
 set(GLSLANG_INTRINSIC_H          "${GLSLANG_GENERATED_INCLUDEDIR}/glslang/glsl_intrinsic_header.h")
 set(GLSLANG_INTRINSIC_PY         "${CMAKE_CURRENT_SOURCE_DIR}/../gen_extension_headers.py")
@@ -39,7 +39,7 @@ set(GLSLANG_INTRINSIC_HEADER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../glslang/Extensi
 
 add_custom_command(
     OUTPUT  ${GLSLANG_INTRINSIC_H}
-    COMMAND ${PYTHON_EXECUTABLE} "${GLSLANG_INTRINSIC_PY}"
+    COMMAND Python3::Interpreter "${GLSLANG_INTRINSIC_PY}"
             "-i" ${GLSLANG_INTRINSIC_HEADER_DIR}
             "-o" ${GLSLANG_INTRINSIC_H}
     DEPENDS ${GLSLANG_INTRINSIC_PY}


### PR DESCRIPTION
The FindPythonInterp and FindPythonLibs modules, which have been deprecated since CMake 3.12, have been removed by policy CMP0148. Port projects to FindPython3, FindPython2, or FindPython.