### PR TITLE
Silence unused parameter warning

### DIFF
--- a/glslang/MachineIndependent/SpirvIntrinsics.cpp
+++ b/glslang/MachineIndependent/SpirvIntrinsics.cpp
@@ -298,7 +298,8 @@ TSpirvTypeParameters* TParseContext::makeSpirvTypeParameters(const TSourceLoc& l
     return spirvTypeParams;
 }
 
-TSpirvTypeParameters* TParseContext::makeSpirvTypeParameters(const TSourceLoc& loc, const TPublicType& type)
+TSpirvTypeParameters* TParseContext::makeSpirvTypeParameters(const TSourceLoc& /* loc */,
+                                                             const TPublicType& type)
 {
     TSpirvTypeParameters* spirvTypeParams = new TSpirvTypeParameters;
     spirvTypeParams->push_back(TSpirvTypeParameter(new TType(type)));


### PR DESCRIPTION
The parameter could be removed, but keep it for consistency with other `makeSpirvTypeParameters` overloads.