### PR TITLE
cmake: Fix symlink on Windows

### DIFF
--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -109,14 +109,18 @@ if(ENABLE_GLSLANG_INSTALL)
 
     # Create a symbolic link to glslang named glslangValidator for backwards compatibility
     set(legacy_glslang_name "glslangValidator${CMAKE_EXECUTABLE_SUFFIX}")
+    set(link_method create_symlink)
+    if (WIN32 OR MINGW)
+        set(link_method copy_if_different)
+    endif()
     add_custom_command(TARGET glslang-standalone
                        POST_BUILD
-                       COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_NAME:glslang-standalone> ${legacy_glslang_name}
+                       COMMAND ${CMAKE_COMMAND} -E ${link_method} $<TARGET_FILE_NAME:glslang-standalone> ${legacy_glslang_name}
                        WORKING_DIRECTORY $<TARGET_FILE_DIR:glslang-standalone>)
 
     # Create the same symlink at install time
     install(CODE "execute_process( \
-                      COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_NAME:glslang-standalone> ${legacy_glslang_name} \
+                      COMMAND ${CMAKE_COMMAND} -E ${link_method} $<TARGET_FILE_NAME:glslang-standalone> ${legacy_glslang_name} \
                       WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})")
 
     if(ENABLE_SPVREMAPPER)


### PR DESCRIPTION
Copy the old glslangValidator name on Windows rather than creating a symlink. While cmake 3.13 and above supports creating symlinks on Windows, a security policy change is required in general to allow the creation of symlinks for non-trusted users. See https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-symbolic-links

Fixes #3268.