### PR TITLE
cmake: Rename glslang to glslangValidator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ if(NOT ${SKIP_GLSLANG_INSTALL})
 endif()
 option(ENABLE_SPVREMAPPER "Enables building of SPVRemapper" ON)
 
-option(ENABLE_GLSLANG_BINARIES "Builds glslangValidator and spirv-remap" ON)
+option(ENABLE_GLSLANG_BINARIES "Builds glslang and spirv-remap" ON)
 
 option(ENABLE_GLSLANG_JS
     "If using Emscripten, build glslang.js. Otherwise, builds a sample executable for binary-size testing." OFF)
@@ -319,11 +319,11 @@ if(ENABLE_CTEST AND BUILD_TESTING)
 
     if (CMAKE_CONFIGURATION_TYPES)
         set(RESULTS_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/localResults)
-        set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/$<CONFIG>/glslangValidator)
+        set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/$<CONFIG>/glslang)
         set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/$<CONFIG>/spirv-remap)
     else()
         set(RESULTS_PATH ${CMAKE_CURRENT_BINARY_DIR}/localResults)
-        set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/glslangValidator)
+        set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/glslang)
         set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/spirv-remap)
     endif()
 

--- a/README-spirv-remap.txt
+++ b/README-spirv-remap.txt
@@ -112,7 +112,7 @@ BUILD DEPENDENCIES:
 
 BUILDING
 --------------------------------------------------------------------------------
-The standalone remapper is built along side glslangValidator through its
+The standalone remapper is built along side glslang through its
 normal build process.
 
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ An API for getting reflection information from the AST, reflection types/variabl
 
 ### Standalone Wrapper
 
-`glslangValidator` is command-line tool for accessing the functionality above.
+`glslang` is command-line tool for accessing the functionality above.
 
 Status: Complete.
 
@@ -65,7 +65,7 @@ The above page, while not kept up to date, includes additional information regar
 
 ## Execution of Standalone Wrapper
 
-To use the standalone binary form, execute `glslangValidator`, and it will print
+To use the standalone binary form, execute `glslang`, and it will print
 a usage statement.  Basic operation is to give it a file containing a shader,
 and it will print out warnings/errors and optionally an AST.
 

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -45,13 +45,12 @@ add_custom_command(
     DEPENDS ${GLSLANG_INTRINSIC_PY}
     COMMENT "Generating ${GLSLANG_INTRINSIC_H}")
 
-#add_custom_target(glslangValidator DEPENDS ${GLSLANG_INTRINSIC_H})
-
 set(SOURCES StandAlone.cpp DirStackFileIncluder.h  ${GLSLANG_INTRINSIC_H})
 
-add_executable(glslangValidator ${SOURCES})
-set_property(TARGET glslangValidator PROPERTY FOLDER tools)
-glslang_set_link_args(glslangValidator)
+add_executable(glslang-standalone ${SOURCES})
+set_property(TARGET glslang-standalone PROPERTY FOLDER tools)
+set_property(TARGET glslang-standalone PROPERTY OUTPUT_NAME glslang)
+glslang_set_link_args(glslang-standalone)
 
 set(LIBRARIES
     glslang
@@ -70,13 +69,13 @@ elseif(UNIX)
     endif()
 endif()
 
-target_link_libraries(glslangValidator ${LIBRARIES})
-target_include_directories(glslangValidator PUBLIC
+target_link_libraries(glslang-standalone ${LIBRARIES})
+target_include_directories(glslang-standalone PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../External>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/External>)
 
 if(ENABLE_OPT)
-    target_include_directories(glslangValidator
+    target_include_directories(glslang-standalone
         PRIVATE ${spirv-tools_SOURCE_DIR}/include
     )
 endif()
@@ -94,19 +93,31 @@ if(WIN32)
 endif()
 
 if(ENABLE_GLSLANG_INSTALL)
-    install(TARGETS glslangValidator EXPORT glslang-targets)
+    install(TARGETS glslang-standalone EXPORT glslang-targets)
 
     # Backward compatibility
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/glslangValidatorTargets.cmake" "
-        message(WARNING \"Using `glslangValidatorTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/glslang-standaloneTargets.cmake" "
+        message(WARNING \"Using `glslang-standaloneTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
 
-        if (NOT TARGET glslang::glslangValidator)
+        if (NOT TARGET glslang::glslang-standalone)
             include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
         endif()
 
-        add_library(glslangValidator ALIAS glslang::glslangValidator)
+        add_library(glslang-standalone ALIAS glslang::glslang-standalone)
     ")
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/glslangValidatorTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/glslang-standaloneTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+
+    # Create a symbolic link to glslang named glslangValidator for backwards compatibility
+    set(legacy_glslang_name "glslangValidator${CMAKE_EXECUTABLE_SUFFIX}")
+    add_custom_command(TARGET glslang-standalone
+                       POST_BUILD
+                       COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_NAME:glslang-standalone> ${legacy_glslang_name}
+                       WORKING_DIRECTORY $<TARGET_FILE_DIR:glslang-standalone>)
+
+    # Create the same symlink at install time
+    install(CODE "execute_process( \
+                      COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_NAME:glslang-standalone> ${legacy_glslang_name} \
+                      WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})")
 
     if(ENABLE_SPVREMAPPER)
         install(TARGETS spirv-remap EXPORT glslang-targets)

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -1884,7 +1884,7 @@ void CompileFile(const char* fileName, ShHandle compiler)
 //
 void usage()
 {
-    printf("Usage: glslangValidator [option]... [file]...\n"
+    printf("Usage: glslang [option]... [file]...\n"
            "\n"
            "'file' can end in .<stage> for auto-stage classification, where <stage> is:\n"
            "    .conf   to provide a config file that replaces the default configuration\n"
@@ -2089,8 +2089,7 @@ void usage()
            "  --variable-name <name>\n"
            "  --vn <name>                       creates a C header file that contains a\n"
            "                                    uint32_t array named <name>\n"
-           "                                    initialized with the shader binary code\n"
-           );
+           "                                    initialized with the shader binary code\n");
 
     exit(EFailUsage);
 }

--- a/Test/baseResults/size
+++ b/Test/baseResults/size
@@ -1,1 +1,1 @@
-399360 ../build/install/bin/glslangValidator.exe
+399360 ../build/install/bin/glslang.exe

--- a/Test/glsl.versionOverride.geom
+++ b/Test/glsl.versionOverride.geom
@@ -1,6 +1,6 @@
 /*
 
-glslangValidator.exe --glsl-version 430 -V -S geom -o glsl.versionOverride.geom.out glsl.versionOverride.geom
+glslang.exe --glsl-version 430 -V -S geom -o glsl.versionOverride.geom.out glsl.versionOverride.geom
 
 */
 

--- a/Test/glsl.versionOverride.tesc
+++ b/Test/glsl.versionOverride.tesc
@@ -1,6 +1,6 @@
 /*
 
-glslangValidator.exe --glsl-version 440 -V -S tesc -o glsl.versionOverride.tesc.out glsl.versionOverride.tesc
+glslang.exe --glsl-version 440 -V -S tesc -o glsl.versionOverride.tesc.out glsl.versionOverride.tesc
 
 */
 

--- a/Test/glsl.versionOverride.tese
+++ b/Test/glsl.versionOverride.tese
@@ -1,6 +1,6 @@
 /*
 
-glslangValidator.exe --glsl-version 450 -V -S tese -o glsl.versionOverride.tese.out glsl.versionOverride.tese
+glslang.exe --glsl-version 450 -V -S tese -o glsl.versionOverride.tese.out glsl.versionOverride.tese
 
 */
 

--- a/Test/glslangValidator
+++ b/Test/glslangValidator
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-../build/install/bin/glslangValidator $*
+../build/install/bin/glslang $*

--- a/Test/makeDoc
+++ b/Test/makeDoc
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-./glslangValidator -p > instDesc
+./glslang -p > instDesc
 asciidoc --backend=html5 instDesc

--- a/Test/runtests
+++ b/Test/runtests
@@ -2,12 +2,12 @@
 
 # Arguments:
 #  1- TargetDirectory, where to write test results and intermediary files
-#  2- Path to glslangValidator
+#  2- Path to glslang
 #  3- Path to spirv-remap
 
 TARGETDIR=${1:-localResults}
 BASEDIR=baseResults
-EXE=${2:-../build/install/bin/glslangValidator}
+EXE=${2:-../build/install/bin/glslang}
 REMAPEXE=${3:-../build/install/bin/spirv-remap}
 HASERROR=0
 mkdir -p $TARGETDIR

--- a/Test/validate-shaders.sh
+++ b/Test/validate-shaders.sh
@@ -4,7 +4,7 @@
 # It is not meant to preclude the possible addition of the validator to
 # glslang.
 
-declare -r EXE='../build/install/bin/glslangValidator'
+declare -r EXE='../build/install/bin/glslang'
 
 # search common locations for spirv-tools: keep first one
 for toolsdir in '../External/spirv-tools/build/tools' '../../SPIRV-Tools/build/tools/bin' '/usr/local/bin'; do

--- a/Test/web.runtests
+++ b/Test/web.runtests
@@ -3,7 +3,7 @@
 TESTLIST=web.testlist
 TARGETDIR=localResults
 BASEDIR=baseResults
-EXE=../build/install/bin/glslangValidator.exe
+EXE=../build/install/bin/glslang.exe
 HASERROR=0
 mkdir -p $TARGETDIR
 

--- a/gtests/TestFixture.h
+++ b/gtests/TestFixture.h
@@ -471,7 +471,7 @@ public:
             targetLanguageVersion, false, EShTexSampTransKeep, enableOptimizer, enableDebug,
             enableNonSemanticShaderDebugInfo, automap);
 
-        // Generate the hybrid output in the way of glslangValidator.
+        // Generate the hybrid output in the way of glslang.
         std::ostringstream stream;
         outputResultToStream(&stream, result, controls);
 
@@ -501,7 +501,7 @@ public:
         GlslangResult result = compileAndLink(testName, input, entryPointName, controls, clientTargetVersion,
             targetLanguageVersion, false, EShTexSampTransKeep, false, automap);
 
-        // Generate the hybrid output in the way of glslangValidator.
+        // Generate the hybrid output in the way of glslang.
         std::ostringstream stream;
         outputResultToStream(&stream, result, controls);
 
@@ -527,7 +527,7 @@ public:
         GlslangResult result = compileAndLink(testName, input, entryPointName, controls,
                                               glslang::EShTargetVulkan_1_0, glslang::EShTargetSpv_1_0, true);
 
-        // Generate the hybrid output in the way of glslangValidator.
+        // Generate the hybrid output in the way of glslang.
         std::ostringstream stream;
         outputResultToStream(&stream, result, controls);
 
@@ -564,7 +564,7 @@ public:
                                                 autoMapBindings,
                                                 flattenUniformArrays);
 
-        // Generate the hybrid output in the way of glslangValidator.
+        // Generate the hybrid output in the way of glslang.
         std::ostringstream stream;
         outputResultToStream(&stream, result, controls);
 
@@ -591,7 +591,7 @@ public:
         const EShMessages controls = DeriveOptions(source, semantics, target);
         GlslangResult result = compileLinkRemap(testName, input, entryPointName, controls, remapOptions);
 
-        // Generate the hybrid output in the way of glslangValidator.
+        // Generate the hybrid output in the way of glslang.
         std::ostringstream stream;
         outputResultToStream(&stream, result, controls);
 
@@ -618,7 +618,7 @@ public:
         const EShMessages controls = DeriveOptions(source, semantics, target);
         GlslangResult result = remap(testName, input, controls, remapOptions);
 
-        // Generate the hybrid output in the way of glslangValidator.
+        // Generate the hybrid output in the way of glslang.
         std::ostringstream stream;
         outputResultToStream(&stream, result, controls);
 
@@ -698,7 +698,7 @@ public:
                                               glslang::EShTargetVulkan_1_0, glslang::EShTargetSpv_1_0, false,
                                               EShTexSampTransUpgradeTextureRemoveSampler);
 
-        // Generate the hybrid output in the way of glslangValidator.
+        // Generate the hybrid output in the way of glslang.
         std::ostringstream stream;
         outputResultToStream(&stream, result, controls);
 


### PR DESCRIPTION
Rename glslangValidator to glslang and adds a glslangValidator symlink to the build and install directories.

Closes #47.