### PR TITLE
Use googletest version 1.14.0

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -56,21 +56,7 @@ jobs:
               run: |
                   sudo apt-get -qq update
                   sudo apt-get install -y clang-6.0
-            - name: Install GoogleTest
-              run: |
-                  # check out pre-breakage version of googletest; can be deleted when
-                  # issue 3128 is fixed
-                  # git clone --depth=1 https://github.com/google/googletest.git External/googletest
-                  mkdir -p External/googletest
-                  cd External/googletest
-                  git init
-                  git remote add origin https://github.com/google/googletest.git
-                  git fetch --depth 1 origin 0c400f67fcf305869c5fb113dd296eca266c9725
-                  git reset --hard FETCH_HEAD
-                  cd ../..
-            - name: Update Glslang Sources
-              run: |
-                  ./update_glslang_sources.py
+            - run: ./update_glslang_sources.py
             - name: Build
               env:
                   CC: ${{matrix.compiler.cc}}
@@ -132,21 +118,7 @@ jobs:
             - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
               with:
                   python-version: '3.7'
-            - name: Install GoogleTest
-              run: |
-                  # check out pre-breakage version of googletest; can be deleted when
-                  # issue 3128 is fixed
-                  # git clone --depth=1 https://github.com/google/googletest.git External/googletest
-                  mkdir -p External/googletest
-                  cd External/googletest
-                  git init
-                  git remote add origin https://github.com/google/googletest.git
-                  git fetch --depth 1 origin 0c400f67fcf305869c5fb113dd296eca266c9725
-                  git reset --hard FETCH_HEAD
-                  cd ../..
-            - name: Update Glslang Sources
-              run: |
-                  ./update_glslang_sources.py
+            - run: ./update_glslang_sources.py
             - name: Build
               env:
                   CC: ${{matrix.compiler.cc}}
@@ -205,21 +177,7 @@ jobs:
             - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
               with:
                   python-version: '3.7'
-            - name: Install GoogleTest
-              run: |
-                  # check out pre-breakage version of googletest; can be deleted when
-                  # issue 3128 is fixed
-                  # git clone --depth=1 https://github.com/google/googletest.git External/googletest
-                  mkdir -p External/googletest
-                  cd External/googletest
-                  git init
-                  git remote add origin https://github.com/google/googletest.git
-                  git fetch --depth 1 origin 0c400f67fcf305869c5fb113dd296eca266c9725
-                  git reset --hard FETCH_HEAD
-                  cd ../..
-            - name: Update Glslang Sources
-              run: |
-                  python update_glslang_sources.py
+            - run: python update_glslang_sources.py
             - name: Build
               run: |
                   cmake -S. -Bbuild -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="$PWD/build/install"

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -32,20 +32,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@6d1841ec156c39a52b1b23a810da917ab98da1f4 # v1.2.10
         with:
           key: ubuntu-22-${{ matrix.cmake_build_type }}-${{ matrix.compiler.cc }}-${{matrix.compiler.cxx}}
-      - name: Install GoogleTest
-        run: |
-          # check out pre-breakage version of googletest; can be deleted when
-          # issue 3128 is fixed
-          # git clone --depth=1 https://github.com/google/googletest.git External/googletest
-          mkdir -p External/googletest
-          cd External/googletest
-          git init
-          git remote add origin https://github.com/google/googletest.git
-          git fetch --depth 1 origin 0c400f67fcf305869c5fb113dd296eca266c9725
-          git reset --hard FETCH_HEAD
-          cd ../..
-      - name: Update Glslang Sources
-        run: ./update_glslang_sources.py
+      - run: ./update_glslang_sources.py
       - name: Configure
         run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }}
         env:
@@ -81,20 +68,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@6d1841ec156c39a52b1b23a810da917ab98da1f4 # v1.2.10
         with:
           key: ubuntu-22-${{ matrix.cmake_build_type }}-${{ matrix.compiler.cc }}-${{matrix.compiler.cxx}}-${{matrix.flags}}
-      - name: Install GoogleTest
-        run: |
-          # check out pre-breakage version of googletest; can be deleted when
-          # issue 3128 is fixed
-          # git clone --depth=1 https://github.com/google/googletest.git External/googletest
-          mkdir -p External/googletest
-          cd External/googletest
-          git init
-          git remote add origin https://github.com/google/googletest.git
-          git fetch --depth 1 origin 0c400f67fcf305869c5fb113dd296eca266c9725
-          git reset --hard FETCH_HEAD
-          cd ../..
-      - name: Update Glslang Sources
-        run: ./update_glslang_sources.py
+      - run: ./update_glslang_sources.py
       - name: Configure
         run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }}
         env:
@@ -131,20 +105,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@6d1841ec156c39a52b1b23a810da917ab98da1f4 # v1.2.10
         with:
           key: linux_backcompat
-      - name: Install GoogleTest
-        run: |
-          # check out pre-breakage version of googletest; can be deleted when
-          # issue 3128 is fixed
-          # git clone --depth=1 https://github.com/google/googletest.git External/googletest
-          mkdir -p External/googletest
-          cd External/googletest
-          git init
-          git remote add origin https://github.com/google/googletest.git
-          git fetch --depth 1 origin 0c400f67fcf305869c5fb113dd296eca266c9725
-          git reset --hard FETCH_HEAD
-          cd ../..
-      - name: Update Glslang Sources
-        run: ./update_glslang_sources.py
+      - run: ./update_glslang_sources.py
       - name: Configure
         run: cmake -S . -B build -D CMAKE_BUILD_TYPE=Release
         env:
@@ -173,20 +134,7 @@ jobs:
         with:
           python-version: '3.7'
       - uses: lukka/get-cmake@8be6cca406b575906541e8e3b885d46f416bba39 # v3.27.7
-      - name: Install GoogleTest
-        run: |
-          # check out pre-breakage version of googletest; can be deleted when
-          # issue 3128 is fixed
-          # git clone --depth=1 https://github.com/google/googletest.git External/googletest
-          mkdir -p External/googletest
-          cd External/googletest
-          git init
-          git remote add origin https://github.com/google/googletest.git
-          git fetch --depth 1 origin 0c400f67fcf305869c5fb113dd296eca266c9725
-          git reset --hard FETCH_HEAD
-          cd ../..
-      - name: Update Glslang Sources
-        run: ./update_glslang_sources.py
+      - run: ./update_glslang_sources.py
       - name: Configure
         run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{matrix.cmake_build_type}} -G "Ninja"
         env:
@@ -216,21 +164,7 @@ jobs:
       - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
           python-version: '3.7'
-      - name: Install GoogleTest
-        run: |
-          # check out pre-breakage version of googletest; can be deleted when
-          # issue 3128 is fixed
-          # git clone --depth=1 https://github.com/google/googletest.git External/googletest
-          mkdir -p External/googletest
-          cd External/googletest
-          git init
-          git remote add origin https://github.com/google/googletest.git
-          git fetch --depth 1 origin 0c400f67fcf305869c5fb113dd296eca266c9725
-          git reset --hard FETCH_HEAD
-          cd ../..
-      - name: Update Glslang Sources
-        run: |
-          python update_glslang_sources.py
+      - run: python update_glslang_sources.py
       - name: Build
         run: |
           cmake -S. -Bbuild -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="$PWD/build/install"

--- a/README.md
+++ b/README.md
@@ -122,24 +122,6 @@ git clone https://github.com/KhronosGroup/glslang.git
 #### 2) Check-Out External Projects
 
 ```bash
-cd <the directory glslang was cloned to, "External" will be a subdirectory>
-git clone https://github.com/google/googletest.git External/googletest
-```
-
-TEMPORARY NOTICE: additionally perform the following to avoid a current
-breakage in googletest:
-
-```bash
-cd External/googletest
-git checkout 0c400f67fcf305869c5fb113dd296eca266c9725
-cd ../..
-```
-
-If you wish to assure that SPIR-V generated from HLSL is legal for Vulkan,
-wish to invoke -Os to reduce SPIR-V size from HLSL or GLSL, or wish to run the
-integrated test suite, install spirv-tools with this:
-
-```bash
 ./update_glslang_sources.py
 ```
 

--- a/known_good.json
+++ b/known_good.json
@@ -13,6 +13,13 @@
       "subrepo" : "KhronosGroup/SPIRV-Headers",
       "subdir" : "External/spirv-tools/external/spirv-headers",
       "commit" : "e867c06631767a2d96424cbec530f9ee5e78180f"
+    },
+    {
+      "name": "googletest",
+      "site": "github",
+      "subrepo": "google/googletest",
+      "subdir": "External/googletest",
+      "commit": "v1.14.0"
     }
   ]
 }

--- a/known_good_khr.json
+++ b/known_good_khr.json
@@ -13,6 +13,13 @@
       "subrepo" : "spirv/SPIRV-Headers",
       "subdir" : "External/spirv-tools/external/spirv-headers",
       "commit" : "gitlab-prelim-rc4"
+    },
+    {
+      "name": "googletest",
+      "site": "github",
+      "subrepo": "google/googletest",
+      "subdir": "External/googletest",
+      "commit": "v1.14.0"
     }
   ]
 }


### PR DESCRIPTION
https://github.com/google/googletest/issues/3128

Seems like at one point googletest had an issue with an older version of Xcode. I wasn't able to repro the build failure with v1.14.0

This adds googletest to the known_good.json to simplify CI / developer workflow