### PR TITLE
Fix interpolant ES error

### DIFF
--- a/Test/baseResults/glsl.interpOp.error.frag.out
+++ b/Test/baseResults/glsl.interpOp.error.frag.out
@@ -1,0 +1,501 @@
+glsl.interpOp.error.frag
+ERROR: 0:39: 'interpolateAtCentroid' : first argument must be an interpolant, or interpolant-array element. Using the field of a named struct as an interpolant argument is not allowed (ES-only). 
+ERROR: 0:40: 'interpolateAtCentroid' : first argument must be an interpolant, or interpolant-array element 
+ERROR: 0:41: 'interpolateAtCentroid' : first argument must be an interpolant, or interpolant-array element. Using the field of a named struct as an interpolant argument is not allowed (ES-only). 
+ERROR: 0:54: 'interpolateAtSample' : first argument must be an interpolant, or interpolant-array element. Using the field of a named struct as an interpolant argument is not allowed (ES-only). 
+ERROR: 0:55: 'interpolateAtSample' : first argument must be an interpolant, or interpolant-array element 
+ERROR: 0:56: 'interpolateAtSample' : first argument must be an interpolant, or interpolant-array element. Using the field of a named struct as an interpolant argument is not allowed (ES-only). 
+ERROR: 0:69: 'interpolateAtOffset' : first argument must be an interpolant, or interpolant-array element. Using the field of a named struct as an interpolant argument is not allowed (ES-only). 
+ERROR: 0:70: 'interpolateAtOffset' : first argument must be an interpolant, or interpolant-array element 
+ERROR: 0:71: 'interpolateAtOffset' : first argument must be an interpolant, or interpolant-array element. Using the field of a named struct as an interpolant argument is not allowed (ES-only). 
+ERROR: 9 compilation errors.  No code generated.
+
+
+Shader version: 320
+ERROR: node is still EOpNull!
+0:27  Function Definition: main( ( global void)
+0:27    Function Parameters: 
+0:32    Sequence
+0:32      Sequence
+0:32        move second child to first child ( temp mediump 4-component vector of float)
+0:32          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:32          Construct vec4 ( temp mediump 4-component vector of float)
+0:32            interpolateAtCentroid ( global highp float)
+0:32              'v' (layout( location=2) smooth in highp float)
+0:33        move second child to first child ( temp mediump 4-component vector of float)
+0:33          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:33          Construct vec4 ( temp mediump 4-component vector of float)
+0:33            interpolateAtCentroid ( global highp float)
+0:33              x: direct index for structure ( in highp float)
+0:33                'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:33                Constant:
+0:33                  0 (const uint)
+0:34        move second child to first child ( temp mediump 4-component vector of float)
+0:34          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:34          Construct vec4 ( temp mediump 4-component vector of float)
+0:34            interpolateAtCentroid ( global highp float)
+0:34              direct index (layout( location=7) smooth temp highp float)
+0:34                'z' (layout( location=7) smooth in 1-element array of highp float)
+0:34                Constant:
+0:34                  0 (const int)
+0:35        move second child to first child ( temp highp 4-component vector of float)
+0:35          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:35          interpolateAtCentroid ( global highp 4-component vector of float)
+0:35            'w' (layout( location=8) smooth in highp 4-component vector of float)
+0:36        move second child to first child ( temp highp 4-component vector of float)
+0:36          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:36          interpolateAtCentroid ( global highp 4-component vector of float)
+0:36            direct index ( temp highp 4-component vector of float)
+0:36              xyz: direct index for structure ( in 1-element array of highp 4-component vector of float)
+0:36                'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:36                Constant:
+0:36                  1 (const uint)
+0:36              Constant:
+0:36                0 (const int)
+0:39        move second child to first child ( temp mediump 4-component vector of float)
+0:39          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:39          Construct vec4 ( temp mediump 4-component vector of float)
+0:39            interpolateAtCentroid ( global highp float)
+0:39              a: direct index for structure ( global highp float)
+0:39                'v_var' (layout( location=0) smooth in structure{ global highp float a,  global highp float b})
+0:39                Constant:
+0:39                  0 (const int)
+0:40        move second child to first child ( temp mediump 4-component vector of float)
+0:40          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:40          Construct vec4 ( temp mediump 4-component vector of float)
+0:40            interpolateAtCentroid ( global highp float)
+0:40              direct index ( temp highp float)
+0:40                'w' (layout( location=8) smooth in highp 4-component vector of float)
+0:40                Constant:
+0:40                  0 (const int)
+0:41        move second child to first child ( temp mediump 4-component vector of float)
+0:41          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:41          Construct vec4 ( temp mediump 4-component vector of float)
+0:41            interpolateAtCentroid ( global highp 4-component vector of float)
+0:41              s_v: direct index for structure ( global highp 4-component vector of float)
+0:41                s0: direct index for structure ( in structure{ global highp 4-component vector of float s_v})
+0:41                  'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:41                  Constant:
+0:41                    2 (const uint)
+0:41                Constant:
+0:41                  0 (const int)
+0:47      Sequence
+0:47        move second child to first child ( temp mediump 4-component vector of float)
+0:47          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:47          Construct vec4 ( temp mediump 4-component vector of float)
+0:47            interpolateAtSample ( global highp float)
+0:47              'v' (layout( location=2) smooth in highp float)
+0:47              Constant:
+0:47                0 (const int)
+0:48        move second child to first child ( temp mediump 4-component vector of float)
+0:48          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:48          Construct vec4 ( temp mediump 4-component vector of float)
+0:48            interpolateAtSample ( global highp float)
+0:48              x: direct index for structure ( in highp float)
+0:48                'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:48                Constant:
+0:48                  0 (const uint)
+0:48              Constant:
+0:48                0 (const int)
+0:49        move second child to first child ( temp mediump 4-component vector of float)
+0:49          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:49          Construct vec4 ( temp mediump 4-component vector of float)
+0:49            interpolateAtSample ( global highp float)
+0:49              direct index (layout( location=7) smooth temp highp float)
+0:49                'z' (layout( location=7) smooth in 1-element array of highp float)
+0:49                Constant:
+0:49                  0 (const int)
+0:49              Constant:
+0:49                0 (const int)
+0:50        move second child to first child ( temp highp 4-component vector of float)
+0:50          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:50          interpolateAtSample ( global highp 4-component vector of float)
+0:50            'w' (layout( location=8) smooth in highp 4-component vector of float)
+0:50            Constant:
+0:50              0 (const int)
+0:51        move second child to first child ( temp highp 4-component vector of float)
+0:51          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:51          interpolateAtSample ( global highp 4-component vector of float)
+0:51            direct index ( temp highp 4-component vector of float)
+0:51              xyz: direct index for structure ( in 1-element array of highp 4-component vector of float)
+0:51                'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:51                Constant:
+0:51                  1 (const uint)
+0:51              Constant:
+0:51                0 (const int)
+0:51            Constant:
+0:51              0 (const int)
+0:54        move second child to first child ( temp mediump 4-component vector of float)
+0:54          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:54          Construct vec4 ( temp mediump 4-component vector of float)
+0:54            interpolateAtSample ( global highp float)
+0:54              a: direct index for structure ( global highp float)
+0:54                'v_var' (layout( location=0) smooth in structure{ global highp float a,  global highp float b})
+0:54                Constant:
+0:54                  0 (const int)
+0:54              Constant:
+0:54                0 (const int)
+0:55        move second child to first child ( temp mediump 4-component vector of float)
+0:55          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:55          Construct vec4 ( temp mediump 4-component vector of float)
+0:55            interpolateAtSample ( global highp float)
+0:55              direct index ( temp highp float)
+0:55                'w' (layout( location=8) smooth in highp 4-component vector of float)
+0:55                Constant:
+0:55                  0 (const int)
+0:55              Constant:
+0:55                0 (const int)
+0:56        move second child to first child ( temp mediump 4-component vector of float)
+0:56          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:56          Construct vec4 ( temp mediump 4-component vector of float)
+0:56            interpolateAtSample ( global highp 4-component vector of float)
+0:56              s_v: direct index for structure ( global highp 4-component vector of float)
+0:56                s0: direct index for structure ( in structure{ global highp 4-component vector of float s_v})
+0:56                  'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:56                  Constant:
+0:56                    2 (const uint)
+0:56                Constant:
+0:56                  0 (const int)
+0:56              Constant:
+0:56                0 (const int)
+0:62      Sequence
+0:62        move second child to first child ( temp mediump 4-component vector of float)
+0:62          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:62          Construct vec4 ( temp mediump 4-component vector of float)
+0:62            interpolateAtOffset ( global highp float)
+0:62              'v' (layout( location=2) smooth in highp float)
+0:62              Constant:
+0:62                0.000000
+0:62                0.000000
+0:63        move second child to first child ( temp mediump 4-component vector of float)
+0:63          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:63          Construct vec4 ( temp mediump 4-component vector of float)
+0:63            interpolateAtOffset ( global highp float)
+0:63              x: direct index for structure ( in highp float)
+0:63                'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:63                Constant:
+0:63                  0 (const uint)
+0:63              Constant:
+0:63                0.000000
+0:63                0.000000
+0:64        move second child to first child ( temp mediump 4-component vector of float)
+0:64          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:64          Construct vec4 ( temp mediump 4-component vector of float)
+0:64            interpolateAtOffset ( global highp float)
+0:64              direct index (layout( location=7) smooth temp highp float)
+0:64                'z' (layout( location=7) smooth in 1-element array of highp float)
+0:64                Constant:
+0:64                  0 (const int)
+0:64              Constant:
+0:64                0.000000
+0:64                0.000000
+0:65        move second child to first child ( temp highp 4-component vector of float)
+0:65          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:65          interpolateAtOffset ( global highp 4-component vector of float)
+0:65            'w' (layout( location=8) smooth in highp 4-component vector of float)
+0:65            Constant:
+0:65              0.000000
+0:65              0.000000
+0:66        move second child to first child ( temp highp 4-component vector of float)
+0:66          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:66          interpolateAtOffset ( global highp 4-component vector of float)
+0:66            direct index ( temp highp 4-component vector of float)
+0:66              xyz: direct index for structure ( in 1-element array of highp 4-component vector of float)
+0:66                'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:66                Constant:
+0:66                  1 (const uint)
+0:66              Constant:
+0:66                0 (const int)
+0:66            Constant:
+0:66              0.000000
+0:66              0.000000
+0:69        move second child to first child ( temp mediump 4-component vector of float)
+0:69          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:69          Construct vec4 ( temp mediump 4-component vector of float)
+0:69            interpolateAtOffset ( global highp float)
+0:69              a: direct index for structure ( global highp float)
+0:69                'v_var' (layout( location=0) smooth in structure{ global highp float a,  global highp float b})
+0:69                Constant:
+0:69                  0 (const int)
+0:69              Constant:
+0:69                0.000000
+0:69                0.000000
+0:70        move second child to first child ( temp mediump 4-component vector of float)
+0:70          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:70          Construct vec4 ( temp mediump 4-component vector of float)
+0:70            interpolateAtOffset ( global highp float)
+0:70              direct index ( temp highp float)
+0:70                'w' (layout( location=8) smooth in highp 4-component vector of float)
+0:70                Constant:
+0:70                  0 (const int)
+0:70              Constant:
+0:70                0.000000
+0:70                0.000000
+0:71        move second child to first child ( temp mediump 4-component vector of float)
+0:71          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:71          Construct vec4 ( temp mediump 4-component vector of float)
+0:71            interpolateAtOffset ( global highp 4-component vector of float)
+0:71              s_v: direct index for structure ( global highp 4-component vector of float)
+0:71                s0: direct index for structure ( in structure{ global highp 4-component vector of float s_v})
+0:71                  'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:71                  Constant:
+0:71                    2 (const uint)
+0:71                Constant:
+0:71                  0 (const int)
+0:71              Constant:
+0:71                0.000000
+0:71                0.000000
+0:?   Linker Objects
+0:?     'v_var' (layout( location=0) smooth in structure{ global highp float a,  global highp float b})
+0:?     'v' (layout( location=2) smooth in highp float)
+0:?     'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:?     'z' (layout( location=7) smooth in 1-element array of highp float)
+0:?     'w' (layout( location=8) smooth in highp 4-component vector of float)
+0:?     'fragColor' (layout( location=0) out mediump 4-component vector of float)
+
+
+Linked fragment stage:
+
+
+Shader version: 320
+ERROR: node is still EOpNull!
+0:27  Function Definition: main( ( global void)
+0:27    Function Parameters: 
+0:32    Sequence
+0:32      Sequence
+0:32        move second child to first child ( temp mediump 4-component vector of float)
+0:32          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:32          Construct vec4 ( temp mediump 4-component vector of float)
+0:32            interpolateAtCentroid ( global highp float)
+0:32              'v' (layout( location=2) smooth in highp float)
+0:33        move second child to first child ( temp mediump 4-component vector of float)
+0:33          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:33          Construct vec4 ( temp mediump 4-component vector of float)
+0:33            interpolateAtCentroid ( global highp float)
+0:33              x: direct index for structure ( in highp float)
+0:33                'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:33                Constant:
+0:33                  0 (const uint)
+0:34        move second child to first child ( temp mediump 4-component vector of float)
+0:34          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:34          Construct vec4 ( temp mediump 4-component vector of float)
+0:34            interpolateAtCentroid ( global highp float)
+0:34              direct index (layout( location=7) smooth temp highp float)
+0:34                'z' (layout( location=7) smooth in 1-element array of highp float)
+0:34                Constant:
+0:34                  0 (const int)
+0:35        move second child to first child ( temp highp 4-component vector of float)
+0:35          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:35          interpolateAtCentroid ( global highp 4-component vector of float)
+0:35            'w' (layout( location=8) smooth in highp 4-component vector of float)
+0:36        move second child to first child ( temp highp 4-component vector of float)
+0:36          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:36          interpolateAtCentroid ( global highp 4-component vector of float)
+0:36            direct index ( temp highp 4-component vector of float)
+0:36              xyz: direct index for structure ( in 1-element array of highp 4-component vector of float)
+0:36                'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:36                Constant:
+0:36                  1 (const uint)
+0:36              Constant:
+0:36                0 (const int)
+0:39        move second child to first child ( temp mediump 4-component vector of float)
+0:39          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:39          Construct vec4 ( temp mediump 4-component vector of float)
+0:39            interpolateAtCentroid ( global highp float)
+0:39              a: direct index for structure ( global highp float)
+0:39                'v_var' (layout( location=0) smooth in structure{ global highp float a,  global highp float b})
+0:39                Constant:
+0:39                  0 (const int)
+0:40        move second child to first child ( temp mediump 4-component vector of float)
+0:40          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:40          Construct vec4 ( temp mediump 4-component vector of float)
+0:40            interpolateAtCentroid ( global highp float)
+0:40              direct index ( temp highp float)
+0:40                'w' (layout( location=8) smooth in highp 4-component vector of float)
+0:40                Constant:
+0:40                  0 (const int)
+0:41        move second child to first child ( temp mediump 4-component vector of float)
+0:41          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:41          Construct vec4 ( temp mediump 4-component vector of float)
+0:41            interpolateAtCentroid ( global highp 4-component vector of float)
+0:41              s_v: direct index for structure ( global highp 4-component vector of float)
+0:41                s0: direct index for structure ( in structure{ global highp 4-component vector of float s_v})
+0:41                  'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:41                  Constant:
+0:41                    2 (const uint)
+0:41                Constant:
+0:41                  0 (const int)
+0:47      Sequence
+0:47        move second child to first child ( temp mediump 4-component vector of float)
+0:47          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:47          Construct vec4 ( temp mediump 4-component vector of float)
+0:47            interpolateAtSample ( global highp float)
+0:47              'v' (layout( location=2) smooth in highp float)
+0:47              Constant:
+0:47                0 (const int)
+0:48        move second child to first child ( temp mediump 4-component vector of float)
+0:48          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:48          Construct vec4 ( temp mediump 4-component vector of float)
+0:48            interpolateAtSample ( global highp float)
+0:48              x: direct index for structure ( in highp float)
+0:48                'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:48                Constant:
+0:48                  0 (const uint)
+0:48              Constant:
+0:48                0 (const int)
+0:49        move second child to first child ( temp mediump 4-component vector of float)
+0:49          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:49          Construct vec4 ( temp mediump 4-component vector of float)
+0:49            interpolateAtSample ( global highp float)
+0:49              direct index (layout( location=7) smooth temp highp float)
+0:49                'z' (layout( location=7) smooth in 1-element array of highp float)
+0:49                Constant:
+0:49                  0 (const int)
+0:49              Constant:
+0:49                0 (const int)
+0:50        move second child to first child ( temp highp 4-component vector of float)
+0:50          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:50          interpolateAtSample ( global highp 4-component vector of float)
+0:50            'w' (layout( location=8) smooth in highp 4-component vector of float)
+0:50            Constant:
+0:50              0 (const int)
+0:51        move second child to first child ( temp highp 4-component vector of float)
+0:51          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:51          interpolateAtSample ( global highp 4-component vector of float)
+0:51            direct index ( temp highp 4-component vector of float)
+0:51              xyz: direct index for structure ( in 1-element array of highp 4-component vector of float)
+0:51                'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:51                Constant:
+0:51                  1 (const uint)
+0:51              Constant:
+0:51                0 (const int)
+0:51            Constant:
+0:51              0 (const int)
+0:54        move second child to first child ( temp mediump 4-component vector of float)
+0:54          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:54          Construct vec4 ( temp mediump 4-component vector of float)
+0:54            interpolateAtSample ( global highp float)
+0:54              a: direct index for structure ( global highp float)
+0:54                'v_var' (layout( location=0) smooth in structure{ global highp float a,  global highp float b})
+0:54                Constant:
+0:54                  0 (const int)
+0:54              Constant:
+0:54                0 (const int)
+0:55        move second child to first child ( temp mediump 4-component vector of float)
+0:55          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:55          Construct vec4 ( temp mediump 4-component vector of float)
+0:55            interpolateAtSample ( global highp float)
+0:55              direct index ( temp highp float)
+0:55                'w' (layout( location=8) smooth in highp 4-component vector of float)
+0:55                Constant:
+0:55                  0 (const int)
+0:55              Constant:
+0:55                0 (const int)
+0:56        move second child to first child ( temp mediump 4-component vector of float)
+0:56          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:56          Construct vec4 ( temp mediump 4-component vector of float)
+0:56            interpolateAtSample ( global highp 4-component vector of float)
+0:56              s_v: direct index for structure ( global highp 4-component vector of float)
+0:56                s0: direct index for structure ( in structure{ global highp 4-component vector of float s_v})
+0:56                  'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:56                  Constant:
+0:56                    2 (const uint)
+0:56                Constant:
+0:56                  0 (const int)
+0:56              Constant:
+0:56                0 (const int)
+0:62      Sequence
+0:62        move second child to first child ( temp mediump 4-component vector of float)
+0:62          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:62          Construct vec4 ( temp mediump 4-component vector of float)
+0:62            interpolateAtOffset ( global highp float)
+0:62              'v' (layout( location=2) smooth in highp float)
+0:62              Constant:
+0:62                0.000000
+0:62                0.000000
+0:63        move second child to first child ( temp mediump 4-component vector of float)
+0:63          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:63          Construct vec4 ( temp mediump 4-component vector of float)
+0:63            interpolateAtOffset ( global highp float)
+0:63              x: direct index for structure ( in highp float)
+0:63                'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:63                Constant:
+0:63                  0 (const uint)
+0:63              Constant:
+0:63                0.000000
+0:63                0.000000
+0:64        move second child to first child ( temp mediump 4-component vector of float)
+0:64          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:64          Construct vec4 ( temp mediump 4-component vector of float)
+0:64            interpolateAtOffset ( global highp float)
+0:64              direct index (layout( location=7) smooth temp highp float)
+0:64                'z' (layout( location=7) smooth in 1-element array of highp float)
+0:64                Constant:
+0:64                  0 (const int)
+0:64              Constant:
+0:64                0.000000
+0:64                0.000000
+0:65        move second child to first child ( temp highp 4-component vector of float)
+0:65          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:65          interpolateAtOffset ( global highp 4-component vector of float)
+0:65            'w' (layout( location=8) smooth in highp 4-component vector of float)
+0:65            Constant:
+0:65              0.000000
+0:65              0.000000
+0:66        move second child to first child ( temp highp 4-component vector of float)
+0:66          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:66          interpolateAtOffset ( global highp 4-component vector of float)
+0:66            direct index ( temp highp 4-component vector of float)
+0:66              xyz: direct index for structure ( in 1-element array of highp 4-component vector of float)
+0:66                'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:66                Constant:
+0:66                  1 (const uint)
+0:66              Constant:
+0:66                0 (const int)
+0:66            Constant:
+0:66              0.000000
+0:66              0.000000
+0:69        move second child to first child ( temp mediump 4-component vector of float)
+0:69          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:69          Construct vec4 ( temp mediump 4-component vector of float)
+0:69            interpolateAtOffset ( global highp float)
+0:69              a: direct index for structure ( global highp float)
+0:69                'v_var' (layout( location=0) smooth in structure{ global highp float a,  global highp float b})
+0:69                Constant:
+0:69                  0 (const int)
+0:69              Constant:
+0:69                0.000000
+0:69                0.000000
+0:70        move second child to first child ( temp mediump 4-component vector of float)
+0:70          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:70          Construct vec4 ( temp mediump 4-component vector of float)
+0:70            interpolateAtOffset ( global highp float)
+0:70              direct index ( temp highp float)
+0:70                'w' (layout( location=8) smooth in highp 4-component vector of float)
+0:70                Constant:
+0:70                  0 (const int)
+0:70              Constant:
+0:70                0.000000
+0:70                0.000000
+0:71        move second child to first child ( temp mediump 4-component vector of float)
+0:71          'fragColor' (layout( location=0) out mediump 4-component vector of float)
+0:71          Construct vec4 ( temp mediump 4-component vector of float)
+0:71            interpolateAtOffset ( global highp 4-component vector of float)
+0:71              s_v: direct index for structure ( global highp 4-component vector of float)
+0:71                s0: direct index for structure ( in structure{ global highp 4-component vector of float s_v})
+0:71                  'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:71                  Constant:
+0:71                    2 (const uint)
+0:71                Constant:
+0:71                  0 (const int)
+0:71              Constant:
+0:71                0.000000
+0:71                0.000000
+0:?   Linker Objects
+0:?     'v_var' (layout( location=0) smooth in structure{ global highp float a,  global highp float b})
+0:?     'v' (layout( location=2) smooth in highp float)
+0:?     'anon@0' (layout( location=3) in block{ in highp float x,  in 1-element array of highp 4-component vector of float xyz,  in structure{ global highp 4-component vector of float s_v} s0})
+0:?     'z' (layout( location=7) smooth in 1-element array of highp float)
+0:?     'w' (layout( location=8) smooth in highp 4-component vector of float)
+0:?     'fragColor' (layout( location=0) out mediump 4-component vector of float)
+

--- a/Test/glsl.interpOp.error.frag
+++ b/Test/glsl.interpOp.error.frag
@@ -1,0 +1,73 @@
+#version 320 es
+
+struct S
+{
+    highp float a;
+    highp float b;
+};
+layout(location = 0) in S v_var;
+
+layout(location = 2) in highp float v;
+
+struct S0 {
+    highp vec4 s_v;
+};
+
+layout(location = 3) in FIn {
+    highp float x;
+    highp vec4 xyz[1];
+    S0 s0;
+};
+
+layout(location = 7) in highp float z[1];
+
+layout(location = 8) in highp vec4 w;
+
+layout(location = 0) out mediump vec4 fragColor;
+void main (void)
+{
+    // Centroid
+    {
+        // valid
+        fragColor = vec4(interpolateAtCentroid(v));
+        fragColor = vec4(interpolateAtCentroid(x));
+        fragColor = vec4(interpolateAtCentroid(z[0]));
+        fragColor = interpolateAtCentroid(w);
+        fragColor = interpolateAtCentroid(xyz[0]);
+
+        //// invalid
+        fragColor = vec4(interpolateAtCentroid(v_var.a));
+        fragColor = vec4(interpolateAtCentroid(w.x));
+        fragColor = vec4(interpolateAtCentroid(s0.s_v));
+    }
+
+    // Sample
+    {
+        // valid
+        fragColor = vec4(interpolateAtSample(v, 0));
+        fragColor = vec4(interpolateAtSample(x, 0));
+        fragColor = vec4(interpolateAtSample(z[0], 0));
+        fragColor = interpolateAtSample(w, 0);
+        fragColor = interpolateAtSample(xyz[0], 0);
+
+        // invalid
+        fragColor = vec4(interpolateAtSample(v_var.a, 0));
+        fragColor = vec4(interpolateAtSample(w.x, 0));
+        fragColor = vec4(interpolateAtSample(s0.s_v, 0));
+    }
+
+    // Offset
+    {
+        // valid
+        fragColor = vec4(interpolateAtOffset(v,    vec2(0)));
+        fragColor = vec4(interpolateAtOffset(x,    vec2(0)));
+        fragColor = vec4(interpolateAtOffset(z[0], vec2(0)));
+        fragColor = interpolateAtOffset(w,         vec2(0));
+        fragColor = interpolateAtOffset(xyz[0],    vec2(0));
+
+        // invalid
+        fragColor = vec4(interpolateAtOffset(v_var.a, vec2(0)));
+        fragColor = vec4(interpolateAtOffset(w.x,     vec2(0)));
+        fragColor = vec4(interpolateAtOffset(s0.s_v, vec2(0)));
+    }
+}

--- a/glslang/MachineIndependent/ParseContextBase.cpp
+++ b/glslang/MachineIndependent/ParseContextBase.cpp
@@ -208,7 +208,7 @@ bool TParseContextBase::lValueErrorCheck(const TSourceLoc& loc, const char* op, 
     //
     // If we get here, we have an error and a message.
     //
-    const TIntermTyped* leftMostTypeNode = TIntermediate::findLValueBase(node, true);
+    const TIntermTyped* leftMostTypeNode = TIntermediate::traverseLValueBase(node, true);
 
     if (symNode)
         error(loc, " l-value required", op, "\"%s\" (%s)", symbol, message);
@@ -234,7 +234,7 @@ void TParseContextBase::rValueErrorCheck(const TSourceLoc& loc, const char* op, 
     const TIntermSymbol* symNode = node->getAsSymbolNode();
 
     if (node->getQualifier().isWriteOnly()) {
-        const TIntermTyped* leftMostTypeNode = TIntermediate::findLValueBase(node, true);
+        const TIntermTyped* leftMostTypeNode = TIntermediate::traverseLValueBase(node, true);
 
         if (symNode != nullptr)
             error(loc, "can't read from writeonly object: ", op, symNode->getName().c_str());

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -2571,7 +2571,7 @@ void TParseContext::builtInOpCheck(const TSourceLoc& loc, const TFunction& fnCan
             requireExtensions(loc, 1, &E_GL_EXT_shader_atomic_float2, fnCandidate.getName().c_str());
         }
 
-        const TIntermTyped* base = TIntermediate::findLValueBase(arg0, true , true);
+        const TIntermTyped* base = TIntermediate::traverseLValueBase(arg0, true, true);
         const char* errMsg = "Only l-values corresponding to shader block storage or shared variables can be used with "
                              "atomic memory functions.";
         if (base) {
@@ -2591,20 +2591,57 @@ void TParseContext::builtInOpCheck(const TSourceLoc& loc, const TFunction& fnCan
     case EOpInterpolateAtCentroid:
     case EOpInterpolateAtSample:
     case EOpInterpolateAtOffset:
-    case EOpInterpolateAtVertex:
-        // Make sure the first argument is an interpolant, or an array element of an interpolant
+    case EOpInterpolateAtVertex: {
         if (arg0->getType().getQualifier().storage != EvqVaryingIn) {
-            // It might still be an array element.
+            // Traverse down the left branch of arg0 to ensure this argument is a valid interpolant.
             //
-            // We could check more, but the semantics of the first argument are already met; the
-            // only way to turn an array into a float/vec* is array dereference and swizzle.
+            // For desktop GL >4.3 we effectively only need to ensure that arg0 represents an l-value from an
+            // input declaration.
             //
-            // ES and desktop 4.3 and earlier:  swizzles may not be used
-            // desktop 4.4 and later: swizzles may be used
-            bool swizzleOkay = (!isEsProfile()) && (version >= 440);
-            const TIntermTyped* base = TIntermediate::findLValueBase(arg0, swizzleOkay);
-            if (base == nullptr || base->getType().getQualifier().storage != EvqVaryingIn)
-                error(loc, "first argument must be an interpolant, or interpolant-array element", fnCandidate.getName().c_str(), "");
+            // For desktop GL <= 4.3 and ES, we must also ensure that swizzling is not used
+            //
+            // For ES, we must also ensure that a field selection operator (i.e., '.') is not used on a named
+            // struct.
+
+            const bool esProfile = isEsProfile();
+            const bool swizzleOkay = !esProfile && (version >= 440);
+
+            std::string interpolantErrorMsg = "first argument must be an interpolant, or interpolant-array element";
+            bool isValid = true; // Assume that the interpolant is valid until we find a condition making it invalid
+            bool isIn = false;   // Checks whether or not the interpolant is a shader input
+            bool structAccessOp = false; // Whether or not the previous node in the chain is a struct accessor
+            TIntermediate::traverseLValueBase(
+                arg0, swizzleOkay, false,
+                [&isValid, &isIn, &interpolantErrorMsg, esProfile, &structAccessOp](const TIntermNode& n) -> bool {
+                    auto* type = n.getAsTyped();
+                    if (type) {
+                        if (type->getType().getQualifier().storage == EvqVaryingIn) {
+                            isIn = true;
+                        }
+                        // If a field accessor was used, it can only be used to access a field with an input block, not a struct.
+                        if (structAccessOp && (type->getType().getBasicType() != EbtBlock)) {
+                            interpolantErrorMsg +=
+                                ". Using the field of a named struct as an interpolant argument is not "
+                                "allowed (ES-only).";
+                            isValid = false;
+                        }
+                    }
+
+                    // ES has different requirements for interpolants than GL
+                    if (esProfile) {
+                        // Swizzling will be taken care of by the 'swizzleOkay' argument passsed to traverseLValueBase,
+                        // so we only ned to check whether or not a field accessor has been used with a named struct.
+                        auto* binary = n.getAsBinaryNode();
+                        if (binary && (binary->getOp() == EOpIndexDirectStruct)) {
+                            structAccessOp = true;
+                        }
+                    }
+                    // Don't continue traversing if we know we have an invalid interpolant at this point.
+                    return isValid;
+                });
+            if (!isIn || !isValid) {
+                error(loc, interpolantErrorMsg.c_str(), fnCandidate.getName().c_str(), "");
+            }
         }
 
         if (callNode.getOp() == EOpInterpolateAtVertex) {
@@ -2620,7 +2657,7 @@ void TParseContext::builtInOpCheck(const TSourceLoc& loc, const TFunction& fnCan
                 }
             }
         }
-        break;
+    } break;
 
     case EOpEmitStreamVertex:
     case EOpEndStreamPrimitive:

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -43,11 +43,12 @@
 #include "../Public/ShaderLang.h"
 #include "Versions.h"
 
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <set>
 #include <string>
 #include <vector>
-#include <algorithm>
-#include <set>
-#include <array>
 
 class TInfoSink;
 
@@ -572,7 +573,8 @@ public:
     TIntermTyped* foldSwizzle(TIntermTyped* node, TSwizzleSelectors<TVectorSelector>& fields, const TSourceLoc&);
 
     // Tree ops
-    static const TIntermTyped* findLValueBase(const TIntermTyped*, bool swizzleOkay , bool BufferReferenceOk = false);
+    static const TIntermTyped* traverseLValueBase(const TIntermTyped*, bool swizzleOkay, bool bufferReferenceOk = false,
+                                                  std::function<bool(const TIntermNode&)> proc = {});
 
     // Linkage related
     void addSymbolLinkageNodes(TIntermAggregate*& linkage, EShLanguage, TSymbolTable&);

--- a/gtests/AST.FromFile.cpp
+++ b/gtests/AST.FromFile.cpp
@@ -299,7 +299,8 @@ INSTANTIATE_TEST_SUITE_P(
         "EndStreamPrimitive.geom",
         "floatBitsToInt.vert",
         "coord_conventions.frag",
-        "gl_FragCoord.frag"
+        "gl_FragCoord.frag",
+        "glsl.interpOp.error.frag",
     })),
     FileNameAsCustomTestSuffix
 );


### PR DESCRIPTION
The restriction of no swizzling and no struct fields as an interpolant were not being checked when using the ES profile.

Fixes #3277.