### PR TITLE
Generate pkg-config file during install builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,4 +370,35 @@ if(ENABLE_GLSLANG_INSTALL)
         DESTINATION
             "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
     )
+
+    # Generate a pkg-config file, so that software projects which use
+    # pkg-config to locate dependencies can find glslang
+
+    # This template is filled-in by CMake's `configure_file(... @ONLY)`.
+    # The `@...@` are substituted by CMake's configure_file(), either
+    # from variables set in CMakeLists.txt or by CMake itself.
+    # (Based on: https://www.scivision.dev/cmake-generate-pkg-config/)
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc.in" [=[
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${prefix}/lib"
+includedir="${prefix}/include"
+
+Name: @PROJECT_NAME@
+Description: official reference compiler front end for the OpenGL ES and OpenGL shading languages
+Version: @PROJECT_VERSION@
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" -l@PROJECT_NAME@
+    ]=])
+    configure_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+        @ONLY
+    )
+    install(
+        FILES
+            "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+        DESTINATION
+            "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+    )
 endif()


### PR DESCRIPTION
This commit causes CMake to generate a pkg-config file when `ENABLE_GLSLANG_INSTALL` is enabled. This allows software projects that use pkg-config (and not CMake) to locate external dependencies (e.g., Godot 4.x), to find and properly link to a pre-built glslang package.

Closes #1715.