### PR TITLE
Use std::call_once in spv::Parameterize()

### DIFF
--- a/SPIRV/doc.cpp
+++ b/SPIRV/doc.cpp
@@ -45,6 +45,7 @@
 #include <cstdio>
 #include <cstring>
 #include <algorithm>
+#include <mutex>
 
 namespace spv {
     extern "C" {
@@ -1540,1753 +1541,1752 @@ EnumParameters MemoryAccessParams[MemoryAccessCeiling];
 void Parameterize()
 {
     // only do this once.
-    static bool initialized = false;
-    if (initialized)
-        return;
-    initialized = true;
-
-    // Exceptions to having a result <id> and a resulting type <id>.
-    // (Everything is initialized to have both).
-
-    InstructionDesc[OpNop].setResultAndType(false, false);
-    InstructionDesc[OpSource].setResultAndType(false, false);
-    InstructionDesc[OpSourceContinued].setResultAndType(false, false);
-    InstructionDesc[OpSourceExtension].setResultAndType(false, false);
-    InstructionDesc[OpExtension].setResultAndType(false, false);
-    InstructionDesc[OpExtInstImport].setResultAndType(true, false);
-    InstructionDesc[OpCapability].setResultAndType(false, false);
-    InstructionDesc[OpMemoryModel].setResultAndType(false, false);
-    InstructionDesc[OpEntryPoint].setResultAndType(false, false);
-    InstructionDesc[OpExecutionMode].setResultAndType(false, false);
-    InstructionDesc[OpExecutionModeId].setResultAndType(false, false);
-    InstructionDesc[OpTypeVoid].setResultAndType(true, false);
-    InstructionDesc[OpTypeBool].setResultAndType(true, false);
-    InstructionDesc[OpTypeInt].setResultAndType(true, false);
-    InstructionDesc[OpTypeFloat].setResultAndType(true, false);
-    InstructionDesc[OpTypeVector].setResultAndType(true, false);
-    InstructionDesc[OpTypeMatrix].setResultAndType(true, false);
-    InstructionDesc[OpTypeImage].setResultAndType(true, false);
-    InstructionDesc[OpTypeSampler].setResultAndType(true, false);
-    InstructionDesc[OpTypeSampledImage].setResultAndType(true, false);
-    InstructionDesc[OpTypeArray].setResultAndType(true, false);
-    InstructionDesc[OpTypeRuntimeArray].setResultAndType(true, false);
-    InstructionDesc[OpTypeStruct].setResultAndType(true, false);
-    InstructionDesc[OpTypeOpaque].setResultAndType(true, false);
-    InstructionDesc[OpTypePointer].setResultAndType(true, false);
-    InstructionDesc[OpTypeForwardPointer].setResultAndType(false, false);
-    InstructionDesc[OpTypeFunction].setResultAndType(true, false);
-    InstructionDesc[OpTypeEvent].setResultAndType(true, false);
-    InstructionDesc[OpTypeDeviceEvent].setResultAndType(true, false);
-    InstructionDesc[OpTypeReserveId].setResultAndType(true, false);
-    InstructionDesc[OpTypeQueue].setResultAndType(true, false);
-    InstructionDesc[OpTypePipe].setResultAndType(true, false);
-    InstructionDesc[OpFunctionEnd].setResultAndType(false, false);
-    InstructionDesc[OpStore].setResultAndType(false, false);
-    InstructionDesc[OpImageWrite].setResultAndType(false, false);
-    InstructionDesc[OpDecorationGroup].setResultAndType(true, false);
-    InstructionDesc[OpDecorate].setResultAndType(false, false);
-    InstructionDesc[OpDecorateId].setResultAndType(false, false);
-    InstructionDesc[OpDecorateStringGOOGLE].setResultAndType(false, false);
-    InstructionDesc[OpMemberDecorate].setResultAndType(false, false);
-    InstructionDesc[OpMemberDecorateStringGOOGLE].setResultAndType(false, false);
-    InstructionDesc[OpGroupDecorate].setResultAndType(false, false);
-    InstructionDesc[OpGroupMemberDecorate].setResultAndType(false, false);
-    InstructionDesc[OpName].setResultAndType(false, false);
-    InstructionDesc[OpMemberName].setResultAndType(false, false);
-    InstructionDesc[OpString].setResultAndType(true, false);
-    InstructionDesc[OpLine].setResultAndType(false, false);
-    InstructionDesc[OpNoLine].setResultAndType(false, false);
-    InstructionDesc[OpCopyMemory].setResultAndType(false, false);
-    InstructionDesc[OpCopyMemorySized].setResultAndType(false, false);
-    InstructionDesc[OpEmitVertex].setResultAndType(false, false);
-    InstructionDesc[OpEndPrimitive].setResultAndType(false, false);
-    InstructionDesc[OpEmitStreamVertex].setResultAndType(false, false);
-    InstructionDesc[OpEndStreamPrimitive].setResultAndType(false, false);
-    InstructionDesc[OpControlBarrier].setResultAndType(false, false);
-    InstructionDesc[OpMemoryBarrier].setResultAndType(false, false);
-    InstructionDesc[OpAtomicStore].setResultAndType(false, false);
-    InstructionDesc[OpLoopMerge].setResultAndType(false, false);
-    InstructionDesc[OpSelectionMerge].setResultAndType(false, false);
-    InstructionDesc[OpLabel].setResultAndType(true, false);
-    InstructionDesc[OpBranch].setResultAndType(false, false);
-    InstructionDesc[OpBranchConditional].setResultAndType(false, false);
-    InstructionDesc[OpSwitch].setResultAndType(false, false);
-    InstructionDesc[OpKill].setResultAndType(false, false);
-    InstructionDesc[OpTerminateInvocation].setResultAndType(false, false);
-    InstructionDesc[OpReturn].setResultAndType(false, false);
-    InstructionDesc[OpReturnValue].setResultAndType(false, false);
-    InstructionDesc[OpUnreachable].setResultAndType(false, false);
-    InstructionDesc[OpLifetimeStart].setResultAndType(false, false);
-    InstructionDesc[OpLifetimeStop].setResultAndType(false, false);
-    InstructionDesc[OpCommitReadPipe].setResultAndType(false, false);
-    InstructionDesc[OpCommitWritePipe].setResultAndType(false, false);
-    InstructionDesc[OpGroupCommitWritePipe].setResultAndType(false, false);
-    InstructionDesc[OpGroupCommitReadPipe].setResultAndType(false, false);
-    InstructionDesc[OpCaptureEventProfilingInfo].setResultAndType(false, false);
-    InstructionDesc[OpSetUserEventStatus].setResultAndType(false, false);
-    InstructionDesc[OpRetainEvent].setResultAndType(false, false);
-    InstructionDesc[OpReleaseEvent].setResultAndType(false, false);
-    InstructionDesc[OpGroupWaitEvents].setResultAndType(false, false);
-    InstructionDesc[OpAtomicFlagClear].setResultAndType(false, false);
-    InstructionDesc[OpModuleProcessed].setResultAndType(false, false);
-    InstructionDesc[OpTypeCooperativeMatrixNV].setResultAndType(true, false);
-    InstructionDesc[OpCooperativeMatrixStoreNV].setResultAndType(false, false);
-    InstructionDesc[OpBeginInvocationInterlockEXT].setResultAndType(false, false);
-    InstructionDesc[OpEndInvocationInterlockEXT].setResultAndType(false, false);
-
-    // Specific additional context-dependent operands
-
-    ExecutionModeOperands[ExecutionModeInvocations].push(OperandLiteralNumber, "'Number of <<Invocation,invocations>>'");
-
-    ExecutionModeOperands[ExecutionModeLocalSize].push(OperandLiteralNumber, "'x size'");
-    ExecutionModeOperands[ExecutionModeLocalSize].push(OperandLiteralNumber, "'y size'");
-    ExecutionModeOperands[ExecutionModeLocalSize].push(OperandLiteralNumber, "'z size'");
-
-    ExecutionModeOperands[ExecutionModeLocalSizeHint].push(OperandLiteralNumber, "'x size'");
-    ExecutionModeOperands[ExecutionModeLocalSizeHint].push(OperandLiteralNumber, "'y size'");
-    ExecutionModeOperands[ExecutionModeLocalSizeHint].push(OperandLiteralNumber, "'z size'");
-
-    ExecutionModeOperands[ExecutionModeOutputVertices].push(OperandLiteralNumber, "'Vertex count'");
-    ExecutionModeOperands[ExecutionModeVecTypeHint].push(OperandLiteralNumber, "'Vector type'");
-
-    DecorationOperands[DecorationStream].push(OperandLiteralNumber, "'Stream Number'");
-    DecorationOperands[DecorationLocation].push(OperandLiteralNumber, "'Location'");
-    DecorationOperands[DecorationComponent].push(OperandLiteralNumber, "'Component'");
-    DecorationOperands[DecorationIndex].push(OperandLiteralNumber, "'Index'");
-    DecorationOperands[DecorationBinding].push(OperandLiteralNumber, "'Binding Point'");
-    DecorationOperands[DecorationDescriptorSet].push(OperandLiteralNumber, "'Descriptor Set'");
-    DecorationOperands[DecorationOffset].push(OperandLiteralNumber, "'Byte Offset'");
-    DecorationOperands[DecorationXfbBuffer].push(OperandLiteralNumber, "'XFB Buffer Number'");
-    DecorationOperands[DecorationXfbStride].push(OperandLiteralNumber, "'XFB Stride'");
-    DecorationOperands[DecorationArrayStride].push(OperandLiteralNumber, "'Array Stride'");
-    DecorationOperands[DecorationMatrixStride].push(OperandLiteralNumber, "'Matrix Stride'");
-    DecorationOperands[DecorationBuiltIn].push(OperandLiteralNumber, "See <<BuiltIn,*BuiltIn*>>");
-    DecorationOperands[DecorationFPRoundingMode].push(OperandFPRoundingMode, "'Floating-Point Rounding Mode'");
-    DecorationOperands[DecorationFPFastMathMode].push(OperandFPFastMath, "'Fast-Math Mode'");
-    DecorationOperands[DecorationLinkageAttributes].push(OperandLiteralString, "'Name'");
-    DecorationOperands[DecorationLinkageAttributes].push(OperandLinkageType, "'Linkage Type'");
-    DecorationOperands[DecorationFuncParamAttr].push(OperandFuncParamAttr, "'Function Parameter Attribute'");
-    DecorationOperands[DecorationSpecId].push(OperandLiteralNumber, "'Specialization Constant ID'");
-    DecorationOperands[DecorationInputAttachmentIndex].push(OperandLiteralNumber, "'Attachment Index'");
-    DecorationOperands[DecorationAlignment].push(OperandLiteralNumber, "'Alignment'");
-
-    OperandClassParams[OperandSource].set(0, SourceString, nullptr);
-    OperandClassParams[OperandExecutionModel].set(0, ExecutionModelString, nullptr);
-    OperandClassParams[OperandAddressing].set(0, AddressingString, nullptr);
-    OperandClassParams[OperandMemory].set(0, MemoryString, nullptr);
-    OperandClassParams[OperandExecutionMode].set(ExecutionModeCeiling, ExecutionModeString, ExecutionModeParams);
-    OperandClassParams[OperandExecutionMode].setOperands(ExecutionModeOperands);
-    OperandClassParams[OperandStorage].set(0, StorageClassString, nullptr);
-    OperandClassParams[OperandDimensionality].set(0, DimensionString, nullptr);
-    OperandClassParams[OperandSamplerAddressingMode].set(0, SamplerAddressingModeString, nullptr);
-    OperandClassParams[OperandSamplerFilterMode].set(0, SamplerFilterModeString, nullptr);
-    OperandClassParams[OperandSamplerImageFormat].set(0, ImageFormatString, nullptr);
-    OperandClassParams[OperandImageChannelOrder].set(0, ImageChannelOrderString, nullptr);
-    OperandClassParams[OperandImageChannelDataType].set(0, ImageChannelDataTypeString, nullptr);
-    OperandClassParams[OperandImageOperands].set(ImageOperandsCeiling, ImageOperandsString, ImageOperandsParams, true);
-    OperandClassParams[OperandFPFastMath].set(0, FPFastMathString, nullptr, true);
-    OperandClassParams[OperandFPRoundingMode].set(0, FPRoundingModeString, nullptr);
-    OperandClassParams[OperandLinkageType].set(0, LinkageTypeString, nullptr);
-    OperandClassParams[OperandFuncParamAttr].set(0, FuncParamAttrString, nullptr);
-    OperandClassParams[OperandAccessQualifier].set(0, AccessQualifierString, nullptr);
-    OperandClassParams[OperandDecoration].set(DecorationCeiling, DecorationString, DecorationParams);
-    OperandClassParams[OperandDecoration].setOperands(DecorationOperands);
-    OperandClassParams[OperandBuiltIn].set(0, BuiltInString, nullptr);
-    OperandClassParams[OperandSelect].set(SelectControlCeiling, SelectControlString, SelectionControlParams, true);
-    OperandClassParams[OperandLoop].set(LoopControlCeiling, LoopControlString, LoopControlParams, true);
-    OperandClassParams[OperandFunction].set(FunctionControlCeiling, FunctionControlString, FunctionControlParams, true);
-    OperandClassParams[OperandMemorySemantics].set(0, MemorySemanticsString, nullptr, true);
-    OperandClassParams[OperandMemoryAccess].set(MemoryAccessCeiling, MemoryAccessString, MemoryAccessParams, true);
-    OperandClassParams[OperandScope].set(0, ScopeString, nullptr);
-    OperandClassParams[OperandGroupOperation].set(0, GroupOperationString, nullptr);
-    OperandClassParams[OperandKernelEnqueueFlags].set(0, KernelEnqueueFlagsString, nullptr);
-    OperandClassParams[OperandKernelProfilingInfo].set(0, KernelProfilingInfoString, nullptr, true);
-    OperandClassParams[OperandCapability].set(0, CapabilityString, nullptr);
-    OperandClassParams[OperandOpcode].set(OpCodeMask + 1, OpcodeString, nullptr);
-
-    // set name of operator, an initial set of <id> style operands, and the description
-
-    InstructionDesc[OpSource].operands.push(OperandSource, "");
-    InstructionDesc[OpSource].operands.push(OperandLiteralNumber, "'Version'");
-    InstructionDesc[OpSource].operands.push(OperandId, "'File'", true);
-    InstructionDesc[OpSource].operands.push(OperandLiteralString, "'Source'", true);
-
-    InstructionDesc[OpSourceContinued].operands.push(OperandLiteralString, "'Continued Source'");
-
-    InstructionDesc[OpSourceExtension].operands.push(OperandLiteralString, "'Extension'");
-
-    InstructionDesc[OpName].operands.push(OperandId, "'Target'");
-    InstructionDesc[OpName].operands.push(OperandLiteralString, "'Name'");
-
-    InstructionDesc[OpMemberName].operands.push(OperandId, "'Type'");
-    InstructionDesc[OpMemberName].operands.push(OperandLiteralNumber, "'Member'");
-    InstructionDesc[OpMemberName].operands.push(OperandLiteralString, "'Name'");
-
-    InstructionDesc[OpString].operands.push(OperandLiteralString, "'String'");
-
-    InstructionDesc[OpLine].operands.push(OperandId, "'File'");
-    InstructionDesc[OpLine].operands.push(OperandLiteralNumber, "'Line'");
-    InstructionDesc[OpLine].operands.push(OperandLiteralNumber, "'Column'");
-
-    InstructionDesc[OpExtension].operands.push(OperandLiteralString, "'Name'");
-
-    InstructionDesc[OpExtInstImport].operands.push(OperandLiteralString, "'Name'");
-
-    InstructionDesc[OpCapability].operands.push(OperandCapability, "'Capability'");
-
-    InstructionDesc[OpMemoryModel].operands.push(OperandAddressing, "");
-    InstructionDesc[OpMemoryModel].operands.push(OperandMemory, "");
-
-    InstructionDesc[OpEntryPoint].operands.push(OperandExecutionModel, "");
-    InstructionDesc[OpEntryPoint].operands.push(OperandId, "'Entry Point'");
-    InstructionDesc[OpEntryPoint].operands.push(OperandLiteralString, "'Name'");
-    InstructionDesc[OpEntryPoint].operands.push(OperandVariableIds, "'Interface'");
-
-    InstructionDesc[OpExecutionMode].operands.push(OperandId, "'Entry Point'");
-    InstructionDesc[OpExecutionMode].operands.push(OperandExecutionMode, "'Mode'");
-    InstructionDesc[OpExecutionMode].operands.push(OperandOptionalLiteral, "See <<Execution_Mode,Execution Mode>>");
-
-    InstructionDesc[OpExecutionModeId].operands.push(OperandId, "'Entry Point'");
-    InstructionDesc[OpExecutionModeId].operands.push(OperandExecutionMode, "'Mode'");
-    InstructionDesc[OpExecutionModeId].operands.push(OperandVariableIds, "See <<Execution_Mode,Execution Mode>>");
-
-    InstructionDesc[OpTypeInt].operands.push(OperandLiteralNumber, "'Width'");
-    InstructionDesc[OpTypeInt].operands.push(OperandLiteralNumber, "'Signedness'");
-
-    InstructionDesc[OpTypeFloat].operands.push(OperandLiteralNumber, "'Width'");
-
-    InstructionDesc[OpTypeVector].operands.push(OperandId, "'Component Type'");
-    InstructionDesc[OpTypeVector].operands.push(OperandLiteralNumber, "'Component Count'");
-
-    InstructionDesc[OpTypeMatrix].operands.push(OperandId, "'Column Type'");
-    InstructionDesc[OpTypeMatrix].operands.push(OperandLiteralNumber, "'Column Count'");
-
-    InstructionDesc[OpTypeImage].operands.push(OperandId, "'Sampled Type'");
-    InstructionDesc[OpTypeImage].operands.push(OperandDimensionality, "");
-    InstructionDesc[OpTypeImage].operands.push(OperandLiteralNumber, "'Depth'");
-    InstructionDesc[OpTypeImage].operands.push(OperandLiteralNumber, "'Arrayed'");
-    InstructionDesc[OpTypeImage].operands.push(OperandLiteralNumber, "'MS'");
-    InstructionDesc[OpTypeImage].operands.push(OperandLiteralNumber, "'Sampled'");
-    InstructionDesc[OpTypeImage].operands.push(OperandSamplerImageFormat, "");
-    InstructionDesc[OpTypeImage].operands.push(OperandAccessQualifier, "", true);
-
-    InstructionDesc[OpTypeSampledImage].operands.push(OperandId, "'Image Type'");
-
-    InstructionDesc[OpTypeArray].operands.push(OperandId, "'Element Type'");
-    InstructionDesc[OpTypeArray].operands.push(OperandId, "'Length'");
-
-    InstructionDesc[OpTypeRuntimeArray].operands.push(OperandId, "'Element Type'");
-
-    InstructionDesc[OpTypeStruct].operands.push(OperandVariableIds, "'Member 0 type', +\n'member 1 type', +\n...");
-
-    InstructionDesc[OpTypeOpaque].operands.push(OperandLiteralString, "The name of the opaque type.");
-
-    InstructionDesc[OpTypePointer].operands.push(OperandStorage, "");
-    InstructionDesc[OpTypePointer].operands.push(OperandId, "'Type'");
+    static std::once_flag initialized;
+    std::call_once(initialized, [](){
+
+        // Exceptions to having a result <id> and a resulting type <id>.
+        // (Everything is initialized to have both).
+
+        InstructionDesc[OpNop].setResultAndType(false, false);
+        InstructionDesc[OpSource].setResultAndType(false, false);
+        InstructionDesc[OpSourceContinued].setResultAndType(false, false);
+        InstructionDesc[OpSourceExtension].setResultAndType(false, false);
+        InstructionDesc[OpExtension].setResultAndType(false, false);
+        InstructionDesc[OpExtInstImport].setResultAndType(true, false);
+        InstructionDesc[OpCapability].setResultAndType(false, false);
+        InstructionDesc[OpMemoryModel].setResultAndType(false, false);
+        InstructionDesc[OpEntryPoint].setResultAndType(false, false);
+        InstructionDesc[OpExecutionMode].setResultAndType(false, false);
+        InstructionDesc[OpExecutionModeId].setResultAndType(false, false);
+        InstructionDesc[OpTypeVoid].setResultAndType(true, false);
+        InstructionDesc[OpTypeBool].setResultAndType(true, false);
+        InstructionDesc[OpTypeInt].setResultAndType(true, false);
+        InstructionDesc[OpTypeFloat].setResultAndType(true, false);
+        InstructionDesc[OpTypeVector].setResultAndType(true, false);
+        InstructionDesc[OpTypeMatrix].setResultAndType(true, false);
+        InstructionDesc[OpTypeImage].setResultAndType(true, false);
+        InstructionDesc[OpTypeSampler].setResultAndType(true, false);
+        InstructionDesc[OpTypeSampledImage].setResultAndType(true, false);
+        InstructionDesc[OpTypeArray].setResultAndType(true, false);
+        InstructionDesc[OpTypeRuntimeArray].setResultAndType(true, false);
+        InstructionDesc[OpTypeStruct].setResultAndType(true, false);
+        InstructionDesc[OpTypeOpaque].setResultAndType(true, false);
+        InstructionDesc[OpTypePointer].setResultAndType(true, false);
+        InstructionDesc[OpTypeForwardPointer].setResultAndType(false, false);
+        InstructionDesc[OpTypeFunction].setResultAndType(true, false);
+        InstructionDesc[OpTypeEvent].setResultAndType(true, false);
+        InstructionDesc[OpTypeDeviceEvent].setResultAndType(true, false);
+        InstructionDesc[OpTypeReserveId].setResultAndType(true, false);
+        InstructionDesc[OpTypeQueue].setResultAndType(true, false);
+        InstructionDesc[OpTypePipe].setResultAndType(true, false);
+        InstructionDesc[OpFunctionEnd].setResultAndType(false, false);
+        InstructionDesc[OpStore].setResultAndType(false, false);
+        InstructionDesc[OpImageWrite].setResultAndType(false, false);
+        InstructionDesc[OpDecorationGroup].setResultAndType(true, false);
+        InstructionDesc[OpDecorate].setResultAndType(false, false);
+        InstructionDesc[OpDecorateId].setResultAndType(false, false);
+        InstructionDesc[OpDecorateStringGOOGLE].setResultAndType(false, false);
+        InstructionDesc[OpMemberDecorate].setResultAndType(false, false);
+        InstructionDesc[OpMemberDecorateStringGOOGLE].setResultAndType(false, false);
+        InstructionDesc[OpGroupDecorate].setResultAndType(false, false);
+        InstructionDesc[OpGroupMemberDecorate].setResultAndType(false, false);
+        InstructionDesc[OpName].setResultAndType(false, false);
+        InstructionDesc[OpMemberName].setResultAndType(false, false);
+        InstructionDesc[OpString].setResultAndType(true, false);
+        InstructionDesc[OpLine].setResultAndType(false, false);
+        InstructionDesc[OpNoLine].setResultAndType(false, false);
+        InstructionDesc[OpCopyMemory].setResultAndType(false, false);
+        InstructionDesc[OpCopyMemorySized].setResultAndType(false, false);
+        InstructionDesc[OpEmitVertex].setResultAndType(false, false);
+        InstructionDesc[OpEndPrimitive].setResultAndType(false, false);
+        InstructionDesc[OpEmitStreamVertex].setResultAndType(false, false);
+        InstructionDesc[OpEndStreamPrimitive].setResultAndType(false, false);
+        InstructionDesc[OpControlBarrier].setResultAndType(false, false);
+        InstructionDesc[OpMemoryBarrier].setResultAndType(false, false);
+        InstructionDesc[OpAtomicStore].setResultAndType(false, false);
+        InstructionDesc[OpLoopMerge].setResultAndType(false, false);
+        InstructionDesc[OpSelectionMerge].setResultAndType(false, false);
+        InstructionDesc[OpLabel].setResultAndType(true, false);
+        InstructionDesc[OpBranch].setResultAndType(false, false);
+        InstructionDesc[OpBranchConditional].setResultAndType(false, false);
+        InstructionDesc[OpSwitch].setResultAndType(false, false);
+        InstructionDesc[OpKill].setResultAndType(false, false);
+        InstructionDesc[OpTerminateInvocation].setResultAndType(false, false);
+        InstructionDesc[OpReturn].setResultAndType(false, false);
+        InstructionDesc[OpReturnValue].setResultAndType(false, false);
+        InstructionDesc[OpUnreachable].setResultAndType(false, false);
+        InstructionDesc[OpLifetimeStart].setResultAndType(false, false);
+        InstructionDesc[OpLifetimeStop].setResultAndType(false, false);
+        InstructionDesc[OpCommitReadPipe].setResultAndType(false, false);
+        InstructionDesc[OpCommitWritePipe].setResultAndType(false, false);
+        InstructionDesc[OpGroupCommitWritePipe].setResultAndType(false, false);
+        InstructionDesc[OpGroupCommitReadPipe].setResultAndType(false, false);
+        InstructionDesc[OpCaptureEventProfilingInfo].setResultAndType(false, false);
+        InstructionDesc[OpSetUserEventStatus].setResultAndType(false, false);
+        InstructionDesc[OpRetainEvent].setResultAndType(false, false);
+        InstructionDesc[OpReleaseEvent].setResultAndType(false, false);
+        InstructionDesc[OpGroupWaitEvents].setResultAndType(false, false);
+        InstructionDesc[OpAtomicFlagClear].setResultAndType(false, false);
+        InstructionDesc[OpModuleProcessed].setResultAndType(false, false);
+        InstructionDesc[OpTypeCooperativeMatrixNV].setResultAndType(true, false);
+        InstructionDesc[OpCooperativeMatrixStoreNV].setResultAndType(false, false);
+        InstructionDesc[OpBeginInvocationInterlockEXT].setResultAndType(false, false);
+        InstructionDesc[OpEndInvocationInterlockEXT].setResultAndType(false, false);
+
+        // Specific additional context-dependent operands
+
+        ExecutionModeOperands[ExecutionModeInvocations].push(OperandLiteralNumber, "'Number of <<Invocation,invocations>>'");
+
+        ExecutionModeOperands[ExecutionModeLocalSize].push(OperandLiteralNumber, "'x size'");
+        ExecutionModeOperands[ExecutionModeLocalSize].push(OperandLiteralNumber, "'y size'");
+        ExecutionModeOperands[ExecutionModeLocalSize].push(OperandLiteralNumber, "'z size'");
+
+        ExecutionModeOperands[ExecutionModeLocalSizeHint].push(OperandLiteralNumber, "'x size'");
+        ExecutionModeOperands[ExecutionModeLocalSizeHint].push(OperandLiteralNumber, "'y size'");
+        ExecutionModeOperands[ExecutionModeLocalSizeHint].push(OperandLiteralNumber, "'z size'");
+
+        ExecutionModeOperands[ExecutionModeOutputVertices].push(OperandLiteralNumber, "'Vertex count'");
+        ExecutionModeOperands[ExecutionModeVecTypeHint].push(OperandLiteralNumber, "'Vector type'");
+
+        DecorationOperands[DecorationStream].push(OperandLiteralNumber, "'Stream Number'");
+        DecorationOperands[DecorationLocation].push(OperandLiteralNumber, "'Location'");
+        DecorationOperands[DecorationComponent].push(OperandLiteralNumber, "'Component'");
+        DecorationOperands[DecorationIndex].push(OperandLiteralNumber, "'Index'");
+        DecorationOperands[DecorationBinding].push(OperandLiteralNumber, "'Binding Point'");
+        DecorationOperands[DecorationDescriptorSet].push(OperandLiteralNumber, "'Descriptor Set'");
+        DecorationOperands[DecorationOffset].push(OperandLiteralNumber, "'Byte Offset'");
+        DecorationOperands[DecorationXfbBuffer].push(OperandLiteralNumber, "'XFB Buffer Number'");
+        DecorationOperands[DecorationXfbStride].push(OperandLiteralNumber, "'XFB Stride'");
+        DecorationOperands[DecorationArrayStride].push(OperandLiteralNumber, "'Array Stride'");
+        DecorationOperands[DecorationMatrixStride].push(OperandLiteralNumber, "'Matrix Stride'");
+        DecorationOperands[DecorationBuiltIn].push(OperandLiteralNumber, "See <<BuiltIn,*BuiltIn*>>");
+        DecorationOperands[DecorationFPRoundingMode].push(OperandFPRoundingMode, "'Floating-Point Rounding Mode'");
+        DecorationOperands[DecorationFPFastMathMode].push(OperandFPFastMath, "'Fast-Math Mode'");
+        DecorationOperands[DecorationLinkageAttributes].push(OperandLiteralString, "'Name'");
+        DecorationOperands[DecorationLinkageAttributes].push(OperandLinkageType, "'Linkage Type'");
+        DecorationOperands[DecorationFuncParamAttr].push(OperandFuncParamAttr, "'Function Parameter Attribute'");
+        DecorationOperands[DecorationSpecId].push(OperandLiteralNumber, "'Specialization Constant ID'");
+        DecorationOperands[DecorationInputAttachmentIndex].push(OperandLiteralNumber, "'Attachment Index'");
+        DecorationOperands[DecorationAlignment].push(OperandLiteralNumber, "'Alignment'");
+
+        OperandClassParams[OperandSource].set(0, SourceString, nullptr);
+        OperandClassParams[OperandExecutionModel].set(0, ExecutionModelString, nullptr);
+        OperandClassParams[OperandAddressing].set(0, AddressingString, nullptr);
+        OperandClassParams[OperandMemory].set(0, MemoryString, nullptr);
+        OperandClassParams[OperandExecutionMode].set(ExecutionModeCeiling, ExecutionModeString, ExecutionModeParams);
+        OperandClassParams[OperandExecutionMode].setOperands(ExecutionModeOperands);
+        OperandClassParams[OperandStorage].set(0, StorageClassString, nullptr);
+        OperandClassParams[OperandDimensionality].set(0, DimensionString, nullptr);
+        OperandClassParams[OperandSamplerAddressingMode].set(0, SamplerAddressingModeString, nullptr);
+        OperandClassParams[OperandSamplerFilterMode].set(0, SamplerFilterModeString, nullptr);
+        OperandClassParams[OperandSamplerImageFormat].set(0, ImageFormatString, nullptr);
+        OperandClassParams[OperandImageChannelOrder].set(0, ImageChannelOrderString, nullptr);
+        OperandClassParams[OperandImageChannelDataType].set(0, ImageChannelDataTypeString, nullptr);
+        OperandClassParams[OperandImageOperands].set(ImageOperandsCeiling, ImageOperandsString, ImageOperandsParams, true);
+        OperandClassParams[OperandFPFastMath].set(0, FPFastMathString, nullptr, true);
+        OperandClassParams[OperandFPRoundingMode].set(0, FPRoundingModeString, nullptr);
+        OperandClassParams[OperandLinkageType].set(0, LinkageTypeString, nullptr);
+        OperandClassParams[OperandFuncParamAttr].set(0, FuncParamAttrString, nullptr);
+        OperandClassParams[OperandAccessQualifier].set(0, AccessQualifierString, nullptr);
+        OperandClassParams[OperandDecoration].set(DecorationCeiling, DecorationString, DecorationParams);
+        OperandClassParams[OperandDecoration].setOperands(DecorationOperands);
+        OperandClassParams[OperandBuiltIn].set(0, BuiltInString, nullptr);
+        OperandClassParams[OperandSelect].set(SelectControlCeiling, SelectControlString, SelectionControlParams, true);
+        OperandClassParams[OperandLoop].set(LoopControlCeiling, LoopControlString, LoopControlParams, true);
+        OperandClassParams[OperandFunction].set(FunctionControlCeiling, FunctionControlString, FunctionControlParams, true);
+        OperandClassParams[OperandMemorySemantics].set(0, MemorySemanticsString, nullptr, true);
+        OperandClassParams[OperandMemoryAccess].set(MemoryAccessCeiling, MemoryAccessString, MemoryAccessParams, true);
+        OperandClassParams[OperandScope].set(0, ScopeString, nullptr);
+        OperandClassParams[OperandGroupOperation].set(0, GroupOperationString, nullptr);
+        OperandClassParams[OperandKernelEnqueueFlags].set(0, KernelEnqueueFlagsString, nullptr);
+        OperandClassParams[OperandKernelProfilingInfo].set(0, KernelProfilingInfoString, nullptr, true);
+        OperandClassParams[OperandCapability].set(0, CapabilityString, nullptr);
+        OperandClassParams[OperandOpcode].set(OpCodeMask + 1, OpcodeString, nullptr);
+
+        // set name of operator, an initial set of <id> style operands, and the description
+
+        InstructionDesc[OpSource].operands.push(OperandSource, "");
+        InstructionDesc[OpSource].operands.push(OperandLiteralNumber, "'Version'");
+        InstructionDesc[OpSource].operands.push(OperandId, "'File'", true);
+        InstructionDesc[OpSource].operands.push(OperandLiteralString, "'Source'", true);
+
+        InstructionDesc[OpSourceContinued].operands.push(OperandLiteralString, "'Continued Source'");
+
+        InstructionDesc[OpSourceExtension].operands.push(OperandLiteralString, "'Extension'");
+
+        InstructionDesc[OpName].operands.push(OperandId, "'Target'");
+        InstructionDesc[OpName].operands.push(OperandLiteralString, "'Name'");
+
+        InstructionDesc[OpMemberName].operands.push(OperandId, "'Type'");
+        InstructionDesc[OpMemberName].operands.push(OperandLiteralNumber, "'Member'");
+        InstructionDesc[OpMemberName].operands.push(OperandLiteralString, "'Name'");
+
+        InstructionDesc[OpString].operands.push(OperandLiteralString, "'String'");
+
+        InstructionDesc[OpLine].operands.push(OperandId, "'File'");
+        InstructionDesc[OpLine].operands.push(OperandLiteralNumber, "'Line'");
+        InstructionDesc[OpLine].operands.push(OperandLiteralNumber, "'Column'");
+
+        InstructionDesc[OpExtension].operands.push(OperandLiteralString, "'Name'");
+
+        InstructionDesc[OpExtInstImport].operands.push(OperandLiteralString, "'Name'");
+
+        InstructionDesc[OpCapability].operands.push(OperandCapability, "'Capability'");
+
+        InstructionDesc[OpMemoryModel].operands.push(OperandAddressing, "");
+        InstructionDesc[OpMemoryModel].operands.push(OperandMemory, "");
+
+        InstructionDesc[OpEntryPoint].operands.push(OperandExecutionModel, "");
+        InstructionDesc[OpEntryPoint].operands.push(OperandId, "'Entry Point'");
+        InstructionDesc[OpEntryPoint].operands.push(OperandLiteralString, "'Name'");
+        InstructionDesc[OpEntryPoint].operands.push(OperandVariableIds, "'Interface'");
+
+        InstructionDesc[OpExecutionMode].operands.push(OperandId, "'Entry Point'");
+        InstructionDesc[OpExecutionMode].operands.push(OperandExecutionMode, "'Mode'");
+        InstructionDesc[OpExecutionMode].operands.push(OperandOptionalLiteral, "See <<Execution_Mode,Execution Mode>>");
+
+        InstructionDesc[OpExecutionModeId].operands.push(OperandId, "'Entry Point'");
+        InstructionDesc[OpExecutionModeId].operands.push(OperandExecutionMode, "'Mode'");
+        InstructionDesc[OpExecutionModeId].operands.push(OperandVariableIds, "See <<Execution_Mode,Execution Mode>>");
+
+        InstructionDesc[OpTypeInt].operands.push(OperandLiteralNumber, "'Width'");
+        InstructionDesc[OpTypeInt].operands.push(OperandLiteralNumber, "'Signedness'");
+
+        InstructionDesc[OpTypeFloat].operands.push(OperandLiteralNumber, "'Width'");
+
+        InstructionDesc[OpTypeVector].operands.push(OperandId, "'Component Type'");
+        InstructionDesc[OpTypeVector].operands.push(OperandLiteralNumber, "'Component Count'");
+
+        InstructionDesc[OpTypeMatrix].operands.push(OperandId, "'Column Type'");
+        InstructionDesc[OpTypeMatrix].operands.push(OperandLiteralNumber, "'Column Count'");
+
+        InstructionDesc[OpTypeImage].operands.push(OperandId, "'Sampled Type'");
+        InstructionDesc[OpTypeImage].operands.push(OperandDimensionality, "");
+        InstructionDesc[OpTypeImage].operands.push(OperandLiteralNumber, "'Depth'");
+        InstructionDesc[OpTypeImage].operands.push(OperandLiteralNumber, "'Arrayed'");
+        InstructionDesc[OpTypeImage].operands.push(OperandLiteralNumber, "'MS'");
+        InstructionDesc[OpTypeImage].operands.push(OperandLiteralNumber, "'Sampled'");
+        InstructionDesc[OpTypeImage].operands.push(OperandSamplerImageFormat, "");
+        InstructionDesc[OpTypeImage].operands.push(OperandAccessQualifier, "", true);
+
+        InstructionDesc[OpTypeSampledImage].operands.push(OperandId, "'Image Type'");
+
+        InstructionDesc[OpTypeArray].operands.push(OperandId, "'Element Type'");
+        InstructionDesc[OpTypeArray].operands.push(OperandId, "'Length'");
+
+        InstructionDesc[OpTypeRuntimeArray].operands.push(OperandId, "'Element Type'");
+
+        InstructionDesc[OpTypeStruct].operands.push(OperandVariableIds, "'Member 0 type', +\n'member 1 type', +\n...");
+
+        InstructionDesc[OpTypeOpaque].operands.push(OperandLiteralString, "The name of the opaque type.");
+
+        InstructionDesc[OpTypePointer].operands.push(OperandStorage, "");
+        InstructionDesc[OpTypePointer].operands.push(OperandId, "'Type'");
+
+        InstructionDesc[OpTypeForwardPointer].operands.push(OperandId, "'Pointer Type'");
+        InstructionDesc[OpTypeForwardPointer].operands.push(OperandStorage, "");
+
+        InstructionDesc[OpTypePipe].operands.push(OperandAccessQualifier, "'Qualifier'");
+
+        InstructionDesc[OpTypeFunction].operands.push(OperandId, "'Return Type'");
+        InstructionDesc[OpTypeFunction].operands.push(OperandVariableIds, "'Parameter 0 Type', +\n'Parameter 1 Type', +\n...");
+
+        InstructionDesc[OpConstant].operands.push(OperandVariableLiterals, "'Value'");
+
+        InstructionDesc[OpConstantComposite].operands.push(OperandVariableIds, "'Constituents'");
+
+        InstructionDesc[OpConstantSampler].operands.push(OperandSamplerAddressingMode, "");
+        InstructionDesc[OpConstantSampler].operands.push(OperandLiteralNumber, "'Param'");
+        InstructionDesc[OpConstantSampler].operands.push(OperandSamplerFilterMode, "");
+
+        InstructionDesc[OpSpecConstant].operands.push(OperandVariableLiterals, "'Value'");
+
+        InstructionDesc[OpSpecConstantComposite].operands.push(OperandVariableIds, "'Constituents'");
+
+        InstructionDesc[OpSpecConstantOp].operands.push(OperandLiteralNumber, "'Opcode'");
+        InstructionDesc[OpSpecConstantOp].operands.push(OperandVariableIds, "'Operands'");
+
+        InstructionDesc[OpVariable].operands.push(OperandStorage, "");
+        InstructionDesc[OpVariable].operands.push(OperandId, "'Initializer'", true);
+
+        InstructionDesc[OpFunction].operands.push(OperandFunction, "");
+        InstructionDesc[OpFunction].operands.push(OperandId, "'Function Type'");
+
+        InstructionDesc[OpFunctionCall].operands.push(OperandId, "'Function'");
+        InstructionDesc[OpFunctionCall].operands.push(OperandVariableIds, "'Argument 0', +\n'Argument 1', +\n...");
+
+        InstructionDesc[OpExtInst].operands.push(OperandId, "'Set'");
+        InstructionDesc[OpExtInst].operands.push(OperandLiteralNumber, "'Instruction'");
+        InstructionDesc[OpExtInst].operands.push(OperandVariableIds, "'Operand 1', +\n'Operand 2', +\n...");
+
+        InstructionDesc[OpLoad].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpLoad].operands.push(OperandMemoryAccess, "", true);
+        InstructionDesc[OpLoad].operands.push(OperandLiteralNumber, "", true);
+        InstructionDesc[OpLoad].operands.push(OperandId, "", true);
+
+        InstructionDesc[OpStore].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpStore].operands.push(OperandId, "'Object'");
+        InstructionDesc[OpStore].operands.push(OperandMemoryAccess, "", true);
+        InstructionDesc[OpStore].operands.push(OperandLiteralNumber, "", true);
+        InstructionDesc[OpStore].operands.push(OperandId, "", true);
+
+        InstructionDesc[OpPhi].operands.push(OperandVariableIds, "'Variable, Parent, ...'");
+
+        InstructionDesc[OpDecorate].operands.push(OperandId, "'Target'");
+        InstructionDesc[OpDecorate].operands.push(OperandDecoration, "");
+        InstructionDesc[OpDecorate].operands.push(OperandVariableLiterals, "See <<Decoration,'Decoration'>>.");
+
+        InstructionDesc[OpDecorateId].operands.push(OperandId, "'Target'");
+        InstructionDesc[OpDecorateId].operands.push(OperandDecoration, "");
+        InstructionDesc[OpDecorateId].operands.push(OperandVariableIds, "See <<Decoration,'Decoration'>>.");
+
+        InstructionDesc[OpDecorateStringGOOGLE].operands.push(OperandId, "'Target'");
+        InstructionDesc[OpDecorateStringGOOGLE].operands.push(OperandDecoration, "");
+        InstructionDesc[OpDecorateStringGOOGLE].operands.push(OperandVariableLiteralStrings, "'Literal Strings'");
+
+        InstructionDesc[OpMemberDecorate].operands.push(OperandId, "'Structure Type'");
+        InstructionDesc[OpMemberDecorate].operands.push(OperandLiteralNumber, "'Member'");
+        InstructionDesc[OpMemberDecorate].operands.push(OperandDecoration, "");
+        InstructionDesc[OpMemberDecorate].operands.push(OperandVariableLiterals, "See <<Decoration,'Decoration'>>.");
+
+        InstructionDesc[OpMemberDecorateStringGOOGLE].operands.push(OperandId, "'Structure Type'");
+        InstructionDesc[OpMemberDecorateStringGOOGLE].operands.push(OperandLiteralNumber, "'Member'");
+        InstructionDesc[OpMemberDecorateStringGOOGLE].operands.push(OperandDecoration, "");
+        InstructionDesc[OpMemberDecorateStringGOOGLE].operands.push(OperandVariableLiteralStrings, "'Literal Strings'");
+
+        InstructionDesc[OpGroupDecorate].operands.push(OperandId, "'Decoration Group'");
+        InstructionDesc[OpGroupDecorate].operands.push(OperandVariableIds, "'Targets'");
+
+        InstructionDesc[OpGroupMemberDecorate].operands.push(OperandId, "'Decoration Group'");
+        InstructionDesc[OpGroupMemberDecorate].operands.push(OperandVariableIdLiteral, "'Targets'");
+
+        InstructionDesc[OpVectorExtractDynamic].operands.push(OperandId, "'Vector'");
+        InstructionDesc[OpVectorExtractDynamic].operands.push(OperandId, "'Index'");
+
+        InstructionDesc[OpVectorInsertDynamic].operands.push(OperandId, "'Vector'");
+        InstructionDesc[OpVectorInsertDynamic].operands.push(OperandId, "'Component'");
+        InstructionDesc[OpVectorInsertDynamic].operands.push(OperandId, "'Index'");
+
+        InstructionDesc[OpVectorShuffle].operands.push(OperandId, "'Vector 1'");
+        InstructionDesc[OpVectorShuffle].operands.push(OperandId, "'Vector 2'");
+        InstructionDesc[OpVectorShuffle].operands.push(OperandVariableLiterals, "'Components'");
+
+        InstructionDesc[OpCompositeConstruct].operands.push(OperandVariableIds, "'Constituents'");
+
+        InstructionDesc[OpCompositeExtract].operands.push(OperandId, "'Composite'");
+        InstructionDesc[OpCompositeExtract].operands.push(OperandVariableLiterals, "'Indexes'");
+
+        InstructionDesc[OpCompositeInsert].operands.push(OperandId, "'Object'");
+        InstructionDesc[OpCompositeInsert].operands.push(OperandId, "'Composite'");
+        InstructionDesc[OpCompositeInsert].operands.push(OperandVariableLiterals, "'Indexes'");
+
+        InstructionDesc[OpCopyObject].operands.push(OperandId, "'Operand'");
+
+        InstructionDesc[OpCopyMemory].operands.push(OperandId, "'Target'");
+        InstructionDesc[OpCopyMemory].operands.push(OperandId, "'Source'");
+        InstructionDesc[OpCopyMemory].operands.push(OperandMemoryAccess, "", true);
+
+        InstructionDesc[OpCopyMemorySized].operands.push(OperandId, "'Target'");
+        InstructionDesc[OpCopyMemorySized].operands.push(OperandId, "'Source'");
+        InstructionDesc[OpCopyMemorySized].operands.push(OperandId, "'Size'");
+        InstructionDesc[OpCopyMemorySized].operands.push(OperandMemoryAccess, "", true);
+
+        InstructionDesc[OpSampledImage].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpSampledImage].operands.push(OperandId, "'Sampler'");
+
+        InstructionDesc[OpImage].operands.push(OperandId, "'Sampled Image'");
+
+        InstructionDesc[OpImageRead].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpImageRead].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageRead].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageRead].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageWrite].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpImageWrite].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageWrite].operands.push(OperandId, "'Texel'");
+        InstructionDesc[OpImageWrite].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageWrite].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageSampleImplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSampleImplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSampleImplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSampleImplicitLod].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageSampleExplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSampleExplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSampleExplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSampleExplicitLod].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageSampleDrefImplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSampleDrefImplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSampleDrefImplicitLod].operands.push(OperandId, "'D~ref~'");
+        InstructionDesc[OpImageSampleDrefImplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSampleDrefImplicitLod].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageSampleDrefExplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSampleDrefExplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSampleDrefExplicitLod].operands.push(OperandId, "'D~ref~'");
+        InstructionDesc[OpImageSampleDrefExplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSampleDrefExplicitLod].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageSampleProjImplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSampleProjImplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSampleProjImplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSampleProjImplicitLod].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageSampleProjExplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSampleProjExplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSampleProjExplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSampleProjExplicitLod].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageSampleProjDrefImplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSampleProjDrefImplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSampleProjDrefImplicitLod].operands.push(OperandId, "'D~ref~'");
+        InstructionDesc[OpImageSampleProjDrefImplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSampleProjDrefImplicitLod].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageSampleProjDrefExplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSampleProjDrefExplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSampleProjDrefExplicitLod].operands.push(OperandId, "'D~ref~'");
+        InstructionDesc[OpImageSampleProjDrefExplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSampleProjDrefExplicitLod].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageFetch].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpImageFetch].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageFetch].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageFetch].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageGather].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageGather].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageGather].operands.push(OperandId, "'Component'");
+        InstructionDesc[OpImageGather].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageGather].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageDrefGather].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageDrefGather].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageDrefGather].operands.push(OperandId, "'D~ref~'");
+        InstructionDesc[OpImageDrefGather].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageDrefGather].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageSparseSampleImplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSparseSampleImplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSparseSampleImplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSparseSampleImplicitLod].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageSparseSampleExplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSparseSampleExplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSparseSampleExplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSparseSampleExplicitLod].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageSparseSampleDrefImplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSparseSampleDrefImplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSparseSampleDrefImplicitLod].operands.push(OperandId, "'D~ref~'");
+        InstructionDesc[OpImageSparseSampleDrefImplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSparseSampleDrefImplicitLod].operands.push(OperandVariableIds, "", true);
+
+        InstructionDesc[OpImageSparseSampleDrefExplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSparseSampleDrefExplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSparseSampleDrefExplicitLod].operands.push(OperandId, "'D~ref~'");
+        InstructionDesc[OpImageSparseSampleDrefExplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSparseSampleDrefExplicitLod].operands.push(OperandVariableIds, "", true);
 
-    InstructionDesc[OpTypeForwardPointer].operands.push(OperandId, "'Pointer Type'");
-    InstructionDesc[OpTypeForwardPointer].operands.push(OperandStorage, "");
-
-    InstructionDesc[OpTypePipe].operands.push(OperandAccessQualifier, "'Qualifier'");
+        InstructionDesc[OpImageSparseSampleProjImplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSparseSampleProjImplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSparseSampleProjImplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSparseSampleProjImplicitLod].operands.push(OperandVariableIds, "", true);
 
-    InstructionDesc[OpTypeFunction].operands.push(OperandId, "'Return Type'");
-    InstructionDesc[OpTypeFunction].operands.push(OperandVariableIds, "'Parameter 0 Type', +\n'Parameter 1 Type', +\n...");
-
-    InstructionDesc[OpConstant].operands.push(OperandVariableLiterals, "'Value'");
-
-    InstructionDesc[OpConstantComposite].operands.push(OperandVariableIds, "'Constituents'");
+        InstructionDesc[OpImageSparseSampleProjExplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSparseSampleProjExplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSparseSampleProjExplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSparseSampleProjExplicitLod].operands.push(OperandVariableIds, "", true);
 
-    InstructionDesc[OpConstantSampler].operands.push(OperandSamplerAddressingMode, "");
-    InstructionDesc[OpConstantSampler].operands.push(OperandLiteralNumber, "'Param'");
-    InstructionDesc[OpConstantSampler].operands.push(OperandSamplerFilterMode, "");
+        InstructionDesc[OpImageSparseSampleProjDrefImplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSparseSampleProjDrefImplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSparseSampleProjDrefImplicitLod].operands.push(OperandId, "'D~ref~'");
+        InstructionDesc[OpImageSparseSampleProjDrefImplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSparseSampleProjDrefImplicitLod].operands.push(OperandVariableIds, "", true);
 
-    InstructionDesc[OpSpecConstant].operands.push(OperandVariableLiterals, "'Value'");
-
-    InstructionDesc[OpSpecConstantComposite].operands.push(OperandVariableIds, "'Constituents'");
+        InstructionDesc[OpImageSparseSampleProjDrefExplicitLod].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSparseSampleProjDrefExplicitLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSparseSampleProjDrefExplicitLod].operands.push(OperandId, "'D~ref~'");
+        InstructionDesc[OpImageSparseSampleProjDrefExplicitLod].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSparseSampleProjDrefExplicitLod].operands.push(OperandVariableIds, "", true);
 
-    InstructionDesc[OpSpecConstantOp].operands.push(OperandLiteralNumber, "'Opcode'");
-    InstructionDesc[OpSpecConstantOp].operands.push(OperandVariableIds, "'Operands'");
-
-    InstructionDesc[OpVariable].operands.push(OperandStorage, "");
-    InstructionDesc[OpVariable].operands.push(OperandId, "'Initializer'", true);
-
-    InstructionDesc[OpFunction].operands.push(OperandFunction, "");
-    InstructionDesc[OpFunction].operands.push(OperandId, "'Function Type'");
-
-    InstructionDesc[OpFunctionCall].operands.push(OperandId, "'Function'");
-    InstructionDesc[OpFunctionCall].operands.push(OperandVariableIds, "'Argument 0', +\n'Argument 1', +\n...");
-
-    InstructionDesc[OpExtInst].operands.push(OperandId, "'Set'");
-    InstructionDesc[OpExtInst].operands.push(OperandLiteralNumber, "'Instruction'");
-    InstructionDesc[OpExtInst].operands.push(OperandVariableIds, "'Operand 1', +\n'Operand 2', +\n...");
-
-    InstructionDesc[OpLoad].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpLoad].operands.push(OperandMemoryAccess, "", true);
-    InstructionDesc[OpLoad].operands.push(OperandLiteralNumber, "", true);
-    InstructionDesc[OpLoad].operands.push(OperandId, "", true);
-
-    InstructionDesc[OpStore].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpStore].operands.push(OperandId, "'Object'");
-    InstructionDesc[OpStore].operands.push(OperandMemoryAccess, "", true);
-    InstructionDesc[OpStore].operands.push(OperandLiteralNumber, "", true);
-    InstructionDesc[OpStore].operands.push(OperandId, "", true);
-
-    InstructionDesc[OpPhi].operands.push(OperandVariableIds, "'Variable, Parent, ...'");
-
-    InstructionDesc[OpDecorate].operands.push(OperandId, "'Target'");
-    InstructionDesc[OpDecorate].operands.push(OperandDecoration, "");
-    InstructionDesc[OpDecorate].operands.push(OperandVariableLiterals, "See <<Decoration,'Decoration'>>.");
-
-    InstructionDesc[OpDecorateId].operands.push(OperandId, "'Target'");
-    InstructionDesc[OpDecorateId].operands.push(OperandDecoration, "");
-    InstructionDesc[OpDecorateId].operands.push(OperandVariableIds, "See <<Decoration,'Decoration'>>.");
-
-    InstructionDesc[OpDecorateStringGOOGLE].operands.push(OperandId, "'Target'");
-    InstructionDesc[OpDecorateStringGOOGLE].operands.push(OperandDecoration, "");
-    InstructionDesc[OpDecorateStringGOOGLE].operands.push(OperandVariableLiteralStrings, "'Literal Strings'");
-
-    InstructionDesc[OpMemberDecorate].operands.push(OperandId, "'Structure Type'");
-    InstructionDesc[OpMemberDecorate].operands.push(OperandLiteralNumber, "'Member'");
-    InstructionDesc[OpMemberDecorate].operands.push(OperandDecoration, "");
-    InstructionDesc[OpMemberDecorate].operands.push(OperandVariableLiterals, "See <<Decoration,'Decoration'>>.");
-
-    InstructionDesc[OpMemberDecorateStringGOOGLE].operands.push(OperandId, "'Structure Type'");
-    InstructionDesc[OpMemberDecorateStringGOOGLE].operands.push(OperandLiteralNumber, "'Member'");
-    InstructionDesc[OpMemberDecorateStringGOOGLE].operands.push(OperandDecoration, "");
-    InstructionDesc[OpMemberDecorateStringGOOGLE].operands.push(OperandVariableLiteralStrings, "'Literal Strings'");
-
-    InstructionDesc[OpGroupDecorate].operands.push(OperandId, "'Decoration Group'");
-    InstructionDesc[OpGroupDecorate].operands.push(OperandVariableIds, "'Targets'");
-
-    InstructionDesc[OpGroupMemberDecorate].operands.push(OperandId, "'Decoration Group'");
-    InstructionDesc[OpGroupMemberDecorate].operands.push(OperandVariableIdLiteral, "'Targets'");
-
-    InstructionDesc[OpVectorExtractDynamic].operands.push(OperandId, "'Vector'");
-    InstructionDesc[OpVectorExtractDynamic].operands.push(OperandId, "'Index'");
-
-    InstructionDesc[OpVectorInsertDynamic].operands.push(OperandId, "'Vector'");
-    InstructionDesc[OpVectorInsertDynamic].operands.push(OperandId, "'Component'");
-    InstructionDesc[OpVectorInsertDynamic].operands.push(OperandId, "'Index'");
-
-    InstructionDesc[OpVectorShuffle].operands.push(OperandId, "'Vector 1'");
-    InstructionDesc[OpVectorShuffle].operands.push(OperandId, "'Vector 2'");
-    InstructionDesc[OpVectorShuffle].operands.push(OperandVariableLiterals, "'Components'");
-
-    InstructionDesc[OpCompositeConstruct].operands.push(OperandVariableIds, "'Constituents'");
-
-    InstructionDesc[OpCompositeExtract].operands.push(OperandId, "'Composite'");
-    InstructionDesc[OpCompositeExtract].operands.push(OperandVariableLiterals, "'Indexes'");
-
-    InstructionDesc[OpCompositeInsert].operands.push(OperandId, "'Object'");
-    InstructionDesc[OpCompositeInsert].operands.push(OperandId, "'Composite'");
-    InstructionDesc[OpCompositeInsert].operands.push(OperandVariableLiterals, "'Indexes'");
-
-    InstructionDesc[OpCopyObject].operands.push(OperandId, "'Operand'");
-
-    InstructionDesc[OpCopyMemory].operands.push(OperandId, "'Target'");
-    InstructionDesc[OpCopyMemory].operands.push(OperandId, "'Source'");
-    InstructionDesc[OpCopyMemory].operands.push(OperandMemoryAccess, "", true);
-
-    InstructionDesc[OpCopyMemorySized].operands.push(OperandId, "'Target'");
-    InstructionDesc[OpCopyMemorySized].operands.push(OperandId, "'Source'");
-    InstructionDesc[OpCopyMemorySized].operands.push(OperandId, "'Size'");
-    InstructionDesc[OpCopyMemorySized].operands.push(OperandMemoryAccess, "", true);
-
-    InstructionDesc[OpSampledImage].operands.push(OperandId, "'Image'");
-    InstructionDesc[OpSampledImage].operands.push(OperandId, "'Sampler'");
-
-    InstructionDesc[OpImage].operands.push(OperandId, "'Sampled Image'");
-
-    InstructionDesc[OpImageRead].operands.push(OperandId, "'Image'");
-    InstructionDesc[OpImageRead].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageRead].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageRead].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageWrite].operands.push(OperandId, "'Image'");
-    InstructionDesc[OpImageWrite].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageWrite].operands.push(OperandId, "'Texel'");
-    InstructionDesc[OpImageWrite].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageWrite].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageSampleImplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSampleImplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSampleImplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSampleImplicitLod].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageSampleExplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSampleExplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSampleExplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSampleExplicitLod].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageSampleDrefImplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSampleDrefImplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSampleDrefImplicitLod].operands.push(OperandId, "'D~ref~'");
-    InstructionDesc[OpImageSampleDrefImplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSampleDrefImplicitLod].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageSampleDrefExplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSampleDrefExplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSampleDrefExplicitLod].operands.push(OperandId, "'D~ref~'");
-    InstructionDesc[OpImageSampleDrefExplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSampleDrefExplicitLod].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageSampleProjImplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSampleProjImplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSampleProjImplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSampleProjImplicitLod].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageSampleProjExplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSampleProjExplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSampleProjExplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSampleProjExplicitLod].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageSampleProjDrefImplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSampleProjDrefImplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSampleProjDrefImplicitLod].operands.push(OperandId, "'D~ref~'");
-    InstructionDesc[OpImageSampleProjDrefImplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSampleProjDrefImplicitLod].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageSampleProjDrefExplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSampleProjDrefExplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSampleProjDrefExplicitLod].operands.push(OperandId, "'D~ref~'");
-    InstructionDesc[OpImageSampleProjDrefExplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSampleProjDrefExplicitLod].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageFetch].operands.push(OperandId, "'Image'");
-    InstructionDesc[OpImageFetch].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageFetch].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageFetch].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageGather].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageGather].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageGather].operands.push(OperandId, "'Component'");
-    InstructionDesc[OpImageGather].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageGather].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageDrefGather].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageDrefGather].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageDrefGather].operands.push(OperandId, "'D~ref~'");
-    InstructionDesc[OpImageDrefGather].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageDrefGather].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageSparseSampleImplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSparseSampleImplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSparseSampleImplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSparseSampleImplicitLod].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageSparseSampleExplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSparseSampleExplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSparseSampleExplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSparseSampleExplicitLod].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageSparseSampleDrefImplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSparseSampleDrefImplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSparseSampleDrefImplicitLod].operands.push(OperandId, "'D~ref~'");
-    InstructionDesc[OpImageSparseSampleDrefImplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSparseSampleDrefImplicitLod].operands.push(OperandVariableIds, "", true);
-
-    InstructionDesc[OpImageSparseSampleDrefExplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSparseSampleDrefExplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSparseSampleDrefExplicitLod].operands.push(OperandId, "'D~ref~'");
-    InstructionDesc[OpImageSparseSampleDrefExplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSparseSampleDrefExplicitLod].operands.push(OperandVariableIds, "", true);
+        InstructionDesc[OpImageSparseFetch].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpImageSparseFetch].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSparseFetch].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSparseFetch].operands.push(OperandVariableIds, "", true);
 
-    InstructionDesc[OpImageSparseSampleProjImplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSparseSampleProjImplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSparseSampleProjImplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSparseSampleProjImplicitLod].operands.push(OperandVariableIds, "", true);
+        InstructionDesc[OpImageSparseGather].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSparseGather].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSparseGather].operands.push(OperandId, "'Component'");
+        InstructionDesc[OpImageSparseGather].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSparseGather].operands.push(OperandVariableIds, "", true);
 
-    InstructionDesc[OpImageSparseSampleProjExplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSparseSampleProjExplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSparseSampleProjExplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSparseSampleProjExplicitLod].operands.push(OperandVariableIds, "", true);
+        InstructionDesc[OpImageSparseDrefGather].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSparseDrefGather].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSparseDrefGather].operands.push(OperandId, "'D~ref~'");
+        InstructionDesc[OpImageSparseDrefGather].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSparseDrefGather].operands.push(OperandVariableIds, "", true);
 
-    InstructionDesc[OpImageSparseSampleProjDrefImplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSparseSampleProjDrefImplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSparseSampleProjDrefImplicitLod].operands.push(OperandId, "'D~ref~'");
-    InstructionDesc[OpImageSparseSampleProjDrefImplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSparseSampleProjDrefImplicitLod].operands.push(OperandVariableIds, "", true);
+        InstructionDesc[OpImageSparseRead].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpImageSparseRead].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSparseRead].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSparseRead].operands.push(OperandVariableIds, "", true);
 
-    InstructionDesc[OpImageSparseSampleProjDrefExplicitLod].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSparseSampleProjDrefExplicitLod].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSparseSampleProjDrefExplicitLod].operands.push(OperandId, "'D~ref~'");
-    InstructionDesc[OpImageSparseSampleProjDrefExplicitLod].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSparseSampleProjDrefExplicitLod].operands.push(OperandVariableIds, "", true);
+        InstructionDesc[OpImageSparseTexelsResident].operands.push(OperandId, "'Resident Code'");
 
-    InstructionDesc[OpImageSparseFetch].operands.push(OperandId, "'Image'");
-    InstructionDesc[OpImageSparseFetch].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSparseFetch].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSparseFetch].operands.push(OperandVariableIds, "", true);
+        InstructionDesc[OpImageQuerySizeLod].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpImageQuerySizeLod].operands.push(OperandId, "'Level of Detail'");
 
-    InstructionDesc[OpImageSparseGather].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSparseGather].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSparseGather].operands.push(OperandId, "'Component'");
-    InstructionDesc[OpImageSparseGather].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSparseGather].operands.push(OperandVariableIds, "", true);
+        InstructionDesc[OpImageQuerySize].operands.push(OperandId, "'Image'");
 
-    InstructionDesc[OpImageSparseDrefGather].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSparseDrefGather].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSparseDrefGather].operands.push(OperandId, "'D~ref~'");
-    InstructionDesc[OpImageSparseDrefGather].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSparseDrefGather].operands.push(OperandVariableIds, "", true);
+        InstructionDesc[OpImageQueryLod].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpImageQueryLod].operands.push(OperandId, "'Coordinate'");
 
-    InstructionDesc[OpImageSparseRead].operands.push(OperandId, "'Image'");
-    InstructionDesc[OpImageSparseRead].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSparseRead].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSparseRead].operands.push(OperandVariableIds, "", true);
+        InstructionDesc[OpImageQueryLevels].operands.push(OperandId, "'Image'");
 
-    InstructionDesc[OpImageSparseTexelsResident].operands.push(OperandId, "'Resident Code'");
+        InstructionDesc[OpImageQuerySamples].operands.push(OperandId, "'Image'");
 
-    InstructionDesc[OpImageQuerySizeLod].operands.push(OperandId, "'Image'");
-    InstructionDesc[OpImageQuerySizeLod].operands.push(OperandId, "'Level of Detail'");
+        InstructionDesc[OpImageQueryFormat].operands.push(OperandId, "'Image'");
 
-    InstructionDesc[OpImageQuerySize].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpImageQueryOrder].operands.push(OperandId, "'Image'");
 
-    InstructionDesc[OpImageQueryLod].operands.push(OperandId, "'Image'");
-    InstructionDesc[OpImageQueryLod].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpAccessChain].operands.push(OperandId, "'Base'");
+        InstructionDesc[OpAccessChain].operands.push(OperandVariableIds, "'Indexes'");
 
-    InstructionDesc[OpImageQueryLevels].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpInBoundsAccessChain].operands.push(OperandId, "'Base'");
+        InstructionDesc[OpInBoundsAccessChain].operands.push(OperandVariableIds, "'Indexes'");
 
-    InstructionDesc[OpImageQuerySamples].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpPtrAccessChain].operands.push(OperandId, "'Base'");
+        InstructionDesc[OpPtrAccessChain].operands.push(OperandId, "'Element'");
+        InstructionDesc[OpPtrAccessChain].operands.push(OperandVariableIds, "'Indexes'");
 
-    InstructionDesc[OpImageQueryFormat].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpInBoundsPtrAccessChain].operands.push(OperandId, "'Base'");
+        InstructionDesc[OpInBoundsPtrAccessChain].operands.push(OperandId, "'Element'");
+        InstructionDesc[OpInBoundsPtrAccessChain].operands.push(OperandVariableIds, "'Indexes'");
 
-    InstructionDesc[OpImageQueryOrder].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpSNegate].operands.push(OperandId, "'Operand'");
 
-    InstructionDesc[OpAccessChain].operands.push(OperandId, "'Base'");
-    InstructionDesc[OpAccessChain].operands.push(OperandVariableIds, "'Indexes'");
+        InstructionDesc[OpFNegate].operands.push(OperandId, "'Operand'");
 
-    InstructionDesc[OpInBoundsAccessChain].operands.push(OperandId, "'Base'");
-    InstructionDesc[OpInBoundsAccessChain].operands.push(OperandVariableIds, "'Indexes'");
+        InstructionDesc[OpNot].operands.push(OperandId, "'Operand'");
 
-    InstructionDesc[OpPtrAccessChain].operands.push(OperandId, "'Base'");
-    InstructionDesc[OpPtrAccessChain].operands.push(OperandId, "'Element'");
-    InstructionDesc[OpPtrAccessChain].operands.push(OperandVariableIds, "'Indexes'");
+        InstructionDesc[OpAny].operands.push(OperandId, "'Vector'");
 
-    InstructionDesc[OpInBoundsPtrAccessChain].operands.push(OperandId, "'Base'");
-    InstructionDesc[OpInBoundsPtrAccessChain].operands.push(OperandId, "'Element'");
-    InstructionDesc[OpInBoundsPtrAccessChain].operands.push(OperandVariableIds, "'Indexes'");
+        InstructionDesc[OpAll].operands.push(OperandId, "'Vector'");
 
-    InstructionDesc[OpSNegate].operands.push(OperandId, "'Operand'");
+        InstructionDesc[OpConvertFToU].operands.push(OperandId, "'Float Value'");
 
-    InstructionDesc[OpFNegate].operands.push(OperandId, "'Operand'");
+        InstructionDesc[OpConvertFToS].operands.push(OperandId, "'Float Value'");
 
-    InstructionDesc[OpNot].operands.push(OperandId, "'Operand'");
+        InstructionDesc[OpConvertSToF].operands.push(OperandId, "'Signed Value'");
 
-    InstructionDesc[OpAny].operands.push(OperandId, "'Vector'");
+        InstructionDesc[OpConvertUToF].operands.push(OperandId, "'Unsigned Value'");
 
-    InstructionDesc[OpAll].operands.push(OperandId, "'Vector'");
+        InstructionDesc[OpUConvert].operands.push(OperandId, "'Unsigned Value'");
 
-    InstructionDesc[OpConvertFToU].operands.push(OperandId, "'Float Value'");
+        InstructionDesc[OpSConvert].operands.push(OperandId, "'Signed Value'");
 
-    InstructionDesc[OpConvertFToS].operands.push(OperandId, "'Float Value'");
+        InstructionDesc[OpFConvert].operands.push(OperandId, "'Float Value'");
 
-    InstructionDesc[OpConvertSToF].operands.push(OperandId, "'Signed Value'");
+        InstructionDesc[OpSatConvertSToU].operands.push(OperandId, "'Signed Value'");
 
-    InstructionDesc[OpConvertUToF].operands.push(OperandId, "'Unsigned Value'");
+        InstructionDesc[OpSatConvertUToS].operands.push(OperandId, "'Unsigned Value'");
 
-    InstructionDesc[OpUConvert].operands.push(OperandId, "'Unsigned Value'");
+        InstructionDesc[OpConvertPtrToU].operands.push(OperandId, "'Pointer'");
 
-    InstructionDesc[OpSConvert].operands.push(OperandId, "'Signed Value'");
+        InstructionDesc[OpConvertUToPtr].operands.push(OperandId, "'Integer Value'");
 
-    InstructionDesc[OpFConvert].operands.push(OperandId, "'Float Value'");
+        InstructionDesc[OpPtrCastToGeneric].operands.push(OperandId, "'Pointer'");
 
-    InstructionDesc[OpSatConvertSToU].operands.push(OperandId, "'Signed Value'");
+        InstructionDesc[OpGenericCastToPtr].operands.push(OperandId, "'Pointer'");
 
-    InstructionDesc[OpSatConvertUToS].operands.push(OperandId, "'Unsigned Value'");
+        InstructionDesc[OpGenericCastToPtrExplicit].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpGenericCastToPtrExplicit].operands.push(OperandStorage, "'Storage'");
 
-    InstructionDesc[OpConvertPtrToU].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpGenericPtrMemSemantics].operands.push(OperandId, "'Pointer'");
 
-    InstructionDesc[OpConvertUToPtr].operands.push(OperandId, "'Integer Value'");
+        InstructionDesc[OpBitcast].operands.push(OperandId, "'Operand'");
 
-    InstructionDesc[OpPtrCastToGeneric].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpQuantizeToF16].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpGenericCastToPtr].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpTranspose].operands.push(OperandId, "'Matrix'");
 
-    InstructionDesc[OpGenericCastToPtrExplicit].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpGenericCastToPtrExplicit].operands.push(OperandStorage, "'Storage'");
+        InstructionDesc[OpCopyLogical].operands.push(OperandId, "'Operand'");
 
-    InstructionDesc[OpGenericPtrMemSemantics].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpIsNan].operands.push(OperandId, "'x'");
 
-    InstructionDesc[OpBitcast].operands.push(OperandId, "'Operand'");
+        InstructionDesc[OpIsInf].operands.push(OperandId, "'x'");
 
-    InstructionDesc[OpQuantizeToF16].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpIsFinite].operands.push(OperandId, "'x'");
 
-    InstructionDesc[OpTranspose].operands.push(OperandId, "'Matrix'");
+        InstructionDesc[OpIsNormal].operands.push(OperandId, "'x'");
 
-    InstructionDesc[OpCopyLogical].operands.push(OperandId, "'Operand'");
+        InstructionDesc[OpSignBitSet].operands.push(OperandId, "'x'");
 
-    InstructionDesc[OpIsNan].operands.push(OperandId, "'x'");
+        InstructionDesc[OpLessOrGreater].operands.push(OperandId, "'x'");
+        InstructionDesc[OpLessOrGreater].operands.push(OperandId, "'y'");
 
-    InstructionDesc[OpIsInf].operands.push(OperandId, "'x'");
+        InstructionDesc[OpOrdered].operands.push(OperandId, "'x'");
+        InstructionDesc[OpOrdered].operands.push(OperandId, "'y'");
 
-    InstructionDesc[OpIsFinite].operands.push(OperandId, "'x'");
+        InstructionDesc[OpUnordered].operands.push(OperandId, "'x'");
+        InstructionDesc[OpUnordered].operands.push(OperandId, "'y'");
 
-    InstructionDesc[OpIsNormal].operands.push(OperandId, "'x'");
+        InstructionDesc[OpArrayLength].operands.push(OperandId, "'Structure'");
+        InstructionDesc[OpArrayLength].operands.push(OperandLiteralNumber, "'Array member'");
 
-    InstructionDesc[OpSignBitSet].operands.push(OperandId, "'x'");
+        InstructionDesc[OpIAdd].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpIAdd].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpLessOrGreater].operands.push(OperandId, "'x'");
-    InstructionDesc[OpLessOrGreater].operands.push(OperandId, "'y'");
+        InstructionDesc[OpFAdd].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFAdd].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpOrdered].operands.push(OperandId, "'x'");
-    InstructionDesc[OpOrdered].operands.push(OperandId, "'y'");
+        InstructionDesc[OpISub].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpISub].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpUnordered].operands.push(OperandId, "'x'");
-    InstructionDesc[OpUnordered].operands.push(OperandId, "'y'");
+        InstructionDesc[OpFSub].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFSub].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpArrayLength].operands.push(OperandId, "'Structure'");
-    InstructionDesc[OpArrayLength].operands.push(OperandLiteralNumber, "'Array member'");
+        InstructionDesc[OpIMul].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpIMul].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpIAdd].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpIAdd].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpFMul].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFMul].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpFAdd].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFAdd].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpUDiv].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpUDiv].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpISub].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpISub].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpSDiv].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpSDiv].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpFSub].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFSub].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpFDiv].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFDiv].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpIMul].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpIMul].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpUMod].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpUMod].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpFMul].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFMul].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpSRem].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpSRem].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpUDiv].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpUDiv].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpSMod].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpSMod].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpSDiv].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpSDiv].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpFRem].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFRem].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpFDiv].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFDiv].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpFMod].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFMod].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpUMod].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpUMod].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpVectorTimesScalar].operands.push(OperandId, "'Vector'");
+        InstructionDesc[OpVectorTimesScalar].operands.push(OperandId, "'Scalar'");
 
-    InstructionDesc[OpSRem].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpSRem].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpMatrixTimesScalar].operands.push(OperandId, "'Matrix'");
+        InstructionDesc[OpMatrixTimesScalar].operands.push(OperandId, "'Scalar'");
 
-    InstructionDesc[OpSMod].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpSMod].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpVectorTimesMatrix].operands.push(OperandId, "'Vector'");
+        InstructionDesc[OpVectorTimesMatrix].operands.push(OperandId, "'Matrix'");
 
-    InstructionDesc[OpFRem].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFRem].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpMatrixTimesVector].operands.push(OperandId, "'Matrix'");
+        InstructionDesc[OpMatrixTimesVector].operands.push(OperandId, "'Vector'");
 
-    InstructionDesc[OpFMod].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFMod].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpMatrixTimesMatrix].operands.push(OperandId, "'LeftMatrix'");
+        InstructionDesc[OpMatrixTimesMatrix].operands.push(OperandId, "'RightMatrix'");
 
-    InstructionDesc[OpVectorTimesScalar].operands.push(OperandId, "'Vector'");
-    InstructionDesc[OpVectorTimesScalar].operands.push(OperandId, "'Scalar'");
+        InstructionDesc[OpOuterProduct].operands.push(OperandId, "'Vector 1'");
+        InstructionDesc[OpOuterProduct].operands.push(OperandId, "'Vector 2'");
 
-    InstructionDesc[OpMatrixTimesScalar].operands.push(OperandId, "'Matrix'");
-    InstructionDesc[OpMatrixTimesScalar].operands.push(OperandId, "'Scalar'");
+        InstructionDesc[OpDot].operands.push(OperandId, "'Vector 1'");
+        InstructionDesc[OpDot].operands.push(OperandId, "'Vector 2'");
 
-    InstructionDesc[OpVectorTimesMatrix].operands.push(OperandId, "'Vector'");
-    InstructionDesc[OpVectorTimesMatrix].operands.push(OperandId, "'Matrix'");
+        InstructionDesc[OpIAddCarry].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpIAddCarry].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpMatrixTimesVector].operands.push(OperandId, "'Matrix'");
-    InstructionDesc[OpMatrixTimesVector].operands.push(OperandId, "'Vector'");
+        InstructionDesc[OpISubBorrow].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpISubBorrow].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpMatrixTimesMatrix].operands.push(OperandId, "'LeftMatrix'");
-    InstructionDesc[OpMatrixTimesMatrix].operands.push(OperandId, "'RightMatrix'");
+        InstructionDesc[OpUMulExtended].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpUMulExtended].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpOuterProduct].operands.push(OperandId, "'Vector 1'");
-    InstructionDesc[OpOuterProduct].operands.push(OperandId, "'Vector 2'");
+        InstructionDesc[OpSMulExtended].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpSMulExtended].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpDot].operands.push(OperandId, "'Vector 1'");
-    InstructionDesc[OpDot].operands.push(OperandId, "'Vector 2'");
+        InstructionDesc[OpShiftRightLogical].operands.push(OperandId, "'Base'");
+        InstructionDesc[OpShiftRightLogical].operands.push(OperandId, "'Shift'");
 
-    InstructionDesc[OpIAddCarry].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpIAddCarry].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpShiftRightArithmetic].operands.push(OperandId, "'Base'");
+        InstructionDesc[OpShiftRightArithmetic].operands.push(OperandId, "'Shift'");
 
-    InstructionDesc[OpISubBorrow].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpISubBorrow].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpShiftLeftLogical].operands.push(OperandId, "'Base'");
+        InstructionDesc[OpShiftLeftLogical].operands.push(OperandId, "'Shift'");
 
-    InstructionDesc[OpUMulExtended].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpUMulExtended].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpLogicalOr].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpLogicalOr].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpSMulExtended].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpSMulExtended].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpLogicalAnd].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpLogicalAnd].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpShiftRightLogical].operands.push(OperandId, "'Base'");
-    InstructionDesc[OpShiftRightLogical].operands.push(OperandId, "'Shift'");
+        InstructionDesc[OpLogicalEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpLogicalEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpShiftRightArithmetic].operands.push(OperandId, "'Base'");
-    InstructionDesc[OpShiftRightArithmetic].operands.push(OperandId, "'Shift'");
+        InstructionDesc[OpLogicalNotEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpLogicalNotEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpShiftLeftLogical].operands.push(OperandId, "'Base'");
-    InstructionDesc[OpShiftLeftLogical].operands.push(OperandId, "'Shift'");
+        InstructionDesc[OpLogicalNot].operands.push(OperandId, "'Operand'");
 
-    InstructionDesc[OpLogicalOr].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpLogicalOr].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpBitwiseOr].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpBitwiseOr].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpLogicalAnd].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpLogicalAnd].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpBitwiseXor].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpBitwiseXor].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpLogicalEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpLogicalEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpBitwiseAnd].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpBitwiseAnd].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpLogicalNotEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpLogicalNotEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpBitFieldInsert].operands.push(OperandId, "'Base'");
+        InstructionDesc[OpBitFieldInsert].operands.push(OperandId, "'Insert'");
+        InstructionDesc[OpBitFieldInsert].operands.push(OperandId, "'Offset'");
+        InstructionDesc[OpBitFieldInsert].operands.push(OperandId, "'Count'");
 
-    InstructionDesc[OpLogicalNot].operands.push(OperandId, "'Operand'");
+        InstructionDesc[OpBitFieldSExtract].operands.push(OperandId, "'Base'");
+        InstructionDesc[OpBitFieldSExtract].operands.push(OperandId, "'Offset'");
+        InstructionDesc[OpBitFieldSExtract].operands.push(OperandId, "'Count'");
 
-    InstructionDesc[OpBitwiseOr].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpBitwiseOr].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpBitFieldUExtract].operands.push(OperandId, "'Base'");
+        InstructionDesc[OpBitFieldUExtract].operands.push(OperandId, "'Offset'");
+        InstructionDesc[OpBitFieldUExtract].operands.push(OperandId, "'Count'");
 
-    InstructionDesc[OpBitwiseXor].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpBitwiseXor].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpBitReverse].operands.push(OperandId, "'Base'");
 
-    InstructionDesc[OpBitwiseAnd].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpBitwiseAnd].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpBitCount].operands.push(OperandId, "'Base'");
 
-    InstructionDesc[OpBitFieldInsert].operands.push(OperandId, "'Base'");
-    InstructionDesc[OpBitFieldInsert].operands.push(OperandId, "'Insert'");
-    InstructionDesc[OpBitFieldInsert].operands.push(OperandId, "'Offset'");
-    InstructionDesc[OpBitFieldInsert].operands.push(OperandId, "'Count'");
+        InstructionDesc[OpSelect].operands.push(OperandId, "'Condition'");
+        InstructionDesc[OpSelect].operands.push(OperandId, "'Object 1'");
+        InstructionDesc[OpSelect].operands.push(OperandId, "'Object 2'");
 
-    InstructionDesc[OpBitFieldSExtract].operands.push(OperandId, "'Base'");
-    InstructionDesc[OpBitFieldSExtract].operands.push(OperandId, "'Offset'");
-    InstructionDesc[OpBitFieldSExtract].operands.push(OperandId, "'Count'");
+        InstructionDesc[OpIEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpIEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpBitFieldUExtract].operands.push(OperandId, "'Base'");
-    InstructionDesc[OpBitFieldUExtract].operands.push(OperandId, "'Offset'");
-    InstructionDesc[OpBitFieldUExtract].operands.push(OperandId, "'Count'");
+        InstructionDesc[OpFOrdEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFOrdEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpBitReverse].operands.push(OperandId, "'Base'");
+        InstructionDesc[OpFUnordEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFUnordEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpBitCount].operands.push(OperandId, "'Base'");
+        InstructionDesc[OpINotEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpINotEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpSelect].operands.push(OperandId, "'Condition'");
-    InstructionDesc[OpSelect].operands.push(OperandId, "'Object 1'");
-    InstructionDesc[OpSelect].operands.push(OperandId, "'Object 2'");
+        InstructionDesc[OpFOrdNotEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFOrdNotEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpIEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpIEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpFUnordNotEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFUnordNotEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpFOrdEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFOrdEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpULessThan].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpULessThan].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpFUnordEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFUnordEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpSLessThan].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpSLessThan].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpINotEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpINotEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpFOrdLessThan].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFOrdLessThan].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpFOrdNotEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFOrdNotEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpFUnordLessThan].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFUnordLessThan].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpFUnordNotEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFUnordNotEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpUGreaterThan].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpUGreaterThan].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpULessThan].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpULessThan].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpSGreaterThan].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpSGreaterThan].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpSLessThan].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpSLessThan].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpFOrdGreaterThan].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFOrdGreaterThan].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpFOrdLessThan].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFOrdLessThan].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpFUnordGreaterThan].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFUnordGreaterThan].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpFUnordLessThan].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFUnordLessThan].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpULessThanEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpULessThanEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpUGreaterThan].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpUGreaterThan].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpSLessThanEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpSLessThanEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpSGreaterThan].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpSGreaterThan].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpFOrdLessThanEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFOrdLessThanEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpFOrdGreaterThan].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFOrdGreaterThan].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpFUnordLessThanEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFUnordLessThanEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpFUnordGreaterThan].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFUnordGreaterThan].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpUGreaterThanEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpUGreaterThanEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpULessThanEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpULessThanEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpSGreaterThanEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpSGreaterThanEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpSLessThanEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpSLessThanEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpFOrdGreaterThanEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFOrdGreaterThanEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpFOrdLessThanEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFOrdLessThanEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpFUnordGreaterThanEqual].operands.push(OperandId, "'Operand 1'");
+        InstructionDesc[OpFUnordGreaterThanEqual].operands.push(OperandId, "'Operand 2'");
 
-    InstructionDesc[OpFUnordLessThanEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFUnordLessThanEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpDPdx].operands.push(OperandId, "'P'");
 
-    InstructionDesc[OpUGreaterThanEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpUGreaterThanEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpDPdy].operands.push(OperandId, "'P'");
 
-    InstructionDesc[OpSGreaterThanEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpSGreaterThanEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpFwidth].operands.push(OperandId, "'P'");
 
-    InstructionDesc[OpFOrdGreaterThanEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFOrdGreaterThanEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpDPdxFine].operands.push(OperandId, "'P'");
 
-    InstructionDesc[OpFUnordGreaterThanEqual].operands.push(OperandId, "'Operand 1'");
-    InstructionDesc[OpFUnordGreaterThanEqual].operands.push(OperandId, "'Operand 2'");
+        InstructionDesc[OpDPdyFine].operands.push(OperandId, "'P'");
 
-    InstructionDesc[OpDPdx].operands.push(OperandId, "'P'");
+        InstructionDesc[OpFwidthFine].operands.push(OperandId, "'P'");
 
-    InstructionDesc[OpDPdy].operands.push(OperandId, "'P'");
+        InstructionDesc[OpDPdxCoarse].operands.push(OperandId, "'P'");
 
-    InstructionDesc[OpFwidth].operands.push(OperandId, "'P'");
+        InstructionDesc[OpDPdyCoarse].operands.push(OperandId, "'P'");
 
-    InstructionDesc[OpDPdxFine].operands.push(OperandId, "'P'");
+        InstructionDesc[OpFwidthCoarse].operands.push(OperandId, "'P'");
 
-    InstructionDesc[OpDPdyFine].operands.push(OperandId, "'P'");
+        InstructionDesc[OpEmitStreamVertex].operands.push(OperandId, "'Stream'");
 
-    InstructionDesc[OpFwidthFine].operands.push(OperandId, "'P'");
+        InstructionDesc[OpEndStreamPrimitive].operands.push(OperandId, "'Stream'");
 
-    InstructionDesc[OpDPdxCoarse].operands.push(OperandId, "'P'");
+        InstructionDesc[OpControlBarrier].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpControlBarrier].operands.push(OperandScope, "'Memory'");
+        InstructionDesc[OpControlBarrier].operands.push(OperandMemorySemantics, "'Semantics'");
 
-    InstructionDesc[OpDPdyCoarse].operands.push(OperandId, "'P'");
+        InstructionDesc[OpMemoryBarrier].operands.push(OperandScope, "'Memory'");
+        InstructionDesc[OpMemoryBarrier].operands.push(OperandMemorySemantics, "'Semantics'");
 
-    InstructionDesc[OpFwidthCoarse].operands.push(OperandId, "'P'");
+        InstructionDesc[OpImageTexelPointer].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpImageTexelPointer].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageTexelPointer].operands.push(OperandId, "'Sample'");
 
-    InstructionDesc[OpEmitStreamVertex].operands.push(OperandId, "'Stream'");
+        InstructionDesc[OpAtomicLoad].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicLoad].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicLoad].operands.push(OperandMemorySemantics, "'Semantics'");
 
-    InstructionDesc[OpEndStreamPrimitive].operands.push(OperandId, "'Stream'");
+        InstructionDesc[OpAtomicStore].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicStore].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicStore].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicStore].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpControlBarrier].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpControlBarrier].operands.push(OperandScope, "'Memory'");
-    InstructionDesc[OpControlBarrier].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicExchange].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicExchange].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicExchange].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicExchange].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpMemoryBarrier].operands.push(OperandScope, "'Memory'");
-    InstructionDesc[OpMemoryBarrier].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicCompareExchange].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicCompareExchange].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicCompareExchange].operands.push(OperandMemorySemantics, "'Equal'");
+        InstructionDesc[OpAtomicCompareExchange].operands.push(OperandMemorySemantics, "'Unequal'");
+        InstructionDesc[OpAtomicCompareExchange].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpAtomicCompareExchange].operands.push(OperandId, "'Comparator'");
 
-    InstructionDesc[OpImageTexelPointer].operands.push(OperandId, "'Image'");
-    InstructionDesc[OpImageTexelPointer].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageTexelPointer].operands.push(OperandId, "'Sample'");
+        InstructionDesc[OpAtomicCompareExchangeWeak].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicCompareExchangeWeak].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicCompareExchangeWeak].operands.push(OperandMemorySemantics, "'Equal'");
+        InstructionDesc[OpAtomicCompareExchangeWeak].operands.push(OperandMemorySemantics, "'Unequal'");
+        InstructionDesc[OpAtomicCompareExchangeWeak].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpAtomicCompareExchangeWeak].operands.push(OperandId, "'Comparator'");
 
-    InstructionDesc[OpAtomicLoad].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicLoad].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicLoad].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicIIncrement].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicIIncrement].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicIIncrement].operands.push(OperandMemorySemantics, "'Semantics'");
 
-    InstructionDesc[OpAtomicStore].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicStore].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicStore].operands.push(OperandMemorySemantics, "'Semantics'");
-    InstructionDesc[OpAtomicStore].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpAtomicIDecrement].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicIDecrement].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicIDecrement].operands.push(OperandMemorySemantics, "'Semantics'");
 
-    InstructionDesc[OpAtomicExchange].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicExchange].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicExchange].operands.push(OperandMemorySemantics, "'Semantics'");
-    InstructionDesc[OpAtomicExchange].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpAtomicIAdd].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicIAdd].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicIAdd].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicIAdd].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpAtomicCompareExchange].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicCompareExchange].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicCompareExchange].operands.push(OperandMemorySemantics, "'Equal'");
-    InstructionDesc[OpAtomicCompareExchange].operands.push(OperandMemorySemantics, "'Unequal'");
-    InstructionDesc[OpAtomicCompareExchange].operands.push(OperandId, "'Value'");
-    InstructionDesc[OpAtomicCompareExchange].operands.push(OperandId, "'Comparator'");
+        InstructionDesc[OpAtomicFAddEXT].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicFAddEXT].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicFAddEXT].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicFAddEXT].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpAtomicCompareExchangeWeak].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicCompareExchangeWeak].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicCompareExchangeWeak].operands.push(OperandMemorySemantics, "'Equal'");
-    InstructionDesc[OpAtomicCompareExchangeWeak].operands.push(OperandMemorySemantics, "'Unequal'");
-    InstructionDesc[OpAtomicCompareExchangeWeak].operands.push(OperandId, "'Value'");
-    InstructionDesc[OpAtomicCompareExchangeWeak].operands.push(OperandId, "'Comparator'");
+        InstructionDesc[OpAtomicISub].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicISub].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicISub].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicISub].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpAtomicIIncrement].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicIIncrement].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicIIncrement].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicUMin].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicUMin].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicUMin].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicUMin].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpAtomicIDecrement].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicIDecrement].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicIDecrement].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicUMax].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicUMax].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicUMax].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicUMax].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpAtomicIAdd].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicIAdd].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicIAdd].operands.push(OperandMemorySemantics, "'Semantics'");
-    InstructionDesc[OpAtomicIAdd].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpAtomicSMin].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicSMin].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicSMin].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicSMin].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpAtomicFAddEXT].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicFAddEXT].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicFAddEXT].operands.push(OperandMemorySemantics, "'Semantics'");
-    InstructionDesc[OpAtomicFAddEXT].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpAtomicSMax].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicSMax].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicSMax].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicSMax].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpAtomicISub].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicISub].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicISub].operands.push(OperandMemorySemantics, "'Semantics'");
-    InstructionDesc[OpAtomicISub].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpAtomicFMinEXT].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicFMinEXT].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicFMinEXT].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicFMinEXT].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpAtomicUMin].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicUMin].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicUMin].operands.push(OperandMemorySemantics, "'Semantics'");
-    InstructionDesc[OpAtomicUMin].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpAtomicFMaxEXT].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicFMaxEXT].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicFMaxEXT].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicFMaxEXT].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpAtomicUMax].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicUMax].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicUMax].operands.push(OperandMemorySemantics, "'Semantics'");
-    InstructionDesc[OpAtomicUMax].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpAtomicAnd].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicAnd].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicAnd].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicAnd].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpAtomicSMin].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicSMin].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicSMin].operands.push(OperandMemorySemantics, "'Semantics'");
-    InstructionDesc[OpAtomicSMin].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpAtomicOr].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicOr].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicOr].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicOr].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpAtomicSMax].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicSMax].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicSMax].operands.push(OperandMemorySemantics, "'Semantics'");
-    InstructionDesc[OpAtomicSMax].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpAtomicXor].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicXor].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicXor].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpAtomicXor].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpAtomicFMinEXT].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicFMinEXT].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicFMinEXT].operands.push(OperandMemorySemantics, "'Semantics'");
-    InstructionDesc[OpAtomicFMinEXT].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpAtomicFlagTestAndSet].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicFlagTestAndSet].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicFlagTestAndSet].operands.push(OperandMemorySemantics, "'Semantics'");
 
-    InstructionDesc[OpAtomicFMaxEXT].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicFMaxEXT].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicFMaxEXT].operands.push(OperandMemorySemantics, "'Semantics'");
-    InstructionDesc[OpAtomicFMaxEXT].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpAtomicFlagClear].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpAtomicFlagClear].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpAtomicFlagClear].operands.push(OperandMemorySemantics, "'Semantics'");
 
-    InstructionDesc[OpAtomicAnd].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicAnd].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicAnd].operands.push(OperandMemorySemantics, "'Semantics'");
-    InstructionDesc[OpAtomicAnd].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpLoopMerge].operands.push(OperandId, "'Merge Block'");
+        InstructionDesc[OpLoopMerge].operands.push(OperandId, "'Continue Target'");
+        InstructionDesc[OpLoopMerge].operands.push(OperandLoop, "");
+        InstructionDesc[OpLoopMerge].operands.push(OperandOptionalLiteral, "");
 
-    InstructionDesc[OpAtomicOr].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicOr].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicOr].operands.push(OperandMemorySemantics, "'Semantics'");
-    InstructionDesc[OpAtomicOr].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpSelectionMerge].operands.push(OperandId, "'Merge Block'");
+        InstructionDesc[OpSelectionMerge].operands.push(OperandSelect, "");
 
-    InstructionDesc[OpAtomicXor].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicXor].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicXor].operands.push(OperandMemorySemantics, "'Semantics'");
-    InstructionDesc[OpAtomicXor].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpBranch].operands.push(OperandId, "'Target Label'");
 
-    InstructionDesc[OpAtomicFlagTestAndSet].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicFlagTestAndSet].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicFlagTestAndSet].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpBranchConditional].operands.push(OperandId, "'Condition'");
+        InstructionDesc[OpBranchConditional].operands.push(OperandId, "'True Label'");
+        InstructionDesc[OpBranchConditional].operands.push(OperandId, "'False Label'");
+        InstructionDesc[OpBranchConditional].operands.push(OperandVariableLiterals, "'Branch weights'");
 
-    InstructionDesc[OpAtomicFlagClear].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpAtomicFlagClear].operands.push(OperandScope, "'Scope'");
-    InstructionDesc[OpAtomicFlagClear].operands.push(OperandMemorySemantics, "'Semantics'");
+        InstructionDesc[OpSwitch].operands.push(OperandId, "'Selector'");
+        InstructionDesc[OpSwitch].operands.push(OperandId, "'Default'");
+        InstructionDesc[OpSwitch].operands.push(OperandVariableLiteralId, "'Target'");
 
-    InstructionDesc[OpLoopMerge].operands.push(OperandId, "'Merge Block'");
-    InstructionDesc[OpLoopMerge].operands.push(OperandId, "'Continue Target'");
-    InstructionDesc[OpLoopMerge].operands.push(OperandLoop, "");
-    InstructionDesc[OpLoopMerge].operands.push(OperandOptionalLiteral, "");
 
-    InstructionDesc[OpSelectionMerge].operands.push(OperandId, "'Merge Block'");
-    InstructionDesc[OpSelectionMerge].operands.push(OperandSelect, "");
+        InstructionDesc[OpReturnValue].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpBranch].operands.push(OperandId, "'Target Label'");
+        InstructionDesc[OpLifetimeStart].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpLifetimeStart].operands.push(OperandLiteralNumber, "'Size'");
 
-    InstructionDesc[OpBranchConditional].operands.push(OperandId, "'Condition'");
-    InstructionDesc[OpBranchConditional].operands.push(OperandId, "'True Label'");
-    InstructionDesc[OpBranchConditional].operands.push(OperandId, "'False Label'");
-    InstructionDesc[OpBranchConditional].operands.push(OperandVariableLiterals, "'Branch weights'");
+        InstructionDesc[OpLifetimeStop].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpLifetimeStop].operands.push(OperandLiteralNumber, "'Size'");
 
-    InstructionDesc[OpSwitch].operands.push(OperandId, "'Selector'");
-    InstructionDesc[OpSwitch].operands.push(OperandId, "'Default'");
-    InstructionDesc[OpSwitch].operands.push(OperandVariableLiteralId, "'Target'");
+        InstructionDesc[OpGroupAsyncCopy].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupAsyncCopy].operands.push(OperandId, "'Destination'");
+        InstructionDesc[OpGroupAsyncCopy].operands.push(OperandId, "'Source'");
+        InstructionDesc[OpGroupAsyncCopy].operands.push(OperandId, "'Num Elements'");
+        InstructionDesc[OpGroupAsyncCopy].operands.push(OperandId, "'Stride'");
+        InstructionDesc[OpGroupAsyncCopy].operands.push(OperandId, "'Event'");
 
+        InstructionDesc[OpGroupWaitEvents].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupWaitEvents].operands.push(OperandId, "'Num Events'");
+        InstructionDesc[OpGroupWaitEvents].operands.push(OperandId, "'Events List'");
 
-    InstructionDesc[OpReturnValue].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpGroupAll].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupAll].operands.push(OperandId, "'Predicate'");
 
-    InstructionDesc[OpLifetimeStart].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpLifetimeStart].operands.push(OperandLiteralNumber, "'Size'");
+        InstructionDesc[OpGroupAny].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupAny].operands.push(OperandId, "'Predicate'");
 
-    InstructionDesc[OpLifetimeStop].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpLifetimeStop].operands.push(OperandLiteralNumber, "'Size'");
+        InstructionDesc[OpGroupBroadcast].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupBroadcast].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpGroupBroadcast].operands.push(OperandId, "'LocalId'");
 
-    InstructionDesc[OpGroupAsyncCopy].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupAsyncCopy].operands.push(OperandId, "'Destination'");
-    InstructionDesc[OpGroupAsyncCopy].operands.push(OperandId, "'Source'");
-    InstructionDesc[OpGroupAsyncCopy].operands.push(OperandId, "'Num Elements'");
-    InstructionDesc[OpGroupAsyncCopy].operands.push(OperandId, "'Stride'");
-    InstructionDesc[OpGroupAsyncCopy].operands.push(OperandId, "'Event'");
+        InstructionDesc[OpGroupIAdd].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupIAdd].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupIAdd].operands.push(OperandId, "'X'");
 
-    InstructionDesc[OpGroupWaitEvents].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupWaitEvents].operands.push(OperandId, "'Num Events'");
-    InstructionDesc[OpGroupWaitEvents].operands.push(OperandId, "'Events List'");
+        InstructionDesc[OpGroupFAdd].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupFAdd].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupFAdd].operands.push(OperandId, "'X'");
 
-    InstructionDesc[OpGroupAll].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupAll].operands.push(OperandId, "'Predicate'");
+        InstructionDesc[OpGroupUMin].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupUMin].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupUMin].operands.push(OperandId, "'X'");
 
-    InstructionDesc[OpGroupAny].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupAny].operands.push(OperandId, "'Predicate'");
+        InstructionDesc[OpGroupSMin].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupSMin].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupSMin].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupBroadcast].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupBroadcast].operands.push(OperandId, "'Value'");
-    InstructionDesc[OpGroupBroadcast].operands.push(OperandId, "'LocalId'");
+        InstructionDesc[OpGroupFMin].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupFMin].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupFMin].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupIAdd].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupIAdd].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupIAdd].operands.push(OperandId, "'X'");
+        InstructionDesc[OpGroupUMax].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupUMax].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupUMax].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupFAdd].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupFAdd].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupFAdd].operands.push(OperandId, "'X'");
+        InstructionDesc[OpGroupSMax].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupSMax].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupSMax].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupUMin].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupUMin].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupUMin].operands.push(OperandId, "'X'");
+        InstructionDesc[OpGroupFMax].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupFMax].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupFMax].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupSMin].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupSMin].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupSMin].operands.push(OperandId, "X");
+        InstructionDesc[OpReadPipe].operands.push(OperandId, "'Pipe'");
+        InstructionDesc[OpReadPipe].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpReadPipe].operands.push(OperandId, "'Packet Size'");
+        InstructionDesc[OpReadPipe].operands.push(OperandId, "'Packet Alignment'");
 
-    InstructionDesc[OpGroupFMin].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupFMin].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupFMin].operands.push(OperandId, "X");
+        InstructionDesc[OpWritePipe].operands.push(OperandId, "'Pipe'");
+        InstructionDesc[OpWritePipe].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpWritePipe].operands.push(OperandId, "'Packet Size'");
+        InstructionDesc[OpWritePipe].operands.push(OperandId, "'Packet Alignment'");
 
-    InstructionDesc[OpGroupUMax].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupUMax].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupUMax].operands.push(OperandId, "X");
+        InstructionDesc[OpReservedReadPipe].operands.push(OperandId, "'Pipe'");
+        InstructionDesc[OpReservedReadPipe].operands.push(OperandId, "'Reserve Id'");
+        InstructionDesc[OpReservedReadPipe].operands.push(OperandId, "'Index'");
+        InstructionDesc[OpReservedReadPipe].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpReservedReadPipe].operands.push(OperandId, "'Packet Size'");
+        InstructionDesc[OpReservedReadPipe].operands.push(OperandId, "'Packet Alignment'");
 
-    InstructionDesc[OpGroupSMax].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupSMax].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupSMax].operands.push(OperandId, "X");
+        InstructionDesc[OpReservedWritePipe].operands.push(OperandId, "'Pipe'");
+        InstructionDesc[OpReservedWritePipe].operands.push(OperandId, "'Reserve Id'");
+        InstructionDesc[OpReservedWritePipe].operands.push(OperandId, "'Index'");
+        InstructionDesc[OpReservedWritePipe].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpReservedWritePipe].operands.push(OperandId, "'Packet Size'");
+        InstructionDesc[OpReservedWritePipe].operands.push(OperandId, "'Packet Alignment'");
 
-    InstructionDesc[OpGroupFMax].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupFMax].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupFMax].operands.push(OperandId, "X");
+        InstructionDesc[OpReserveReadPipePackets].operands.push(OperandId, "'Pipe'");
+        InstructionDesc[OpReserveReadPipePackets].operands.push(OperandId, "'Num Packets'");
+        InstructionDesc[OpReserveReadPipePackets].operands.push(OperandId, "'Packet Size'");
+        InstructionDesc[OpReserveReadPipePackets].operands.push(OperandId, "'Packet Alignment'");
 
-    InstructionDesc[OpReadPipe].operands.push(OperandId, "'Pipe'");
-    InstructionDesc[OpReadPipe].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpReadPipe].operands.push(OperandId, "'Packet Size'");
-    InstructionDesc[OpReadPipe].operands.push(OperandId, "'Packet Alignment'");
+        InstructionDesc[OpReserveWritePipePackets].operands.push(OperandId, "'Pipe'");
+        InstructionDesc[OpReserveWritePipePackets].operands.push(OperandId, "'Num Packets'");
+        InstructionDesc[OpReserveWritePipePackets].operands.push(OperandId, "'Packet Size'");
+        InstructionDesc[OpReserveWritePipePackets].operands.push(OperandId, "'Packet Alignment'");
 
-    InstructionDesc[OpWritePipe].operands.push(OperandId, "'Pipe'");
-    InstructionDesc[OpWritePipe].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpWritePipe].operands.push(OperandId, "'Packet Size'");
-    InstructionDesc[OpWritePipe].operands.push(OperandId, "'Packet Alignment'");
+        InstructionDesc[OpCommitReadPipe].operands.push(OperandId, "'Pipe'");
+        InstructionDesc[OpCommitReadPipe].operands.push(OperandId, "'Reserve Id'");
+        InstructionDesc[OpCommitReadPipe].operands.push(OperandId, "'Packet Size'");
+        InstructionDesc[OpCommitReadPipe].operands.push(OperandId, "'Packet Alignment'");
 
-    InstructionDesc[OpReservedReadPipe].operands.push(OperandId, "'Pipe'");
-    InstructionDesc[OpReservedReadPipe].operands.push(OperandId, "'Reserve Id'");
-    InstructionDesc[OpReservedReadPipe].operands.push(OperandId, "'Index'");
-    InstructionDesc[OpReservedReadPipe].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpReservedReadPipe].operands.push(OperandId, "'Packet Size'");
-    InstructionDesc[OpReservedReadPipe].operands.push(OperandId, "'Packet Alignment'");
+        InstructionDesc[OpCommitWritePipe].operands.push(OperandId, "'Pipe'");
+        InstructionDesc[OpCommitWritePipe].operands.push(OperandId, "'Reserve Id'");
+        InstructionDesc[OpCommitWritePipe].operands.push(OperandId, "'Packet Size'");
+        InstructionDesc[OpCommitWritePipe].operands.push(OperandId, "'Packet Alignment'");
 
-    InstructionDesc[OpReservedWritePipe].operands.push(OperandId, "'Pipe'");
-    InstructionDesc[OpReservedWritePipe].operands.push(OperandId, "'Reserve Id'");
-    InstructionDesc[OpReservedWritePipe].operands.push(OperandId, "'Index'");
-    InstructionDesc[OpReservedWritePipe].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpReservedWritePipe].operands.push(OperandId, "'Packet Size'");
-    InstructionDesc[OpReservedWritePipe].operands.push(OperandId, "'Packet Alignment'");
+        InstructionDesc[OpIsValidReserveId].operands.push(OperandId, "'Reserve Id'");
 
-    InstructionDesc[OpReserveReadPipePackets].operands.push(OperandId, "'Pipe'");
-    InstructionDesc[OpReserveReadPipePackets].operands.push(OperandId, "'Num Packets'");
-    InstructionDesc[OpReserveReadPipePackets].operands.push(OperandId, "'Packet Size'");
-    InstructionDesc[OpReserveReadPipePackets].operands.push(OperandId, "'Packet Alignment'");
+        InstructionDesc[OpGetNumPipePackets].operands.push(OperandId, "'Pipe'");
+        InstructionDesc[OpGetNumPipePackets].operands.push(OperandId, "'Packet Size'");
+        InstructionDesc[OpGetNumPipePackets].operands.push(OperandId, "'Packet Alignment'");
 
-    InstructionDesc[OpReserveWritePipePackets].operands.push(OperandId, "'Pipe'");
-    InstructionDesc[OpReserveWritePipePackets].operands.push(OperandId, "'Num Packets'");
-    InstructionDesc[OpReserveWritePipePackets].operands.push(OperandId, "'Packet Size'");
-    InstructionDesc[OpReserveWritePipePackets].operands.push(OperandId, "'Packet Alignment'");
+        InstructionDesc[OpGetMaxPipePackets].operands.push(OperandId, "'Pipe'");
+        InstructionDesc[OpGetMaxPipePackets].operands.push(OperandId, "'Packet Size'");
+        InstructionDesc[OpGetMaxPipePackets].operands.push(OperandId, "'Packet Alignment'");
 
-    InstructionDesc[OpCommitReadPipe].operands.push(OperandId, "'Pipe'");
-    InstructionDesc[OpCommitReadPipe].operands.push(OperandId, "'Reserve Id'");
-    InstructionDesc[OpCommitReadPipe].operands.push(OperandId, "'Packet Size'");
-    InstructionDesc[OpCommitReadPipe].operands.push(OperandId, "'Packet Alignment'");
+        InstructionDesc[OpGroupReserveReadPipePackets].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupReserveReadPipePackets].operands.push(OperandId, "'Pipe'");
+        InstructionDesc[OpGroupReserveReadPipePackets].operands.push(OperandId, "'Num Packets'");
+        InstructionDesc[OpGroupReserveReadPipePackets].operands.push(OperandId, "'Packet Size'");
+        InstructionDesc[OpGroupReserveReadPipePackets].operands.push(OperandId, "'Packet Alignment'");
 
-    InstructionDesc[OpCommitWritePipe].operands.push(OperandId, "'Pipe'");
-    InstructionDesc[OpCommitWritePipe].operands.push(OperandId, "'Reserve Id'");
-    InstructionDesc[OpCommitWritePipe].operands.push(OperandId, "'Packet Size'");
-    InstructionDesc[OpCommitWritePipe].operands.push(OperandId, "'Packet Alignment'");
+        InstructionDesc[OpGroupReserveWritePipePackets].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupReserveWritePipePackets].operands.push(OperandId, "'Pipe'");
+        InstructionDesc[OpGroupReserveWritePipePackets].operands.push(OperandId, "'Num Packets'");
+        InstructionDesc[OpGroupReserveWritePipePackets].operands.push(OperandId, "'Packet Size'");
+        InstructionDesc[OpGroupReserveWritePipePackets].operands.push(OperandId, "'Packet Alignment'");
 
-    InstructionDesc[OpIsValidReserveId].operands.push(OperandId, "'Reserve Id'");
+        InstructionDesc[OpGroupCommitReadPipe].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupCommitReadPipe].operands.push(OperandId, "'Pipe'");
+        InstructionDesc[OpGroupCommitReadPipe].operands.push(OperandId, "'Reserve Id'");
+        InstructionDesc[OpGroupCommitReadPipe].operands.push(OperandId, "'Packet Size'");
+        InstructionDesc[OpGroupCommitReadPipe].operands.push(OperandId, "'Packet Alignment'");
 
-    InstructionDesc[OpGetNumPipePackets].operands.push(OperandId, "'Pipe'");
-    InstructionDesc[OpGetNumPipePackets].operands.push(OperandId, "'Packet Size'");
-    InstructionDesc[OpGetNumPipePackets].operands.push(OperandId, "'Packet Alignment'");
+        InstructionDesc[OpGroupCommitWritePipe].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupCommitWritePipe].operands.push(OperandId, "'Pipe'");
+        InstructionDesc[OpGroupCommitWritePipe].operands.push(OperandId, "'Reserve Id'");
+        InstructionDesc[OpGroupCommitWritePipe].operands.push(OperandId, "'Packet Size'");
+        InstructionDesc[OpGroupCommitWritePipe].operands.push(OperandId, "'Packet Alignment'");
 
-    InstructionDesc[OpGetMaxPipePackets].operands.push(OperandId, "'Pipe'");
-    InstructionDesc[OpGetMaxPipePackets].operands.push(OperandId, "'Packet Size'");
-    InstructionDesc[OpGetMaxPipePackets].operands.push(OperandId, "'Packet Alignment'");
+        InstructionDesc[OpBuildNDRange].operands.push(OperandId, "'GlobalWorkSize'");
+        InstructionDesc[OpBuildNDRange].operands.push(OperandId, "'LocalWorkSize'");
+        InstructionDesc[OpBuildNDRange].operands.push(OperandId, "'GlobalWorkOffset'");
 
-    InstructionDesc[OpGroupReserveReadPipePackets].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupReserveReadPipePackets].operands.push(OperandId, "'Pipe'");
-    InstructionDesc[OpGroupReserveReadPipePackets].operands.push(OperandId, "'Num Packets'");
-    InstructionDesc[OpGroupReserveReadPipePackets].operands.push(OperandId, "'Packet Size'");
-    InstructionDesc[OpGroupReserveReadPipePackets].operands.push(OperandId, "'Packet Alignment'");
+        InstructionDesc[OpCaptureEventProfilingInfo].operands.push(OperandId, "'Event'");
+        InstructionDesc[OpCaptureEventProfilingInfo].operands.push(OperandId, "'Profiling Info'");
+        InstructionDesc[OpCaptureEventProfilingInfo].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpGroupReserveWritePipePackets].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupReserveWritePipePackets].operands.push(OperandId, "'Pipe'");
-    InstructionDesc[OpGroupReserveWritePipePackets].operands.push(OperandId, "'Num Packets'");
-    InstructionDesc[OpGroupReserveWritePipePackets].operands.push(OperandId, "'Packet Size'");
-    InstructionDesc[OpGroupReserveWritePipePackets].operands.push(OperandId, "'Packet Alignment'");
+        InstructionDesc[OpSetUserEventStatus].operands.push(OperandId, "'Event'");
+        InstructionDesc[OpSetUserEventStatus].operands.push(OperandId, "'Status'");
 
-    InstructionDesc[OpGroupCommitReadPipe].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupCommitReadPipe].operands.push(OperandId, "'Pipe'");
-    InstructionDesc[OpGroupCommitReadPipe].operands.push(OperandId, "'Reserve Id'");
-    InstructionDesc[OpGroupCommitReadPipe].operands.push(OperandId, "'Packet Size'");
-    InstructionDesc[OpGroupCommitReadPipe].operands.push(OperandId, "'Packet Alignment'");
+        InstructionDesc[OpIsValidEvent].operands.push(OperandId, "'Event'");
 
-    InstructionDesc[OpGroupCommitWritePipe].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupCommitWritePipe].operands.push(OperandId, "'Pipe'");
-    InstructionDesc[OpGroupCommitWritePipe].operands.push(OperandId, "'Reserve Id'");
-    InstructionDesc[OpGroupCommitWritePipe].operands.push(OperandId, "'Packet Size'");
-    InstructionDesc[OpGroupCommitWritePipe].operands.push(OperandId, "'Packet Alignment'");
+        InstructionDesc[OpRetainEvent].operands.push(OperandId, "'Event'");
 
-    InstructionDesc[OpBuildNDRange].operands.push(OperandId, "'GlobalWorkSize'");
-    InstructionDesc[OpBuildNDRange].operands.push(OperandId, "'LocalWorkSize'");
-    InstructionDesc[OpBuildNDRange].operands.push(OperandId, "'GlobalWorkOffset'");
+        InstructionDesc[OpReleaseEvent].operands.push(OperandId, "'Event'");
 
-    InstructionDesc[OpCaptureEventProfilingInfo].operands.push(OperandId, "'Event'");
-    InstructionDesc[OpCaptureEventProfilingInfo].operands.push(OperandId, "'Profiling Info'");
-    InstructionDesc[OpCaptureEventProfilingInfo].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpGetKernelWorkGroupSize].operands.push(OperandId, "'Invoke'");
+        InstructionDesc[OpGetKernelWorkGroupSize].operands.push(OperandId, "'Param'");
+        InstructionDesc[OpGetKernelWorkGroupSize].operands.push(OperandId, "'Param Size'");
+        InstructionDesc[OpGetKernelWorkGroupSize].operands.push(OperandId, "'Param Align'");
 
-    InstructionDesc[OpSetUserEventStatus].operands.push(OperandId, "'Event'");
-    InstructionDesc[OpSetUserEventStatus].operands.push(OperandId, "'Status'");
+        InstructionDesc[OpGetKernelPreferredWorkGroupSizeMultiple].operands.push(OperandId, "'Invoke'");
+        InstructionDesc[OpGetKernelPreferredWorkGroupSizeMultiple].operands.push(OperandId, "'Param'");
+        InstructionDesc[OpGetKernelPreferredWorkGroupSizeMultiple].operands.push(OperandId, "'Param Size'");
+        InstructionDesc[OpGetKernelPreferredWorkGroupSizeMultiple].operands.push(OperandId, "'Param Align'");
 
-    InstructionDesc[OpIsValidEvent].operands.push(OperandId, "'Event'");
+        InstructionDesc[OpGetKernelNDrangeSubGroupCount].operands.push(OperandId, "'ND Range'");
+        InstructionDesc[OpGetKernelNDrangeSubGroupCount].operands.push(OperandId, "'Invoke'");
+        InstructionDesc[OpGetKernelNDrangeSubGroupCount].operands.push(OperandId, "'Param'");
+        InstructionDesc[OpGetKernelNDrangeSubGroupCount].operands.push(OperandId, "'Param Size'");
+        InstructionDesc[OpGetKernelNDrangeSubGroupCount].operands.push(OperandId, "'Param Align'");
 
-    InstructionDesc[OpRetainEvent].operands.push(OperandId, "'Event'");
+        InstructionDesc[OpGetKernelNDrangeMaxSubGroupSize].operands.push(OperandId, "'ND Range'");
+        InstructionDesc[OpGetKernelNDrangeMaxSubGroupSize].operands.push(OperandId, "'Invoke'");
+        InstructionDesc[OpGetKernelNDrangeMaxSubGroupSize].operands.push(OperandId, "'Param'");
+        InstructionDesc[OpGetKernelNDrangeMaxSubGroupSize].operands.push(OperandId, "'Param Size'");
+        InstructionDesc[OpGetKernelNDrangeMaxSubGroupSize].operands.push(OperandId, "'Param Align'");
 
-    InstructionDesc[OpReleaseEvent].operands.push(OperandId, "'Event'");
+        InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Queue'");
+        InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Flags'");
+        InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'ND Range'");
+        InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Num Events'");
+        InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Wait Events'");
+        InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Ret Event'");
+        InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Invoke'");
+        InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Param'");
+        InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Param Size'");
+        InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Param Align'");
+        InstructionDesc[OpEnqueueKernel].operands.push(OperandVariableIds, "'Local Size'");
 
-    InstructionDesc[OpGetKernelWorkGroupSize].operands.push(OperandId, "'Invoke'");
-    InstructionDesc[OpGetKernelWorkGroupSize].operands.push(OperandId, "'Param'");
-    InstructionDesc[OpGetKernelWorkGroupSize].operands.push(OperandId, "'Param Size'");
-    InstructionDesc[OpGetKernelWorkGroupSize].operands.push(OperandId, "'Param Align'");
+        InstructionDesc[OpEnqueueMarker].operands.push(OperandId, "'Queue'");
+        InstructionDesc[OpEnqueueMarker].operands.push(OperandId, "'Num Events'");
+        InstructionDesc[OpEnqueueMarker].operands.push(OperandId, "'Wait Events'");
+        InstructionDesc[OpEnqueueMarker].operands.push(OperandId, "'Ret Event'");
 
-    InstructionDesc[OpGetKernelPreferredWorkGroupSizeMultiple].operands.push(OperandId, "'Invoke'");
-    InstructionDesc[OpGetKernelPreferredWorkGroupSizeMultiple].operands.push(OperandId, "'Param'");
-    InstructionDesc[OpGetKernelPreferredWorkGroupSizeMultiple].operands.push(OperandId, "'Param Size'");
-    InstructionDesc[OpGetKernelPreferredWorkGroupSizeMultiple].operands.push(OperandId, "'Param Align'");
+        InstructionDesc[OpGroupNonUniformElect].operands.push(OperandScope, "'Execution'");
 
-    InstructionDesc[OpGetKernelNDrangeSubGroupCount].operands.push(OperandId, "'ND Range'");
-    InstructionDesc[OpGetKernelNDrangeSubGroupCount].operands.push(OperandId, "'Invoke'");
-    InstructionDesc[OpGetKernelNDrangeSubGroupCount].operands.push(OperandId, "'Param'");
-    InstructionDesc[OpGetKernelNDrangeSubGroupCount].operands.push(OperandId, "'Param Size'");
-    InstructionDesc[OpGetKernelNDrangeSubGroupCount].operands.push(OperandId, "'Param Align'");
+        InstructionDesc[OpGroupNonUniformAll].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformAll].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGetKernelNDrangeMaxSubGroupSize].operands.push(OperandId, "'ND Range'");
-    InstructionDesc[OpGetKernelNDrangeMaxSubGroupSize].operands.push(OperandId, "'Invoke'");
-    InstructionDesc[OpGetKernelNDrangeMaxSubGroupSize].operands.push(OperandId, "'Param'");
-    InstructionDesc[OpGetKernelNDrangeMaxSubGroupSize].operands.push(OperandId, "'Param Size'");
-    InstructionDesc[OpGetKernelNDrangeMaxSubGroupSize].operands.push(OperandId, "'Param Align'");
+        InstructionDesc[OpGroupNonUniformAny].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformAny].operands.push(OperandId, "X");
 
-    InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Queue'");
-    InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Flags'");
-    InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'ND Range'");
-    InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Num Events'");
-    InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Wait Events'");
-    InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Ret Event'");
-    InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Invoke'");
-    InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Param'");
-    InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Param Size'");
-    InstructionDesc[OpEnqueueKernel].operands.push(OperandId, "'Param Align'");
-    InstructionDesc[OpEnqueueKernel].operands.push(OperandVariableIds, "'Local Size'");
+        InstructionDesc[OpGroupNonUniformAllEqual].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformAllEqual].operands.push(OperandId, "X");
 
-    InstructionDesc[OpEnqueueMarker].operands.push(OperandId, "'Queue'");
-    InstructionDesc[OpEnqueueMarker].operands.push(OperandId, "'Num Events'");
-    InstructionDesc[OpEnqueueMarker].operands.push(OperandId, "'Wait Events'");
-    InstructionDesc[OpEnqueueMarker].operands.push(OperandId, "'Ret Event'");
+        InstructionDesc[OpGroupNonUniformBroadcast].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformBroadcast].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformBroadcast].operands.push(OperandId, "ID");
 
-    InstructionDesc[OpGroupNonUniformElect].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformBroadcastFirst].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformBroadcastFirst].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupNonUniformAll].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformAll].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformBallot].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformBallot].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupNonUniformAny].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformAny].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformInverseBallot].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformInverseBallot].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupNonUniformAllEqual].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformAllEqual].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformBallotBitExtract].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformBallotBitExtract].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformBallotBitExtract].operands.push(OperandId, "Bit");
 
-    InstructionDesc[OpGroupNonUniformBroadcast].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformBroadcast].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformBroadcast].operands.push(OperandId, "ID");
+        InstructionDesc[OpGroupNonUniformBallotBitCount].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformBallotBitCount].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformBallotBitCount].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupNonUniformBroadcastFirst].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformBroadcastFirst].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformBallotFindLSB].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformBallotFindLSB].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupNonUniformBallot].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformBallot].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformBallotFindMSB].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformBallotFindMSB].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupNonUniformInverseBallot].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformInverseBallot].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformShuffle].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformShuffle].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformShuffle].operands.push(OperandId, "'Id'");
 
-    InstructionDesc[OpGroupNonUniformBallotBitExtract].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformBallotBitExtract].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformBallotBitExtract].operands.push(OperandId, "Bit");
+        InstructionDesc[OpGroupNonUniformShuffleXor].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformShuffleXor].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformShuffleXor].operands.push(OperandId, "Mask");
 
-    InstructionDesc[OpGroupNonUniformBallotBitCount].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformBallotBitCount].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformBallotBitCount].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformShuffleUp].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformShuffleUp].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformShuffleUp].operands.push(OperandId, "Offset");
 
-    InstructionDesc[OpGroupNonUniformBallotFindLSB].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformBallotFindLSB].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformShuffleDown].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformShuffleDown].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformShuffleDown].operands.push(OperandId, "Offset");
 
-    InstructionDesc[OpGroupNonUniformBallotFindMSB].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformBallotFindMSB].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformIAdd].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformIAdd].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformIAdd].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformIAdd].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformShuffle].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformShuffle].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformShuffle].operands.push(OperandId, "'Id'");
+        InstructionDesc[OpGroupNonUniformFAdd].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformFAdd].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformFAdd].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformFAdd].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformShuffleXor].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformShuffleXor].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformShuffleXor].operands.push(OperandId, "Mask");
+        InstructionDesc[OpGroupNonUniformIMul].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformIMul].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformIMul].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformIMul].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformShuffleUp].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformShuffleUp].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformShuffleUp].operands.push(OperandId, "Offset");
+        InstructionDesc[OpGroupNonUniformFMul].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformFMul].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformFMul].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformFMul].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformShuffleDown].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformShuffleDown].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformShuffleDown].operands.push(OperandId, "Offset");
+        InstructionDesc[OpGroupNonUniformSMin].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformSMin].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformSMin].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformSMin].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformIAdd].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformIAdd].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformIAdd].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformIAdd].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpGroupNonUniformUMin].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformUMin].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformUMin].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformUMin].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformFAdd].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformFAdd].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformFAdd].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformFAdd].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpGroupNonUniformFMin].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformFMin].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformFMin].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformFMin].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformIMul].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformIMul].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformIMul].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformIMul].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpGroupNonUniformSMax].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformSMax].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformSMax].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformSMax].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformFMul].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformFMul].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformFMul].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformFMul].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpGroupNonUniformUMax].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformUMax].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformUMax].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformUMax].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformSMin].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformSMin].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformSMin].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformSMin].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpGroupNonUniformFMax].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformFMax].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformFMax].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformFMax].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformUMin].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformUMin].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformUMin].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformUMin].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpGroupNonUniformBitwiseAnd].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformBitwiseAnd].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformBitwiseAnd].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformBitwiseAnd].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformFMin].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformFMin].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformFMin].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformFMin].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpGroupNonUniformBitwiseOr].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformBitwiseOr].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformBitwiseOr].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformBitwiseOr].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformSMax].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformSMax].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformSMax].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformSMax].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpGroupNonUniformBitwiseXor].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformBitwiseXor].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformBitwiseXor].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformBitwiseXor].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformUMax].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformUMax].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformUMax].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformUMax].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpGroupNonUniformLogicalAnd].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformLogicalAnd].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformLogicalAnd].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformLogicalAnd].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformFMax].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformFMax].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformFMax].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformFMax].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpGroupNonUniformLogicalOr].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformLogicalOr].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformLogicalOr].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformLogicalOr].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformBitwiseAnd].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformBitwiseAnd].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformBitwiseAnd].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformBitwiseAnd].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpGroupNonUniformLogicalXor].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformLogicalXor].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupNonUniformLogicalXor].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformLogicalXor].operands.push(OperandId, "'ClusterSize'", true);
 
-    InstructionDesc[OpGroupNonUniformBitwiseOr].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformBitwiseOr].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformBitwiseOr].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformBitwiseOr].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpGroupNonUniformQuadBroadcast].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformQuadBroadcast].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformQuadBroadcast].operands.push(OperandId, "'Id'");
 
-    InstructionDesc[OpGroupNonUniformBitwiseXor].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformBitwiseXor].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformBitwiseXor].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformBitwiseXor].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpGroupNonUniformQuadSwap].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupNonUniformQuadSwap].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformQuadSwap].operands.push(OperandId, "'Direction'");
 
-    InstructionDesc[OpGroupNonUniformLogicalAnd].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformLogicalAnd].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformLogicalAnd].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformLogicalAnd].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpSubgroupBallotKHR].operands.push(OperandId, "'Predicate'");
 
-    InstructionDesc[OpGroupNonUniformLogicalOr].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformLogicalOr].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformLogicalOr].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformLogicalOr].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpSubgroupFirstInvocationKHR].operands.push(OperandId, "'Value'");
 
-    InstructionDesc[OpGroupNonUniformLogicalXor].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformLogicalXor].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupNonUniformLogicalXor].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformLogicalXor].operands.push(OperandId, "'ClusterSize'", true);
+        InstructionDesc[OpSubgroupAnyKHR].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpSubgroupAnyKHR].operands.push(OperandId, "'Predicate'");
 
-    InstructionDesc[OpGroupNonUniformQuadBroadcast].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformQuadBroadcast].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformQuadBroadcast].operands.push(OperandId, "'Id'");
+        InstructionDesc[OpSubgroupAllKHR].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpSubgroupAllKHR].operands.push(OperandId, "'Predicate'");
 
-    InstructionDesc[OpGroupNonUniformQuadSwap].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupNonUniformQuadSwap].operands.push(OperandId, "X");
-    InstructionDesc[OpGroupNonUniformQuadSwap].operands.push(OperandId, "'Direction'");
+        InstructionDesc[OpSubgroupAllEqualKHR].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpSubgroupAllEqualKHR].operands.push(OperandId, "'Predicate'");
 
-    InstructionDesc[OpSubgroupBallotKHR].operands.push(OperandId, "'Predicate'");
+        InstructionDesc[OpSubgroupReadInvocationKHR].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpSubgroupReadInvocationKHR].operands.push(OperandId, "'Index'");
 
-    InstructionDesc[OpSubgroupFirstInvocationKHR].operands.push(OperandId, "'Value'");
+        InstructionDesc[OpModuleProcessed].operands.push(OperandLiteralString, "'process'");
 
-    InstructionDesc[OpSubgroupAnyKHR].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpSubgroupAnyKHR].operands.push(OperandId, "'Predicate'");
+        InstructionDesc[OpGroupIAddNonUniformAMD].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupIAddNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupIAddNonUniformAMD].operands.push(OperandId, "'X'");
 
-    InstructionDesc[OpSubgroupAllKHR].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpSubgroupAllKHR].operands.push(OperandId, "'Predicate'");
+        InstructionDesc[OpGroupFAddNonUniformAMD].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupFAddNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupFAddNonUniformAMD].operands.push(OperandId, "'X'");
 
-    InstructionDesc[OpSubgroupAllEqualKHR].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpSubgroupAllEqualKHR].operands.push(OperandId, "'Predicate'");
+        InstructionDesc[OpGroupUMinNonUniformAMD].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupUMinNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupUMinNonUniformAMD].operands.push(OperandId, "'X'");
 
-    InstructionDesc[OpSubgroupReadInvocationKHR].operands.push(OperandId, "'Value'");
-    InstructionDesc[OpSubgroupReadInvocationKHR].operands.push(OperandId, "'Index'");
+        InstructionDesc[OpGroupSMinNonUniformAMD].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupSMinNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupSMinNonUniformAMD].operands.push(OperandId, "X");
 
-    InstructionDesc[OpModuleProcessed].operands.push(OperandLiteralString, "'process'");
+        InstructionDesc[OpGroupFMinNonUniformAMD].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupFMinNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupFMinNonUniformAMD].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupIAddNonUniformAMD].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupIAddNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupIAddNonUniformAMD].operands.push(OperandId, "'X'");
+        InstructionDesc[OpGroupUMaxNonUniformAMD].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupUMaxNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupUMaxNonUniformAMD].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupFAddNonUniformAMD].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupFAddNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupFAddNonUniformAMD].operands.push(OperandId, "'X'");
+        InstructionDesc[OpGroupSMaxNonUniformAMD].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupSMaxNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupSMaxNonUniformAMD].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupUMinNonUniformAMD].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupUMinNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupUMinNonUniformAMD].operands.push(OperandId, "'X'");
+        InstructionDesc[OpGroupFMaxNonUniformAMD].operands.push(OperandScope, "'Execution'");
+        InstructionDesc[OpGroupFMaxNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
+        InstructionDesc[OpGroupFMaxNonUniformAMD].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupSMinNonUniformAMD].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupSMinNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupSMinNonUniformAMD].operands.push(OperandId, "X");
+        InstructionDesc[OpFragmentMaskFetchAMD].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpFragmentMaskFetchAMD].operands.push(OperandId, "'Coordinate'");
 
-    InstructionDesc[OpGroupFMinNonUniformAMD].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupFMinNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupFMinNonUniformAMD].operands.push(OperandId, "X");
+        InstructionDesc[OpFragmentFetchAMD].operands.push(OperandId, "'Image'");
+        InstructionDesc[OpFragmentFetchAMD].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpFragmentFetchAMD].operands.push(OperandId, "'Fragment Index'");
 
-    InstructionDesc[OpGroupUMaxNonUniformAMD].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupUMaxNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupUMaxNonUniformAMD].operands.push(OperandId, "X");
+        InstructionDesc[OpGroupNonUniformPartitionNV].operands.push(OperandId, "X");
 
-    InstructionDesc[OpGroupSMaxNonUniformAMD].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupSMaxNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupSMaxNonUniformAMD].operands.push(OperandId, "X");
+        InstructionDesc[OpTypeAccelerationStructureKHR].setResultAndType(true, false);
 
-    InstructionDesc[OpGroupFMaxNonUniformAMD].operands.push(OperandScope, "'Execution'");
-    InstructionDesc[OpGroupFMaxNonUniformAMD].operands.push(OperandGroupOperation, "'Operation'");
-    InstructionDesc[OpGroupFMaxNonUniformAMD].operands.push(OperandId, "X");
+        InstructionDesc[OpTraceNV].operands.push(OperandId, "'Acceleration Structure'");
+        InstructionDesc[OpTraceNV].operands.push(OperandId, "'Ray Flags'");
+        InstructionDesc[OpTraceNV].operands.push(OperandId, "'Cull Mask'");
+        InstructionDesc[OpTraceNV].operands.push(OperandId, "'SBT Record Offset'");
+        InstructionDesc[OpTraceNV].operands.push(OperandId, "'SBT Record Stride'");
+        InstructionDesc[OpTraceNV].operands.push(OperandId, "'Miss Index'");
+        InstructionDesc[OpTraceNV].operands.push(OperandId, "'Ray Origin'");
+        InstructionDesc[OpTraceNV].operands.push(OperandId, "'TMin'");
+        InstructionDesc[OpTraceNV].operands.push(OperandId, "'Ray Direction'");
+        InstructionDesc[OpTraceNV].operands.push(OperandId, "'TMax'");
+        InstructionDesc[OpTraceNV].operands.push(OperandId, "'Payload'");
+        InstructionDesc[OpTraceNV].setResultAndType(false, false);
 
-    InstructionDesc[OpFragmentMaskFetchAMD].operands.push(OperandId, "'Image'");
-    InstructionDesc[OpFragmentMaskFetchAMD].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Acceleration Structure'");
+        InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Ray Flags'");
+        InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Cull Mask'");
+        InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'SBT Record Offset'");
+        InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'SBT Record Stride'");
+        InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Miss Index'");
+        InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Ray Origin'");
+        InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'TMin'");
+        InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Ray Direction'");
+        InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'TMax'");
+        InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Time'");
+        InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Payload'");
+        InstructionDesc[OpTraceRayMotionNV].setResultAndType(false, false);
 
-    InstructionDesc[OpFragmentFetchAMD].operands.push(OperandId, "'Image'");
-    InstructionDesc[OpFragmentFetchAMD].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpFragmentFetchAMD].operands.push(OperandId, "'Fragment Index'");
+        InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'Acceleration Structure'");
+        InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'Ray Flags'");
+        InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'Cull Mask'");
+        InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'SBT Record Offset'");
+        InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'SBT Record Stride'");
+        InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'Miss Index'");
+        InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'Ray Origin'");
+        InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'TMin'");
+        InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'Ray Direction'");
+        InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'TMax'");
+        InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'Payload'");
+        InstructionDesc[OpTraceRayKHR].setResultAndType(false, false);
 
-    InstructionDesc[OpGroupNonUniformPartitionNV].operands.push(OperandId, "X");
+        InstructionDesc[OpReportIntersectionKHR].operands.push(OperandId, "'Hit Parameter'");
+        InstructionDesc[OpReportIntersectionKHR].operands.push(OperandId, "'Hit Kind'");
 
-    InstructionDesc[OpTypeAccelerationStructureKHR].setResultAndType(true, false);
+        InstructionDesc[OpIgnoreIntersectionNV].setResultAndType(false, false);
 
-    InstructionDesc[OpTraceNV].operands.push(OperandId, "'Acceleration Structure'");
-    InstructionDesc[OpTraceNV].operands.push(OperandId, "'Ray Flags'");
-    InstructionDesc[OpTraceNV].operands.push(OperandId, "'Cull Mask'");
-    InstructionDesc[OpTraceNV].operands.push(OperandId, "'SBT Record Offset'");
-    InstructionDesc[OpTraceNV].operands.push(OperandId, "'SBT Record Stride'");
-    InstructionDesc[OpTraceNV].operands.push(OperandId, "'Miss Index'");
-    InstructionDesc[OpTraceNV].operands.push(OperandId, "'Ray Origin'");
-    InstructionDesc[OpTraceNV].operands.push(OperandId, "'TMin'");
-    InstructionDesc[OpTraceNV].operands.push(OperandId, "'Ray Direction'");
-    InstructionDesc[OpTraceNV].operands.push(OperandId, "'TMax'");
-    InstructionDesc[OpTraceNV].operands.push(OperandId, "'Payload'");
-    InstructionDesc[OpTraceNV].setResultAndType(false, false);
+        InstructionDesc[OpIgnoreIntersectionKHR].setResultAndType(false, false);
 
-    InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Acceleration Structure'");
-    InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Ray Flags'");
-    InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Cull Mask'");
-    InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'SBT Record Offset'");
-    InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'SBT Record Stride'");
-    InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Miss Index'");
-    InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Ray Origin'");
-    InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'TMin'");
-    InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Ray Direction'");
-    InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'TMax'");
-    InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Time'");
-    InstructionDesc[OpTraceRayMotionNV].operands.push(OperandId, "'Payload'");
-    InstructionDesc[OpTraceRayMotionNV].setResultAndType(false, false);
+        InstructionDesc[OpTerminateRayNV].setResultAndType(false, false);
 
-    InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'Acceleration Structure'");
-    InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'Ray Flags'");
-    InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'Cull Mask'");
-    InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'SBT Record Offset'");
-    InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'SBT Record Stride'");
-    InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'Miss Index'");
-    InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'Ray Origin'");
-    InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'TMin'");
-    InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'Ray Direction'");
-    InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'TMax'");
-    InstructionDesc[OpTraceRayKHR].operands.push(OperandId, "'Payload'");
-    InstructionDesc[OpTraceRayKHR].setResultAndType(false, false);
+        InstructionDesc[OpTerminateRayKHR].setResultAndType(false, false);
 
-    InstructionDesc[OpReportIntersectionKHR].operands.push(OperandId, "'Hit Parameter'");
-    InstructionDesc[OpReportIntersectionKHR].operands.push(OperandId, "'Hit Kind'");
+        InstructionDesc[OpExecuteCallableNV].operands.push(OperandId, "SBT Record Index");
+        InstructionDesc[OpExecuteCallableNV].operands.push(OperandId, "CallableData ID");
+        InstructionDesc[OpExecuteCallableNV].setResultAndType(false, false);
 
-    InstructionDesc[OpIgnoreIntersectionNV].setResultAndType(false, false);
+        InstructionDesc[OpExecuteCallableKHR].operands.push(OperandId, "SBT Record Index");
+        InstructionDesc[OpExecuteCallableKHR].operands.push(OperandId, "CallableData");
+        InstructionDesc[OpExecuteCallableKHR].setResultAndType(false, false);
 
-    InstructionDesc[OpIgnoreIntersectionKHR].setResultAndType(false, false);
+        InstructionDesc[OpConvertUToAccelerationStructureKHR].operands.push(OperandId, "Value");
+        InstructionDesc[OpConvertUToAccelerationStructureKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpTerminateRayNV].setResultAndType(false, false);
+        // Ray Query
+        InstructionDesc[OpTypeAccelerationStructureKHR].setResultAndType(true, false);
+        InstructionDesc[OpTypeRayQueryKHR].setResultAndType(true, false);
 
-    InstructionDesc[OpTerminateRayKHR].setResultAndType(false, false);
+        InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'AccelerationS'");
+        InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'RayFlags'");
+        InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'CullMask'");
+        InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'Origin'");
+        InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'Tmin'");
+        InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'Direction'");
+        InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'Tmax'");
+        InstructionDesc[OpRayQueryInitializeKHR].setResultAndType(false, false);
 
-    InstructionDesc[OpExecuteCallableNV].operands.push(OperandId, "SBT Record Index");
-    InstructionDesc[OpExecuteCallableNV].operands.push(OperandId, "CallableData ID");
-    InstructionDesc[OpExecuteCallableNV].setResultAndType(false, false);
+        InstructionDesc[OpRayQueryTerminateKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryTerminateKHR].setResultAndType(false, false);
 
-    InstructionDesc[OpExecuteCallableKHR].operands.push(OperandId, "SBT Record Index");
-    InstructionDesc[OpExecuteCallableKHR].operands.push(OperandId, "CallableData");
-    InstructionDesc[OpExecuteCallableKHR].setResultAndType(false, false);
+        InstructionDesc[OpRayQueryGenerateIntersectionKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGenerateIntersectionKHR].operands.push(OperandId, "'THit'");
+        InstructionDesc[OpRayQueryGenerateIntersectionKHR].setResultAndType(false, false);
 
-    InstructionDesc[OpConvertUToAccelerationStructureKHR].operands.push(OperandId, "Value");
-    InstructionDesc[OpConvertUToAccelerationStructureKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryConfirmIntersectionKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryConfirmIntersectionKHR].setResultAndType(false, false);
 
-    // Ray Query
-    InstructionDesc[OpTypeAccelerationStructureKHR].setResultAndType(true, false);
-    InstructionDesc[OpTypeRayQueryKHR].setResultAndType(true, false);
+        InstructionDesc[OpRayQueryProceedKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryProceedKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'AccelerationS'");
-    InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'RayFlags'");
-    InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'CullMask'");
-    InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'Origin'");
-    InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'Tmin'");
-    InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'Direction'");
-    InstructionDesc[OpRayQueryInitializeKHR].operands.push(OperandId, "'Tmax'");
-    InstructionDesc[OpRayQueryInitializeKHR].setResultAndType(false, false);
+        InstructionDesc[OpRayQueryGetIntersectionTypeKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetIntersectionTypeKHR].operands.push(OperandId, "'Committed'");
+        InstructionDesc[OpRayQueryGetIntersectionTypeKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryTerminateKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryTerminateKHR].setResultAndType(false, false);
+        InstructionDesc[OpRayQueryGetRayTMinKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetRayTMinKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGenerateIntersectionKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGenerateIntersectionKHR].operands.push(OperandId, "'THit'");
-    InstructionDesc[OpRayQueryGenerateIntersectionKHR].setResultAndType(false, false);
+        InstructionDesc[OpRayQueryGetRayFlagsKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetRayFlagsKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryConfirmIntersectionKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryConfirmIntersectionKHR].setResultAndType(false, false);
+        InstructionDesc[OpRayQueryGetIntersectionTKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetIntersectionTKHR].operands.push(OperandId, "'Committed'");
+        InstructionDesc[OpRayQueryGetIntersectionTKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryProceedKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryProceedKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryGetIntersectionInstanceCustomIndexKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetIntersectionInstanceCustomIndexKHR].operands.push(OperandId, "'Committed'");
+        InstructionDesc[OpRayQueryGetIntersectionInstanceCustomIndexKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGetIntersectionTypeKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetIntersectionTypeKHR].operands.push(OperandId, "'Committed'");
-    InstructionDesc[OpRayQueryGetIntersectionTypeKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryGetIntersectionInstanceIdKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetIntersectionInstanceIdKHR].operands.push(OperandId, "'Committed'");
+        InstructionDesc[OpRayQueryGetIntersectionInstanceIdKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGetRayTMinKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetRayTMinKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR].operands.push(OperandId, "'Committed'");
+        InstructionDesc[OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGetRayFlagsKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetRayFlagsKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryGetIntersectionGeometryIndexKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetIntersectionGeometryIndexKHR].operands.push(OperandId, "'Committed'");
+        InstructionDesc[OpRayQueryGetIntersectionGeometryIndexKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGetIntersectionTKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetIntersectionTKHR].operands.push(OperandId, "'Committed'");
-    InstructionDesc[OpRayQueryGetIntersectionTKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryGetIntersectionPrimitiveIndexKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetIntersectionPrimitiveIndexKHR].operands.push(OperandId, "'Committed'");
+        InstructionDesc[OpRayQueryGetIntersectionPrimitiveIndexKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGetIntersectionInstanceCustomIndexKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetIntersectionInstanceCustomIndexKHR].operands.push(OperandId, "'Committed'");
-    InstructionDesc[OpRayQueryGetIntersectionInstanceCustomIndexKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryGetIntersectionBarycentricsKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetIntersectionBarycentricsKHR].operands.push(OperandId, "'Committed'");
+        InstructionDesc[OpRayQueryGetIntersectionBarycentricsKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGetIntersectionInstanceIdKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetIntersectionInstanceIdKHR].operands.push(OperandId, "'Committed'");
-    InstructionDesc[OpRayQueryGetIntersectionInstanceIdKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryGetIntersectionFrontFaceKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetIntersectionFrontFaceKHR].operands.push(OperandId, "'Committed'");
+        InstructionDesc[OpRayQueryGetIntersectionFrontFaceKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR].operands.push(OperandId, "'Committed'");
-    InstructionDesc[OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryGetIntersectionCandidateAABBOpaqueKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetIntersectionCandidateAABBOpaqueKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGetIntersectionGeometryIndexKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetIntersectionGeometryIndexKHR].operands.push(OperandId, "'Committed'");
-    InstructionDesc[OpRayQueryGetIntersectionGeometryIndexKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryGetIntersectionObjectRayDirectionKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetIntersectionObjectRayDirectionKHR].operands.push(OperandId, "'Committed'");
+        InstructionDesc[OpRayQueryGetIntersectionObjectRayDirectionKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGetIntersectionPrimitiveIndexKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetIntersectionPrimitiveIndexKHR].operands.push(OperandId, "'Committed'");
-    InstructionDesc[OpRayQueryGetIntersectionPrimitiveIndexKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryGetIntersectionObjectRayOriginKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetIntersectionObjectRayOriginKHR].operands.push(OperandId, "'Committed'");
+        InstructionDesc[OpRayQueryGetIntersectionObjectRayOriginKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGetIntersectionBarycentricsKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetIntersectionBarycentricsKHR].operands.push(OperandId, "'Committed'");
-    InstructionDesc[OpRayQueryGetIntersectionBarycentricsKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryGetWorldRayDirectionKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetWorldRayDirectionKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGetIntersectionFrontFaceKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetIntersectionFrontFaceKHR].operands.push(OperandId, "'Committed'");
-    InstructionDesc[OpRayQueryGetIntersectionFrontFaceKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryGetWorldRayOriginKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetWorldRayOriginKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGetIntersectionCandidateAABBOpaqueKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetIntersectionCandidateAABBOpaqueKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryGetIntersectionObjectToWorldKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetIntersectionObjectToWorldKHR].operands.push(OperandId, "'Committed'");
+        InstructionDesc[OpRayQueryGetIntersectionObjectToWorldKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGetIntersectionObjectRayDirectionKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetIntersectionObjectRayDirectionKHR].operands.push(OperandId, "'Committed'");
-    InstructionDesc[OpRayQueryGetIntersectionObjectRayDirectionKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryGetIntersectionWorldToObjectKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetIntersectionWorldToObjectKHR].operands.push(OperandId, "'Committed'");
+        InstructionDesc[OpRayQueryGetIntersectionWorldToObjectKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGetIntersectionObjectRayOriginKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetIntersectionObjectRayOriginKHR].operands.push(OperandId, "'Committed'");
-    InstructionDesc[OpRayQueryGetIntersectionObjectRayOriginKHR].setResultAndType(true, true);
+        InstructionDesc[OpRayQueryGetIntersectionTriangleVertexPositionsKHR].operands.push(OperandId, "'RayQuery'");
+        InstructionDesc[OpRayQueryGetIntersectionTriangleVertexPositionsKHR].operands.push(OperandId, "'Committed'");
+        InstructionDesc[OpRayQueryGetIntersectionWorldToObjectKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpRayQueryGetWorldRayDirectionKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetWorldRayDirectionKHR].setResultAndType(true, true);
+        InstructionDesc[OpImageSampleFootprintNV].operands.push(OperandId, "'Sampled Image'");
+        InstructionDesc[OpImageSampleFootprintNV].operands.push(OperandId, "'Coordinate'");
+        InstructionDesc[OpImageSampleFootprintNV].operands.push(OperandId, "'Granularity'");
+        InstructionDesc[OpImageSampleFootprintNV].operands.push(OperandId, "'Coarse'");
+        InstructionDesc[OpImageSampleFootprintNV].operands.push(OperandImageOperands, "", true);
+        InstructionDesc[OpImageSampleFootprintNV].operands.push(OperandVariableIds, "", true);
 
-    InstructionDesc[OpRayQueryGetWorldRayOriginKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetWorldRayOriginKHR].setResultAndType(true, true);
+        InstructionDesc[OpWritePackedPrimitiveIndices4x8NV].operands.push(OperandId, "'Index Offset'");
+        InstructionDesc[OpWritePackedPrimitiveIndices4x8NV].operands.push(OperandId, "'Packed Indices'");
 
-    InstructionDesc[OpRayQueryGetIntersectionObjectToWorldKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetIntersectionObjectToWorldKHR].operands.push(OperandId, "'Committed'");
-    InstructionDesc[OpRayQueryGetIntersectionObjectToWorldKHR].setResultAndType(true, true);
+        InstructionDesc[OpEmitMeshTasksEXT].operands.push(OperandId, "'groupCountX'");
+        InstructionDesc[OpEmitMeshTasksEXT].operands.push(OperandId, "'groupCountY'");
+        InstructionDesc[OpEmitMeshTasksEXT].operands.push(OperandId, "'groupCountZ'");
+        InstructionDesc[OpEmitMeshTasksEXT].operands.push(OperandId, "'Payload'");
+        InstructionDesc[OpEmitMeshTasksEXT].setResultAndType(false, false);
 
-    InstructionDesc[OpRayQueryGetIntersectionWorldToObjectKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetIntersectionWorldToObjectKHR].operands.push(OperandId, "'Committed'");
-    InstructionDesc[OpRayQueryGetIntersectionWorldToObjectKHR].setResultAndType(true, true);
+        InstructionDesc[OpSetMeshOutputsEXT].operands.push(OperandId, "'vertexCount'");
+        InstructionDesc[OpSetMeshOutputsEXT].operands.push(OperandId, "'primitiveCount'");
+        InstructionDesc[OpSetMeshOutputsEXT].setResultAndType(false, false);
 
-    InstructionDesc[OpRayQueryGetIntersectionTriangleVertexPositionsKHR].operands.push(OperandId, "'RayQuery'");
-    InstructionDesc[OpRayQueryGetIntersectionTriangleVertexPositionsKHR].operands.push(OperandId, "'Committed'");
-    InstructionDesc[OpRayQueryGetIntersectionWorldToObjectKHR].setResultAndType(true, true);
 
-    InstructionDesc[OpImageSampleFootprintNV].operands.push(OperandId, "'Sampled Image'");
-    InstructionDesc[OpImageSampleFootprintNV].operands.push(OperandId, "'Coordinate'");
-    InstructionDesc[OpImageSampleFootprintNV].operands.push(OperandId, "'Granularity'");
-    InstructionDesc[OpImageSampleFootprintNV].operands.push(OperandId, "'Coarse'");
-    InstructionDesc[OpImageSampleFootprintNV].operands.push(OperandImageOperands, "", true);
-    InstructionDesc[OpImageSampleFootprintNV].operands.push(OperandVariableIds, "", true);
+        InstructionDesc[OpTypeCooperativeMatrixNV].operands.push(OperandId, "'Component Type'");
+        InstructionDesc[OpTypeCooperativeMatrixNV].operands.push(OperandId, "'Scope'");
+        InstructionDesc[OpTypeCooperativeMatrixNV].operands.push(OperandId, "'Rows'");
+        InstructionDesc[OpTypeCooperativeMatrixNV].operands.push(OperandId, "'Columns'");
 
-    InstructionDesc[OpWritePackedPrimitiveIndices4x8NV].operands.push(OperandId, "'Index Offset'");
-    InstructionDesc[OpWritePackedPrimitiveIndices4x8NV].operands.push(OperandId, "'Packed Indices'");
+        InstructionDesc[OpCooperativeMatrixLoadNV].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpCooperativeMatrixLoadNV].operands.push(OperandId, "'Stride'");
+        InstructionDesc[OpCooperativeMatrixLoadNV].operands.push(OperandId, "'Column Major'");
+        InstructionDesc[OpCooperativeMatrixLoadNV].operands.push(OperandMemoryAccess, "'Memory Access'");
+        InstructionDesc[OpCooperativeMatrixLoadNV].operands.push(OperandLiteralNumber, "", true);
+        InstructionDesc[OpCooperativeMatrixLoadNV].operands.push(OperandId, "", true);
 
-    InstructionDesc[OpEmitMeshTasksEXT].operands.push(OperandId, "'groupCountX'");
-    InstructionDesc[OpEmitMeshTasksEXT].operands.push(OperandId, "'groupCountY'");
-    InstructionDesc[OpEmitMeshTasksEXT].operands.push(OperandId, "'groupCountZ'");
-    InstructionDesc[OpEmitMeshTasksEXT].operands.push(OperandId, "'Payload'");
-    InstructionDesc[OpEmitMeshTasksEXT].setResultAndType(false, false);
+        InstructionDesc[OpCooperativeMatrixStoreNV].operands.push(OperandId, "'Pointer'");
+        InstructionDesc[OpCooperativeMatrixStoreNV].operands.push(OperandId, "'Object'");
+        InstructionDesc[OpCooperativeMatrixStoreNV].operands.push(OperandId, "'Stride'");
+        InstructionDesc[OpCooperativeMatrixStoreNV].operands.push(OperandId, "'Column Major'");
+        InstructionDesc[OpCooperativeMatrixStoreNV].operands.push(OperandMemoryAccess, "'Memory Access'");
+        InstructionDesc[OpCooperativeMatrixStoreNV].operands.push(OperandLiteralNumber, "", true);
+        InstructionDesc[OpCooperativeMatrixStoreNV].operands.push(OperandId, "", true);
 
-    InstructionDesc[OpSetMeshOutputsEXT].operands.push(OperandId, "'vertexCount'");
-    InstructionDesc[OpSetMeshOutputsEXT].operands.push(OperandId, "'primitiveCount'");
-    InstructionDesc[OpSetMeshOutputsEXT].setResultAndType(false, false);
+        InstructionDesc[OpCooperativeMatrixMulAddNV].operands.push(OperandId, "'A'");
+        InstructionDesc[OpCooperativeMatrixMulAddNV].operands.push(OperandId, "'B'");
+        InstructionDesc[OpCooperativeMatrixMulAddNV].operands.push(OperandId, "'C'");
 
+        InstructionDesc[OpCooperativeMatrixLengthNV].operands.push(OperandId, "'Type'");
 
-    InstructionDesc[OpTypeCooperativeMatrixNV].operands.push(OperandId, "'Component Type'");
-    InstructionDesc[OpTypeCooperativeMatrixNV].operands.push(OperandId, "'Scope'");
-    InstructionDesc[OpTypeCooperativeMatrixNV].operands.push(OperandId, "'Rows'");
-    InstructionDesc[OpTypeCooperativeMatrixNV].operands.push(OperandId, "'Columns'");
+        InstructionDesc[OpDemoteToHelperInvocationEXT].setResultAndType(false, false);
 
-    InstructionDesc[OpCooperativeMatrixLoadNV].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpCooperativeMatrixLoadNV].operands.push(OperandId, "'Stride'");
-    InstructionDesc[OpCooperativeMatrixLoadNV].operands.push(OperandId, "'Column Major'");
-    InstructionDesc[OpCooperativeMatrixLoadNV].operands.push(OperandMemoryAccess, "'Memory Access'");
-    InstructionDesc[OpCooperativeMatrixLoadNV].operands.push(OperandLiteralNumber, "", true);
-    InstructionDesc[OpCooperativeMatrixLoadNV].operands.push(OperandId, "", true);
+        InstructionDesc[OpReadClockKHR].operands.push(OperandScope, "'Scope'");
 
-    InstructionDesc[OpCooperativeMatrixStoreNV].operands.push(OperandId, "'Pointer'");
-    InstructionDesc[OpCooperativeMatrixStoreNV].operands.push(OperandId, "'Object'");
-    InstructionDesc[OpCooperativeMatrixStoreNV].operands.push(OperandId, "'Stride'");
-    InstructionDesc[OpCooperativeMatrixStoreNV].operands.push(OperandId, "'Column Major'");
-    InstructionDesc[OpCooperativeMatrixStoreNV].operands.push(OperandMemoryAccess, "'Memory Access'");
-    InstructionDesc[OpCooperativeMatrixStoreNV].operands.push(OperandLiteralNumber, "", true);
-    InstructionDesc[OpCooperativeMatrixStoreNV].operands.push(OperandId, "", true);
+        InstructionDesc[OpTypeHitObjectNV].setResultAndType(true, false);
 
-    InstructionDesc[OpCooperativeMatrixMulAddNV].operands.push(OperandId, "'A'");
-    InstructionDesc[OpCooperativeMatrixMulAddNV].operands.push(OperandId, "'B'");
-    InstructionDesc[OpCooperativeMatrixMulAddNV].operands.push(OperandId, "'C'");
+        InstructionDesc[OpHitObjectGetShaderRecordBufferHandleNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetShaderRecordBufferHandleNV].setResultAndType(true, true);
 
-    InstructionDesc[OpCooperativeMatrixLengthNV].operands.push(OperandId, "'Type'");
+        InstructionDesc[OpReorderThreadWithHintNV].operands.push(OperandId, "'Hint'");
+        InstructionDesc[OpReorderThreadWithHintNV].operands.push(OperandId, "'Bits'");
+        InstructionDesc[OpReorderThreadWithHintNV].setResultAndType(false, false);
 
-    InstructionDesc[OpDemoteToHelperInvocationEXT].setResultAndType(false, false);
+        InstructionDesc[OpReorderThreadWithHitObjectNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpReorderThreadWithHitObjectNV].operands.push(OperandId, "'Hint'");
+        InstructionDesc[OpReorderThreadWithHitObjectNV].operands.push(OperandId, "'Bits'");
+        InstructionDesc[OpReorderThreadWithHitObjectNV].setResultAndType(false, false);
 
-    InstructionDesc[OpReadClockKHR].operands.push(OperandScope, "'Scope'");
+        InstructionDesc[OpHitObjectGetCurrentTimeNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetCurrentTimeNV].setResultAndType(true, true);
 
-    InstructionDesc[OpTypeHitObjectNV].setResultAndType(true, false);
+        InstructionDesc[OpHitObjectGetHitKindNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetHitKindNV].setResultAndType(true, true);
 
-    InstructionDesc[OpHitObjectGetShaderRecordBufferHandleNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetShaderRecordBufferHandleNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectGetPrimitiveIndexNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetPrimitiveIndexNV].setResultAndType(true, true);
 
-    InstructionDesc[OpReorderThreadWithHintNV].operands.push(OperandId, "'Hint'");
-    InstructionDesc[OpReorderThreadWithHintNV].operands.push(OperandId, "'Bits'");
-    InstructionDesc[OpReorderThreadWithHintNV].setResultAndType(false, false);
+        InstructionDesc[OpHitObjectGetGeometryIndexNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetGeometryIndexNV].setResultAndType(true, true);
 
-    InstructionDesc[OpReorderThreadWithHitObjectNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpReorderThreadWithHitObjectNV].operands.push(OperandId, "'Hint'");
-    InstructionDesc[OpReorderThreadWithHitObjectNV].operands.push(OperandId, "'Bits'");
-    InstructionDesc[OpReorderThreadWithHitObjectNV].setResultAndType(false, false);
+        InstructionDesc[OpHitObjectGetInstanceIdNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetInstanceIdNV].setResultAndType(true, true);
 
-    InstructionDesc[OpHitObjectGetCurrentTimeNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetCurrentTimeNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectGetInstanceCustomIndexNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetInstanceCustomIndexNV].setResultAndType(true, true);
 
-    InstructionDesc[OpHitObjectGetHitKindNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetHitKindNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectGetObjectRayDirectionNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetObjectRayDirectionNV].setResultAndType(true, true);
 
-    InstructionDesc[OpHitObjectGetPrimitiveIndexNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetPrimitiveIndexNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectGetObjectRayOriginNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetObjectRayOriginNV].setResultAndType(true, true);
 
-    InstructionDesc[OpHitObjectGetGeometryIndexNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetGeometryIndexNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectGetWorldRayDirectionNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetWorldRayDirectionNV].setResultAndType(true, true);
 
-    InstructionDesc[OpHitObjectGetInstanceIdNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetInstanceIdNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectGetWorldRayOriginNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetWorldRayOriginNV].setResultAndType(true, true);
 
-    InstructionDesc[OpHitObjectGetInstanceCustomIndexNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetInstanceCustomIndexNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectGetWorldToObjectNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetWorldToObjectNV].setResultAndType(true, true);
 
-    InstructionDesc[OpHitObjectGetObjectRayDirectionNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetObjectRayDirectionNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectGetObjectToWorldNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetObjectToWorldNV].setResultAndType(true, true);
 
-    InstructionDesc[OpHitObjectGetObjectRayOriginNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetObjectRayOriginNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectGetRayTMaxNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetRayTMaxNV].setResultAndType(true, true);
 
-    InstructionDesc[OpHitObjectGetWorldRayDirectionNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetWorldRayDirectionNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectGetRayTMinNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetRayTMinNV].setResultAndType(true, true);
 
-    InstructionDesc[OpHitObjectGetWorldRayOriginNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetWorldRayOriginNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectGetShaderBindingTableRecordIndexNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetShaderBindingTableRecordIndexNV].setResultAndType(true, true);
 
-    InstructionDesc[OpHitObjectGetWorldToObjectNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetWorldToObjectNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectIsEmptyNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectIsEmptyNV].setResultAndType(true, true);
 
-    InstructionDesc[OpHitObjectGetObjectToWorldNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetObjectToWorldNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectIsHitNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectIsHitNV].setResultAndType(true, true);
 
-    InstructionDesc[OpHitObjectGetRayTMaxNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetRayTMaxNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectIsMissNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectIsMissNV].setResultAndType(true, true);
 
-    InstructionDesc[OpHitObjectGetRayTMinNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetRayTMinNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectGetAttributesNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectGetAttributesNV].operands.push(OperandId, "'HitObjectAttribute'");
+        InstructionDesc[OpHitObjectGetAttributesNV].setResultAndType(false, false);
 
-    InstructionDesc[OpHitObjectGetShaderBindingTableRecordIndexNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetShaderBindingTableRecordIndexNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectExecuteShaderNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectExecuteShaderNV].operands.push(OperandId, "'Payload'");
+        InstructionDesc[OpHitObjectExecuteShaderNV].setResultAndType(false, false);
 
-    InstructionDesc[OpHitObjectIsEmptyNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectIsEmptyNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'Acceleration Structure'");
+        InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'InstanceId'");
+        InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'PrimitiveId'");
+        InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'GeometryIndex'");
+        InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'HitKind'");
+        InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'SBT Record Offset'");
+        InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'SBT Record Stride'");
+        InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'Origin'");
+        InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'TMin'");
+        InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'Direction'");
+        InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'TMax'");
+        InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'HitObject Attribute'");
+        InstructionDesc[OpHitObjectRecordHitNV].setResultAndType(false, false);
 
-    InstructionDesc[OpHitObjectIsHitNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectIsHitNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'Acceleration Structure'");
+        InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'InstanceId'");
+        InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'PrimitiveId'");
+        InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'GeometryIndex'");
+        InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'HitKind'");
+        InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'SBT Record Offset'");
+        InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'SBT Record Stride'");
+        InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'Origin'");
+        InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'TMin'");
+        InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'Direction'");
+        InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'TMax'");
+        InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'Current Time'");
+        InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'HitObject Attribute'");
+        InstructionDesc[OpHitObjectRecordHitMotionNV].setResultAndType(false, false);
 
-    InstructionDesc[OpHitObjectIsMissNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectIsMissNV].setResultAndType(true, true);
+        InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'Acceleration Structure'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'InstanceId'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'PrimitiveId'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'GeometryIndex'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'HitKind'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'SBT Record Index'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'Origin'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'TMin'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'Direction'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'TMax'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'HitObject Attribute'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexNV].setResultAndType(false, false);
 
-    InstructionDesc[OpHitObjectGetAttributesNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectGetAttributesNV].operands.push(OperandId, "'HitObjectAttribute'");
-    InstructionDesc[OpHitObjectGetAttributesNV].setResultAndType(false, false);
+        InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'Acceleration Structure'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'InstanceId'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'PrimitiveId'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'GeometryIndex'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'HitKind'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'SBT Record Index'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'Origin'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'TMin'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'Direction'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'TMax'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'Current Time'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'HitObject Attribute'");
+        InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].setResultAndType(false, false);
 
-    InstructionDesc[OpHitObjectExecuteShaderNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectExecuteShaderNV].operands.push(OperandId, "'Payload'");
-    InstructionDesc[OpHitObjectExecuteShaderNV].setResultAndType(false, false);
+        InstructionDesc[OpHitObjectRecordMissNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectRecordMissNV].operands.push(OperandId, "'SBT Index'");
+        InstructionDesc[OpHitObjectRecordMissNV].operands.push(OperandId, "'Origin'");
+        InstructionDesc[OpHitObjectRecordMissNV].operands.push(OperandId, "'TMin'");
+        InstructionDesc[OpHitObjectRecordMissNV].operands.push(OperandId, "'Direction'");
+        InstructionDesc[OpHitObjectRecordMissNV].operands.push(OperandId, "'TMax'");
+        InstructionDesc[OpHitObjectRecordMissNV].setResultAndType(false, false);
 
-    InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'Acceleration Structure'");
-    InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'InstanceId'");
-    InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'PrimitiveId'");
-    InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'GeometryIndex'");
-    InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'HitKind'");
-    InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'SBT Record Offset'");
-    InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'SBT Record Stride'");
-    InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'Origin'");
-    InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'TMin'");
-    InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'Direction'");
-    InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'TMax'");
-    InstructionDesc[OpHitObjectRecordHitNV].operands.push(OperandId, "'HitObject Attribute'");
-    InstructionDesc[OpHitObjectRecordHitNV].setResultAndType(false, false);
+        InstructionDesc[OpHitObjectRecordMissMotionNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectRecordMissMotionNV].operands.push(OperandId, "'SBT Index'");
+        InstructionDesc[OpHitObjectRecordMissMotionNV].operands.push(OperandId, "'Origin'");
+        InstructionDesc[OpHitObjectRecordMissMotionNV].operands.push(OperandId, "'TMin'");
+        InstructionDesc[OpHitObjectRecordMissMotionNV].operands.push(OperandId, "'Direction'");
+        InstructionDesc[OpHitObjectRecordMissMotionNV].operands.push(OperandId, "'TMax'");
+        InstructionDesc[OpHitObjectRecordMissMotionNV].operands.push(OperandId, "'Current Time'");
+        InstructionDesc[OpHitObjectRecordMissMotionNV].setResultAndType(false, false);
 
-    InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'Acceleration Structure'");
-    InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'InstanceId'");
-    InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'PrimitiveId'");
-    InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'GeometryIndex'");
-    InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'HitKind'");
-    InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'SBT Record Offset'");
-    InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'SBT Record Stride'");
-    InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'Origin'");
-    InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'TMin'");
-    InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'Direction'");
-    InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'TMax'");
-    InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'Current Time'");
-    InstructionDesc[OpHitObjectRecordHitMotionNV].operands.push(OperandId, "'HitObject Attribute'");
-    InstructionDesc[OpHitObjectRecordHitMotionNV].setResultAndType(false, false);
+        InstructionDesc[OpHitObjectRecordEmptyNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectRecordEmptyNV].setResultAndType(false, false);
 
-    InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'Acceleration Structure'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'InstanceId'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'PrimitiveId'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'GeometryIndex'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'HitKind'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'SBT Record Index'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'Origin'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'TMin'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'Direction'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'TMax'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexNV].operands.push(OperandId, "'HitObject Attribute'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexNV].setResultAndType(false, false);
+        InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'Acceleration Structure'");
+        InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'RayFlags'");
+        InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'Cullmask'");
+        InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'SBT Record Offset'");
+        InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'SBT Record Stride'");
+        InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'Miss Index'");
+        InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'Origin'");
+        InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'TMin'");
+        InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'Direction'");
+        InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'TMax'");
+        InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'Payload'");
+        InstructionDesc[OpHitObjectTraceRayNV].setResultAndType(false, false);
 
-    InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'Acceleration Structure'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'InstanceId'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'PrimitiveId'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'GeometryIndex'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'HitKind'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'SBT Record Index'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'Origin'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'TMin'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'Direction'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'TMax'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'Current Time'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].operands.push(OperandId, "'HitObject Attribute'");
-    InstructionDesc[OpHitObjectRecordHitWithIndexMotionNV].setResultAndType(false, false);
+        InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'HitObject'");
+        InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'Acceleration Structure'");
+        InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'RayFlags'");
+        InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'Cullmask'");
+        InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'SBT Record Offset'");
+        InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'SBT Record Stride'");
+        InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'Miss Index'");
+        InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'Origin'");
+        InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'TMin'");
+        InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'Direction'");
+        InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'TMax'");
+        InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'Time'");
+        InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'Payload'");
+        InstructionDesc[OpHitObjectTraceRayMotionNV].setResultAndType(false, false);
 
-    InstructionDesc[OpHitObjectRecordMissNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectRecordMissNV].operands.push(OperandId, "'SBT Index'");
-    InstructionDesc[OpHitObjectRecordMissNV].operands.push(OperandId, "'Origin'");
-    InstructionDesc[OpHitObjectRecordMissNV].operands.push(OperandId, "'TMin'");
-    InstructionDesc[OpHitObjectRecordMissNV].operands.push(OperandId, "'Direction'");
-    InstructionDesc[OpHitObjectRecordMissNV].operands.push(OperandId, "'TMax'");
-    InstructionDesc[OpHitObjectRecordMissNV].setResultAndType(false, false);
-
-    InstructionDesc[OpHitObjectRecordMissMotionNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectRecordMissMotionNV].operands.push(OperandId, "'SBT Index'");
-    InstructionDesc[OpHitObjectRecordMissMotionNV].operands.push(OperandId, "'Origin'");
-    InstructionDesc[OpHitObjectRecordMissMotionNV].operands.push(OperandId, "'TMin'");
-    InstructionDesc[OpHitObjectRecordMissMotionNV].operands.push(OperandId, "'Direction'");
-    InstructionDesc[OpHitObjectRecordMissMotionNV].operands.push(OperandId, "'TMax'");
-    InstructionDesc[OpHitObjectRecordMissMotionNV].operands.push(OperandId, "'Current Time'");
-    InstructionDesc[OpHitObjectRecordMissMotionNV].setResultAndType(false, false);
-
-    InstructionDesc[OpHitObjectRecordEmptyNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectRecordEmptyNV].setResultAndType(false, false);
-
-    InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'Acceleration Structure'");
-    InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'RayFlags'");
-    InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'Cullmask'");
-    InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'SBT Record Offset'");
-    InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'SBT Record Stride'");
-    InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'Miss Index'");
-    InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'Origin'");
-    InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'TMin'");
-    InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'Direction'");
-    InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'TMax'");
-    InstructionDesc[OpHitObjectTraceRayNV].operands.push(OperandId, "'Payload'");
-    InstructionDesc[OpHitObjectTraceRayNV].setResultAndType(false, false);
-
-    InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'HitObject'");
-    InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'Acceleration Structure'");
-    InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'RayFlags'");
-    InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'Cullmask'");
-    InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'SBT Record Offset'");
-    InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'SBT Record Stride'");
-    InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'Miss Index'");
-    InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'Origin'");
-    InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'TMin'");
-    InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'Direction'");
-    InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'TMax'");
-    InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'Time'");
-    InstructionDesc[OpHitObjectTraceRayMotionNV].operands.push(OperandId, "'Payload'");
-    InstructionDesc[OpHitObjectTraceRayMotionNV].setResultAndType(false, false);
-
-    InstructionDesc[OpColorAttachmentReadEXT].operands.push(OperandId, "'Attachment'");
-    InstructionDesc[OpColorAttachmentReadEXT].operands.push(OperandId, "'Sample'", true);
-    InstructionDesc[OpStencilAttachmentReadEXT].operands.push(OperandId, "'Sample'", true);
-    InstructionDesc[OpDepthAttachmentReadEXT].operands.push(OperandId, "'Sample'", true);
+        InstructionDesc[OpColorAttachmentReadEXT].operands.push(OperandId, "'Attachment'");
+        InstructionDesc[OpColorAttachmentReadEXT].operands.push(OperandId, "'Sample'", true);
+        InstructionDesc[OpStencilAttachmentReadEXT].operands.push(OperandId, "'Sample'", true);
+        InstructionDesc[OpDepthAttachmentReadEXT].operands.push(OperandId, "'Sample'", true);
+    });
 }
 
 }; // end spv namespace


### PR DESCRIPTION
There was a race condition in this function as it used a static variable to attempt to ensure global initialization was only done once, which was not thread-safe. Instead, use std::call_once, which was added to C++11 for this exact case.

Fixes #342