### PR TITLE
Add missing initialization of `compile_only` field for SPIRV C interface

### DIFF
--- a/SPIRV/CInterface/spirv_c_interface.cpp
+++ b/SPIRV/CInterface/spirv_c_interface.cpp
@@ -92,6 +92,7 @@ GLSLANG_EXPORT void glslang_program_SPIRV_generate(glslang_program_t* program, g
     spv_options.optimize_size = false;
     spv_options.disassemble = false;
     spv_options.validate = true;
+    spv_options.compile_only = false;
 
     glslang_program_SPIRV_generate_with_options(program, stage, &spv_options);
 }


### PR DESCRIPTION
Looks like the `compile_only` struct field of `glslang_spv_options_t` is not being set, so it's just holding garbage memory and causing unwanted behaviour by implicitly resolving to `true` most times.