### PR TITLE
Fix ByteAddressBuffer as function parameter

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -2014,7 +2014,7 @@ void TGlslangToSpvTraverser::visitSymbol(glslang::TIntermSymbol* symbol)
                 spv::StorageClass sc = builder.getStorageClass(id);
                 // Before SPIR-V 1.4, we only want to include Input and Output.
                 // Starting with SPIR-V 1.4, we want all globals.
-                if ((glslangIntermediate->getSpv().spv >= glslang::EShTargetSpv_1_4 && builder.isGlobalStorage(id)) ||
+                if ((glslangIntermediate->getSpv().spv >= glslang::EShTargetSpv_1_4 && builder.isGlobalVariable(id)) ||
                     (sc == spv::StorageClassInput || sc == spv::StorageClassOutput)) {
                     iOSet.insert(id);
                 }

--- a/Test/baseResults/hlsl.buffer_ref_parameter.comp.out
+++ b/Test/baseResults/hlsl.buffer_ref_parameter.comp.out
@@ -1,0 +1,390 @@
+hlsl.buffer_ref_parameter.comp
+Shader version: 500
+local_size = (64, 1, 1)
+0:? Sequence
+0:4  Function Definition: pull_position(block--u1[0]1;u1; ( temp 3-component vector of float)
+0:4    Function Parameters: 
+0:4      'buffer_position' (layout( row_major std430) readonly buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:4      'vertex_id' ( in uint)
+0:?     Sequence
+0:5      Branch: Return with expression
+0:?         intBitsToFloat ( temp 3-component vector of float)
+0:?           Sequence
+0:5            move second child to first child ( temp int)
+0:5              'byteAddrTemp' ( temp int)
+0:5              right-shift ( temp int)
+0:5                component-wise multiply ( temp uint)
+0:5                  component-wise multiply ( temp uint)
+0:5                    'vertex_id' ( in uint)
+0:5                    Constant:
+0:5                      3 (const uint)
+0:5                  Constant:
+0:5                    4 (const uint)
+0:5                Constant:
+0:5                  2 (const int)
+0:?             Construct vec3 ( temp 3-component vector of uint)
+0:5              indirect index ( temp uint)
+0:5                @data: direct index for structure (layout( row_major std430) buffer unsized 1-element array of uint)
+0:5                  'buffer_position' (layout( row_major std430) readonly buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:5                  Constant:
+0:5                    0 (const uint)
+0:5                'byteAddrTemp' ( temp int)
+0:5              indirect index ( temp uint)
+0:5                @data: direct index for structure (layout( row_major std430) buffer unsized 1-element array of uint)
+0:5                  'buffer_position' (layout( row_major std430) readonly buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:5                  Constant:
+0:5                    0 (const uint)
+0:5                add ( temp int)
+0:5                  'byteAddrTemp' ( temp int)
+0:5                  Constant:
+0:5                    1 (const int)
+0:5              indirect index ( temp uint)
+0:5                @data: direct index for structure (layout( row_major std430) buffer unsized 1-element array of uint)
+0:5                  'buffer_position' (layout( row_major std430) readonly buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:5                  Constant:
+0:5                    0 (const uint)
+0:5                add ( temp int)
+0:5                  'byteAddrTemp' ( temp int)
+0:5                  Constant:
+0:5                    2 (const int)
+0:9  Function Definition: @main(u1; ( temp void)
+0:9    Function Parameters: 
+0:9      'gi' ( in uint)
+0:?     Sequence
+0:10      Sequence
+0:10        move second child to first child ( temp 3-component vector of float)
+0:10          'position_ms' ( temp 3-component vector of float)
+0:10          Function Call: pull_position(block--u1[0]1;u1; ( temp 3-component vector of float)
+0:10            'buffer_position_ms' (layout( set=0 binding=0 row_major std430) readonly buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:10            'gi' ( in uint)
+0:?       Sequence
+0:12        move second child to first child ( temp int)
+0:12          'byteAddrTemp' ( temp int)
+0:12          right-shift ( temp int)
+0:12            Constant:
+0:12              0 (const int)
+0:12            Constant:
+0:12              2 (const int)
+0:12        move second child to first child ( temp uint)
+0:12          indirect index (layout( row_major std430) buffer uint)
+0:12            @data: direct index for structure (layout( row_major std430) buffer unsized 1-element array of uint)
+0:12              'r' (layout( set=0 binding=1 row_major std430) buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:12              Constant:
+0:12                0 (const uint)
+0:12            'byteAddrTemp' ( temp int)
+0:12          direct index ( temp uint)
+0:12            floatBitsToUint ( temp 3-component vector of uint)
+0:12              'position_ms' ( temp 3-component vector of float)
+0:12            Constant:
+0:12              0 (const int)
+0:12        move second child to first child ( temp uint)
+0:12          indirect index (layout( row_major std430) buffer uint)
+0:12            @data: direct index for structure (layout( row_major std430) buffer unsized 1-element array of uint)
+0:12              'r' (layout( set=0 binding=1 row_major std430) buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:12              Constant:
+0:12                0 (const uint)
+0:12            add ( temp int)
+0:12              'byteAddrTemp' ( temp int)
+0:12              Constant:
+0:12                1 (const int)
+0:12          direct index ( temp uint)
+0:12            floatBitsToUint ( temp 3-component vector of uint)
+0:12              'position_ms' ( temp 3-component vector of float)
+0:12            Constant:
+0:12              1 (const int)
+0:12        move second child to first child ( temp uint)
+0:12          indirect index (layout( row_major std430) buffer uint)
+0:12            @data: direct index for structure (layout( row_major std430) buffer unsized 1-element array of uint)
+0:12              'r' (layout( set=0 binding=1 row_major std430) buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:12              Constant:
+0:12                0 (const uint)
+0:12            add ( temp int)
+0:12              'byteAddrTemp' ( temp int)
+0:12              Constant:
+0:12                2 (const int)
+0:12          direct index ( temp uint)
+0:12            floatBitsToUint ( temp 3-component vector of uint)
+0:12              'position_ms' ( temp 3-component vector of float)
+0:12            Constant:
+0:12              2 (const int)
+0:9  Function Definition: main( ( temp void)
+0:9    Function Parameters: 
+0:?     Sequence
+0:9      move second child to first child ( temp uint)
+0:?         'gi' ( temp uint)
+0:?         'gi' ( in uint LocalInvocationIndex)
+0:9      Function Call: @main(u1; ( temp void)
+0:?         'gi' ( temp uint)
+0:?   Linker Objects
+0:?     'buffer_position_ms' (layout( set=0 binding=0 row_major std430) readonly buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:?     'r' (layout( set=0 binding=1 row_major std430) buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:?     'gi' ( in uint LocalInvocationIndex)
+
+
+Linked compute stage:
+
+
+Shader version: 500
+local_size = (64, 1, 1)
+0:? Sequence
+0:4  Function Definition: pull_position(block--u1[0]1;u1; ( temp 3-component vector of float)
+0:4    Function Parameters: 
+0:4      'buffer_position' (layout( row_major std430) readonly buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:4      'vertex_id' ( in uint)
+0:?     Sequence
+0:5      Branch: Return with expression
+0:?         intBitsToFloat ( temp 3-component vector of float)
+0:?           Sequence
+0:5            move second child to first child ( temp int)
+0:5              'byteAddrTemp' ( temp int)
+0:5              right-shift ( temp int)
+0:5                component-wise multiply ( temp uint)
+0:5                  component-wise multiply ( temp uint)
+0:5                    'vertex_id' ( in uint)
+0:5                    Constant:
+0:5                      3 (const uint)
+0:5                  Constant:
+0:5                    4 (const uint)
+0:5                Constant:
+0:5                  2 (const int)
+0:?             Construct vec3 ( temp 3-component vector of uint)
+0:5              indirect index ( temp uint)
+0:5                @data: direct index for structure (layout( row_major std430) buffer unsized 1-element array of uint)
+0:5                  'buffer_position' (layout( row_major std430) readonly buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:5                  Constant:
+0:5                    0 (const uint)
+0:5                'byteAddrTemp' ( temp int)
+0:5              indirect index ( temp uint)
+0:5                @data: direct index for structure (layout( row_major std430) buffer unsized 1-element array of uint)
+0:5                  'buffer_position' (layout( row_major std430) readonly buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:5                  Constant:
+0:5                    0 (const uint)
+0:5                add ( temp int)
+0:5                  'byteAddrTemp' ( temp int)
+0:5                  Constant:
+0:5                    1 (const int)
+0:5              indirect index ( temp uint)
+0:5                @data: direct index for structure (layout( row_major std430) buffer unsized 1-element array of uint)
+0:5                  'buffer_position' (layout( row_major std430) readonly buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:5                  Constant:
+0:5                    0 (const uint)
+0:5                add ( temp int)
+0:5                  'byteAddrTemp' ( temp int)
+0:5                  Constant:
+0:5                    2 (const int)
+0:9  Function Definition: @main(u1; ( temp void)
+0:9    Function Parameters: 
+0:9      'gi' ( in uint)
+0:?     Sequence
+0:10      Sequence
+0:10        move second child to first child ( temp 3-component vector of float)
+0:10          'position_ms' ( temp 3-component vector of float)
+0:10          Function Call: pull_position(block--u1[0]1;u1; ( temp 3-component vector of float)
+0:10            'buffer_position_ms' (layout( set=0 binding=0 row_major std430) readonly buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:10            'gi' ( in uint)
+0:?       Sequence
+0:12        move second child to first child ( temp int)
+0:12          'byteAddrTemp' ( temp int)
+0:12          right-shift ( temp int)
+0:12            Constant:
+0:12              0 (const int)
+0:12            Constant:
+0:12              2 (const int)
+0:12        move second child to first child ( temp uint)
+0:12          indirect index (layout( row_major std430) buffer uint)
+0:12            @data: direct index for structure (layout( row_major std430) buffer unsized 1-element array of uint)
+0:12              'r' (layout( set=0 binding=1 row_major std430) buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:12              Constant:
+0:12                0 (const uint)
+0:12            'byteAddrTemp' ( temp int)
+0:12          direct index ( temp uint)
+0:12            floatBitsToUint ( temp 3-component vector of uint)
+0:12              'position_ms' ( temp 3-component vector of float)
+0:12            Constant:
+0:12              0 (const int)
+0:12        move second child to first child ( temp uint)
+0:12          indirect index (layout( row_major std430) buffer uint)
+0:12            @data: direct index for structure (layout( row_major std430) buffer unsized 1-element array of uint)
+0:12              'r' (layout( set=0 binding=1 row_major std430) buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:12              Constant:
+0:12                0 (const uint)
+0:12            add ( temp int)
+0:12              'byteAddrTemp' ( temp int)
+0:12              Constant:
+0:12                1 (const int)
+0:12          direct index ( temp uint)
+0:12            floatBitsToUint ( temp 3-component vector of uint)
+0:12              'position_ms' ( temp 3-component vector of float)
+0:12            Constant:
+0:12              1 (const int)
+0:12        move second child to first child ( temp uint)
+0:12          indirect index (layout( row_major std430) buffer uint)
+0:12            @data: direct index for structure (layout( row_major std430) buffer unsized 1-element array of uint)
+0:12              'r' (layout( set=0 binding=1 row_major std430) buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:12              Constant:
+0:12                0 (const uint)
+0:12            add ( temp int)
+0:12              'byteAddrTemp' ( temp int)
+0:12              Constant:
+0:12                2 (const int)
+0:12          direct index ( temp uint)
+0:12            floatBitsToUint ( temp 3-component vector of uint)
+0:12              'position_ms' ( temp 3-component vector of float)
+0:12            Constant:
+0:12              2 (const int)
+0:9  Function Definition: main( ( temp void)
+0:9    Function Parameters: 
+0:?     Sequence
+0:9      move second child to first child ( temp uint)
+0:?         'gi' ( temp uint)
+0:?         'gi' ( in uint LocalInvocationIndex)
+0:9      Function Call: @main(u1; ( temp void)
+0:?         'gi' ( temp uint)
+0:?   Linker Objects
+0:?     'buffer_position_ms' (layout( set=0 binding=0 row_major std430) readonly buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:?     'r' (layout( set=0 binding=1 row_major std430) buffer block{layout( row_major std430) buffer unsized 1-element array of uint @data})
+0:?     'gi' ( in uint LocalInvocationIndex)
+
+// Module Version 10400
+// Generated by (magic number): 8000b
+// Id's are bound by 90
+
+                              Capability Shader
+               1:             ExtInstImport  "GLSL.std.450"
+                              MemoryModel Logical GLSL450
+                              EntryPoint GLCompute 4  "main" 53 62 85
+                              ExecutionMode 4 LocalSize 64 1 1
+                              Source HLSL 500
+                              Name 4  "main"
+                              Name 8  ""
+                              MemberName 8 0  "@data"
+                              Name 16  "pull_position(block--u1[0]1;u1;"
+                              Name 14  "buffer_position"
+                              Name 15  "vertex_id"
+                              Name 20  "@main(u1;"
+                              Name 19  "gi"
+                              Name 24  "byteAddrTemp"
+                              Name 52  "position_ms"
+                              Name 53  "buffer_position_ms"
+                              Name 54  "param"
+                              Name 57  "byteAddrTemp"
+                              Name 60  "r"
+                              MemberName 60(r) 0  "@data"
+                              Name 62  "r"
+                              Name 83  "gi"
+                              Name 85  "gi"
+                              Name 87  "param"
+                              Decorate 7 ArrayStride 4
+                              MemberDecorate 8 0 NonWritable
+                              MemberDecorate 8 0 Offset 0
+                              Decorate 8 Block
+                              Decorate 14(buffer_position) NonWritable
+                              Decorate 53(buffer_position_ms) DescriptorSet 0
+                              Decorate 53(buffer_position_ms) Binding 0
+                              Decorate 59 ArrayStride 4
+                              MemberDecorate 60(r) 0 Offset 0
+                              Decorate 60(r) Block
+                              Decorate 62(r) DescriptorSet 0
+                              Decorate 62(r) Binding 1
+                              Decorate 85(gi) BuiltIn LocalInvocationIndex
+               2:             TypeVoid
+               3:             TypeFunction 2
+               6:             TypeInt 32 0
+               7:             TypeRuntimeArray 6(int)
+               8:             TypeStruct 7
+               9:             TypePointer StorageBuffer 8(struct)
+              10:             TypePointer Function 6(int)
+              11:             TypeFloat 32
+              12:             TypeVector 11(float) 3
+              13:             TypeFunction 12(fvec3) 9(ptr) 10(ptr)
+              18:             TypeFunction 2 10(ptr)
+              22:             TypeInt 32 1
+              23:             TypePointer Function 22(int)
+              26:      6(int) Constant 3
+              28:      6(int) Constant 4
+              30:     22(int) Constant 2
+              32:     22(int) Constant 0
+              34:             TypePointer StorageBuffer 6(int)
+              38:     22(int) Constant 1
+              46:             TypeVector 6(int) 3
+              51:             TypePointer Function 12(fvec3)
+53(buffer_position_ms):      9(ptr) Variable StorageBuffer
+              59:             TypeRuntimeArray 6(int)
+           60(r):             TypeStruct 59
+              61:             TypePointer StorageBuffer 60(r)
+           62(r):     61(ptr) Variable StorageBuffer
+              66:      6(int) Constant 0
+              73:      6(int) Constant 1
+              80:      6(int) Constant 2
+              84:             TypePointer Input 6(int)
+          85(gi):     84(ptr) Variable Input
+         4(main):           2 Function None 3
+               5:             Label
+          83(gi):     10(ptr) Variable Function
+       87(param):     10(ptr) Variable Function
+              86:      6(int) Load 85(gi)
+                              Store 83(gi) 86
+              88:      6(int) Load 83(gi)
+                              Store 87(param) 88
+              89:           2 FunctionCall 20(@main(u1;) 87(param)
+                              Return
+                              FunctionEnd
+16(pull_position(block--u1[0]1;u1;):   12(fvec3) Function None 13
+14(buffer_position):      9(ptr) FunctionParameter
+   15(vertex_id):     10(ptr) FunctionParameter
+              17:             Label
+24(byteAddrTemp):     23(ptr) Variable Function
+              25:      6(int) Load 15(vertex_id)
+              27:      6(int) IMul 25 26
+              29:      6(int) IMul 27 28
+              31:     22(int) ShiftRightLogical 29 30
+                              Store 24(byteAddrTemp) 31
+              33:     22(int) Load 24(byteAddrTemp)
+              35:     34(ptr) AccessChain 14(buffer_position) 32 33
+              36:      6(int) Load 35
+              37:     22(int) Load 24(byteAddrTemp)
+              39:     22(int) IAdd 37 38
+              40:     34(ptr) AccessChain 14(buffer_position) 32 39
+              41:      6(int) Load 40
+              42:     22(int) Load 24(byteAddrTemp)
+              43:     22(int) IAdd 42 30
+              44:     34(ptr) AccessChain 14(buffer_position) 32 43
+              45:      6(int) Load 44
+              47:   46(ivec3) CompositeConstruct 36 41 45
+              48:   12(fvec3) Bitcast 47
+                              ReturnValue 48
+                              FunctionEnd
+   20(@main(u1;):           2 Function None 18
+          19(gi):     10(ptr) FunctionParameter
+              21:             Label
+ 52(position_ms):     51(ptr) Variable Function
+       54(param):     10(ptr) Variable Function
+57(byteAddrTemp):     23(ptr) Variable Function
+              55:      6(int) Load 19(gi)
+                              Store 54(param) 55
+              56:   12(fvec3) FunctionCall 16(pull_position(block--u1[0]1;u1;) 53(buffer_position_ms) 54(param)
+                              Store 52(position_ms) 56
+              58:     22(int) ShiftRightArithmetic 32 30
+                              Store 57(byteAddrTemp) 58
+              63:     22(int) Load 57(byteAddrTemp)
+              64:   12(fvec3) Load 52(position_ms)
+              65:   46(ivec3) Bitcast 64
+              67:      6(int) CompositeExtract 65 0
+              68:     34(ptr) AccessChain 62(r) 32 63
+                              Store 68 67
+              69:     22(int) Load 57(byteAddrTemp)
+              70:     22(int) IAdd 69 38
+              71:   12(fvec3) Load 52(position_ms)
+              72:   46(ivec3) Bitcast 71
+              74:      6(int) CompositeExtract 72 1
+              75:     34(ptr) AccessChain 62(r) 32 70
+                              Store 75 74
+              76:     22(int) Load 57(byteAddrTemp)
+              77:     22(int) IAdd 76 30
+              78:   12(fvec3) Load 52(position_ms)
+              79:   46(ivec3) Bitcast 78
+              81:      6(int) CompositeExtract 79 2
+              82:     34(ptr) AccessChain 62(r) 32 77
+                              Store 82 81
+                              Return
+                              FunctionEnd

--- a/Test/hlsl.buffer_ref_parameter.comp
+++ b/Test/hlsl.buffer_ref_parameter.comp
@@ -1,0 +1,13 @@
+[[vk::binding(0, 0)]] ByteAddressBuffer buffer_position_ms;
+[[vk::binding(1, 0)]] RWByteAddressBuffer r;
+
+float3 pull_position(ByteAddressBuffer buffer_position, uint vertex_id) {
+    return asfloat(buffer_position.Load3(vertex_id * 3 * 4));
+}
+
+[numthreads(64, 1, 1)]
+void main(uint gi : SV_GroupIndex) {
+    float3 position_ms = pull_position(buffer_position_ms, gi);
+
+    r.Store3(0, asuint(position_ms));
+}

--- a/gtests/Hlsl.FromFile.cpp
+++ b/gtests/Hlsl.FromFile.cpp
@@ -59,6 +59,7 @@ std::string FileNameAsCustomTestSuffix(
 
 using HlslCompileTest = GlslangTest<::testing::TestWithParam<FileNameEntryPointPair>>;
 using HlslVulkan1_1CompileTest = GlslangTest<::testing::TestWithParam<FileNameEntryPointPair>>;
+using HlslVulkan1_2CompileTest = GlslangTest<::testing::TestWithParam<FileNameEntryPointPair>>;
 using HlslSpv1_6CompileTest = GlslangTest<::testing::TestWithParam<FileNameEntryPointPair>>;
 using HlslCompileAndFlattenTest = GlslangTest<::testing::TestWithParam<FileNameEntryPointPair>>;
 using HlslLegalizeTest = GlslangTest<::testing::TestWithParam<FileNameEntryPointPair>>;
@@ -81,6 +82,13 @@ TEST_P(HlslVulkan1_1CompileTest, FromFile)
     loadFileCompileAndCheck(GlobalTestSettings.testRoot, GetParam().fileName,
                             Source::HLSL, Semantics::Vulkan, glslang::EShTargetVulkan_1_1, glslang::EShTargetSpv_1_3,
                             Target::BothASTAndSpv, true, GetParam().entryPoint);
+}
+
+TEST_P(HlslVulkan1_2CompileTest, FromFile)
+{
+    loadFileCompileAndCheck(GlobalTestSettings.testRoot, GetParam().fileName, Source::HLSL, Semantics::Vulkan,
+                            glslang::EShTargetVulkan_1_2, glslang::EShTargetSpv_1_4, Target::BothASTAndSpv, true,
+                            GetParam().entryPoint);
 }
 
 TEST_P(HlslSpv1_6CompileTest, FromFile)
@@ -466,6 +474,14 @@ INSTANTIATE_TEST_SUITE_P(
         {"hlsl.wavevote.comp", "CSMain"},
         { "hlsl.type.type.conversion.valid.frag", "main" },
         {"hlsl.int.dot.frag", "main"}
+    }),
+    FileNameAsCustomTestSuffix
+);
+
+INSTANTIATE_TEST_SUITE_P(
+    ToSpirv, HlslVulkan1_2CompileTest,
+    ::testing::ValuesIn(std::vector<FileNameEntryPointPair>{
+        {"hlsl.buffer_ref_parameter.comp", "main"},
     }),
     FileNameAsCustomTestSuffix
 );


### PR DESCRIPTION
Make sure that an id represents a variable before adding it to an entry point's interface.

Fixes #3297.