### PR TITLE
Implement relaxed rule for opaque struct members

### DIFF
--- a/Test/baseResults/vk.relaxed.frag.out
+++ b/Test/baseResults/vk.relaxed.frag.out
@@ -5,111 +5,71 @@ WARNING: 0:8: 'c' : ignoring layout qualifier for uniform location
 Shader version: 460
 gl_FragCoord origin is upper left
 0:? Sequence
-0:36  Function Definition: bar( ( global highp uint)
-0:36    Function Parameters: 
-0:37    Sequence
-0:37      Sequence
-0:37        move second child to first child ( temp highp uint)
-0:37          'j' ( temp highp uint)
-0:37          Constant:
-0:37            0 (const uint)
-0:38      move second child to first child ( temp highp uint)
-0:38        'j' ( temp highp uint)
-0:38        AtomicAdd ( global highp uint)
-0:38          counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:38            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:38            Constant:
-0:38              0 (const uint)
-0:38          Constant:
-0:38            1 (const uint)
-0:39      move second child to first child ( temp highp uint)
-0:39        'j' ( temp highp uint)
-0:39        subtract ( temp highp uint)
-0:39          AtomicAdd ( global highp uint)
-0:39            counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:39              'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:39              Constant:
-0:39                0 (const uint)
-0:39            Constant:
-0:39              4294967295 (const uint)
-0:39          Constant:
-0:39            1 (const uint)
-0:40      move second child to first child ( temp highp uint)
-0:40        'j' ( temp highp uint)
-0:40        counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:40          'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:40          Constant:
-0:40            0 (const uint)
-0:42      move second child to first child ( temp highp uint)
-0:42        'j' ( temp highp uint)
-0:42        AtomicAdd ( global highp uint)
-0:42          counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:42            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:42            Constant:
-0:42              0 (const uint)
-0:42          Constant:
-0:42            1 (const uint)
-0:43      move second child to first child ( temp highp uint)
-0:43        'j' ( temp highp uint)
-0:43        AtomicAdd ( global highp uint)
-0:43          counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:43            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:43            Constant:
-0:43              0 (const uint)
-0:43          Constant:
-0:43            4294967295 (const uint)
-0:44      move second child to first child ( temp highp uint)
-0:44        'j' ( temp highp uint)
-0:44        AtomicSubtract ( global highp uint)
-0:44          counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:44            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:44            Constant:
-0:44              0 (const uint)
+0:43  Function Definition: bar( ( global highp uint)
+0:43    Function Parameters: 
+0:44    Sequence
+0:44      Sequence
+0:44        move second child to first child ( temp highp uint)
+0:44          'j' ( temp highp uint)
 0:44          Constant:
-0:44            1 (const uint)
+0:44            0 (const uint)
+0:45      move second child to first child ( temp highp uint)
+0:45        'j' ( temp highp uint)
+0:45        AtomicAdd ( global highp uint)
+0:45          counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:45            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:45            Constant:
+0:45              0 (const uint)
+0:45          Constant:
+0:45            1 (const uint)
 0:46      move second child to first child ( temp highp uint)
 0:46        'j' ( temp highp uint)
-0:46        AtomicMin ( global highp uint)
-0:46          counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:46            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:46        subtract ( temp highp uint)
+0:46          AtomicAdd ( global highp uint)
+0:46            counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:46              'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:46              Constant:
+0:46                0 (const uint)
 0:46            Constant:
-0:46              0 (const uint)
-0:46          'j' ( temp highp uint)
+0:46              4294967295 (const uint)
+0:46          Constant:
+0:46            1 (const uint)
 0:47      move second child to first child ( temp highp uint)
 0:47        'j' ( temp highp uint)
-0:47        AtomicMax ( global highp uint)
-0:47          counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:47            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:47            Constant:
-0:47              0 (const uint)
-0:47          'j' ( temp highp uint)
-0:48      move second child to first child ( temp highp uint)
-0:48        'j' ( temp highp uint)
-0:48        AtomicAnd ( global highp uint)
-0:48          counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:48            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:48            Constant:
-0:48              0 (const uint)
-0:48          'j' ( temp highp uint)
+0:47        counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:47          'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:47          Constant:
+0:47            0 (const uint)
+0:49      move second child to first child ( temp highp uint)
+0:49        'j' ( temp highp uint)
+0:49        AtomicAdd ( global highp uint)
+0:49          counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:49            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:49            Constant:
+0:49              0 (const uint)
+0:49          Constant:
+0:49            1 (const uint)
 0:50      move second child to first child ( temp highp uint)
 0:50        'j' ( temp highp uint)
-0:50        AtomicOr ( global highp uint)
+0:50        AtomicAdd ( global highp uint)
 0:50          counter1: direct index for structure ( coherent volatile buffer highp uint)
 0:50            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
 0:50            Constant:
 0:50              0 (const uint)
-0:50          'j' ( temp highp uint)
+0:50          Constant:
+0:50            4294967295 (const uint)
 0:51      move second child to first child ( temp highp uint)
 0:51        'j' ( temp highp uint)
-0:51        AtomicXor ( global highp uint)
+0:51        AtomicSubtract ( global highp uint)
 0:51          counter1: direct index for structure ( coherent volatile buffer highp uint)
 0:51            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
 0:51            Constant:
 0:51              0 (const uint)
-0:51          'j' ( temp highp uint)
+0:51          Constant:
+0:51            1 (const uint)
 0:53      move second child to first child ( temp highp uint)
 0:53        'j' ( temp highp uint)
-0:53        AtomicExchange ( global highp uint)
+0:53        AtomicMin ( global highp uint)
 0:53          counter1: direct index for structure ( coherent volatile buffer highp uint)
 0:53            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
 0:53            Constant:
@@ -117,158 +77,254 @@ gl_FragCoord origin is upper left
 0:53          'j' ( temp highp uint)
 0:54      move second child to first child ( temp highp uint)
 0:54        'j' ( temp highp uint)
-0:54        AtomicCompSwap ( global highp uint)
+0:54        AtomicMax ( global highp uint)
 0:54          counter1: direct index for structure ( coherent volatile buffer highp uint)
 0:54            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
 0:54            Constant:
 0:54              0 (const uint)
-0:54          Constant:
-0:54            0 (const uint)
 0:54          'j' ( temp highp uint)
-0:56      AtomicAdd ( global highp uint)
-0:56        counter2: direct index for structure ( coherent volatile buffer highp uint)
-0:56          'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:56          Constant:
-0:56            1 (const uint)
-0:56        Constant:
-0:56          1 (const uint)
-0:57      AtomicAdd ( global highp uint)
-0:57        counter3: direct index for structure ( coherent volatile buffer highp uint)
-0:57          'anon@3' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter3})
-0:57          Constant:
-0:57            0 (const uint)
-0:57        Constant:
-0:57          1 (const uint)
-0:59      MemoryBarrierBuffer ( global void)
-0:61      Branch: Return with expression
+0:55      move second child to first child ( temp highp uint)
+0:55        'j' ( temp highp uint)
+0:55        AtomicAnd ( global highp uint)
+0:55          counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:55            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:55            Constant:
+0:55              0 (const uint)
+0:55          'j' ( temp highp uint)
+0:57      move second child to first child ( temp highp uint)
+0:57        'j' ( temp highp uint)
+0:57        AtomicOr ( global highp uint)
+0:57          counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:57            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:57            Constant:
+0:57              0 (const uint)
+0:57          'j' ( temp highp uint)
+0:58      move second child to first child ( temp highp uint)
+0:58        'j' ( temp highp uint)
+0:58        AtomicXor ( global highp uint)
+0:58          counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:58            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:58            Constant:
+0:58              0 (const uint)
+0:58          'j' ( temp highp uint)
+0:60      move second child to first child ( temp highp uint)
+0:60        'j' ( temp highp uint)
+0:60        AtomicExchange ( global highp uint)
+0:60          counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:60            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:60            Constant:
+0:60              0 (const uint)
+0:60          'j' ( temp highp uint)
+0:61      move second child to first child ( temp highp uint)
 0:61        'j' ( temp highp uint)
-0:64  Function Definition: foo( ( global highp 4-component vector of float)
-0:64    Function Parameters: 
-0:65    Sequence
-0:65      Sequence
-0:65        move second child to first child ( temp highp float)
-0:65          'f' ( temp highp float)
-0:65          add ( temp highp float)
-0:65            add ( temp highp float)
-0:65              add ( temp highp float)
-0:65                j: direct index for structure (layout( column_major std140) uniform highp float)
-0:65                  'anon@1' (layout( column_major std140) uniform block{layout( column_major std140) uniform highp float j, layout( column_major std140) uniform highp 4-component vector of float k})
-0:65                  Constant:
-0:65                    0 (const uint)
-0:65                j: direct index for structure (layout( column_major std430) buffer highp float)
-0:65                  'bufferInstance' (layout( column_major std430) buffer block{layout( column_major std430) buffer highp float j, layout( column_major std430) buffer highp 4-component vector of float k})
-0:65                  Constant:
-0:65                    0 (const int)
-0:65              y: direct index for structure ( global highp float)
-0:65                structUniform: direct index for structure ( uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z})
-0:65                  'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:65                  Constant:
-0:65                    4 (const uint)
-0:65                Constant:
-0:65                  1 (const int)
-0:65            Convert uint to float ( temp highp float)
-0:65              z: direct index for structure ( global highp uint)
-0:65                structUniform: direct index for structure ( uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z})
-0:65                  'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:65                  Constant:
-0:65                    4 (const uint)
-0:65                Constant:
-0:65                  2 (const int)
-0:66      Sequence
-0:66        move second child to first child ( temp highp 2-component vector of float)
-0:66          'v2' ( temp highp 2-component vector of float)
-0:66          add ( temp highp 2-component vector of float)
-0:66            add ( temp highp 2-component vector of float)
-0:66              b: direct index for structure ( uniform highp 2-component vector of float)
-0:66                'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:66                Constant:
-0:66                  1 (const uint)
-0:66              c: direct index for structure ( uniform highp 2-component vector of float)
-0:66                'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:66                Constant:
-0:66                  2 (const uint)
-0:66            x: direct index for structure ( global highp 2-component vector of float)
-0:66              structUniform: direct index for structure ( uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z})
-0:66                'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:66                Constant:
-0:66                  4 (const uint)
-0:66              Constant:
-0:66                0 (const int)
-0:67      Sequence
-0:67        move second child to first child ( temp highp 4-component vector of float)
-0:67          'v4' ( temp highp 4-component vector of float)
-0:67          add ( temp highp 4-component vector of float)
-0:67            add ( temp highp 4-component vector of float)
-0:67              add ( temp highp 4-component vector of float)
-0:67                add ( temp highp 4-component vector of float)
-0:67                  add ( temp highp 4-component vector of float)
-0:67                    add ( temp highp 4-component vector of float)
-0:67                      a: direct index for structure ( uniform highp 4-component vector of float)
-0:67                        'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:67                        Constant:
-0:67                          0 (const uint)
-0:67                      direct index ( temp highp 4-component vector of float)
-0:67                        d: direct index for structure ( uniform 10-element array of highp 4-component vector of float)
-0:67                          'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:67                          Constant:
-0:67                            3 (const uint)
-0:67                        Constant:
-0:67                          0 (const int)
-0:67                    direct index ( temp highp 4-component vector of float)
-0:67                      d: direct index for structure ( uniform 10-element array of highp 4-component vector of float)
-0:67                        'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:67                        Constant:
-0:67                          3 (const uint)
-0:67                      Constant:
-0:67                        1 (const int)
-0:67                  direct index ( temp highp 4-component vector of float)
-0:67                    d: direct index for structure ( uniform 10-element array of highp 4-component vector of float)
-0:67                      'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:67                      Constant:
-0:67                        3 (const uint)
-0:67                    Constant:
-0:67                      2 (const int)
-0:67                k: direct index for structure (layout( column_major std140) uniform highp 4-component vector of float)
-0:67                  'anon@1' (layout( column_major std140) uniform block{layout( column_major std140) uniform highp float j, layout( column_major std140) uniform highp 4-component vector of float k})
-0:67                  Constant:
-0:67                    1 (const uint)
-0:67              k: direct index for structure (layout( column_major std430) buffer highp 4-component vector of float)
-0:67                'bufferInstance' (layout( column_major std430) buffer block{layout( column_major std430) buffer highp float j, layout( column_major std430) buffer highp 4-component vector of float k})
-0:67                Constant:
-0:67                  1 (const int)
-0:67            texture ( global highp 4-component vector of float)
-0:67              't1' ( uniform highp sampler2D)
-0:67              Constant:
-0:67                0.000000
-0:67                0.000000
+0:61        AtomicCompSwap ( global highp uint)
+0:61          counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:61            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:61            Constant:
+0:61              0 (const uint)
+0:61          Constant:
+0:61            0 (const uint)
+0:61          'j' ( temp highp uint)
+0:63      AtomicAdd ( global highp uint)
+0:63        counter2: direct index for structure ( coherent volatile buffer highp uint)
+0:63          'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:63          Constant:
+0:63            1 (const uint)
+0:63        Constant:
+0:63          1 (const uint)
+0:64      AtomicAdd ( global highp uint)
+0:64        counter3: direct index for structure ( coherent volatile buffer highp uint)
+0:64          'anon@3' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter3})
+0:64          Constant:
+0:64            0 (const uint)
+0:64        Constant:
+0:64          1 (const uint)
+0:66      MemoryBarrierBuffer ( global void)
 0:68      Branch: Return with expression
-0:68        component-wise multiply ( temp highp 4-component vector of float)
-0:68          component-wise multiply ( temp highp 4-component vector of float)
-0:68            Construct vec4 ( temp highp 4-component vector of float)
-0:68              'f' ( temp highp float)
-0:68            Construct vec4 ( temp highp 4-component vector of float)
-0:68              'v2' ( temp highp 2-component vector of float)
-0:68              Constant:
-0:68                1.000000
-0:68              Constant:
-0:68                1.000000
-0:68          'v4' ( temp highp 4-component vector of float)
-0:71  Function Definition: main( ( global void)
+0:68        'j' ( temp highp uint)
+0:71  Function Definition: foo( ( global highp 4-component vector of float)
 0:71    Function Parameters: 
 0:72    Sequence
 0:72      Sequence
 0:72        move second child to first child ( temp highp float)
-0:72          'j' ( temp highp float)
-0:72          Convert uint to float ( temp highp float)
-0:72            Function Call: bar( ( global highp uint)
-0:73      move second child to first child ( temp highp 4-component vector of float)
-0:73        'o' ( out highp 4-component vector of float)
-0:73        vector-scale ( temp highp 4-component vector of float)
-0:73          'j' ( temp highp float)
-0:73          Function Call: foo( ( global highp 4-component vector of float)
+0:72          'f' ( temp highp float)
+0:72          add ( temp highp float)
+0:72            add ( temp highp float)
+0:72              add ( temp highp float)
+0:72                j: direct index for structure (layout( column_major std140) uniform highp float)
+0:72                  'anon@1' (layout( column_major std140) uniform block{layout( column_major std140) uniform highp float j, layout( column_major std140) uniform highp 4-component vector of float k})
+0:72                  Constant:
+0:72                    0 (const uint)
+0:72                j: direct index for structure (layout( column_major std430) buffer highp float)
+0:72                  'bufferInstance' (layout( column_major std430) buffer block{layout( column_major std430) buffer highp float j, layout( column_major std430) buffer highp 4-component vector of float k})
+0:72                  Constant:
+0:72                    0 (const int)
+0:72              y: direct index for structure ( global highp float)
+0:72                structUniform: direct index for structure ( uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers})
+0:72                  'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:72                  Constant:
+0:72                    4 (const uint)
+0:72                Constant:
+0:72                  1 (const int)
+0:72            Convert uint to float ( temp highp float)
+0:72              z: direct index for structure ( global highp uint)
+0:72                structUniform: direct index for structure ( uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers})
+0:72                  'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:72                  Constant:
+0:72                    4 (const uint)
+0:72                Constant:
+0:72                  2 (const int)
+0:73      Sequence
+0:73        move second child to first child ( temp highp 2-component vector of float)
+0:73          'v2' ( temp highp 2-component vector of float)
+0:73          add ( temp highp 2-component vector of float)
+0:73            add ( temp highp 2-component vector of float)
+0:73              b: direct index for structure ( uniform highp 2-component vector of float)
+0:73                'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:73                Constant:
+0:73                  1 (const uint)
+0:73              c: direct index for structure ( uniform highp 2-component vector of float)
+0:73                'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:73                Constant:
+0:73                  2 (const uint)
+0:73            x: direct index for structure ( global highp 2-component vector of float)
+0:73              structUniform: direct index for structure ( uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers})
+0:73                'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:73                Constant:
+0:73                  4 (const uint)
+0:73              Constant:
+0:73                0 (const int)
+0:74      Sequence
+0:74        move second child to first child ( temp highp 4-component vector of float)
+0:74          'v4' ( temp highp 4-component vector of float)
+0:74          add ( temp highp 4-component vector of float)
+0:74            add ( temp highp 4-component vector of float)
+0:74              add ( temp highp 4-component vector of float)
+0:74                add ( temp highp 4-component vector of float)
+0:74                  add ( temp highp 4-component vector of float)
+0:74                    add ( temp highp 4-component vector of float)
+0:74                      add ( temp highp 4-component vector of float)
+0:74                        a: direct index for structure ( uniform highp 4-component vector of float)
+0:74                          'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:74                          Constant:
+0:74                            0 (const uint)
+0:74                        direct index ( temp highp 4-component vector of float)
+0:74                          d: direct index for structure ( uniform 10-element array of highp 4-component vector of float)
+0:74                            'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:74                            Constant:
+0:74                              3 (const uint)
+0:74                          Constant:
+0:74                            0 (const int)
+0:74                      direct index ( temp highp 4-component vector of float)
+0:74                        d: direct index for structure ( uniform 10-element array of highp 4-component vector of float)
+0:74                          'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:74                          Constant:
+0:74                            3 (const uint)
+0:74                        Constant:
+0:74                          1 (const int)
+0:74                    direct index ( temp highp 4-component vector of float)
+0:74                      d: direct index for structure ( uniform 10-element array of highp 4-component vector of float)
+0:74                        'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:74                        Constant:
+0:74                          3 (const uint)
+0:74                      Constant:
+0:74                        2 (const int)
+0:74                  k: direct index for structure (layout( column_major std140) uniform highp 4-component vector of float)
+0:74                    'anon@1' (layout( column_major std140) uniform block{layout( column_major std140) uniform highp float j, layout( column_major std140) uniform highp 4-component vector of float k})
+0:74                    Constant:
+0:74                      1 (const uint)
+0:74                k: direct index for structure (layout( column_major std430) buffer highp 4-component vector of float)
+0:74                  'bufferInstance' (layout( column_major std430) buffer block{layout( column_major std430) buffer highp float j, layout( column_major std430) buffer highp 4-component vector of float k})
+0:74                  Constant:
+0:74                    1 (const int)
+0:74              texture ( global highp 4-component vector of float)
+0:74                't1' ( uniform highp sampler2D)
+0:74                Constant:
+0:74                  0.000000
+0:74                  0.000000
+0:74            texture ( global highp 4-component vector of float)
+0:74              'structUniform.t0' ( uniform highp sampler2D)
+0:74              Constant:
+0:74                0.000000
+0:74                0.000000
+0:75      Branch: Return with expression
+0:75        component-wise multiply ( temp highp 4-component vector of float)
+0:75          component-wise multiply ( temp highp 4-component vector of float)
+0:75            Construct vec4 ( temp highp 4-component vector of float)
+0:75              'f' ( temp highp float)
+0:75            Construct vec4 ( temp highp 4-component vector of float)
+0:75              'v2' ( temp highp 2-component vector of float)
+0:75              Constant:
+0:75                1.000000
+0:75              Constant:
+0:75                1.000000
+0:75          'v4' ( temp highp 4-component vector of float)
+0:78  Function Definition: baz(struct-SamplerArray-s21[4]1;s21;s21;s21;s21; ( global highp 4-component vector of float)
+0:78    Function Parameters: 
+0:78      'samplers' ( in structure{ global 4-element array of highp int /*tn*/})
+0:78      'samplers.tn[0]' ( in highp sampler2D)
+0:78      'samplers.tn[1]' ( in highp sampler2D)
+0:78      'samplers.tn[2]' ( in highp sampler2D)
+0:78      'samplers.tn[3]' ( in highp sampler2D)
+0:79    Sequence
+0:79      Branch: Return with expression
+0:79        add ( temp highp 4-component vector of float)
+0:79          add ( temp highp 4-component vector of float)
+0:79            add ( temp highp 4-component vector of float)
+0:79              texture ( global highp 4-component vector of float)
+0:79                'samplers.tn[0]' ( in highp sampler2D)
+0:79                Constant:
+0:79                  0.000000
+0:79                  0.000000
+0:79              texture ( global highp 4-component vector of float)
+0:79                'samplers.tn[1]' ( in highp sampler2D)
+0:79                Constant:
+0:79                  0.000000
+0:79                  0.000000
+0:79            texture ( global highp 4-component vector of float)
+0:79              'samplers.tn[2]' ( in highp sampler2D)
+0:79              Constant:
+0:79                0.000000
+0:79                0.000000
+0:79          texture ( global highp 4-component vector of float)
+0:79            'samplers.tn[3]' ( in highp sampler2D)
+0:79            Constant:
+0:79              0.000000
+0:79              0.000000
+0:82  Function Definition: main( ( global void)
+0:82    Function Parameters: 
+0:83    Sequence
+0:83      Sequence
+0:83        move second child to first child ( temp highp float)
+0:83          'j' ( temp highp float)
+0:83          Convert uint to float ( temp highp float)
+0:83            Function Call: bar( ( global highp uint)
+0:84      move second child to first child ( temp highp 4-component vector of float)
+0:84        'o' ( out highp 4-component vector of float)
+0:84        add ( temp highp 4-component vector of float)
+0:84          vector-scale ( temp highp 4-component vector of float)
+0:84            'j' ( temp highp float)
+0:84            Function Call: foo( ( global highp 4-component vector of float)
+0:84          Function Call: baz(struct-SamplerArray-s21[4]1;s21;s21;s21;s21; ( global highp 4-component vector of float)
+0:84            samplers: direct index for structure ( global structure{ global 4-element array of highp int /*tn*/})
+0:84              structUniform: direct index for structure ( uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers})
+0:84                'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:84                Constant:
+0:84                  4 (const uint)
+0:84              Constant:
+0:84                4 (const int)
+0:84            'structUniform.samplers.tn[0]' ( uniform highp sampler2D)
+0:84            'structUniform.samplers.tn[1]' ( uniform highp sampler2D)
+0:84            'structUniform.samplers.tn[2]' ( uniform highp sampler2D)
+0:84            'structUniform.samplers.tn[3]' ( uniform highp sampler2D)
 0:?   Linker Objects
 0:?     'o' ( out highp 4-component vector of float)
-0:?     'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
+0:?     'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:?     'structUniform.t0' ( uniform highp sampler2D)
+0:?     'structUniform.samplers.tn[0]' ( uniform highp sampler2D)
+0:?     'structUniform.samplers.tn[1]' ( uniform highp sampler2D)
+0:?     'structUniform.samplers.tn[2]' ( uniform highp sampler2D)
+0:?     'structUniform.samplers.tn[3]' ( uniform highp sampler2D)
 0:?     't1' ( uniform highp sampler2D)
 0:?     'anon@1' (layout( column_major std140) uniform block{layout( column_major std140) uniform highp float j, layout( column_major std140) uniform highp 4-component vector of float k})
 0:?     'bufferInstance' (layout( column_major std430) buffer block{layout( column_major std430) buffer highp float j, layout( column_major std430) buffer highp 4-component vector of float k})
@@ -282,111 +338,71 @@ Linked fragment stage:
 Shader version: 460
 gl_FragCoord origin is upper left
 0:? Sequence
-0:36  Function Definition: bar( ( global highp uint)
-0:36    Function Parameters: 
-0:37    Sequence
-0:37      Sequence
-0:37        move second child to first child ( temp highp uint)
-0:37          'j' ( temp highp uint)
-0:37          Constant:
-0:37            0 (const uint)
-0:38      move second child to first child ( temp highp uint)
-0:38        'j' ( temp highp uint)
-0:38        AtomicAdd ( global highp uint)
-0:38          counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:38            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:38            Constant:
-0:38              0 (const uint)
-0:38          Constant:
-0:38            1 (const uint)
-0:39      move second child to first child ( temp highp uint)
-0:39        'j' ( temp highp uint)
-0:39        subtract ( temp highp uint)
-0:39          AtomicAdd ( global highp uint)
-0:39            counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:39              'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:39              Constant:
-0:39                0 (const uint)
-0:39            Constant:
-0:39              4294967295 (const uint)
-0:39          Constant:
-0:39            1 (const uint)
-0:40      move second child to first child ( temp highp uint)
-0:40        'j' ( temp highp uint)
-0:40        counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:40          'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:40          Constant:
-0:40            0 (const uint)
-0:42      move second child to first child ( temp highp uint)
-0:42        'j' ( temp highp uint)
-0:42        AtomicAdd ( global highp uint)
-0:42          counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:42            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:42            Constant:
-0:42              0 (const uint)
-0:42          Constant:
-0:42            1 (const uint)
-0:43      move second child to first child ( temp highp uint)
-0:43        'j' ( temp highp uint)
-0:43        AtomicAdd ( global highp uint)
-0:43          counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:43            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:43            Constant:
-0:43              0 (const uint)
-0:43          Constant:
-0:43            4294967295 (const uint)
-0:44      move second child to first child ( temp highp uint)
-0:44        'j' ( temp highp uint)
-0:44        AtomicSubtract ( global highp uint)
-0:44          counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:44            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:44            Constant:
-0:44              0 (const uint)
+0:43  Function Definition: bar( ( global highp uint)
+0:43    Function Parameters: 
+0:44    Sequence
+0:44      Sequence
+0:44        move second child to first child ( temp highp uint)
+0:44          'j' ( temp highp uint)
 0:44          Constant:
-0:44            1 (const uint)
+0:44            0 (const uint)
+0:45      move second child to first child ( temp highp uint)
+0:45        'j' ( temp highp uint)
+0:45        AtomicAdd ( global highp uint)
+0:45          counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:45            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:45            Constant:
+0:45              0 (const uint)
+0:45          Constant:
+0:45            1 (const uint)
 0:46      move second child to first child ( temp highp uint)
 0:46        'j' ( temp highp uint)
-0:46        AtomicMin ( global highp uint)
-0:46          counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:46            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:46        subtract ( temp highp uint)
+0:46          AtomicAdd ( global highp uint)
+0:46            counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:46              'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:46              Constant:
+0:46                0 (const uint)
 0:46            Constant:
-0:46              0 (const uint)
-0:46          'j' ( temp highp uint)
+0:46              4294967295 (const uint)
+0:46          Constant:
+0:46            1 (const uint)
 0:47      move second child to first child ( temp highp uint)
 0:47        'j' ( temp highp uint)
-0:47        AtomicMax ( global highp uint)
-0:47          counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:47            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:47            Constant:
-0:47              0 (const uint)
-0:47          'j' ( temp highp uint)
-0:48      move second child to first child ( temp highp uint)
-0:48        'j' ( temp highp uint)
-0:48        AtomicAnd ( global highp uint)
-0:48          counter1: direct index for structure ( coherent volatile buffer highp uint)
-0:48            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:48            Constant:
-0:48              0 (const uint)
-0:48          'j' ( temp highp uint)
+0:47        counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:47          'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:47          Constant:
+0:47            0 (const uint)
+0:49      move second child to first child ( temp highp uint)
+0:49        'j' ( temp highp uint)
+0:49        AtomicAdd ( global highp uint)
+0:49          counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:49            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:49            Constant:
+0:49              0 (const uint)
+0:49          Constant:
+0:49            1 (const uint)
 0:50      move second child to first child ( temp highp uint)
 0:50        'j' ( temp highp uint)
-0:50        AtomicOr ( global highp uint)
+0:50        AtomicAdd ( global highp uint)
 0:50          counter1: direct index for structure ( coherent volatile buffer highp uint)
 0:50            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
 0:50            Constant:
 0:50              0 (const uint)
-0:50          'j' ( temp highp uint)
+0:50          Constant:
+0:50            4294967295 (const uint)
 0:51      move second child to first child ( temp highp uint)
 0:51        'j' ( temp highp uint)
-0:51        AtomicXor ( global highp uint)
+0:51        AtomicSubtract ( global highp uint)
 0:51          counter1: direct index for structure ( coherent volatile buffer highp uint)
 0:51            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
 0:51            Constant:
 0:51              0 (const uint)
-0:51          'j' ( temp highp uint)
+0:51          Constant:
+0:51            1 (const uint)
 0:53      move second child to first child ( temp highp uint)
 0:53        'j' ( temp highp uint)
-0:53        AtomicExchange ( global highp uint)
+0:53        AtomicMin ( global highp uint)
 0:53          counter1: direct index for structure ( coherent volatile buffer highp uint)
 0:53            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
 0:53            Constant:
@@ -394,158 +410,254 @@ gl_FragCoord origin is upper left
 0:53          'j' ( temp highp uint)
 0:54      move second child to first child ( temp highp uint)
 0:54        'j' ( temp highp uint)
-0:54        AtomicCompSwap ( global highp uint)
+0:54        AtomicMax ( global highp uint)
 0:54          counter1: direct index for structure ( coherent volatile buffer highp uint)
 0:54            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
 0:54            Constant:
 0:54              0 (const uint)
-0:54          Constant:
-0:54            0 (const uint)
 0:54          'j' ( temp highp uint)
-0:56      AtomicAdd ( global highp uint)
-0:56        counter2: direct index for structure ( coherent volatile buffer highp uint)
-0:56          'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
-0:56          Constant:
-0:56            1 (const uint)
-0:56        Constant:
-0:56          1 (const uint)
-0:57      AtomicAdd ( global highp uint)
-0:57        counter3: direct index for structure ( coherent volatile buffer highp uint)
-0:57          'anon@3' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter3})
-0:57          Constant:
-0:57            0 (const uint)
-0:57        Constant:
-0:57          1 (const uint)
-0:59      MemoryBarrierBuffer ( global void)
-0:61      Branch: Return with expression
+0:55      move second child to first child ( temp highp uint)
+0:55        'j' ( temp highp uint)
+0:55        AtomicAnd ( global highp uint)
+0:55          counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:55            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:55            Constant:
+0:55              0 (const uint)
+0:55          'j' ( temp highp uint)
+0:57      move second child to first child ( temp highp uint)
+0:57        'j' ( temp highp uint)
+0:57        AtomicOr ( global highp uint)
+0:57          counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:57            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:57            Constant:
+0:57              0 (const uint)
+0:57          'j' ( temp highp uint)
+0:58      move second child to first child ( temp highp uint)
+0:58        'j' ( temp highp uint)
+0:58        AtomicXor ( global highp uint)
+0:58          counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:58            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:58            Constant:
+0:58              0 (const uint)
+0:58          'j' ( temp highp uint)
+0:60      move second child to first child ( temp highp uint)
+0:60        'j' ( temp highp uint)
+0:60        AtomicExchange ( global highp uint)
+0:60          counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:60            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:60            Constant:
+0:60              0 (const uint)
+0:60          'j' ( temp highp uint)
+0:61      move second child to first child ( temp highp uint)
 0:61        'j' ( temp highp uint)
-0:64  Function Definition: foo( ( global highp 4-component vector of float)
-0:64    Function Parameters: 
-0:65    Sequence
-0:65      Sequence
-0:65        move second child to first child ( temp highp float)
-0:65          'f' ( temp highp float)
-0:65          add ( temp highp float)
-0:65            add ( temp highp float)
-0:65              add ( temp highp float)
-0:65                j: direct index for structure (layout( column_major std140) uniform highp float)
-0:65                  'anon@1' (layout( column_major std140) uniform block{layout( column_major std140) uniform highp float j, layout( column_major std140) uniform highp 4-component vector of float k})
-0:65                  Constant:
-0:65                    0 (const uint)
-0:65                j: direct index for structure (layout( column_major std430) buffer highp float)
-0:65                  'bufferInstance' (layout( column_major std430) buffer block{layout( column_major std430) buffer highp float j, layout( column_major std430) buffer highp 4-component vector of float k})
-0:65                  Constant:
-0:65                    0 (const int)
-0:65              y: direct index for structure ( global highp float)
-0:65                structUniform: direct index for structure ( uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z})
-0:65                  'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:65                  Constant:
-0:65                    4 (const uint)
-0:65                Constant:
-0:65                  1 (const int)
-0:65            Convert uint to float ( temp highp float)
-0:65              z: direct index for structure ( global highp uint)
-0:65                structUniform: direct index for structure ( uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z})
-0:65                  'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:65                  Constant:
-0:65                    4 (const uint)
-0:65                Constant:
-0:65                  2 (const int)
-0:66      Sequence
-0:66        move second child to first child ( temp highp 2-component vector of float)
-0:66          'v2' ( temp highp 2-component vector of float)
-0:66          add ( temp highp 2-component vector of float)
-0:66            add ( temp highp 2-component vector of float)
-0:66              b: direct index for structure ( uniform highp 2-component vector of float)
-0:66                'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:66                Constant:
-0:66                  1 (const uint)
-0:66              c: direct index for structure ( uniform highp 2-component vector of float)
-0:66                'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:66                Constant:
-0:66                  2 (const uint)
-0:66            x: direct index for structure ( global highp 2-component vector of float)
-0:66              structUniform: direct index for structure ( uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z})
-0:66                'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:66                Constant:
-0:66                  4 (const uint)
-0:66              Constant:
-0:66                0 (const int)
-0:67      Sequence
-0:67        move second child to first child ( temp highp 4-component vector of float)
-0:67          'v4' ( temp highp 4-component vector of float)
-0:67          add ( temp highp 4-component vector of float)
-0:67            add ( temp highp 4-component vector of float)
-0:67              add ( temp highp 4-component vector of float)
-0:67                add ( temp highp 4-component vector of float)
-0:67                  add ( temp highp 4-component vector of float)
-0:67                    add ( temp highp 4-component vector of float)
-0:67                      a: direct index for structure ( uniform highp 4-component vector of float)
-0:67                        'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:67                        Constant:
-0:67                          0 (const uint)
-0:67                      direct index ( temp highp 4-component vector of float)
-0:67                        d: direct index for structure ( uniform 10-element array of highp 4-component vector of float)
-0:67                          'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:67                          Constant:
-0:67                            3 (const uint)
-0:67                        Constant:
-0:67                          0 (const int)
-0:67                    direct index ( temp highp 4-component vector of float)
-0:67                      d: direct index for structure ( uniform 10-element array of highp 4-component vector of float)
-0:67                        'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:67                        Constant:
-0:67                          3 (const uint)
-0:67                      Constant:
-0:67                        1 (const int)
-0:67                  direct index ( temp highp 4-component vector of float)
-0:67                    d: direct index for structure ( uniform 10-element array of highp 4-component vector of float)
-0:67                      'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
-0:67                      Constant:
-0:67                        3 (const uint)
-0:67                    Constant:
-0:67                      2 (const int)
-0:67                k: direct index for structure (layout( column_major std140) uniform highp 4-component vector of float)
-0:67                  'anon@1' (layout( column_major std140) uniform block{layout( column_major std140) uniform highp float j, layout( column_major std140) uniform highp 4-component vector of float k})
-0:67                  Constant:
-0:67                    1 (const uint)
-0:67              k: direct index for structure (layout( column_major std430) buffer highp 4-component vector of float)
-0:67                'bufferInstance' (layout( column_major std430) buffer block{layout( column_major std430) buffer highp float j, layout( column_major std430) buffer highp 4-component vector of float k})
-0:67                Constant:
-0:67                  1 (const int)
-0:67            texture ( global highp 4-component vector of float)
-0:67              't1' ( uniform highp sampler2D)
-0:67              Constant:
-0:67                0.000000
-0:67                0.000000
+0:61        AtomicCompSwap ( global highp uint)
+0:61          counter1: direct index for structure ( coherent volatile buffer highp uint)
+0:61            'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:61            Constant:
+0:61              0 (const uint)
+0:61          Constant:
+0:61            0 (const uint)
+0:61          'j' ( temp highp uint)
+0:63      AtomicAdd ( global highp uint)
+0:63        counter2: direct index for structure ( coherent volatile buffer highp uint)
+0:63          'anon@2' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter1,  coherent volatile buffer highp uint counter2})
+0:63          Constant:
+0:63            1 (const uint)
+0:63        Constant:
+0:63          1 (const uint)
+0:64      AtomicAdd ( global highp uint)
+0:64        counter3: direct index for structure ( coherent volatile buffer highp uint)
+0:64          'anon@3' (layout( column_major std430) buffer block{ coherent volatile buffer highp uint counter3})
+0:64          Constant:
+0:64            0 (const uint)
+0:64        Constant:
+0:64          1 (const uint)
+0:66      MemoryBarrierBuffer ( global void)
 0:68      Branch: Return with expression
-0:68        component-wise multiply ( temp highp 4-component vector of float)
-0:68          component-wise multiply ( temp highp 4-component vector of float)
-0:68            Construct vec4 ( temp highp 4-component vector of float)
-0:68              'f' ( temp highp float)
-0:68            Construct vec4 ( temp highp 4-component vector of float)
-0:68              'v2' ( temp highp 2-component vector of float)
-0:68              Constant:
-0:68                1.000000
-0:68              Constant:
-0:68                1.000000
-0:68          'v4' ( temp highp 4-component vector of float)
-0:71  Function Definition: main( ( global void)
+0:68        'j' ( temp highp uint)
+0:71  Function Definition: foo( ( global highp 4-component vector of float)
 0:71    Function Parameters: 
 0:72    Sequence
 0:72      Sequence
 0:72        move second child to first child ( temp highp float)
-0:72          'j' ( temp highp float)
-0:72          Convert uint to float ( temp highp float)
-0:72            Function Call: bar( ( global highp uint)
-0:73      move second child to first child ( temp highp 4-component vector of float)
-0:73        'o' ( out highp 4-component vector of float)
-0:73        vector-scale ( temp highp 4-component vector of float)
-0:73          'j' ( temp highp float)
-0:73          Function Call: foo( ( global highp 4-component vector of float)
+0:72          'f' ( temp highp float)
+0:72          add ( temp highp float)
+0:72            add ( temp highp float)
+0:72              add ( temp highp float)
+0:72                j: direct index for structure (layout( column_major std140) uniform highp float)
+0:72                  'anon@1' (layout( column_major std140) uniform block{layout( column_major std140) uniform highp float j, layout( column_major std140) uniform highp 4-component vector of float k})
+0:72                  Constant:
+0:72                    0 (const uint)
+0:72                j: direct index for structure (layout( column_major std430) buffer highp float)
+0:72                  'bufferInstance' (layout( column_major std430) buffer block{layout( column_major std430) buffer highp float j, layout( column_major std430) buffer highp 4-component vector of float k})
+0:72                  Constant:
+0:72                    0 (const int)
+0:72              y: direct index for structure ( global highp float)
+0:72                structUniform: direct index for structure ( uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers})
+0:72                  'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:72                  Constant:
+0:72                    4 (const uint)
+0:72                Constant:
+0:72                  1 (const int)
+0:72            Convert uint to float ( temp highp float)
+0:72              z: direct index for structure ( global highp uint)
+0:72                structUniform: direct index for structure ( uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers})
+0:72                  'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:72                  Constant:
+0:72                    4 (const uint)
+0:72                Constant:
+0:72                  2 (const int)
+0:73      Sequence
+0:73        move second child to first child ( temp highp 2-component vector of float)
+0:73          'v2' ( temp highp 2-component vector of float)
+0:73          add ( temp highp 2-component vector of float)
+0:73            add ( temp highp 2-component vector of float)
+0:73              b: direct index for structure ( uniform highp 2-component vector of float)
+0:73                'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:73                Constant:
+0:73                  1 (const uint)
+0:73              c: direct index for structure ( uniform highp 2-component vector of float)
+0:73                'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:73                Constant:
+0:73                  2 (const uint)
+0:73            x: direct index for structure ( global highp 2-component vector of float)
+0:73              structUniform: direct index for structure ( uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers})
+0:73                'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:73                Constant:
+0:73                  4 (const uint)
+0:73              Constant:
+0:73                0 (const int)
+0:74      Sequence
+0:74        move second child to first child ( temp highp 4-component vector of float)
+0:74          'v4' ( temp highp 4-component vector of float)
+0:74          add ( temp highp 4-component vector of float)
+0:74            add ( temp highp 4-component vector of float)
+0:74              add ( temp highp 4-component vector of float)
+0:74                add ( temp highp 4-component vector of float)
+0:74                  add ( temp highp 4-component vector of float)
+0:74                    add ( temp highp 4-component vector of float)
+0:74                      add ( temp highp 4-component vector of float)
+0:74                        a: direct index for structure ( uniform highp 4-component vector of float)
+0:74                          'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:74                          Constant:
+0:74                            0 (const uint)
+0:74                        direct index ( temp highp 4-component vector of float)
+0:74                          d: direct index for structure ( uniform 10-element array of highp 4-component vector of float)
+0:74                            'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:74                            Constant:
+0:74                              3 (const uint)
+0:74                          Constant:
+0:74                            0 (const int)
+0:74                      direct index ( temp highp 4-component vector of float)
+0:74                        d: direct index for structure ( uniform 10-element array of highp 4-component vector of float)
+0:74                          'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:74                          Constant:
+0:74                            3 (const uint)
+0:74                        Constant:
+0:74                          1 (const int)
+0:74                    direct index ( temp highp 4-component vector of float)
+0:74                      d: direct index for structure ( uniform 10-element array of highp 4-component vector of float)
+0:74                        'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:74                        Constant:
+0:74                          3 (const uint)
+0:74                      Constant:
+0:74                        2 (const int)
+0:74                  k: direct index for structure (layout( column_major std140) uniform highp 4-component vector of float)
+0:74                    'anon@1' (layout( column_major std140) uniform block{layout( column_major std140) uniform highp float j, layout( column_major std140) uniform highp 4-component vector of float k})
+0:74                    Constant:
+0:74                      1 (const uint)
+0:74                k: direct index for structure (layout( column_major std430) buffer highp 4-component vector of float)
+0:74                  'bufferInstance' (layout( column_major std430) buffer block{layout( column_major std430) buffer highp float j, layout( column_major std430) buffer highp 4-component vector of float k})
+0:74                  Constant:
+0:74                    1 (const int)
+0:74              texture ( global highp 4-component vector of float)
+0:74                't1' ( uniform highp sampler2D)
+0:74                Constant:
+0:74                  0.000000
+0:74                  0.000000
+0:74            texture ( global highp 4-component vector of float)
+0:74              'structUniform.t0' ( uniform highp sampler2D)
+0:74              Constant:
+0:74                0.000000
+0:74                0.000000
+0:75      Branch: Return with expression
+0:75        component-wise multiply ( temp highp 4-component vector of float)
+0:75          component-wise multiply ( temp highp 4-component vector of float)
+0:75            Construct vec4 ( temp highp 4-component vector of float)
+0:75              'f' ( temp highp float)
+0:75            Construct vec4 ( temp highp 4-component vector of float)
+0:75              'v2' ( temp highp 2-component vector of float)
+0:75              Constant:
+0:75                1.000000
+0:75              Constant:
+0:75                1.000000
+0:75          'v4' ( temp highp 4-component vector of float)
+0:78  Function Definition: baz(struct-SamplerArray-s21[4]1;s21;s21;s21;s21; ( global highp 4-component vector of float)
+0:78    Function Parameters: 
+0:78      'samplers' ( in structure{ global 4-element array of highp int /*tn*/})
+0:78      'samplers.tn[0]' ( in highp sampler2D)
+0:78      'samplers.tn[1]' ( in highp sampler2D)
+0:78      'samplers.tn[2]' ( in highp sampler2D)
+0:78      'samplers.tn[3]' ( in highp sampler2D)
+0:79    Sequence
+0:79      Branch: Return with expression
+0:79        add ( temp highp 4-component vector of float)
+0:79          add ( temp highp 4-component vector of float)
+0:79            add ( temp highp 4-component vector of float)
+0:79              texture ( global highp 4-component vector of float)
+0:79                'samplers.tn[0]' ( in highp sampler2D)
+0:79                Constant:
+0:79                  0.000000
+0:79                  0.000000
+0:79              texture ( global highp 4-component vector of float)
+0:79                'samplers.tn[1]' ( in highp sampler2D)
+0:79                Constant:
+0:79                  0.000000
+0:79                  0.000000
+0:79            texture ( global highp 4-component vector of float)
+0:79              'samplers.tn[2]' ( in highp sampler2D)
+0:79              Constant:
+0:79                0.000000
+0:79                0.000000
+0:79          texture ( global highp 4-component vector of float)
+0:79            'samplers.tn[3]' ( in highp sampler2D)
+0:79            Constant:
+0:79              0.000000
+0:79              0.000000
+0:82  Function Definition: main( ( global void)
+0:82    Function Parameters: 
+0:83    Sequence
+0:83      Sequence
+0:83        move second child to first child ( temp highp float)
+0:83          'j' ( temp highp float)
+0:83          Convert uint to float ( temp highp float)
+0:83            Function Call: bar( ( global highp uint)
+0:84      move second child to first child ( temp highp 4-component vector of float)
+0:84        'o' ( out highp 4-component vector of float)
+0:84        add ( temp highp 4-component vector of float)
+0:84          vector-scale ( temp highp 4-component vector of float)
+0:84            'j' ( temp highp float)
+0:84            Function Call: foo( ( global highp 4-component vector of float)
+0:84          Function Call: baz(struct-SamplerArray-s21[4]1;s21;s21;s21;s21; ( global highp 4-component vector of float)
+0:84            samplers: direct index for structure ( global structure{ global 4-element array of highp int /*tn*/})
+0:84              structUniform: direct index for structure ( uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers})
+0:84                'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:84                Constant:
+0:84                  4 (const uint)
+0:84              Constant:
+0:84                4 (const int)
+0:84            'structUniform.samplers.tn[0]' ( uniform highp sampler2D)
+0:84            'structUniform.samplers.tn[1]' ( uniform highp sampler2D)
+0:84            'structUniform.samplers.tn[2]' ( uniform highp sampler2D)
+0:84            'structUniform.samplers.tn[3]' ( uniform highp sampler2D)
 0:?   Linker Objects
 0:?     'o' ( out highp 4-component vector of float)
-0:?     'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z} structUniform})
+0:?     'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp 2-component vector of float b,  uniform highp 2-component vector of float c,  uniform 10-element array of highp 4-component vector of float d,  uniform structure{ global highp 2-component vector of float x,  global highp float y,  global highp uint z,  global highp int /*t0*/,  global structure{ global 4-element array of highp int /*tn*/} samplers} structUniform})
+0:?     'structUniform.t0' ( uniform highp sampler2D)
+0:?     'structUniform.samplers.tn[0]' ( uniform highp sampler2D)
+0:?     'structUniform.samplers.tn[1]' ( uniform highp sampler2D)
+0:?     'structUniform.samplers.tn[2]' ( uniform highp sampler2D)
+0:?     'structUniform.samplers.tn[3]' ( uniform highp sampler2D)
 0:?     't1' ( uniform highp sampler2D)
 0:?     'anon@1' (layout( column_major std140) uniform block{layout( column_major std140) uniform highp float j, layout( column_major std140) uniform highp 4-component vector of float k})
 0:?     'bufferInstance' (layout( column_major std430) buffer block{layout( column_major std430) buffer highp float j, layout( column_major std430) buffer highp 4-component vector of float k})
@@ -554,93 +666,125 @@ gl_FragCoord origin is upper left
 
 // Module Version 10000
 // Generated by (magic number): 8000b
-// Id's are bound by 163
+// Id's are bound by 216
 
                               Capability Shader
                1:             ExtInstImport  "GLSL.std.450"
                               MemoryModel Logical GLSL450
-                              EntryPoint Fragment 4  "main" 159
+                              EntryPoint Fragment 4  "main" 190
                               ExecutionMode 4 OriginUpperLeft
                               Source GLSL 460
                               Name 4  "main"
                               Name 8  "bar("
                               Name 13  "foo("
-                              Name 16  "j"
-                              Name 18  "gl_AtomicCounterBlock_0"
-                              MemberName 18(gl_AtomicCounterBlock_0) 0  "counter1"
-                              MemberName 18(gl_AtomicCounterBlock_0) 1  "counter2"
-                              Name 20  ""
-                              Name 63  "gl_AtomicCounterBlock_1"
-                              MemberName 63(gl_AtomicCounterBlock_1) 0  "counter3"
-                              Name 65  ""
-                              Name 73  "f"
-                              Name 74  "UniformBlock"
-                              MemberName 74(UniformBlock) 0  "j"
-                              MemberName 74(UniformBlock) 1  "k"
-                              Name 76  ""
-                              Name 80  "BufferBlock"
-                              MemberName 80(BufferBlock) 0  "j"
-                              MemberName 80(BufferBlock) 1  "k"
-                              Name 82  "bufferInstance"
-                              Name 89  "e"
-                              MemberName 89(e) 0  "x"
-                              MemberName 89(e) 1  "y"
-                              MemberName 89(e) 2  "z"
-                              Name 90  "gl_DefaultUniformBlock"
-                              MemberName 90(gl_DefaultUniformBlock) 0  "a"
-                              MemberName 90(gl_DefaultUniformBlock) 1  "b"
-                              MemberName 90(gl_DefaultUniformBlock) 2  "c"
-                              MemberName 90(gl_DefaultUniformBlock) 3  "d"
-                              MemberName 90(gl_DefaultUniformBlock) 4  "structUniform"
-                              Name 92  ""
-                              Name 103  "v2"
-                              Name 114  "v4"
-                              Name 137  "t1"
-                              Name 155  "j"
-                              Name 159  "o"
-                              MemberDecorate 18(gl_AtomicCounterBlock_0) 0 Coherent
-                              MemberDecorate 18(gl_AtomicCounterBlock_0) 0 Volatile
-                              MemberDecorate 18(gl_AtomicCounterBlock_0) 0 Coherent
-                              MemberDecorate 18(gl_AtomicCounterBlock_0) 0 Offset 0
-                              MemberDecorate 18(gl_AtomicCounterBlock_0) 1 Coherent
-                              MemberDecorate 18(gl_AtomicCounterBlock_0) 1 Volatile
-                              MemberDecorate 18(gl_AtomicCounterBlock_0) 1 Coherent
-                              MemberDecorate 18(gl_AtomicCounterBlock_0) 1 Offset 4
-                              Decorate 18(gl_AtomicCounterBlock_0) BufferBlock
-                              Decorate 20 DescriptorSet 0
-                              Decorate 20 Binding 4
-                              MemberDecorate 63(gl_AtomicCounterBlock_1) 0 Coherent
-                              MemberDecorate 63(gl_AtomicCounterBlock_1) 0 Volatile
-                              MemberDecorate 63(gl_AtomicCounterBlock_1) 0 Coherent
-                              MemberDecorate 63(gl_AtomicCounterBlock_1) 0 Offset 0
-                              Decorate 63(gl_AtomicCounterBlock_1) BufferBlock
-                              Decorate 65 DescriptorSet 0
-                              Decorate 65 Binding 5
-                              MemberDecorate 74(UniformBlock) 0 Offset 0
-                              MemberDecorate 74(UniformBlock) 1 Offset 16
-                              Decorate 74(UniformBlock) Block
-                              Decorate 76 DescriptorSet 0
-                              Decorate 76 Binding 2
-                              MemberDecorate 80(BufferBlock) 0 Offset 0
-                              MemberDecorate 80(BufferBlock) 1 Offset 16
-                              Decorate 80(BufferBlock) BufferBlock
-                              Decorate 82(bufferInstance) DescriptorSet 0
-                              Decorate 82(bufferInstance) Binding 3
-                              Decorate 88 ArrayStride 16
-                              MemberDecorate 89(e) 0 Offset 0
-                              MemberDecorate 89(e) 1 Offset 8
-                              MemberDecorate 89(e) 2 Offset 12
-                              MemberDecorate 90(gl_DefaultUniformBlock) 0 Offset 0
-                              MemberDecorate 90(gl_DefaultUniformBlock) 1 Offset 16
-                              MemberDecorate 90(gl_DefaultUniformBlock) 2 Offset 24
-                              MemberDecorate 90(gl_DefaultUniformBlock) 3 Offset 32
-                              MemberDecorate 90(gl_DefaultUniformBlock) 4 Offset 192
-                              Decorate 90(gl_DefaultUniformBlock) Block
-                              Decorate 92 DescriptorSet 0
-                              Decorate 92 Binding 0
-                              Decorate 137(t1) DescriptorSet 0
-                              Decorate 137(t1) Binding 1
-                              Decorate 159(o) Location 0
+                              Name 18  "SamplerArray"
+                              MemberName 18(SamplerArray) 0  "/*tn*/"
+                              Name 29  "baz(struct-SamplerArray-s21[4]1;s21;s21;s21;s21;"
+                              Name 24  "samplers"
+                              Name 25  "samplers.tn[0]"
+                              Name 26  "samplers.tn[1]"
+                              Name 27  "samplers.tn[2]"
+                              Name 28  "samplers.tn[3]"
+                              Name 32  "j"
+                              Name 34  "gl_AtomicCounterBlock_0"
+                              MemberName 34(gl_AtomicCounterBlock_0) 0  "counter1"
+                              MemberName 34(gl_AtomicCounterBlock_0) 1  "counter2"
+                              Name 36  ""
+                              Name 78  "gl_AtomicCounterBlock_1"
+                              MemberName 78(gl_AtomicCounterBlock_1) 0  "counter3"
+                              Name 80  ""
+                              Name 88  "f"
+                              Name 89  "UniformBlock"
+                              MemberName 89(UniformBlock) 0  "j"
+                              MemberName 89(UniformBlock) 1  "k"
+                              Name 91  ""
+                              Name 95  "BufferBlock"
+                              MemberName 95(BufferBlock) 0  "j"
+                              MemberName 95(BufferBlock) 1  "k"
+                              Name 97  "bufferInstance"
+                              Name 105  "SamplerArray"
+                              MemberName 105(SamplerArray) 0  "/*tn*/"
+                              Name 106  "e"
+                              MemberName 106(e) 0  "x"
+                              MemberName 106(e) 1  "y"
+                              MemberName 106(e) 2  "z"
+                              MemberName 106(e) 3  "/*t0*/"
+                              MemberName 106(e) 4  "samplers"
+                              Name 107  "gl_DefaultUniformBlock"
+                              MemberName 107(gl_DefaultUniformBlock) 0  "a"
+                              MemberName 107(gl_DefaultUniformBlock) 1  "b"
+                              MemberName 107(gl_DefaultUniformBlock) 2  "c"
+                              MemberName 107(gl_DefaultUniformBlock) 3  "d"
+                              MemberName 107(gl_DefaultUniformBlock) 4  "structUniform"
+                              Name 109  ""
+                              Name 120  "v2"
+                              Name 131  "v4"
+                              Name 151  "t1"
+                              Name 157  "structUniform.t0"
+                              Name 186  "j"
+                              Name 190  "o"
+                              Name 194  "structUniform.samplers.tn[0]"
+                              Name 195  "structUniform.samplers.tn[1]"
+                              Name 196  "structUniform.samplers.tn[2]"
+                              Name 197  "structUniform.samplers.tn[3]"
+                              Name 198  "param"
+                              MemberDecorate 34(gl_AtomicCounterBlock_0) 0 Coherent
+                              MemberDecorate 34(gl_AtomicCounterBlock_0) 0 Volatile
+                              MemberDecorate 34(gl_AtomicCounterBlock_0) 0 Coherent
+                              MemberDecorate 34(gl_AtomicCounterBlock_0) 0 Offset 0
+                              MemberDecorate 34(gl_AtomicCounterBlock_0) 1 Coherent
+                              MemberDecorate 34(gl_AtomicCounterBlock_0) 1 Volatile
+                              MemberDecorate 34(gl_AtomicCounterBlock_0) 1 Coherent
+                              MemberDecorate 34(gl_AtomicCounterBlock_0) 1 Offset 4
+                              Decorate 34(gl_AtomicCounterBlock_0) BufferBlock
+                              Decorate 36 DescriptorSet 0
+                              Decorate 36 Binding 9
+                              MemberDecorate 78(gl_AtomicCounterBlock_1) 0 Coherent
+                              MemberDecorate 78(gl_AtomicCounterBlock_1) 0 Volatile
+                              MemberDecorate 78(gl_AtomicCounterBlock_1) 0 Coherent
+                              MemberDecorate 78(gl_AtomicCounterBlock_1) 0 Offset 0
+                              Decorate 78(gl_AtomicCounterBlock_1) BufferBlock
+                              Decorate 80 DescriptorSet 0
+                              Decorate 80 Binding 10
+                              MemberDecorate 89(UniformBlock) 0 Offset 0
+                              MemberDecorate 89(UniformBlock) 1 Offset 16
+                              Decorate 89(UniformBlock) Block
+                              Decorate 91 DescriptorSet 0
+                              Decorate 91 Binding 7
+                              MemberDecorate 95(BufferBlock) 0 Offset 0
+                              MemberDecorate 95(BufferBlock) 1 Offset 16
+                              Decorate 95(BufferBlock) BufferBlock
+                              Decorate 97(bufferInstance) DescriptorSet 0
+                              Decorate 97(bufferInstance) Binding 8
+                              Decorate 103 ArrayStride 16
+                              Decorate 104 ArrayStride 16
+                              MemberDecorate 105(SamplerArray) 0 Offset 0
+                              MemberDecorate 106(e) 0 Offset 0
+                              MemberDecorate 106(e) 1 Offset 8
+                              MemberDecorate 106(e) 2 Offset 12
+                              MemberDecorate 106(e) 3 Offset 16
+                              MemberDecorate 106(e) 4 Offset 32
+                              MemberDecorate 107(gl_DefaultUniformBlock) 0 Offset 0
+                              MemberDecorate 107(gl_DefaultUniformBlock) 1 Offset 16
+                              MemberDecorate 107(gl_DefaultUniformBlock) 2 Offset 24
+                              MemberDecorate 107(gl_DefaultUniformBlock) 3 Offset 32
+                              MemberDecorate 107(gl_DefaultUniformBlock) 4 Offset 192
+                              Decorate 107(gl_DefaultUniformBlock) Block
+                              Decorate 109 DescriptorSet 0
+                              Decorate 109 Binding 0
+                              Decorate 151(t1) DescriptorSet 0
+                              Decorate 151(t1) Binding 6
+                              Decorate 157(structUniform.t0) DescriptorSet 0
+                              Decorate 157(structUniform.t0) Binding 1
+                              Decorate 190(o) Location 0
+                              Decorate 194(structUniform.samplers.tn[0]) DescriptorSet 0
+                              Decorate 194(structUniform.samplers.tn[0]) Binding 2
+                              Decorate 195(structUniform.samplers.tn[1]) DescriptorSet 0
+                              Decorate 195(structUniform.samplers.tn[1]) Binding 3
+                              Decorate 196(structUniform.samplers.tn[2]) DescriptorSet 0
+                              Decorate 196(structUniform.samplers.tn[2]) Binding 4
+                              Decorate 197(structUniform.samplers.tn[3]) DescriptorSet 0
+                              Decorate 197(structUniform.samplers.tn[3]) Binding 5
                2:             TypeVoid
                3:             TypeFunction 2
                6:             TypeInt 32 0
@@ -648,179 +792,236 @@ gl_FragCoord origin is upper left
               10:             TypeFloat 32
               11:             TypeVector 10(float) 4
               12:             TypeFunction 11(fvec4)
-              15:             TypePointer Function 6(int)
-              17:      6(int) Constant 0
-18(gl_AtomicCounterBlock_0):             TypeStruct 6(int) 6(int)
-              19:             TypePointer Uniform 18(gl_AtomicCounterBlock_0)
-              20:     19(ptr) Variable Uniform
-              21:             TypeInt 32 1
-              22:     21(int) Constant 0
-              23:             TypePointer Uniform 6(int)
-              25:      6(int) Constant 1
-              28:      6(int) Constant 4294967295
-              60:     21(int) Constant 1
-63(gl_AtomicCounterBlock_1):             TypeStruct 6(int)
-              64:             TypePointer Uniform 63(gl_AtomicCounterBlock_1)
-              65:     64(ptr) Variable Uniform
-              68:      6(int) Constant 72
-              72:             TypePointer Function 10(float)
-74(UniformBlock):             TypeStruct 10(float) 11(fvec4)
-              75:             TypePointer Uniform 74(UniformBlock)
-              76:     75(ptr) Variable Uniform
-              77:             TypePointer Uniform 10(float)
- 80(BufferBlock):             TypeStruct 10(float) 11(fvec4)
-              81:             TypePointer Uniform 80(BufferBlock)
-82(bufferInstance):     81(ptr) Variable Uniform
-              86:             TypeVector 10(float) 2
-              87:      6(int) Constant 10
-              88:             TypeArray 11(fvec4) 87
-           89(e):             TypeStruct 86(fvec2) 10(float) 6(int)
-90(gl_DefaultUniformBlock):             TypeStruct 11(fvec4) 86(fvec2) 86(fvec2) 88 89(e)
-              91:             TypePointer Uniform 90(gl_DefaultUniformBlock)
-              92:     91(ptr) Variable Uniform
-              93:     21(int) Constant 4
-              97:     21(int) Constant 2
-             102:             TypePointer Function 86(fvec2)
-             104:             TypePointer Uniform 86(fvec2)
-             113:             TypePointer Function 11(fvec4)
-             115:             TypePointer Uniform 11(fvec4)
-             118:     21(int) Constant 3
-             134:             TypeImage 10(float) 2D sampled format:Unknown
-             135:             TypeSampledImage 134
-             136:             TypePointer UniformConstant 135
-         137(t1):    136(ptr) Variable UniformConstant
-             139:   10(float) Constant 0
-             140:   86(fvec2) ConstantComposite 139 139
-             146:   10(float) Constant 1065353216
-             158:             TypePointer Output 11(fvec4)
-          159(o):    158(ptr) Variable Output
+              15:             TypeInt 32 1
+              16:      6(int) Constant 4
+              17:             TypeArray 15(int) 16
+18(SamplerArray):             TypeStruct 17
+              19:             TypePointer Function 18(SamplerArray)
+              20:             TypeImage 10(float) 2D sampled format:Unknown
+              21:             TypeSampledImage 20
+              22:             TypePointer UniformConstant 21
+              23:             TypeFunction 11(fvec4) 19(ptr) 22(ptr) 22(ptr) 22(ptr) 22(ptr)
+              31:             TypePointer Function 6(int)
+              33:      6(int) Constant 0
+34(gl_AtomicCounterBlock_0):             TypeStruct 6(int) 6(int)
+              35:             TypePointer Uniform 34(gl_AtomicCounterBlock_0)
+              36:     35(ptr) Variable Uniform
+              37:     15(int) Constant 0
+              38:             TypePointer Uniform 6(int)
+              40:      6(int) Constant 1
+              43:      6(int) Constant 4294967295
+              75:     15(int) Constant 1
+78(gl_AtomicCounterBlock_1):             TypeStruct 6(int)
+              79:             TypePointer Uniform 78(gl_AtomicCounterBlock_1)
+              80:     79(ptr) Variable Uniform
+              83:      6(int) Constant 72
+              87:             TypePointer Function 10(float)
+89(UniformBlock):             TypeStruct 10(float) 11(fvec4)
+              90:             TypePointer Uniform 89(UniformBlock)
+              91:     90(ptr) Variable Uniform
+              92:             TypePointer Uniform 10(float)
+ 95(BufferBlock):             TypeStruct 10(float) 11(fvec4)
+              96:             TypePointer Uniform 95(BufferBlock)
+97(bufferInstance):     96(ptr) Variable Uniform
+             101:             TypeVector 10(float) 2
+             102:      6(int) Constant 10
+             103:             TypeArray 11(fvec4) 102
+             104:             TypeArray 15(int) 16
+105(SamplerArray):             TypeStruct 104
+          106(e):             TypeStruct 101(fvec2) 10(float) 6(int) 15(int) 105(SamplerArray)
+107(gl_DefaultUniformBlock):             TypeStruct 11(fvec4) 101(fvec2) 101(fvec2) 103 106(e)
+             108:             TypePointer Uniform 107(gl_DefaultUniformBlock)
+             109:    108(ptr) Variable Uniform
+             110:     15(int) Constant 4
+             114:     15(int) Constant 2
+             119:             TypePointer Function 101(fvec2)
+             121:             TypePointer Uniform 101(fvec2)
+             130:             TypePointer Function 11(fvec4)
+             132:             TypePointer Uniform 11(fvec4)
+             135:     15(int) Constant 3
+         151(t1):     22(ptr) Variable UniformConstant
+             153:   10(float) Constant 0
+             154:  101(fvec2) ConstantComposite 153 153
+157(structUniform.t0):     22(ptr) Variable UniformConstant
+             164:   10(float) Constant 1065353216
+             189:             TypePointer Output 11(fvec4)
+          190(o):    189(ptr) Variable Output
+194(structUniform.samplers.tn[0]):     22(ptr) Variable UniformConstant
+195(structUniform.samplers.tn[1]):     22(ptr) Variable UniformConstant
+196(structUniform.samplers.tn[2]):     22(ptr) Variable UniformConstant
+197(structUniform.samplers.tn[3]):     22(ptr) Variable UniformConstant
+             199:             TypePointer Uniform 105(SamplerArray)
+             203:             TypePointer Function 17
+             206:             TypePointer Function 15(int)
          4(main):           2 Function None 3
                5:             Label
-          155(j):     72(ptr) Variable Function
-             156:      6(int) FunctionCall 8(bar()
-             157:   10(float) ConvertUToF 156
-                              Store 155(j) 157
-             160:   10(float) Load 155(j)
-             161:   11(fvec4) FunctionCall 13(foo()
-             162:   11(fvec4) VectorTimesScalar 161 160
-                              Store 159(o) 162
+          186(j):     87(ptr) Variable Function
+      198(param):     19(ptr) Variable Function
+             187:      6(int) FunctionCall 8(bar()
+             188:   10(float) ConvertUToF 187
+                              Store 186(j) 188
+             191:   10(float) Load 186(j)
+             192:   11(fvec4) FunctionCall 13(foo()
+             193:   11(fvec4) VectorTimesScalar 192 191
+             200:    199(ptr) AccessChain 109 110 110
+             201:105(SamplerArray) Load 200
+             202:         104 CompositeExtract 201 0
+             204:    203(ptr) AccessChain 198(param) 37
+             205:     15(int) CompositeExtract 202 0
+             207:    206(ptr) AccessChain 204 37
+                              Store 207 205
+             208:     15(int) CompositeExtract 202 1
+             209:    206(ptr) AccessChain 204 75
+                              Store 209 208
+             210:     15(int) CompositeExtract 202 2
+             211:    206(ptr) AccessChain 204 114
+                              Store 211 210
+             212:     15(int) CompositeExtract 202 3
+             213:    206(ptr) AccessChain 204 135
+                              Store 213 212
+             214:   11(fvec4) FunctionCall 29(baz(struct-SamplerArray-s21[4]1;s21;s21;s21;s21;) 198(param) 194(structUniform.samplers.tn[0]) 195(structUniform.samplers.tn[1]) 196(structUniform.samplers.tn[2]) 197(structUniform.samplers.tn[3])
+             215:   11(fvec4) FAdd 193 214
+                              Store 190(o) 215
                               Return
                               FunctionEnd
          8(bar():      6(int) Function None 7
                9:             Label
-           16(j):     15(ptr) Variable Function
-                              Store 16(j) 17
-              24:     23(ptr) AccessChain 20 22
-              26:      6(int) AtomicIAdd 24 25 17 25
-                              Store 16(j) 26
-              27:     23(ptr) AccessChain 20 22
-              29:      6(int) AtomicIAdd 27 25 17 28
-              30:      6(int) ISub 29 25
-                              Store 16(j) 30
-              31:     23(ptr) AccessChain 20 22
-              32:      6(int) Load 31
-                              Store 16(j) 32
-              33:     23(ptr) AccessChain 20 22
-              34:      6(int) AtomicIAdd 33 25 17 25
-                              Store 16(j) 34
-              35:     23(ptr) AccessChain 20 22
-              36:      6(int) AtomicIAdd 35 25 17 28
-                              Store 16(j) 36
-              37:     23(ptr) AccessChain 20 22
-              38:      6(int) AtomicISub 37 25 17 25
-                              Store 16(j) 38
-              39:     23(ptr) AccessChain 20 22
-              40:      6(int) Load 16(j)
-              41:      6(int) AtomicUMin 39 25 17 40
-                              Store 16(j) 41
-              42:     23(ptr) AccessChain 20 22
-              43:      6(int) Load 16(j)
-              44:      6(int) AtomicUMax 42 25 17 43
-                              Store 16(j) 44
-              45:     23(ptr) AccessChain 20 22
-              46:      6(int) Load 16(j)
-              47:      6(int) AtomicAnd 45 25 17 46
-                              Store 16(j) 47
-              48:     23(ptr) AccessChain 20 22
-              49:      6(int) Load 16(j)
-              50:      6(int) AtomicOr 48 25 17 49
-                              Store 16(j) 50
-              51:     23(ptr) AccessChain 20 22
-              52:      6(int) Load 16(j)
-              53:      6(int) AtomicXor 51 25 17 52
-                              Store 16(j) 53
-              54:     23(ptr) AccessChain 20 22
-              55:      6(int) Load 16(j)
-              56:      6(int) AtomicExchange 54 25 17 55
-                              Store 16(j) 56
-              57:     23(ptr) AccessChain 20 22
-              58:      6(int) Load 16(j)
-              59:      6(int) AtomicCompareExchange 57 25 17 17 58 17
-                              Store 16(j) 59
-              61:     23(ptr) AccessChain 20 60
-              62:      6(int) AtomicIAdd 61 25 17 25
-              66:     23(ptr) AccessChain 65 22
-              67:      6(int) AtomicIAdd 66 25 17 25
-                              MemoryBarrier 25 68
-              69:      6(int) Load 16(j)
-                              ReturnValue 69
+           32(j):     31(ptr) Variable Function
+                              Store 32(j) 33
+              39:     38(ptr) AccessChain 36 37
+              41:      6(int) AtomicIAdd 39 40 33 40
+                              Store 32(j) 41
+              42:     38(ptr) AccessChain 36 37
+              44:      6(int) AtomicIAdd 42 40 33 43
+              45:      6(int) ISub 44 40
+                              Store 32(j) 45
+              46:     38(ptr) AccessChain 36 37
+              47:      6(int) Load 46
+                              Store 32(j) 47
+              48:     38(ptr) AccessChain 36 37
+              49:      6(int) AtomicIAdd 48 40 33 40
+                              Store 32(j) 49
+              50:     38(ptr) AccessChain 36 37
+              51:      6(int) AtomicIAdd 50 40 33 43
+                              Store 32(j) 51
+              52:     38(ptr) AccessChain 36 37
+              53:      6(int) AtomicISub 52 40 33 40
+                              Store 32(j) 53
+              54:     38(ptr) AccessChain 36 37
+              55:      6(int) Load 32(j)
+              56:      6(int) AtomicUMin 54 40 33 55
+                              Store 32(j) 56
+              57:     38(ptr) AccessChain 36 37
+              58:      6(int) Load 32(j)
+              59:      6(int) AtomicUMax 57 40 33 58
+                              Store 32(j) 59
+              60:     38(ptr) AccessChain 36 37
+              61:      6(int) Load 32(j)
+              62:      6(int) AtomicAnd 60 40 33 61
+                              Store 32(j) 62
+              63:     38(ptr) AccessChain 36 37
+              64:      6(int) Load 32(j)
+              65:      6(int) AtomicOr 63 40 33 64
+                              Store 32(j) 65
+              66:     38(ptr) AccessChain 36 37
+              67:      6(int) Load 32(j)
+              68:      6(int) AtomicXor 66 40 33 67
+                              Store 32(j) 68
+              69:     38(ptr) AccessChain 36 37
+              70:      6(int) Load 32(j)
+              71:      6(int) AtomicExchange 69 40 33 70
+                              Store 32(j) 71
+              72:     38(ptr) AccessChain 36 37
+              73:      6(int) Load 32(j)
+              74:      6(int) AtomicCompareExchange 72 40 33 33 73 33
+                              Store 32(j) 74
+              76:     38(ptr) AccessChain 36 75
+              77:      6(int) AtomicIAdd 76 40 33 40
+              81:     38(ptr) AccessChain 80 37
+              82:      6(int) AtomicIAdd 81 40 33 40
+                              MemoryBarrier 40 83
+              84:      6(int) Load 32(j)
+                              ReturnValue 84
                               FunctionEnd
         13(foo():   11(fvec4) Function None 12
               14:             Label
-           73(f):     72(ptr) Variable Function
-         103(v2):    102(ptr) Variable Function
-         114(v4):    113(ptr) Variable Function
-              78:     77(ptr) AccessChain 76 22
-              79:   10(float) Load 78
-              83:     77(ptr) AccessChain 82(bufferInstance) 22
-              84:   10(float) Load 83
-              85:   10(float) FAdd 79 84
-              94:     77(ptr) AccessChain 92 93 60
-              95:   10(float) Load 94
-              96:   10(float) FAdd 85 95
-              98:     23(ptr) AccessChain 92 93 97
-              99:      6(int) Load 98
-             100:   10(float) ConvertUToF 99
-             101:   10(float) FAdd 96 100
-                              Store 73(f) 101
-             105:    104(ptr) AccessChain 92 60
-             106:   86(fvec2) Load 105
-             107:    104(ptr) AccessChain 92 97
-             108:   86(fvec2) Load 107
-             109:   86(fvec2) FAdd 106 108
-             110:    104(ptr) AccessChain 92 93 22
-             111:   86(fvec2) Load 110
-             112:   86(fvec2) FAdd 109 111
-                              Store 103(v2) 112
-             116:    115(ptr) AccessChain 92 22
-             117:   11(fvec4) Load 116
-             119:    115(ptr) AccessChain 92 118 22
-             120:   11(fvec4) Load 119
-             121:   11(fvec4) FAdd 117 120
-             122:    115(ptr) AccessChain 92 118 60
-             123:   11(fvec4) Load 122
-             124:   11(fvec4) FAdd 121 123
-             125:    115(ptr) AccessChain 92 118 97
-             126:   11(fvec4) Load 125
-             127:   11(fvec4) FAdd 124 126
-             128:    115(ptr) AccessChain 76 60
-             129:   11(fvec4) Load 128
-             130:   11(fvec4) FAdd 127 129
-             131:    115(ptr) AccessChain 82(bufferInstance) 60
-             132:   11(fvec4) Load 131
-             133:   11(fvec4) FAdd 130 132
-             138:         135 Load 137(t1)
-             141:   11(fvec4) ImageSampleImplicitLod 138 140
-             142:   11(fvec4) FAdd 133 141
-                              Store 114(v4) 142
-             143:   10(float) Load 73(f)
-             144:   11(fvec4) CompositeConstruct 143 143 143 143
-             145:   86(fvec2) Load 103(v2)
-             147:   10(float) CompositeExtract 145 0
-             148:   10(float) CompositeExtract 145 1
-             149:   11(fvec4) CompositeConstruct 147 148 146 146
-             150:   11(fvec4) FMul 144 149
-             151:   11(fvec4) Load 114(v4)
-             152:   11(fvec4) FMul 150 151
-                              ReturnValue 152
+           88(f):     87(ptr) Variable Function
+         120(v2):    119(ptr) Variable Function
+         131(v4):    130(ptr) Variable Function
+              93:     92(ptr) AccessChain 91 37
+              94:   10(float) Load 93
+              98:     92(ptr) AccessChain 97(bufferInstance) 37
+              99:   10(float) Load 98
+             100:   10(float) FAdd 94 99
+             111:     92(ptr) AccessChain 109 110 75
+             112:   10(float) Load 111
+             113:   10(float) FAdd 100 112
+             115:     38(ptr) AccessChain 109 110 114
+             116:      6(int) Load 115
+             117:   10(float) ConvertUToF 116
+             118:   10(float) FAdd 113 117
+                              Store 88(f) 118
+             122:    121(ptr) AccessChain 109 75
+             123:  101(fvec2) Load 122
+             124:    121(ptr) AccessChain 109 114
+             125:  101(fvec2) Load 124
+             126:  101(fvec2) FAdd 123 125
+             127:    121(ptr) AccessChain 109 110 37
+             128:  101(fvec2) Load 127
+             129:  101(fvec2) FAdd 126 128
+                              Store 120(v2) 129
+             133:    132(ptr) AccessChain 109 37
+             134:   11(fvec4) Load 133
+             136:    132(ptr) AccessChain 109 135 37
+             137:   11(fvec4) Load 136
+             138:   11(fvec4) FAdd 134 137
+             139:    132(ptr) AccessChain 109 135 75
+             140:   11(fvec4) Load 139
+             141:   11(fvec4) FAdd 138 140
+             142:    132(ptr) AccessChain 109 135 114
+             143:   11(fvec4) Load 142
+             144:   11(fvec4) FAdd 141 143
+             145:    132(ptr) AccessChain 91 75
+             146:   11(fvec4) Load 145
+             147:   11(fvec4) FAdd 144 146
+             148:    132(ptr) AccessChain 97(bufferInstance) 75
+             149:   11(fvec4) Load 148
+             150:   11(fvec4) FAdd 147 149
+             152:          21 Load 151(t1)
+             155:   11(fvec4) ImageSampleImplicitLod 152 154
+             156:   11(fvec4) FAdd 150 155
+             158:          21 Load 157(structUniform.t0)
+             159:   11(fvec4) ImageSampleImplicitLod 158 154
+             160:   11(fvec4) FAdd 156 159
+                              Store 131(v4) 160
+             161:   10(float) Load 88(f)
+             162:   11(fvec4) CompositeConstruct 161 161 161 161
+             163:  101(fvec2) Load 120(v2)
+             165:   10(float) CompositeExtract 163 0
+             166:   10(float) CompositeExtract 163 1
+             167:   11(fvec4) CompositeConstruct 165 166 164 164
+             168:   11(fvec4) FMul 162 167
+             169:   11(fvec4) Load 131(v4)
+             170:   11(fvec4) FMul 168 169
+                              ReturnValue 170
+                              FunctionEnd
+29(baz(struct-SamplerArray-s21[4]1;s21;s21;s21;s21;):   11(fvec4) Function None 23
+    24(samplers):     19(ptr) FunctionParameter
+25(samplers.tn[0]):     22(ptr) FunctionParameter
+26(samplers.tn[1]):     22(ptr) FunctionParameter
+27(samplers.tn[2]):     22(ptr) FunctionParameter
+28(samplers.tn[3]):     22(ptr) FunctionParameter
+              30:             Label
+             173:          21 Load 25(samplers.tn[0])
+             174:   11(fvec4) ImageSampleImplicitLod 173 154
+             175:          21 Load 26(samplers.tn[1])
+             176:   11(fvec4) ImageSampleImplicitLod 175 154
+             177:   11(fvec4) FAdd 174 176
+             178:          21 Load 27(samplers.tn[2])
+             179:   11(fvec4) ImageSampleImplicitLod 178 154
+             180:   11(fvec4) FAdd 177 179
+             181:          21 Load 28(samplers.tn[3])
+             182:   11(fvec4) ImageSampleImplicitLod 181 154
+             183:   11(fvec4) FAdd 180 182
+                              ReturnValue 183
                               FunctionEnd

--- a/Test/vk.relaxed.frag
+++ b/Test/vk.relaxed.frag
@@ -7,10 +7,17 @@ uniform vec4 a;
 uniform vec2 b = vec2(0, 0);            // initializer will be ignored
 layout(location = 0) uniform vec2 c;    // location qualifier will be ignored
 uniform vec4 d[10];
+
+struct SamplerArray{
+    sampler2D tn[4];
+};
+
 uniform struct e {                      
     vec2 x;
     float y;
     uint z;
+    sampler2D t0;
+    SamplerArray samplers;
 } structUniform; 
 
 // opaque types will not be grouped into uniform block
@@ -64,11 +71,15 @@ uint bar() {
 vec4 foo() {
     float f = j + bufferInstance.j + structUniform.y + structUniform.z;
     vec2 v2 = b + c + structUniform.x;
-    vec4 v4 = a + d[0] + d[1] + d[2] + k + bufferInstance.k + texture(t1, vec2(0, 0));
+    vec4 v4 = a + d[0] + d[1] + d[2] + k + bufferInstance.k + texture(t1, vec2(0, 0)) + texture(structUniform.t0, vec2(0, 0));
     return vec4(f) * vec4(v2, 1, 1) * v4;
+}
+
+vec4 baz(SamplerArray samplers) {
+    return texture(samplers.tn[0], vec2(0, 0)) + texture(samplers.tn[1], vec2(0, 0)) + texture(samplers.tn[2], vec2(0, 0)) + texture(samplers.tn[3], vec2(0, 0));
 }
 
 void main() {
     float j = float(bar());
-    o = j * foo();
+    o = j * foo() + baz(structUniform.samplers);
 }

--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -2317,6 +2317,40 @@ TIntermAggregate* TIntermediate::growAggregate(TIntermNode* left, TIntermNode* r
     return aggNode;
 }
 
+TIntermAggregate* TIntermediate::mergeAggregate(TIntermNode* left, TIntermNode* right)
+{
+    if (left == nullptr && right == nullptr)
+        return nullptr;
+
+    TIntermAggregate* aggNode = nullptr;
+    if (left != nullptr)
+        aggNode = left->getAsAggregate();
+    if (aggNode == nullptr || aggNode->getOp() != EOpNull) {
+        aggNode = new TIntermAggregate;
+        if (left != nullptr)
+            aggNode->getSequence().push_back(left);
+    }
+
+    TIntermAggregate* rhsagg = right->getAsAggregate();
+    if (rhsagg == nullptr || rhsagg->getOp() != EOpNull)
+        aggNode->getSequence().push_back(right);
+    else
+        aggNode->getSequence().insert(aggNode->getSequence().end(),
+                                      rhsagg->getSequence().begin(),
+                                      rhsagg->getSequence().end());
+
+    return aggNode;
+}
+
+TIntermAggregate* TIntermediate::mergeAggregate(TIntermNode* left, TIntermNode* right, const TSourceLoc& loc)
+{
+    TIntermAggregate* aggNode = mergeAggregate(left, right);
+    if (aggNode)
+        aggNode->setLoc(loc);
+
+    return aggNode;
+}
+
 //
 // Turn an existing node into an aggregate.
 //

--- a/glslang/MachineIndependent/ParseContextBase.cpp
+++ b/glslang/MachineIndependent/ParseContextBase.cpp
@@ -724,6 +724,24 @@ void TParseContextBase::finish()
     if (parsingBuiltins)
         return;
 
+    for (const TString& relaxedSymbol : relaxedSymbols)
+    {
+        TSymbol* symbol = symbolTable.find(relaxedSymbol);
+        TType& type = symbol->getWritableType();
+        for (const TTypeLoc& typeLoc : *type.getStruct())
+        {
+            if (typeLoc.type->isOpaque())
+            {
+                typeLoc.type->getSampler() = TSampler{};
+                typeLoc.type->setBasicType(EbtInt);
+                TString fieldName("/*");
+                fieldName.append(typeLoc.type->getFieldName());
+                fieldName.append("*/");
+                typeLoc.type->setFieldName(fieldName);
+            }
+        }
+    }
+
     // Transfer the linkage symbols to AST nodes, preserving order.
     TIntermAggregate* linkage = new TIntermAggregate;
     for (auto i = linkageSymbols.begin(); i != linkageSymbols.end(); ++i)

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -7473,8 +7473,6 @@ void TParseContext::vkRelaxedRemapUniformMembers(const TSourceLoc& loc, const TP
 
     ForEachOpaque(type, identifier,
                   [&publicType, &loc, this](const TType& type, const TString& path) {
-                      TString& structMemberName = *(NewPoolTString(path.c_str()));
-
                       TArraySizes arraySizes = {};
                       if (type.getArraySizes()) arraySizes = *type.getArraySizes();
                       TTypeParameters typeParameters = {};
@@ -7498,6 +7496,7 @@ void TParseContext::vkRelaxedRemapUniformMembers(const TSourceLoc& loc, const TP
                       memberType.qualifier.storage = publicType.qualifier.storage;
                       memberType.shaderQualifiers = publicType.shaderQualifiers;
 
+                      TString& structMemberName = *NewPoolTString(path.c_str()); // A copy is required due to declareVariable() signature.
                       declareVariable(loc, structMemberName, memberType, nullptr, nullptr);
                   });
 }
@@ -7570,7 +7569,6 @@ struct AccessChainTraverser : public TIntermTraverser {
             path.append(symbol->getName());
     }
 };
-
 
 TIntermNode* TParseContext::vkRelaxedRemapFunctionArgument(const TSourceLoc& loc, TFunction* function, TIntermTyped* intermTyped)
 {

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -932,6 +932,8 @@ TIntermTyped* TParseContext::handleUnaryMath(const TSourceLoc& loc, const char* 
     return childNode;
 }
 
+
+
 //
 // Handle seeing a base.field dereference in the grammar.
 //
@@ -993,17 +995,25 @@ TIntermTyped* TParseContext::handleDotDereference(const TSourceLoc& loc, TInterm
                 break;
             }
         }
+
         if (fieldFound) {
-            if (base->getType().getQualifier().isFrontEndConstant())
-                result = intermediate.foldDereference(base, member, loc);
-            else {
-                blockMemberExtensionCheck(loc, base, member, field);
-                TIntermTyped* index = intermediate.addConstantUnion(member, loc);
-                result = intermediate.addIndex(EOpIndexDirectStruct, base, index, loc);
-                result->setType(*(*fields)[member].type);
-                if ((*fields)[member].type->getQualifier().isIo())
-                    intermediate.addIoAccessed(field);
+            if (spvVersion.vulkan != 0 && spvVersion.vulkanRelaxed)
+                result = vkRelaxedRemapDotDereference(loc, *base, *(*fields)[member].type, field);
+
+            if (result == base)
+            {
+                if (base->getType().getQualifier().isFrontEndConstant())
+                    result = intermediate.foldDereference(base, member, loc);
+                else {
+                    blockMemberExtensionCheck(loc, base, member, field);
+                    TIntermTyped* index = intermediate.addConstantUnion(member, loc);
+                    result = intermediate.addIndex(EOpIndexDirectStruct, base, index, loc);
+                    result->setType(*(*fields)[member].type);
+                    if ((*fields)[member].type->getQualifier().isIo())
+                        intermediate.addIoAccessed(field);
+                }
             }
+
             inheritMemoryQualifiers(base->getQualifier(), result->getWritableType().getQualifier());
         } else {
             auto baseSymbol = base;
@@ -7321,12 +7331,14 @@ void TParseContext::coopMatTypeParametersCheck(const TSourceLoc& loc, const TPub
     }
 }
 
-bool TParseContext::vkRelaxedRemapUniformVariable(const TSourceLoc& loc, TString& identifier, const TPublicType&,
+bool TParseContext::vkRelaxedRemapUniformVariable(const TSourceLoc& loc, TString& identifier, const TPublicType& publicType,
     TArraySizes*, TIntermTyped* initializer, TType& type)
 {
+    vkRelaxedRemapUniformMembers(loc, publicType, type, identifier);
+
     if (parsingBuiltins || symbolTable.atBuiltInLevel() || !symbolTable.atGlobalLevel() ||
         type.getQualifier().storage != EvqUniform ||
-        !(type.containsNonOpaque()|| type.getBasicType() == EbtAtomicUint)) {
+        !(type.containsNonOpaque() || type.getBasicType() == EbtAtomicUint || (type.containsSampler() && type.isStruct()))) {
         return false;
     }
 
@@ -7398,6 +7410,253 @@ bool TParseContext::vkRelaxedRemapUniformVariable(const TSourceLoc& loc, TString
     mergeObjectLayoutQualifiers(updatedBlock->getWritableType().getQualifier(), type.getQualifier(), true);
 
     return true;
+}
+
+template <typename Function>
+static void ForEachOpaque(const TType& type, const TString& path, Function callback)
+{
+    auto recursion = [&callback](const TType& type, const TString& path, bool skipArray, auto& recursion) -> void {
+        if (!skipArray && type.isArray())
+        {
+            std::vector<int> indices(type.getArraySizes()->getNumDims());
+            for (int flatIndex = 0;
+                 flatIndex < type.getArraySizes()->getCumulativeSize();
+                 ++flatIndex)
+            {
+                TString subscriptPath = path;
+                for (int dimIndex = 0; dimIndex < indices.size(); ++dimIndex)
+                {
+                    int index = indices[dimIndex];
+                    subscriptPath.append("[");
+                    subscriptPath.append(String(index));
+                    subscriptPath.append("]");
+                }
+
+                recursion(type, subscriptPath, true, recursion);
+
+                for (int dimIndex = 0; dimIndex < indices.size(); ++dimIndex)
+                {
+                    ++indices[dimIndex];
+                    if (indices[dimIndex] < type.getArraySizes()->getDimSize(dimIndex))
+                        break;
+                    else
+                        indices[dimIndex] = 0;
+                }
+            }
+        }
+
+        else if (type.isStruct() && type.containsOpaque())
+        {
+            const TTypeList& types = *type.getStruct();
+            for (const TTypeLoc& typeLoc : types)
+            {
+                TString nextPath = path;
+                nextPath.append(".");
+                nextPath.append(typeLoc.type->getFieldName());
+
+                recursion(*(typeLoc.type), nextPath, false, recursion);
+            }
+        }
+
+        else if (type.isOpaque())
+        {
+            callback(type, path);
+        }
+    };
+
+    recursion(type, path, false, recursion);
+}
+
+void TParseContext::vkRelaxedRemapUniformMembers(const TSourceLoc& loc, const TPublicType& publicType, const TType& type,
+    const TString& identifier)
+{
+    if (!type.isStruct() || !type.containsOpaque())
+        return;
+
+    ForEachOpaque(type, identifier,
+                  [&publicType, &loc, this](const TType& type, const TString& path) {
+                      TString& structMemberName = *(new TString(path));
+
+                      TArraySizes arraySizes = {};
+                      if (type.getArraySizes()) arraySizes = *type.getArraySizes();
+                      TTypeParameters typeParameters = {};
+                      if (type.getTypeParameters()) typeParameters = *type.getTypeParameters();
+
+                      TPublicType memberType{};
+                      memberType.basicType = type.getBasicType();
+                      memberType.sampler = type.getSampler();
+                      memberType.qualifier = type.getQualifier();
+                      memberType.vectorSize = type.getVectorSize();
+                      memberType.matrixCols = type.getMatrixCols();
+                      memberType.matrixRows = type.getMatrixRows();
+                      memberType.coopmatNV = type.isCoopMatNV();
+                      memberType.coopmatKHR = type.isCoopMatKHR();
+                      memberType.arraySizes = nullptr;
+                      memberType.userDef = nullptr;
+                      memberType.loc = loc;
+                      memberType.typeParameters = (type.getTypeParameters() ? &typeParameters : nullptr);
+                      memberType.spirvType = nullptr;
+
+                      memberType.qualifier.storage = publicType.qualifier.storage;
+                      memberType.shaderQualifiers = publicType.shaderQualifiers;
+
+                      declareVariable(loc, structMemberName, memberType, nullptr, nullptr);
+                  });
+}
+
+void TParseContext::vkRelaxedRemapFunctionParameter(const TSourceLoc& loc, TFunction* function, TParameter& param, std::vector<TParameter*>* newParams)
+{
+    function->addParameter(param);
+
+    if (!param.type->isStruct() || !param.type->containsOpaque())
+        return;
+
+
+    ForEachOpaque(*param.type, (param.name ? *param.name : param.type->getFieldName()),
+                  [function, param, newParams](const TType& type, const TString& path) {
+                      TString* memberName = new TString(path);
+
+                      TType* memberType = new TType();
+                      memberType->shallowCopy(type);
+                      memberType->getQualifier().storage = param.type->getQualifier().storage;
+                      memberType->clearArraySizes();
+
+                      TParameter* memberParam = new TParameter();
+                      memberParam->name = memberName;
+                      memberParam->type = memberType;
+                      memberParam->defaultValue = nullptr;
+                      function->addParameter(*memberParam);
+                      if (newParams)
+                          newParams->push_back(memberParam);
+                  });
+}
+
+//
+// Generates a valid GLSL dereferencing string for the input TIntermNode
+//
+struct AccessChainTraverser : public TIntermTraverser {
+    AccessChainTraverser() : TIntermTraverser(false, false, true)
+    {}
+
+    TString path = "";
+
+    bool visitBinary(TVisit, TIntermBinary* binary) override {
+        if (binary->getOp() == EOpIndexDirectStruct)
+        {
+            const TTypeList& members = *binary->getLeft()->getType().getStruct();
+            const TTypeLoc& member =
+                members[binary->getRight()->getAsConstantUnion()->getConstArray()[0].getIConst()];
+            TString memberName = member.type->getFieldName();
+
+            if (path != "")
+                path.append(".");
+
+            path.append(memberName);
+        }
+
+        if (binary->getOp() == EOpIndexDirect)
+        {
+            const TConstUnionArray& indices = binary->getRight()->getAsConstantUnion()->getConstArray();
+            for (int index = 0; index < indices.size(); ++index)
+            {
+                path.append("[");
+                path.append(String(indices[index].getIConst()));
+                path.append("]");
+            }
+        }
+
+        return true;
+    }
+
+    void visitSymbol(TIntermSymbol* symbol) override {
+        if (!IsAnonymous(symbol->getName()))
+            path.append(symbol->getName());
+    }
+};
+
+
+TIntermNode* TParseContext::vkRelaxedRemapFunctionArgument(const TSourceLoc& loc, TFunction* function, TIntermTyped* intermTyped)
+{
+    AccessChainTraverser accessChainTraverser{};
+    intermTyped->traverse(&accessChainTraverser);
+
+    TParameter param = { NewPoolTString(accessChainTraverser.path.c_str()), new TType };
+    param.type->shallowCopy(intermTyped->getType());
+
+    std::vector<TParameter*> newParams = {};
+    vkRelaxedRemapFunctionParameter(loc, function, param, &newParams);
+
+    if (intermTyped->getType().isOpaque())
+    {
+        TIntermNode* remappedArgument = intermTyped;
+        {
+            TIntermSymbol* intermSymbol = nullptr;
+            TSymbol* symbol = symbolTable.find(*param.name);
+            if (symbol && symbol->getAsVariable())
+                intermSymbol = intermediate.addSymbol(*symbol->getAsVariable(), loc);
+            else
+            {
+                TVariable* variable = new TVariable(param.name, *param.type);
+                intermSymbol = intermediate.addSymbol(*variable, loc);
+            }
+
+            remappedArgument = intermSymbol;
+        }
+
+        return remappedArgument;
+    }
+    else if (!(intermTyped->isStruct() && intermTyped->getType().containsOpaque()))
+        return intermTyped;
+    else
+    {
+        TIntermNode* remappedArgument = intermTyped;
+        {
+            TSymbol* symbol = symbolTable.find(*param.name);
+            if (symbol && symbol->getAsVariable())
+                remappedArgument = intermediate.addSymbol(*symbol->getAsVariable(), loc);
+        }
+
+        if (!newParams.empty())
+            remappedArgument = intermediate.makeAggregate(remappedArgument, loc);
+
+        for (TParameter* newParam : newParams)
+        {
+            TIntermSymbol* intermSymbol = nullptr;
+            TSymbol* symbol = symbolTable.find(*newParam->name);
+            if (symbol && symbol->getAsVariable())
+                intermSymbol = intermediate.addSymbol(*symbol->getAsVariable(), loc);
+            else
+            {
+                TVariable* variable = new TVariable(newParam->name, *newParam->type);
+                intermSymbol = intermediate.addSymbol(*variable, loc);
+            }
+
+            remappedArgument = intermediate.growAggregate(remappedArgument, intermSymbol);
+        }
+
+        return remappedArgument;
+    }
+}
+
+TIntermTyped* TParseContext::vkRelaxedRemapDotDereference(const TSourceLoc&, TIntermTyped& base, const TType& member,
+    const TString& identifier)
+{
+    if (!member.isOpaque())
+        return &base;
+
+    AccessChainTraverser traverser{};
+    base.traverse(&traverser);
+    if (!traverser.path.empty())
+        traverser.path.append(".");
+    traverser.path.append(identifier);
+
+    const TSymbol* symbol = symbolTable.find(traverser.path);
+    if (!symbol)
+        return &base;
+
+    TIntermTyped* result = intermediate.addSymbol(*symbol->getAsVariable());
+    result->setType(symbol->getType());
+    return result;
 }
 
 //

--- a/glslang/MachineIndependent/ParseHelper.h
+++ b/glslang/MachineIndependent/ParseHelper.h
@@ -180,6 +180,7 @@ public:
     // Basic parsing state, easily accessible to the grammar
 
     TSymbolTable& symbolTable;        // symbol table that goes with the current language, version, and profile
+    TVector<TString> relaxedSymbols;
     int statementNestingLevel;        // 0 if outside all flow control or compound statements
     int loopNestingLevel;             // 0 if outside all loops
     int structNestingLevel;           // 0 if outside structures
@@ -367,6 +368,10 @@ public:
     TIntermTyped* vkRelaxedRemapFunctionCall(const TSourceLoc&, TFunction*, TIntermNode*);
     // returns true if the variable was remapped to something else
     bool vkRelaxedRemapUniformVariable(const TSourceLoc&, TString&, const TPublicType&, TArraySizes*, TIntermTyped*, TType&);
+    void vkRelaxedRemapUniformMembers(const TSourceLoc&, const TPublicType&, const TType&, const TString&);
+    void vkRelaxedRemapFunctionParameter(const TSourceLoc&, TFunction*, TParameter&, std::vector<TParameter*>* newParams = nullptr);
+    TIntermNode* vkRelaxedRemapFunctionArgument(const TSourceLoc&, TFunction*, TIntermTyped*);
+    TIntermTyped* vkRelaxedRemapDotDereference(const TSourceLoc&, TIntermTyped&, const TType&, const TString&);
 
     void assignError(const TSourceLoc&, const char* op, TString left, TString right);
     void unaryOpError(const TSourceLoc&, const char* op, TString operand);

--- a/glslang/MachineIndependent/ParseHelper.h
+++ b/glslang/MachineIndependent/ParseHelper.h
@@ -369,7 +369,7 @@ public:
     // returns true if the variable was remapped to something else
     bool vkRelaxedRemapUniformVariable(const TSourceLoc&, TString&, const TPublicType&, TArraySizes*, TIntermTyped*, TType&);
     void vkRelaxedRemapUniformMembers(const TSourceLoc&, const TPublicType&, const TType&, const TString&);
-    void vkRelaxedRemapFunctionParameter(const TSourceLoc&, TFunction*, TParameter&, std::vector<TParameter*>* newParams = nullptr);
+    void vkRelaxedRemapFunctionParameter(const TSourceLoc&, TFunction*, TParameter&, std::vector<int>* newParams = nullptr);
     TIntermNode* vkRelaxedRemapFunctionArgument(const TSourceLoc&, TFunction*, TIntermTyped*);
     TIntermTyped* vkRelaxedRemapDotDereference(const TSourceLoc&, TIntermTyped&, const TType&, const TString&);
 

--- a/glslang/MachineIndependent/glslang.y
+++ b/glslang/MachineIndependent/glslang.y
@@ -492,18 +492,41 @@ function_call_header_no_parameters
 
 function_call_header_with_parameters
     : function_call_header assignment_expression {
-        TParameter param = { 0, new TType };
-        param.type->shallowCopy($2->getType());
-        $1.function->addParameter(param);
-        $$.function = $1.function;
-        $$.intermNode = $2;
+        if (!(parseContext.spvVersion.vulkan > 0
+              && parseContext.spvVersion.vulkanRelaxed)
+            || !$2->getType().containsOpaque())
+        {
+            TParameter param = { 0, new TType };
+            param.type->shallowCopy($2->getType());
+
+            $1.function->addParameter(param);
+            $$.function = $1.function;
+            $$.intermNode = $2;
+        }
+        else
+        {
+            $$.intermNode = parseContext.vkRelaxedRemapFunctionArgument($$.loc, $1.function, $2);
+            $$.function = $1.function;
+        }
     }
     | function_call_header_with_parameters COMMA assignment_expression {
-        TParameter param = { 0, new TType };
-        param.type->shallowCopy($3->getType());
-        $1.function->addParameter(param);
-        $$.function = $1.function;
-        $$.intermNode = parseContext.intermediate.growAggregate($1.intermNode, $3, $2.loc);
+        if (!(parseContext.spvVersion.vulkan > 0
+              && parseContext.spvVersion.vulkanRelaxed)
+            || !$3->getType().containsOpaque())
+        {
+            TParameter param = { 0, new TType };
+            param.type->shallowCopy($3->getType());
+
+            $1.function->addParameter(param);
+            $$.function = $1.function;
+            $$.intermNode = parseContext.intermediate.growAggregate($1.intermNode, $3, $2.loc);
+        }
+        else
+        {
+            TIntermNode* remappedNode = parseContext.vkRelaxedRemapFunctionArgument($2.loc, $1.function, $3);
+            $$.intermNode = parseContext.intermediate.mergeAggregate($1.intermNode, remappedNode, $2.loc);
+            $$.function = $1.function;
+        }
     }
     ;
 
@@ -980,7 +1003,12 @@ function_header_with_parameters
         // Add the parameter
         $$ = $1;
         if ($2.param.type->getBasicType() != EbtVoid)
-            $1->addParameter($2.param);
+        {
+            if (!(parseContext.spvVersion.vulkan > 0 && parseContext.spvVersion.vulkanRelaxed))
+                $1->addParameter($2.param);
+            else
+                parseContext.vkRelaxedRemapFunctionParameter($2.loc, $1, $2.param);
+        }
         else
             delete $2.param.type;
     }
@@ -998,7 +1026,10 @@ function_header_with_parameters
         } else {
             // Add the parameter
             $$ = $1;
-            $1->addParameter($3.param);
+            if (!(parseContext.spvVersion.vulkan > 0 && parseContext.spvVersion.vulkanRelaxed))
+                $1->addParameter($3.param);
+            else
+                parseContext.vkRelaxedRemapFunctionParameter($3.loc, $1, $3.param);
         }
     }
     ;
@@ -3549,11 +3580,17 @@ precision_qualifier
 
 struct_specifier
     : STRUCT IDENTIFIER LEFT_BRACE { parseContext.nestedStructCheck($1.loc); } struct_declaration_list RIGHT_BRACE {
+
         TType* structure = new TType($5, *$2.string);
         parseContext.structArrayCheck($2.loc, *structure);
+
         TVariable* userTypeDef = new TVariable($2.string, *structure, true);
         if (! parseContext.symbolTable.insert(*userTypeDef))
             parseContext.error($2.loc, "redefinition", $2.string->c_str(), "struct");
+        else if (parseContext.spvVersion.vulkanRelaxed
+                 && structure->containsOpaque())
+            parseContext.relaxedSymbols.push_back(structure->getTypeName());
+
         $$.init($1.loc);
         $$.basicType = EbtStruct;
         $$.userDef = structure;

--- a/glslang/MachineIndependent/glslang_tab.cpp
+++ b/glslang/MachineIndependent/glslang_tab.cpp
@@ -1170,74 +1170,74 @@ static const yytype_int16 yyrline[] =
        0,   362,   362,   368,   371,   376,   379,   382,   386,   389,
      392,   396,   400,   404,   408,   412,   416,   422,   429,   432,
      435,   438,   441,   446,   454,   461,   468,   474,   478,   485,
-     488,   494,   501,   511,   519,   524,   551,   559,   565,   569,
-     573,   593,   594,   595,   596,   602,   603,   608,   613,   622,
-     623,   628,   636,   637,   643,   652,   653,   658,   663,   668,
-     676,   677,   686,   698,   699,   708,   709,   718,   719,   728,
-     729,   737,   738,   746,   747,   755,   756,   756,   774,   775,
-     791,   795,   799,   803,   808,   812,   816,   820,   824,   828,
-     832,   839,   842,   853,   860,   865,   872,   877,   882,   889,
-     893,   897,   901,   906,   911,   920,   920,   931,   935,   942,
-     947,   953,   959,   969,   972,   979,   987,  1007,  1030,  1045,
-    1070,  1081,  1091,  1101,  1111,  1120,  1123,  1127,  1131,  1136,
-    1144,  1149,  1154,  1159,  1164,  1173,  1183,  1210,  1219,  1226,
-    1233,  1240,  1247,  1255,  1263,  1273,  1283,  1290,  1300,  1306,
-    1309,  1316,  1320,  1324,  1332,  1341,  1344,  1355,  1358,  1361,
-    1365,  1369,  1373,  1377,  1380,  1385,  1389,  1394,  1402,  1406,
-    1411,  1417,  1423,  1430,  1435,  1440,  1448,  1453,  1465,  1479,
-    1485,  1490,  1498,  1506,  1514,  1522,  1530,  1538,  1546,  1554,
-    1562,  1569,  1576,  1580,  1585,  1590,  1595,  1600,  1605,  1610,
-    1614,  1618,  1622,  1626,  1632,  1638,  1648,  1655,  1658,  1666,
-    1673,  1684,  1689,  1697,  1701,  1711,  1714,  1720,  1726,  1731,
-    1739,  1749,  1753,  1757,  1761,  1766,  1770,  1775,  1780,  1785,
-    1790,  1795,  1800,  1805,  1810,  1815,  1821,  1827,  1833,  1838,
-    1843,  1848,  1853,  1858,  1863,  1868,  1873,  1878,  1883,  1888,
-    1893,  1900,  1905,  1910,  1915,  1920,  1925,  1930,  1935,  1940,
-    1945,  1950,  1955,  1963,  1971,  1979,  1985,  1991,  1997,  2003,
-    2009,  2015,  2021,  2027,  2033,  2039,  2045,  2051,  2057,  2063,
-    2069,  2075,  2081,  2087,  2093,  2099,  2105,  2111,  2117,  2123,
-    2129,  2135,  2141,  2147,  2153,  2159,  2165,  2171,  2177,  2185,
-    2193,  2201,  2209,  2217,  2225,  2233,  2241,  2249,  2257,  2265,
-    2273,  2279,  2285,  2291,  2297,  2303,  2309,  2315,  2321,  2327,
-    2333,  2339,  2345,  2351,  2357,  2363,  2369,  2375,  2381,  2387,
-    2393,  2399,  2405,  2411,  2417,  2423,  2429,  2435,  2441,  2447,
-    2453,  2459,  2465,  2471,  2477,  2483,  2489,  2493,  2497,  2501,
-    2506,  2511,  2516,  2521,  2526,  2531,  2536,  2541,  2546,  2551,
-    2556,  2561,  2566,  2571,  2577,  2583,  2589,  2595,  2601,  2607,
-    2613,  2619,  2625,  2631,  2637,  2643,  2649,  2654,  2659,  2664,
-    2669,  2674,  2679,  2684,  2689,  2694,  2699,  2704,  2709,  2714,
-    2719,  2724,  2729,  2734,  2739,  2744,  2749,  2754,  2759,  2764,
-    2769,  2774,  2779,  2784,  2789,  2794,  2799,  2804,  2809,  2814,
-    2820,  2826,  2831,  2836,  2841,  2847,  2852,  2857,  2862,  2868,
-    2873,  2878,  2883,  2889,  2894,  2899,  2904,  2910,  2916,  2922,
-    2928,  2933,  2939,  2945,  2951,  2956,  2961,  2966,  2971,  2976,
-    2982,  2987,  2992,  2997,  3003,  3008,  3013,  3018,  3024,  3029,
-    3034,  3039,  3045,  3050,  3055,  3060,  3066,  3071,  3076,  3081,
-    3087,  3092,  3097,  3102,  3108,  3113,  3118,  3123,  3129,  3134,
-    3139,  3144,  3150,  3155,  3160,  3165,  3171,  3176,  3181,  3186,
-    3192,  3197,  3202,  3207,  3213,  3218,  3223,  3228,  3234,  3239,
-    3244,  3249,  3255,  3260,  3265,  3270,  3276,  3281,  3286,  3291,
-    3296,  3301,  3306,  3311,  3316,  3321,  3326,  3331,  3336,  3341,
-    3346,  3351,  3356,  3361,  3366,  3371,  3376,  3381,  3386,  3391,
-    3396,  3402,  3408,  3414,  3420,  3426,  3432,  3438,  3445,  3452,
-    3458,  3464,  3470,  3476,  3483,  3490,  3497,  3504,  3508,  3512,
-    3517,  3533,  3538,  3543,  3551,  3551,  3562,  3562,  3572,  3575,
-    3588,  3610,  3637,  3641,  3647,  3652,  3663,  3666,  3672,  3678,
-    3687,  3690,  3696,  3700,  3701,  3707,  3708,  3709,  3710,  3711,
-    3712,  3713,  3714,  3718,  3726,  3727,  3731,  3727,  3743,  3744,
-    3748,  3748,  3755,  3755,  3769,  3772,  3780,  3788,  3799,  3800,
-    3804,  3807,  3814,  3821,  3825,  3833,  3837,  3850,  3853,  3860,
-    3860,  3880,  3883,  3889,  3901,  3913,  3916,  3923,  3923,  3938,
-    3938,  3956,  3956,  3977,  3980,  3986,  3989,  3995,  3999,  4006,
-    4011,  4016,  4023,  4026,  4030,  4034,  4038,  4047,  4051,  4060,
-    4063,  4066,  4074,  4074,  4116,  4121,  4124,  4129,  4132,  4137,
-    4140,  4145,  4148,  4153,  4156,  4161,  4164,  4169,  4173,  4178,
-    4182,  4187,  4191,  4198,  4201,  4206,  4209,  4212,  4215,  4218,
-    4223,  4232,  4243,  4248,  4256,  4260,  4265,  4269,  4274,  4278,
-    4283,  4287,  4294,  4297,  4302,  4305,  4308,  4311,  4316,  4319,
-    4324,  4330,  4333,  4336,  4339,  4344,  4348,  4353,  4357,  4362,
-    4366,  4373,  4376,  4381,  4384,  4389,  4392,  4398,  4401,  4406,
-    4409
+     488,   494,   512,   534,   542,   547,   574,   582,   588,   592,
+     596,   616,   617,   618,   619,   625,   626,   631,   636,   645,
+     646,   651,   659,   660,   666,   675,   676,   681,   686,   691,
+     699,   700,   709,   721,   722,   731,   732,   741,   742,   751,
+     752,   760,   761,   769,   770,   778,   779,   779,   797,   798,
+     814,   818,   822,   826,   831,   835,   839,   843,   847,   851,
+     855,   862,   865,   876,   883,   888,   895,   900,   905,   912,
+     916,   920,   924,   929,   934,   943,   943,   954,   958,   965,
+     970,   976,   982,   992,   995,  1002,  1015,  1038,  1061,  1076,
+    1101,  1112,  1122,  1132,  1142,  1151,  1154,  1158,  1162,  1167,
+    1175,  1180,  1185,  1190,  1195,  1204,  1214,  1241,  1250,  1257,
+    1264,  1271,  1278,  1286,  1294,  1304,  1314,  1321,  1331,  1337,
+    1340,  1347,  1351,  1355,  1363,  1372,  1375,  1386,  1389,  1392,
+    1396,  1400,  1404,  1408,  1411,  1416,  1420,  1425,  1433,  1437,
+    1442,  1448,  1454,  1461,  1466,  1471,  1479,  1484,  1496,  1510,
+    1516,  1521,  1529,  1537,  1545,  1553,  1561,  1569,  1577,  1585,
+    1593,  1600,  1607,  1611,  1616,  1621,  1626,  1631,  1636,  1641,
+    1645,  1649,  1653,  1657,  1663,  1669,  1679,  1686,  1689,  1697,
+    1704,  1715,  1720,  1728,  1732,  1742,  1745,  1751,  1757,  1762,
+    1770,  1780,  1784,  1788,  1792,  1797,  1801,  1806,  1811,  1816,
+    1821,  1826,  1831,  1836,  1841,  1846,  1852,  1858,  1864,  1869,
+    1874,  1879,  1884,  1889,  1894,  1899,  1904,  1909,  1914,  1919,
+    1924,  1931,  1936,  1941,  1946,  1951,  1956,  1961,  1966,  1971,
+    1976,  1981,  1986,  1994,  2002,  2010,  2016,  2022,  2028,  2034,
+    2040,  2046,  2052,  2058,  2064,  2070,  2076,  2082,  2088,  2094,
+    2100,  2106,  2112,  2118,  2124,  2130,  2136,  2142,  2148,  2154,
+    2160,  2166,  2172,  2178,  2184,  2190,  2196,  2202,  2208,  2216,
+    2224,  2232,  2240,  2248,  2256,  2264,  2272,  2280,  2288,  2296,
+    2304,  2310,  2316,  2322,  2328,  2334,  2340,  2346,  2352,  2358,
+    2364,  2370,  2376,  2382,  2388,  2394,  2400,  2406,  2412,  2418,
+    2424,  2430,  2436,  2442,  2448,  2454,  2460,  2466,  2472,  2478,
+    2484,  2490,  2496,  2502,  2508,  2514,  2520,  2524,  2528,  2532,
+    2537,  2542,  2547,  2552,  2557,  2562,  2567,  2572,  2577,  2582,
+    2587,  2592,  2597,  2602,  2608,  2614,  2620,  2626,  2632,  2638,
+    2644,  2650,  2656,  2662,  2668,  2674,  2680,  2685,  2690,  2695,
+    2700,  2705,  2710,  2715,  2720,  2725,  2730,  2735,  2740,  2745,
+    2750,  2755,  2760,  2765,  2770,  2775,  2780,  2785,  2790,  2795,
+    2800,  2805,  2810,  2815,  2820,  2825,  2830,  2835,  2840,  2845,
+    2851,  2857,  2862,  2867,  2872,  2878,  2883,  2888,  2893,  2899,
+    2904,  2909,  2914,  2920,  2925,  2930,  2935,  2941,  2947,  2953,
+    2959,  2964,  2970,  2976,  2982,  2987,  2992,  2997,  3002,  3007,
+    3013,  3018,  3023,  3028,  3034,  3039,  3044,  3049,  3055,  3060,
+    3065,  3070,  3076,  3081,  3086,  3091,  3097,  3102,  3107,  3112,
+    3118,  3123,  3128,  3133,  3139,  3144,  3149,  3154,  3160,  3165,
+    3170,  3175,  3181,  3186,  3191,  3196,  3202,  3207,  3212,  3217,
+    3223,  3228,  3233,  3238,  3244,  3249,  3254,  3259,  3265,  3270,
+    3275,  3280,  3286,  3291,  3296,  3301,  3307,  3312,  3317,  3322,
+    3327,  3332,  3337,  3342,  3347,  3352,  3357,  3362,  3367,  3372,
+    3377,  3382,  3387,  3392,  3397,  3402,  3407,  3412,  3417,  3422,
+    3427,  3433,  3439,  3445,  3451,  3457,  3463,  3469,  3476,  3483,
+    3489,  3495,  3501,  3507,  3514,  3521,  3528,  3535,  3539,  3543,
+    3548,  3564,  3569,  3574,  3582,  3582,  3599,  3599,  3609,  3612,
+    3625,  3647,  3674,  3678,  3684,  3689,  3700,  3703,  3709,  3715,
+    3724,  3727,  3733,  3737,  3738,  3744,  3745,  3746,  3747,  3748,
+    3749,  3750,  3751,  3755,  3763,  3764,  3768,  3764,  3780,  3781,
+    3785,  3785,  3792,  3792,  3806,  3809,  3817,  3825,  3836,  3837,
+    3841,  3844,  3851,  3858,  3862,  3870,  3874,  3887,  3890,  3897,
+    3897,  3917,  3920,  3926,  3938,  3950,  3953,  3960,  3960,  3975,
+    3975,  3993,  3993,  4014,  4017,  4023,  4026,  4032,  4036,  4043,
+    4048,  4053,  4060,  4063,  4067,  4071,  4075,  4084,  4088,  4097,
+    4100,  4103,  4111,  4111,  4153,  4158,  4161,  4166,  4169,  4174,
+    4177,  4182,  4185,  4190,  4193,  4198,  4201,  4206,  4210,  4215,
+    4219,  4224,  4228,  4235,  4238,  4243,  4246,  4249,  4252,  4255,
+    4260,  4269,  4280,  4285,  4293,  4297,  4302,  4306,  4311,  4315,
+    4320,  4324,  4331,  4334,  4339,  4342,  4345,  4348,  4353,  4356,
+    4361,  4367,  4370,  4373,  4376,  4381,  4385,  4390,  4394,  4399,
+    4403,  4410,  4413,  4418,  4421,  4426,  4429,  4435,  4438,  4443,
+    4446
 };
 #endif
 
@@ -5465,47 +5465,70 @@ yyreduce:
   case 31: /* function_call_header_with_parameters: function_call_header assignment_expression  */
 #line 494 "MachineIndependent/glslang.y"
                                                  {
-        TParameter param = { 0, new TType };
-        param.type->shallowCopy((yyvsp[0].interm.intermTypedNode)->getType());
-        (yyvsp[-1].interm).function->addParameter(param);
-        (yyval.interm).function = (yyvsp[-1].interm).function;
-        (yyval.interm).intermNode = (yyvsp[0].interm.intermTypedNode);
+        if (!(parseContext.spvVersion.vulkan > 0
+              && parseContext.spvVersion.vulkanRelaxed)
+            || !(yyvsp[0].interm.intermTypedNode)->getType().containsOpaque())
+        {
+            TParameter param = { 0, new TType };
+            param.type->shallowCopy((yyvsp[0].interm.intermTypedNode)->getType());
+
+            (yyvsp[-1].interm).function->addParameter(param);
+            (yyval.interm).function = (yyvsp[-1].interm).function;
+            (yyval.interm).intermNode = (yyvsp[0].interm.intermTypedNode);
+        }
+        else
+        {
+            (yyval.interm).intermNode = parseContext.vkRelaxedRemapFunctionArgument((yyval.interm).loc, (yyvsp[-1].interm).function, (yyvsp[0].interm.intermTypedNode));
+            (yyval.interm).function = (yyvsp[-1].interm).function;
+        }
     }
-#line 5475 "MachineIndependent/glslang_tab.cpp"
+#line 5486 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 32: /* function_call_header_with_parameters: function_call_header_with_parameters COMMA assignment_expression  */
-#line 501 "MachineIndependent/glslang.y"
+#line 512 "MachineIndependent/glslang.y"
                                                                        {
-        TParameter param = { 0, new TType };
-        param.type->shallowCopy((yyvsp[0].interm.intermTypedNode)->getType());
-        (yyvsp[-2].interm).function->addParameter(param);
-        (yyval.interm).function = (yyvsp[-2].interm).function;
-        (yyval.interm).intermNode = parseContext.intermediate.growAggregate((yyvsp[-2].interm).intermNode, (yyvsp[0].interm.intermTypedNode), (yyvsp[-1].lex).loc);
+        if (!(parseContext.spvVersion.vulkan > 0
+              && parseContext.spvVersion.vulkanRelaxed)
+            || !(yyvsp[0].interm.intermTypedNode)->getType().containsOpaque())
+        {
+            TParameter param = { 0, new TType };
+            param.type->shallowCopy((yyvsp[0].interm.intermTypedNode)->getType());
+
+            (yyvsp[-2].interm).function->addParameter(param);
+            (yyval.interm).function = (yyvsp[-2].interm).function;
+            (yyval.interm).intermNode = parseContext.intermediate.growAggregate((yyvsp[-2].interm).intermNode, (yyvsp[0].interm.intermTypedNode), (yyvsp[-1].lex).loc);
+        }
+        else
+        {
+            TIntermNode* remappedNode = parseContext.vkRelaxedRemapFunctionArgument((yyvsp[-1].lex).loc, (yyvsp[-2].interm).function, (yyvsp[0].interm.intermTypedNode));
+            (yyval.interm).intermNode = parseContext.intermediate.mergeAggregate((yyvsp[-2].interm).intermNode, remappedNode, (yyvsp[-1].lex).loc);
+            (yyval.interm).function = (yyvsp[-2].interm).function;
+        }
     }
-#line 5487 "MachineIndependent/glslang_tab.cpp"
+#line 5510 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 33: /* function_call_header: function_identifier LEFT_PAREN  */
-#line 511 "MachineIndependent/glslang.y"
+#line 534 "MachineIndependent/glslang.y"
                                      {
         (yyval.interm) = (yyvsp[-1].interm);
     }
-#line 5495 "MachineIndependent/glslang_tab.cpp"
+#line 5518 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 34: /* function_identifier: type_specifier  */
-#line 519 "MachineIndependent/glslang.y"
+#line 542 "MachineIndependent/glslang.y"
                      {
         // Constructor
         (yyval.interm).intermNode = 0;
         (yyval.interm).function = parseContext.handleConstructorCall((yyvsp[0].interm.type).loc, (yyvsp[0].interm.type));
     }
-#line 5505 "MachineIndependent/glslang_tab.cpp"
+#line 5528 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 35: /* function_identifier: postfix_expression  */
-#line 524 "MachineIndependent/glslang.y"
+#line 547 "MachineIndependent/glslang.y"
                          {
         //
         // Should be a method or subroutine call, but we haven't recognized the arguments yet.
@@ -5533,50 +5556,50 @@ yyreduce:
             (yyval.interm).function = new TFunction(empty, TType(EbtVoid), EOpNull);
         }
     }
-#line 5537 "MachineIndependent/glslang_tab.cpp"
+#line 5560 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 36: /* function_identifier: non_uniform_qualifier  */
-#line 551 "MachineIndependent/glslang.y"
+#line 574 "MachineIndependent/glslang.y"
                             {
         // Constructor
         (yyval.interm).intermNode = 0;
         (yyval.interm).function = parseContext.handleConstructorCall((yyvsp[0].interm.type).loc, (yyvsp[0].interm.type));
     }
-#line 5547 "MachineIndependent/glslang_tab.cpp"
+#line 5570 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 37: /* unary_expression: postfix_expression  */
-#line 559 "MachineIndependent/glslang.y"
+#line 582 "MachineIndependent/glslang.y"
                          {
         parseContext.variableCheck((yyvsp[0].interm.intermTypedNode));
         (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode);
         if (TIntermMethod* method = (yyvsp[0].interm.intermTypedNode)->getAsMethodNode())
             parseContext.error((yyvsp[0].interm.intermTypedNode)->getLoc(), "incomplete method syntax", method->getMethodName().c_str(), "");
     }
-#line 5558 "MachineIndependent/glslang_tab.cpp"
+#line 5581 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 38: /* unary_expression: INC_OP unary_expression  */
-#line 565 "MachineIndependent/glslang.y"
+#line 588 "MachineIndependent/glslang.y"
                               {
         parseContext.lValueErrorCheck((yyvsp[-1].lex).loc, "++", (yyvsp[0].interm.intermTypedNode));
         (yyval.interm.intermTypedNode) = parseContext.handleUnaryMath((yyvsp[-1].lex).loc, "++", EOpPreIncrement, (yyvsp[0].interm.intermTypedNode));
     }
-#line 5567 "MachineIndependent/glslang_tab.cpp"
+#line 5590 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 39: /* unary_expression: DEC_OP unary_expression  */
-#line 569 "MachineIndependent/glslang.y"
+#line 592 "MachineIndependent/glslang.y"
                               {
         parseContext.lValueErrorCheck((yyvsp[-1].lex).loc, "--", (yyvsp[0].interm.intermTypedNode));
         (yyval.interm.intermTypedNode) = parseContext.handleUnaryMath((yyvsp[-1].lex).loc, "--", EOpPreDecrement, (yyvsp[0].interm.intermTypedNode));
     }
-#line 5576 "MachineIndependent/glslang_tab.cpp"
+#line 5599 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 40: /* unary_expression: unary_operator unary_expression  */
-#line 573 "MachineIndependent/glslang.y"
+#line 596 "MachineIndependent/glslang.y"
                                       {
         if ((yyvsp[-1].interm).op != EOpNull) {
             char errorOp[2] = {0, 0};
@@ -5593,179 +5616,179 @@ yyreduce:
                 (yyval.interm.intermTypedNode)->getAsConstantUnion()->setExpression();
         }
     }
-#line 5597 "MachineIndependent/glslang_tab.cpp"
+#line 5620 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 41: /* unary_operator: PLUS  */
-#line 593 "MachineIndependent/glslang.y"
+#line 616 "MachineIndependent/glslang.y"
             { (yyval.interm).loc = (yyvsp[0].lex).loc; (yyval.interm).op = EOpNull; }
-#line 5603 "MachineIndependent/glslang_tab.cpp"
+#line 5626 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 42: /* unary_operator: DASH  */
-#line 594 "MachineIndependent/glslang.y"
+#line 617 "MachineIndependent/glslang.y"
             { (yyval.interm).loc = (yyvsp[0].lex).loc; (yyval.interm).op = EOpNegative; }
-#line 5609 "MachineIndependent/glslang_tab.cpp"
+#line 5632 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 43: /* unary_operator: BANG  */
-#line 595 "MachineIndependent/glslang.y"
+#line 618 "MachineIndependent/glslang.y"
             { (yyval.interm).loc = (yyvsp[0].lex).loc; (yyval.interm).op = EOpLogicalNot; }
-#line 5615 "MachineIndependent/glslang_tab.cpp"
+#line 5638 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 44: /* unary_operator: TILDE  */
-#line 596 "MachineIndependent/glslang.y"
+#line 619 "MachineIndependent/glslang.y"
             { (yyval.interm).loc = (yyvsp[0].lex).loc; (yyval.interm).op = EOpBitwiseNot;
               parseContext.fullIntegerCheck((yyvsp[0].lex).loc, "bitwise not"); }
-#line 5622 "MachineIndependent/glslang_tab.cpp"
+#line 5645 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 45: /* multiplicative_expression: unary_expression  */
-#line 602 "MachineIndependent/glslang.y"
+#line 625 "MachineIndependent/glslang.y"
                        { (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode); }
-#line 5628 "MachineIndependent/glslang_tab.cpp"
+#line 5651 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 46: /* multiplicative_expression: multiplicative_expression STAR unary_expression  */
-#line 603 "MachineIndependent/glslang.y"
+#line 626 "MachineIndependent/glslang.y"
                                                       {
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, "*", EOpMul, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = (yyvsp[-2].interm.intermTypedNode);
     }
-#line 5638 "MachineIndependent/glslang_tab.cpp"
+#line 5661 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 47: /* multiplicative_expression: multiplicative_expression SLASH unary_expression  */
-#line 608 "MachineIndependent/glslang.y"
+#line 631 "MachineIndependent/glslang.y"
                                                        {
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, "/", EOpDiv, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = (yyvsp[-2].interm.intermTypedNode);
     }
-#line 5648 "MachineIndependent/glslang_tab.cpp"
+#line 5671 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 48: /* multiplicative_expression: multiplicative_expression PERCENT unary_expression  */
-#line 613 "MachineIndependent/glslang.y"
+#line 636 "MachineIndependent/glslang.y"
                                                          {
         parseContext.fullIntegerCheck((yyvsp[-1].lex).loc, "%");
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, "%", EOpMod, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = (yyvsp[-2].interm.intermTypedNode);
     }
-#line 5659 "MachineIndependent/glslang_tab.cpp"
+#line 5682 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 49: /* additive_expression: multiplicative_expression  */
-#line 622 "MachineIndependent/glslang.y"
+#line 645 "MachineIndependent/glslang.y"
                                 { (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode); }
-#line 5665 "MachineIndependent/glslang_tab.cpp"
+#line 5688 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 50: /* additive_expression: additive_expression PLUS multiplicative_expression  */
-#line 623 "MachineIndependent/glslang.y"
+#line 646 "MachineIndependent/glslang.y"
                                                          {
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, "+", EOpAdd, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = (yyvsp[-2].interm.intermTypedNode);
     }
-#line 5675 "MachineIndependent/glslang_tab.cpp"
+#line 5698 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 51: /* additive_expression: additive_expression DASH multiplicative_expression  */
-#line 628 "MachineIndependent/glslang.y"
+#line 651 "MachineIndependent/glslang.y"
                                                          {
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, "-", EOpSub, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = (yyvsp[-2].interm.intermTypedNode);
     }
-#line 5685 "MachineIndependent/glslang_tab.cpp"
+#line 5708 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 52: /* shift_expression: additive_expression  */
-#line 636 "MachineIndependent/glslang.y"
+#line 659 "MachineIndependent/glslang.y"
                           { (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode); }
-#line 5691 "MachineIndependent/glslang_tab.cpp"
+#line 5714 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 53: /* shift_expression: shift_expression LEFT_OP additive_expression  */
-#line 637 "MachineIndependent/glslang.y"
+#line 660 "MachineIndependent/glslang.y"
                                                    {
         parseContext.fullIntegerCheck((yyvsp[-1].lex).loc, "bit shift left");
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, "<<", EOpLeftShift, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = (yyvsp[-2].interm.intermTypedNode);
     }
-#line 5702 "MachineIndependent/glslang_tab.cpp"
+#line 5725 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 54: /* shift_expression: shift_expression RIGHT_OP additive_expression  */
-#line 643 "MachineIndependent/glslang.y"
+#line 666 "MachineIndependent/glslang.y"
                                                     {
         parseContext.fullIntegerCheck((yyvsp[-1].lex).loc, "bit shift right");
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, ">>", EOpRightShift, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = (yyvsp[-2].interm.intermTypedNode);
     }
-#line 5713 "MachineIndependent/glslang_tab.cpp"
+#line 5736 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 55: /* relational_expression: shift_expression  */
-#line 652 "MachineIndependent/glslang.y"
+#line 675 "MachineIndependent/glslang.y"
                        { (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode); }
-#line 5719 "MachineIndependent/glslang_tab.cpp"
+#line 5742 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 56: /* relational_expression: relational_expression LEFT_ANGLE shift_expression  */
-#line 653 "MachineIndependent/glslang.y"
+#line 676 "MachineIndependent/glslang.y"
                                                         {
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, "<", EOpLessThan, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = parseContext.intermediate.addConstantUnion(false, (yyvsp[-1].lex).loc);
     }
-#line 5729 "MachineIndependent/glslang_tab.cpp"
+#line 5752 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 57: /* relational_expression: relational_expression RIGHT_ANGLE shift_expression  */
-#line 658 "MachineIndependent/glslang.y"
+#line 681 "MachineIndependent/glslang.y"
                                                           {
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, ">", EOpGreaterThan, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = parseContext.intermediate.addConstantUnion(false, (yyvsp[-1].lex).loc);
     }
-#line 5739 "MachineIndependent/glslang_tab.cpp"
+#line 5762 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 58: /* relational_expression: relational_expression LE_OP shift_expression  */
-#line 663 "MachineIndependent/glslang.y"
+#line 686 "MachineIndependent/glslang.y"
                                                     {
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, "<=", EOpLessThanEqual, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = parseContext.intermediate.addConstantUnion(false, (yyvsp[-1].lex).loc);
     }
-#line 5749 "MachineIndependent/glslang_tab.cpp"
+#line 5772 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 59: /* relational_expression: relational_expression GE_OP shift_expression  */
-#line 668 "MachineIndependent/glslang.y"
+#line 691 "MachineIndependent/glslang.y"
                                                     {
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, ">=", EOpGreaterThanEqual, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = parseContext.intermediate.addConstantUnion(false, (yyvsp[-1].lex).loc);
     }
-#line 5759 "MachineIndependent/glslang_tab.cpp"
+#line 5782 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 60: /* equality_expression: relational_expression  */
-#line 676 "MachineIndependent/glslang.y"
+#line 699 "MachineIndependent/glslang.y"
                             { (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode); }
-#line 5765 "MachineIndependent/glslang_tab.cpp"
+#line 5788 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 61: /* equality_expression: equality_expression EQ_OP relational_expression  */
-#line 677 "MachineIndependent/glslang.y"
+#line 700 "MachineIndependent/glslang.y"
                                                        {
         parseContext.arrayObjectCheck((yyvsp[-1].lex).loc, (yyvsp[-2].interm.intermTypedNode)->getType(), "array comparison");
         parseContext.opaqueCheck((yyvsp[-1].lex).loc, (yyvsp[-2].interm.intermTypedNode)->getType(), "==");
@@ -5775,11 +5798,11 @@ yyreduce:
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = parseContext.intermediate.addConstantUnion(false, (yyvsp[-1].lex).loc);
     }
-#line 5779 "MachineIndependent/glslang_tab.cpp"
+#line 5802 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 62: /* equality_expression: equality_expression NE_OP relational_expression  */
-#line 686 "MachineIndependent/glslang.y"
+#line 709 "MachineIndependent/glslang.y"
                                                       {
         parseContext.arrayObjectCheck((yyvsp[-1].lex).loc, (yyvsp[-2].interm.intermTypedNode)->getType(), "array comparison");
         parseContext.opaqueCheck((yyvsp[-1].lex).loc, (yyvsp[-2].interm.intermTypedNode)->getType(), "!=");
@@ -5789,124 +5812,124 @@ yyreduce:
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = parseContext.intermediate.addConstantUnion(false, (yyvsp[-1].lex).loc);
     }
-#line 5793 "MachineIndependent/glslang_tab.cpp"
+#line 5816 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 63: /* and_expression: equality_expression  */
-#line 698 "MachineIndependent/glslang.y"
+#line 721 "MachineIndependent/glslang.y"
                           { (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode); }
-#line 5799 "MachineIndependent/glslang_tab.cpp"
+#line 5822 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 64: /* and_expression: and_expression AMPERSAND equality_expression  */
-#line 699 "MachineIndependent/glslang.y"
+#line 722 "MachineIndependent/glslang.y"
                                                    {
         parseContext.fullIntegerCheck((yyvsp[-1].lex).loc, "bitwise and");
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, "&", EOpAnd, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = (yyvsp[-2].interm.intermTypedNode);
     }
-#line 5810 "MachineIndependent/glslang_tab.cpp"
+#line 5833 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 65: /* exclusive_or_expression: and_expression  */
-#line 708 "MachineIndependent/glslang.y"
+#line 731 "MachineIndependent/glslang.y"
                      { (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode); }
-#line 5816 "MachineIndependent/glslang_tab.cpp"
+#line 5839 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 66: /* exclusive_or_expression: exclusive_or_expression CARET and_expression  */
-#line 709 "MachineIndependent/glslang.y"
+#line 732 "MachineIndependent/glslang.y"
                                                    {
         parseContext.fullIntegerCheck((yyvsp[-1].lex).loc, "bitwise exclusive or");
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, "^", EOpExclusiveOr, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = (yyvsp[-2].interm.intermTypedNode);
     }
-#line 5827 "MachineIndependent/glslang_tab.cpp"
+#line 5850 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 67: /* inclusive_or_expression: exclusive_or_expression  */
-#line 718 "MachineIndependent/glslang.y"
+#line 741 "MachineIndependent/glslang.y"
                               { (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode); }
-#line 5833 "MachineIndependent/glslang_tab.cpp"
+#line 5856 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 68: /* inclusive_or_expression: inclusive_or_expression VERTICAL_BAR exclusive_or_expression  */
-#line 719 "MachineIndependent/glslang.y"
+#line 742 "MachineIndependent/glslang.y"
                                                                    {
         parseContext.fullIntegerCheck((yyvsp[-1].lex).loc, "bitwise inclusive or");
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, "|", EOpInclusiveOr, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = (yyvsp[-2].interm.intermTypedNode);
     }
-#line 5844 "MachineIndependent/glslang_tab.cpp"
+#line 5867 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 69: /* logical_and_expression: inclusive_or_expression  */
-#line 728 "MachineIndependent/glslang.y"
+#line 751 "MachineIndependent/glslang.y"
                               { (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode); }
-#line 5850 "MachineIndependent/glslang_tab.cpp"
+#line 5873 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 70: /* logical_and_expression: logical_and_expression AND_OP inclusive_or_expression  */
-#line 729 "MachineIndependent/glslang.y"
+#line 752 "MachineIndependent/glslang.y"
                                                             {
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, "&&", EOpLogicalAnd, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = parseContext.intermediate.addConstantUnion(false, (yyvsp[-1].lex).loc);
     }
-#line 5860 "MachineIndependent/glslang_tab.cpp"
+#line 5883 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 71: /* logical_xor_expression: logical_and_expression  */
-#line 737 "MachineIndependent/glslang.y"
+#line 760 "MachineIndependent/glslang.y"
                              { (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode); }
-#line 5866 "MachineIndependent/glslang_tab.cpp"
+#line 5889 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 72: /* logical_xor_expression: logical_xor_expression XOR_OP logical_and_expression  */
-#line 738 "MachineIndependent/glslang.y"
+#line 761 "MachineIndependent/glslang.y"
                                                             {
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, "^^", EOpLogicalXor, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = parseContext.intermediate.addConstantUnion(false, (yyvsp[-1].lex).loc);
     }
-#line 5876 "MachineIndependent/glslang_tab.cpp"
+#line 5899 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 73: /* logical_or_expression: logical_xor_expression  */
-#line 746 "MachineIndependent/glslang.y"
+#line 769 "MachineIndependent/glslang.y"
                              { (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode); }
-#line 5882 "MachineIndependent/glslang_tab.cpp"
+#line 5905 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 74: /* logical_or_expression: logical_or_expression OR_OP logical_xor_expression  */
-#line 747 "MachineIndependent/glslang.y"
+#line 770 "MachineIndependent/glslang.y"
                                                           {
         (yyval.interm.intermTypedNode) = parseContext.handleBinaryMath((yyvsp[-1].lex).loc, "||", EOpLogicalOr, (yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
         if ((yyval.interm.intermTypedNode) == 0)
             (yyval.interm.intermTypedNode) = parseContext.intermediate.addConstantUnion(false, (yyvsp[-1].lex).loc);
     }
-#line 5892 "MachineIndependent/glslang_tab.cpp"
+#line 5915 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 75: /* conditional_expression: logical_or_expression  */
-#line 755 "MachineIndependent/glslang.y"
+#line 778 "MachineIndependent/glslang.y"
                             { (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode); }
-#line 5898 "MachineIndependent/glslang_tab.cpp"
+#line 5921 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 76: /* $@1: %empty  */
-#line 756 "MachineIndependent/glslang.y"
+#line 779 "MachineIndependent/glslang.y"
                                      {
         ++parseContext.controlFlowNestingLevel;
     }
-#line 5906 "MachineIndependent/glslang_tab.cpp"
+#line 5929 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 77: /* conditional_expression: logical_or_expression QUESTION $@1 expression COLON assignment_expression  */
-#line 759 "MachineIndependent/glslang.y"
+#line 782 "MachineIndependent/glslang.y"
                                              {
         --parseContext.controlFlowNestingLevel;
         parseContext.boolCheck((yyvsp[-4].lex).loc, (yyvsp[-5].interm.intermTypedNode));
@@ -5919,17 +5942,17 @@ yyreduce:
             (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode);
         }
     }
-#line 5923 "MachineIndependent/glslang_tab.cpp"
+#line 5946 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 78: /* assignment_expression: conditional_expression  */
-#line 774 "MachineIndependent/glslang.y"
+#line 797 "MachineIndependent/glslang.y"
                              { (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode); }
-#line 5929 "MachineIndependent/glslang_tab.cpp"
+#line 5952 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 79: /* assignment_expression: unary_expression assignment_operator assignment_expression  */
-#line 775 "MachineIndependent/glslang.y"
+#line 798 "MachineIndependent/glslang.y"
                                                                  {
         parseContext.arrayObjectCheck((yyvsp[-1].interm).loc, (yyvsp[-2].interm.intermTypedNode)->getType(), "array assignment");
         parseContext.opaqueCheck((yyvsp[-1].interm).loc, (yyvsp[-2].interm.intermTypedNode)->getType(), "=");
@@ -5943,119 +5966,119 @@ yyreduce:
             (yyval.interm.intermTypedNode) = (yyvsp[-2].interm.intermTypedNode);
         }
     }
-#line 5947 "MachineIndependent/glslang_tab.cpp"
+#line 5970 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 80: /* assignment_operator: EQUAL  */
-#line 791 "MachineIndependent/glslang.y"
+#line 814 "MachineIndependent/glslang.y"
             {
         (yyval.interm).loc = (yyvsp[0].lex).loc;
         (yyval.interm).op = EOpAssign;
     }
-#line 5956 "MachineIndependent/glslang_tab.cpp"
+#line 5979 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 81: /* assignment_operator: MUL_ASSIGN  */
-#line 795 "MachineIndependent/glslang.y"
+#line 818 "MachineIndependent/glslang.y"
                  {
         (yyval.interm).loc = (yyvsp[0].lex).loc;
         (yyval.interm).op = EOpMulAssign;
     }
-#line 5965 "MachineIndependent/glslang_tab.cpp"
+#line 5988 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 82: /* assignment_operator: DIV_ASSIGN  */
-#line 799 "MachineIndependent/glslang.y"
+#line 822 "MachineIndependent/glslang.y"
                  {
         (yyval.interm).loc = (yyvsp[0].lex).loc;
         (yyval.interm).op = EOpDivAssign;
     }
-#line 5974 "MachineIndependent/glslang_tab.cpp"
+#line 5997 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 83: /* assignment_operator: MOD_ASSIGN  */
-#line 803 "MachineIndependent/glslang.y"
+#line 826 "MachineIndependent/glslang.y"
                  {
         parseContext.fullIntegerCheck((yyvsp[0].lex).loc, "%=");
         (yyval.interm).loc = (yyvsp[0].lex).loc;
         (yyval.interm).op = EOpModAssign;
     }
-#line 5984 "MachineIndependent/glslang_tab.cpp"
+#line 6007 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 84: /* assignment_operator: ADD_ASSIGN  */
-#line 808 "MachineIndependent/glslang.y"
+#line 831 "MachineIndependent/glslang.y"
                  {
         (yyval.interm).loc = (yyvsp[0].lex).loc;
         (yyval.interm).op = EOpAddAssign;
     }
-#line 5993 "MachineIndependent/glslang_tab.cpp"
+#line 6016 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 85: /* assignment_operator: SUB_ASSIGN  */
-#line 812 "MachineIndependent/glslang.y"
+#line 835 "MachineIndependent/glslang.y"
                  {
         (yyval.interm).loc = (yyvsp[0].lex).loc;
         (yyval.interm).op = EOpSubAssign;
     }
-#line 6002 "MachineIndependent/glslang_tab.cpp"
+#line 6025 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 86: /* assignment_operator: LEFT_ASSIGN  */
-#line 816 "MachineIndependent/glslang.y"
+#line 839 "MachineIndependent/glslang.y"
                   {
         parseContext.fullIntegerCheck((yyvsp[0].lex).loc, "bit-shift left assign");
         (yyval.interm).loc = (yyvsp[0].lex).loc; (yyval.interm).op = EOpLeftShiftAssign;
     }
-#line 6011 "MachineIndependent/glslang_tab.cpp"
+#line 6034 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 87: /* assignment_operator: RIGHT_ASSIGN  */
-#line 820 "MachineIndependent/glslang.y"
+#line 843 "MachineIndependent/glslang.y"
                    {
         parseContext.fullIntegerCheck((yyvsp[0].lex).loc, "bit-shift right assign");
         (yyval.interm).loc = (yyvsp[0].lex).loc; (yyval.interm).op = EOpRightShiftAssign;
     }
-#line 6020 "MachineIndependent/glslang_tab.cpp"
+#line 6043 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 88: /* assignment_operator: AND_ASSIGN  */
-#line 824 "MachineIndependent/glslang.y"
+#line 847 "MachineIndependent/glslang.y"
                  {
         parseContext.fullIntegerCheck((yyvsp[0].lex).loc, "bitwise-and assign");
         (yyval.interm).loc = (yyvsp[0].lex).loc; (yyval.interm).op = EOpAndAssign;
     }
-#line 6029 "MachineIndependent/glslang_tab.cpp"
+#line 6052 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 89: /* assignment_operator: XOR_ASSIGN  */
-#line 828 "MachineIndependent/glslang.y"
+#line 851 "MachineIndependent/glslang.y"
                  {
         parseContext.fullIntegerCheck((yyvsp[0].lex).loc, "bitwise-xor assign");
         (yyval.interm).loc = (yyvsp[0].lex).loc; (yyval.interm).op = EOpExclusiveOrAssign;
     }
-#line 6038 "MachineIndependent/glslang_tab.cpp"
+#line 6061 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 90: /* assignment_operator: OR_ASSIGN  */
-#line 832 "MachineIndependent/glslang.y"
+#line 855 "MachineIndependent/glslang.y"
                 {
         parseContext.fullIntegerCheck((yyvsp[0].lex).loc, "bitwise-or assign");
         (yyval.interm).loc = (yyvsp[0].lex).loc; (yyval.interm).op = EOpInclusiveOrAssign;
     }
-#line 6047 "MachineIndependent/glslang_tab.cpp"
+#line 6070 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 91: /* expression: assignment_expression  */
-#line 839 "MachineIndependent/glslang.y"
+#line 862 "MachineIndependent/glslang.y"
                             {
         (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode);
     }
-#line 6055 "MachineIndependent/glslang_tab.cpp"
+#line 6078 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 92: /* expression: expression COMMA assignment_expression  */
-#line 842 "MachineIndependent/glslang.y"
+#line 865 "MachineIndependent/glslang.y"
                                              {
         parseContext.samplerConstructorLocationCheck((yyvsp[-1].lex).loc, ",", (yyvsp[0].interm.intermTypedNode));
         (yyval.interm.intermTypedNode) = parseContext.intermediate.addComma((yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode), (yyvsp[-1].lex).loc);
@@ -6064,30 +6087,30 @@ yyreduce:
             (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode);
         }
     }
-#line 6068 "MachineIndependent/glslang_tab.cpp"
+#line 6091 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 93: /* constant_expression: conditional_expression  */
-#line 853 "MachineIndependent/glslang.y"
+#line 876 "MachineIndependent/glslang.y"
                              {
         parseContext.constantValueCheck((yyvsp[0].interm.intermTypedNode), "");
         (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode);
     }
-#line 6077 "MachineIndependent/glslang_tab.cpp"
+#line 6100 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 94: /* declaration: function_prototype SEMICOLON  */
-#line 860 "MachineIndependent/glslang.y"
+#line 883 "MachineIndependent/glslang.y"
                                    {
         parseContext.handleFunctionDeclarator((yyvsp[-1].interm).loc, *(yyvsp[-1].interm).function, true /* prototype */);
         (yyval.interm.intermNode) = 0;
         // TODO: 4.0 functionality: subroutines: make the identifier a user type for this signature
     }
-#line 6087 "MachineIndependent/glslang_tab.cpp"
+#line 6110 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 95: /* declaration: spirv_instruction_qualifier function_prototype SEMICOLON  */
-#line 865 "MachineIndependent/glslang.y"
+#line 888 "MachineIndependent/glslang.y"
                                                                {
         parseContext.requireExtensions((yyvsp[-1].interm).loc, 1, &E_GL_EXT_spirv_intrinsics, "SPIR-V instruction qualifier");
         (yyvsp[-1].interm).function->setSpirvInstruction(*(yyvsp[-2].interm.spirvInst)); // Attach SPIR-V intruction qualifier
@@ -6095,31 +6118,31 @@ yyreduce:
         (yyval.interm.intermNode) = 0;
         // TODO: 4.0 functionality: subroutines: make the identifier a user type for this signature
     }
-#line 6099 "MachineIndependent/glslang_tab.cpp"
+#line 6122 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 96: /* declaration: spirv_execution_mode_qualifier SEMICOLON  */
-#line 872 "MachineIndependent/glslang.y"
+#line 895 "MachineIndependent/glslang.y"
                                                {
         parseContext.globalCheck((yyvsp[0].lex).loc, "SPIR-V execution mode qualifier");
         parseContext.requireExtensions((yyvsp[0].lex).loc, 1, &E_GL_EXT_spirv_intrinsics, "SPIR-V execution mode qualifier");
         (yyval.interm.intermNode) = 0;
     }
-#line 6109 "MachineIndependent/glslang_tab.cpp"
+#line 6132 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 97: /* declaration: init_declarator_list SEMICOLON  */
-#line 877 "MachineIndependent/glslang.y"
+#line 900 "MachineIndependent/glslang.y"
                                      {
         if ((yyvsp[-1].interm).intermNode && (yyvsp[-1].interm).intermNode->getAsAggregate())
             (yyvsp[-1].interm).intermNode->getAsAggregate()->setOperator(EOpSequence);
         (yyval.interm.intermNode) = (yyvsp[-1].interm).intermNode;
     }
-#line 6119 "MachineIndependent/glslang_tab.cpp"
+#line 6142 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 98: /* declaration: PRECISION precision_qualifier type_specifier SEMICOLON  */
-#line 882 "MachineIndependent/glslang.y"
+#line 905 "MachineIndependent/glslang.y"
                                                              {
         parseContext.profileRequires((yyvsp[-3].lex).loc, ENoProfile, 130, 0, "precision statement");
         // lazy setting of the previous scope's defaults, has effect only the first time it is called in a particular scope
@@ -6127,75 +6150,75 @@ yyreduce:
         parseContext.setDefaultPrecision((yyvsp[-3].lex).loc, (yyvsp[-1].interm.type), (yyvsp[-2].interm.type).qualifier.precision);
         (yyval.interm.intermNode) = 0;
     }
-#line 6131 "MachineIndependent/glslang_tab.cpp"
+#line 6154 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 99: /* declaration: block_structure SEMICOLON  */
-#line 889 "MachineIndependent/glslang.y"
+#line 912 "MachineIndependent/glslang.y"
                                 {
         parseContext.declareBlock((yyvsp[-1].interm).loc, *(yyvsp[-1].interm).typeList);
         (yyval.interm.intermNode) = 0;
     }
-#line 6140 "MachineIndependent/glslang_tab.cpp"
+#line 6163 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 100: /* declaration: block_structure IDENTIFIER SEMICOLON  */
-#line 893 "MachineIndependent/glslang.y"
+#line 916 "MachineIndependent/glslang.y"
                                            {
         parseContext.declareBlock((yyvsp[-2].interm).loc, *(yyvsp[-2].interm).typeList, (yyvsp[-1].lex).string);
         (yyval.interm.intermNode) = 0;
     }
-#line 6149 "MachineIndependent/glslang_tab.cpp"
+#line 6172 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 101: /* declaration: block_structure IDENTIFIER array_specifier SEMICOLON  */
-#line 897 "MachineIndependent/glslang.y"
+#line 920 "MachineIndependent/glslang.y"
                                                            {
         parseContext.declareBlock((yyvsp[-3].interm).loc, *(yyvsp[-3].interm).typeList, (yyvsp[-2].lex).string, (yyvsp[-1].interm).arraySizes);
         (yyval.interm.intermNode) = 0;
     }
-#line 6158 "MachineIndependent/glslang_tab.cpp"
+#line 6181 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 102: /* declaration: type_qualifier SEMICOLON  */
-#line 901 "MachineIndependent/glslang.y"
+#line 924 "MachineIndependent/glslang.y"
                                {
         parseContext.globalQualifierFixCheck((yyvsp[-1].interm.type).loc, (yyvsp[-1].interm.type).qualifier);
         parseContext.updateStandaloneQualifierDefaults((yyvsp[-1].interm.type).loc, (yyvsp[-1].interm.type));
         (yyval.interm.intermNode) = 0;
     }
-#line 6168 "MachineIndependent/glslang_tab.cpp"
+#line 6191 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 103: /* declaration: type_qualifier IDENTIFIER SEMICOLON  */
-#line 906 "MachineIndependent/glslang.y"
+#line 929 "MachineIndependent/glslang.y"
                                           {
         parseContext.checkNoShaderLayouts((yyvsp[-2].interm.type).loc, (yyvsp[-2].interm.type).shaderQualifiers);
         parseContext.addQualifierToExisting((yyvsp[-2].interm.type).loc, (yyvsp[-2].interm.type).qualifier, *(yyvsp[-1].lex).string);
         (yyval.interm.intermNode) = 0;
     }
-#line 6178 "MachineIndependent/glslang_tab.cpp"
+#line 6201 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 104: /* declaration: type_qualifier IDENTIFIER identifier_list SEMICOLON  */
-#line 911 "MachineIndependent/glslang.y"
+#line 934 "MachineIndependent/glslang.y"
                                                           {
         parseContext.checkNoShaderLayouts((yyvsp[-3].interm.type).loc, (yyvsp[-3].interm.type).shaderQualifiers);
         (yyvsp[-1].interm.identifierList)->push_back((yyvsp[-2].lex).string);
         parseContext.addQualifierToExisting((yyvsp[-3].interm.type).loc, (yyvsp[-3].interm.type).qualifier, *(yyvsp[-1].interm.identifierList));
         (yyval.interm.intermNode) = 0;
     }
-#line 6189 "MachineIndependent/glslang_tab.cpp"
+#line 6212 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 105: /* $@2: %empty  */
-#line 920 "MachineIndependent/glslang.y"
+#line 943 "MachineIndependent/glslang.y"
                                            { parseContext.nestedBlockCheck((yyvsp[-2].interm.type).loc); }
-#line 6195 "MachineIndependent/glslang_tab.cpp"
+#line 6218 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 106: /* block_structure: type_qualifier IDENTIFIER LEFT_BRACE $@2 struct_declaration_list RIGHT_BRACE  */
-#line 920 "MachineIndependent/glslang.y"
+#line 943 "MachineIndependent/glslang.y"
                                                                                                                           {
         --parseContext.blockNestingLevel;
         parseContext.blockName = (yyvsp[-4].lex).string;
@@ -6205,61 +6228,61 @@ yyreduce:
         (yyval.interm).loc = (yyvsp[-5].interm.type).loc;
         (yyval.interm).typeList = (yyvsp[-1].interm.typeList);
     }
-#line 6209 "MachineIndependent/glslang_tab.cpp"
+#line 6232 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 107: /* identifier_list: COMMA IDENTIFIER  */
-#line 931 "MachineIndependent/glslang.y"
+#line 954 "MachineIndependent/glslang.y"
                        {
         (yyval.interm.identifierList) = new TIdentifierList;
         (yyval.interm.identifierList)->push_back((yyvsp[0].lex).string);
     }
-#line 6218 "MachineIndependent/glslang_tab.cpp"
+#line 6241 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 108: /* identifier_list: identifier_list COMMA IDENTIFIER  */
-#line 935 "MachineIndependent/glslang.y"
+#line 958 "MachineIndependent/glslang.y"
                                        {
         (yyval.interm.identifierList) = (yyvsp[-2].interm.identifierList);
         (yyval.interm.identifierList)->push_back((yyvsp[0].lex).string);
     }
-#line 6227 "MachineIndependent/glslang_tab.cpp"
+#line 6250 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 109: /* function_prototype: function_declarator RIGHT_PAREN  */
-#line 942 "MachineIndependent/glslang.y"
+#line 965 "MachineIndependent/glslang.y"
                                        {
         (yyval.interm).function = (yyvsp[-1].interm.function);
         if (parseContext.compileOnly) (yyval.interm).function->setExport();
         (yyval.interm).loc = (yyvsp[0].lex).loc;
     }
-#line 6237 "MachineIndependent/glslang_tab.cpp"
+#line 6260 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 110: /* function_prototype: function_declarator RIGHT_PAREN attribute  */
-#line 947 "MachineIndependent/glslang.y"
+#line 970 "MachineIndependent/glslang.y"
                                                 {
         (yyval.interm).function = (yyvsp[-2].interm.function);
         if (parseContext.compileOnly) (yyval.interm).function->setExport();
         (yyval.interm).loc = (yyvsp[-1].lex).loc;
         parseContext.handleFunctionAttributes((yyvsp[-1].lex).loc, *(yyvsp[0].interm.attributes));
     }
-#line 6248 "MachineIndependent/glslang_tab.cpp"
+#line 6271 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 111: /* function_prototype: attribute function_declarator RIGHT_PAREN  */
-#line 953 "MachineIndependent/glslang.y"
+#line 976 "MachineIndependent/glslang.y"
                                                 {
         (yyval.interm).function = (yyvsp[-1].interm.function);
         if (parseContext.compileOnly) (yyval.interm).function->setExport();
         (yyval.interm).loc = (yyvsp[0].lex).loc;
         parseContext.handleFunctionAttributes((yyvsp[0].lex).loc, *(yyvsp[-2].interm.attributes));
     }
-#line 6259 "MachineIndependent/glslang_tab.cpp"
+#line 6282 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 112: /* function_prototype: attribute function_declarator RIGHT_PAREN attribute  */
-#line 959 "MachineIndependent/glslang.y"
+#line 982 "MachineIndependent/glslang.y"
                                                           {
         (yyval.interm).function = (yyvsp[-2].interm.function);
         if (parseContext.compileOnly) (yyval.interm).function->setExport();
@@ -6267,40 +6290,45 @@ yyreduce:
         parseContext.handleFunctionAttributes((yyvsp[-1].lex).loc, *(yyvsp[-3].interm.attributes));
         parseContext.handleFunctionAttributes((yyvsp[-1].lex).loc, *(yyvsp[0].interm.attributes));
     }
-#line 6271 "MachineIndependent/glslang_tab.cpp"
+#line 6294 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 113: /* function_declarator: function_header  */
-#line 969 "MachineIndependent/glslang.y"
+#line 992 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.function) = (yyvsp[0].interm.function);
     }
-#line 6279 "MachineIndependent/glslang_tab.cpp"
+#line 6302 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 114: /* function_declarator: function_header_with_parameters  */
-#line 972 "MachineIndependent/glslang.y"
+#line 995 "MachineIndependent/glslang.y"
                                       {
         (yyval.interm.function) = (yyvsp[0].interm.function);
     }
-#line 6287 "MachineIndependent/glslang_tab.cpp"
+#line 6310 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 115: /* function_header_with_parameters: function_header parameter_declaration  */
-#line 979 "MachineIndependent/glslang.y"
+#line 1002 "MachineIndependent/glslang.y"
                                             {
         // Add the parameter
         (yyval.interm.function) = (yyvsp[-1].interm.function);
         if ((yyvsp[0].interm).param.type->getBasicType() != EbtVoid)
-            (yyvsp[-1].interm.function)->addParameter((yyvsp[0].interm).param);
+        {
+            if (!(parseContext.spvVersion.vulkan > 0 && parseContext.spvVersion.vulkanRelaxed))
+                (yyvsp[-1].interm.function)->addParameter((yyvsp[0].interm).param);
+            else
+                parseContext.vkRelaxedRemapFunctionParameter((yyvsp[0].interm).loc, (yyvsp[-1].interm.function), (yyvsp[0].interm).param);
+        }
         else
             delete (yyvsp[0].interm).param.type;
     }
-#line 6300 "MachineIndependent/glslang_tab.cpp"
+#line 6328 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 116: /* function_header_with_parameters: function_header_with_parameters COMMA parameter_declaration  */
-#line 987 "MachineIndependent/glslang.y"
+#line 1015 "MachineIndependent/glslang.y"
                                                                   {
         //
         // Only first parameter of one-parameter functions can be void
@@ -6315,14 +6343,17 @@ yyreduce:
         } else {
             // Add the parameter
             (yyval.interm.function) = (yyvsp[-2].interm.function);
-            (yyvsp[-2].interm.function)->addParameter((yyvsp[0].interm).param);
+            if (!(parseContext.spvVersion.vulkan > 0 && parseContext.spvVersion.vulkanRelaxed))
+                (yyvsp[-2].interm.function)->addParameter((yyvsp[0].interm).param);
+            else
+                parseContext.vkRelaxedRemapFunctionParameter((yyvsp[0].interm).loc, (yyvsp[-2].interm.function), (yyvsp[0].interm).param);
         }
     }
-#line 6322 "MachineIndependent/glslang_tab.cpp"
+#line 6353 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 117: /* function_header: fully_specified_type IDENTIFIER LEFT_PAREN  */
-#line 1007 "MachineIndependent/glslang.y"
+#line 1038 "MachineIndependent/glslang.y"
                                                  {
         if ((yyvsp[-2].interm.type).qualifier.storage != EvqGlobal && (yyvsp[-2].interm.type).qualifier.storage != EvqTemporary) {
             parseContext.error((yyvsp[-1].lex).loc, "no qualifiers allowed for function return",
@@ -6342,11 +6373,11 @@ yyreduce:
         function = new TFunction((yyvsp[-1].lex).string, type);
         (yyval.interm.function) = function;
     }
-#line 6346 "MachineIndependent/glslang_tab.cpp"
+#line 6377 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 118: /* parameter_declarator: type_specifier IDENTIFIER  */
-#line 1030 "MachineIndependent/glslang.y"
+#line 1061 "MachineIndependent/glslang.y"
                                 {
         if ((yyvsp[-1].interm.type).arraySizes) {
             parseContext.profileRequires((yyvsp[-1].interm.type).loc, ENoProfile, 120, E_GL_3DL_array_objects, "arrayed type");
@@ -6362,11 +6393,11 @@ yyreduce:
         (yyval.interm).loc = (yyvsp[0].lex).loc;
         (yyval.interm).param = param;
     }
-#line 6366 "MachineIndependent/glslang_tab.cpp"
+#line 6397 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 119: /* parameter_declarator: type_specifier IDENTIFIER array_specifier  */
-#line 1045 "MachineIndependent/glslang.y"
+#line 1076 "MachineIndependent/glslang.y"
                                                 {
         if ((yyvsp[-2].interm.type).arraySizes) {
             parseContext.profileRequires((yyvsp[-2].interm.type).loc, ENoProfile, 120, E_GL_3DL_array_objects, "arrayed type");
@@ -6386,11 +6417,11 @@ yyreduce:
         (yyval.interm).loc = (yyvsp[-1].lex).loc;
         (yyval.interm).param = param;
     }
-#line 6390 "MachineIndependent/glslang_tab.cpp"
+#line 6421 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 120: /* parameter_declaration: type_qualifier parameter_declarator  */
-#line 1070 "MachineIndependent/glslang.y"
+#line 1101 "MachineIndependent/glslang.y"
                                           {
         (yyval.interm) = (yyvsp[0].interm);
         if ((yyvsp[-1].interm.type).qualifier.precision != EpqNone)
@@ -6402,11 +6433,11 @@ yyreduce:
         parseContext.paramCheckFix((yyvsp[-1].interm.type).loc, (yyvsp[-1].interm.type).qualifier, *(yyval.interm).param.type);
 
     }
-#line 6406 "MachineIndependent/glslang_tab.cpp"
+#line 6437 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 121: /* parameter_declaration: parameter_declarator  */
-#line 1081 "MachineIndependent/glslang.y"
+#line 1112 "MachineIndependent/glslang.y"
                            {
         (yyval.interm) = (yyvsp[0].interm);
 
@@ -6414,11 +6445,11 @@ yyreduce:
         parseContext.paramCheckFixStorage((yyvsp[0].interm).loc, EvqTemporary, *(yyval.interm).param.type);
         parseContext.precisionQualifierCheck((yyval.interm).loc, (yyval.interm).param.type->getBasicType(), (yyval.interm).param.type->getQualifier(), (yyval.interm).param.type->isCoopMat());
     }
-#line 6418 "MachineIndependent/glslang_tab.cpp"
+#line 6449 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 122: /* parameter_declaration: type_qualifier parameter_type_specifier  */
-#line 1091 "MachineIndependent/glslang.y"
+#line 1122 "MachineIndependent/glslang.y"
                                               {
         (yyval.interm) = (yyvsp[0].interm);
         if ((yyvsp[-1].interm.type).qualifier.precision != EpqNone)
@@ -6429,11 +6460,11 @@ yyreduce:
         parseContext.parameterTypeCheck((yyvsp[0].interm).loc, (yyvsp[-1].interm.type).qualifier.storage, *(yyval.interm).param.type);
         parseContext.paramCheckFix((yyvsp[-1].interm.type).loc, (yyvsp[-1].interm.type).qualifier, *(yyval.interm).param.type);
     }
-#line 6433 "MachineIndependent/glslang_tab.cpp"
+#line 6464 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 123: /* parameter_declaration: parameter_type_specifier  */
-#line 1101 "MachineIndependent/glslang.y"
+#line 1132 "MachineIndependent/glslang.y"
                                {
         (yyval.interm) = (yyvsp[0].interm);
 
@@ -6441,118 +6472,118 @@ yyreduce:
         parseContext.paramCheckFixStorage((yyvsp[0].interm).loc, EvqTemporary, *(yyval.interm).param.type);
         parseContext.precisionQualifierCheck((yyval.interm).loc, (yyval.interm).param.type->getBasicType(), (yyval.interm).param.type->getQualifier(), (yyval.interm).param.type->isCoopMat());
     }
-#line 6445 "MachineIndependent/glslang_tab.cpp"
+#line 6476 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 124: /* parameter_type_specifier: type_specifier  */
-#line 1111 "MachineIndependent/glslang.y"
+#line 1142 "MachineIndependent/glslang.y"
                      {
         TParameter param = { 0, new TType((yyvsp[0].interm.type)) };
         (yyval.interm).param = param;
         if ((yyvsp[0].interm.type).arraySizes)
             parseContext.arraySizeRequiredCheck((yyvsp[0].interm.type).loc, *(yyvsp[0].interm.type).arraySizes);
     }
-#line 6456 "MachineIndependent/glslang_tab.cpp"
+#line 6487 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 125: /* init_declarator_list: single_declaration  */
-#line 1120 "MachineIndependent/glslang.y"
+#line 1151 "MachineIndependent/glslang.y"
                          {
         (yyval.interm) = (yyvsp[0].interm);
     }
-#line 6464 "MachineIndependent/glslang_tab.cpp"
+#line 6495 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 126: /* init_declarator_list: init_declarator_list COMMA IDENTIFIER  */
-#line 1123 "MachineIndependent/glslang.y"
+#line 1154 "MachineIndependent/glslang.y"
                                             {
         (yyval.interm) = (yyvsp[-2].interm);
         parseContext.declareVariable((yyvsp[0].lex).loc, *(yyvsp[0].lex).string, (yyvsp[-2].interm).type);
     }
-#line 6473 "MachineIndependent/glslang_tab.cpp"
+#line 6504 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 127: /* init_declarator_list: init_declarator_list COMMA IDENTIFIER array_specifier  */
-#line 1127 "MachineIndependent/glslang.y"
+#line 1158 "MachineIndependent/glslang.y"
                                                             {
         (yyval.interm) = (yyvsp[-3].interm);
         parseContext.declareVariable((yyvsp[-1].lex).loc, *(yyvsp[-1].lex).string, (yyvsp[-3].interm).type, (yyvsp[0].interm).arraySizes);
     }
-#line 6482 "MachineIndependent/glslang_tab.cpp"
+#line 6513 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 128: /* init_declarator_list: init_declarator_list COMMA IDENTIFIER array_specifier EQUAL initializer  */
-#line 1131 "MachineIndependent/glslang.y"
+#line 1162 "MachineIndependent/glslang.y"
                                                                               {
         (yyval.interm).type = (yyvsp[-5].interm).type;
         TIntermNode* initNode = parseContext.declareVariable((yyvsp[-3].lex).loc, *(yyvsp[-3].lex).string, (yyvsp[-5].interm).type, (yyvsp[-2].interm).arraySizes, (yyvsp[0].interm.intermTypedNode));
         (yyval.interm).intermNode = parseContext.intermediate.growAggregate((yyvsp[-5].interm).intermNode, initNode, (yyvsp[-1].lex).loc);
     }
-#line 6492 "MachineIndependent/glslang_tab.cpp"
+#line 6523 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 129: /* init_declarator_list: init_declarator_list COMMA IDENTIFIER EQUAL initializer  */
-#line 1136 "MachineIndependent/glslang.y"
+#line 1167 "MachineIndependent/glslang.y"
                                                               {
         (yyval.interm).type = (yyvsp[-4].interm).type;
         TIntermNode* initNode = parseContext.declareVariable((yyvsp[-2].lex).loc, *(yyvsp[-2].lex).string, (yyvsp[-4].interm).type, 0, (yyvsp[0].interm.intermTypedNode));
         (yyval.interm).intermNode = parseContext.intermediate.growAggregate((yyvsp[-4].interm).intermNode, initNode, (yyvsp[-1].lex).loc);
     }
-#line 6502 "MachineIndependent/glslang_tab.cpp"
+#line 6533 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 130: /* single_declaration: fully_specified_type  */
-#line 1144 "MachineIndependent/glslang.y"
+#line 1175 "MachineIndependent/glslang.y"
                            {
         (yyval.interm).type = (yyvsp[0].interm.type);
         (yyval.interm).intermNode = 0;
         parseContext.declareTypeDefaults((yyval.interm).loc, (yyval.interm).type);
     }
-#line 6512 "MachineIndependent/glslang_tab.cpp"
+#line 6543 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 131: /* single_declaration: fully_specified_type IDENTIFIER  */
-#line 1149 "MachineIndependent/glslang.y"
+#line 1180 "MachineIndependent/glslang.y"
                                       {
         (yyval.interm).type = (yyvsp[-1].interm.type);
         (yyval.interm).intermNode = 0;
         parseContext.declareVariable((yyvsp[0].lex).loc, *(yyvsp[0].lex).string, (yyvsp[-1].interm.type));
     }
-#line 6522 "MachineIndependent/glslang_tab.cpp"
+#line 6553 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 132: /* single_declaration: fully_specified_type IDENTIFIER array_specifier  */
-#line 1154 "MachineIndependent/glslang.y"
+#line 1185 "MachineIndependent/glslang.y"
                                                       {
         (yyval.interm).type = (yyvsp[-2].interm.type);
         (yyval.interm).intermNode = 0;
         parseContext.declareVariable((yyvsp[-1].lex).loc, *(yyvsp[-1].lex).string, (yyvsp[-2].interm.type), (yyvsp[0].interm).arraySizes);
     }
-#line 6532 "MachineIndependent/glslang_tab.cpp"
+#line 6563 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 133: /* single_declaration: fully_specified_type IDENTIFIER array_specifier EQUAL initializer  */
-#line 1159 "MachineIndependent/glslang.y"
+#line 1190 "MachineIndependent/glslang.y"
                                                                         {
         (yyval.interm).type = (yyvsp[-4].interm.type);
         TIntermNode* initNode = parseContext.declareVariable((yyvsp[-3].lex).loc, *(yyvsp[-3].lex).string, (yyvsp[-4].interm.type), (yyvsp[-2].interm).arraySizes, (yyvsp[0].interm.intermTypedNode));
         (yyval.interm).intermNode = parseContext.intermediate.growAggregate(0, initNode, (yyvsp[-1].lex).loc);
     }
-#line 6542 "MachineIndependent/glslang_tab.cpp"
+#line 6573 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 134: /* single_declaration: fully_specified_type IDENTIFIER EQUAL initializer  */
-#line 1164 "MachineIndependent/glslang.y"
+#line 1195 "MachineIndependent/glslang.y"
                                                         {
         (yyval.interm).type = (yyvsp[-3].interm.type);
         TIntermNode* initNode = parseContext.declareVariable((yyvsp[-2].lex).loc, *(yyvsp[-2].lex).string, (yyvsp[-3].interm.type), 0, (yyvsp[0].interm.intermTypedNode));
         (yyval.interm).intermNode = parseContext.intermediate.growAggregate(0, initNode, (yyvsp[-1].lex).loc);
     }
-#line 6552 "MachineIndependent/glslang_tab.cpp"
+#line 6583 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 135: /* fully_specified_type: type_specifier  */
-#line 1173 "MachineIndependent/glslang.y"
+#line 1204 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type) = (yyvsp[0].interm.type);
 
@@ -6563,11 +6594,11 @@ yyreduce:
         }
         parseContext.precisionQualifierCheck((yyval.interm.type).loc, (yyval.interm.type).basicType, (yyval.interm.type).qualifier, (yyval.interm.type).isCoopmat());
     }
-#line 6567 "MachineIndependent/glslang_tab.cpp"
+#line 6598 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 136: /* fully_specified_type: type_qualifier type_specifier  */
-#line 1183 "MachineIndependent/glslang.y"
+#line 1214 "MachineIndependent/glslang.y"
                                      {
         parseContext.globalQualifierFixCheck((yyvsp[-1].interm.type).loc, (yyvsp[-1].interm.type).qualifier, false, &(yyvsp[0].interm.type));
         parseContext.globalQualifierTypeCheck((yyvsp[-1].interm.type).loc, (yyvsp[-1].interm.type).qualifier, (yyvsp[0].interm.type));
@@ -6592,22 +6623,22 @@ yyreduce:
              (parseContext.language == EShLangFragment && (yyval.interm.type).qualifier.storage == EvqVaryingIn)))
             (yyval.interm.type).qualifier.smooth = true;
     }
-#line 6596 "MachineIndependent/glslang_tab.cpp"
+#line 6627 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 137: /* invariant_qualifier: INVARIANT  */
-#line 1210 "MachineIndependent/glslang.y"
+#line 1241 "MachineIndependent/glslang.y"
                 {
         parseContext.globalCheck((yyvsp[0].lex).loc, "invariant");
         parseContext.profileRequires((yyval.interm.type).loc, ENoProfile, 120, 0, "invariant");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.invariant = true;
     }
-#line 6607 "MachineIndependent/glslang_tab.cpp"
+#line 6638 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 138: /* interpolation_qualifier: SMOOTH  */
-#line 1219 "MachineIndependent/glslang.y"
+#line 1250 "MachineIndependent/glslang.y"
              {
         parseContext.globalCheck((yyvsp[0].lex).loc, "smooth");
         parseContext.profileRequires((yyvsp[0].lex).loc, ENoProfile, 130, 0, "smooth");
@@ -6615,11 +6646,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.smooth = true;
     }
-#line 6619 "MachineIndependent/glslang_tab.cpp"
+#line 6650 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 139: /* interpolation_qualifier: FLAT  */
-#line 1226 "MachineIndependent/glslang.y"
+#line 1257 "MachineIndependent/glslang.y"
            {
         parseContext.globalCheck((yyvsp[0].lex).loc, "flat");
         parseContext.profileRequires((yyvsp[0].lex).loc, ENoProfile, 130, 0, "flat");
@@ -6627,11 +6658,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.flat = true;
     }
-#line 6631 "MachineIndependent/glslang_tab.cpp"
+#line 6662 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 140: /* interpolation_qualifier: NOPERSPECTIVE  */
-#line 1233 "MachineIndependent/glslang.y"
+#line 1264 "MachineIndependent/glslang.y"
                     {
         parseContext.globalCheck((yyvsp[0].lex).loc, "noperspective");
         parseContext.profileRequires((yyvsp[0].lex).loc, EEsProfile, 0, E_GL_NV_shader_noperspective_interpolation, "noperspective");
@@ -6639,11 +6670,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.nopersp = true;
     }
-#line 6643 "MachineIndependent/glslang_tab.cpp"
+#line 6674 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 141: /* interpolation_qualifier: EXPLICITINTERPAMD  */
-#line 1240 "MachineIndependent/glslang.y"
+#line 1271 "MachineIndependent/glslang.y"
                         {
         parseContext.globalCheck((yyvsp[0].lex).loc, "__explicitInterpAMD");
         parseContext.profileRequires((yyvsp[0].lex).loc, ECoreProfile, 450, E_GL_AMD_shader_explicit_vertex_parameter, "explicit interpolation");
@@ -6651,11 +6682,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.explicitInterp = true;
     }
-#line 6655 "MachineIndependent/glslang_tab.cpp"
+#line 6686 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 142: /* interpolation_qualifier: PERVERTEXNV  */
-#line 1247 "MachineIndependent/glslang.y"
+#line 1278 "MachineIndependent/glslang.y"
                   {
         parseContext.globalCheck((yyvsp[0].lex).loc, "pervertexNV");
         parseContext.profileRequires((yyvsp[0].lex).loc, ECoreProfile, 0, E_GL_NV_fragment_shader_barycentric, "fragment shader barycentric");
@@ -6664,11 +6695,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.pervertexNV = true;
     }
-#line 6668 "MachineIndependent/glslang_tab.cpp"
+#line 6699 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 143: /* interpolation_qualifier: PERVERTEXEXT  */
-#line 1255 "MachineIndependent/glslang.y"
+#line 1286 "MachineIndependent/glslang.y"
                    {
         parseContext.globalCheck((yyvsp[0].lex).loc, "pervertexEXT");
         parseContext.profileRequires((yyvsp[0].lex).loc, ECoreProfile, 0, E_GL_EXT_fragment_shader_barycentric, "fragment shader barycentric");
@@ -6677,11 +6708,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.pervertexEXT = true;
     }
-#line 6681 "MachineIndependent/glslang_tab.cpp"
+#line 6712 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 144: /* interpolation_qualifier: PERPRIMITIVENV  */
-#line 1263 "MachineIndependent/glslang.y"
+#line 1294 "MachineIndependent/glslang.y"
                      {
         // No need for profile version or extension check. Shader stage already checks both.
         parseContext.globalCheck((yyvsp[0].lex).loc, "perprimitiveNV");
@@ -6692,11 +6723,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.perPrimitiveNV = true;
     }
-#line 6696 "MachineIndependent/glslang_tab.cpp"
+#line 6727 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 145: /* interpolation_qualifier: PERPRIMITIVEEXT  */
-#line 1273 "MachineIndependent/glslang.y"
+#line 1304 "MachineIndependent/glslang.y"
                       {
         // No need for profile version or extension check. Shader stage already checks both.
         parseContext.globalCheck((yyvsp[0].lex).loc, "perprimitiveEXT");
@@ -6707,11 +6738,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.perPrimitiveNV = true;
     }
-#line 6711 "MachineIndependent/glslang_tab.cpp"
+#line 6742 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 146: /* interpolation_qualifier: PERVIEWNV  */
-#line 1283 "MachineIndependent/glslang.y"
+#line 1314 "MachineIndependent/glslang.y"
                 {
         // No need for profile version or extension check. Shader stage already checks both.
         parseContext.globalCheck((yyvsp[0].lex).loc, "perviewNV");
@@ -6719,11 +6750,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.perViewNV = true;
     }
-#line 6723 "MachineIndependent/glslang_tab.cpp"
+#line 6754 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 147: /* interpolation_qualifier: PERTASKNV  */
-#line 1290 "MachineIndependent/glslang.y"
+#line 1321 "MachineIndependent/glslang.y"
                 {
         // No need for profile version or extension check. Shader stage already checks both.
         parseContext.globalCheck((yyvsp[0].lex).loc, "taskNV");
@@ -6731,84 +6762,84 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.perTaskNV = true;
     }
-#line 6735 "MachineIndependent/glslang_tab.cpp"
+#line 6766 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 148: /* layout_qualifier: LAYOUT LEFT_PAREN layout_qualifier_id_list RIGHT_PAREN  */
-#line 1300 "MachineIndependent/glslang.y"
+#line 1331 "MachineIndependent/glslang.y"
                                                              {
         (yyval.interm.type) = (yyvsp[-1].interm.type);
     }
-#line 6743 "MachineIndependent/glslang_tab.cpp"
+#line 6774 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 149: /* layout_qualifier_id_list: layout_qualifier_id  */
-#line 1306 "MachineIndependent/glslang.y"
+#line 1337 "MachineIndependent/glslang.y"
                           {
         (yyval.interm.type) = (yyvsp[0].interm.type);
     }
-#line 6751 "MachineIndependent/glslang_tab.cpp"
+#line 6782 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 150: /* layout_qualifier_id_list: layout_qualifier_id_list COMMA layout_qualifier_id  */
-#line 1309 "MachineIndependent/glslang.y"
+#line 1340 "MachineIndependent/glslang.y"
                                                          {
         (yyval.interm.type) = (yyvsp[-2].interm.type);
         (yyval.interm.type).shaderQualifiers.merge((yyvsp[0].interm.type).shaderQualifiers);
         parseContext.mergeObjectLayoutQualifiers((yyval.interm.type).qualifier, (yyvsp[0].interm.type).qualifier, false);
     }
-#line 6761 "MachineIndependent/glslang_tab.cpp"
+#line 6792 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 151: /* layout_qualifier_id: IDENTIFIER  */
-#line 1316 "MachineIndependent/glslang.y"
+#line 1347 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         parseContext.setLayoutQualifier((yyvsp[0].lex).loc, (yyval.interm.type), *(yyvsp[0].lex).string);
     }
-#line 6770 "MachineIndependent/glslang_tab.cpp"
+#line 6801 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 152: /* layout_qualifier_id: IDENTIFIER EQUAL constant_expression  */
-#line 1320 "MachineIndependent/glslang.y"
+#line 1351 "MachineIndependent/glslang.y"
                                            {
         (yyval.interm.type).init((yyvsp[-2].lex).loc);
         parseContext.setLayoutQualifier((yyvsp[-2].lex).loc, (yyval.interm.type), *(yyvsp[-2].lex).string, (yyvsp[0].interm.intermTypedNode));
     }
-#line 6779 "MachineIndependent/glslang_tab.cpp"
+#line 6810 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 153: /* layout_qualifier_id: SHARED  */
-#line 1324 "MachineIndependent/glslang.y"
+#line 1355 "MachineIndependent/glslang.y"
              { // because "shared" is both an identifier and a keyword
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         TString strShared("shared");
         parseContext.setLayoutQualifier((yyvsp[0].lex).loc, (yyval.interm.type), strShared);
     }
-#line 6789 "MachineIndependent/glslang_tab.cpp"
+#line 6820 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 154: /* precise_qualifier: PRECISE  */
-#line 1332 "MachineIndependent/glslang.y"
+#line 1363 "MachineIndependent/glslang.y"
               {
         parseContext.profileRequires((yyval.interm.type).loc, ECoreProfile | ECompatibilityProfile, 400, E_GL_ARB_gpu_shader5, "precise");
         parseContext.profileRequires((yyvsp[0].lex).loc, EEsProfile, 320, Num_AEP_gpu_shader5, AEP_gpu_shader5, "precise");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.noContraction = true;
     }
-#line 6800 "MachineIndependent/glslang_tab.cpp"
+#line 6831 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 155: /* type_qualifier: single_type_qualifier  */
-#line 1341 "MachineIndependent/glslang.y"
+#line 1372 "MachineIndependent/glslang.y"
                             {
         (yyval.interm.type) = (yyvsp[0].interm.type);
     }
-#line 6808 "MachineIndependent/glslang_tab.cpp"
+#line 6839 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 156: /* type_qualifier: type_qualifier single_type_qualifier  */
-#line 1344 "MachineIndependent/glslang.y"
+#line 1375 "MachineIndependent/glslang.y"
                                            {
         (yyval.interm.type) = (yyvsp[-1].interm.type);
         if ((yyval.interm.type).basicType == EbtVoid)
@@ -6817,151 +6848,151 @@ yyreduce:
         (yyval.interm.type).shaderQualifiers.merge((yyvsp[0].interm.type).shaderQualifiers);
         parseContext.mergeQualifiers((yyval.interm.type).loc, (yyval.interm.type).qualifier, (yyvsp[0].interm.type).qualifier, false);
     }
-#line 6821 "MachineIndependent/glslang_tab.cpp"
+#line 6852 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 157: /* single_type_qualifier: storage_qualifier  */
-#line 1355 "MachineIndependent/glslang.y"
+#line 1386 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.type) = (yyvsp[0].interm.type);
     }
-#line 6829 "MachineIndependent/glslang_tab.cpp"
+#line 6860 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 158: /* single_type_qualifier: layout_qualifier  */
-#line 1358 "MachineIndependent/glslang.y"
+#line 1389 "MachineIndependent/glslang.y"
                        {
         (yyval.interm.type) = (yyvsp[0].interm.type);
     }
-#line 6837 "MachineIndependent/glslang_tab.cpp"
+#line 6868 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 159: /* single_type_qualifier: precision_qualifier  */
-#line 1361 "MachineIndependent/glslang.y"
+#line 1392 "MachineIndependent/glslang.y"
                           {
         parseContext.checkPrecisionQualifier((yyvsp[0].interm.type).loc, (yyvsp[0].interm.type).qualifier.precision);
         (yyval.interm.type) = (yyvsp[0].interm.type);
     }
-#line 6846 "MachineIndependent/glslang_tab.cpp"
+#line 6877 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 160: /* single_type_qualifier: interpolation_qualifier  */
-#line 1365 "MachineIndependent/glslang.y"
+#line 1396 "MachineIndependent/glslang.y"
                               {
         // allow inheritance of storage qualifier from block declaration
         (yyval.interm.type) = (yyvsp[0].interm.type);
     }
-#line 6855 "MachineIndependent/glslang_tab.cpp"
+#line 6886 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 161: /* single_type_qualifier: invariant_qualifier  */
-#line 1369 "MachineIndependent/glslang.y"
+#line 1400 "MachineIndependent/glslang.y"
                           {
         // allow inheritance of storage qualifier from block declaration
         (yyval.interm.type) = (yyvsp[0].interm.type);
     }
-#line 6864 "MachineIndependent/glslang_tab.cpp"
+#line 6895 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 162: /* single_type_qualifier: precise_qualifier  */
-#line 1373 "MachineIndependent/glslang.y"
+#line 1404 "MachineIndependent/glslang.y"
                         {
         // allow inheritance of storage qualifier from block declaration
         (yyval.interm.type) = (yyvsp[0].interm.type);
     }
-#line 6873 "MachineIndependent/glslang_tab.cpp"
+#line 6904 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 163: /* single_type_qualifier: non_uniform_qualifier  */
-#line 1377 "MachineIndependent/glslang.y"
+#line 1408 "MachineIndependent/glslang.y"
                             {
         (yyval.interm.type) = (yyvsp[0].interm.type);
     }
-#line 6881 "MachineIndependent/glslang_tab.cpp"
+#line 6912 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 164: /* single_type_qualifier: spirv_storage_class_qualifier  */
-#line 1380 "MachineIndependent/glslang.y"
+#line 1411 "MachineIndependent/glslang.y"
                                     {
         parseContext.globalCheck((yyvsp[0].interm.type).loc, "spirv_storage_class");
         parseContext.requireExtensions((yyvsp[0].interm.type).loc, 1, &E_GL_EXT_spirv_intrinsics, "SPIR-V storage class qualifier");
         (yyval.interm.type) = (yyvsp[0].interm.type);
     }
-#line 6891 "MachineIndependent/glslang_tab.cpp"
+#line 6922 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 165: /* single_type_qualifier: spirv_decorate_qualifier  */
-#line 1385 "MachineIndependent/glslang.y"
+#line 1416 "MachineIndependent/glslang.y"
                                {
         parseContext.requireExtensions((yyvsp[0].interm.type).loc, 1, &E_GL_EXT_spirv_intrinsics, "SPIR-V decorate qualifier");
         (yyval.interm.type) = (yyvsp[0].interm.type);
     }
-#line 6900 "MachineIndependent/glslang_tab.cpp"
+#line 6931 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 166: /* single_type_qualifier: SPIRV_BY_REFERENCE  */
-#line 1389 "MachineIndependent/glslang.y"
+#line 1420 "MachineIndependent/glslang.y"
                          {
         parseContext.requireExtensions((yyvsp[0].lex).loc, 1, &E_GL_EXT_spirv_intrinsics, "spirv_by_reference");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.setSpirvByReference();
     }
-#line 6910 "MachineIndependent/glslang_tab.cpp"
+#line 6941 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 167: /* single_type_qualifier: SPIRV_LITERAL  */
-#line 1394 "MachineIndependent/glslang.y"
+#line 1425 "MachineIndependent/glslang.y"
                     {
         parseContext.requireExtensions((yyvsp[0].lex).loc, 1, &E_GL_EXT_spirv_intrinsics, "spirv_by_literal");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.setSpirvLiteral();
     }
-#line 6920 "MachineIndependent/glslang_tab.cpp"
+#line 6951 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 168: /* storage_qualifier: CONST  */
-#line 1402 "MachineIndependent/glslang.y"
+#line 1433 "MachineIndependent/glslang.y"
             {
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqConst;  // will later turn into EvqConstReadOnly, if the initializer is not constant
     }
-#line 6929 "MachineIndependent/glslang_tab.cpp"
+#line 6960 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 169: /* storage_qualifier: INOUT  */
-#line 1406 "MachineIndependent/glslang.y"
+#line 1437 "MachineIndependent/glslang.y"
             {
         parseContext.globalCheck((yyvsp[0].lex).loc, "inout");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqInOut;
     }
-#line 6939 "MachineIndependent/glslang_tab.cpp"
+#line 6970 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 170: /* storage_qualifier: IN  */
-#line 1411 "MachineIndependent/glslang.y"
+#line 1442 "MachineIndependent/glslang.y"
          {
         parseContext.globalCheck((yyvsp[0].lex).loc, "in");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         // whether this is a parameter "in" or a pipeline "in" will get sorted out a bit later
         (yyval.interm.type).qualifier.storage = EvqIn;
     }
-#line 6950 "MachineIndependent/glslang_tab.cpp"
+#line 6981 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 171: /* storage_qualifier: OUT  */
-#line 1417 "MachineIndependent/glslang.y"
+#line 1448 "MachineIndependent/glslang.y"
           {
         parseContext.globalCheck((yyvsp[0].lex).loc, "out");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         // whether this is a parameter "out" or a pipeline "out" will get sorted out a bit later
         (yyval.interm.type).qualifier.storage = EvqOut;
     }
-#line 6961 "MachineIndependent/glslang_tab.cpp"
+#line 6992 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 172: /* storage_qualifier: CENTROID  */
-#line 1423 "MachineIndependent/glslang.y"
+#line 1454 "MachineIndependent/glslang.y"
                {
         parseContext.profileRequires((yyvsp[0].lex).loc, ENoProfile, 120, 0, "centroid");
         parseContext.profileRequires((yyvsp[0].lex).loc, EEsProfile, 300, 0, "centroid");
@@ -6969,31 +7000,31 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.centroid = true;
     }
-#line 6973 "MachineIndependent/glslang_tab.cpp"
+#line 7004 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 173: /* storage_qualifier: UNIFORM  */
-#line 1430 "MachineIndependent/glslang.y"
+#line 1461 "MachineIndependent/glslang.y"
               {
         parseContext.globalCheck((yyvsp[0].lex).loc, "uniform");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqUniform;
     }
-#line 6983 "MachineIndependent/glslang_tab.cpp"
+#line 7014 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 174: /* storage_qualifier: TILEIMAGEEXT  */
-#line 1435 "MachineIndependent/glslang.y"
+#line 1466 "MachineIndependent/glslang.y"
                    {
         parseContext.globalCheck((yyvsp[0].lex).loc, "tileImageEXT");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqTileImageEXT;
     }
-#line 6993 "MachineIndependent/glslang_tab.cpp"
+#line 7024 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 175: /* storage_qualifier: SHARED  */
-#line 1440 "MachineIndependent/glslang.y"
+#line 1471 "MachineIndependent/glslang.y"
              {
         parseContext.globalCheck((yyvsp[0].lex).loc, "shared");
         parseContext.profileRequires((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, 430, E_GL_ARB_compute_shader, "shared");
@@ -7002,21 +7033,21 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqShared;
     }
-#line 7006 "MachineIndependent/glslang_tab.cpp"
+#line 7037 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 176: /* storage_qualifier: BUFFER  */
-#line 1448 "MachineIndependent/glslang.y"
+#line 1479 "MachineIndependent/glslang.y"
              {
         parseContext.globalCheck((yyvsp[0].lex).loc, "buffer");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqBuffer;
     }
-#line 7016 "MachineIndependent/glslang_tab.cpp"
+#line 7047 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 177: /* storage_qualifier: ATTRIBUTE  */
-#line 1453 "MachineIndependent/glslang.y"
+#line 1484 "MachineIndependent/glslang.y"
                 {
         parseContext.requireStage((yyvsp[0].lex).loc, EShLangVertex, "attribute");
         parseContext.checkDeprecated((yyvsp[0].lex).loc, ECoreProfile, 130, "attribute");
@@ -7029,11 +7060,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqVaryingIn;
     }
-#line 7033 "MachineIndependent/glslang_tab.cpp"
+#line 7064 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 178: /* storage_qualifier: VARYING  */
-#line 1465 "MachineIndependent/glslang.y"
+#line 1496 "MachineIndependent/glslang.y"
               {
         parseContext.checkDeprecated((yyvsp[0].lex).loc, ENoProfile, 130, "varying");
         parseContext.checkDeprecated((yyvsp[0].lex).loc, ECoreProfile, 130, "varying");
@@ -7048,32 +7079,32 @@ yyreduce:
         else
             (yyval.interm.type).qualifier.storage = EvqVaryingIn;
     }
-#line 7052 "MachineIndependent/glslang_tab.cpp"
+#line 7083 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 179: /* storage_qualifier: PATCH  */
-#line 1479 "MachineIndependent/glslang.y"
+#line 1510 "MachineIndependent/glslang.y"
             {
         parseContext.globalCheck((yyvsp[0].lex).loc, "patch");
         parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangTessControlMask | EShLangTessEvaluationMask), "patch");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.patch = true;
     }
-#line 7063 "MachineIndependent/glslang_tab.cpp"
+#line 7094 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 180: /* storage_qualifier: SAMPLE  */
-#line 1485 "MachineIndependent/glslang.y"
+#line 1516 "MachineIndependent/glslang.y"
              {
         parseContext.globalCheck((yyvsp[0].lex).loc, "sample");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.sample = true;
     }
-#line 7073 "MachineIndependent/glslang_tab.cpp"
+#line 7104 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 181: /* storage_qualifier: HITATTRNV  */
-#line 1490 "MachineIndependent/glslang.y"
+#line 1521 "MachineIndependent/glslang.y"
                 {
         parseContext.globalCheck((yyvsp[0].lex).loc, "hitAttributeNV");
         parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangIntersectMask | EShLangClosestHitMask
@@ -7082,11 +7113,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqHitAttr;
     }
-#line 7086 "MachineIndependent/glslang_tab.cpp"
+#line 7117 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 182: /* storage_qualifier: HITOBJECTATTRNV  */
-#line 1498 "MachineIndependent/glslang.y"
+#line 1529 "MachineIndependent/glslang.y"
                           {
         parseContext.globalCheck((yyvsp[0].lex).loc, "hitAttributeNV");
         parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangRayGenMask | EShLangClosestHitMask
@@ -7095,11 +7126,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqHitObjectAttrNV;
 	}
-#line 7099 "MachineIndependent/glslang_tab.cpp"
+#line 7130 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 183: /* storage_qualifier: HITATTREXT  */
-#line 1506 "MachineIndependent/glslang.y"
+#line 1537 "MachineIndependent/glslang.y"
                  {
         parseContext.globalCheck((yyvsp[0].lex).loc, "hitAttributeEXT");
         parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangIntersectMask | EShLangClosestHitMask
@@ -7108,11 +7139,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqHitAttr;
     }
-#line 7112 "MachineIndependent/glslang_tab.cpp"
+#line 7143 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 184: /* storage_qualifier: PAYLOADNV  */
-#line 1514 "MachineIndependent/glslang.y"
+#line 1545 "MachineIndependent/glslang.y"
                 {
         parseContext.globalCheck((yyvsp[0].lex).loc, "rayPayloadNV");
         parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangRayGenMask | EShLangClosestHitMask |
@@ -7121,11 +7152,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqPayload;
     }
-#line 7125 "MachineIndependent/glslang_tab.cpp"
+#line 7156 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 185: /* storage_qualifier: PAYLOADEXT  */
-#line 1522 "MachineIndependent/glslang.y"
+#line 1553 "MachineIndependent/glslang.y"
                  {
         parseContext.globalCheck((yyvsp[0].lex).loc, "rayPayloadEXT");
         parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangRayGenMask | EShLangClosestHitMask |
@@ -7134,11 +7165,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqPayload;
     }
-#line 7138 "MachineIndependent/glslang_tab.cpp"
+#line 7169 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 186: /* storage_qualifier: PAYLOADINNV  */
-#line 1530 "MachineIndependent/glslang.y"
+#line 1561 "MachineIndependent/glslang.y"
                   {
         parseContext.globalCheck((yyvsp[0].lex).loc, "rayPayloadInNV");
         parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangClosestHitMask |
@@ -7147,11 +7178,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqPayloadIn;
     }
-#line 7151 "MachineIndependent/glslang_tab.cpp"
+#line 7182 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 187: /* storage_qualifier: PAYLOADINEXT  */
-#line 1538 "MachineIndependent/glslang.y"
+#line 1569 "MachineIndependent/glslang.y"
                    {
         parseContext.globalCheck((yyvsp[0].lex).loc, "rayPayloadInEXT");
         parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangClosestHitMask |
@@ -7160,11 +7191,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqPayloadIn;
     }
-#line 7164 "MachineIndependent/glslang_tab.cpp"
+#line 7195 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 188: /* storage_qualifier: CALLDATANV  */
-#line 1546 "MachineIndependent/glslang.y"
+#line 1577 "MachineIndependent/glslang.y"
                  {
         parseContext.globalCheck((yyvsp[0].lex).loc, "callableDataNV");
         parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangRayGenMask |
@@ -7173,11 +7204,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqCallableData;
     }
-#line 7177 "MachineIndependent/glslang_tab.cpp"
+#line 7208 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 189: /* storage_qualifier: CALLDATAEXT  */
-#line 1554 "MachineIndependent/glslang.y"
+#line 1585 "MachineIndependent/glslang.y"
                   {
         parseContext.globalCheck((yyvsp[0].lex).loc, "callableDataEXT");
         parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangRayGenMask |
@@ -7186,11 +7217,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqCallableData;
     }
-#line 7190 "MachineIndependent/glslang_tab.cpp"
+#line 7221 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 190: /* storage_qualifier: CALLDATAINNV  */
-#line 1562 "MachineIndependent/glslang.y"
+#line 1593 "MachineIndependent/glslang.y"
                    {
         parseContext.globalCheck((yyvsp[0].lex).loc, "callableDataInNV");
         parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangCallableMask), "callableDataInNV");
@@ -7198,11 +7229,11 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqCallableDataIn;
     }
-#line 7202 "MachineIndependent/glslang_tab.cpp"
+#line 7233 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 191: /* storage_qualifier: CALLDATAINEXT  */
-#line 1569 "MachineIndependent/glslang.y"
+#line 1600 "MachineIndependent/glslang.y"
                     {
         parseContext.globalCheck((yyvsp[0].lex).loc, "callableDataInEXT");
         parseContext.requireStage((yyvsp[0].lex).loc, (EShLanguageMask)(EShLangCallableMask), "callableDataInEXT");
@@ -7210,138 +7241,138 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqCallableDataIn;
     }
-#line 7214 "MachineIndependent/glslang_tab.cpp"
+#line 7245 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 192: /* storage_qualifier: COHERENT  */
-#line 1576 "MachineIndependent/glslang.y"
+#line 1607 "MachineIndependent/glslang.y"
                {
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.coherent = true;
     }
-#line 7223 "MachineIndependent/glslang_tab.cpp"
+#line 7254 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 193: /* storage_qualifier: DEVICECOHERENT  */
-#line 1580 "MachineIndependent/glslang.y"
+#line 1611 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         parseContext.requireExtensions((yyvsp[0].lex).loc, 1, &E_GL_KHR_memory_scope_semantics, "devicecoherent");
         (yyval.interm.type).qualifier.devicecoherent = true;
     }
-#line 7233 "MachineIndependent/glslang_tab.cpp"
+#line 7264 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 194: /* storage_qualifier: QUEUEFAMILYCOHERENT  */
-#line 1585 "MachineIndependent/glslang.y"
+#line 1616 "MachineIndependent/glslang.y"
                           {
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         parseContext.requireExtensions((yyvsp[0].lex).loc, 1, &E_GL_KHR_memory_scope_semantics, "queuefamilycoherent");
         (yyval.interm.type).qualifier.queuefamilycoherent = true;
     }
-#line 7243 "MachineIndependent/glslang_tab.cpp"
+#line 7274 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 195: /* storage_qualifier: WORKGROUPCOHERENT  */
-#line 1590 "MachineIndependent/glslang.y"
+#line 1621 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         parseContext.requireExtensions((yyvsp[0].lex).loc, 1, &E_GL_KHR_memory_scope_semantics, "workgroupcoherent");
         (yyval.interm.type).qualifier.workgroupcoherent = true;
     }
-#line 7253 "MachineIndependent/glslang_tab.cpp"
+#line 7284 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 196: /* storage_qualifier: SUBGROUPCOHERENT  */
-#line 1595 "MachineIndependent/glslang.y"
+#line 1626 "MachineIndependent/glslang.y"
                        {
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         parseContext.requireExtensions((yyvsp[0].lex).loc, 1, &E_GL_KHR_memory_scope_semantics, "subgroupcoherent");
         (yyval.interm.type).qualifier.subgroupcoherent = true;
     }
-#line 7263 "MachineIndependent/glslang_tab.cpp"
+#line 7294 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 197: /* storage_qualifier: NONPRIVATE  */
-#line 1600 "MachineIndependent/glslang.y"
+#line 1631 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         parseContext.requireExtensions((yyvsp[0].lex).loc, 1, &E_GL_KHR_memory_scope_semantics, "nonprivate");
         (yyval.interm.type).qualifier.nonprivate = true;
     }
-#line 7273 "MachineIndependent/glslang_tab.cpp"
+#line 7304 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 198: /* storage_qualifier: SHADERCALLCOHERENT  */
-#line 1605 "MachineIndependent/glslang.y"
+#line 1636 "MachineIndependent/glslang.y"
                          {
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         parseContext.requireExtensions((yyvsp[0].lex).loc, 1, &E_GL_EXT_ray_tracing, "shadercallcoherent");
         (yyval.interm.type).qualifier.shadercallcoherent = true;
     }
-#line 7283 "MachineIndependent/glslang_tab.cpp"
+#line 7314 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 199: /* storage_qualifier: VOLATILE  */
-#line 1610 "MachineIndependent/glslang.y"
+#line 1641 "MachineIndependent/glslang.y"
                {
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.volatil = true;
     }
-#line 7292 "MachineIndependent/glslang_tab.cpp"
+#line 7323 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 200: /* storage_qualifier: RESTRICT  */
-#line 1614 "MachineIndependent/glslang.y"
+#line 1645 "MachineIndependent/glslang.y"
                {
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.restrict = true;
     }
-#line 7301 "MachineIndependent/glslang_tab.cpp"
+#line 7332 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 201: /* storage_qualifier: READONLY  */
-#line 1618 "MachineIndependent/glslang.y"
+#line 1649 "MachineIndependent/glslang.y"
                {
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.readonly = true;
     }
-#line 7310 "MachineIndependent/glslang_tab.cpp"
+#line 7341 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 202: /* storage_qualifier: WRITEONLY  */
-#line 1622 "MachineIndependent/glslang.y"
+#line 1653 "MachineIndependent/glslang.y"
                 {
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.writeonly = true;
     }
-#line 7319 "MachineIndependent/glslang_tab.cpp"
+#line 7350 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 203: /* storage_qualifier: SUBROUTINE  */
-#line 1626 "MachineIndependent/glslang.y"
+#line 1657 "MachineIndependent/glslang.y"
                  {
         parseContext.spvRemoved((yyvsp[0].lex).loc, "subroutine");
         parseContext.globalCheck((yyvsp[0].lex).loc, "subroutine");
         parseContext.unimplemented((yyvsp[0].lex).loc, "subroutine");
         (yyval.interm.type).init((yyvsp[0].lex).loc);
     }
-#line 7330 "MachineIndependent/glslang_tab.cpp"
+#line 7361 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 204: /* storage_qualifier: SUBROUTINE LEFT_PAREN type_name_list RIGHT_PAREN  */
-#line 1632 "MachineIndependent/glslang.y"
+#line 1663 "MachineIndependent/glslang.y"
                                                        {
         parseContext.spvRemoved((yyvsp[-3].lex).loc, "subroutine");
         parseContext.globalCheck((yyvsp[-3].lex).loc, "subroutine");
         parseContext.unimplemented((yyvsp[-3].lex).loc, "subroutine");
         (yyval.interm.type).init((yyvsp[-3].lex).loc);
     }
-#line 7341 "MachineIndependent/glslang_tab.cpp"
+#line 7372 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 205: /* storage_qualifier: TASKPAYLOADWORKGROUPEXT  */
-#line 1638 "MachineIndependent/glslang.y"
+#line 1669 "MachineIndependent/glslang.y"
                               {
         // No need for profile version or extension check. Shader stage already checks both.
         parseContext.globalCheck((yyvsp[0].lex).loc, "taskPayloadSharedEXT");
@@ -7349,38 +7380,38 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqtaskPayloadSharedEXT;
     }
-#line 7353 "MachineIndependent/glslang_tab.cpp"
+#line 7384 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 206: /* non_uniform_qualifier: NONUNIFORM  */
-#line 1648 "MachineIndependent/glslang.y"
+#line 1679 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc);
         (yyval.interm.type).qualifier.nonUniform = true;
     }
-#line 7362 "MachineIndependent/glslang_tab.cpp"
+#line 7393 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 207: /* type_name_list: IDENTIFIER  */
-#line 1655 "MachineIndependent/glslang.y"
+#line 1686 "MachineIndependent/glslang.y"
                  {
         // TODO
     }
-#line 7370 "MachineIndependent/glslang_tab.cpp"
+#line 7401 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 208: /* type_name_list: type_name_list COMMA IDENTIFIER  */
-#line 1658 "MachineIndependent/glslang.y"
+#line 1689 "MachineIndependent/glslang.y"
                                       {
         // TODO: 4.0 semantics: subroutines
         // 1) make sure each identifier is a type declared earlier with SUBROUTINE
         // 2) save all of the identifiers for future comparison with the declared function
     }
-#line 7380 "MachineIndependent/glslang_tab.cpp"
+#line 7411 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 209: /* type_specifier: type_specifier_nonarray type_parameter_specifier_opt  */
-#line 1666 "MachineIndependent/glslang.y"
+#line 1697 "MachineIndependent/glslang.y"
                                                            {
         (yyval.interm.type) = (yyvsp[-1].interm.type);
         (yyval.interm.type).qualifier.precision = parseContext.getDefaultPrecision((yyval.interm.type));
@@ -7388,11 +7419,11 @@ yyreduce:
         parseContext.coopMatTypeParametersCheck((yyvsp[-1].interm.type).loc, (yyval.interm.type));
 
     }
-#line 7392 "MachineIndependent/glslang_tab.cpp"
+#line 7423 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 210: /* type_specifier: type_specifier_nonarray type_parameter_specifier_opt array_specifier  */
-#line 1673 "MachineIndependent/glslang.y"
+#line 1704 "MachineIndependent/glslang.y"
                                                                            {
         parseContext.arrayOfArrayVersionCheck((yyvsp[0].interm).loc, (yyvsp[0].interm).arraySizes);
         (yyval.interm.type) = (yyvsp[-2].interm.type);
@@ -7401,21 +7432,21 @@ yyreduce:
         (yyval.interm.type).arraySizes = (yyvsp[0].interm).arraySizes;
         parseContext.coopMatTypeParametersCheck((yyvsp[-2].interm.type).loc, (yyval.interm.type));
     }
-#line 7405 "MachineIndependent/glslang_tab.cpp"
+#line 7436 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 211: /* array_specifier: LEFT_BRACKET RIGHT_BRACKET  */
-#line 1684 "MachineIndependent/glslang.y"
+#line 1715 "MachineIndependent/glslang.y"
                                  {
         (yyval.interm).loc = (yyvsp[-1].lex).loc;
         (yyval.interm).arraySizes = new TArraySizes;
         (yyval.interm).arraySizes->addInnerSize();
     }
-#line 7415 "MachineIndependent/glslang_tab.cpp"
+#line 7446 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 212: /* array_specifier: LEFT_BRACKET conditional_expression RIGHT_BRACKET  */
-#line 1689 "MachineIndependent/glslang.y"
+#line 1720 "MachineIndependent/glslang.y"
                                                         {
         (yyval.interm).loc = (yyvsp[-2].lex).loc;
         (yyval.interm).arraySizes = new TArraySizes;
@@ -7424,20 +7455,20 @@ yyreduce:
         parseContext.arraySizeCheck((yyvsp[-1].interm.intermTypedNode)->getLoc(), (yyvsp[-1].interm.intermTypedNode), size, "array size");
         (yyval.interm).arraySizes->addInnerSize(size);
     }
-#line 7428 "MachineIndependent/glslang_tab.cpp"
+#line 7459 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 213: /* array_specifier: array_specifier LEFT_BRACKET RIGHT_BRACKET  */
-#line 1697 "MachineIndependent/glslang.y"
+#line 1728 "MachineIndependent/glslang.y"
                                                  {
         (yyval.interm) = (yyvsp[-2].interm);
         (yyval.interm).arraySizes->addInnerSize();
     }
-#line 7437 "MachineIndependent/glslang_tab.cpp"
+#line 7468 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 214: /* array_specifier: array_specifier LEFT_BRACKET conditional_expression RIGHT_BRACKET  */
-#line 1701 "MachineIndependent/glslang.y"
+#line 1732 "MachineIndependent/glslang.y"
                                                                         {
         (yyval.interm) = (yyvsp[-3].interm);
 
@@ -7445,45 +7476,45 @@ yyreduce:
         parseContext.arraySizeCheck((yyvsp[-1].interm.intermTypedNode)->getLoc(), (yyvsp[-1].interm.intermTypedNode), size, "array size");
         (yyval.interm).arraySizes->addInnerSize(size);
     }
-#line 7449 "MachineIndependent/glslang_tab.cpp"
+#line 7480 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 215: /* type_parameter_specifier_opt: type_parameter_specifier  */
-#line 1711 "MachineIndependent/glslang.y"
+#line 1742 "MachineIndependent/glslang.y"
                                {
         (yyval.interm.typeParameters) = (yyvsp[0].interm.typeParameters);
     }
-#line 7457 "MachineIndependent/glslang_tab.cpp"
+#line 7488 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 216: /* type_parameter_specifier_opt: %empty  */
-#line 1714 "MachineIndependent/glslang.y"
+#line 1745 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.typeParameters) = 0;
     }
-#line 7465 "MachineIndependent/glslang_tab.cpp"
+#line 7496 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 217: /* type_parameter_specifier: LEFT_ANGLE type_parameter_specifier_list RIGHT_ANGLE  */
-#line 1720 "MachineIndependent/glslang.y"
+#line 1751 "MachineIndependent/glslang.y"
                                                            {
         (yyval.interm.typeParameters) = (yyvsp[-1].interm.typeParameters);
     }
-#line 7473 "MachineIndependent/glslang_tab.cpp"
+#line 7504 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 218: /* type_parameter_specifier_list: type_specifier  */
-#line 1726 "MachineIndependent/glslang.y"
+#line 1757 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.typeParameters) = new TTypeParameters;
         (yyval.interm.typeParameters)->arraySizes = new TArraySizes;
         (yyval.interm.typeParameters)->basicType = (yyvsp[0].interm.type).basicType;
     }
-#line 7483 "MachineIndependent/glslang_tab.cpp"
+#line 7514 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 219: /* type_parameter_specifier_list: unary_expression  */
-#line 1731 "MachineIndependent/glslang.y"
+#line 1762 "MachineIndependent/glslang.y"
                        {
         (yyval.interm.typeParameters) = new TTypeParameters;
         (yyval.interm.typeParameters)->arraySizes = new TArraySizes;
@@ -7492,11 +7523,11 @@ yyreduce:
         parseContext.arraySizeCheck((yyvsp[0].interm.intermTypedNode)->getLoc(), (yyvsp[0].interm.intermTypedNode), size, "type parameter", true);
         (yyval.interm.typeParameters)->arraySizes->addInnerSize(size);
     }
-#line 7496 "MachineIndependent/glslang_tab.cpp"
+#line 7527 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 220: /* type_parameter_specifier_list: type_parameter_specifier_list COMMA unary_expression  */
-#line 1739 "MachineIndependent/glslang.y"
+#line 1770 "MachineIndependent/glslang.y"
                                                            {
         (yyval.interm.typeParameters) = (yyvsp[-2].interm.typeParameters);
 
@@ -7504,300 +7535,300 @@ yyreduce:
         parseContext.arraySizeCheck((yyvsp[0].interm.intermTypedNode)->getLoc(), (yyvsp[0].interm.intermTypedNode), size, "type parameter", true);
         (yyval.interm.typeParameters)->arraySizes->addInnerSize(size);
     }
-#line 7508 "MachineIndependent/glslang_tab.cpp"
+#line 7539 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 221: /* type_specifier_nonarray: VOID  */
-#line 1749 "MachineIndependent/glslang.y"
+#line 1780 "MachineIndependent/glslang.y"
            {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtVoid;
     }
-#line 7517 "MachineIndependent/glslang_tab.cpp"
+#line 7548 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 222: /* type_specifier_nonarray: FLOAT  */
-#line 1753 "MachineIndependent/glslang.y"
+#line 1784 "MachineIndependent/glslang.y"
             {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
     }
-#line 7526 "MachineIndependent/glslang_tab.cpp"
+#line 7557 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 223: /* type_specifier_nonarray: INT  */
-#line 1757 "MachineIndependent/glslang.y"
+#line 1788 "MachineIndependent/glslang.y"
           {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt;
     }
-#line 7535 "MachineIndependent/glslang_tab.cpp"
+#line 7566 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 224: /* type_specifier_nonarray: UINT  */
-#line 1761 "MachineIndependent/glslang.y"
+#line 1792 "MachineIndependent/glslang.y"
            {
         parseContext.fullIntegerCheck((yyvsp[0].lex).loc, "unsigned integer");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint;
     }
-#line 7545 "MachineIndependent/glslang_tab.cpp"
+#line 7576 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 225: /* type_specifier_nonarray: BOOL  */
-#line 1766 "MachineIndependent/glslang.y"
+#line 1797 "MachineIndependent/glslang.y"
            {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtBool;
     }
-#line 7554 "MachineIndependent/glslang_tab.cpp"
+#line 7585 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 226: /* type_specifier_nonarray: VEC2  */
-#line 1770 "MachineIndependent/glslang.y"
+#line 1801 "MachineIndependent/glslang.y"
            {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setVector(2);
     }
-#line 7564 "MachineIndependent/glslang_tab.cpp"
+#line 7595 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 227: /* type_specifier_nonarray: VEC3  */
-#line 1775 "MachineIndependent/glslang.y"
+#line 1806 "MachineIndependent/glslang.y"
            {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setVector(3);
     }
-#line 7574 "MachineIndependent/glslang_tab.cpp"
+#line 7605 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 228: /* type_specifier_nonarray: VEC4  */
-#line 1780 "MachineIndependent/glslang.y"
+#line 1811 "MachineIndependent/glslang.y"
            {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setVector(4);
     }
-#line 7584 "MachineIndependent/glslang_tab.cpp"
+#line 7615 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 229: /* type_specifier_nonarray: BVEC2  */
-#line 1785 "MachineIndependent/glslang.y"
+#line 1816 "MachineIndependent/glslang.y"
             {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtBool;
         (yyval.interm.type).setVector(2);
     }
-#line 7594 "MachineIndependent/glslang_tab.cpp"
+#line 7625 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 230: /* type_specifier_nonarray: BVEC3  */
-#line 1790 "MachineIndependent/glslang.y"
+#line 1821 "MachineIndependent/glslang.y"
             {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtBool;
         (yyval.interm.type).setVector(3);
     }
-#line 7604 "MachineIndependent/glslang_tab.cpp"
+#line 7635 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 231: /* type_specifier_nonarray: BVEC4  */
-#line 1795 "MachineIndependent/glslang.y"
+#line 1826 "MachineIndependent/glslang.y"
             {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtBool;
         (yyval.interm.type).setVector(4);
     }
-#line 7614 "MachineIndependent/glslang_tab.cpp"
+#line 7645 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 232: /* type_specifier_nonarray: IVEC2  */
-#line 1800 "MachineIndependent/glslang.y"
+#line 1831 "MachineIndependent/glslang.y"
             {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt;
-        (yyval.interm.type).setVector(2);
-    }
-#line 7624 "MachineIndependent/glslang_tab.cpp"
-    break;
-
-  case 233: /* type_specifier_nonarray: IVEC3  */
-#line 1805 "MachineIndependent/glslang.y"
-            {
-        (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
-        (yyval.interm.type).basicType = EbtInt;
-        (yyval.interm.type).setVector(3);
-    }
-#line 7634 "MachineIndependent/glslang_tab.cpp"
-    break;
-
-  case 234: /* type_specifier_nonarray: IVEC4  */
-#line 1810 "MachineIndependent/glslang.y"
-            {
-        (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
-        (yyval.interm.type).basicType = EbtInt;
-        (yyval.interm.type).setVector(4);
-    }
-#line 7644 "MachineIndependent/glslang_tab.cpp"
-    break;
-
-  case 235: /* type_specifier_nonarray: UVEC2  */
-#line 1815 "MachineIndependent/glslang.y"
-            {
-        parseContext.fullIntegerCheck((yyvsp[0].lex).loc, "unsigned integer vector");
-        (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
-        (yyval.interm.type).basicType = EbtUint;
         (yyval.interm.type).setVector(2);
     }
 #line 7655 "MachineIndependent/glslang_tab.cpp"
     break;
 
+  case 233: /* type_specifier_nonarray: IVEC3  */
+#line 1836 "MachineIndependent/glslang.y"
+            {
+        (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
+        (yyval.interm.type).basicType = EbtInt;
+        (yyval.interm.type).setVector(3);
+    }
+#line 7665 "MachineIndependent/glslang_tab.cpp"
+    break;
+
+  case 234: /* type_specifier_nonarray: IVEC4  */
+#line 1841 "MachineIndependent/glslang.y"
+            {
+        (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
+        (yyval.interm.type).basicType = EbtInt;
+        (yyval.interm.type).setVector(4);
+    }
+#line 7675 "MachineIndependent/glslang_tab.cpp"
+    break;
+
+  case 235: /* type_specifier_nonarray: UVEC2  */
+#line 1846 "MachineIndependent/glslang.y"
+            {
+        parseContext.fullIntegerCheck((yyvsp[0].lex).loc, "unsigned integer vector");
+        (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
+        (yyval.interm.type).basicType = EbtUint;
+        (yyval.interm.type).setVector(2);
+    }
+#line 7686 "MachineIndependent/glslang_tab.cpp"
+    break;
+
   case 236: /* type_specifier_nonarray: UVEC3  */
-#line 1821 "MachineIndependent/glslang.y"
+#line 1852 "MachineIndependent/glslang.y"
             {
         parseContext.fullIntegerCheck((yyvsp[0].lex).loc, "unsigned integer vector");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint;
         (yyval.interm.type).setVector(3);
     }
-#line 7666 "MachineIndependent/glslang_tab.cpp"
+#line 7697 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 237: /* type_specifier_nonarray: UVEC4  */
-#line 1827 "MachineIndependent/glslang.y"
+#line 1858 "MachineIndependent/glslang.y"
             {
         parseContext.fullIntegerCheck((yyvsp[0].lex).loc, "unsigned integer vector");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint;
         (yyval.interm.type).setVector(4);
     }
-#line 7677 "MachineIndependent/glslang_tab.cpp"
+#line 7708 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 238: /* type_specifier_nonarray: MAT2  */
-#line 1833 "MachineIndependent/glslang.y"
+#line 1864 "MachineIndependent/glslang.y"
            {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(2, 2);
     }
-#line 7687 "MachineIndependent/glslang_tab.cpp"
+#line 7718 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 239: /* type_specifier_nonarray: MAT3  */
-#line 1838 "MachineIndependent/glslang.y"
+#line 1869 "MachineIndependent/glslang.y"
            {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(3, 3);
     }
-#line 7697 "MachineIndependent/glslang_tab.cpp"
+#line 7728 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 240: /* type_specifier_nonarray: MAT4  */
-#line 1843 "MachineIndependent/glslang.y"
+#line 1874 "MachineIndependent/glslang.y"
            {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(4, 4);
     }
-#line 7707 "MachineIndependent/glslang_tab.cpp"
+#line 7738 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 241: /* type_specifier_nonarray: MAT2X2  */
-#line 1848 "MachineIndependent/glslang.y"
+#line 1879 "MachineIndependent/glslang.y"
              {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(2, 2);
     }
-#line 7717 "MachineIndependent/glslang_tab.cpp"
+#line 7748 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 242: /* type_specifier_nonarray: MAT2X3  */
-#line 1853 "MachineIndependent/glslang.y"
+#line 1884 "MachineIndependent/glslang.y"
              {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(2, 3);
     }
-#line 7727 "MachineIndependent/glslang_tab.cpp"
+#line 7758 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 243: /* type_specifier_nonarray: MAT2X4  */
-#line 1858 "MachineIndependent/glslang.y"
+#line 1889 "MachineIndependent/glslang.y"
              {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(2, 4);
     }
-#line 7737 "MachineIndependent/glslang_tab.cpp"
+#line 7768 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 244: /* type_specifier_nonarray: MAT3X2  */
-#line 1863 "MachineIndependent/glslang.y"
+#line 1894 "MachineIndependent/glslang.y"
              {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(3, 2);
     }
-#line 7747 "MachineIndependent/glslang_tab.cpp"
+#line 7778 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 245: /* type_specifier_nonarray: MAT3X3  */
-#line 1868 "MachineIndependent/glslang.y"
+#line 1899 "MachineIndependent/glslang.y"
              {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(3, 3);
     }
-#line 7757 "MachineIndependent/glslang_tab.cpp"
+#line 7788 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 246: /* type_specifier_nonarray: MAT3X4  */
-#line 1873 "MachineIndependent/glslang.y"
+#line 1904 "MachineIndependent/glslang.y"
              {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(3, 4);
     }
-#line 7767 "MachineIndependent/glslang_tab.cpp"
+#line 7798 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 247: /* type_specifier_nonarray: MAT4X2  */
-#line 1878 "MachineIndependent/glslang.y"
+#line 1909 "MachineIndependent/glslang.y"
              {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(4, 2);
     }
-#line 7777 "MachineIndependent/glslang_tab.cpp"
+#line 7808 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 248: /* type_specifier_nonarray: MAT4X3  */
-#line 1883 "MachineIndependent/glslang.y"
+#line 1914 "MachineIndependent/glslang.y"
              {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(4, 3);
     }
-#line 7787 "MachineIndependent/glslang_tab.cpp"
+#line 7818 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 249: /* type_specifier_nonarray: MAT4X4  */
-#line 1888 "MachineIndependent/glslang.y"
+#line 1919 "MachineIndependent/glslang.y"
              {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(4, 4);
     }
-#line 7797 "MachineIndependent/glslang_tab.cpp"
+#line 7828 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 250: /* type_specifier_nonarray: DOUBLE  */
-#line 1893 "MachineIndependent/glslang.y"
+#line 1924 "MachineIndependent/glslang.y"
              {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -7805,121 +7836,121 @@ yyreduce:
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
     }
-#line 7809 "MachineIndependent/glslang_tab.cpp"
+#line 7840 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 251: /* type_specifier_nonarray: FLOAT16_T  */
-#line 1900 "MachineIndependent/glslang.y"
+#line 1931 "MachineIndependent/glslang.y"
                 {
         parseContext.float16ScalarVectorCheck((yyvsp[0].lex).loc, "float16_t", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
     }
-#line 7819 "MachineIndependent/glslang_tab.cpp"
+#line 7850 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 252: /* type_specifier_nonarray: FLOAT32_T  */
-#line 1905 "MachineIndependent/glslang.y"
+#line 1936 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
     }
-#line 7829 "MachineIndependent/glslang_tab.cpp"
+#line 7860 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 253: /* type_specifier_nonarray: FLOAT64_T  */
-#line 1910 "MachineIndependent/glslang.y"
+#line 1941 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
     }
-#line 7839 "MachineIndependent/glslang_tab.cpp"
+#line 7870 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 254: /* type_specifier_nonarray: INT8_T  */
-#line 1915 "MachineIndependent/glslang.y"
+#line 1946 "MachineIndependent/glslang.y"
              {
         parseContext.int8ScalarVectorCheck((yyvsp[0].lex).loc, "8-bit signed integer", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt8;
     }
-#line 7849 "MachineIndependent/glslang_tab.cpp"
+#line 7880 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 255: /* type_specifier_nonarray: UINT8_T  */
-#line 1920 "MachineIndependent/glslang.y"
+#line 1951 "MachineIndependent/glslang.y"
               {
         parseContext.int8ScalarVectorCheck((yyvsp[0].lex).loc, "8-bit unsigned integer", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint8;
     }
-#line 7859 "MachineIndependent/glslang_tab.cpp"
+#line 7890 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 256: /* type_specifier_nonarray: INT16_T  */
-#line 1925 "MachineIndependent/glslang.y"
+#line 1956 "MachineIndependent/glslang.y"
               {
         parseContext.int16ScalarVectorCheck((yyvsp[0].lex).loc, "16-bit signed integer", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt16;
     }
-#line 7869 "MachineIndependent/glslang_tab.cpp"
+#line 7900 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 257: /* type_specifier_nonarray: UINT16_T  */
-#line 1930 "MachineIndependent/glslang.y"
+#line 1961 "MachineIndependent/glslang.y"
                {
         parseContext.int16ScalarVectorCheck((yyvsp[0].lex).loc, "16-bit unsigned integer", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint16;
     }
-#line 7879 "MachineIndependent/glslang_tab.cpp"
+#line 7910 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 258: /* type_specifier_nonarray: INT32_T  */
-#line 1935 "MachineIndependent/glslang.y"
+#line 1966 "MachineIndependent/glslang.y"
               {
         parseContext.explicitInt32Check((yyvsp[0].lex).loc, "32-bit signed integer", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt;
     }
-#line 7889 "MachineIndependent/glslang_tab.cpp"
+#line 7920 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 259: /* type_specifier_nonarray: UINT32_T  */
-#line 1940 "MachineIndependent/glslang.y"
+#line 1971 "MachineIndependent/glslang.y"
                {
         parseContext.explicitInt32Check((yyvsp[0].lex).loc, "32-bit unsigned integer", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint;
     }
-#line 7899 "MachineIndependent/glslang_tab.cpp"
+#line 7930 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 260: /* type_specifier_nonarray: INT64_T  */
-#line 1945 "MachineIndependent/glslang.y"
+#line 1976 "MachineIndependent/glslang.y"
               {
         parseContext.int64Check((yyvsp[0].lex).loc, "64-bit integer", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt64;
     }
-#line 7909 "MachineIndependent/glslang_tab.cpp"
+#line 7940 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 261: /* type_specifier_nonarray: UINT64_T  */
-#line 1950 "MachineIndependent/glslang.y"
+#line 1981 "MachineIndependent/glslang.y"
                {
         parseContext.int64Check((yyvsp[0].lex).loc, "64-bit unsigned integer", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint64;
     }
-#line 7919 "MachineIndependent/glslang_tab.cpp"
+#line 7950 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 262: /* type_specifier_nonarray: DVEC2  */
-#line 1955 "MachineIndependent/glslang.y"
+#line 1986 "MachineIndependent/glslang.y"
             {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double vector");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -7928,11 +7959,11 @@ yyreduce:
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setVector(2);
     }
-#line 7932 "MachineIndependent/glslang_tab.cpp"
+#line 7963 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 263: /* type_specifier_nonarray: DVEC3  */
-#line 1963 "MachineIndependent/glslang.y"
+#line 1994 "MachineIndependent/glslang.y"
             {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double vector");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -7941,11 +7972,11 @@ yyreduce:
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setVector(3);
     }
-#line 7945 "MachineIndependent/glslang_tab.cpp"
+#line 7976 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 264: /* type_specifier_nonarray: DVEC4  */
-#line 1971 "MachineIndependent/glslang.y"
+#line 2002 "MachineIndependent/glslang.y"
             {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double vector");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -7954,374 +7985,374 @@ yyreduce:
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setVector(4);
     }
-#line 7958 "MachineIndependent/glslang_tab.cpp"
+#line 7989 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 265: /* type_specifier_nonarray: F16VEC2  */
-#line 1979 "MachineIndependent/glslang.y"
+#line 2010 "MachineIndependent/glslang.y"
               {
         parseContext.float16ScalarVectorCheck((yyvsp[0].lex).loc, "half float vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
         (yyval.interm.type).setVector(2);
     }
-#line 7969 "MachineIndependent/glslang_tab.cpp"
+#line 8000 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 266: /* type_specifier_nonarray: F16VEC3  */
-#line 1985 "MachineIndependent/glslang.y"
+#line 2016 "MachineIndependent/glslang.y"
               {
         parseContext.float16ScalarVectorCheck((yyvsp[0].lex).loc, "half float vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
         (yyval.interm.type).setVector(3);
     }
-#line 7980 "MachineIndependent/glslang_tab.cpp"
+#line 8011 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 267: /* type_specifier_nonarray: F16VEC4  */
-#line 1991 "MachineIndependent/glslang.y"
+#line 2022 "MachineIndependent/glslang.y"
               {
         parseContext.float16ScalarVectorCheck((yyvsp[0].lex).loc, "half float vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
         (yyval.interm.type).setVector(4);
     }
-#line 7991 "MachineIndependent/glslang_tab.cpp"
+#line 8022 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 268: /* type_specifier_nonarray: F32VEC2  */
-#line 1997 "MachineIndependent/glslang.y"
+#line 2028 "MachineIndependent/glslang.y"
               {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setVector(2);
     }
-#line 8002 "MachineIndependent/glslang_tab.cpp"
+#line 8033 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 269: /* type_specifier_nonarray: F32VEC3  */
-#line 2003 "MachineIndependent/glslang.y"
+#line 2034 "MachineIndependent/glslang.y"
               {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setVector(3);
     }
-#line 8013 "MachineIndependent/glslang_tab.cpp"
+#line 8044 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 270: /* type_specifier_nonarray: F32VEC4  */
-#line 2009 "MachineIndependent/glslang.y"
+#line 2040 "MachineIndependent/glslang.y"
               {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setVector(4);
     }
-#line 8024 "MachineIndependent/glslang_tab.cpp"
+#line 8055 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 271: /* type_specifier_nonarray: F64VEC2  */
-#line 2015 "MachineIndependent/glslang.y"
+#line 2046 "MachineIndependent/glslang.y"
               {
         parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setVector(2);
     }
-#line 8035 "MachineIndependent/glslang_tab.cpp"
+#line 8066 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 272: /* type_specifier_nonarray: F64VEC3  */
-#line 2021 "MachineIndependent/glslang.y"
+#line 2052 "MachineIndependent/glslang.y"
               {
         parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setVector(3);
     }
-#line 8046 "MachineIndependent/glslang_tab.cpp"
+#line 8077 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 273: /* type_specifier_nonarray: F64VEC4  */
-#line 2027 "MachineIndependent/glslang.y"
+#line 2058 "MachineIndependent/glslang.y"
               {
         parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setVector(4);
     }
-#line 8057 "MachineIndependent/glslang_tab.cpp"
+#line 8088 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 274: /* type_specifier_nonarray: I8VEC2  */
-#line 2033 "MachineIndependent/glslang.y"
+#line 2064 "MachineIndependent/glslang.y"
              {
         parseContext.int8ScalarVectorCheck((yyvsp[0].lex).loc, "8-bit signed integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt8;
         (yyval.interm.type).setVector(2);
     }
-#line 8068 "MachineIndependent/glslang_tab.cpp"
+#line 8099 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 275: /* type_specifier_nonarray: I8VEC3  */
-#line 2039 "MachineIndependent/glslang.y"
+#line 2070 "MachineIndependent/glslang.y"
              {
         parseContext.int8ScalarVectorCheck((yyvsp[0].lex).loc, "8-bit signed integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt8;
         (yyval.interm.type).setVector(3);
     }
-#line 8079 "MachineIndependent/glslang_tab.cpp"
+#line 8110 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 276: /* type_specifier_nonarray: I8VEC4  */
-#line 2045 "MachineIndependent/glslang.y"
+#line 2076 "MachineIndependent/glslang.y"
              {
         parseContext.int8ScalarVectorCheck((yyvsp[0].lex).loc, "8-bit signed integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt8;
         (yyval.interm.type).setVector(4);
     }
-#line 8090 "MachineIndependent/glslang_tab.cpp"
+#line 8121 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 277: /* type_specifier_nonarray: I16VEC2  */
-#line 2051 "MachineIndependent/glslang.y"
+#line 2082 "MachineIndependent/glslang.y"
               {
         parseContext.int16ScalarVectorCheck((yyvsp[0].lex).loc, "16-bit signed integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt16;
         (yyval.interm.type).setVector(2);
     }
-#line 8101 "MachineIndependent/glslang_tab.cpp"
+#line 8132 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 278: /* type_specifier_nonarray: I16VEC3  */
-#line 2057 "MachineIndependent/glslang.y"
+#line 2088 "MachineIndependent/glslang.y"
               {
         parseContext.int16ScalarVectorCheck((yyvsp[0].lex).loc, "16-bit signed integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt16;
         (yyval.interm.type).setVector(3);
     }
-#line 8112 "MachineIndependent/glslang_tab.cpp"
+#line 8143 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 279: /* type_specifier_nonarray: I16VEC4  */
-#line 2063 "MachineIndependent/glslang.y"
+#line 2094 "MachineIndependent/glslang.y"
               {
         parseContext.int16ScalarVectorCheck((yyvsp[0].lex).loc, "16-bit signed integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt16;
         (yyval.interm.type).setVector(4);
     }
-#line 8123 "MachineIndependent/glslang_tab.cpp"
+#line 8154 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 280: /* type_specifier_nonarray: I32VEC2  */
-#line 2069 "MachineIndependent/glslang.y"
+#line 2100 "MachineIndependent/glslang.y"
               {
         parseContext.explicitInt32Check((yyvsp[0].lex).loc, "32-bit signed integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt;
         (yyval.interm.type).setVector(2);
     }
-#line 8134 "MachineIndependent/glslang_tab.cpp"
+#line 8165 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 281: /* type_specifier_nonarray: I32VEC3  */
-#line 2075 "MachineIndependent/glslang.y"
+#line 2106 "MachineIndependent/glslang.y"
               {
         parseContext.explicitInt32Check((yyvsp[0].lex).loc, "32-bit signed integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt;
         (yyval.interm.type).setVector(3);
     }
-#line 8145 "MachineIndependent/glslang_tab.cpp"
+#line 8176 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 282: /* type_specifier_nonarray: I32VEC4  */
-#line 2081 "MachineIndependent/glslang.y"
+#line 2112 "MachineIndependent/glslang.y"
               {
         parseContext.explicitInt32Check((yyvsp[0].lex).loc, "32-bit signed integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt;
         (yyval.interm.type).setVector(4);
     }
-#line 8156 "MachineIndependent/glslang_tab.cpp"
+#line 8187 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 283: /* type_specifier_nonarray: I64VEC2  */
-#line 2087 "MachineIndependent/glslang.y"
+#line 2118 "MachineIndependent/glslang.y"
               {
         parseContext.int64Check((yyvsp[0].lex).loc, "64-bit integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt64;
         (yyval.interm.type).setVector(2);
     }
-#line 8167 "MachineIndependent/glslang_tab.cpp"
+#line 8198 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 284: /* type_specifier_nonarray: I64VEC3  */
-#line 2093 "MachineIndependent/glslang.y"
+#line 2124 "MachineIndependent/glslang.y"
               {
         parseContext.int64Check((yyvsp[0].lex).loc, "64-bit integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt64;
         (yyval.interm.type).setVector(3);
     }
-#line 8178 "MachineIndependent/glslang_tab.cpp"
+#line 8209 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 285: /* type_specifier_nonarray: I64VEC4  */
-#line 2099 "MachineIndependent/glslang.y"
+#line 2130 "MachineIndependent/glslang.y"
               {
         parseContext.int64Check((yyvsp[0].lex).loc, "64-bit integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtInt64;
         (yyval.interm.type).setVector(4);
     }
-#line 8189 "MachineIndependent/glslang_tab.cpp"
+#line 8220 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 286: /* type_specifier_nonarray: U8VEC2  */
-#line 2105 "MachineIndependent/glslang.y"
+#line 2136 "MachineIndependent/glslang.y"
              {
         parseContext.int8ScalarVectorCheck((yyvsp[0].lex).loc, "8-bit unsigned integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint8;
         (yyval.interm.type).setVector(2);
     }
-#line 8200 "MachineIndependent/glslang_tab.cpp"
+#line 8231 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 287: /* type_specifier_nonarray: U8VEC3  */
-#line 2111 "MachineIndependent/glslang.y"
+#line 2142 "MachineIndependent/glslang.y"
              {
         parseContext.int8ScalarVectorCheck((yyvsp[0].lex).loc, "8-bit unsigned integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint8;
         (yyval.interm.type).setVector(3);
     }
-#line 8211 "MachineIndependent/glslang_tab.cpp"
+#line 8242 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 288: /* type_specifier_nonarray: U8VEC4  */
-#line 2117 "MachineIndependent/glslang.y"
+#line 2148 "MachineIndependent/glslang.y"
              {
         parseContext.int8ScalarVectorCheck((yyvsp[0].lex).loc, "8-bit unsigned integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint8;
         (yyval.interm.type).setVector(4);
     }
-#line 8222 "MachineIndependent/glslang_tab.cpp"
+#line 8253 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 289: /* type_specifier_nonarray: U16VEC2  */
-#line 2123 "MachineIndependent/glslang.y"
+#line 2154 "MachineIndependent/glslang.y"
               {
         parseContext.int16ScalarVectorCheck((yyvsp[0].lex).loc, "16-bit unsigned integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint16;
         (yyval.interm.type).setVector(2);
     }
-#line 8233 "MachineIndependent/glslang_tab.cpp"
+#line 8264 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 290: /* type_specifier_nonarray: U16VEC3  */
-#line 2129 "MachineIndependent/glslang.y"
+#line 2160 "MachineIndependent/glslang.y"
               {
         parseContext.int16ScalarVectorCheck((yyvsp[0].lex).loc, "16-bit unsigned integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint16;
         (yyval.interm.type).setVector(3);
     }
-#line 8244 "MachineIndependent/glslang_tab.cpp"
+#line 8275 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 291: /* type_specifier_nonarray: U16VEC4  */
-#line 2135 "MachineIndependent/glslang.y"
+#line 2166 "MachineIndependent/glslang.y"
               {
         parseContext.int16ScalarVectorCheck((yyvsp[0].lex).loc, "16-bit unsigned integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint16;
         (yyval.interm.type).setVector(4);
     }
-#line 8255 "MachineIndependent/glslang_tab.cpp"
+#line 8286 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 292: /* type_specifier_nonarray: U32VEC2  */
-#line 2141 "MachineIndependent/glslang.y"
+#line 2172 "MachineIndependent/glslang.y"
               {
         parseContext.explicitInt32Check((yyvsp[0].lex).loc, "32-bit unsigned integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint;
         (yyval.interm.type).setVector(2);
     }
-#line 8266 "MachineIndependent/glslang_tab.cpp"
+#line 8297 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 293: /* type_specifier_nonarray: U32VEC3  */
-#line 2147 "MachineIndependent/glslang.y"
+#line 2178 "MachineIndependent/glslang.y"
               {
         parseContext.explicitInt32Check((yyvsp[0].lex).loc, "32-bit unsigned integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint;
         (yyval.interm.type).setVector(3);
     }
-#line 8277 "MachineIndependent/glslang_tab.cpp"
+#line 8308 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 294: /* type_specifier_nonarray: U32VEC4  */
-#line 2153 "MachineIndependent/glslang.y"
+#line 2184 "MachineIndependent/glslang.y"
               {
         parseContext.explicitInt32Check((yyvsp[0].lex).loc, "32-bit unsigned integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint;
         (yyval.interm.type).setVector(4);
     }
-#line 8288 "MachineIndependent/glslang_tab.cpp"
+#line 8319 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 295: /* type_specifier_nonarray: U64VEC2  */
-#line 2159 "MachineIndependent/glslang.y"
+#line 2190 "MachineIndependent/glslang.y"
               {
         parseContext.int64Check((yyvsp[0].lex).loc, "64-bit unsigned integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint64;
         (yyval.interm.type).setVector(2);
     }
-#line 8299 "MachineIndependent/glslang_tab.cpp"
+#line 8330 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 296: /* type_specifier_nonarray: U64VEC3  */
-#line 2165 "MachineIndependent/glslang.y"
+#line 2196 "MachineIndependent/glslang.y"
               {
         parseContext.int64Check((yyvsp[0].lex).loc, "64-bit unsigned integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint64;
         (yyval.interm.type).setVector(3);
     }
-#line 8310 "MachineIndependent/glslang_tab.cpp"
+#line 8341 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 297: /* type_specifier_nonarray: U64VEC4  */
-#line 2171 "MachineIndependent/glslang.y"
+#line 2202 "MachineIndependent/glslang.y"
               {
         parseContext.int64Check((yyvsp[0].lex).loc, "64-bit unsigned integer vector", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtUint64;
         (yyval.interm.type).setVector(4);
     }
-#line 8321 "MachineIndependent/glslang_tab.cpp"
+#line 8352 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 298: /* type_specifier_nonarray: DMAT2  */
-#line 2177 "MachineIndependent/glslang.y"
+#line 2208 "MachineIndependent/glslang.y"
             {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -8330,11 +8361,11 @@ yyreduce:
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 2);
     }
-#line 8334 "MachineIndependent/glslang_tab.cpp"
+#line 8365 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 299: /* type_specifier_nonarray: DMAT3  */
-#line 2185 "MachineIndependent/glslang.y"
+#line 2216 "MachineIndependent/glslang.y"
             {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -8343,11 +8374,11 @@ yyreduce:
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 3);
     }
-#line 8347 "MachineIndependent/glslang_tab.cpp"
+#line 8378 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 300: /* type_specifier_nonarray: DMAT4  */
-#line 2193 "MachineIndependent/glslang.y"
+#line 2224 "MachineIndependent/glslang.y"
             {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -8356,11 +8387,11 @@ yyreduce:
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(4, 4);
     }
-#line 8360 "MachineIndependent/glslang_tab.cpp"
+#line 8391 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 301: /* type_specifier_nonarray: DMAT2X2  */
-#line 2201 "MachineIndependent/glslang.y"
+#line 2232 "MachineIndependent/glslang.y"
               {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -8369,11 +8400,11 @@ yyreduce:
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 2);
     }
-#line 8373 "MachineIndependent/glslang_tab.cpp"
+#line 8404 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 302: /* type_specifier_nonarray: DMAT2X3  */
-#line 2209 "MachineIndependent/glslang.y"
+#line 2240 "MachineIndependent/glslang.y"
               {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -8382,11 +8413,11 @@ yyreduce:
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 3);
     }
-#line 8386 "MachineIndependent/glslang_tab.cpp"
+#line 8417 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 303: /* type_specifier_nonarray: DMAT2X4  */
-#line 2217 "MachineIndependent/glslang.y"
+#line 2248 "MachineIndependent/glslang.y"
               {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -8395,11 +8426,11 @@ yyreduce:
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 4);
     }
-#line 8399 "MachineIndependent/glslang_tab.cpp"
+#line 8430 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 304: /* type_specifier_nonarray: DMAT3X2  */
-#line 2225 "MachineIndependent/glslang.y"
+#line 2256 "MachineIndependent/glslang.y"
               {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -8408,11 +8439,11 @@ yyreduce:
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 2);
     }
-#line 8412 "MachineIndependent/glslang_tab.cpp"
+#line 8443 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 305: /* type_specifier_nonarray: DMAT3X3  */
-#line 2233 "MachineIndependent/glslang.y"
+#line 2264 "MachineIndependent/glslang.y"
               {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -8421,11 +8452,11 @@ yyreduce:
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 3);
     }
-#line 8425 "MachineIndependent/glslang_tab.cpp"
+#line 8456 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 306: /* type_specifier_nonarray: DMAT3X4  */
-#line 2241 "MachineIndependent/glslang.y"
+#line 2272 "MachineIndependent/glslang.y"
               {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -8434,11 +8465,11 @@ yyreduce:
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 4);
     }
-#line 8438 "MachineIndependent/glslang_tab.cpp"
+#line 8469 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 307: /* type_specifier_nonarray: DMAT4X2  */
-#line 2249 "MachineIndependent/glslang.y"
+#line 2280 "MachineIndependent/glslang.y"
               {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -8447,11 +8478,11 @@ yyreduce:
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(4, 2);
     }
-#line 8451 "MachineIndependent/glslang_tab.cpp"
+#line 8482 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 308: /* type_specifier_nonarray: DMAT4X3  */
-#line 2257 "MachineIndependent/glslang.y"
+#line 2288 "MachineIndependent/glslang.y"
               {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -8460,11 +8491,11 @@ yyreduce:
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(4, 3);
     }
-#line 8464 "MachineIndependent/glslang_tab.cpp"
+#line 8495 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 309: /* type_specifier_nonarray: DMAT4X4  */
-#line 2265 "MachineIndependent/glslang.y"
+#line 2296 "MachineIndependent/glslang.y"
               {
         parseContext.requireProfile((yyvsp[0].lex).loc, ECoreProfile | ECompatibilityProfile, "double matrix");
         if (! parseContext.symbolTable.atBuiltInLevel())
@@ -8473,2261 +8504,2261 @@ yyreduce:
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(4, 4);
     }
-#line 8477 "MachineIndependent/glslang_tab.cpp"
+#line 8508 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 310: /* type_specifier_nonarray: F16MAT2  */
-#line 2273 "MachineIndependent/glslang.y"
+#line 2304 "MachineIndependent/glslang.y"
               {
         parseContext.float16Check((yyvsp[0].lex).loc, "half float matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
         (yyval.interm.type).setMatrix(2, 2);
     }
-#line 8488 "MachineIndependent/glslang_tab.cpp"
+#line 8519 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 311: /* type_specifier_nonarray: F16MAT3  */
-#line 2279 "MachineIndependent/glslang.y"
+#line 2310 "MachineIndependent/glslang.y"
               {
         parseContext.float16Check((yyvsp[0].lex).loc, "half float matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
         (yyval.interm.type).setMatrix(3, 3);
     }
-#line 8499 "MachineIndependent/glslang_tab.cpp"
+#line 8530 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 312: /* type_specifier_nonarray: F16MAT4  */
-#line 2285 "MachineIndependent/glslang.y"
+#line 2316 "MachineIndependent/glslang.y"
               {
         parseContext.float16Check((yyvsp[0].lex).loc, "half float matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
         (yyval.interm.type).setMatrix(4, 4);
     }
-#line 8510 "MachineIndependent/glslang_tab.cpp"
+#line 8541 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 313: /* type_specifier_nonarray: F16MAT2X2  */
-#line 2291 "MachineIndependent/glslang.y"
+#line 2322 "MachineIndependent/glslang.y"
                 {
         parseContext.float16Check((yyvsp[0].lex).loc, "half float matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
         (yyval.interm.type).setMatrix(2, 2);
     }
-#line 8521 "MachineIndependent/glslang_tab.cpp"
+#line 8552 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 314: /* type_specifier_nonarray: F16MAT2X3  */
-#line 2297 "MachineIndependent/glslang.y"
+#line 2328 "MachineIndependent/glslang.y"
                 {
         parseContext.float16Check((yyvsp[0].lex).loc, "half float matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
         (yyval.interm.type).setMatrix(2, 3);
     }
-#line 8532 "MachineIndependent/glslang_tab.cpp"
+#line 8563 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 315: /* type_specifier_nonarray: F16MAT2X4  */
-#line 2303 "MachineIndependent/glslang.y"
+#line 2334 "MachineIndependent/glslang.y"
                 {
         parseContext.float16Check((yyvsp[0].lex).loc, "half float matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
         (yyval.interm.type).setMatrix(2, 4);
     }
-#line 8543 "MachineIndependent/glslang_tab.cpp"
+#line 8574 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 316: /* type_specifier_nonarray: F16MAT3X2  */
-#line 2309 "MachineIndependent/glslang.y"
+#line 2340 "MachineIndependent/glslang.y"
                 {
         parseContext.float16Check((yyvsp[0].lex).loc, "half float matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
         (yyval.interm.type).setMatrix(3, 2);
     }
-#line 8554 "MachineIndependent/glslang_tab.cpp"
+#line 8585 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 317: /* type_specifier_nonarray: F16MAT3X3  */
-#line 2315 "MachineIndependent/glslang.y"
+#line 2346 "MachineIndependent/glslang.y"
                 {
         parseContext.float16Check((yyvsp[0].lex).loc, "half float matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
         (yyval.interm.type).setMatrix(3, 3);
     }
-#line 8565 "MachineIndependent/glslang_tab.cpp"
+#line 8596 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 318: /* type_specifier_nonarray: F16MAT3X4  */
-#line 2321 "MachineIndependent/glslang.y"
+#line 2352 "MachineIndependent/glslang.y"
                 {
         parseContext.float16Check((yyvsp[0].lex).loc, "half float matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
         (yyval.interm.type).setMatrix(3, 4);
     }
-#line 8576 "MachineIndependent/glslang_tab.cpp"
+#line 8607 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 319: /* type_specifier_nonarray: F16MAT4X2  */
-#line 2327 "MachineIndependent/glslang.y"
+#line 2358 "MachineIndependent/glslang.y"
                 {
         parseContext.float16Check((yyvsp[0].lex).loc, "half float matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
         (yyval.interm.type).setMatrix(4, 2);
     }
-#line 8587 "MachineIndependent/glslang_tab.cpp"
+#line 8618 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 320: /* type_specifier_nonarray: F16MAT4X3  */
-#line 2333 "MachineIndependent/glslang.y"
+#line 2364 "MachineIndependent/glslang.y"
                 {
         parseContext.float16Check((yyvsp[0].lex).loc, "half float matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
         (yyval.interm.type).setMatrix(4, 3);
     }
-#line 8598 "MachineIndependent/glslang_tab.cpp"
+#line 8629 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 321: /* type_specifier_nonarray: F16MAT4X4  */
-#line 2339 "MachineIndependent/glslang.y"
+#line 2370 "MachineIndependent/glslang.y"
                 {
         parseContext.float16Check((yyvsp[0].lex).loc, "half float matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat16;
         (yyval.interm.type).setMatrix(4, 4);
     }
-#line 8609 "MachineIndependent/glslang_tab.cpp"
+#line 8640 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 322: /* type_specifier_nonarray: F32MAT2  */
-#line 2345 "MachineIndependent/glslang.y"
+#line 2376 "MachineIndependent/glslang.y"
               {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(2, 2);
     }
-#line 8620 "MachineIndependent/glslang_tab.cpp"
+#line 8651 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 323: /* type_specifier_nonarray: F32MAT3  */
-#line 2351 "MachineIndependent/glslang.y"
+#line 2382 "MachineIndependent/glslang.y"
               {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(3, 3);
     }
-#line 8631 "MachineIndependent/glslang_tab.cpp"
+#line 8662 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 324: /* type_specifier_nonarray: F32MAT4  */
-#line 2357 "MachineIndependent/glslang.y"
+#line 2388 "MachineIndependent/glslang.y"
               {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(4, 4);
     }
-#line 8642 "MachineIndependent/glslang_tab.cpp"
+#line 8673 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 325: /* type_specifier_nonarray: F32MAT2X2  */
-#line 2363 "MachineIndependent/glslang.y"
+#line 2394 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(2, 2);
     }
-#line 8653 "MachineIndependent/glslang_tab.cpp"
+#line 8684 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 326: /* type_specifier_nonarray: F32MAT2X3  */
-#line 2369 "MachineIndependent/glslang.y"
+#line 2400 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(2, 3);
     }
-#line 8664 "MachineIndependent/glslang_tab.cpp"
+#line 8695 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 327: /* type_specifier_nonarray: F32MAT2X4  */
-#line 2375 "MachineIndependent/glslang.y"
+#line 2406 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(2, 4);
     }
-#line 8675 "MachineIndependent/glslang_tab.cpp"
+#line 8706 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 328: /* type_specifier_nonarray: F32MAT3X2  */
-#line 2381 "MachineIndependent/glslang.y"
+#line 2412 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(3, 2);
     }
-#line 8686 "MachineIndependent/glslang_tab.cpp"
+#line 8717 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 329: /* type_specifier_nonarray: F32MAT3X3  */
-#line 2387 "MachineIndependent/glslang.y"
+#line 2418 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(3, 3);
     }
-#line 8697 "MachineIndependent/glslang_tab.cpp"
+#line 8728 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 330: /* type_specifier_nonarray: F32MAT3X4  */
-#line 2393 "MachineIndependent/glslang.y"
+#line 2424 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(3, 4);
     }
-#line 8708 "MachineIndependent/glslang_tab.cpp"
+#line 8739 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 331: /* type_specifier_nonarray: F32MAT4X2  */
-#line 2399 "MachineIndependent/glslang.y"
+#line 2430 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(4, 2);
     }
-#line 8719 "MachineIndependent/glslang_tab.cpp"
+#line 8750 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 332: /* type_specifier_nonarray: F32MAT4X3  */
-#line 2405 "MachineIndependent/glslang.y"
+#line 2436 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(4, 3);
     }
-#line 8730 "MachineIndependent/glslang_tab.cpp"
+#line 8761 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 333: /* type_specifier_nonarray: F32MAT4X4  */
-#line 2411 "MachineIndependent/glslang.y"
+#line 2442 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat32Check((yyvsp[0].lex).loc, "float32_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtFloat;
         (yyval.interm.type).setMatrix(4, 4);
     }
-#line 8741 "MachineIndependent/glslang_tab.cpp"
+#line 8772 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 334: /* type_specifier_nonarray: F64MAT2  */
-#line 2417 "MachineIndependent/glslang.y"
+#line 2448 "MachineIndependent/glslang.y"
               {
         parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 2);
     }
-#line 8752 "MachineIndependent/glslang_tab.cpp"
+#line 8783 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 335: /* type_specifier_nonarray: F64MAT3  */
-#line 2423 "MachineIndependent/glslang.y"
+#line 2454 "MachineIndependent/glslang.y"
               {
         parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 3);
     }
-#line 8763 "MachineIndependent/glslang_tab.cpp"
+#line 8794 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 336: /* type_specifier_nonarray: F64MAT4  */
-#line 2429 "MachineIndependent/glslang.y"
+#line 2460 "MachineIndependent/glslang.y"
               {
         parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(4, 4);
     }
-#line 8774 "MachineIndependent/glslang_tab.cpp"
+#line 8805 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 337: /* type_specifier_nonarray: F64MAT2X2  */
-#line 2435 "MachineIndependent/glslang.y"
+#line 2466 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 2);
     }
-#line 8785 "MachineIndependent/glslang_tab.cpp"
+#line 8816 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 338: /* type_specifier_nonarray: F64MAT2X3  */
-#line 2441 "MachineIndependent/glslang.y"
+#line 2472 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 3);
     }
-#line 8796 "MachineIndependent/glslang_tab.cpp"
+#line 8827 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 339: /* type_specifier_nonarray: F64MAT2X4  */
-#line 2447 "MachineIndependent/glslang.y"
+#line 2478 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(2, 4);
     }
-#line 8807 "MachineIndependent/glslang_tab.cpp"
+#line 8838 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 340: /* type_specifier_nonarray: F64MAT3X2  */
-#line 2453 "MachineIndependent/glslang.y"
+#line 2484 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 2);
     }
-#line 8818 "MachineIndependent/glslang_tab.cpp"
+#line 8849 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 341: /* type_specifier_nonarray: F64MAT3X3  */
-#line 2459 "MachineIndependent/glslang.y"
+#line 2490 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 3);
     }
-#line 8829 "MachineIndependent/glslang_tab.cpp"
+#line 8860 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 342: /* type_specifier_nonarray: F64MAT3X4  */
-#line 2465 "MachineIndependent/glslang.y"
+#line 2496 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(3, 4);
     }
-#line 8840 "MachineIndependent/glslang_tab.cpp"
+#line 8871 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 343: /* type_specifier_nonarray: F64MAT4X2  */
-#line 2471 "MachineIndependent/glslang.y"
+#line 2502 "MachineIndependent/glslang.y"
                 {
         parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t matrix", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtDouble;
         (yyval.interm.type).setMatrix(4, 2);
-    }
-#line 8851 "MachineIndependent/glslang_tab.cpp"
-    break;
-
-  case 344: /* type_specifier_nonarray: F64MAT4X3  */
-#line 2477 "MachineIndependent/glslang.y"
-                {
-        parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t matrix", parseContext.symbolTable.atBuiltInLevel());
-        (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
-        (yyval.interm.type).basicType = EbtDouble;
-        (yyval.interm.type).setMatrix(4, 3);
-    }
-#line 8862 "MachineIndependent/glslang_tab.cpp"
-    break;
-
-  case 345: /* type_specifier_nonarray: F64MAT4X4  */
-#line 2483 "MachineIndependent/glslang.y"
-                {
-        parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t matrix", parseContext.symbolTable.atBuiltInLevel());
-        (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
-        (yyval.interm.type).basicType = EbtDouble;
-        (yyval.interm.type).setMatrix(4, 4);
-    }
-#line 8873 "MachineIndependent/glslang_tab.cpp"
-    break;
-
-  case 346: /* type_specifier_nonarray: ACCSTRUCTNV  */
-#line 2489 "MachineIndependent/glslang.y"
-                  {
-       (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
-       (yyval.interm.type).basicType = EbtAccStruct;
     }
 #line 8882 "MachineIndependent/glslang_tab.cpp"
     break;
 
+  case 344: /* type_specifier_nonarray: F64MAT4X3  */
+#line 2508 "MachineIndependent/glslang.y"
+                {
+        parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t matrix", parseContext.symbolTable.atBuiltInLevel());
+        (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
+        (yyval.interm.type).basicType = EbtDouble;
+        (yyval.interm.type).setMatrix(4, 3);
+    }
+#line 8893 "MachineIndependent/glslang_tab.cpp"
+    break;
+
+  case 345: /* type_specifier_nonarray: F64MAT4X4  */
+#line 2514 "MachineIndependent/glslang.y"
+                {
+        parseContext.explicitFloat64Check((yyvsp[0].lex).loc, "float64_t matrix", parseContext.symbolTable.atBuiltInLevel());
+        (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
+        (yyval.interm.type).basicType = EbtDouble;
+        (yyval.interm.type).setMatrix(4, 4);
+    }
+#line 8904 "MachineIndependent/glslang_tab.cpp"
+    break;
+
+  case 346: /* type_specifier_nonarray: ACCSTRUCTNV  */
+#line 2520 "MachineIndependent/glslang.y"
+                  {
+       (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
+       (yyval.interm.type).basicType = EbtAccStruct;
+    }
+#line 8913 "MachineIndependent/glslang_tab.cpp"
+    break;
+
   case 347: /* type_specifier_nonarray: ACCSTRUCTEXT  */
-#line 2493 "MachineIndependent/glslang.y"
+#line 2524 "MachineIndependent/glslang.y"
                    {
        (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
        (yyval.interm.type).basicType = EbtAccStruct;
     }
-#line 8891 "MachineIndependent/glslang_tab.cpp"
+#line 8922 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 348: /* type_specifier_nonarray: RAYQUERYEXT  */
-#line 2497 "MachineIndependent/glslang.y"
+#line 2528 "MachineIndependent/glslang.y"
                   {
        (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
        (yyval.interm.type).basicType = EbtRayQuery;
     }
-#line 8900 "MachineIndependent/glslang_tab.cpp"
+#line 8931 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 349: /* type_specifier_nonarray: ATOMIC_UINT  */
-#line 2501 "MachineIndependent/glslang.y"
+#line 2532 "MachineIndependent/glslang.y"
                   {
         parseContext.vulkanRemoved((yyvsp[0].lex).loc, "atomic counter types");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtAtomicUint;
     }
-#line 8910 "MachineIndependent/glslang_tab.cpp"
+#line 8941 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 350: /* type_specifier_nonarray: SAMPLER1D  */
-#line 2506 "MachineIndependent/glslang.y"
+#line 2537 "MachineIndependent/glslang.y"
                 {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, Esd1D);
     }
-#line 8920 "MachineIndependent/glslang_tab.cpp"
+#line 8951 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 351: /* type_specifier_nonarray: SAMPLER2D  */
-#line 2511 "MachineIndependent/glslang.y"
+#line 2542 "MachineIndependent/glslang.y"
                 {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, Esd2D);
     }
-#line 8930 "MachineIndependent/glslang_tab.cpp"
+#line 8961 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 352: /* type_specifier_nonarray: SAMPLER3D  */
-#line 2516 "MachineIndependent/glslang.y"
+#line 2547 "MachineIndependent/glslang.y"
                 {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, Esd3D);
     }
-#line 8940 "MachineIndependent/glslang_tab.cpp"
+#line 8971 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 353: /* type_specifier_nonarray: SAMPLERCUBE  */
-#line 2521 "MachineIndependent/glslang.y"
+#line 2552 "MachineIndependent/glslang.y"
                   {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, EsdCube);
     }
-#line 8950 "MachineIndependent/glslang_tab.cpp"
+#line 8981 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 354: /* type_specifier_nonarray: SAMPLER2DSHADOW  */
-#line 2526 "MachineIndependent/glslang.y"
+#line 2557 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, Esd2D, false, true);
     }
-#line 8960 "MachineIndependent/glslang_tab.cpp"
+#line 8991 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 355: /* type_specifier_nonarray: SAMPLERCUBESHADOW  */
-#line 2531 "MachineIndependent/glslang.y"
+#line 2562 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, EsdCube, false, true);
     }
-#line 8970 "MachineIndependent/glslang_tab.cpp"
+#line 9001 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 356: /* type_specifier_nonarray: SAMPLER2DARRAY  */
-#line 2536 "MachineIndependent/glslang.y"
+#line 2567 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, Esd2D, true);
     }
-#line 8980 "MachineIndependent/glslang_tab.cpp"
+#line 9011 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 357: /* type_specifier_nonarray: SAMPLER2DARRAYSHADOW  */
-#line 2541 "MachineIndependent/glslang.y"
+#line 2572 "MachineIndependent/glslang.y"
                            {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, Esd2D, true, true);
     }
-#line 8990 "MachineIndependent/glslang_tab.cpp"
+#line 9021 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 358: /* type_specifier_nonarray: SAMPLER1DSHADOW  */
-#line 2546 "MachineIndependent/glslang.y"
+#line 2577 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, Esd1D, false, true);
     }
-#line 9000 "MachineIndependent/glslang_tab.cpp"
+#line 9031 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 359: /* type_specifier_nonarray: SAMPLER1DARRAY  */
-#line 2551 "MachineIndependent/glslang.y"
+#line 2582 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, Esd1D, true);
     }
-#line 9010 "MachineIndependent/glslang_tab.cpp"
+#line 9041 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 360: /* type_specifier_nonarray: SAMPLER1DARRAYSHADOW  */
-#line 2556 "MachineIndependent/glslang.y"
+#line 2587 "MachineIndependent/glslang.y"
                            {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, Esd1D, true, true);
     }
-#line 9020 "MachineIndependent/glslang_tab.cpp"
+#line 9051 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 361: /* type_specifier_nonarray: SAMPLERCUBEARRAY  */
-#line 2561 "MachineIndependent/glslang.y"
+#line 2592 "MachineIndependent/glslang.y"
                        {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, EsdCube, true);
     }
-#line 9030 "MachineIndependent/glslang_tab.cpp"
+#line 9061 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 362: /* type_specifier_nonarray: SAMPLERCUBEARRAYSHADOW  */
-#line 2566 "MachineIndependent/glslang.y"
+#line 2597 "MachineIndependent/glslang.y"
                              {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, EsdCube, true, true);
     }
-#line 9040 "MachineIndependent/glslang_tab.cpp"
+#line 9071 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 363: /* type_specifier_nonarray: F16SAMPLER1D  */
-#line 2571 "MachineIndependent/glslang.y"
+#line 2602 "MachineIndependent/glslang.y"
                    {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, Esd1D);
     }
-#line 9051 "MachineIndependent/glslang_tab.cpp"
+#line 9082 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 364: /* type_specifier_nonarray: F16SAMPLER2D  */
-#line 2577 "MachineIndependent/glslang.y"
+#line 2608 "MachineIndependent/glslang.y"
                    {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, Esd2D);
     }
-#line 9062 "MachineIndependent/glslang_tab.cpp"
+#line 9093 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 365: /* type_specifier_nonarray: F16SAMPLER3D  */
-#line 2583 "MachineIndependent/glslang.y"
+#line 2614 "MachineIndependent/glslang.y"
                    {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, Esd3D);
     }
-#line 9073 "MachineIndependent/glslang_tab.cpp"
+#line 9104 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 366: /* type_specifier_nonarray: F16SAMPLERCUBE  */
-#line 2589 "MachineIndependent/glslang.y"
+#line 2620 "MachineIndependent/glslang.y"
                      {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, EsdCube);
     }
-#line 9084 "MachineIndependent/glslang_tab.cpp"
+#line 9115 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 367: /* type_specifier_nonarray: F16SAMPLER1DSHADOW  */
-#line 2595 "MachineIndependent/glslang.y"
+#line 2626 "MachineIndependent/glslang.y"
                          {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, Esd1D, false, true);
     }
-#line 9095 "MachineIndependent/glslang_tab.cpp"
+#line 9126 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 368: /* type_specifier_nonarray: F16SAMPLER2DSHADOW  */
-#line 2601 "MachineIndependent/glslang.y"
+#line 2632 "MachineIndependent/glslang.y"
                          {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, Esd2D, false, true);
     }
-#line 9106 "MachineIndependent/glslang_tab.cpp"
+#line 9137 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 369: /* type_specifier_nonarray: F16SAMPLERCUBESHADOW  */
-#line 2607 "MachineIndependent/glslang.y"
+#line 2638 "MachineIndependent/glslang.y"
                            {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, EsdCube, false, true);
     }
-#line 9117 "MachineIndependent/glslang_tab.cpp"
+#line 9148 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 370: /* type_specifier_nonarray: F16SAMPLER1DARRAY  */
-#line 2613 "MachineIndependent/glslang.y"
+#line 2644 "MachineIndependent/glslang.y"
                         {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, Esd1D, true);
     }
-#line 9128 "MachineIndependent/glslang_tab.cpp"
+#line 9159 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 371: /* type_specifier_nonarray: F16SAMPLER2DARRAY  */
-#line 2619 "MachineIndependent/glslang.y"
+#line 2650 "MachineIndependent/glslang.y"
                         {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, Esd2D, true);
     }
-#line 9139 "MachineIndependent/glslang_tab.cpp"
+#line 9170 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 372: /* type_specifier_nonarray: F16SAMPLER1DARRAYSHADOW  */
-#line 2625 "MachineIndependent/glslang.y"
+#line 2656 "MachineIndependent/glslang.y"
                               {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, Esd1D, true, true);
     }
-#line 9150 "MachineIndependent/glslang_tab.cpp"
+#line 9181 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 373: /* type_specifier_nonarray: F16SAMPLER2DARRAYSHADOW  */
-#line 2631 "MachineIndependent/glslang.y"
+#line 2662 "MachineIndependent/glslang.y"
                               {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, Esd2D, true, true);
     }
-#line 9161 "MachineIndependent/glslang_tab.cpp"
+#line 9192 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 374: /* type_specifier_nonarray: F16SAMPLERCUBEARRAY  */
-#line 2637 "MachineIndependent/glslang.y"
+#line 2668 "MachineIndependent/glslang.y"
                           {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, EsdCube, true);
     }
-#line 9172 "MachineIndependent/glslang_tab.cpp"
+#line 9203 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 375: /* type_specifier_nonarray: F16SAMPLERCUBEARRAYSHADOW  */
-#line 2643 "MachineIndependent/glslang.y"
+#line 2674 "MachineIndependent/glslang.y"
                                 {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, EsdCube, true, true);
     }
-#line 9183 "MachineIndependent/glslang_tab.cpp"
+#line 9214 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 376: /* type_specifier_nonarray: ISAMPLER1D  */
-#line 2649 "MachineIndependent/glslang.y"
+#line 2680 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtInt, Esd1D);
     }
-#line 9193 "MachineIndependent/glslang_tab.cpp"
+#line 9224 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 377: /* type_specifier_nonarray: ISAMPLER2D  */
-#line 2654 "MachineIndependent/glslang.y"
+#line 2685 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtInt, Esd2D);
     }
-#line 9203 "MachineIndependent/glslang_tab.cpp"
+#line 9234 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 378: /* type_specifier_nonarray: ISAMPLER3D  */
-#line 2659 "MachineIndependent/glslang.y"
+#line 2690 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtInt, Esd3D);
     }
-#line 9213 "MachineIndependent/glslang_tab.cpp"
+#line 9244 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 379: /* type_specifier_nonarray: ISAMPLERCUBE  */
-#line 2664 "MachineIndependent/glslang.y"
+#line 2695 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtInt, EsdCube);
     }
-#line 9223 "MachineIndependent/glslang_tab.cpp"
+#line 9254 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 380: /* type_specifier_nonarray: ISAMPLER2DARRAY  */
-#line 2669 "MachineIndependent/glslang.y"
+#line 2700 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtInt, Esd2D, true);
     }
-#line 9233 "MachineIndependent/glslang_tab.cpp"
+#line 9264 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 381: /* type_specifier_nonarray: USAMPLER2D  */
-#line 2674 "MachineIndependent/glslang.y"
+#line 2705 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtUint, Esd2D);
     }
-#line 9243 "MachineIndependent/glslang_tab.cpp"
+#line 9274 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 382: /* type_specifier_nonarray: USAMPLER3D  */
-#line 2679 "MachineIndependent/glslang.y"
+#line 2710 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtUint, Esd3D);
     }
-#line 9253 "MachineIndependent/glslang_tab.cpp"
+#line 9284 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 383: /* type_specifier_nonarray: USAMPLERCUBE  */
-#line 2684 "MachineIndependent/glslang.y"
+#line 2715 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtUint, EsdCube);
     }
-#line 9263 "MachineIndependent/glslang_tab.cpp"
+#line 9294 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 384: /* type_specifier_nonarray: ISAMPLER1DARRAY  */
-#line 2689 "MachineIndependent/glslang.y"
+#line 2720 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtInt, Esd1D, true);
     }
-#line 9273 "MachineIndependent/glslang_tab.cpp"
+#line 9304 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 385: /* type_specifier_nonarray: ISAMPLERCUBEARRAY  */
-#line 2694 "MachineIndependent/glslang.y"
+#line 2725 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtInt, EsdCube, true);
     }
-#line 9283 "MachineIndependent/glslang_tab.cpp"
+#line 9314 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 386: /* type_specifier_nonarray: USAMPLER1D  */
-#line 2699 "MachineIndependent/glslang.y"
+#line 2730 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtUint, Esd1D);
     }
-#line 9293 "MachineIndependent/glslang_tab.cpp"
+#line 9324 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 387: /* type_specifier_nonarray: USAMPLER1DARRAY  */
-#line 2704 "MachineIndependent/glslang.y"
+#line 2735 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtUint, Esd1D, true);
     }
-#line 9303 "MachineIndependent/glslang_tab.cpp"
+#line 9334 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 388: /* type_specifier_nonarray: USAMPLERCUBEARRAY  */
-#line 2709 "MachineIndependent/glslang.y"
+#line 2740 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtUint, EsdCube, true);
     }
-#line 9313 "MachineIndependent/glslang_tab.cpp"
+#line 9344 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 389: /* type_specifier_nonarray: TEXTURECUBEARRAY  */
-#line 2714 "MachineIndependent/glslang.y"
+#line 2745 "MachineIndependent/glslang.y"
                        {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat, EsdCube, true);
     }
-#line 9323 "MachineIndependent/glslang_tab.cpp"
+#line 9354 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 390: /* type_specifier_nonarray: ITEXTURECUBEARRAY  */
-#line 2719 "MachineIndependent/glslang.y"
+#line 2750 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtInt, EsdCube, true);
     }
-#line 9333 "MachineIndependent/glslang_tab.cpp"
+#line 9364 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 391: /* type_specifier_nonarray: UTEXTURECUBEARRAY  */
-#line 2724 "MachineIndependent/glslang.y"
+#line 2755 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtUint, EsdCube, true);
     }
-#line 9343 "MachineIndependent/glslang_tab.cpp"
+#line 9374 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 392: /* type_specifier_nonarray: USAMPLER2DARRAY  */
-#line 2729 "MachineIndependent/glslang.y"
+#line 2760 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtUint, Esd2D, true);
     }
-#line 9353 "MachineIndependent/glslang_tab.cpp"
+#line 9384 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 393: /* type_specifier_nonarray: TEXTURE2D  */
-#line 2734 "MachineIndependent/glslang.y"
+#line 2765 "MachineIndependent/glslang.y"
                 {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat, Esd2D);
     }
-#line 9363 "MachineIndependent/glslang_tab.cpp"
+#line 9394 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 394: /* type_specifier_nonarray: TEXTURE3D  */
-#line 2739 "MachineIndependent/glslang.y"
+#line 2770 "MachineIndependent/glslang.y"
                 {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat, Esd3D);
     }
-#line 9373 "MachineIndependent/glslang_tab.cpp"
+#line 9404 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 395: /* type_specifier_nonarray: TEXTURE2DARRAY  */
-#line 2744 "MachineIndependent/glslang.y"
+#line 2775 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat, Esd2D, true);
     }
-#line 9383 "MachineIndependent/glslang_tab.cpp"
+#line 9414 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 396: /* type_specifier_nonarray: TEXTURECUBE  */
-#line 2749 "MachineIndependent/glslang.y"
+#line 2780 "MachineIndependent/glslang.y"
                   {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat, EsdCube);
     }
-#line 9393 "MachineIndependent/glslang_tab.cpp"
+#line 9424 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 397: /* type_specifier_nonarray: ITEXTURE2D  */
-#line 2754 "MachineIndependent/glslang.y"
+#line 2785 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtInt, Esd2D);
     }
-#line 9403 "MachineIndependent/glslang_tab.cpp"
+#line 9434 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 398: /* type_specifier_nonarray: ITEXTURE3D  */
-#line 2759 "MachineIndependent/glslang.y"
+#line 2790 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtInt, Esd3D);
     }
-#line 9413 "MachineIndependent/glslang_tab.cpp"
+#line 9444 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 399: /* type_specifier_nonarray: ITEXTURECUBE  */
-#line 2764 "MachineIndependent/glslang.y"
+#line 2795 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtInt, EsdCube);
     }
-#line 9423 "MachineIndependent/glslang_tab.cpp"
+#line 9454 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 400: /* type_specifier_nonarray: ITEXTURE2DARRAY  */
-#line 2769 "MachineIndependent/glslang.y"
+#line 2800 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtInt, Esd2D, true);
     }
-#line 9433 "MachineIndependent/glslang_tab.cpp"
+#line 9464 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 401: /* type_specifier_nonarray: UTEXTURE2D  */
-#line 2774 "MachineIndependent/glslang.y"
+#line 2805 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtUint, Esd2D);
     }
-#line 9443 "MachineIndependent/glslang_tab.cpp"
+#line 9474 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 402: /* type_specifier_nonarray: UTEXTURE3D  */
-#line 2779 "MachineIndependent/glslang.y"
+#line 2810 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtUint, Esd3D);
     }
-#line 9453 "MachineIndependent/glslang_tab.cpp"
+#line 9484 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 403: /* type_specifier_nonarray: UTEXTURECUBE  */
-#line 2784 "MachineIndependent/glslang.y"
+#line 2815 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtUint, EsdCube);
     }
-#line 9463 "MachineIndependent/glslang_tab.cpp"
+#line 9494 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 404: /* type_specifier_nonarray: UTEXTURE2DARRAY  */
-#line 2789 "MachineIndependent/glslang.y"
+#line 2820 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtUint, Esd2D, true);
     }
-#line 9473 "MachineIndependent/glslang_tab.cpp"
+#line 9504 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 405: /* type_specifier_nonarray: SAMPLER  */
-#line 2794 "MachineIndependent/glslang.y"
+#line 2825 "MachineIndependent/glslang.y"
               {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setPureSampler(false);
     }
-#line 9483 "MachineIndependent/glslang_tab.cpp"
+#line 9514 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 406: /* type_specifier_nonarray: SAMPLERSHADOW  */
-#line 2799 "MachineIndependent/glslang.y"
+#line 2830 "MachineIndependent/glslang.y"
                     {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setPureSampler(true);
     }
-#line 9493 "MachineIndependent/glslang_tab.cpp"
+#line 9524 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 407: /* type_specifier_nonarray: SAMPLER2DRECT  */
-#line 2804 "MachineIndependent/glslang.y"
+#line 2835 "MachineIndependent/glslang.y"
                     {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, EsdRect);
     }
-#line 9503 "MachineIndependent/glslang_tab.cpp"
+#line 9534 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 408: /* type_specifier_nonarray: SAMPLER2DRECTSHADOW  */
-#line 2809 "MachineIndependent/glslang.y"
+#line 2840 "MachineIndependent/glslang.y"
                           {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, EsdRect, false, true);
     }
-#line 9513 "MachineIndependent/glslang_tab.cpp"
+#line 9544 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 409: /* type_specifier_nonarray: F16SAMPLER2DRECT  */
-#line 2814 "MachineIndependent/glslang.y"
+#line 2845 "MachineIndependent/glslang.y"
                        {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, EsdRect);
     }
-#line 9524 "MachineIndependent/glslang_tab.cpp"
+#line 9555 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 410: /* type_specifier_nonarray: F16SAMPLER2DRECTSHADOW  */
-#line 2820 "MachineIndependent/glslang.y"
+#line 2851 "MachineIndependent/glslang.y"
                              {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, EsdRect, false, true);
     }
-#line 9535 "MachineIndependent/glslang_tab.cpp"
+#line 9566 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 411: /* type_specifier_nonarray: ISAMPLER2DRECT  */
-#line 2826 "MachineIndependent/glslang.y"
+#line 2857 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtInt, EsdRect);
     }
-#line 9545 "MachineIndependent/glslang_tab.cpp"
+#line 9576 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 412: /* type_specifier_nonarray: USAMPLER2DRECT  */
-#line 2831 "MachineIndependent/glslang.y"
+#line 2862 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtUint, EsdRect);
     }
-#line 9555 "MachineIndependent/glslang_tab.cpp"
+#line 9586 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 413: /* type_specifier_nonarray: SAMPLERBUFFER  */
-#line 2836 "MachineIndependent/glslang.y"
+#line 2867 "MachineIndependent/glslang.y"
                     {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, EsdBuffer);
     }
-#line 9565 "MachineIndependent/glslang_tab.cpp"
+#line 9596 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 414: /* type_specifier_nonarray: F16SAMPLERBUFFER  */
-#line 2841 "MachineIndependent/glslang.y"
+#line 2872 "MachineIndependent/glslang.y"
                        {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, EsdBuffer);
     }
-#line 9576 "MachineIndependent/glslang_tab.cpp"
+#line 9607 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 415: /* type_specifier_nonarray: ISAMPLERBUFFER  */
-#line 2847 "MachineIndependent/glslang.y"
+#line 2878 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtInt, EsdBuffer);
     }
-#line 9586 "MachineIndependent/glslang_tab.cpp"
+#line 9617 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 416: /* type_specifier_nonarray: USAMPLERBUFFER  */
-#line 2852 "MachineIndependent/glslang.y"
+#line 2883 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtUint, EsdBuffer);
     }
-#line 9596 "MachineIndependent/glslang_tab.cpp"
+#line 9627 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 417: /* type_specifier_nonarray: SAMPLER2DMS  */
-#line 2857 "MachineIndependent/glslang.y"
+#line 2888 "MachineIndependent/glslang.y"
                   {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, Esd2D, false, false, true);
     }
-#line 9606 "MachineIndependent/glslang_tab.cpp"
+#line 9637 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 418: /* type_specifier_nonarray: F16SAMPLER2DMS  */
-#line 2862 "MachineIndependent/glslang.y"
+#line 2893 "MachineIndependent/glslang.y"
                      {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, Esd2D, false, false, true);
     }
-#line 9617 "MachineIndependent/glslang_tab.cpp"
+#line 9648 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 419: /* type_specifier_nonarray: ISAMPLER2DMS  */
-#line 2868 "MachineIndependent/glslang.y"
+#line 2899 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtInt, Esd2D, false, false, true);
     }
-#line 9627 "MachineIndependent/glslang_tab.cpp"
+#line 9658 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 420: /* type_specifier_nonarray: USAMPLER2DMS  */
-#line 2873 "MachineIndependent/glslang.y"
+#line 2904 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtUint, Esd2D, false, false, true);
     }
-#line 9637 "MachineIndependent/glslang_tab.cpp"
+#line 9668 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 421: /* type_specifier_nonarray: SAMPLER2DMSARRAY  */
-#line 2878 "MachineIndependent/glslang.y"
+#line 2909 "MachineIndependent/glslang.y"
                        {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, Esd2D, true, false, true);
     }
-#line 9647 "MachineIndependent/glslang_tab.cpp"
+#line 9678 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 422: /* type_specifier_nonarray: F16SAMPLER2DMSARRAY  */
-#line 2883 "MachineIndependent/glslang.y"
+#line 2914 "MachineIndependent/glslang.y"
                           {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float sampler", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat16, Esd2D, true, false, true);
     }
-#line 9658 "MachineIndependent/glslang_tab.cpp"
+#line 9689 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 423: /* type_specifier_nonarray: ISAMPLER2DMSARRAY  */
-#line 2889 "MachineIndependent/glslang.y"
+#line 2920 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtInt, Esd2D, true, false, true);
     }
-#line 9668 "MachineIndependent/glslang_tab.cpp"
+#line 9699 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 424: /* type_specifier_nonarray: USAMPLER2DMSARRAY  */
-#line 2894 "MachineIndependent/glslang.y"
+#line 2925 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtUint, Esd2D, true, false, true);
     }
-#line 9678 "MachineIndependent/glslang_tab.cpp"
+#line 9709 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 425: /* type_specifier_nonarray: TEXTURE1D  */
-#line 2899 "MachineIndependent/glslang.y"
+#line 2930 "MachineIndependent/glslang.y"
                 {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat, Esd1D);
     }
-#line 9688 "MachineIndependent/glslang_tab.cpp"
+#line 9719 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 426: /* type_specifier_nonarray: F16TEXTURE1D  */
-#line 2904 "MachineIndependent/glslang.y"
+#line 2935 "MachineIndependent/glslang.y"
                    {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float texture", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat16, Esd1D);
     }
-#line 9699 "MachineIndependent/glslang_tab.cpp"
+#line 9730 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 427: /* type_specifier_nonarray: F16TEXTURE2D  */
-#line 2910 "MachineIndependent/glslang.y"
+#line 2941 "MachineIndependent/glslang.y"
                    {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float texture", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat16, Esd2D);
     }
-#line 9710 "MachineIndependent/glslang_tab.cpp"
+#line 9741 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 428: /* type_specifier_nonarray: F16TEXTURE3D  */
-#line 2916 "MachineIndependent/glslang.y"
+#line 2947 "MachineIndependent/glslang.y"
                    {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float texture", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat16, Esd3D);
     }
-#line 9721 "MachineIndependent/glslang_tab.cpp"
+#line 9752 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 429: /* type_specifier_nonarray: F16TEXTURECUBE  */
-#line 2922 "MachineIndependent/glslang.y"
+#line 2953 "MachineIndependent/glslang.y"
                      {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float texture", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat16, EsdCube);
     }
-#line 9732 "MachineIndependent/glslang_tab.cpp"
+#line 9763 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 430: /* type_specifier_nonarray: TEXTURE1DARRAY  */
-#line 2928 "MachineIndependent/glslang.y"
+#line 2959 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat, Esd1D, true);
     }
-#line 9742 "MachineIndependent/glslang_tab.cpp"
+#line 9773 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 431: /* type_specifier_nonarray: F16TEXTURE1DARRAY  */
-#line 2933 "MachineIndependent/glslang.y"
+#line 2964 "MachineIndependent/glslang.y"
                         {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float texture", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat16, Esd1D, true);
     }
-#line 9753 "MachineIndependent/glslang_tab.cpp"
+#line 9784 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 432: /* type_specifier_nonarray: F16TEXTURE2DARRAY  */
-#line 2939 "MachineIndependent/glslang.y"
+#line 2970 "MachineIndependent/glslang.y"
                         {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float texture", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat16, Esd2D, true);
     }
-#line 9764 "MachineIndependent/glslang_tab.cpp"
+#line 9795 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 433: /* type_specifier_nonarray: F16TEXTURECUBEARRAY  */
-#line 2945 "MachineIndependent/glslang.y"
+#line 2976 "MachineIndependent/glslang.y"
                           {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float texture", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat16, EsdCube, true);
     }
-#line 9775 "MachineIndependent/glslang_tab.cpp"
+#line 9806 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 434: /* type_specifier_nonarray: ITEXTURE1D  */
-#line 2951 "MachineIndependent/glslang.y"
+#line 2982 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtInt, Esd1D);
     }
-#line 9785 "MachineIndependent/glslang_tab.cpp"
+#line 9816 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 435: /* type_specifier_nonarray: ITEXTURE1DARRAY  */
-#line 2956 "MachineIndependent/glslang.y"
+#line 2987 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtInt, Esd1D, true);
     }
-#line 9795 "MachineIndependent/glslang_tab.cpp"
+#line 9826 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 436: /* type_specifier_nonarray: UTEXTURE1D  */
-#line 2961 "MachineIndependent/glslang.y"
+#line 2992 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtUint, Esd1D);
     }
-#line 9805 "MachineIndependent/glslang_tab.cpp"
+#line 9836 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 437: /* type_specifier_nonarray: UTEXTURE1DARRAY  */
-#line 2966 "MachineIndependent/glslang.y"
+#line 2997 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtUint, Esd1D, true);
     }
-#line 9815 "MachineIndependent/glslang_tab.cpp"
+#line 9846 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 438: /* type_specifier_nonarray: TEXTURE2DRECT  */
-#line 2971 "MachineIndependent/glslang.y"
+#line 3002 "MachineIndependent/glslang.y"
                     {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat, EsdRect);
     }
-#line 9825 "MachineIndependent/glslang_tab.cpp"
+#line 9856 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 439: /* type_specifier_nonarray: F16TEXTURE2DRECT  */
-#line 2976 "MachineIndependent/glslang.y"
+#line 3007 "MachineIndependent/glslang.y"
                        {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float texture", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat16, EsdRect);
     }
-#line 9836 "MachineIndependent/glslang_tab.cpp"
+#line 9867 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 440: /* type_specifier_nonarray: ITEXTURE2DRECT  */
-#line 2982 "MachineIndependent/glslang.y"
+#line 3013 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtInt, EsdRect);
     }
-#line 9846 "MachineIndependent/glslang_tab.cpp"
+#line 9877 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 441: /* type_specifier_nonarray: UTEXTURE2DRECT  */
-#line 2987 "MachineIndependent/glslang.y"
+#line 3018 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtUint, EsdRect);
     }
-#line 9856 "MachineIndependent/glslang_tab.cpp"
+#line 9887 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 442: /* type_specifier_nonarray: TEXTUREBUFFER  */
-#line 2992 "MachineIndependent/glslang.y"
+#line 3023 "MachineIndependent/glslang.y"
                     {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat, EsdBuffer);
     }
-#line 9866 "MachineIndependent/glslang_tab.cpp"
+#line 9897 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 443: /* type_specifier_nonarray: F16TEXTUREBUFFER  */
-#line 2997 "MachineIndependent/glslang.y"
+#line 3028 "MachineIndependent/glslang.y"
                        {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float texture", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat16, EsdBuffer);
     }
-#line 9877 "MachineIndependent/glslang_tab.cpp"
+#line 9908 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 444: /* type_specifier_nonarray: ITEXTUREBUFFER  */
-#line 3003 "MachineIndependent/glslang.y"
+#line 3034 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtInt, EsdBuffer);
     }
-#line 9887 "MachineIndependent/glslang_tab.cpp"
+#line 9918 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 445: /* type_specifier_nonarray: UTEXTUREBUFFER  */
-#line 3008 "MachineIndependent/glslang.y"
+#line 3039 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtUint, EsdBuffer);
     }
-#line 9897 "MachineIndependent/glslang_tab.cpp"
+#line 9928 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 446: /* type_specifier_nonarray: TEXTURE2DMS  */
-#line 3013 "MachineIndependent/glslang.y"
+#line 3044 "MachineIndependent/glslang.y"
                   {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat, Esd2D, false, false, true);
     }
-#line 9907 "MachineIndependent/glslang_tab.cpp"
+#line 9938 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 447: /* type_specifier_nonarray: F16TEXTURE2DMS  */
-#line 3018 "MachineIndependent/glslang.y"
+#line 3049 "MachineIndependent/glslang.y"
                      {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float texture", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat16, Esd2D, false, false, true);
     }
-#line 9918 "MachineIndependent/glslang_tab.cpp"
+#line 9949 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 448: /* type_specifier_nonarray: ITEXTURE2DMS  */
-#line 3024 "MachineIndependent/glslang.y"
+#line 3055 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtInt, Esd2D, false, false, true);
     }
-#line 9928 "MachineIndependent/glslang_tab.cpp"
+#line 9959 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 449: /* type_specifier_nonarray: UTEXTURE2DMS  */
-#line 3029 "MachineIndependent/glslang.y"
+#line 3060 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtUint, Esd2D, false, false, true);
     }
-#line 9938 "MachineIndependent/glslang_tab.cpp"
+#line 9969 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 450: /* type_specifier_nonarray: TEXTURE2DMSARRAY  */
-#line 3034 "MachineIndependent/glslang.y"
+#line 3065 "MachineIndependent/glslang.y"
                        {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat, Esd2D, true, false, true);
     }
-#line 9948 "MachineIndependent/glslang_tab.cpp"
+#line 9979 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 451: /* type_specifier_nonarray: F16TEXTURE2DMSARRAY  */
-#line 3039 "MachineIndependent/glslang.y"
+#line 3070 "MachineIndependent/glslang.y"
                           {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float texture", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtFloat16, Esd2D, true, false, true);
     }
-#line 9959 "MachineIndependent/glslang_tab.cpp"
+#line 9990 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 452: /* type_specifier_nonarray: ITEXTURE2DMSARRAY  */
-#line 3045 "MachineIndependent/glslang.y"
+#line 3076 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtInt, Esd2D, true, false, true);
     }
-#line 9969 "MachineIndependent/glslang_tab.cpp"
+#line 10000 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 453: /* type_specifier_nonarray: UTEXTURE2DMSARRAY  */
-#line 3050 "MachineIndependent/glslang.y"
+#line 3081 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setTexture(EbtUint, Esd2D, true, false, true);
     }
-#line 9979 "MachineIndependent/glslang_tab.cpp"
+#line 10010 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 454: /* type_specifier_nonarray: IMAGE1D  */
-#line 3055 "MachineIndependent/glslang.y"
+#line 3086 "MachineIndependent/glslang.y"
               {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat, Esd1D);
     }
-#line 9989 "MachineIndependent/glslang_tab.cpp"
+#line 10020 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 455: /* type_specifier_nonarray: F16IMAGE1D  */
-#line 3060 "MachineIndependent/glslang.y"
+#line 3091 "MachineIndependent/glslang.y"
                  {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float image", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat16, Esd1D);
     }
-#line 10000 "MachineIndependent/glslang_tab.cpp"
+#line 10031 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 456: /* type_specifier_nonarray: IIMAGE1D  */
-#line 3066 "MachineIndependent/glslang.y"
+#line 3097 "MachineIndependent/glslang.y"
                {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt, Esd1D);
     }
-#line 10010 "MachineIndependent/glslang_tab.cpp"
+#line 10041 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 457: /* type_specifier_nonarray: UIMAGE1D  */
-#line 3071 "MachineIndependent/glslang.y"
+#line 3102 "MachineIndependent/glslang.y"
                {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint, Esd1D);
     }
-#line 10020 "MachineIndependent/glslang_tab.cpp"
+#line 10051 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 458: /* type_specifier_nonarray: IMAGE2D  */
-#line 3076 "MachineIndependent/glslang.y"
+#line 3107 "MachineIndependent/glslang.y"
               {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat, Esd2D);
     }
-#line 10030 "MachineIndependent/glslang_tab.cpp"
+#line 10061 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 459: /* type_specifier_nonarray: F16IMAGE2D  */
-#line 3081 "MachineIndependent/glslang.y"
+#line 3112 "MachineIndependent/glslang.y"
                  {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float image", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat16, Esd2D);
     }
-#line 10041 "MachineIndependent/glslang_tab.cpp"
+#line 10072 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 460: /* type_specifier_nonarray: IIMAGE2D  */
-#line 3087 "MachineIndependent/glslang.y"
+#line 3118 "MachineIndependent/glslang.y"
                {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt, Esd2D);
     }
-#line 10051 "MachineIndependent/glslang_tab.cpp"
+#line 10082 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 461: /* type_specifier_nonarray: UIMAGE2D  */
-#line 3092 "MachineIndependent/glslang.y"
+#line 3123 "MachineIndependent/glslang.y"
                {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint, Esd2D);
     }
-#line 10061 "MachineIndependent/glslang_tab.cpp"
+#line 10092 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 462: /* type_specifier_nonarray: IMAGE3D  */
-#line 3097 "MachineIndependent/glslang.y"
+#line 3128 "MachineIndependent/glslang.y"
               {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat, Esd3D);
     }
-#line 10071 "MachineIndependent/glslang_tab.cpp"
+#line 10102 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 463: /* type_specifier_nonarray: F16IMAGE3D  */
-#line 3102 "MachineIndependent/glslang.y"
+#line 3133 "MachineIndependent/glslang.y"
                  {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float image", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat16, Esd3D);
     }
-#line 10082 "MachineIndependent/glslang_tab.cpp"
+#line 10113 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 464: /* type_specifier_nonarray: IIMAGE3D  */
-#line 3108 "MachineIndependent/glslang.y"
+#line 3139 "MachineIndependent/glslang.y"
                {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt, Esd3D);
     }
-#line 10092 "MachineIndependent/glslang_tab.cpp"
+#line 10123 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 465: /* type_specifier_nonarray: UIMAGE3D  */
-#line 3113 "MachineIndependent/glslang.y"
+#line 3144 "MachineIndependent/glslang.y"
                {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint, Esd3D);
     }
-#line 10102 "MachineIndependent/glslang_tab.cpp"
+#line 10133 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 466: /* type_specifier_nonarray: IMAGE2DRECT  */
-#line 3118 "MachineIndependent/glslang.y"
+#line 3149 "MachineIndependent/glslang.y"
                   {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat, EsdRect);
     }
-#line 10112 "MachineIndependent/glslang_tab.cpp"
+#line 10143 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 467: /* type_specifier_nonarray: F16IMAGE2DRECT  */
-#line 3123 "MachineIndependent/glslang.y"
+#line 3154 "MachineIndependent/glslang.y"
                      {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float image", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat16, EsdRect);
     }
-#line 10123 "MachineIndependent/glslang_tab.cpp"
+#line 10154 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 468: /* type_specifier_nonarray: IIMAGE2DRECT  */
-#line 3129 "MachineIndependent/glslang.y"
+#line 3160 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt, EsdRect);
     }
-#line 10133 "MachineIndependent/glslang_tab.cpp"
+#line 10164 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 469: /* type_specifier_nonarray: UIMAGE2DRECT  */
-#line 3134 "MachineIndependent/glslang.y"
+#line 3165 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint, EsdRect);
     }
-#line 10143 "MachineIndependent/glslang_tab.cpp"
+#line 10174 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 470: /* type_specifier_nonarray: IMAGECUBE  */
-#line 3139 "MachineIndependent/glslang.y"
+#line 3170 "MachineIndependent/glslang.y"
                 {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat, EsdCube);
     }
-#line 10153 "MachineIndependent/glslang_tab.cpp"
+#line 10184 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 471: /* type_specifier_nonarray: F16IMAGECUBE  */
-#line 3144 "MachineIndependent/glslang.y"
+#line 3175 "MachineIndependent/glslang.y"
                    {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float image", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat16, EsdCube);
     }
-#line 10164 "MachineIndependent/glslang_tab.cpp"
+#line 10195 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 472: /* type_specifier_nonarray: IIMAGECUBE  */
-#line 3150 "MachineIndependent/glslang.y"
+#line 3181 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt, EsdCube);
     }
-#line 10174 "MachineIndependent/glslang_tab.cpp"
+#line 10205 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 473: /* type_specifier_nonarray: UIMAGECUBE  */
-#line 3155 "MachineIndependent/glslang.y"
+#line 3186 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint, EsdCube);
     }
-#line 10184 "MachineIndependent/glslang_tab.cpp"
+#line 10215 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 474: /* type_specifier_nonarray: IMAGEBUFFER  */
-#line 3160 "MachineIndependent/glslang.y"
+#line 3191 "MachineIndependent/glslang.y"
                   {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat, EsdBuffer);
     }
-#line 10194 "MachineIndependent/glslang_tab.cpp"
+#line 10225 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 475: /* type_specifier_nonarray: F16IMAGEBUFFER  */
-#line 3165 "MachineIndependent/glslang.y"
+#line 3196 "MachineIndependent/glslang.y"
                      {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float image", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat16, EsdBuffer);
     }
-#line 10205 "MachineIndependent/glslang_tab.cpp"
+#line 10236 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 476: /* type_specifier_nonarray: IIMAGEBUFFER  */
-#line 3171 "MachineIndependent/glslang.y"
+#line 3202 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt, EsdBuffer);
     }
-#line 10215 "MachineIndependent/glslang_tab.cpp"
+#line 10246 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 477: /* type_specifier_nonarray: UIMAGEBUFFER  */
-#line 3176 "MachineIndependent/glslang.y"
+#line 3207 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint, EsdBuffer);
     }
-#line 10225 "MachineIndependent/glslang_tab.cpp"
+#line 10256 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 478: /* type_specifier_nonarray: IMAGE1DARRAY  */
-#line 3181 "MachineIndependent/glslang.y"
+#line 3212 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat, Esd1D, true);
     }
-#line 10235 "MachineIndependent/glslang_tab.cpp"
+#line 10266 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 479: /* type_specifier_nonarray: F16IMAGE1DARRAY  */
-#line 3186 "MachineIndependent/glslang.y"
+#line 3217 "MachineIndependent/glslang.y"
                       {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float image", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat16, Esd1D, true);
     }
-#line 10246 "MachineIndependent/glslang_tab.cpp"
+#line 10277 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 480: /* type_specifier_nonarray: IIMAGE1DARRAY  */
-#line 3192 "MachineIndependent/glslang.y"
+#line 3223 "MachineIndependent/glslang.y"
                     {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt, Esd1D, true);
     }
-#line 10256 "MachineIndependent/glslang_tab.cpp"
+#line 10287 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 481: /* type_specifier_nonarray: UIMAGE1DARRAY  */
-#line 3197 "MachineIndependent/glslang.y"
+#line 3228 "MachineIndependent/glslang.y"
                     {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint, Esd1D, true);
     }
-#line 10266 "MachineIndependent/glslang_tab.cpp"
+#line 10297 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 482: /* type_specifier_nonarray: IMAGE2DARRAY  */
-#line 3202 "MachineIndependent/glslang.y"
+#line 3233 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat, Esd2D, true);
     }
-#line 10276 "MachineIndependent/glslang_tab.cpp"
+#line 10307 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 483: /* type_specifier_nonarray: F16IMAGE2DARRAY  */
-#line 3207 "MachineIndependent/glslang.y"
+#line 3238 "MachineIndependent/glslang.y"
                       {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float image", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat16, Esd2D, true);
     }
-#line 10287 "MachineIndependent/glslang_tab.cpp"
+#line 10318 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 484: /* type_specifier_nonarray: IIMAGE2DARRAY  */
-#line 3213 "MachineIndependent/glslang.y"
+#line 3244 "MachineIndependent/glslang.y"
                     {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt, Esd2D, true);
     }
-#line 10297 "MachineIndependent/glslang_tab.cpp"
+#line 10328 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 485: /* type_specifier_nonarray: UIMAGE2DARRAY  */
-#line 3218 "MachineIndependent/glslang.y"
+#line 3249 "MachineIndependent/glslang.y"
                     {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint, Esd2D, true);
     }
-#line 10307 "MachineIndependent/glslang_tab.cpp"
+#line 10338 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 486: /* type_specifier_nonarray: IMAGECUBEARRAY  */
-#line 3223 "MachineIndependent/glslang.y"
+#line 3254 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat, EsdCube, true);
     }
-#line 10317 "MachineIndependent/glslang_tab.cpp"
+#line 10348 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 487: /* type_specifier_nonarray: F16IMAGECUBEARRAY  */
-#line 3228 "MachineIndependent/glslang.y"
+#line 3259 "MachineIndependent/glslang.y"
                         {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float image", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat16, EsdCube, true);
     }
-#line 10328 "MachineIndependent/glslang_tab.cpp"
+#line 10359 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 488: /* type_specifier_nonarray: IIMAGECUBEARRAY  */
-#line 3234 "MachineIndependent/glslang.y"
+#line 3265 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt, EsdCube, true);
     }
-#line 10338 "MachineIndependent/glslang_tab.cpp"
+#line 10369 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 489: /* type_specifier_nonarray: UIMAGECUBEARRAY  */
-#line 3239 "MachineIndependent/glslang.y"
+#line 3270 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint, EsdCube, true);
     }
-#line 10348 "MachineIndependent/glslang_tab.cpp"
+#line 10379 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 490: /* type_specifier_nonarray: IMAGE2DMS  */
-#line 3244 "MachineIndependent/glslang.y"
+#line 3275 "MachineIndependent/glslang.y"
                 {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat, Esd2D, false, false, true);
     }
-#line 10358 "MachineIndependent/glslang_tab.cpp"
+#line 10389 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 491: /* type_specifier_nonarray: F16IMAGE2DMS  */
-#line 3249 "MachineIndependent/glslang.y"
+#line 3280 "MachineIndependent/glslang.y"
                    {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float image", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat16, Esd2D, false, false, true);
     }
-#line 10369 "MachineIndependent/glslang_tab.cpp"
+#line 10400 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 492: /* type_specifier_nonarray: IIMAGE2DMS  */
-#line 3255 "MachineIndependent/glslang.y"
+#line 3286 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt, Esd2D, false, false, true);
     }
-#line 10379 "MachineIndependent/glslang_tab.cpp"
+#line 10410 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 493: /* type_specifier_nonarray: UIMAGE2DMS  */
-#line 3260 "MachineIndependent/glslang.y"
+#line 3291 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint, Esd2D, false, false, true);
     }
-#line 10389 "MachineIndependent/glslang_tab.cpp"
+#line 10420 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 494: /* type_specifier_nonarray: IMAGE2DMSARRAY  */
-#line 3265 "MachineIndependent/glslang.y"
+#line 3296 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat, Esd2D, true, false, true);
     }
-#line 10399 "MachineIndependent/glslang_tab.cpp"
+#line 10430 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 495: /* type_specifier_nonarray: F16IMAGE2DMSARRAY  */
-#line 3270 "MachineIndependent/glslang.y"
+#line 3301 "MachineIndependent/glslang.y"
                         {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float image", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtFloat16, Esd2D, true, false, true);
     }
-#line 10410 "MachineIndependent/glslang_tab.cpp"
+#line 10441 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 496: /* type_specifier_nonarray: IIMAGE2DMSARRAY  */
-#line 3276 "MachineIndependent/glslang.y"
+#line 3307 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt, Esd2D, true, false, true);
     }
-#line 10420 "MachineIndependent/glslang_tab.cpp"
+#line 10451 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 497: /* type_specifier_nonarray: UIMAGE2DMSARRAY  */
-#line 3281 "MachineIndependent/glslang.y"
+#line 3312 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint, Esd2D, true, false, true);
     }
-#line 10430 "MachineIndependent/glslang_tab.cpp"
+#line 10461 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 498: /* type_specifier_nonarray: I64IMAGE1D  */
-#line 3286 "MachineIndependent/glslang.y"
+#line 3317 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt64, Esd1D);
     }
-#line 10440 "MachineIndependent/glslang_tab.cpp"
+#line 10471 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 499: /* type_specifier_nonarray: U64IMAGE1D  */
-#line 3291 "MachineIndependent/glslang.y"
+#line 3322 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint64, Esd1D);
     }
-#line 10450 "MachineIndependent/glslang_tab.cpp"
+#line 10481 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 500: /* type_specifier_nonarray: I64IMAGE2D  */
-#line 3296 "MachineIndependent/glslang.y"
+#line 3327 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt64, Esd2D);
     }
-#line 10460 "MachineIndependent/glslang_tab.cpp"
+#line 10491 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 501: /* type_specifier_nonarray: U64IMAGE2D  */
-#line 3301 "MachineIndependent/glslang.y"
+#line 3332 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint64, Esd2D);
     }
-#line 10470 "MachineIndependent/glslang_tab.cpp"
+#line 10501 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 502: /* type_specifier_nonarray: I64IMAGE3D  */
-#line 3306 "MachineIndependent/glslang.y"
+#line 3337 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt64, Esd3D);
     }
-#line 10480 "MachineIndependent/glslang_tab.cpp"
+#line 10511 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 503: /* type_specifier_nonarray: U64IMAGE3D  */
-#line 3311 "MachineIndependent/glslang.y"
+#line 3342 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint64, Esd3D);
     }
-#line 10490 "MachineIndependent/glslang_tab.cpp"
+#line 10521 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 504: /* type_specifier_nonarray: I64IMAGE2DRECT  */
-#line 3316 "MachineIndependent/glslang.y"
+#line 3347 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt64, EsdRect);
     }
-#line 10500 "MachineIndependent/glslang_tab.cpp"
+#line 10531 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 505: /* type_specifier_nonarray: U64IMAGE2DRECT  */
-#line 3321 "MachineIndependent/glslang.y"
+#line 3352 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint64, EsdRect);
     }
-#line 10510 "MachineIndependent/glslang_tab.cpp"
+#line 10541 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 506: /* type_specifier_nonarray: I64IMAGECUBE  */
-#line 3326 "MachineIndependent/glslang.y"
+#line 3357 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt64, EsdCube);
     }
-#line 10520 "MachineIndependent/glslang_tab.cpp"
+#line 10551 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 507: /* type_specifier_nonarray: U64IMAGECUBE  */
-#line 3331 "MachineIndependent/glslang.y"
+#line 3362 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint64, EsdCube);
     }
-#line 10530 "MachineIndependent/glslang_tab.cpp"
+#line 10561 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 508: /* type_specifier_nonarray: I64IMAGEBUFFER  */
-#line 3336 "MachineIndependent/glslang.y"
+#line 3367 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt64, EsdBuffer);
     }
-#line 10540 "MachineIndependent/glslang_tab.cpp"
+#line 10571 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 509: /* type_specifier_nonarray: U64IMAGEBUFFER  */
-#line 3341 "MachineIndependent/glslang.y"
+#line 3372 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint64, EsdBuffer);
     }
-#line 10550 "MachineIndependent/glslang_tab.cpp"
+#line 10581 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 510: /* type_specifier_nonarray: I64IMAGE1DARRAY  */
-#line 3346 "MachineIndependent/glslang.y"
+#line 3377 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt64, Esd1D, true);
     }
-#line 10560 "MachineIndependent/glslang_tab.cpp"
+#line 10591 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 511: /* type_specifier_nonarray: U64IMAGE1DARRAY  */
-#line 3351 "MachineIndependent/glslang.y"
+#line 3382 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint64, Esd1D, true);
     }
-#line 10570 "MachineIndependent/glslang_tab.cpp"
+#line 10601 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 512: /* type_specifier_nonarray: I64IMAGE2DARRAY  */
-#line 3356 "MachineIndependent/glslang.y"
+#line 3387 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt64, Esd2D, true);
     }
-#line 10580 "MachineIndependent/glslang_tab.cpp"
+#line 10611 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 513: /* type_specifier_nonarray: U64IMAGE2DARRAY  */
-#line 3361 "MachineIndependent/glslang.y"
+#line 3392 "MachineIndependent/glslang.y"
                       {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint64, Esd2D, true);
     }
-#line 10590 "MachineIndependent/glslang_tab.cpp"
+#line 10621 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 514: /* type_specifier_nonarray: I64IMAGECUBEARRAY  */
-#line 3366 "MachineIndependent/glslang.y"
+#line 3397 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt64, EsdCube, true);
     }
-#line 10600 "MachineIndependent/glslang_tab.cpp"
+#line 10631 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 515: /* type_specifier_nonarray: U64IMAGECUBEARRAY  */
-#line 3371 "MachineIndependent/glslang.y"
+#line 3402 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint64, EsdCube, true);
     }
-#line 10610 "MachineIndependent/glslang_tab.cpp"
+#line 10641 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 516: /* type_specifier_nonarray: I64IMAGE2DMS  */
-#line 3376 "MachineIndependent/glslang.y"
+#line 3407 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt64, Esd2D, false, false, true);
     }
-#line 10620 "MachineIndependent/glslang_tab.cpp"
+#line 10651 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 517: /* type_specifier_nonarray: U64IMAGE2DMS  */
-#line 3381 "MachineIndependent/glslang.y"
+#line 3412 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint64, Esd2D, false, false, true);
     }
-#line 10630 "MachineIndependent/glslang_tab.cpp"
+#line 10661 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 518: /* type_specifier_nonarray: I64IMAGE2DMSARRAY  */
-#line 3386 "MachineIndependent/glslang.y"
+#line 3417 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtInt64, Esd2D, true, false, true);
     }
-#line 10640 "MachineIndependent/glslang_tab.cpp"
+#line 10671 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 519: /* type_specifier_nonarray: U64IMAGE2DMSARRAY  */
-#line 3391 "MachineIndependent/glslang.y"
+#line 3422 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setImage(EbtUint64, Esd2D, true, false, true);
     }
-#line 10650 "MachineIndependent/glslang_tab.cpp"
+#line 10681 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 520: /* type_specifier_nonarray: SAMPLEREXTERNALOES  */
-#line 3396 "MachineIndependent/glslang.y"
+#line 3427 "MachineIndependent/glslang.y"
                          {  // GL_OES_EGL_image_external
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, Esd2D);
         (yyval.interm.type).sampler.external = true;
     }
-#line 10661 "MachineIndependent/glslang_tab.cpp"
+#line 10692 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 521: /* type_specifier_nonarray: SAMPLEREXTERNAL2DY2YEXT  */
-#line 3402 "MachineIndependent/glslang.y"
+#line 3433 "MachineIndependent/glslang.y"
                               { // GL_EXT_YUV_target
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.set(EbtFloat, Esd2D);
         (yyval.interm.type).sampler.yuv = true;
     }
-#line 10672 "MachineIndependent/glslang_tab.cpp"
+#line 10703 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 522: /* type_specifier_nonarray: ATTACHMENTEXT  */
-#line 3408 "MachineIndependent/glslang.y"
+#line 3439 "MachineIndependent/glslang.y"
                     {
         parseContext.requireStage((yyvsp[0].lex).loc, EShLangFragment, "attachmentEXT input");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setAttachmentEXT(EbtFloat);
     }
-#line 10683 "MachineIndependent/glslang_tab.cpp"
+#line 10714 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 523: /* type_specifier_nonarray: IATTACHMENTEXT  */
-#line 3414 "MachineIndependent/glslang.y"
+#line 3445 "MachineIndependent/glslang.y"
                      {
         parseContext.requireStage((yyvsp[0].lex).loc, EShLangFragment, "attachmentEXT input");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setAttachmentEXT(EbtInt);
     }
-#line 10694 "MachineIndependent/glslang_tab.cpp"
+#line 10725 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 524: /* type_specifier_nonarray: UATTACHMENTEXT  */
-#line 3420 "MachineIndependent/glslang.y"
+#line 3451 "MachineIndependent/glslang.y"
                      {
         parseContext.requireStage((yyvsp[0].lex).loc, EShLangFragment, "attachmentEXT input");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setAttachmentEXT(EbtUint);
     }
-#line 10705 "MachineIndependent/glslang_tab.cpp"
+#line 10736 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 525: /* type_specifier_nonarray: SUBPASSINPUT  */
-#line 3426 "MachineIndependent/glslang.y"
+#line 3457 "MachineIndependent/glslang.y"
                    {
         parseContext.requireStage((yyvsp[0].lex).loc, EShLangFragment, "subpass input");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setSubpass(EbtFloat);
     }
-#line 10716 "MachineIndependent/glslang_tab.cpp"
+#line 10747 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 526: /* type_specifier_nonarray: SUBPASSINPUTMS  */
-#line 3432 "MachineIndependent/glslang.y"
+#line 3463 "MachineIndependent/glslang.y"
                      {
         parseContext.requireStage((yyvsp[0].lex).loc, EShLangFragment, "subpass input");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setSubpass(EbtFloat, true);
     }
-#line 10727 "MachineIndependent/glslang_tab.cpp"
+#line 10758 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 527: /* type_specifier_nonarray: F16SUBPASSINPUT  */
-#line 3438 "MachineIndependent/glslang.y"
+#line 3469 "MachineIndependent/glslang.y"
                       {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float subpass input", parseContext.symbolTable.atBuiltInLevel());
         parseContext.requireStage((yyvsp[0].lex).loc, EShLangFragment, "subpass input");
@@ -10735,11 +10766,11 @@ yyreduce:
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setSubpass(EbtFloat16);
     }
-#line 10739 "MachineIndependent/glslang_tab.cpp"
+#line 10770 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 528: /* type_specifier_nonarray: F16SUBPASSINPUTMS  */
-#line 3445 "MachineIndependent/glslang.y"
+#line 3476 "MachineIndependent/glslang.y"
                         {
         parseContext.float16OpaqueCheck((yyvsp[0].lex).loc, "half float subpass input", parseContext.symbolTable.atBuiltInLevel());
         parseContext.requireStage((yyvsp[0].lex).loc, EShLangFragment, "subpass input");
@@ -10747,55 +10778,55 @@ yyreduce:
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setSubpass(EbtFloat16, true);
     }
-#line 10751 "MachineIndependent/glslang_tab.cpp"
+#line 10782 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 529: /* type_specifier_nonarray: ISUBPASSINPUT  */
-#line 3452 "MachineIndependent/glslang.y"
+#line 3483 "MachineIndependent/glslang.y"
                     {
         parseContext.requireStage((yyvsp[0].lex).loc, EShLangFragment, "subpass input");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setSubpass(EbtInt);
     }
-#line 10762 "MachineIndependent/glslang_tab.cpp"
+#line 10793 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 530: /* type_specifier_nonarray: ISUBPASSINPUTMS  */
-#line 3458 "MachineIndependent/glslang.y"
+#line 3489 "MachineIndependent/glslang.y"
                       {
         parseContext.requireStage((yyvsp[0].lex).loc, EShLangFragment, "subpass input");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setSubpass(EbtInt, true);
     }
-#line 10773 "MachineIndependent/glslang_tab.cpp"
+#line 10804 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 531: /* type_specifier_nonarray: USUBPASSINPUT  */
-#line 3464 "MachineIndependent/glslang.y"
+#line 3495 "MachineIndependent/glslang.y"
                     {
         parseContext.requireStage((yyvsp[0].lex).loc, EShLangFragment, "subpass input");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setSubpass(EbtUint);
     }
-#line 10784 "MachineIndependent/glslang_tab.cpp"
+#line 10815 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 532: /* type_specifier_nonarray: USUBPASSINPUTMS  */
-#line 3470 "MachineIndependent/glslang.y"
+#line 3501 "MachineIndependent/glslang.y"
                       {
         parseContext.requireStage((yyvsp[0].lex).loc, EShLangFragment, "subpass input");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).basicType = EbtSampler;
         (yyval.interm.type).sampler.setSubpass(EbtUint, true);
     }
-#line 10795 "MachineIndependent/glslang_tab.cpp"
+#line 10826 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 533: /* type_specifier_nonarray: FCOOPMATNV  */
-#line 3476 "MachineIndependent/glslang.y"
+#line 3507 "MachineIndependent/glslang.y"
                  {
         parseContext.fcoopmatCheckNV((yyvsp[0].lex).loc, "fcoopmatNV", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
@@ -10803,11 +10834,11 @@ yyreduce:
         (yyval.interm.type).coopmatNV = true;
         (yyval.interm.type).coopmatKHR = false;
     }
-#line 10807 "MachineIndependent/glslang_tab.cpp"
+#line 10838 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 534: /* type_specifier_nonarray: ICOOPMATNV  */
-#line 3483 "MachineIndependent/glslang.y"
+#line 3514 "MachineIndependent/glslang.y"
                  {
         parseContext.intcoopmatCheckNV((yyvsp[0].lex).loc, "icoopmatNV", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
@@ -10815,11 +10846,11 @@ yyreduce:
         (yyval.interm.type).coopmatNV = true;
         (yyval.interm.type).coopmatKHR = false;
     }
-#line 10819 "MachineIndependent/glslang_tab.cpp"
+#line 10850 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 535: /* type_specifier_nonarray: UCOOPMATNV  */
-#line 3490 "MachineIndependent/glslang.y"
+#line 3521 "MachineIndependent/glslang.y"
                  {
         parseContext.intcoopmatCheckNV((yyvsp[0].lex).loc, "ucoopmatNV", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
@@ -10827,11 +10858,11 @@ yyreduce:
         (yyval.interm.type).coopmatNV = true;
         (yyval.interm.type).coopmatKHR = false;
     }
-#line 10831 "MachineIndependent/glslang_tab.cpp"
+#line 10862 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 536: /* type_specifier_nonarray: COOPMAT  */
-#line 3497 "MachineIndependent/glslang.y"
+#line 3528 "MachineIndependent/glslang.y"
               {
         parseContext.coopmatCheck((yyvsp[0].lex).loc, "coopmat", parseContext.symbolTable.atBuiltInLevel());
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
@@ -10839,39 +10870,39 @@ yyreduce:
         (yyval.interm.type).coopmatNV = false;
         (yyval.interm.type).coopmatKHR = true;
     }
-#line 10843 "MachineIndependent/glslang_tab.cpp"
+#line 10874 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 537: /* type_specifier_nonarray: spirv_type_specifier  */
-#line 3504 "MachineIndependent/glslang.y"
+#line 3535 "MachineIndependent/glslang.y"
                            {
         parseContext.requireExtensions((yyvsp[0].interm.type).loc, 1, &E_GL_EXT_spirv_intrinsics, "SPIR-V type specifier");
         (yyval.interm.type) = (yyvsp[0].interm.type);
     }
-#line 10852 "MachineIndependent/glslang_tab.cpp"
+#line 10883 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 538: /* type_specifier_nonarray: HITOBJECTNV  */
-#line 3508 "MachineIndependent/glslang.y"
+#line 3539 "MachineIndependent/glslang.y"
                       {
        (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
        (yyval.interm.type).basicType = EbtHitObjectNV;
 	}
-#line 10861 "MachineIndependent/glslang_tab.cpp"
+#line 10892 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 539: /* type_specifier_nonarray: struct_specifier  */
-#line 3512 "MachineIndependent/glslang.y"
+#line 3543 "MachineIndependent/glslang.y"
                        {
         (yyval.interm.type) = (yyvsp[0].interm.type);
         (yyval.interm.type).qualifier.storage = parseContext.symbolTable.atGlobalLevel() ? EvqGlobal : EvqTemporary;
         parseContext.structTypeCheck((yyval.interm.type).loc, (yyval.interm.type));
     }
-#line 10871 "MachineIndependent/glslang_tab.cpp"
+#line 10902 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 540: /* type_specifier_nonarray: TYPE_NAME  */
-#line 3517 "MachineIndependent/glslang.y"
+#line 3548 "MachineIndependent/glslang.y"
                 {
         //
         // This is for user defined type names.  The lexical phase looked up the
@@ -10885,69 +10916,75 @@ yyreduce:
         } else
             parseContext.error((yyvsp[0].lex).loc, "expected type name", (yyvsp[0].lex).string->c_str(), "");
     }
-#line 10889 "MachineIndependent/glslang_tab.cpp"
+#line 10920 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 541: /* precision_qualifier: HIGH_PRECISION  */
-#line 3533 "MachineIndependent/glslang.y"
+#line 3564 "MachineIndependent/glslang.y"
                      {
         parseContext.profileRequires((yyvsp[0].lex).loc, ENoProfile, 130, 0, "highp precision qualifier");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         parseContext.handlePrecisionQualifier((yyvsp[0].lex).loc, (yyval.interm.type).qualifier, EpqHigh);
     }
-#line 10899 "MachineIndependent/glslang_tab.cpp"
+#line 10930 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 542: /* precision_qualifier: MEDIUM_PRECISION  */
-#line 3538 "MachineIndependent/glslang.y"
+#line 3569 "MachineIndependent/glslang.y"
                        {
         parseContext.profileRequires((yyvsp[0].lex).loc, ENoProfile, 130, 0, "mediump precision qualifier");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         parseContext.handlePrecisionQualifier((yyvsp[0].lex).loc, (yyval.interm.type).qualifier, EpqMedium);
     }
-#line 10909 "MachineIndependent/glslang_tab.cpp"
+#line 10940 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 543: /* precision_qualifier: LOW_PRECISION  */
-#line 3543 "MachineIndependent/glslang.y"
+#line 3574 "MachineIndependent/glslang.y"
                     {
         parseContext.profileRequires((yyvsp[0].lex).loc, ENoProfile, 130, 0, "lowp precision qualifier");
         (yyval.interm.type).init((yyvsp[0].lex).loc, parseContext.symbolTable.atGlobalLevel());
         parseContext.handlePrecisionQualifier((yyvsp[0].lex).loc, (yyval.interm.type).qualifier, EpqLow);
     }
-#line 10919 "MachineIndependent/glslang_tab.cpp"
+#line 10950 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 544: /* $@3: %empty  */
-#line 3551 "MachineIndependent/glslang.y"
+#line 3582 "MachineIndependent/glslang.y"
                                    { parseContext.nestedStructCheck((yyvsp[-2].lex).loc); }
-#line 10925 "MachineIndependent/glslang_tab.cpp"
+#line 10956 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 545: /* struct_specifier: STRUCT IDENTIFIER LEFT_BRACE $@3 struct_declaration_list RIGHT_BRACE  */
-#line 3551 "MachineIndependent/glslang.y"
+#line 3582 "MachineIndependent/glslang.y"
                                                                                                                    {
+
         TType* structure = new TType((yyvsp[-1].interm.typeList), *(yyvsp[-4].lex).string);
         parseContext.structArrayCheck((yyvsp[-4].lex).loc, *structure);
+
         TVariable* userTypeDef = new TVariable((yyvsp[-4].lex).string, *structure, true);
         if (! parseContext.symbolTable.insert(*userTypeDef))
             parseContext.error((yyvsp[-4].lex).loc, "redefinition", (yyvsp[-4].lex).string->c_str(), "struct");
+        else if (parseContext.spvVersion.vulkanRelaxed
+                 && structure->containsOpaque())
+            parseContext.relaxedSymbols.push_back(structure->getTypeName());
+
         (yyval.interm.type).init((yyvsp[-5].lex).loc);
         (yyval.interm.type).basicType = EbtStruct;
         (yyval.interm.type).userDef = structure;
         --parseContext.structNestingLevel;
     }
-#line 10941 "MachineIndependent/glslang_tab.cpp"
+#line 10978 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 546: /* $@4: %empty  */
-#line 3562 "MachineIndependent/glslang.y"
+#line 3599 "MachineIndependent/glslang.y"
                         { parseContext.nestedStructCheck((yyvsp[-1].lex).loc); }
-#line 10947 "MachineIndependent/glslang_tab.cpp"
+#line 10984 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 547: /* struct_specifier: STRUCT LEFT_BRACE $@4 struct_declaration_list RIGHT_BRACE  */
-#line 3562 "MachineIndependent/glslang.y"
+#line 3599 "MachineIndependent/glslang.y"
                                                                                                         {
         TType* structure = new TType((yyvsp[-1].interm.typeList), TString(""));
         (yyval.interm.type).init((yyvsp[-4].lex).loc);
@@ -10955,19 +10992,19 @@ yyreduce:
         (yyval.interm.type).userDef = structure;
         --parseContext.structNestingLevel;
     }
-#line 10959 "MachineIndependent/glslang_tab.cpp"
+#line 10996 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 548: /* struct_declaration_list: struct_declaration  */
-#line 3572 "MachineIndependent/glslang.y"
+#line 3609 "MachineIndependent/glslang.y"
                          {
         (yyval.interm.typeList) = (yyvsp[0].interm.typeList);
     }
-#line 10967 "MachineIndependent/glslang_tab.cpp"
+#line 11004 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 549: /* struct_declaration_list: struct_declaration_list struct_declaration  */
-#line 3575 "MachineIndependent/glslang.y"
+#line 3612 "MachineIndependent/glslang.y"
                                                  {
         (yyval.interm.typeList) = (yyvsp[-1].interm.typeList);
         for (unsigned int i = 0; i < (yyvsp[0].interm.typeList)->size(); ++i) {
@@ -10978,11 +11015,11 @@ yyreduce:
             (yyval.interm.typeList)->push_back((*(yyvsp[0].interm.typeList))[i]);
         }
     }
-#line 10982 "MachineIndependent/glslang_tab.cpp"
+#line 11019 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 550: /* struct_declaration: type_specifier struct_declarator_list SEMICOLON  */
-#line 3588 "MachineIndependent/glslang.y"
+#line 3625 "MachineIndependent/glslang.y"
                                                       {
         if ((yyvsp[-2].interm.type).arraySizes) {
             parseContext.profileRequires((yyvsp[-2].interm.type).loc, ENoProfile, 120, E_GL_3DL_array_objects, "arrayed type");
@@ -11005,11 +11042,11 @@ yyreduce:
             (*(yyval.interm.typeList))[i].type->shallowCopy(type);
         }
     }
-#line 11009 "MachineIndependent/glslang_tab.cpp"
+#line 11046 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 551: /* struct_declaration: type_qualifier type_specifier struct_declarator_list SEMICOLON  */
-#line 3610 "MachineIndependent/glslang.y"
+#line 3647 "MachineIndependent/glslang.y"
                                                                      {
         if ((yyvsp[-2].interm.type).arraySizes) {
             parseContext.profileRequires((yyvsp[-2].interm.type).loc, ENoProfile, 120, E_GL_3DL_array_objects, "arrayed type");
@@ -11034,38 +11071,38 @@ yyreduce:
             (*(yyval.interm.typeList))[i].type->shallowCopy(type);
         }
     }
-#line 11038 "MachineIndependent/glslang_tab.cpp"
+#line 11075 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 552: /* struct_declarator_list: struct_declarator  */
-#line 3637 "MachineIndependent/glslang.y"
+#line 3674 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.typeList) = new TTypeList;
         (yyval.interm.typeList)->push_back((yyvsp[0].interm.typeLine));
     }
-#line 11047 "MachineIndependent/glslang_tab.cpp"
+#line 11084 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 553: /* struct_declarator_list: struct_declarator_list COMMA struct_declarator  */
-#line 3641 "MachineIndependent/glslang.y"
+#line 3678 "MachineIndependent/glslang.y"
                                                      {
         (yyval.interm.typeList)->push_back((yyvsp[0].interm.typeLine));
     }
-#line 11055 "MachineIndependent/glslang_tab.cpp"
+#line 11092 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 554: /* struct_declarator: IDENTIFIER  */
-#line 3647 "MachineIndependent/glslang.y"
+#line 3684 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.typeLine).type = new TType(EbtVoid);
         (yyval.interm.typeLine).loc = (yyvsp[0].lex).loc;
         (yyval.interm.typeLine).type->setFieldName(*(yyvsp[0].lex).string);
     }
-#line 11065 "MachineIndependent/glslang_tab.cpp"
+#line 11102 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 555: /* struct_declarator: IDENTIFIER array_specifier  */
-#line 3652 "MachineIndependent/glslang.y"
+#line 3689 "MachineIndependent/glslang.y"
                                  {
         parseContext.arrayOfArrayVersionCheck((yyvsp[-1].lex).loc, (yyvsp[0].interm).arraySizes);
 
@@ -11074,246 +11111,246 @@ yyreduce:
         (yyval.interm.typeLine).type->setFieldName(*(yyvsp[-1].lex).string);
         (yyval.interm.typeLine).type->transferArraySizes((yyvsp[0].interm).arraySizes);
     }
-#line 11078 "MachineIndependent/glslang_tab.cpp"
+#line 11115 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 556: /* initializer: assignment_expression  */
-#line 3663 "MachineIndependent/glslang.y"
+#line 3700 "MachineIndependent/glslang.y"
                             {
         (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode);
     }
-#line 11086 "MachineIndependent/glslang_tab.cpp"
+#line 11123 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 557: /* initializer: LEFT_BRACE initializer_list RIGHT_BRACE  */
-#line 3666 "MachineIndependent/glslang.y"
+#line 3703 "MachineIndependent/glslang.y"
                                               {
         const char* initFeature = "{ } style initializers";
         parseContext.requireProfile((yyvsp[-2].lex).loc, ~EEsProfile, initFeature);
         parseContext.profileRequires((yyvsp[-2].lex).loc, ~EEsProfile, 420, E_GL_ARB_shading_language_420pack, initFeature);
         (yyval.interm.intermTypedNode) = (yyvsp[-1].interm.intermTypedNode);
     }
-#line 11097 "MachineIndependent/glslang_tab.cpp"
+#line 11134 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 558: /* initializer: LEFT_BRACE initializer_list COMMA RIGHT_BRACE  */
-#line 3672 "MachineIndependent/glslang.y"
+#line 3709 "MachineIndependent/glslang.y"
                                                     {
         const char* initFeature = "{ } style initializers";
         parseContext.requireProfile((yyvsp[-3].lex).loc, ~EEsProfile, initFeature);
         parseContext.profileRequires((yyvsp[-3].lex).loc, ~EEsProfile, 420, E_GL_ARB_shading_language_420pack, initFeature);
         (yyval.interm.intermTypedNode) = (yyvsp[-2].interm.intermTypedNode);
     }
-#line 11108 "MachineIndependent/glslang_tab.cpp"
+#line 11145 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 559: /* initializer: LEFT_BRACE RIGHT_BRACE  */
-#line 3678 "MachineIndependent/glslang.y"
+#line 3715 "MachineIndependent/glslang.y"
                              {
         const char* initFeature = "empty { } initializer";
         parseContext.profileRequires((yyvsp[-1].lex).loc, EEsProfile, 0, E_GL_EXT_null_initializer, initFeature);
         parseContext.profileRequires((yyvsp[-1].lex).loc, ~EEsProfile, 0, E_GL_EXT_null_initializer, initFeature);
         (yyval.interm.intermTypedNode) = parseContext.intermediate.makeAggregate((yyvsp[-1].lex).loc);
     }
-#line 11119 "MachineIndependent/glslang_tab.cpp"
+#line 11156 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 560: /* initializer_list: initializer  */
-#line 3687 "MachineIndependent/glslang.y"
+#line 3724 "MachineIndependent/glslang.y"
                   {
         (yyval.interm.intermTypedNode) = parseContext.intermediate.growAggregate(0, (yyvsp[0].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode)->getLoc());
     }
-#line 11127 "MachineIndependent/glslang_tab.cpp"
+#line 11164 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 561: /* initializer_list: initializer_list COMMA initializer  */
-#line 3690 "MachineIndependent/glslang.y"
+#line 3727 "MachineIndependent/glslang.y"
                                          {
         (yyval.interm.intermTypedNode) = parseContext.intermediate.growAggregate((yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.intermTypedNode));
     }
-#line 11135 "MachineIndependent/glslang_tab.cpp"
+#line 11172 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 562: /* declaration_statement: declaration  */
-#line 3696 "MachineIndependent/glslang.y"
+#line 3733 "MachineIndependent/glslang.y"
                   { (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode); }
-#line 11141 "MachineIndependent/glslang_tab.cpp"
+#line 11178 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 563: /* statement: compound_statement  */
-#line 3700 "MachineIndependent/glslang.y"
+#line 3737 "MachineIndependent/glslang.y"
                           { (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode); }
-#line 11147 "MachineIndependent/glslang_tab.cpp"
+#line 11184 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 564: /* statement: simple_statement  */
-#line 3701 "MachineIndependent/glslang.y"
+#line 3738 "MachineIndependent/glslang.y"
                           { (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode); }
-#line 11153 "MachineIndependent/glslang_tab.cpp"
+#line 11190 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 565: /* simple_statement: declaration_statement  */
-#line 3707 "MachineIndependent/glslang.y"
+#line 3744 "MachineIndependent/glslang.y"
                             { (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode); }
-#line 11159 "MachineIndependent/glslang_tab.cpp"
+#line 11196 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 566: /* simple_statement: expression_statement  */
-#line 3708 "MachineIndependent/glslang.y"
+#line 3745 "MachineIndependent/glslang.y"
                             { (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode); }
-#line 11165 "MachineIndependent/glslang_tab.cpp"
+#line 11202 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 567: /* simple_statement: selection_statement  */
-#line 3709 "MachineIndependent/glslang.y"
+#line 3746 "MachineIndependent/glslang.y"
                             { (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode); }
-#line 11171 "MachineIndependent/glslang_tab.cpp"
+#line 11208 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 568: /* simple_statement: switch_statement  */
-#line 3710 "MachineIndependent/glslang.y"
+#line 3747 "MachineIndependent/glslang.y"
                             { (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode); }
-#line 11177 "MachineIndependent/glslang_tab.cpp"
+#line 11214 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 569: /* simple_statement: case_label  */
-#line 3711 "MachineIndependent/glslang.y"
+#line 3748 "MachineIndependent/glslang.y"
                             { (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode); }
-#line 11183 "MachineIndependent/glslang_tab.cpp"
+#line 11220 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 570: /* simple_statement: iteration_statement  */
-#line 3712 "MachineIndependent/glslang.y"
+#line 3749 "MachineIndependent/glslang.y"
                             { (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode); }
-#line 11189 "MachineIndependent/glslang_tab.cpp"
+#line 11226 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 571: /* simple_statement: jump_statement  */
-#line 3713 "MachineIndependent/glslang.y"
+#line 3750 "MachineIndependent/glslang.y"
                             { (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode); }
-#line 11195 "MachineIndependent/glslang_tab.cpp"
+#line 11232 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 572: /* simple_statement: demote_statement  */
-#line 3714 "MachineIndependent/glslang.y"
+#line 3751 "MachineIndependent/glslang.y"
                             { (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode); }
-#line 11201 "MachineIndependent/glslang_tab.cpp"
+#line 11238 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 573: /* demote_statement: DEMOTE SEMICOLON  */
-#line 3718 "MachineIndependent/glslang.y"
+#line 3755 "MachineIndependent/glslang.y"
                        {
         parseContext.requireStage((yyvsp[-1].lex).loc, EShLangFragment, "demote");
         parseContext.requireExtensions((yyvsp[-1].lex).loc, 1, &E_GL_EXT_demote_to_helper_invocation, "demote");
         (yyval.interm.intermNode) = parseContext.intermediate.addBranch(EOpDemote, (yyvsp[-1].lex).loc);
     }
-#line 11211 "MachineIndependent/glslang_tab.cpp"
+#line 11248 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 574: /* compound_statement: LEFT_BRACE RIGHT_BRACE  */
-#line 3726 "MachineIndependent/glslang.y"
+#line 3763 "MachineIndependent/glslang.y"
                              { (yyval.interm.intermNode) = 0; }
-#line 11217 "MachineIndependent/glslang_tab.cpp"
+#line 11254 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 575: /* $@5: %empty  */
-#line 3727 "MachineIndependent/glslang.y"
+#line 3764 "MachineIndependent/glslang.y"
                  {
         parseContext.symbolTable.push();
         ++parseContext.statementNestingLevel;
     }
-#line 11226 "MachineIndependent/glslang_tab.cpp"
+#line 11263 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 576: /* $@6: %empty  */
-#line 3731 "MachineIndependent/glslang.y"
+#line 3768 "MachineIndependent/glslang.y"
                      {
         parseContext.symbolTable.pop(&parseContext.defaultPrecision[0]);
         --parseContext.statementNestingLevel;
     }
-#line 11235 "MachineIndependent/glslang_tab.cpp"
+#line 11272 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 577: /* compound_statement: LEFT_BRACE $@5 statement_list $@6 RIGHT_BRACE  */
-#line 3735 "MachineIndependent/glslang.y"
+#line 3772 "MachineIndependent/glslang.y"
                   {
         if ((yyvsp[-2].interm.intermNode) && (yyvsp[-2].interm.intermNode)->getAsAggregate())
             (yyvsp[-2].interm.intermNode)->getAsAggregate()->setOperator(parseContext.intermediate.getDebugInfo() ? EOpScope : EOpSequence);
         (yyval.interm.intermNode) = (yyvsp[-2].interm.intermNode);
     }
-#line 11245 "MachineIndependent/glslang_tab.cpp"
+#line 11282 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 578: /* statement_no_new_scope: compound_statement_no_new_scope  */
-#line 3743 "MachineIndependent/glslang.y"
+#line 3780 "MachineIndependent/glslang.y"
                                       { (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode); }
-#line 11251 "MachineIndependent/glslang_tab.cpp"
+#line 11288 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 579: /* statement_no_new_scope: simple_statement  */
-#line 3744 "MachineIndependent/glslang.y"
+#line 3781 "MachineIndependent/glslang.y"
                                       { (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode); }
-#line 11257 "MachineIndependent/glslang_tab.cpp"
+#line 11294 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 580: /* $@7: %empty  */
-#line 3748 "MachineIndependent/glslang.y"
+#line 3785 "MachineIndependent/glslang.y"
       {
         ++parseContext.controlFlowNestingLevel;
     }
-#line 11265 "MachineIndependent/glslang_tab.cpp"
+#line 11302 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 581: /* statement_scoped: $@7 compound_statement  */
-#line 3751 "MachineIndependent/glslang.y"
+#line 3788 "MachineIndependent/glslang.y"
                           {
         --parseContext.controlFlowNestingLevel;
         (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode);
     }
-#line 11274 "MachineIndependent/glslang_tab.cpp"
+#line 11311 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 582: /* $@8: %empty  */
-#line 3755 "MachineIndependent/glslang.y"
+#line 3792 "MachineIndependent/glslang.y"
       {
         parseContext.symbolTable.push();
         ++parseContext.statementNestingLevel;
         ++parseContext.controlFlowNestingLevel;
     }
-#line 11284 "MachineIndependent/glslang_tab.cpp"
+#line 11321 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 583: /* statement_scoped: $@8 simple_statement  */
-#line 3760 "MachineIndependent/glslang.y"
+#line 3797 "MachineIndependent/glslang.y"
                        {
         parseContext.symbolTable.pop(&parseContext.defaultPrecision[0]);
         --parseContext.statementNestingLevel;
         --parseContext.controlFlowNestingLevel;
         (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode);
     }
-#line 11295 "MachineIndependent/glslang_tab.cpp"
+#line 11332 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 584: /* compound_statement_no_new_scope: LEFT_BRACE RIGHT_BRACE  */
-#line 3769 "MachineIndependent/glslang.y"
+#line 3806 "MachineIndependent/glslang.y"
                              {
         (yyval.interm.intermNode) = 0;
     }
-#line 11303 "MachineIndependent/glslang_tab.cpp"
+#line 11340 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 585: /* compound_statement_no_new_scope: LEFT_BRACE statement_list RIGHT_BRACE  */
-#line 3772 "MachineIndependent/glslang.y"
+#line 3809 "MachineIndependent/glslang.y"
                                             {
         if ((yyvsp[-1].interm.intermNode) && (yyvsp[-1].interm.intermNode)->getAsAggregate())
             (yyvsp[-1].interm.intermNode)->getAsAggregate()->setOperator(EOpSequence);
         (yyval.interm.intermNode) = (yyvsp[-1].interm.intermNode);
     }
-#line 11313 "MachineIndependent/glslang_tab.cpp"
+#line 11350 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 586: /* statement_list: statement  */
-#line 3780 "MachineIndependent/glslang.y"
+#line 3817 "MachineIndependent/glslang.y"
                 {
         (yyval.interm.intermNode) = parseContext.intermediate.makeAggregate((yyvsp[0].interm.intermNode));
         if ((yyvsp[0].interm.intermNode) && (yyvsp[0].interm.intermNode)->getAsBranchNode() && ((yyvsp[0].interm.intermNode)->getAsBranchNode()->getFlowOp() == EOpCase ||
@@ -11322,11 +11359,11 @@ yyreduce:
             (yyval.interm.intermNode) = 0;  // start a fresh subsequence for what's after this case
         }
     }
-#line 11326 "MachineIndependent/glslang_tab.cpp"
+#line 11363 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 587: /* statement_list: statement_list statement  */
-#line 3788 "MachineIndependent/glslang.y"
+#line 3825 "MachineIndependent/glslang.y"
                                {
         if ((yyvsp[0].interm.intermNode) && (yyvsp[0].interm.intermNode)->getAsBranchNode() && ((yyvsp[0].interm.intermNode)->getAsBranchNode()->getFlowOp() == EOpCase ||
                                             (yyvsp[0].interm.intermNode)->getAsBranchNode()->getFlowOp() == EOpDefault)) {
@@ -11335,77 +11372,77 @@ yyreduce:
         } else
             (yyval.interm.intermNode) = parseContext.intermediate.growAggregate((yyvsp[-1].interm.intermNode), (yyvsp[0].interm.intermNode));
     }
-#line 11339 "MachineIndependent/glslang_tab.cpp"
+#line 11376 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 588: /* expression_statement: SEMICOLON  */
-#line 3799 "MachineIndependent/glslang.y"
+#line 3836 "MachineIndependent/glslang.y"
                  { (yyval.interm.intermNode) = 0; }
-#line 11345 "MachineIndependent/glslang_tab.cpp"
+#line 11382 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 589: /* expression_statement: expression SEMICOLON  */
-#line 3800 "MachineIndependent/glslang.y"
+#line 3837 "MachineIndependent/glslang.y"
                             { (yyval.interm.intermNode) = static_cast<TIntermNode*>((yyvsp[-1].interm.intermTypedNode)); }
-#line 11351 "MachineIndependent/glslang_tab.cpp"
+#line 11388 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 590: /* selection_statement: selection_statement_nonattributed  */
-#line 3804 "MachineIndependent/glslang.y"
+#line 3841 "MachineIndependent/glslang.y"
                                         {
         (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode);
     }
-#line 11359 "MachineIndependent/glslang_tab.cpp"
+#line 11396 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 591: /* selection_statement: attribute selection_statement_nonattributed  */
-#line 3807 "MachineIndependent/glslang.y"
+#line 3844 "MachineIndependent/glslang.y"
                                                   {
         parseContext.requireExtensions((yyvsp[0].interm.intermNode)->getLoc(), 1, &E_GL_EXT_control_flow_attributes, "attribute");
         parseContext.handleSelectionAttributes(*(yyvsp[-1].interm.attributes), (yyvsp[0].interm.intermNode));
         (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode);
     }
-#line 11369 "MachineIndependent/glslang_tab.cpp"
+#line 11406 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 592: /* selection_statement_nonattributed: IF LEFT_PAREN expression RIGHT_PAREN selection_rest_statement  */
-#line 3814 "MachineIndependent/glslang.y"
+#line 3851 "MachineIndependent/glslang.y"
                                                                     {
         parseContext.boolCheck((yyvsp[-4].lex).loc, (yyvsp[-2].interm.intermTypedNode));
         (yyval.interm.intermNode) = parseContext.intermediate.addSelection((yyvsp[-2].interm.intermTypedNode), (yyvsp[0].interm.nodePair), (yyvsp[-4].lex).loc);
     }
-#line 11378 "MachineIndependent/glslang_tab.cpp"
+#line 11415 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 593: /* selection_rest_statement: statement_scoped ELSE statement_scoped  */
-#line 3821 "MachineIndependent/glslang.y"
+#line 3858 "MachineIndependent/glslang.y"
                                              {
         (yyval.interm.nodePair).node1 = (yyvsp[-2].interm.intermNode);
         (yyval.interm.nodePair).node2 = (yyvsp[0].interm.intermNode);
     }
-#line 11387 "MachineIndependent/glslang_tab.cpp"
+#line 11424 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 594: /* selection_rest_statement: statement_scoped  */
-#line 3825 "MachineIndependent/glslang.y"
+#line 3862 "MachineIndependent/glslang.y"
                        {
         (yyval.interm.nodePair).node1 = (yyvsp[0].interm.intermNode);
         (yyval.interm.nodePair).node2 = 0;
     }
-#line 11396 "MachineIndependent/glslang_tab.cpp"
+#line 11433 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 595: /* condition: expression  */
-#line 3833 "MachineIndependent/glslang.y"
+#line 3870 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode);
         parseContext.boolCheck((yyvsp[0].interm.intermTypedNode)->getLoc(), (yyvsp[0].interm.intermTypedNode));
     }
-#line 11405 "MachineIndependent/glslang_tab.cpp"
+#line 11442 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 596: /* condition: fully_specified_type IDENTIFIER EQUAL initializer  */
-#line 3837 "MachineIndependent/glslang.y"
+#line 3874 "MachineIndependent/glslang.y"
                                                         {
         parseContext.boolCheck((yyvsp[-2].lex).loc, (yyvsp[-3].interm.type));
 
@@ -11416,29 +11453,29 @@ yyreduce:
         else
             (yyval.interm.intermTypedNode) = 0;
     }
-#line 11420 "MachineIndependent/glslang_tab.cpp"
+#line 11457 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 597: /* switch_statement: switch_statement_nonattributed  */
-#line 3850 "MachineIndependent/glslang.y"
+#line 3887 "MachineIndependent/glslang.y"
                                      {
         (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode);
     }
-#line 11428 "MachineIndependent/glslang_tab.cpp"
+#line 11465 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 598: /* switch_statement: attribute switch_statement_nonattributed  */
-#line 3853 "MachineIndependent/glslang.y"
+#line 3890 "MachineIndependent/glslang.y"
                                                {
         parseContext.requireExtensions((yyvsp[0].interm.intermNode)->getLoc(), 1, &E_GL_EXT_control_flow_attributes, "attribute");
         parseContext.handleSwitchAttributes(*(yyvsp[-1].interm.attributes), (yyvsp[0].interm.intermNode));
         (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode);
     }
-#line 11438 "MachineIndependent/glslang_tab.cpp"
+#line 11475 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 599: /* $@9: %empty  */
-#line 3860 "MachineIndependent/glslang.y"
+#line 3897 "MachineIndependent/glslang.y"
                                                {
         // start new switch sequence on the switch stack
         ++parseContext.controlFlowNestingLevel;
@@ -11447,11 +11484,11 @@ yyreduce:
         parseContext.switchLevel.push_back(parseContext.statementNestingLevel);
         parseContext.symbolTable.push();
     }
-#line 11451 "MachineIndependent/glslang_tab.cpp"
+#line 11488 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 600: /* switch_statement_nonattributed: SWITCH LEFT_PAREN expression RIGHT_PAREN $@9 LEFT_BRACE switch_statement_list RIGHT_BRACE  */
-#line 3868 "MachineIndependent/glslang.y"
+#line 3905 "MachineIndependent/glslang.y"
                                                  {
         (yyval.interm.intermNode) = parseContext.addSwitch((yyvsp[-7].lex).loc, (yyvsp[-5].interm.intermTypedNode), (yyvsp[-1].interm.intermNode) ? (yyvsp[-1].interm.intermNode)->getAsAggregate() : 0);
         delete parseContext.switchSequenceStack.back();
@@ -11461,27 +11498,27 @@ yyreduce:
         --parseContext.statementNestingLevel;
         --parseContext.controlFlowNestingLevel;
     }
-#line 11465 "MachineIndependent/glslang_tab.cpp"
+#line 11502 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 601: /* switch_statement_list: %empty  */
-#line 3880 "MachineIndependent/glslang.y"
+#line 3917 "MachineIndependent/glslang.y"
                     {
         (yyval.interm.intermNode) = 0;
     }
-#line 11473 "MachineIndependent/glslang_tab.cpp"
+#line 11510 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 602: /* switch_statement_list: statement_list  */
-#line 3883 "MachineIndependent/glslang.y"
+#line 3920 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode);
     }
-#line 11481 "MachineIndependent/glslang_tab.cpp"
+#line 11518 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 603: /* case_label: CASE expression COLON  */
-#line 3889 "MachineIndependent/glslang.y"
+#line 3926 "MachineIndependent/glslang.y"
                             {
         (yyval.interm.intermNode) = 0;
         if (parseContext.switchLevel.size() == 0)
@@ -11494,11 +11531,11 @@ yyreduce:
             (yyval.interm.intermNode) = parseContext.intermediate.addBranch(EOpCase, (yyvsp[-1].interm.intermTypedNode), (yyvsp[-2].lex).loc);
         }
     }
-#line 11498 "MachineIndependent/glslang_tab.cpp"
+#line 11535 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 604: /* case_label: DEFAULT COLON  */
-#line 3901 "MachineIndependent/glslang.y"
+#line 3938 "MachineIndependent/glslang.y"
                     {
         (yyval.interm.intermNode) = 0;
         if (parseContext.switchLevel.size() == 0)
@@ -11508,29 +11545,29 @@ yyreduce:
         else
             (yyval.interm.intermNode) = parseContext.intermediate.addBranch(EOpDefault, (yyvsp[-1].lex).loc);
     }
-#line 11512 "MachineIndependent/glslang_tab.cpp"
+#line 11549 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 605: /* iteration_statement: iteration_statement_nonattributed  */
-#line 3913 "MachineIndependent/glslang.y"
+#line 3950 "MachineIndependent/glslang.y"
                                         {
         (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode);
     }
-#line 11520 "MachineIndependent/glslang_tab.cpp"
+#line 11557 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 606: /* iteration_statement: attribute iteration_statement_nonattributed  */
-#line 3916 "MachineIndependent/glslang.y"
+#line 3953 "MachineIndependent/glslang.y"
                                                   {
         parseContext.requireExtensions((yyvsp[0].interm.intermNode)->getLoc(), 1, &E_GL_EXT_control_flow_attributes, "attribute");
         parseContext.handleLoopAttributes(*(yyvsp[-1].interm.attributes), (yyvsp[0].interm.intermNode));
         (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode);
     }
-#line 11530 "MachineIndependent/glslang_tab.cpp"
+#line 11567 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 607: /* $@10: %empty  */
-#line 3923 "MachineIndependent/glslang.y"
+#line 3960 "MachineIndependent/glslang.y"
                        {
         if (! parseContext.limits.whileLoops)
             parseContext.error((yyvsp[-1].lex).loc, "while loops not available", "limitation", "");
@@ -11539,11 +11576,11 @@ yyreduce:
         ++parseContext.statementNestingLevel;
         ++parseContext.controlFlowNestingLevel;
     }
-#line 11543 "MachineIndependent/glslang_tab.cpp"
+#line 11580 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 608: /* iteration_statement_nonattributed: WHILE LEFT_PAREN $@10 condition RIGHT_PAREN statement_no_new_scope  */
-#line 3931 "MachineIndependent/glslang.y"
+#line 3968 "MachineIndependent/glslang.y"
                                                    {
         parseContext.symbolTable.pop(&parseContext.defaultPrecision[0]);
         (yyval.interm.intermNode) = parseContext.intermediate.addLoop((yyvsp[0].interm.intermNode), (yyvsp[-2].interm.intermTypedNode), 0, true, (yyvsp[-5].lex).loc);
@@ -11551,22 +11588,22 @@ yyreduce:
         --parseContext.statementNestingLevel;
         --parseContext.controlFlowNestingLevel;
     }
-#line 11555 "MachineIndependent/glslang_tab.cpp"
+#line 11592 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 609: /* $@11: %empty  */
-#line 3938 "MachineIndependent/glslang.y"
+#line 3975 "MachineIndependent/glslang.y"
          {
         parseContext.symbolTable.push();
         ++parseContext.loopNestingLevel;
         ++parseContext.statementNestingLevel;
         ++parseContext.controlFlowNestingLevel;
     }
-#line 11566 "MachineIndependent/glslang_tab.cpp"
+#line 11603 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 610: /* iteration_statement_nonattributed: DO $@11 statement WHILE LEFT_PAREN expression RIGHT_PAREN SEMICOLON  */
-#line 3944 "MachineIndependent/glslang.y"
+#line 3981 "MachineIndependent/glslang.y"
                                                                   {
         if (! parseContext.limits.whileLoops)
             parseContext.error((yyvsp[-7].lex).loc, "do-while loops not available", "limitation", "");
@@ -11579,22 +11616,22 @@ yyreduce:
         --parseContext.statementNestingLevel;
         --parseContext.controlFlowNestingLevel;
     }
-#line 11583 "MachineIndependent/glslang_tab.cpp"
+#line 11620 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 611: /* $@12: %empty  */
-#line 3956 "MachineIndependent/glslang.y"
+#line 3993 "MachineIndependent/glslang.y"
                      {
         parseContext.symbolTable.push();
         ++parseContext.loopNestingLevel;
         ++parseContext.statementNestingLevel;
         ++parseContext.controlFlowNestingLevel;
     }
-#line 11594 "MachineIndependent/glslang_tab.cpp"
+#line 11631 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 612: /* iteration_statement_nonattributed: FOR LEFT_PAREN $@12 for_init_statement for_rest_statement RIGHT_PAREN statement_no_new_scope  */
-#line 3962 "MachineIndependent/glslang.y"
+#line 3999 "MachineIndependent/glslang.y"
                                                                                {
         parseContext.symbolTable.pop(&parseContext.defaultPrecision[0]);
         (yyval.interm.intermNode) = parseContext.intermediate.makeAggregate((yyvsp[-3].interm.intermNode), (yyvsp[-5].lex).loc);
@@ -11607,81 +11644,81 @@ yyreduce:
         --parseContext.statementNestingLevel;
         --parseContext.controlFlowNestingLevel;
     }
-#line 11611 "MachineIndependent/glslang_tab.cpp"
+#line 11648 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 613: /* for_init_statement: expression_statement  */
-#line 3977 "MachineIndependent/glslang.y"
+#line 4014 "MachineIndependent/glslang.y"
                            {
         (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode);
     }
-#line 11619 "MachineIndependent/glslang_tab.cpp"
+#line 11656 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 614: /* for_init_statement: declaration_statement  */
-#line 3980 "MachineIndependent/glslang.y"
+#line 4017 "MachineIndependent/glslang.y"
                             {
         (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode);
     }
-#line 11627 "MachineIndependent/glslang_tab.cpp"
+#line 11664 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 615: /* conditionopt: condition  */
-#line 3986 "MachineIndependent/glslang.y"
+#line 4023 "MachineIndependent/glslang.y"
                 {
         (yyval.interm.intermTypedNode) = (yyvsp[0].interm.intermTypedNode);
     }
-#line 11635 "MachineIndependent/glslang_tab.cpp"
+#line 11672 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 616: /* conditionopt: %empty  */
-#line 3989 "MachineIndependent/glslang.y"
+#line 4026 "MachineIndependent/glslang.y"
                         {
         (yyval.interm.intermTypedNode) = 0;
     }
-#line 11643 "MachineIndependent/glslang_tab.cpp"
+#line 11680 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 617: /* for_rest_statement: conditionopt SEMICOLON  */
-#line 3995 "MachineIndependent/glslang.y"
+#line 4032 "MachineIndependent/glslang.y"
                              {
         (yyval.interm.nodePair).node1 = (yyvsp[-1].interm.intermTypedNode);
         (yyval.interm.nodePair).node2 = 0;
     }
-#line 11652 "MachineIndependent/glslang_tab.cpp"
+#line 11689 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 618: /* for_rest_statement: conditionopt SEMICOLON expression  */
-#line 3999 "MachineIndependent/glslang.y"
+#line 4036 "MachineIndependent/glslang.y"
                                          {
         (yyval.interm.nodePair).node1 = (yyvsp[-2].interm.intermTypedNode);
         (yyval.interm.nodePair).node2 = (yyvsp[0].interm.intermTypedNode);
     }
-#line 11661 "MachineIndependent/glslang_tab.cpp"
+#line 11698 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 619: /* jump_statement: CONTINUE SEMICOLON  */
-#line 4006 "MachineIndependent/glslang.y"
+#line 4043 "MachineIndependent/glslang.y"
                          {
         if (parseContext.loopNestingLevel <= 0)
             parseContext.error((yyvsp[-1].lex).loc, "continue statement only allowed in loops", "", "");
         (yyval.interm.intermNode) = parseContext.intermediate.addBranch(EOpContinue, (yyvsp[-1].lex).loc);
     }
-#line 11671 "MachineIndependent/glslang_tab.cpp"
+#line 11708 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 620: /* jump_statement: BREAK SEMICOLON  */
-#line 4011 "MachineIndependent/glslang.y"
+#line 4048 "MachineIndependent/glslang.y"
                       {
         if (parseContext.loopNestingLevel + parseContext.switchSequenceStack.size() <= 0)
             parseContext.error((yyvsp[-1].lex).loc, "break statement only allowed in switch and loops", "", "");
         (yyval.interm.intermNode) = parseContext.intermediate.addBranch(EOpBreak, (yyvsp[-1].lex).loc);
     }
-#line 11681 "MachineIndependent/glslang_tab.cpp"
+#line 11718 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 621: /* jump_statement: RETURN SEMICOLON  */
-#line 4016 "MachineIndependent/glslang.y"
+#line 4053 "MachineIndependent/glslang.y"
                        {
         (yyval.interm.intermNode) = parseContext.intermediate.addBranch(EOpReturn, (yyvsp[-1].lex).loc);
         if (parseContext.currentFunctionType->getBasicType() != EbtVoid)
@@ -11689,101 +11726,101 @@ yyreduce:
         if (parseContext.inMain)
             parseContext.postEntryPointReturn = true;
     }
-#line 11693 "MachineIndependent/glslang_tab.cpp"
+#line 11730 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 622: /* jump_statement: RETURN expression SEMICOLON  */
-#line 4023 "MachineIndependent/glslang.y"
+#line 4060 "MachineIndependent/glslang.y"
                                   {
         (yyval.interm.intermNode) = parseContext.handleReturnValue((yyvsp[-2].lex).loc, (yyvsp[-1].interm.intermTypedNode));
     }
-#line 11701 "MachineIndependent/glslang_tab.cpp"
+#line 11738 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 623: /* jump_statement: DISCARD SEMICOLON  */
-#line 4026 "MachineIndependent/glslang.y"
+#line 4063 "MachineIndependent/glslang.y"
                         {
         parseContext.requireStage((yyvsp[-1].lex).loc, EShLangFragment, "discard");
         (yyval.interm.intermNode) = parseContext.intermediate.addBranch(EOpKill, (yyvsp[-1].lex).loc);
     }
-#line 11710 "MachineIndependent/glslang_tab.cpp"
+#line 11747 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 624: /* jump_statement: TERMINATE_INVOCATION SEMICOLON  */
-#line 4030 "MachineIndependent/glslang.y"
+#line 4067 "MachineIndependent/glslang.y"
                                      {
         parseContext.requireStage((yyvsp[-1].lex).loc, EShLangFragment, "terminateInvocation");
         (yyval.interm.intermNode) = parseContext.intermediate.addBranch(EOpTerminateInvocation, (yyvsp[-1].lex).loc);
     }
-#line 11719 "MachineIndependent/glslang_tab.cpp"
+#line 11756 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 625: /* jump_statement: TERMINATE_RAY SEMICOLON  */
-#line 4034 "MachineIndependent/glslang.y"
+#line 4071 "MachineIndependent/glslang.y"
                               {
         parseContext.requireStage((yyvsp[-1].lex).loc, EShLangAnyHit, "terminateRayEXT");
         (yyval.interm.intermNode) = parseContext.intermediate.addBranch(EOpTerminateRayKHR, (yyvsp[-1].lex).loc);
     }
-#line 11728 "MachineIndependent/glslang_tab.cpp"
+#line 11765 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 626: /* jump_statement: IGNORE_INTERSECTION SEMICOLON  */
-#line 4038 "MachineIndependent/glslang.y"
+#line 4075 "MachineIndependent/glslang.y"
                                     {
         parseContext.requireStage((yyvsp[-1].lex).loc, EShLangAnyHit, "ignoreIntersectionEXT");
         (yyval.interm.intermNode) = parseContext.intermediate.addBranch(EOpIgnoreIntersectionKHR, (yyvsp[-1].lex).loc);
     }
-#line 11737 "MachineIndependent/glslang_tab.cpp"
+#line 11774 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 627: /* translation_unit: external_declaration  */
-#line 4047 "MachineIndependent/glslang.y"
+#line 4084 "MachineIndependent/glslang.y"
                            {
         (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode);
         parseContext.intermediate.setTreeRoot((yyval.interm.intermNode));
     }
-#line 11746 "MachineIndependent/glslang_tab.cpp"
+#line 11783 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 628: /* translation_unit: translation_unit external_declaration  */
-#line 4051 "MachineIndependent/glslang.y"
+#line 4088 "MachineIndependent/glslang.y"
                                             {
         if ((yyvsp[0].interm.intermNode) != nullptr) {
             (yyval.interm.intermNode) = parseContext.intermediate.growAggregate((yyvsp[-1].interm.intermNode), (yyvsp[0].interm.intermNode));
             parseContext.intermediate.setTreeRoot((yyval.interm.intermNode));
         }
     }
-#line 11757 "MachineIndependent/glslang_tab.cpp"
+#line 11794 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 629: /* external_declaration: function_definition  */
-#line 4060 "MachineIndependent/glslang.y"
+#line 4097 "MachineIndependent/glslang.y"
                           {
         (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode);
     }
-#line 11765 "MachineIndependent/glslang_tab.cpp"
+#line 11802 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 630: /* external_declaration: declaration  */
-#line 4063 "MachineIndependent/glslang.y"
+#line 4100 "MachineIndependent/glslang.y"
                   {
         (yyval.interm.intermNode) = (yyvsp[0].interm.intermNode);
     }
-#line 11773 "MachineIndependent/glslang_tab.cpp"
+#line 11810 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 631: /* external_declaration: SEMICOLON  */
-#line 4066 "MachineIndependent/glslang.y"
+#line 4103 "MachineIndependent/glslang.y"
                 {
         parseContext.requireProfile((yyvsp[0].lex).loc, ~EEsProfile, "extraneous semicolon");
         parseContext.profileRequires((yyvsp[0].lex).loc, ~EEsProfile, 460, nullptr, "extraneous semicolon");
         (yyval.interm.intermNode) = nullptr;
     }
-#line 11783 "MachineIndependent/glslang_tab.cpp"
+#line 11820 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 632: /* $@13: %empty  */
-#line 4074 "MachineIndependent/glslang.y"
+#line 4111 "MachineIndependent/glslang.y"
                          {
         (yyvsp[0].interm).function = parseContext.handleFunctionDeclarator((yyvsp[0].interm).loc, *(yyvsp[0].interm).function, false /* not prototype */);
         (yyvsp[0].interm).intermNode = parseContext.handleFunctionDefinition((yyvsp[0].interm).loc, *(yyvsp[0].interm).function);
@@ -11796,11 +11833,11 @@ yyreduce:
             ++parseContext.statementNestingLevel;
         }
     }
-#line 11800 "MachineIndependent/glslang_tab.cpp"
+#line 11837 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 633: /* function_definition: function_prototype $@13 compound_statement_no_new_scope  */
-#line 4086 "MachineIndependent/glslang.y"
+#line 4123 "MachineIndependent/glslang.y"
                                     {
         //   May be best done as post process phase on intermediate code
         if (parseContext.currentFunctionType->getBasicType() != EbtVoid && ! parseContext.functionReturnsValue)
@@ -11828,228 +11865,228 @@ yyreduce:
             --parseContext.statementNestingLevel;
         }
     }
-#line 11832 "MachineIndependent/glslang_tab.cpp"
+#line 11869 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 634: /* attribute: LEFT_BRACKET LEFT_BRACKET attribute_list RIGHT_BRACKET RIGHT_BRACKET  */
-#line 4116 "MachineIndependent/glslang.y"
+#line 4153 "MachineIndependent/glslang.y"
                                                                            {
         (yyval.interm.attributes) = (yyvsp[-2].interm.attributes);
     }
-#line 11840 "MachineIndependent/glslang_tab.cpp"
+#line 11877 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 635: /* attribute_list: single_attribute  */
-#line 4121 "MachineIndependent/glslang.y"
+#line 4158 "MachineIndependent/glslang.y"
                        {
         (yyval.interm.attributes) = (yyvsp[0].interm.attributes);
     }
-#line 11848 "MachineIndependent/glslang_tab.cpp"
+#line 11885 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 636: /* attribute_list: attribute_list COMMA single_attribute  */
-#line 4124 "MachineIndependent/glslang.y"
+#line 4161 "MachineIndependent/glslang.y"
                                             {
         (yyval.interm.attributes) = parseContext.mergeAttributes((yyvsp[-2].interm.attributes), (yyvsp[0].interm.attributes));
     }
-#line 11856 "MachineIndependent/glslang_tab.cpp"
+#line 11893 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 637: /* single_attribute: IDENTIFIER  */
-#line 4129 "MachineIndependent/glslang.y"
+#line 4166 "MachineIndependent/glslang.y"
                  {
         (yyval.interm.attributes) = parseContext.makeAttributes(*(yyvsp[0].lex).string);
     }
-#line 11864 "MachineIndependent/glslang_tab.cpp"
+#line 11901 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 638: /* single_attribute: IDENTIFIER LEFT_PAREN constant_expression RIGHT_PAREN  */
-#line 4132 "MachineIndependent/glslang.y"
+#line 4169 "MachineIndependent/glslang.y"
                                                             {
         (yyval.interm.attributes) = parseContext.makeAttributes(*(yyvsp[-3].lex).string, (yyvsp[-1].interm.intermTypedNode));
     }
-#line 11872 "MachineIndependent/glslang_tab.cpp"
+#line 11909 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 639: /* spirv_requirements_list: spirv_requirements_parameter  */
-#line 4137 "MachineIndependent/glslang.y"
+#line 4174 "MachineIndependent/glslang.y"
                                    {
         (yyval.interm.spirvReq) = (yyvsp[0].interm.spirvReq);
     }
-#line 11880 "MachineIndependent/glslang_tab.cpp"
+#line 11917 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 640: /* spirv_requirements_list: spirv_requirements_list COMMA spirv_requirements_parameter  */
-#line 4140 "MachineIndependent/glslang.y"
+#line 4177 "MachineIndependent/glslang.y"
                                                                  {
         (yyval.interm.spirvReq) = parseContext.mergeSpirvRequirements((yyvsp[-1].lex).loc, (yyvsp[-2].interm.spirvReq), (yyvsp[0].interm.spirvReq));
     }
-#line 11888 "MachineIndependent/glslang_tab.cpp"
+#line 11925 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 641: /* spirv_requirements_parameter: IDENTIFIER EQUAL LEFT_BRACKET spirv_extension_list RIGHT_BRACKET  */
-#line 4145 "MachineIndependent/glslang.y"
+#line 4182 "MachineIndependent/glslang.y"
                                                                        {
         (yyval.interm.spirvReq) = parseContext.makeSpirvRequirement((yyvsp[-3].lex).loc, *(yyvsp[-4].lex).string, (yyvsp[-1].interm.intermNode)->getAsAggregate(), nullptr);
     }
-#line 11896 "MachineIndependent/glslang_tab.cpp"
+#line 11933 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 642: /* spirv_requirements_parameter: IDENTIFIER EQUAL LEFT_BRACKET spirv_capability_list RIGHT_BRACKET  */
-#line 4148 "MachineIndependent/glslang.y"
+#line 4185 "MachineIndependent/glslang.y"
                                                                         {
         (yyval.interm.spirvReq) = parseContext.makeSpirvRequirement((yyvsp[-3].lex).loc, *(yyvsp[-4].lex).string, nullptr, (yyvsp[-1].interm.intermNode)->getAsAggregate());
     }
-#line 11904 "MachineIndependent/glslang_tab.cpp"
+#line 11941 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 643: /* spirv_extension_list: STRING_LITERAL  */
-#line 4153 "MachineIndependent/glslang.y"
+#line 4190 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.intermNode) = parseContext.intermediate.makeAggregate(parseContext.intermediate.addConstantUnion((yyvsp[0].lex).string, (yyvsp[0].lex).loc, true));
     }
-#line 11912 "MachineIndependent/glslang_tab.cpp"
+#line 11949 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 644: /* spirv_extension_list: spirv_extension_list COMMA STRING_LITERAL  */
-#line 4156 "MachineIndependent/glslang.y"
+#line 4193 "MachineIndependent/glslang.y"
                                                 {
         (yyval.interm.intermNode) = parseContext.intermediate.growAggregate((yyvsp[-2].interm.intermNode), parseContext.intermediate.addConstantUnion((yyvsp[0].lex).string, (yyvsp[0].lex).loc, true));
     }
-#line 11920 "MachineIndependent/glslang_tab.cpp"
+#line 11957 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 645: /* spirv_capability_list: INTCONSTANT  */
-#line 4161 "MachineIndependent/glslang.y"
+#line 4198 "MachineIndependent/glslang.y"
                   {
         (yyval.interm.intermNode) = parseContext.intermediate.makeAggregate(parseContext.intermediate.addConstantUnion((yyvsp[0].lex).i, (yyvsp[0].lex).loc, true));
     }
-#line 11928 "MachineIndependent/glslang_tab.cpp"
+#line 11965 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 646: /* spirv_capability_list: spirv_capability_list COMMA INTCONSTANT  */
-#line 4164 "MachineIndependent/glslang.y"
+#line 4201 "MachineIndependent/glslang.y"
                                               {
         (yyval.interm.intermNode) = parseContext.intermediate.growAggregate((yyvsp[-2].interm.intermNode), parseContext.intermediate.addConstantUnion((yyvsp[0].lex).i, (yyvsp[0].lex).loc, true));
     }
-#line 11936 "MachineIndependent/glslang_tab.cpp"
+#line 11973 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 647: /* spirv_execution_mode_qualifier: SPIRV_EXECUTION_MODE LEFT_PAREN INTCONSTANT RIGHT_PAREN  */
-#line 4169 "MachineIndependent/glslang.y"
+#line 4206 "MachineIndependent/glslang.y"
                                                               {
         parseContext.intermediate.insertSpirvExecutionMode((yyvsp[-1].lex).i);
         (yyval.interm.intermNode) = 0;
     }
-#line 11945 "MachineIndependent/glslang_tab.cpp"
+#line 11982 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 648: /* spirv_execution_mode_qualifier: SPIRV_EXECUTION_MODE LEFT_PAREN spirv_requirements_list COMMA INTCONSTANT RIGHT_PAREN  */
-#line 4173 "MachineIndependent/glslang.y"
+#line 4210 "MachineIndependent/glslang.y"
                                                                                             {
         parseContext.intermediate.insertSpirvRequirement((yyvsp[-3].interm.spirvReq));
         parseContext.intermediate.insertSpirvExecutionMode((yyvsp[-1].lex).i);
         (yyval.interm.intermNode) = 0;
     }
-#line 11955 "MachineIndependent/glslang_tab.cpp"
+#line 11992 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 649: /* spirv_execution_mode_qualifier: SPIRV_EXECUTION_MODE LEFT_PAREN INTCONSTANT COMMA spirv_execution_mode_parameter_list RIGHT_PAREN  */
-#line 4178 "MachineIndependent/glslang.y"
+#line 4215 "MachineIndependent/glslang.y"
                                                                                                         {
         parseContext.intermediate.insertSpirvExecutionMode((yyvsp[-3].lex).i, (yyvsp[-1].interm.intermNode)->getAsAggregate());
         (yyval.interm.intermNode) = 0;
     }
-#line 11964 "MachineIndependent/glslang_tab.cpp"
+#line 12001 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 650: /* spirv_execution_mode_qualifier: SPIRV_EXECUTION_MODE LEFT_PAREN spirv_requirements_list COMMA INTCONSTANT COMMA spirv_execution_mode_parameter_list RIGHT_PAREN  */
-#line 4182 "MachineIndependent/glslang.y"
+#line 4219 "MachineIndependent/glslang.y"
                                                                                                                                       {
         parseContext.intermediate.insertSpirvRequirement((yyvsp[-5].interm.spirvReq));
         parseContext.intermediate.insertSpirvExecutionMode((yyvsp[-3].lex).i, (yyvsp[-1].interm.intermNode)->getAsAggregate());
         (yyval.interm.intermNode) = 0;
     }
-#line 11974 "MachineIndependent/glslang_tab.cpp"
+#line 12011 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 651: /* spirv_execution_mode_qualifier: SPIRV_EXECUTION_MODE_ID LEFT_PAREN INTCONSTANT COMMA spirv_execution_mode_id_parameter_list RIGHT_PAREN  */
-#line 4187 "MachineIndependent/glslang.y"
+#line 4224 "MachineIndependent/glslang.y"
                                                                                                               {
         parseContext.intermediate.insertSpirvExecutionModeId((yyvsp[-3].lex).i, (yyvsp[-1].interm.intermNode)->getAsAggregate());
         (yyval.interm.intermNode) = 0;
     }
-#line 11983 "MachineIndependent/glslang_tab.cpp"
+#line 12020 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 652: /* spirv_execution_mode_qualifier: SPIRV_EXECUTION_MODE_ID LEFT_PAREN spirv_requirements_list COMMA INTCONSTANT COMMA spirv_execution_mode_id_parameter_list RIGHT_PAREN  */
-#line 4191 "MachineIndependent/glslang.y"
+#line 4228 "MachineIndependent/glslang.y"
                                                                                                                                             {
         parseContext.intermediate.insertSpirvRequirement((yyvsp[-5].interm.spirvReq));
         parseContext.intermediate.insertSpirvExecutionModeId((yyvsp[-3].lex).i, (yyvsp[-1].interm.intermNode)->getAsAggregate());
         (yyval.interm.intermNode) = 0;
     }
-#line 11993 "MachineIndependent/glslang_tab.cpp"
+#line 12030 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 653: /* spirv_execution_mode_parameter_list: spirv_execution_mode_parameter  */
-#line 4198 "MachineIndependent/glslang.y"
+#line 4235 "MachineIndependent/glslang.y"
                                      {
         (yyval.interm.intermNode) = parseContext.intermediate.makeAggregate((yyvsp[0].interm.intermNode));
     }
-#line 12001 "MachineIndependent/glslang_tab.cpp"
+#line 12038 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 654: /* spirv_execution_mode_parameter_list: spirv_execution_mode_parameter_list COMMA spirv_execution_mode_parameter  */
-#line 4201 "MachineIndependent/glslang.y"
+#line 4238 "MachineIndependent/glslang.y"
                                                                                {
         (yyval.interm.intermNode) = parseContext.intermediate.growAggregate((yyvsp[-2].interm.intermNode), (yyvsp[0].interm.intermNode));
     }
-#line 12009 "MachineIndependent/glslang_tab.cpp"
+#line 12046 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 655: /* spirv_execution_mode_parameter: FLOATCONSTANT  */
-#line 4206 "MachineIndependent/glslang.y"
+#line 4243 "MachineIndependent/glslang.y"
                     {
         (yyval.interm.intermNode) = parseContext.intermediate.addConstantUnion((yyvsp[0].lex).d, EbtFloat, (yyvsp[0].lex).loc, true);
     }
-#line 12017 "MachineIndependent/glslang_tab.cpp"
+#line 12054 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 656: /* spirv_execution_mode_parameter: INTCONSTANT  */
-#line 4209 "MachineIndependent/glslang.y"
+#line 4246 "MachineIndependent/glslang.y"
                   {
         (yyval.interm.intermNode) = parseContext.intermediate.addConstantUnion((yyvsp[0].lex).i, (yyvsp[0].lex).loc, true);
     }
-#line 12025 "MachineIndependent/glslang_tab.cpp"
+#line 12062 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 657: /* spirv_execution_mode_parameter: UINTCONSTANT  */
-#line 4212 "MachineIndependent/glslang.y"
+#line 4249 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.intermNode) = parseContext.intermediate.addConstantUnion((yyvsp[0].lex).u, (yyvsp[0].lex).loc, true);
     }
-#line 12033 "MachineIndependent/glslang_tab.cpp"
+#line 12070 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 658: /* spirv_execution_mode_parameter: BOOLCONSTANT  */
-#line 4215 "MachineIndependent/glslang.y"
+#line 4252 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.intermNode) = parseContext.intermediate.addConstantUnion((yyvsp[0].lex).b, (yyvsp[0].lex).loc, true);
     }
-#line 12041 "MachineIndependent/glslang_tab.cpp"
+#line 12078 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 659: /* spirv_execution_mode_parameter: STRING_LITERAL  */
-#line 4218 "MachineIndependent/glslang.y"
+#line 4255 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.intermNode) = parseContext.intermediate.addConstantUnion((yyvsp[0].lex).string, (yyvsp[0].lex).loc, true);
     }
-#line 12049 "MachineIndependent/glslang_tab.cpp"
+#line 12086 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 660: /* spirv_execution_mode_id_parameter_list: constant_expression  */
-#line 4223 "MachineIndependent/glslang.y"
+#line 4260 "MachineIndependent/glslang.y"
                           {
         if ((yyvsp[0].interm.intermTypedNode)->getBasicType() != EbtFloat &&
             (yyvsp[0].interm.intermTypedNode)->getBasicType() != EbtInt &&
@@ -12059,11 +12096,11 @@ yyreduce:
             parseContext.error((yyvsp[0].interm.intermTypedNode)->getLoc(), "this type not allowed", (yyvsp[0].interm.intermTypedNode)->getType().getBasicString(), "");
         (yyval.interm.intermNode) = parseContext.intermediate.makeAggregate((yyvsp[0].interm.intermTypedNode));
     }
-#line 12063 "MachineIndependent/glslang_tab.cpp"
+#line 12100 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 661: /* spirv_execution_mode_id_parameter_list: spirv_execution_mode_id_parameter_list COMMA constant_expression  */
-#line 4232 "MachineIndependent/glslang.y"
+#line 4269 "MachineIndependent/glslang.y"
                                                                        {
         if ((yyvsp[0].interm.intermTypedNode)->getBasicType() != EbtFloat &&
             (yyvsp[0].interm.intermTypedNode)->getBasicType() != EbtInt &&
@@ -12073,351 +12110,351 @@ yyreduce:
             parseContext.error((yyvsp[0].interm.intermTypedNode)->getLoc(), "this type not allowed", (yyvsp[0].interm.intermTypedNode)->getType().getBasicString(), "");
         (yyval.interm.intermNode) = parseContext.intermediate.growAggregate((yyvsp[-2].interm.intermNode), (yyvsp[0].interm.intermTypedNode));
     }
-#line 12077 "MachineIndependent/glslang_tab.cpp"
+#line 12114 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 662: /* spirv_storage_class_qualifier: SPIRV_STORAGE_CLASS LEFT_PAREN INTCONSTANT RIGHT_PAREN  */
-#line 4243 "MachineIndependent/glslang.y"
+#line 4280 "MachineIndependent/glslang.y"
                                                              {
         (yyval.interm.type).init((yyvsp[-3].lex).loc);
         (yyval.interm.type).qualifier.storage = EvqSpirvStorageClass;
         (yyval.interm.type).qualifier.spirvStorageClass = (yyvsp[-1].lex).i;
     }
-#line 12087 "MachineIndependent/glslang_tab.cpp"
+#line 12124 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 663: /* spirv_storage_class_qualifier: SPIRV_STORAGE_CLASS LEFT_PAREN spirv_requirements_list COMMA INTCONSTANT RIGHT_PAREN  */
-#line 4248 "MachineIndependent/glslang.y"
+#line 4285 "MachineIndependent/glslang.y"
                                                                                            {
         (yyval.interm.type).init((yyvsp[-5].lex).loc);
         parseContext.intermediate.insertSpirvRequirement((yyvsp[-3].interm.spirvReq));
         (yyval.interm.type).qualifier.storage = EvqSpirvStorageClass;
         (yyval.interm.type).qualifier.spirvStorageClass = (yyvsp[-1].lex).i;
     }
-#line 12098 "MachineIndependent/glslang_tab.cpp"
+#line 12135 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 664: /* spirv_decorate_qualifier: SPIRV_DECORATE LEFT_PAREN INTCONSTANT RIGHT_PAREN  */
-#line 4256 "MachineIndependent/glslang.y"
+#line 4293 "MachineIndependent/glslang.y"
                                                        {
         (yyval.interm.type).init((yyvsp[-3].lex).loc);
         (yyval.interm.type).qualifier.setSpirvDecorate((yyvsp[-1].lex).i);
     }
-#line 12107 "MachineIndependent/glslang_tab.cpp"
+#line 12144 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 665: /* spirv_decorate_qualifier: SPIRV_DECORATE LEFT_PAREN spirv_requirements_list COMMA INTCONSTANT RIGHT_PAREN  */
-#line 4260 "MachineIndependent/glslang.y"
+#line 4297 "MachineIndependent/glslang.y"
                                                                                      {
         (yyval.interm.type).init((yyvsp[-5].lex).loc);
         parseContext.intermediate.insertSpirvRequirement((yyvsp[-3].interm.spirvReq));
         (yyval.interm.type).qualifier.setSpirvDecorate((yyvsp[-1].lex).i);
     }
-#line 12117 "MachineIndependent/glslang_tab.cpp"
+#line 12154 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 666: /* spirv_decorate_qualifier: SPIRV_DECORATE LEFT_PAREN INTCONSTANT COMMA spirv_decorate_parameter_list RIGHT_PAREN  */
-#line 4265 "MachineIndependent/glslang.y"
+#line 4302 "MachineIndependent/glslang.y"
                                                                                             {
         (yyval.interm.type).init((yyvsp[-5].lex).loc);
         (yyval.interm.type).qualifier.setSpirvDecorate((yyvsp[-3].lex).i, (yyvsp[-1].interm.intermNode)->getAsAggregate());
     }
-#line 12126 "MachineIndependent/glslang_tab.cpp"
+#line 12163 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 667: /* spirv_decorate_qualifier: SPIRV_DECORATE LEFT_PAREN spirv_requirements_list COMMA INTCONSTANT COMMA spirv_decorate_parameter_list RIGHT_PAREN  */
-#line 4269 "MachineIndependent/glslang.y"
+#line 4306 "MachineIndependent/glslang.y"
                                                                                                                           {
         (yyval.interm.type).init((yyvsp[-7].lex).loc);
         parseContext.intermediate.insertSpirvRequirement((yyvsp[-5].interm.spirvReq));
         (yyval.interm.type).qualifier.setSpirvDecorate((yyvsp[-3].lex).i, (yyvsp[-1].interm.intermNode)->getAsAggregate());
     }
-#line 12136 "MachineIndependent/glslang_tab.cpp"
+#line 12173 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 668: /* spirv_decorate_qualifier: SPIRV_DECORATE_ID LEFT_PAREN INTCONSTANT COMMA spirv_decorate_id_parameter_list RIGHT_PAREN  */
-#line 4274 "MachineIndependent/glslang.y"
+#line 4311 "MachineIndependent/glslang.y"
                                                                                                   {
         (yyval.interm.type).init((yyvsp[-5].lex).loc);
         (yyval.interm.type).qualifier.setSpirvDecorateId((yyvsp[-3].lex).i, (yyvsp[-1].interm.intermNode)->getAsAggregate());
     }
-#line 12145 "MachineIndependent/glslang_tab.cpp"
+#line 12182 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 669: /* spirv_decorate_qualifier: SPIRV_DECORATE_ID LEFT_PAREN spirv_requirements_list COMMA INTCONSTANT COMMA spirv_decorate_id_parameter_list RIGHT_PAREN  */
-#line 4278 "MachineIndependent/glslang.y"
+#line 4315 "MachineIndependent/glslang.y"
                                                                                                                                 {
         (yyval.interm.type).init((yyvsp[-7].lex).loc);
         parseContext.intermediate.insertSpirvRequirement((yyvsp[-5].interm.spirvReq));
         (yyval.interm.type).qualifier.setSpirvDecorateId((yyvsp[-3].lex).i, (yyvsp[-1].interm.intermNode)->getAsAggregate());
     }
-#line 12155 "MachineIndependent/glslang_tab.cpp"
+#line 12192 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 670: /* spirv_decorate_qualifier: SPIRV_DECORATE_STRING LEFT_PAREN INTCONSTANT COMMA spirv_decorate_string_parameter_list RIGHT_PAREN  */
-#line 4283 "MachineIndependent/glslang.y"
+#line 4320 "MachineIndependent/glslang.y"
                                                                                                           {
         (yyval.interm.type).init((yyvsp[-5].lex).loc);
         (yyval.interm.type).qualifier.setSpirvDecorateString((yyvsp[-3].lex).i, (yyvsp[-1].interm.intermNode)->getAsAggregate());
     }
-#line 12164 "MachineIndependent/glslang_tab.cpp"
+#line 12201 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 671: /* spirv_decorate_qualifier: SPIRV_DECORATE_STRING LEFT_PAREN spirv_requirements_list COMMA INTCONSTANT COMMA spirv_decorate_string_parameter_list RIGHT_PAREN  */
-#line 4287 "MachineIndependent/glslang.y"
+#line 4324 "MachineIndependent/glslang.y"
                                                                                                                                         {
         (yyval.interm.type).init((yyvsp[-7].lex).loc);
         parseContext.intermediate.insertSpirvRequirement((yyvsp[-5].interm.spirvReq));
         (yyval.interm.type).qualifier.setSpirvDecorateString((yyvsp[-3].lex).i, (yyvsp[-1].interm.intermNode)->getAsAggregate());
     }
-#line 12174 "MachineIndependent/glslang_tab.cpp"
+#line 12211 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 672: /* spirv_decorate_parameter_list: spirv_decorate_parameter  */
-#line 4294 "MachineIndependent/glslang.y"
+#line 4331 "MachineIndependent/glslang.y"
                                {
         (yyval.interm.intermNode) = parseContext.intermediate.makeAggregate((yyvsp[0].interm.intermNode));
     }
-#line 12182 "MachineIndependent/glslang_tab.cpp"
+#line 12219 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 673: /* spirv_decorate_parameter_list: spirv_decorate_parameter_list COMMA spirv_decorate_parameter  */
-#line 4297 "MachineIndependent/glslang.y"
+#line 4334 "MachineIndependent/glslang.y"
                                                                    {
         (yyval.interm.intermNode) = parseContext.intermediate.growAggregate((yyvsp[-2].interm.intermNode), (yyvsp[0].interm.intermNode));
     }
-#line 12190 "MachineIndependent/glslang_tab.cpp"
+#line 12227 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 674: /* spirv_decorate_parameter: FLOATCONSTANT  */
-#line 4302 "MachineIndependent/glslang.y"
+#line 4339 "MachineIndependent/glslang.y"
                     {
         (yyval.interm.intermNode) = parseContext.intermediate.addConstantUnion((yyvsp[0].lex).d, EbtFloat, (yyvsp[0].lex).loc, true);
     }
-#line 12198 "MachineIndependent/glslang_tab.cpp"
+#line 12235 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 675: /* spirv_decorate_parameter: INTCONSTANT  */
-#line 4305 "MachineIndependent/glslang.y"
+#line 4342 "MachineIndependent/glslang.y"
                   {
         (yyval.interm.intermNode) = parseContext.intermediate.addConstantUnion((yyvsp[0].lex).i, (yyvsp[0].lex).loc, true);
     }
-#line 12206 "MachineIndependent/glslang_tab.cpp"
+#line 12243 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 676: /* spirv_decorate_parameter: UINTCONSTANT  */
-#line 4308 "MachineIndependent/glslang.y"
+#line 4345 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.intermNode) = parseContext.intermediate.addConstantUnion((yyvsp[0].lex).u, (yyvsp[0].lex).loc, true);
     }
-#line 12214 "MachineIndependent/glslang_tab.cpp"
+#line 12251 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 677: /* spirv_decorate_parameter: BOOLCONSTANT  */
-#line 4311 "MachineIndependent/glslang.y"
+#line 4348 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.intermNode) = parseContext.intermediate.addConstantUnion((yyvsp[0].lex).b, (yyvsp[0].lex).loc, true);
     }
-#line 12222 "MachineIndependent/glslang_tab.cpp"
+#line 12259 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 678: /* spirv_decorate_id_parameter_list: spirv_decorate_id_parameter  */
-#line 4316 "MachineIndependent/glslang.y"
+#line 4353 "MachineIndependent/glslang.y"
                                   {
         (yyval.interm.intermNode) = parseContext.intermediate.makeAggregate((yyvsp[0].interm.intermNode));
     }
-#line 12230 "MachineIndependent/glslang_tab.cpp"
+#line 12267 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 679: /* spirv_decorate_id_parameter_list: spirv_decorate_id_parameter_list COMMA spirv_decorate_id_parameter  */
-#line 4319 "MachineIndependent/glslang.y"
+#line 4356 "MachineIndependent/glslang.y"
                                                                          {
         (yyval.interm.intermNode) = parseContext.intermediate.growAggregate((yyvsp[-2].interm.intermNode), (yyvsp[0].interm.intermNode));
     }
-#line 12238 "MachineIndependent/glslang_tab.cpp"
+#line 12275 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 680: /* spirv_decorate_id_parameter: variable_identifier  */
-#line 4324 "MachineIndependent/glslang.y"
+#line 4361 "MachineIndependent/glslang.y"
                           {
         if ((yyvsp[0].interm.intermTypedNode)->getAsConstantUnion() || (yyvsp[0].interm.intermTypedNode)->getAsSymbolNode())
             (yyval.interm.intermNode) = (yyvsp[0].interm.intermTypedNode);
         else
             parseContext.error((yyvsp[0].interm.intermTypedNode)->getLoc(), "only allow constants or variables which are not elements of a composite", "", "");
     }
-#line 12249 "MachineIndependent/glslang_tab.cpp"
+#line 12286 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 681: /* spirv_decorate_id_parameter: FLOATCONSTANT  */
-#line 4330 "MachineIndependent/glslang.y"
+#line 4367 "MachineIndependent/glslang.y"
                     {
         (yyval.interm.intermNode) = parseContext.intermediate.addConstantUnion((yyvsp[0].lex).d, EbtFloat, (yyvsp[0].lex).loc, true);
     }
-#line 12257 "MachineIndependent/glslang_tab.cpp"
+#line 12294 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 682: /* spirv_decorate_id_parameter: INTCONSTANT  */
-#line 4333 "MachineIndependent/glslang.y"
+#line 4370 "MachineIndependent/glslang.y"
                   {
         (yyval.interm.intermNode) = parseContext.intermediate.addConstantUnion((yyvsp[0].lex).i, (yyvsp[0].lex).loc, true);
     }
-#line 12265 "MachineIndependent/glslang_tab.cpp"
+#line 12302 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 683: /* spirv_decorate_id_parameter: UINTCONSTANT  */
-#line 4336 "MachineIndependent/glslang.y"
+#line 4373 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.intermNode) = parseContext.intermediate.addConstantUnion((yyvsp[0].lex).u, (yyvsp[0].lex).loc, true);
     }
-#line 12273 "MachineIndependent/glslang_tab.cpp"
+#line 12310 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 684: /* spirv_decorate_id_parameter: BOOLCONSTANT  */
-#line 4339 "MachineIndependent/glslang.y"
+#line 4376 "MachineIndependent/glslang.y"
                    {
         (yyval.interm.intermNode) = parseContext.intermediate.addConstantUnion((yyvsp[0].lex).b, (yyvsp[0].lex).loc, true);
     }
-#line 12281 "MachineIndependent/glslang_tab.cpp"
+#line 12318 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 685: /* spirv_decorate_string_parameter_list: STRING_LITERAL  */
-#line 4344 "MachineIndependent/glslang.y"
+#line 4381 "MachineIndependent/glslang.y"
                      {
         (yyval.interm.intermNode) = parseContext.intermediate.makeAggregate(
             parseContext.intermediate.addConstantUnion((yyvsp[0].lex).string, (yyvsp[0].lex).loc, true));
     }
-#line 12290 "MachineIndependent/glslang_tab.cpp"
+#line 12327 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 686: /* spirv_decorate_string_parameter_list: spirv_decorate_string_parameter_list COMMA STRING_LITERAL  */
-#line 4348 "MachineIndependent/glslang.y"
+#line 4385 "MachineIndependent/glslang.y"
                                                                 {
         (yyval.interm.intermNode) = parseContext.intermediate.growAggregate((yyvsp[-2].interm.intermNode), parseContext.intermediate.addConstantUnion((yyvsp[0].lex).string, (yyvsp[0].lex).loc, true));
     }
-#line 12298 "MachineIndependent/glslang_tab.cpp"
+#line 12335 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 687: /* spirv_type_specifier: SPIRV_TYPE LEFT_PAREN spirv_instruction_qualifier_list COMMA spirv_type_parameter_list RIGHT_PAREN  */
-#line 4353 "MachineIndependent/glslang.y"
+#line 4390 "MachineIndependent/glslang.y"
                                                                                                          {
         (yyval.interm.type).init((yyvsp[-5].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).setSpirvType(*(yyvsp[-3].interm.spirvInst), (yyvsp[-1].interm.spirvTypeParams));
     }
-#line 12307 "MachineIndependent/glslang_tab.cpp"
+#line 12344 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 688: /* spirv_type_specifier: SPIRV_TYPE LEFT_PAREN spirv_requirements_list COMMA spirv_instruction_qualifier_list COMMA spirv_type_parameter_list RIGHT_PAREN  */
-#line 4357 "MachineIndependent/glslang.y"
+#line 4394 "MachineIndependent/glslang.y"
                                                                                                                                        {
         (yyval.interm.type).init((yyvsp[-7].lex).loc, parseContext.symbolTable.atGlobalLevel());
         parseContext.intermediate.insertSpirvRequirement((yyvsp[-5].interm.spirvReq));
         (yyval.interm.type).setSpirvType(*(yyvsp[-3].interm.spirvInst), (yyvsp[-1].interm.spirvTypeParams));
     }
-#line 12317 "MachineIndependent/glslang_tab.cpp"
+#line 12354 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 689: /* spirv_type_specifier: SPIRV_TYPE LEFT_PAREN spirv_instruction_qualifier_list RIGHT_PAREN  */
-#line 4362 "MachineIndependent/glslang.y"
+#line 4399 "MachineIndependent/glslang.y"
                                                                          {
         (yyval.interm.type).init((yyvsp[-3].lex).loc, parseContext.symbolTable.atGlobalLevel());
         (yyval.interm.type).setSpirvType(*(yyvsp[-1].interm.spirvInst));
     }
-#line 12326 "MachineIndependent/glslang_tab.cpp"
+#line 12363 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 690: /* spirv_type_specifier: SPIRV_TYPE LEFT_PAREN spirv_requirements_list COMMA spirv_instruction_qualifier_list RIGHT_PAREN  */
-#line 4366 "MachineIndependent/glslang.y"
+#line 4403 "MachineIndependent/glslang.y"
                                                                                                        {
         (yyval.interm.type).init((yyvsp[-5].lex).loc, parseContext.symbolTable.atGlobalLevel());
         parseContext.intermediate.insertSpirvRequirement((yyvsp[-3].interm.spirvReq));
         (yyval.interm.type).setSpirvType(*(yyvsp[-1].interm.spirvInst));
     }
-#line 12336 "MachineIndependent/glslang_tab.cpp"
+#line 12373 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 691: /* spirv_type_parameter_list: spirv_type_parameter  */
-#line 4373 "MachineIndependent/glslang.y"
+#line 4410 "MachineIndependent/glslang.y"
                            {
         (yyval.interm.spirvTypeParams) = (yyvsp[0].interm.spirvTypeParams);
     }
-#line 12344 "MachineIndependent/glslang_tab.cpp"
+#line 12381 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 692: /* spirv_type_parameter_list: spirv_type_parameter_list COMMA spirv_type_parameter  */
-#line 4376 "MachineIndependent/glslang.y"
+#line 4413 "MachineIndependent/glslang.y"
                                                            {
         (yyval.interm.spirvTypeParams) = parseContext.mergeSpirvTypeParameters((yyvsp[-2].interm.spirvTypeParams), (yyvsp[0].interm.spirvTypeParams));
     }
-#line 12352 "MachineIndependent/glslang_tab.cpp"
+#line 12389 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 693: /* spirv_type_parameter: constant_expression  */
-#line 4381 "MachineIndependent/glslang.y"
+#line 4418 "MachineIndependent/glslang.y"
                           {
         (yyval.interm.spirvTypeParams) = parseContext.makeSpirvTypeParameters((yyvsp[0].interm.intermTypedNode)->getLoc(), (yyvsp[0].interm.intermTypedNode)->getAsConstantUnion());
     }
-#line 12360 "MachineIndependent/glslang_tab.cpp"
+#line 12397 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 694: /* spirv_type_parameter: type_specifier_nonarray  */
-#line 4384 "MachineIndependent/glslang.y"
+#line 4421 "MachineIndependent/glslang.y"
                               {
         (yyval.interm.spirvTypeParams) = parseContext.makeSpirvTypeParameters((yyvsp[0].interm.type).loc, (yyvsp[0].interm.type));
     }
-#line 12368 "MachineIndependent/glslang_tab.cpp"
+#line 12405 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 695: /* spirv_instruction_qualifier: SPIRV_INSTRUCTION LEFT_PAREN spirv_instruction_qualifier_list RIGHT_PAREN  */
-#line 4389 "MachineIndependent/glslang.y"
+#line 4426 "MachineIndependent/glslang.y"
                                                                                 {
         (yyval.interm.spirvInst) = (yyvsp[-1].interm.spirvInst);
     }
-#line 12376 "MachineIndependent/glslang_tab.cpp"
+#line 12413 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 696: /* spirv_instruction_qualifier: SPIRV_INSTRUCTION LEFT_PAREN spirv_requirements_list COMMA spirv_instruction_qualifier_list RIGHT_PAREN  */
-#line 4392 "MachineIndependent/glslang.y"
+#line 4429 "MachineIndependent/glslang.y"
                                                                                                               {
         parseContext.intermediate.insertSpirvRequirement((yyvsp[-3].interm.spirvReq));
         (yyval.interm.spirvInst) = (yyvsp[-1].interm.spirvInst);
     }
-#line 12385 "MachineIndependent/glslang_tab.cpp"
+#line 12422 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 697: /* spirv_instruction_qualifier_list: spirv_instruction_qualifier_id  */
-#line 4398 "MachineIndependent/glslang.y"
+#line 4435 "MachineIndependent/glslang.y"
                                      {
         (yyval.interm.spirvInst) = (yyvsp[0].interm.spirvInst);
     }
-#line 12393 "MachineIndependent/glslang_tab.cpp"
+#line 12430 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 698: /* spirv_instruction_qualifier_list: spirv_instruction_qualifier_list COMMA spirv_instruction_qualifier_id  */
-#line 4401 "MachineIndependent/glslang.y"
+#line 4438 "MachineIndependent/glslang.y"
                                                                             {
         (yyval.interm.spirvInst) = parseContext.mergeSpirvInstruction((yyvsp[-1].lex).loc, (yyvsp[-2].interm.spirvInst), (yyvsp[0].interm.spirvInst));
     }
-#line 12401 "MachineIndependent/glslang_tab.cpp"
+#line 12438 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 699: /* spirv_instruction_qualifier_id: IDENTIFIER EQUAL STRING_LITERAL  */
-#line 4406 "MachineIndependent/glslang.y"
+#line 4443 "MachineIndependent/glslang.y"
                                       {
         (yyval.interm.spirvInst) = parseContext.makeSpirvInstruction((yyvsp[-1].lex).loc, *(yyvsp[-2].lex).string, *(yyvsp[0].lex).string);
     }
-#line 12409 "MachineIndependent/glslang_tab.cpp"
+#line 12446 "MachineIndependent/glslang_tab.cpp"
     break;
 
   case 700: /* spirv_instruction_qualifier_id: IDENTIFIER EQUAL INTCONSTANT  */
-#line 4409 "MachineIndependent/glslang.y"
+#line 4446 "MachineIndependent/glslang.y"
                                    {
         (yyval.interm.spirvInst) = parseContext.makeSpirvInstruction((yyvsp[-1].lex).loc, *(yyvsp[-2].lex).string, (yyvsp[0].lex).i);
     }
-#line 12417 "MachineIndependent/glslang_tab.cpp"
+#line 12454 "MachineIndependent/glslang_tab.cpp"
     break;
 
 
-#line 12421 "MachineIndependent/glslang_tab.cpp"
+#line 12458 "MachineIndependent/glslang_tab.cpp"
 
       default: break;
     }
@@ -12641,5 +12678,5 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 4413 "MachineIndependent/glslang.y"
+#line 4450 "MachineIndependent/glslang.y"
 

--- a/glslang/MachineIndependent/glslang_tab.cpp
+++ b/glslang/MachineIndependent/glslang_tab.cpp
@@ -5465,9 +5465,14 @@ yyreduce:
   case 31: /* function_call_header_with_parameters: function_call_header assignment_expression  */
 #line 494 "MachineIndependent/glslang.y"
                                                  {
-        if (!(parseContext.spvVersion.vulkan > 0
-              && parseContext.spvVersion.vulkanRelaxed)
-            || !(yyvsp[0].interm.intermTypedNode)->getType().containsOpaque())
+        if (parseContext.spvVersion.vulkan > 0
+            && parseContext.spvVersion.vulkanRelaxed
+            && (yyvsp[0].interm.intermTypedNode)->getType().containsOpaque())
+        {
+            (yyval.interm).intermNode = parseContext.vkRelaxedRemapFunctionArgument((yyval.interm).loc, (yyvsp[-1].interm).function, (yyvsp[0].interm.intermTypedNode));
+            (yyval.interm).function = (yyvsp[-1].interm).function;
+        }
+        else
         {
             TParameter param = { 0, new TType };
             param.type->shallowCopy((yyvsp[0].interm.intermTypedNode)->getType());
@@ -5476,11 +5481,6 @@ yyreduce:
             (yyval.interm).function = (yyvsp[-1].interm).function;
             (yyval.interm).intermNode = (yyvsp[0].interm.intermTypedNode);
         }
-        else
-        {
-            (yyval.interm).intermNode = parseContext.vkRelaxedRemapFunctionArgument((yyval.interm).loc, (yyvsp[-1].interm).function, (yyvsp[0].interm.intermTypedNode));
-            (yyval.interm).function = (yyvsp[-1].interm).function;
-        }
     }
 #line 5486 "MachineIndependent/glslang_tab.cpp"
     break;
@@ -5488,9 +5488,15 @@ yyreduce:
   case 32: /* function_call_header_with_parameters: function_call_header_with_parameters COMMA assignment_expression  */
 #line 512 "MachineIndependent/glslang.y"
                                                                        {
-        if (!(parseContext.spvVersion.vulkan > 0
-              && parseContext.spvVersion.vulkanRelaxed)
-            || !(yyvsp[0].interm.intermTypedNode)->getType().containsOpaque())
+        if (parseContext.spvVersion.vulkan > 0
+            && parseContext.spvVersion.vulkanRelaxed
+            && (yyvsp[0].interm.intermTypedNode)->getType().containsOpaque())
+        {
+            TIntermNode* remappedNode = parseContext.vkRelaxedRemapFunctionArgument((yyvsp[-1].lex).loc, (yyvsp[-2].interm).function, (yyvsp[0].interm.intermTypedNode));
+            (yyval.interm).intermNode = parseContext.intermediate.mergeAggregate((yyvsp[-2].interm).intermNode, remappedNode, (yyvsp[-1].lex).loc);
+            (yyval.interm).function = (yyvsp[-2].interm).function;
+        }
+        else
         {
             TParameter param = { 0, new TType };
             param.type->shallowCopy((yyvsp[0].interm.intermTypedNode)->getType());
@@ -5498,12 +5504,6 @@ yyreduce:
             (yyvsp[-2].interm).function->addParameter(param);
             (yyval.interm).function = (yyvsp[-2].interm).function;
             (yyval.interm).intermNode = parseContext.intermediate.growAggregate((yyvsp[-2].interm).intermNode, (yyvsp[0].interm.intermTypedNode), (yyvsp[-1].lex).loc);
-        }
-        else
-        {
-            TIntermNode* remappedNode = parseContext.vkRelaxedRemapFunctionArgument((yyvsp[-1].lex).loc, (yyvsp[-2].interm).function, (yyvsp[0].interm.intermTypedNode));
-            (yyval.interm).intermNode = parseContext.intermediate.mergeAggregate((yyvsp[-2].interm).intermNode, remappedNode, (yyvsp[-1].lex).loc);
-            (yyval.interm).function = (yyvsp[-2].interm).function;
         }
     }
 #line 5510 "MachineIndependent/glslang_tab.cpp"

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -527,6 +527,8 @@ public:
     TOperator mapTypeToConstructorOp(const TType&) const;
     TIntermAggregate* growAggregate(TIntermNode* left, TIntermNode* right);
     TIntermAggregate* growAggregate(TIntermNode* left, TIntermNode* right, const TSourceLoc&);
+    TIntermAggregate* mergeAggregate(TIntermNode* left, TIntermNode* right);
+    TIntermAggregate* mergeAggregate(TIntermNode* left, TIntermNode* right, const TSourceLoc&);
     TIntermAggregate* makeAggregate(TIntermNode* node);
     TIntermAggregate* makeAggregate(TIntermNode* node, const TSourceLoc&);
     TIntermAggregate* makeAggregate(const TSourceLoc&);


### PR DESCRIPTION
This PR is a companion to another PR we recently opened on `KhronosGroup/GLSL` : https://github.com/KhronosGroup/GLSL/pull/218
It implements the procedure described in the suggested changes to `GL_EXT_vulkan_glsl_relaxed`.

Samplers are extracted out of structures and moved to the topmost level available. In the context of uniform, that's the global uniform block. For structures passed as function parameters, we create invisible parameters and properly route arguments to them.

We also extend the `vk.relaxed.frag` test shader to demonstrate these added capabilities.