### PR TITLE
Remove debugOptions from internal classes

### DIFF
--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -48,6 +48,11 @@ add_custom_command(
 set(SOURCES StandAlone.cpp DirStackFileIncluder.h  ${GLSLANG_INTRINSIC_H})
 
 add_executable(glslang-standalone ${SOURCES})
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+    target_compile_options(glslang-standalone PRIVATE -Wconversion)
+elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" AND NOT MSVC)
+    target_compile_options(glslang-standalone PRIVATE -Wshorten-64-to-32)
+endif()
 set_property(TARGET glslang-standalone PROPERTY FOLDER tools)
 set_property(TARGET glslang-standalone PROPERTY OUTPUT_NAME glslang)
 glslang_set_link_args(glslang-standalone)

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -516,7 +516,7 @@ void ProcessGlobalBlockSettings(int& argc, char**& argv, std::string* name, unsi
 
     if (set) {
         errno = 0;
-        int setVal = ::strtol(argv[curArg], nullptr, 10);
+        int setVal = static_cast<int>(::strtol(argv[curArg], nullptr, 10));
         if (errno || setVal < 0) {
             printf("%s: invalid set\n", argv[curArg]);
             usage();
@@ -528,7 +528,7 @@ void ProcessGlobalBlockSettings(int& argc, char**& argv, std::string* name, unsi
 
     if (binding) {
         errno = 0;
-        int bindingVal = ::strtol(argv[curArg], nullptr, 10);
+        int bindingVal = static_cast<int>(::strtol(argv[curArg], nullptr, 10));
         if (errno || bindingVal < 0) {
             printf("%s: invalid binding\n", argv[curArg]);
             usage();
@@ -611,7 +611,7 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
             exit(EFailUsage);
         }
         errno = 0;
-        int location = ::strtol(split + 1, nullptr, 10);
+        int location = static_cast<int>(::strtol(split + 1, nullptr, 10));
         if (errno) {
             printf("%s: invalid location\n", arg);
             exit(EFailUsage);
@@ -638,7 +638,7 @@ void ProcessArguments(std::vector<std::unique_ptr<glslang::TWorkItem>>& workItem
                     } else if (lowerword == "uniform-base") {
                         if (argc <= 1)
                             Error("no <base> provided", lowerword.c_str());
-                        uniformBase = ::strtol(argv[1], nullptr, 10);
+                        uniformBase = static_cast<int>(::strtol(argv[1], nullptr, 10));
                         bumpArg();
                         break;
                     } else if (lowerword == "client") {
@@ -1172,7 +1172,7 @@ void CompileShaders(glslang::TWorklist& worklist)
     glslang::TWorkItem* workItem;
     if (Options & EOptionStdin) {
         if (worklist.remove(workItem)) {
-            ShHandle compiler = ShConstructCompiler(FindLanguage("stdin"), Options);
+            ShHandle compiler = ShConstructCompiler(FindLanguage("stdin"), 0);
             if (compiler == nullptr)
                 return;
 
@@ -1185,7 +1185,7 @@ void CompileShaders(glslang::TWorklist& worklist)
         }
     } else {
         while (worklist.remove(workItem)) {
-            ShHandle compiler = ShConstructCompiler(FindLanguage(workItem->name), Options);
+            ShHandle compiler = ShConstructCompiler(FindLanguage(workItem->name), 0);
             if (compiler == nullptr)
                 return;
 
@@ -1876,7 +1876,8 @@ void CompileFile(const char* fileName, ShHandle compiler)
     for (int i = 0; i < ((Options & EOptionMemoryLeakMode) ? 100 : 1); ++i) {
         for (int j = 0; j < ((Options & EOptionMemoryLeakMode) ? 100 : 1); ++j) {
             // ret = ShCompile(compiler, shaderStrings, NumShaderStrings, lengths, EShOptNone, &Resources, Options, (Options & EOptionDefaultDesktop) ? 110 : 100, false, messages);
-            ret = ShCompile(compiler, &shaderString, 1, nullptr, EShOptNone, GetResources(), Options, (Options & EOptionDefaultDesktop) ? 110 : 100, false, messages);
+            ret = ShCompile(compiler, &shaderString, 1, nullptr, EShOptNone, GetResources(), 0,
+                            (Options & EOptionDefaultDesktop) ? 110 : 100, false, messages);
             // const char* multi[12] = { "# ve", "rsion", " 300 e", "s", "\n#err",
             //                         "or should be l", "ine 1", "string 5\n", "float glo", "bal",
             //                         ";\n#error should be line 2\n void main() {", "global = 2.3;}" };

--- a/glslang/GenericCodeGen/CodeGen.cpp
+++ b/glslang/GenericCodeGen/CodeGen.cpp
@@ -41,10 +41,9 @@
 //
 class TGenericCompiler : public TCompiler {
 public:
-    TGenericCompiler(EShLanguage l, int dOptions) : TCompiler(l, infoSink), debugOptions(dOptions) { }
+    TGenericCompiler(EShLanguage l) : TCompiler(l, infoSink) {}
     virtual bool compile(TIntermNode* root, int version = 0, EProfile profile = ENoProfile);
     TInfoSink infoSink;
-    int debugOptions;
 };
 
 //
@@ -52,10 +51,7 @@ public:
 // compile object used by higher level code.  It returns
 // a subclass of TCompiler.
 //
-TCompiler* ConstructCompiler(EShLanguage language, int debugOptions)
-{
-    return new TGenericCompiler(language, debugOptions);
-}
+TCompiler* ConstructCompiler(EShLanguage language, int) { return new TGenericCompiler(language); }
 
 //
 // Delete the compiler made by ConstructCompiler

--- a/glslang/GenericCodeGen/Link.cpp
+++ b/glslang/GenericCodeGen/Link.cpp
@@ -44,11 +44,10 @@
 //
 class TGenericLinker : public TLinker {
 public:
-    TGenericLinker(EShExecutable e, int dOptions) : TLinker(e, infoSink), debugOptions(dOptions) { }
+    TGenericLinker(EShExecutable e) : TLinker(e, infoSink) {}
     bool link(TCompilerList&, TUniformMap*) { return true; }
     void getAttributeBindings(ShBindingTable const **) const { }
     TInfoSink infoSink;
-    int debugOptions;
 };
 
 //
@@ -60,10 +59,7 @@ public:
     virtual int getLocation(const char*) { return 0; }
 };
 
-TShHandleBase* ConstructLinker(EShExecutable executable, int debugOptions)
-{
-    return new TGenericLinker(executable, debugOptions);
-}
+TShHandleBase* ConstructLinker(EShExecutable executable, int) { return new TGenericLinker(executable); }
 
 void DeleteLinker(TShHandleBase* linker)
 {

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -1333,22 +1333,22 @@ int ShInitialize()
 // objects.
 //
 
-ShHandle ShConstructCompiler(const EShLanguage language, int debugOptions)
+ShHandle ShConstructCompiler(const EShLanguage language, int /*debugOptions unused*/)
 {
     if (!InitThread())
         return nullptr;
 
-    TShHandleBase* base = static_cast<TShHandleBase*>(ConstructCompiler(language, debugOptions));
+    TShHandleBase* base = static_cast<TShHandleBase*>(ConstructCompiler(language, 0));
 
     return reinterpret_cast<void*>(base);
 }
 
-ShHandle ShConstructLinker(const EShExecutable executable, int debugOptions)
+ShHandle ShConstructLinker(const EShExecutable executable, int /*debugOptions unused*/)
 {
     if (!InitThread())
         return nullptr;
 
-    TShHandleBase* base = static_cast<TShHandleBase*>(ConstructLinker(executable, debugOptions));
+    TShHandleBase* base = static_cast<TShHandleBase*>(ConstructLinker(executable, 0));
 
     return reinterpret_cast<void*>(base);
 }

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -318,8 +318,8 @@ typedef void* ShHandle;
 // Driver calls these to create and destroy compiler/linker
 // objects.
 //
-GLSLANG_EXPORT ShHandle ShConstructCompiler(const EShLanguage, int debugOptions);  // one per shader
-GLSLANG_EXPORT ShHandle ShConstructLinker(const EShExecutable, int debugOptions);  // one per shader pair
+GLSLANG_EXPORT ShHandle ShConstructCompiler(const EShLanguage, int /*debugOptions unused*/); // one per shader
+GLSLANG_EXPORT ShHandle ShConstructLinker(const EShExecutable, int /*debugOptions unused*/); // one per shader pair
 GLSLANG_EXPORT ShHandle ShConstructUniformMap();                 // one per uniform namespace (currently entire program object)
 GLSLANG_EXPORT void ShDestruct(ShHandle);
 
@@ -330,18 +330,13 @@ GLSLANG_EXPORT void ShDestruct(ShHandle);
 // The info-log should be written by ShCompile into
 // ShHandle, so it can answer future queries.
 //
-GLSLANG_EXPORT int ShCompile(
-    const ShHandle,
-    const char* const shaderStrings[],
-    const int numStrings,
-    const int* lengths,
-    const EShOptimizationLevel,
-    const TBuiltInResource *resources,
-    int debugOptions,
-    int defaultVersion = 110,            // use 100 for ES environment, overridden by #version in shader
-    bool forwardCompatible = false,      // give errors for use of deprecated features
-    EShMessages messages = EShMsgDefault // warnings and errors
-    );
+GLSLANG_EXPORT int ShCompile(const ShHandle, const char* const shaderStrings[], const int numStrings,
+                             const int* lengths, const EShOptimizationLevel, const TBuiltInResource* resources,
+                             int,                      // debugOptions unused
+                             int defaultVersion = 110, // use 100 for ES environment, overridden by #version in shader
+                             bool forwardCompatible = false,      // give errors for use of deprecated features
+                             EShMessages messages = EShMsgDefault // warnings and errors
+);
 
 GLSLANG_EXPORT int ShLinkExt(
     const ShHandle,               // linker object


### PR DESCRIPTION
The debug options passed down from the public ShConstruct* functions to internal code is unused. This change removes the internal debugOptions fields and attempts to make it more obvious these fields are not used.

This change does not change the public-facing interface.

This change also adds the -Wshorten-64-to-32 warning to the StandAlone build in order to avoid unwanted 64-to-32 bit conversions in the future.

Closes #3348.