### PR TITLE
Fix ODR violations

### DIFF
--- a/glslang/Include/PoolAlloc.h
+++ b/glslang/Include/PoolAlloc.h
@@ -118,11 +118,16 @@ private:
     unsigned char* mem;           // beginning of our allocation (pts to header)
     TAllocation* prevAlloc;       // prior allocation in the chain
 
-    const static unsigned char guardBlockBeginVal;
-    const static unsigned char guardBlockEndVal;
-    const static unsigned char userDataFill;
+    static inline constexpr unsigned char guardBlockBeginVal = 0xfb;
+    static inline constexpr unsigned char guardBlockEndVal = 0xfe;
+    static inline constexpr unsigned char userDataFill = 0xcd;
 
-    const static size_t guardBlockSize;
+#   ifdef GUARD_BLOCKS
+    static inline constexpr size_t guardBlockSize = 16;
+#   else
+    static inline constexpr size_t guardBlockSize = 0;
+#   endif
+
 #   ifdef GUARD_BLOCKS
     inline static size_t headerSize() { return sizeof(TAllocation); }
 #   else

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -61,10 +61,6 @@ const bool ARBCompatibility = true;
 
 const bool ForwardCompatibility = false;
 
-// change this back to false if depending on textual spellings of texturing calls when consuming the AST
-// Using PureOperatorBuiltins=false is deprecated.
-bool PureOperatorBuiltins = true;
-
 namespace {
 
 //

--- a/glslang/MachineIndependent/Initialize.h
+++ b/glslang/MachineIndependent/Initialize.h
@@ -107,6 +107,9 @@ protected:
     int dimMap[EsdNumDims];
 };
 
+// change this back to false if depending on textual spellings of texturing calls when consuming the AST
+// Using PureOperatorBuiltins=false is deprecated.
+constexpr bool PureOperatorBuiltins = true;
 } // end namespace glslang
 
 #endif // _INITIALIZE_INCLUDED_

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -38,6 +38,7 @@
 //
 
 #include "ParseHelper.h"
+#include "Initialize.h"
 #include "Scan.h"
 
 #include "../OSDependent/osinclude.h"
@@ -2685,7 +2686,6 @@ void TParseContext::builtInOpCheck(const TSourceLoc& loc, const TFunction& fnCan
     }
 }
 
-extern bool PureOperatorBuiltins;
 
 // Deprecated!  Use PureOperatorBuiltins == true instead, in which case this
 // functionality is handled in builtInOpCheck() instead of here.

--- a/glslang/MachineIndependent/PoolAlloc.cpp
+++ b/glslang/MachineIndependent/PoolAlloc.cpp
@@ -131,16 +131,6 @@ TPoolAllocator::~TPoolAllocator()
     }
 }
 
-const unsigned char TAllocation::guardBlockBeginVal = 0xfb;
-const unsigned char TAllocation::guardBlockEndVal   = 0xfe;
-const unsigned char TAllocation::userDataFill       = 0xcd;
-
-#   ifdef GUARD_BLOCKS
-    const size_t TAllocation::guardBlockSize = 16;
-#   else
-    const size_t TAllocation::guardBlockSize = 0;
-#   endif
-
 //
 // Check a single guard block for damage
 //

--- a/glslang/MachineIndependent/preprocessor/Pp.cpp
+++ b/glslang/MachineIndependent/preprocessor/Pp.cpp
@@ -378,8 +378,6 @@ namespace {
     int op_cmpl(int a) { return ~a; }
     int op_not(int a) { return !a; }
 
-};
-
 struct TBinop {
     int token, precedence, (*op)(int, int);
 } binop[] = {
@@ -411,6 +409,8 @@ struct TUnop {
     { '~', op_cmpl },
     { '!', op_not },
 };
+
+} // anonymous namespace
 
 #define NUM_ELEMENTS(A) (sizeof(A) / sizeof(A[0]))
 


### PR DESCRIPTION
On a shared build, these symbols exist in both libglslang.so and libSPIRV.so, leading to an ODR violation at runtime.
Detected through ASAN.