### PR TITLE
Hash pin and auto-update workflow dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # Necessary to update action hashes	
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Allow up to 3 opened pull requests for github-actions versions
+    open-pull-requests-limit: 3

--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -47,9 +47,9 @@ jobs:
                 compiler: [{cc: clang, cxx: clang++}, {cc: gcc, cxx: g++}]
                 cmake_build_type: [Debug, Release]
         steps:
-            - uses: actions/checkout@v3
-            - uses: lukka/get-cmake@latest
-            - uses: actions/setup-python@v4
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+            - uses: lukka/get-cmake@4dcd3eb73017c61159eb130746fbca35d78a3d5f # v3.27.4
+            - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
               with:
                   python-version: '3.7'
             - name: Install Ubuntu Package Dependencies
@@ -110,7 +110,7 @@ jobs:
               if: ${{ matrix.compiler.cc == 'clang' }}
               env:
                   ARCHIVE: glslang-main-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
-              uses: actions/github-script@v6
+              uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
               with:
                   script: |
                       const script = require('.github/workflows/deploy.js')
@@ -127,9 +127,9 @@ jobs:
                 compiler: [{cc: clang, cxx: clang++}]
                 cmake_build_type: [Debug, Release]
         steps:
-            - uses: actions/checkout@v3
-            - uses: lukka/get-cmake@latest
-            - uses: actions/setup-python@v4
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+            - uses: lukka/get-cmake@4dcd3eb73017c61159eb130746fbca35d78a3d5f # v3.27.4
+            - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
               with:
                   python-version: '3.7'
             - name: Install GoogleTest
@@ -184,7 +184,7 @@ jobs:
             - name: Deploy
               env:
                   ARCHIVE: glslang-main-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
-              uses: actions/github-script@v6
+              uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
               with:
                   script: |
                       const script = require('.github/workflows/deploy.js')
@@ -200,9 +200,9 @@ jobs:
                 os: [{genus: windows-2019, family: windows}]
                 cmake_build_type: [Debug, Release]
         steps:
-            - uses: actions/checkout@v3
-            - uses: lukka/get-cmake@latest
-            - uses: actions/setup-python@v4
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+            - uses: lukka/get-cmake@4dcd3eb73017c61159eb130746fbca35d78a3d5f # v3.27.4
+            - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
               with:
                   python-version: '3.7'
             - name: Install GoogleTest
@@ -276,7 +276,7 @@ jobs:
             - name: Deploy
               env:
                   ARCHIVE: glslang-master-${{matrix.os.family}}-${{matrix.cmake_build_type}}.zip
-              uses: actions/github-script@v6
+              uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
               with:
                   script: |
                       const script = require('.github/workflows/deploy.js')

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -23,13 +23,13 @@ jobs:
                 compiler: [{cc: clang, cxx: clang++}, {cc: gcc, cxx: g++}]
                 cmake_build_type: [Debug, Release]
         steps:
-            - uses: actions/checkout@v3
-            - uses: lukka/get-cmake@latest  
-            - uses: actions/setup-python@v4
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+            - uses: lukka/get-cmake@4dcd3eb73017c61159eb130746fbca35d78a3d5f # v3.27.4  
+            - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
               with:
                   python-version: '3.7'
             - name: Setup ccache
-              uses: hendrikmuhs/ccache-action@v1.2
+              uses: hendrikmuhs/ccache-action@6d1841ec156c39a52b1b23a810da917ab98da1f4 # v1.2.10
               with:
                   key: ubuntu-22-${{ matrix.cmake_build_type }}-${{ matrix.compiler.cc }}-${{matrix.compiler.cxx}}
             - name: Install GoogleTest
@@ -69,15 +69,15 @@ jobs:
       name: Linux Backcompat
       runs-on: ubuntu-20.04
       steps:
-          - uses: actions/checkout@v3
-          - uses: actions/setup-python@v4
+          - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+          - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
             with:
                 python-version: '3.7'
-          - uses: lukka/get-cmake@latest
+          - uses: lukka/get-cmake@4dcd3eb73017c61159eb130746fbca35d78a3d5f # v3.27.4
             with:
               cmakeVersion: 3.17.2
           - name: Setup ccache
-            uses: hendrikmuhs/ccache-action@v1.2
+            uses: hendrikmuhs/ccache-action@6d1841ec156c39a52b1b23a810da917ab98da1f4 # v1.2.10
             with:
               key: linux_backcompat
           - name: Install GoogleTest
@@ -118,11 +118,11 @@ jobs:
                 compiler: [{cc: clang, cxx: clang++}, {cc: gcc, cxx: g++}]
                 cmake_build_type: [Debug, Release]
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-python@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+            - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
               with:
                   python-version: '3.7'
-            - uses: lukka/get-cmake@latest
+            - uses: lukka/get-cmake@4dcd3eb73017c61159eb130746fbca35d78a3d5f # v3.27.4
             - name: Install GoogleTest
               run: |
                   # check out pre-breakage version of googletest; can be deleted when
@@ -162,9 +162,9 @@ jobs:
                 os: [{genus: windows-2019, family: windows}]
                 cmake_build_type: [Debug, Release]
         steps:
-            - uses: actions/checkout@v3
-            - uses: lukka/get-cmake@latest
-            - uses: actions/setup-python@v4
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+            - uses: lukka/get-cmake@4dcd3eb73017c61159eb130746fbca35d78a3d5f # v3.27.4
+            - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
               with:
                   python-version: '3.7'
             - name: Install GoogleTest
@@ -203,13 +203,13 @@ jobs:
             # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#android
             NDK: [23.2.8568313, 25.2.9519653]
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-python@v4
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+            - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
               with:
                   python-version: '3.7'
-            - uses: lukka/get-cmake@latest
+            - uses: lukka/get-cmake@4dcd3eb73017c61159eb130746fbca35d78a3d5f # v3.27.4
             - name: Setup ccache
-              uses: hendrikmuhs/ccache-action@v1.2
+              uses: hendrikmuhs/ccache-action@6d1841ec156c39a52b1b23a810da917ab98da1f4 # v1.2.10
               with:
                   key: android-${{ matrix.LEGACY }}-${{ matrix.NDK }}
             - name: Update Glslang Sources
@@ -232,16 +232,16 @@ jobs:
     emscripten:
         runs-on: ubuntu-22.04
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-python@v4
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+            - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
               with:
                   python-version: '3.7'
-            - uses: lukka/get-cmake@latest
+            - uses: lukka/get-cmake@4dcd3eb73017c61159eb130746fbca35d78a3d5f # v3.27.4
             - name: Setup ccache
-              uses: hendrikmuhs/ccache-action@v1.2
+              uses: hendrikmuhs/ccache-action@6d1841ec156c39a52b1b23a810da917ab98da1f4 # v1.2.10
               with:
                   key: ubuntu-emscripten
-            - uses: mymindstorm/setup-emsdk@v11
+            - uses: mymindstorm/setup-emsdk@ab889da2abbcbb280f91ec4c215d3bb4f3a8f775 # v12
             - name: Update Glslang Sources
               run: ./update_glslang_sources.py
             - name: Configure

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
+        uses: ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031 # v2.2.0
         with:
           results_file: results.sarif
           results_format: sarif
@@ -40,7 +40,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: SARIF file
           path: results.sarif
@@ -48,6 +48,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2.2.4
+        uses: github/codeql-action/upload-sarif@00e563ead9f72a8461b24876bee2d0c2e8bd2ee8 # v2.21.5
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Closes #3321 

I've used step security tool to help on getting the hash commits, but also I've manually validate them 

https://github.com/lukka/get-cmake/commit/4dcd3eb73017c61159eb130746fbca35d78a3d5f - v3.27.4
https://github.com/actions/checkout/commit/f43a0e5ff2bd294095638e18286ca9a3d1956744 -  v3.6.0
https://github.com/actions/setup-python/commit/61a6322f88396a6271a6ee3565807d608ecaddd1 - v4.7.0
https://github.com/actions/github-script/commit/d7906e4ad0b1822421a7e6a35d5ca353c962f410 - v6.4.1
https://github.com/hendrikmuhs/ccache-action/commit/ca3acd2731eef11f1572ccb126356c2f9298d35e - v1.2.10
https://github.com/mymindstorm/setup-emsdk/commit/29ba4851d6da084ffdc1e0fc390efadbd75df9d1 - v12

I've configured the dependabot with a maximum of 3 PRs per week. Though, it is also possible to configure it to group dependencies now https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/.  Let me know if you rather group the PRs instead.

Example of dependabot PR - https://github.com/joycebrum/glslang/pull/6 