### PR TITLE
Replace GlobalLock functions with std::mutex

### DIFF
--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -54,6 +54,7 @@ glslang_set_link_args(glslang-standalone)
 
 set(LIBRARIES
     glslang
+    OSDependent
     SPIRV
     glslang-default-resource-limits)
 

--- a/glslang/OSDependent/Unix/ossource.cpp
+++ b/glslang/OSDependent/Unix/ossource.cpp
@@ -36,49 +36,14 @@
 // This file contains the Linux-specific functions
 //
 #include "../osinclude.h"
-#include "../../../OGLCompilersDLL/InitializeDll.h"
 
-#include <pthread.h>
-#include <semaphore.h>
-#include <assert.h>
-#include <errno.h>
-#include <stdint.h>
 #include <cstdio>
-#include <sys/time.h>
 
 #if !defined(__Fuchsia__)
 #include <sys/resource.h>
 #endif
 
 namespace glslang {
-
-namespace {
-    pthread_mutex_t gMutex;
-}
-
-static void InitMutex(void)
-{
-  pthread_mutexattr_t mutexattr;
-  pthread_mutexattr_init(&mutexattr);
-  pthread_mutexattr_settype(&mutexattr, PTHREAD_MUTEX_RECURSIVE);
-  pthread_mutex_init(&gMutex, &mutexattr);
-}
-
-void InitGlobalLock()
-{
-  static pthread_once_t once = PTHREAD_ONCE_INIT;
-  pthread_once(&once, InitMutex);
-}
-
-void GetGlobalLock()
-{
-  pthread_mutex_lock(&gMutex);
-}
-
-void ReleaseGlobalLock()
-{
-  pthread_mutex_unlock(&gMutex);
-}
 
 // #define DUMP_COUNTERS
 

--- a/glslang/OSDependent/Windows/ossource.cpp
+++ b/glslang/OSDependent/Windows/ossource.cpp
@@ -37,11 +37,9 @@
 #define STRICT
 #define VC_EXTRALEAN 1
 #include <windows.h>
-#include <cassert>
 #include <process.h>
 #include <psapi.h>
 #include <cstdio>
-#include <cstdint>
 
 //
 // This file contains the Window-OS-specific functions
@@ -52,28 +50,6 @@
 #endif
 
 namespace glslang {
-
-HANDLE GlobalLock;
-
-void InitGlobalLock()
-{
-    GlobalLock = CreateMutex(nullptr, false, nullptr);
-}
-
-void GetGlobalLock()
-{
-    WaitForSingleObject(GlobalLock, INFINITE);
-}
-
-void ReleaseGlobalLock()
-{
-    ReleaseMutex(GlobalLock);
-}
-
-unsigned int __stdcall EnterGenericThread (void* entry)
-{
-    return ((TThreadEntrypoint)entry)(nullptr);
-}
 
 //#define DUMP_COUNTERS
 

--- a/glslang/OSDependent/osinclude.h
+++ b/glslang/OSDependent/osinclude.h
@@ -37,12 +37,6 @@
 
 namespace glslang {
 
-void InitGlobalLock();
-void GetGlobalLock();
-void ReleaseGlobalLock();
-
-typedef unsigned int (*TThreadEntrypoint)(void*);
-
 void OS_DumpMemoryCounters();
 
 } // end namespace glslang


### PR DESCRIPTION
The usage of GetGlobalLock/ReleaseGlobalLock/InitGlobalLock is replaced by std::lock_guard which is available as of c++11, and the functions are removed from the OSDependent ossource.cpp files.

std::lock_guard is already used in `StandAlone/WorkList.h` and has been there since 2017.