### PR TITLE
git: Ignore CMakeUserPresets.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Test/localResults/
 External/googletest
 External/spirv-tools
 out/
+CMakeUserPresets.json
 
 # GN generated files
 .cipd/


### PR DESCRIPTION
CMakeUserPresets.json can be useful for developers and is not meant to be checked in.