### PR TITLE
Add emscripten build to CI

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -227,3 +227,27 @@ jobs:
                 CMAKE_CXX_COMPILER_LAUNCHER: ccache
             - name: Build
               run: cmake --build build/
+
+    emscripten:
+        runs-on: ubuntu-22.04
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: '3.7'
+            - uses: lukka/get-cmake@latest
+            - name: Setup ccache
+              uses: hendrikmuhs/ccache-action@v1.2
+              with:
+                  key: ubuntu-emscripten
+            - uses: mymindstorm/setup-emsdk@v11
+            - name: Update Glslang Sources
+              run: ./update_glslang_sources.py
+            - name: Configure
+              run: emcmake cmake -GNinja -Bbuild/web -DCMAKE_BUILD_TYPE=Release -DENABLE_GLSLANG_JS=ON -DBUILD_TESTING=OFF -DENABLE_OPT=OFF
+              env:
+                CMAKE_GENERATOR: Ninja
+                CMAKE_C_COMPILER_LAUNCHER: ccache
+                CMAKE_CXX_COMPILER_LAUNCHER: ccache
+            - name: Build
+              run: cmake --build build/web

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Use the steps in [Build Steps](#build-steps), with the following notes/exception
   Bash-like environments:
   + [Instructions located here](https://emscripten.org/docs/getting_started/downloads.html#sdk-download-and-install)
 * Wrap cmake call: `emcmake cmake`
-* Set `-DBUILD_TESTING=OFF -DENABLE_OPT=OFF -DINSTALL_GTEST=OFF`.
+* Set `-DBUILD_TESTING=OFF -DENABLE_OPT=OFF`.
 * Set `-DENABLE_HLSL=OFF` if HLSL is not needed.
 * For a standalone JS/WASM library, turn on `-DENABLE_GLSLANG_JS=ON`.
 * To get a fully minimized build, make sure to use `brotli` to compress the .js
@@ -260,7 +260,7 @@ Example:
 
 ```sh
 emcmake cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_GLSLANG_JS=ON \
-    -DENABLE_HLSL=OFF -DBUILD_TESTING=OFF -DENABLE_OPT=OFF -DINSTALL_GTEST=OFF ..
+    -DENABLE_HLSL=OFF -DBUILD_TESTING=OFF -DENABLE_OPT=OFF ..
 ```
 
 ## Building glslang - Using vcpkg


### PR DESCRIPTION
Adds a build-only (no test) job for testing the emscripten (web) build on github actions.