### PR TITLE
Fix linking error "ld: unknown option: --no-undefined" on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" AND NOT MSVC)
         # Error if there's symbols that are not found at link time.
         if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
             add_link_options("-Wl,-undefined,error")
-        else()
+        elseif(NOT APPLE)
             add_link_options("-Wl,--no-undefined")
         endif()
     endif()


### PR DESCRIPTION
This PR prevents CMake from attempting to add the `--no-undefined` option when compiling on macOS with a compiler other than `AppleClang`. On Mac OS X 10.9 and older, Apple Clang cannot be used to compile glslang, because the Clang inside of Xcode is so old that the C++17 standard isn't supported. So instead, an updated version of Clang must be used, such as through [MacPorts](https://www.macports.org/) or [Homebrew](https://brew.sh).

However, the `--no-undefined` linking option doesn't exist on the Mac platform, regardless of which Clang is being used, so using a "non-Apple Clang" Clang to build glslang will result in the following error during linking:

```
ld: unknown option: --no-undefined
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This is the same fix that was implemented by NeoVim in neovim/neovim#23263.