### PR TITLE
GL_EXT_spirv_intrinsics: Fix a typo in function naming

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -4946,7 +4946,7 @@ void TGlslangToSpvTraverser::decorateStructType(const glslang::TType& type,
         //
         // Add SPIR-V decorations for members (GL_EXT_spirv_intrinsics)
         //
-        if (glslangMember.getQualifier().hasSprivDecorate()) {
+        if (glslangMember.getQualifier().hasSpirvDecorate()) {
             const glslang::TSpirvDecorate& spirvDecorate = glslangMember.getQualifier().getSpirvDecorate();
 
             // Add spirv_decorate
@@ -9599,9 +9599,9 @@ spv::Id TGlslangToSpvTraverser::getSymbolId(const glslang::TIntermSymbol* symbol
     }
 
     //
-    // Add SPIR-V decorations for structure (GL_EXT_spirv_intrinsics)
+    // Add SPIR-V decorations (GL_EXT_spirv_intrinsics)
     //
-    if (symbol->getType().getQualifier().hasSprivDecorate()) {
+    if (symbol->getType().getQualifier().hasSpirvDecorate()) {
         const glslang::TSpirvDecorate& spirvDecorate = symbol->getType().getQualifier().getSpirvDecorate();
 
         // Add spirv_decorate

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -1075,7 +1075,7 @@ public:
     }
 
     // GL_EXT_spirv_intrinsics
-    bool hasSprivDecorate() const { return spirvDecorate != nullptr; }
+    bool hasSpirvDecorate() const { return spirvDecorate != nullptr; }
     void setSpirvDecorate(int decoration, const TIntermAggregate* args = nullptr);
     void setSpirvDecorateId(int decoration, const TIntermAggregate* args);
     void setSpirvDecorateString(int decoration, const TIntermAggregate* args);
@@ -2096,7 +2096,7 @@ public:
         const auto appendInt  = [&](int i)          { typeString.append(std::to_string(i).c_str()); };
 
         if (getQualifiers) {
-          if (qualifier.hasSprivDecorate())
+          if (qualifier.hasSpirvDecorate())
             appendStr(qualifier.getSpirvDecorateQualifierString().c_str());
 
           if (qualifier.hasLayout()) {

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -4191,8 +4191,8 @@ void TParseContext::mergeQualifiers(const TSourceLoc& loc, TQualifier& dst, cons
     dst.spirvStorageClass = src.spirvStorageClass;
 
     // SPIR-V decorate qualifiers (GL_EXT_spirv_intrinsics)
-    if (src.hasSprivDecorate()) {
-        if (dst.hasSprivDecorate()) {
+    if (src.hasSpirvDecorate()) {
+        if (dst.hasSpirvDecorate()) {
             const TSpirvDecorate& srcSpirvDecorate = src.getSpirvDecorate();
             TSpirvDecorate& dstSpirvDecorate = dst.getSpirvDecorate();
             for (auto& decorate : srcSpirvDecorate.decorates) {
@@ -6326,8 +6326,7 @@ void TParseContext::layoutObjectCheck(const TSourceLoc& loc, const TSymbol& symb
         switch (qualifier.storage) {
         case EvqVaryingIn:
         case EvqVaryingOut:
-            if (!type.getQualifier().isTaskMemory() &&
-                !type.getQualifier().hasSprivDecorate() &&
+            if (!type.getQualifier().isTaskMemory() && !type.getQualifier().hasSpirvDecorate() &&
                 (type.getBasicType() != EbtBlock ||
                  (!(*type.getStruct())[0].type->getQualifier().hasLocation() &&
                    (*type.getStruct())[0].type->getQualifier().builtIn == EbvNone)))
@@ -8540,7 +8539,7 @@ void TParseContext::declareBlock(const TSourceLoc& loc, TTypeList& typeList, con
             memberQualifier.storage = EvqtaskPayloadSharedEXT;
         if (memberQualifier.storage == EvqSpirvStorageClass)
             error(memberLoc, "member cannot have a spirv_storage_class qualifier", memberType.getFieldName().c_str(), "");
-        if (memberQualifier.hasSprivDecorate() && !memberQualifier.getSpirvDecorate().decorateIds.empty())
+        if (memberQualifier.hasSpirvDecorate() && !memberQualifier.getSpirvDecorate().decorateIds.empty())
             error(memberLoc, "member cannot have a spirv_decorate_id qualifier", memberType.getFieldName().c_str(), "");
         if ((currentBlockQualifier.storage == EvqUniform || currentBlockQualifier.storage == EvqBuffer) && (memberQualifier.isInterpolation() || memberQualifier.isAuxiliary()))
             error(memberLoc, "member of uniform or buffer block cannot have an auxiliary or interpolation qualifier", memberType.getFieldName().c_str(), "");

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -866,7 +866,7 @@ int TDefaultIoResolverBase::resolveInOutLocation(EShLanguage stage, TVarEntryInf
     }
 
     // no locations added if already present, a built-in variable, or a variable with SPIR-V decorate
-    if (type.getQualifier().hasLocation() || type.isBuiltIn() || type.getQualifier().hasSprivDecorate()) {
+    if (type.getQualifier().hasLocation() || type.isBuiltIn() || type.getQualifier().hasSpirvDecorate()) {
         return ent.newLocation = -1;
     }
 
@@ -953,7 +953,7 @@ int TDefaultGlslIoResolver::resolveInOutLocation(EShLanguage stage, TVarEntryInf
         return ent.newLocation = type.getQualifier().layoutLocation;
     }
     // no locations added if already present, a built-in variable, or a variable with SPIR-V decorate
-    if (type.isBuiltIn() || type.getQualifier().hasSprivDecorate()) {
+    if (type.isBuiltIn() || type.getQualifier().hasSpirvDecorate()) {
         return ent.newLocation = -1;
     }
     // no locations on blocks of built-in variables


### PR DESCRIPTION
hasSprivDecorate => hasSpirvDecorate