### PR TITLE
Rework how auto push_constant upgrading works a bit.

### DIFF
--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -145,6 +145,8 @@ public:
             base->getWritableType().getQualifier().layoutComponent = at->second.newComponent;
         if (at->second.newIndex != -1)
             base->getWritableType().getQualifier().layoutIndex = at->second.newIndex;
+        if (at->second.upgradedToPushConstant)
+            base->getWritableType().getQualifier().layoutPushConstant = true;
     }
 
   private:
@@ -1670,31 +1672,34 @@ bool TGlslIoMapper::doMap(TIoMapResolver* resolver, TInfoSink& infoSink) {
                     }
                 }
             }
-            // If it's been upgraded to push_constant, then remove it from the uniformVector
+            // If it's been upgraded to push_constant, then set the flag so when its traversed
+            // in the next for loop, all references to this symbol will get their flag changed.
             // so it doesn't get a set/binding assigned to it.
             if (upgraded) {
-                while (1) {
-                    auto at = std::find_if(uniformVector.begin(), uniformVector.end(),
-                                           [this](const TVarLivePair& p) { return p.first == autoPushConstantBlockName; });
-                    if (at != uniformVector.end())
-                        uniformVector.erase(at);
-                    else
-                        break;
-                }
+                std::for_each(uniformVector.begin(), uniformVector.end(),
+                                       [this](TVarLivePair& p) {
+                if (p.first == autoPushConstantBlockName) {
+                        p.second.upgradedToPushConstant = true;
+                    }
+                });
             }
         }
         for (size_t stage = 0; stage < EShLangCount; stage++) {
             if (intermediates[stage] != nullptr) {
                 // traverse each stage, set new location to each input/output and unifom symbol, set new binding to
-                // ubo, ssbo and opaque symbols
+                // ubo, ssbo and opaque symbols. Assign push_constant upgrades as well.
                 TVarLiveMap** pUniformVarMap = uniformResolve.uniformVarMap;
                 std::for_each(uniformVector.begin(), uniformVector.end(), [pUniformVarMap, stage](TVarLivePair p) {
                     auto at = pUniformVarMap[stage]->find(p.second.symbol->getAccessName());
                     if (at != pUniformVarMap[stage]->end() && at->second.id == p.second.id){
-                        int resolvedBinding = at->second.newBinding;
-                        at->second = p.second;
-                        if (resolvedBinding > 0)
-                            at->second.newBinding = resolvedBinding;
+                        if (p.second.upgradedToPushConstant) {
+                            at->second.upgradedToPushConstant = true;
+                        } else {
+                            int resolvedBinding = at->second.newBinding;
+                            at->second = p.second;
+                            if (resolvedBinding > 0)
+                                at->second.newBinding = resolvedBinding;
+                        }
                     }
                 });
                 TVarSetTraverser iter_iomap(*intermediates[stage], *inVarMaps[stage], *outVarMaps[stage],

--- a/glslang/MachineIndependent/iomapper.h
+++ b/glslang/MachineIndependent/iomapper.h
@@ -55,6 +55,7 @@ struct TVarEntryInfo {
     long long id;
     TIntermSymbol* symbol;
     bool live;
+    bool upgradedToPushConstant;
     int newBinding;
     int newSet;
     int newLocation;
@@ -63,6 +64,7 @@ struct TVarEntryInfo {
     EShLanguage stage;
 
     void clearNewAssignments() {
+        upgradedToPushConstant = false;
         newBinding = -1;
         newSet = -1;
         newLocation = -1;


### PR DESCRIPTION
Ensure we traverse the entire tree and upgrade all references to the given symbol so it can be upgraded to push_constant. Without this change only one instance was upgraded, and others were left as uniform buffers.