### PR TITLE
Fixed memleaks using delete operator for dynamically allocated objects

### DIFF
--- a/glslang/HLSL/hlslGrammar.cpp
+++ b/glslang/HLSL/hlslGrammar.cpp
@@ -2623,6 +2623,7 @@ bool HlslGrammar::acceptStructBufferType(TType& type)
     if (hasTemplateType) {
         if (! acceptTokenClass(EHTokLeftAngle)) {
             expected("left angle bracket");
+            delete templateType;
             return false;
         }
     
@@ -3898,11 +3899,13 @@ void HlslGrammar::acceptAttributes(TAttributes& attributes)
         // RIGHT_BRACKET
         if (!acceptTokenClass(EHTokRightBracket)) {
             expected("]");
+            delete expressions;
             return;
         }
         // another RIGHT_BRACKET?
         if (doubleBrackets && !acceptTokenClass(EHTokRightBracket)) {
             expected("]]");
+            delete expressions;
             return;
         }
 

--- a/glslang/HLSL/hlslParseHelper.cpp
+++ b/glslang/HLSL/hlslParseHelper.cpp
@@ -709,6 +709,8 @@ TIntermTyped* HlslParseContext::handleVariable(const TSourceLoc& loc, const TStr
     if (variable->getType().getQualifier().isIo())
         intermediate.addIoAccessed(*string);
 
+    delete variable;
+
     return node;
 }
 
@@ -3342,6 +3344,7 @@ TIntermAggregate* HlslParseContext::handleSamplerTextureCombine(const TSourceLoc
 
         if (texSymbol == nullptr) {
             error(loc, "unable to find texture symbol", "", "");
+            delete txcombine;
             return nullptr;
         }
 

--- a/glslang/Include/ConstantUnion.h
+++ b/glslang/Include/ConstantUnion.h
@@ -876,7 +876,10 @@ public:
     POOL_ALLOCATOR_NEW_DELETE(GetThreadPoolAllocator())
 
     TConstUnionArray() : unionArray(nullptr) { }
-    virtual ~TConstUnionArray() { }
+    virtual ~TConstUnionArray()
+    {
+        delete unionArray;
+    }
 
     explicit TConstUnionArray(int size)
     {

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -1692,7 +1692,12 @@ public:
                                 qualifier.storage = p.qualifier.storage;
                                 referentType = p.clone();
                             }
-    virtual ~TType() {}
+    virtual ~TType()
+    {
+        delete spirvType;
+        delete arraySizes;
+        delete typeParameters;
+    }
 
     // Not for use across pool pops; it will cause multiple instances of TType to point to the same information.
     // This only works if that information (like a structure's list of types) does not change and

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -519,6 +519,8 @@ TIntermTyped* TParseContext::handleVariable(const TSourceLoc& loc, TSymbol* symb
         intermediate.setUseVulkanMemoryModel();
     }
 
+    delete variable;
+
     return node;
 }
 


### PR DESCRIPTION
Minor PR changes that affect small memory leaks in different situations.