### PR TITLE
Fix unused parameter warning in Release builds

### DIFF
--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -2109,7 +2109,8 @@ Function* Builder::makeFunctionEntry(Decoration precision, Id returnType, const 
     return function;
 }
 
-Id Builder::makeDebugFunction(Function* function, Id nameId, Id funcTypeId) {
+Id Builder::makeDebugFunction([[maybe_unused]] Function* function, Id nameId, Id funcTypeId)
+{
     assert(function != nullptr);
     assert(nameId != 0);
     assert(funcTypeId != 0);


### PR DESCRIPTION
The `function` parameter is only used by an assert currently, so mark it as "maybe unused".  Alternatively the parameter could be removed, but avoid such public API churn for now.