### PR TITLE
cmake: add more verbose messages if SPIRV-Tools is not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,10 +268,19 @@ option(ALLOW_EXTERNAL_SPIRV_TOOLS "Allows to build against installed SPIRV-Tools
 if(NOT TARGET SPIRV-Tools-opt)
     if(ALLOW_EXTERNAL_SPIRV_TOOLS)
         # Look for external SPIR-V Tools build, if not building in-tree
+        message(STATUS "Trying to find local SPIR-V tools")
         find_package(SPIRV-Tools-opt)
-    endif()
-    if(NOT TARGET SPIRV-Tools-opt)
-        set(ENABLE_OPT OFF)
+        if(NOT TARGET SPIRV-Tools-opt)
+            if(ENABLE_OPT)
+                message(WARNING "ENABLE_OPT set but SPIR-V tools not found! Disabling SPIR-V optimization.")
+            endif()
+            set(ENABLE_OPT OFF)
+        endif()
+    else()
+        if(ENABLE_OPT)
+            message(SEND_ERROR "ENABLE_OPT set but SPIR-V tools not found. Please run update_glslang_sources.py, "
+                "set the ALLOW_EXTERNAL_SPIRV_TOOLS option to use a local install of SPIRV-Tools, or set ENABLE_OPT=0.")
+        endif()
     endif()
 endif()
 

--- a/kokoro/linux-clang-cmake/build-docker.sh
+++ b/kokoro/linux-clang-cmake/build-docker.sh
@@ -46,5 +46,5 @@ using ninja-1.10.0
 echo "Building..."
 mkdir /build && cd /build
 
-cmake "$ROOT_DIR" -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS
+cmake "$ROOT_DIR" -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS -DENABLE_OPT=0
 ninja install

--- a/kokoro/linux-gcc-cmake/build-docker.sh
+++ b/kokoro/linux-gcc-cmake/build-docker.sh
@@ -46,5 +46,5 @@ using ninja-1.10.0
 echo "Building..."
 mkdir /build && cd /build
 
-cmake "$ROOT_DIR" -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS
+cmake "$ROOT_DIR" -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBS -DENABLE_OPT=0
 ninja install


### PR DESCRIPTION
This makes it more clear to users when SPIR-V optimization is disabled because SPIRV-Tools could not be found, and suggests alternatives for finding it.