### PR TITLE
Fix GL_ARB_shader_storage_buffer_object version

### DIFF
--- a/Test/400.frag
+++ b/Test/400.frag
@@ -7,6 +7,39 @@ uniform sampler2D arrayedSampler[5];
 uniform usampler2DRect samp2dr;
 uniform isampler2DArray isamp2DA;
 
+#extension GL_ARB_shader_storage_buffer_object : enable
+
+buffer Buffer
+{
+    int atomi;
+    uint atomu;
+};
+
+void atomicOpPass()
+{
+    int origi = atomicAdd(atomi, 3);
+    uint origu = atomicAnd(atomu, 7u);
+    origi = atomicExchange(atomi, 4);
+    origu = atomicCompSwap(atomu, 10u, 8u);
+}
+
+buffer ssboElem01
+{
+    int member01;
+    int memberArr01[2];
+    int memberUnsizedArr01[];
+} ssboStd430Arr[2];
+
+// if turns on EShReflectionSharedStd140SSBO, SPIR-V would be different
+buffer ssboElem02
+{
+    int member02;
+    int memberArr02[2];
+    int memberUnsizedArr02[];
+} ssboSharedArr[2];
+
+#extension GL_ARB_shader_storage_buffer_object : disable
+
 void main()
 {
     vec4 v;

--- a/Test/baseResults/400.frag.out
+++ b/Test/baseResults/400.frag.out
@@ -1,510 +1,554 @@
 400.frag
-ERROR: 0:18: 'textureGatherOffsets(...)' : must be a compile-time constant: offsets argument
-ERROR: 0:22: 'textureGatherOffset(...)' : must be a compile-time constant: component argument
-ERROR: 0:23: 'textureGatherOffset(...)' : must be 0, 1, 2, or 3: component argument
-ERROR: 0:30: 'location qualifier on input' : not supported for this version or the enabled extensions 
-ERROR: 0:38: 'location qualifier on uniform or buffer' : not supported for this version or the enabled extensions 
-ERROR: 0:40: 'gl_Color' : identifiers starting with "gl_" are reserved 
-ERROR: 0:41: 'redeclaration' : cannot change qualification of gl_ClipDistance
-ERROR: 0:43: 'gl_FragCoord' : cannot redeclare after use 
-ERROR: 0:51: 'texel offset' : argument must be compile-time constant 
-ERROR: 0:53: 'texel offset' : value is out of range: [gl_MinProgramTexelOffset, gl_MaxProgramTexelOffset]
-ERROR: 0:53: 'texel offset' : value is out of range: [gl_MinProgramTexelOffset, gl_MaxProgramTexelOffset]
-ERROR: 0:54: 'texel offset' : value is out of range: [gl_MinProgramTexelOffset, gl_MaxProgramTexelOffset]
-ERROR: 0:54: 'texel offset' : value is out of range: [gl_MinProgramTexelOffset, gl_MaxProgramTexelOffset]
-ERROR: 0:57: 'patch' : not supported in this stage: fragment
-ERROR: 0:58: 'patch' : not supported in this stage: fragment
-ERROR: 0:58: 'centroid/sample/patch' : can't use auxiliary qualifier on a fragment output 
-ERROR: 0:73: 'dFdxFine' : required extension not requested: GL_ARB_derivative_control
-ERROR: 0:74: 'dFdyCoarse' : required extension not requested: GL_ARB_derivative_control
-ERROR: 0:75: 'fwidthCoarse' : required extension not requested: GL_ARB_derivative_control
-ERROR: 0:75: 'fwidthFine' : required extension not requested: GL_ARB_derivative_control
-ERROR: 0:104: 'centroid/sample/patch' : can't use auxiliary qualifier on a fragment output 
-ERROR: 0:123: 'interpolateAtCentroid' : no matching overloaded function found 
-ERROR: 0:125: 'interpolateAtCentroid' : first argument must be an interpolant, or interpolant-array element 
-ERROR: 0:127: 'interpolateAtSample' : no matching overloaded function found 
-ERROR: 0:132: 'interpolateAtOffset' : no matching overloaded function found 
-ERROR: 0:134: 'interpolateAtOffset' : first argument must be an interpolant, or interpolant-array element 
-ERROR: 0:135: 'interpolateAtOffset' : first argument must be an interpolant, or interpolant-array element 
-ERROR: 0:136: 'interpolateAtOffset' : first argument must be an interpolant, or interpolant-array element 
-ERROR: 0:139: 'interpolateAtCentroid' : first argument must be an interpolant, or interpolant-array element 
-ERROR: 0:140: 'interpolateAtSample' : first argument must be an interpolant, or interpolant-array element 
-ERROR: 0:183: 'textureQueryLod' : no matching overloaded function found 
-ERROR: 0:183: 'assign' :  cannot convert from ' const float' to ' temp 2-component vector of float'
-ERROR: 0:184: 'textureQueryLod' : no matching overloaded function found 
-ERROR: 0:184: 'assign' :  cannot convert from ' const float' to ' temp 2-component vector of float'
-ERROR: 0:197: 'subroutine' : feature not yet implemented 
-ERROR: 0:197: '' : default qualifier requires 'uniform', 'buffer', 'in', 'out' or 'shared' storage qualification 
-ERROR: 0:198: 'subroutine' : feature not yet implemented 
-ERROR: 0:199: 'subroutine' : feature not yet implemented 
-ERROR: 0:201: '' :  syntax error, unexpected PRECISE, expecting IDENTIFIER
+ERROR: 0:51: 'textureGatherOffsets(...)' : must be a compile-time constant: offsets argument
+ERROR: 0:55: 'textureGatherOffset(...)' : must be a compile-time constant: component argument
+ERROR: 0:56: 'textureGatherOffset(...)' : must be 0, 1, 2, or 3: component argument
+ERROR: 0:63: 'location qualifier on input' : not supported for this version or the enabled extensions 
+ERROR: 0:71: 'location qualifier on uniform or buffer' : not supported for this version or the enabled extensions 
+ERROR: 0:73: 'gl_Color' : identifiers starting with "gl_" are reserved 
+ERROR: 0:74: 'redeclaration' : cannot change qualification of gl_ClipDistance
+ERROR: 0:76: 'gl_FragCoord' : cannot redeclare after use 
+ERROR: 0:84: 'texel offset' : argument must be compile-time constant 
+ERROR: 0:86: 'texel offset' : value is out of range: [gl_MinProgramTexelOffset, gl_MaxProgramTexelOffset]
+ERROR: 0:86: 'texel offset' : value is out of range: [gl_MinProgramTexelOffset, gl_MaxProgramTexelOffset]
+ERROR: 0:87: 'texel offset' : value is out of range: [gl_MinProgramTexelOffset, gl_MaxProgramTexelOffset]
+ERROR: 0:87: 'texel offset' : value is out of range: [gl_MinProgramTexelOffset, gl_MaxProgramTexelOffset]
+ERROR: 0:90: 'patch' : not supported in this stage: fragment
+ERROR: 0:91: 'patch' : not supported in this stage: fragment
+ERROR: 0:91: 'centroid/sample/patch' : can't use auxiliary qualifier on a fragment output 
+ERROR: 0:106: 'dFdxFine' : required extension not requested: GL_ARB_derivative_control
+ERROR: 0:107: 'dFdyCoarse' : required extension not requested: GL_ARB_derivative_control
+ERROR: 0:108: 'fwidthCoarse' : required extension not requested: GL_ARB_derivative_control
+ERROR: 0:108: 'fwidthFine' : required extension not requested: GL_ARB_derivative_control
+ERROR: 0:137: 'centroid/sample/patch' : can't use auxiliary qualifier on a fragment output 
+ERROR: 0:156: 'interpolateAtCentroid' : no matching overloaded function found 
+ERROR: 0:158: 'interpolateAtCentroid' : first argument must be an interpolant, or interpolant-array element 
+ERROR: 0:160: 'interpolateAtSample' : no matching overloaded function found 
+ERROR: 0:165: 'interpolateAtOffset' : no matching overloaded function found 
+ERROR: 0:167: 'interpolateAtOffset' : first argument must be an interpolant, or interpolant-array element 
+ERROR: 0:168: 'interpolateAtOffset' : first argument must be an interpolant, or interpolant-array element 
+ERROR: 0:169: 'interpolateAtOffset' : first argument must be an interpolant, or interpolant-array element 
+ERROR: 0:172: 'interpolateAtCentroid' : first argument must be an interpolant, or interpolant-array element 
+ERROR: 0:173: 'interpolateAtSample' : first argument must be an interpolant, or interpolant-array element 
+ERROR: 0:216: 'textureQueryLod' : no matching overloaded function found 
+ERROR: 0:216: 'assign' :  cannot convert from ' const float' to ' temp 2-component vector of float'
+ERROR: 0:217: 'textureQueryLod' : no matching overloaded function found 
+ERROR: 0:217: 'assign' :  cannot convert from ' const float' to ' temp 2-component vector of float'
+ERROR: 0:230: 'subroutine' : feature not yet implemented 
+ERROR: 0:230: '' : default qualifier requires 'uniform', 'buffer', 'in', 'out' or 'shared' storage qualification 
+ERROR: 0:231: 'subroutine' : feature not yet implemented 
+ERROR: 0:232: 'subroutine' : feature not yet implemented 
+ERROR: 0:234: '' :  syntax error, unexpected PRECISE, expecting IDENTIFIER
 ERROR: 39 compilation errors.  No code generated.
 
 
 Shader version: 400
 Requested GL_ARB_derivative_control
 Requested GL_ARB_separate_shader_objects
+Requested GL_ARB_shader_storage_buffer_object
 gl_FragCoord pixel center is integer
 gl_FragCoord origin is upper left
 ERROR: node is still EOpNull!
-0:10  Function Definition: main( ( global void)
-0:10    Function Parameters: 
-0:?     Sequence
-0:13      move second child to first child ( temp 4-component vector of float)
-0:13        'v' ( temp 4-component vector of float)
-0:13        texture ( global 4-component vector of float)
-0:13          indirect index ( temp sampler2D)
-0:13            'arrayedSampler' ( uniform 5-element array of sampler2D)
-0:13            'i' ( flat in int)
-0:13          'c2D' ( smooth in 2-component vector of float)
-0:14      move second child to first child ( temp float)
-0:14        direct index ( temp float)
-0:14          'outp' ( out 4-component vector of float)
-0:14          Constant:
-0:14            0 (const int)
-0:14        direct index ( smooth temp float ClipDistance)
-0:14          'gl_ClipDistance' ( smooth in 4-element array of float ClipDistance)
-0:14          Constant:
-0:14            1 (const int)
-0:18      Sequence
-0:18        move second child to first child ( temp 4-component vector of uint)
-0:18          'uv4' ( temp 4-component vector of uint)
-0:18          textureGatherOffsets ( global 4-component vector of uint)
-0:18            'samp2dr' ( uniform usampler2DRect)
-0:18            'c2D' ( smooth in 2-component vector of float)
-0:18            'offsets' ( temp 4-element array of 2-component vector of int)
-0:18            Constant:
-0:18              2 (const int)
-0:19      move second child to first child ( temp 4-component vector of uint)
-0:19        'uv4' ( temp 4-component vector of uint)
-0:19        textureGatherOffsets ( global 4-component vector of uint)
-0:19          'samp2dr' ( uniform usampler2DRect)
-0:19          'c2D' ( smooth in 2-component vector of float)
-0:19          Constant:
-0:19            1 (const int)
-0:19            2 (const int)
-0:19            3 (const int)
-0:19            4 (const int)
-0:19            15 (const int)
-0:19            16 (const int)
-0:19            -2 (const int)
-0:19            0 (const int)
-0:19          Constant:
-0:19            2 (const int)
+0:18  Function Definition: atomicOpPass( ( global void)
+0:18    Function Parameters: 
+0:20    Sequence
 0:20      Sequence
-0:20        move second child to first child ( temp 4-component vector of float)
-0:20          'v4' ( temp 4-component vector of float)
-0:20          textureGather ( global 4-component vector of float)
-0:20            direct index ( temp sampler2D)
-0:20              'arrayedSampler' ( uniform 5-element array of sampler2D)
+0:20        move second child to first child ( temp int)
+0:20          'origi' ( temp int)
+0:20          AtomicAdd ( global int)
+0:20            atomi: direct index for structure (layout( column_major shared) buffer int)
+0:20              'anon@0' (layout( column_major shared) buffer block{layout( column_major shared) buffer int atomi, layout( column_major shared) buffer uint atomu})
 0:20              Constant:
-0:20                0 (const int)
-0:20            'c2D' ( smooth in 2-component vector of float)
+0:20                0 (const uint)
+0:20            Constant:
+0:20              3 (const int)
 0:21      Sequence
-0:21        move second child to first child ( temp 4-component vector of int)
-0:21          'iv4' ( temp 4-component vector of int)
-0:21          textureGatherOffset ( global 4-component vector of int)
-0:21            'isamp2DA' ( uniform isampler2DArray)
+0:21        move second child to first child ( temp uint)
+0:21          'origu' ( temp uint)
+0:21          AtomicAnd ( global uint)
+0:21            atomu: direct index for structure (layout( column_major shared) buffer uint)
+0:21              'anon@0' (layout( column_major shared) buffer block{layout( column_major shared) buffer int atomi, layout( column_major shared) buffer uint atomu})
+0:21              Constant:
+0:21                1 (const uint)
 0:21            Constant:
-0:21              0.100000
-0:21              0.100000
-0:21              0.100000
-0:21            Constant:
-0:21              1 (const int)
-0:21              1 (const int)
-0:21            Constant:
-0:21              3 (const int)
-0:22      move second child to first child ( temp 4-component vector of int)
-0:22        'iv4' ( temp 4-component vector of int)
-0:22        textureGatherOffset ( global 4-component vector of int)
-0:22          'isamp2DA' ( uniform isampler2DArray)
+0:21              7 (const uint)
+0:22      move second child to first child ( temp int)
+0:22        'origi' ( temp int)
+0:22        AtomicExchange ( global int)
+0:22          atomi: direct index for structure (layout( column_major shared) buffer int)
+0:22            'anon@0' (layout( column_major shared) buffer block{layout( column_major shared) buffer int atomi, layout( column_major shared) buffer uint atomu})
+0:22            Constant:
+0:22              0 (const uint)
 0:22          Constant:
-0:22            0.100000
-0:22            0.100000
-0:22            0.100000
-0:22          Constant:
-0:22            1 (const int)
-0:22            1 (const int)
-0:22          'i' ( flat in int)
-0:23      move second child to first child ( temp 4-component vector of int)
-0:23        'iv4' ( temp 4-component vector of int)
-0:23        textureGatherOffset ( global 4-component vector of int)
-0:23          'isamp2DA' ( uniform isampler2DArray)
+0:22            4 (const int)
+0:23      move second child to first child ( temp uint)
+0:23        'origu' ( temp uint)
+0:23        AtomicCompSwap ( global uint)
+0:23          atomu: direct index for structure (layout( column_major shared) buffer uint)
+0:23            'anon@0' (layout( column_major shared) buffer block{layout( column_major shared) buffer int atomi, layout( column_major shared) buffer uint atomu})
+0:23            Constant:
+0:23              1 (const uint)
 0:23          Constant:
-0:23            0.100000
-0:23            0.100000
-0:23            0.100000
+0:23            10 (const uint)
 0:23          Constant:
-0:23            1 (const int)
-0:23            1 (const int)
-0:23          Constant:
-0:23            4 (const int)
-0:24      move second child to first child ( temp 4-component vector of int)
-0:24        'iv4' ( temp 4-component vector of int)
-0:24        textureGatherOffset ( global 4-component vector of int)
-0:24          'isamp2DA' ( uniform isampler2DArray)
-0:24          Constant:
-0:24            0.100000
-0:24            0.100000
-0:24            0.100000
-0:24          Constant:
-0:24            1 (const int)
-0:24            1 (const int)
-0:24          Constant:
-0:24            3 (const int)
-0:25      move second child to first child ( temp 4-component vector of int)
-0:25        'iv4' ( temp 4-component vector of int)
-0:25        textureGatherOffset ( global 4-component vector of int)
-0:25          'isamp2DA' ( uniform isampler2DArray)
-0:25          Constant:
-0:25            0.100000
-0:25            0.100000
-0:25            0.100000
-0:25          Construct ivec2 ( temp 2-component vector of int)
-0:25            'i' ( flat in int)
-0:27      Sequence
-0:27        move second child to first child ( temp 4-component vector of float)
-0:27          'c' ( temp 4-component vector of float)
-0:27          'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
-0:47  Function Definition: foo23( ( global void)
-0:47    Function Parameters: 
+0:23            8 (const uint)
+0:43  Function Definition: main( ( global void)
+0:43    Function Parameters: 
 0:?     Sequence
-0:51      textureProjGradOffset ( global float)
-0:51        'u2drs' ( uniform sampler2DRectShadow)
-0:51        'outp' ( out 4-component vector of float)
-0:51        Constant:
-0:51          0.000000
-0:51          0.000000
-0:51        Constant:
-0:51          0.000000
-0:51          0.000000
-0:51        Convert float to int ( temp 2-component vector of int)
-0:51          'c2D' ( smooth in 2-component vector of float)
-0:52      textureProjGradOffset ( global float)
-0:52        'u2drs' ( uniform sampler2DRectShadow)
-0:52        'outp' ( out 4-component vector of float)
-0:52        Constant:
-0:52          0.000000
-0:52          0.000000
-0:52        Constant:
-0:52          0.000000
-0:52          0.000000
-0:52        Constant:
-0:52          3 (const int)
-0:52          4 (const int)
-0:53      textureProjGradOffset ( global float)
-0:53        'u2drs' ( uniform sampler2DRectShadow)
-0:53        'outp' ( out 4-component vector of float)
-0:53        Constant:
-0:53          0.000000
-0:53          0.000000
-0:53        Constant:
-0:53          0.000000
-0:53          0.000000
-0:53        Constant:
-0:53          15 (const int)
-0:53          16 (const int)
-0:54      textureProjGradOffset ( global float)
-0:54        'u2drs' ( uniform sampler2DRectShadow)
-0:54        'outp' ( out 4-component vector of float)
-0:54        Constant:
-0:54          0.000000
-0:54          0.000000
-0:54        Constant:
-0:54          0.000000
-0:54          0.000000
-0:54        Constant:
-0:54          -10 (const int)
-0:54          20 (const int)
-0:60  Function Definition: foo24( ( global void)
-0:60    Function Parameters: 
-0:?     Sequence
-0:63      move second child to first child ( temp 3-component vector of double)
-0:63        'df' ( temp 3-component vector of double)
-0:63        modf ( global 3-component vector of double)
-0:63          Convert float to double ( temp 3-component vector of double)
-0:63            vector swizzle ( temp 3-component vector of float)
-0:63              'outp' ( out 4-component vector of float)
-0:63              Sequence
-0:63                Constant:
-0:63                  0 (const int)
-0:63                Constant:
-0:63                  1 (const int)
-0:63                Constant:
-0:63                  2 (const int)
-0:63          'di' ( temp 3-component vector of double)
-0:71  Function Definition: foodc1( ( global void)
-0:71    Function Parameters: 
-0:73    Sequence
-0:73      Sequence
-0:73        move second child to first child ( temp 2-component vector of float)
-0:73          'v2' ( temp 2-component vector of float)
-0:73          dPdxFine ( global 2-component vector of float)
-0:73            'in2' ( smooth in 2-component vector of float)
-0:74      Sequence
-0:74        move second child to first child ( temp 3-component vector of float)
-0:74          'v3' ( temp 3-component vector of float)
-0:74          dPdyCoarse ( global 3-component vector of float)
-0:74            'in3' ( smooth in 3-component vector of float)
-0:75      Sequence
-0:75        move second child to first child ( temp 4-component vector of float)
-0:75          'v4' ( temp 4-component vector of float)
-0:75          add ( temp 4-component vector of float)
-0:75            fwidthCoarse ( global 4-component vector of float)
-0:75              'in4' ( smooth in 4-component vector of float)
-0:75            fwidthFine ( global 4-component vector of float)
-0:75              'in4' ( smooth in 4-component vector of float)
-0:80  Function Definition: foodc2( ( global void)
+0:46      move second child to first child ( temp 4-component vector of float)
+0:46        'v' ( temp 4-component vector of float)
+0:46        texture ( global 4-component vector of float)
+0:46          indirect index ( temp sampler2D)
+0:46            'arrayedSampler' ( uniform 5-element array of sampler2D)
+0:46            'i' ( flat in int)
+0:46          'c2D' ( smooth in 2-component vector of float)
+0:47      move second child to first child ( temp float)
+0:47        direct index ( temp float)
+0:47          'outp' ( out 4-component vector of float)
+0:47          Constant:
+0:47            0 (const int)
+0:47        direct index ( smooth temp float ClipDistance)
+0:47          'gl_ClipDistance' ( smooth in 4-element array of float ClipDistance)
+0:47          Constant:
+0:47            1 (const int)
+0:51      Sequence
+0:51        move second child to first child ( temp 4-component vector of uint)
+0:51          'uv4' ( temp 4-component vector of uint)
+0:51          textureGatherOffsets ( global 4-component vector of uint)
+0:51            'samp2dr' ( uniform usampler2DRect)
+0:51            'c2D' ( smooth in 2-component vector of float)
+0:51            'offsets' ( temp 4-element array of 2-component vector of int)
+0:51            Constant:
+0:51              2 (const int)
+0:52      move second child to first child ( temp 4-component vector of uint)
+0:52        'uv4' ( temp 4-component vector of uint)
+0:52        textureGatherOffsets ( global 4-component vector of uint)
+0:52          'samp2dr' ( uniform usampler2DRect)
+0:52          'c2D' ( smooth in 2-component vector of float)
+0:52          Constant:
+0:52            1 (const int)
+0:52            2 (const int)
+0:52            3 (const int)
+0:52            4 (const int)
+0:52            15 (const int)
+0:52            16 (const int)
+0:52            -2 (const int)
+0:52            0 (const int)
+0:52          Constant:
+0:52            2 (const int)
+0:53      Sequence
+0:53        move second child to first child ( temp 4-component vector of float)
+0:53          'v4' ( temp 4-component vector of float)
+0:53          textureGather ( global 4-component vector of float)
+0:53            direct index ( temp sampler2D)
+0:53              'arrayedSampler' ( uniform 5-element array of sampler2D)
+0:53              Constant:
+0:53                0 (const int)
+0:53            'c2D' ( smooth in 2-component vector of float)
+0:54      Sequence
+0:54        move second child to first child ( temp 4-component vector of int)
+0:54          'iv4' ( temp 4-component vector of int)
+0:54          textureGatherOffset ( global 4-component vector of int)
+0:54            'isamp2DA' ( uniform isampler2DArray)
+0:54            Constant:
+0:54              0.100000
+0:54              0.100000
+0:54              0.100000
+0:54            Constant:
+0:54              1 (const int)
+0:54              1 (const int)
+0:54            Constant:
+0:54              3 (const int)
+0:55      move second child to first child ( temp 4-component vector of int)
+0:55        'iv4' ( temp 4-component vector of int)
+0:55        textureGatherOffset ( global 4-component vector of int)
+0:55          'isamp2DA' ( uniform isampler2DArray)
+0:55          Constant:
+0:55            0.100000
+0:55            0.100000
+0:55            0.100000
+0:55          Constant:
+0:55            1 (const int)
+0:55            1 (const int)
+0:55          'i' ( flat in int)
+0:56      move second child to first child ( temp 4-component vector of int)
+0:56        'iv4' ( temp 4-component vector of int)
+0:56        textureGatherOffset ( global 4-component vector of int)
+0:56          'isamp2DA' ( uniform isampler2DArray)
+0:56          Constant:
+0:56            0.100000
+0:56            0.100000
+0:56            0.100000
+0:56          Constant:
+0:56            1 (const int)
+0:56            1 (const int)
+0:56          Constant:
+0:56            4 (const int)
+0:57      move second child to first child ( temp 4-component vector of int)
+0:57        'iv4' ( temp 4-component vector of int)
+0:57        textureGatherOffset ( global 4-component vector of int)
+0:57          'isamp2DA' ( uniform isampler2DArray)
+0:57          Constant:
+0:57            0.100000
+0:57            0.100000
+0:57            0.100000
+0:57          Constant:
+0:57            1 (const int)
+0:57            1 (const int)
+0:57          Constant:
+0:57            3 (const int)
+0:58      move second child to first child ( temp 4-component vector of int)
+0:58        'iv4' ( temp 4-component vector of int)
+0:58        textureGatherOffset ( global 4-component vector of int)
+0:58          'isamp2DA' ( uniform isampler2DArray)
+0:58          Constant:
+0:58            0.100000
+0:58            0.100000
+0:58            0.100000
+0:58          Construct ivec2 ( temp 2-component vector of int)
+0:58            'i' ( flat in int)
+0:60      Sequence
+0:60        move second child to first child ( temp 4-component vector of float)
+0:60          'c' ( temp 4-component vector of float)
+0:60          'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:80  Function Definition: foo23( ( global void)
 0:80    Function Parameters: 
-0:82    Sequence
-0:82      Sequence
-0:82        move second child to first child ( temp 2-component vector of float)
-0:82          'v2' ( temp 2-component vector of float)
-0:82          dPdxFine ( global 2-component vector of float)
-0:82            'in2' ( smooth in 2-component vector of float)
-0:83      Sequence
-0:83        move second child to first child ( temp 3-component vector of float)
-0:83          'v3' ( temp 3-component vector of float)
-0:83          dPdyCoarse ( global 3-component vector of float)
-0:83            'in3' ( smooth in 3-component vector of float)
-0:84      Sequence
-0:84        move second child to first child ( temp 4-component vector of float)
-0:84          'v4' ( temp 4-component vector of float)
-0:84          add ( temp 4-component vector of float)
-0:84            fwidthCoarse ( global 4-component vector of float)
-0:84              'in4' ( smooth in 4-component vector of float)
-0:84            fwidthFine ( global 4-component vector of float)
-0:84              'in4' ( smooth in 4-component vector of float)
-0:89      move second child to first child ( temp 2-component vector of float)
-0:89        'v2' ( temp 2-component vector of float)
-0:89        frexp ( global 2-component vector of float)
-0:89          'v2' ( temp 2-component vector of float)
-0:89          'i2' ( temp 2-component vector of int)
-0:90      move second child to first child ( temp 3-component vector of float)
-0:90        'v3' ( temp 3-component vector of float)
-0:90        ldexp ( global 3-component vector of float)
-0:90          'v3' ( temp 3-component vector of float)
-0:90          'i3' ( temp 3-component vector of int)
-0:92      move second child to first child ( temp uint)
-0:92        'u1' ( temp uint)
-0:92        PackUnorm4x8 ( global uint)
-0:92          'v4' ( temp 4-component vector of float)
-0:93      move second child to first child ( temp uint)
-0:93        'u1' ( temp uint)
-0:93        PackSnorm4x8 ( global uint)
-0:93          'v4' ( temp 4-component vector of float)
-0:94      move second child to first child ( temp 4-component vector of float)
-0:94        'v4' ( temp 4-component vector of float)
-0:94        UnpackUnorm4x8 ( global 4-component vector of float)
-0:94          'u1' ( temp uint)
-0:95      move second child to first child ( temp 4-component vector of float)
-0:95        'v4' ( temp 4-component vector of float)
-0:95        UnpackSnorm4x8 ( global 4-component vector of float)
-0:95          'u1' ( temp uint)
-0:99      move second child to first child ( temp double)
-0:99        'd' ( temp double)
-0:99        PackDouble2x32 ( global double)
-0:99          'u2' ( temp 2-component vector of uint)
-0:100      move second child to first child ( temp 2-component vector of uint)
-0:100        'u2' ( temp 2-component vector of uint)
-0:100        UnpackDouble2x32 ( global 2-component vector of uint)
-0:100          'd' ( temp double)
-0:117  Function Definition: interp( ( global void)
-0:117    Function Parameters: 
-0:119    Sequence
-0:119      interpolateAtCentroid ( global 2-component vector of float)
-0:119        'colorfc' ( centroid flat in 2-component vector of float)
-0:120      interpolateAtCentroid ( global 4-component vector of float)
-0:120        'colorSampIn' ( smooth sample in 4-component vector of float)
-0:121      interpolateAtCentroid ( global 4-component vector of float)
-0:121        'colorfsi' ( noperspective in 4-component vector of float)
-0:122      interpolateAtCentroid ( global float)
-0:122        'scalarIn' ( smooth in float)
-0:123      Constant:
-0:123        0.000000
-0:124      interpolateAtCentroid ( global 3-component vector of float)
-0:124        direct index ( smooth sample temp 3-component vector of float)
-0:124          'sampInArray' ( smooth sample in 4-element array of 3-component vector of float)
-0:124          Constant:
-0:124            2 (const int)
-0:125      interpolateAtCentroid ( global 2-component vector of float)
-0:125        vector swizzle ( temp 2-component vector of float)
-0:125          direct index ( smooth sample temp 3-component vector of float)
-0:125            'sampInArray' ( smooth sample in 4-element array of 3-component vector of float)
-0:125            Constant:
-0:125              2 (const int)
-0:125          Sequence
-0:125            Constant:
-0:125              0 (const int)
-0:125            Constant:
-0:125              1 (const int)
-0:127      Constant:
-0:127        0.000000
-0:128      interpolateAtSample ( global 3-component vector of float)
-0:128        indirect index ( smooth sample temp 3-component vector of float)
-0:128          'sampInArray' ( smooth sample in 4-element array of 3-component vector of float)
-0:128          'i' ( flat in int)
-0:128        Constant:
-0:128          0 (const int)
-0:129      interpolateAtSample ( global float)
-0:129        x: direct index for structure ( global float)
-0:129          's1' ( smooth in structure{ global float x})
-0:129          Constant:
-0:129            0 (const int)
-0:129        Constant:
-0:129          2 (const int)
-0:130      interpolateAtSample ( global float)
-0:130        'scalarIn' ( smooth in float)
-0:130        Constant:
-0:130          1 (const int)
-0:132      Constant:
-0:132        0.000000
-0:133      interpolateAtOffset ( global 3-component vector of float)
-0:133        direct index ( smooth sample temp 3-component vector of float)
-0:133          'sampInArray' ( smooth sample in 4-element array of 3-component vector of float)
-0:133          Constant:
-0:133            2 (const int)
-0:133        Constant:
-0:133          0.200000
-0:133          0.200000
-0:134      interpolateAtOffset ( global 2-component vector of float)
-0:134        vector swizzle ( temp 2-component vector of float)
-0:134          direct index ( smooth sample temp 3-component vector of float)
-0:134            'sampInArray' ( smooth sample in 4-element array of 3-component vector of float)
-0:134            Constant:
-0:134              2 (const int)
-0:134          Sequence
-0:134            Constant:
-0:134              0 (const int)
-0:134            Constant:
-0:134              1 (const int)
-0:134        Constant:
-0:134          0.200000
-0:134          0.200000
-0:135      interpolateAtOffset ( global float)
-0:135        add ( temp float)
-0:135          'scalarIn' ( smooth in float)
-0:135          'scalarIn' ( smooth in float)
-0:135        Constant:
-0:135          0.200000
-0:135          0.200000
-0:136      interpolateAtOffset ( global float)
-0:136        x: direct index for structure ( global float)
-0:136          's2' ( sample temp structure{ global float x})
-0:136          Constant:
-0:136            0 (const int)
-0:136        Constant:
-0:136          0.200000
-0:136          0.200000
-0:139      interpolateAtCentroid ( global float)
-0:139        'f' ( temp float)
-0:140      interpolateAtSample ( global 4-component vector of float)
-0:140        'outp' ( out 4-component vector of float)
-0:140        Constant:
-0:140          0 (const int)
-0:161  Function Definition: qlod( ( global void)
-0:161    Function Parameters: 
 0:?     Sequence
-0:168      move second child to first child ( temp 2-component vector of float)
-0:168        'lod' ( temp 2-component vector of float)
-0:168        textureQueryLod ( global 2-component vector of float)
-0:168          'samp1D' ( uniform sampler1D)
-0:168          'pf' ( temp float)
-0:169      move second child to first child ( temp 2-component vector of float)
-0:169        'lod' ( temp 2-component vector of float)
-0:169        textureQueryLod ( global 2-component vector of float)
-0:169          'isamp2D' ( uniform isampler2D)
-0:169          'pf2' ( temp 2-component vector of float)
-0:170      move second child to first child ( temp 2-component vector of float)
-0:170        'lod' ( temp 2-component vector of float)
-0:170        textureQueryLod ( global 2-component vector of float)
-0:170          'usamp3D' ( uniform usampler3D)
-0:170          'pf3' ( temp 3-component vector of float)
-0:171      move second child to first child ( temp 2-component vector of float)
-0:171        'lod' ( temp 2-component vector of float)
-0:171        textureQueryLod ( global 2-component vector of float)
-0:171          'sampCube' ( uniform samplerCube)
-0:171          'pf3' ( temp 3-component vector of float)
-0:172      move second child to first child ( temp 2-component vector of float)
-0:172        'lod' ( temp 2-component vector of float)
-0:172        textureQueryLod ( global 2-component vector of float)
-0:172          'isamp1DA' ( uniform isampler1DArray)
-0:172          'pf' ( temp float)
-0:173      move second child to first child ( temp 2-component vector of float)
-0:173        'lod' ( temp 2-component vector of float)
-0:173        textureQueryLod ( global 2-component vector of float)
-0:173          'usamp2DA' ( uniform usampler2DArray)
-0:173          'pf2' ( temp 2-component vector of float)
-0:174      move second child to first child ( temp 2-component vector of float)
-0:174        'lod' ( temp 2-component vector of float)
-0:174        textureQueryLod ( global 2-component vector of float)
-0:174          'isampCubeA' ( uniform isamplerCubeArray)
-0:174          'pf3' ( temp 3-component vector of float)
-0:176      move second child to first child ( temp 2-component vector of float)
-0:176        'lod' ( temp 2-component vector of float)
-0:176        textureQueryLod ( global 2-component vector of float)
-0:176          'samp1Ds' ( uniform sampler1DShadow)
-0:176          'pf' ( temp float)
-0:177      move second child to first child ( temp 2-component vector of float)
-0:177        'lod' ( temp 2-component vector of float)
-0:177        textureQueryLod ( global 2-component vector of float)
-0:177          'samp2Ds' ( uniform sampler2DShadow)
-0:177          'pf2' ( temp 2-component vector of float)
-0:178      move second child to first child ( temp 2-component vector of float)
-0:178        'lod' ( temp 2-component vector of float)
-0:178        textureQueryLod ( global 2-component vector of float)
-0:178          'sampCubes' ( uniform samplerCubeShadow)
-0:178          'pf3' ( temp 3-component vector of float)
-0:179      move second child to first child ( temp 2-component vector of float)
-0:179        'lod' ( temp 2-component vector of float)
-0:179        textureQueryLod ( global 2-component vector of float)
-0:179          'samp1DAs' ( uniform sampler1DArrayShadow)
-0:179          'pf' ( temp float)
-0:180      move second child to first child ( temp 2-component vector of float)
-0:180        'lod' ( temp 2-component vector of float)
-0:180        textureQueryLod ( global 2-component vector of float)
-0:180          'samp2DAs' ( uniform sampler2DArrayShadow)
-0:180          'pf2' ( temp 2-component vector of float)
-0:181      move second child to first child ( temp 2-component vector of float)
-0:181        'lod' ( temp 2-component vector of float)
-0:181        textureQueryLod ( global 2-component vector of float)
-0:181          'sampCubeAs' ( uniform samplerCubeArrayShadow)
-0:181          'pf3' ( temp 3-component vector of float)
-0:183      'lod' ( temp 2-component vector of float)
-0:184      'lod' ( temp 2-component vector of float)
-0:190  Function Definition: bitwiseConv( ( global void)
-0:190    Function Parameters: 
-0:192    Sequence
-0:192      move second child to first child ( temp uint)
-0:192        'iout' ( out uint)
-0:192        bitwise and ( temp uint)
-0:192          'uu' ( uniform uint)
-0:192          Convert int to uint ( temp uint)
-0:192            'i' ( flat in int)
-0:193      add second child into first child ( temp uint)
-0:193        'iout' ( out uint)
-0:193        exclusive-or ( temp uint)
-0:193          'uu' ( uniform uint)
-0:193          Convert int to uint ( temp uint)
-0:193            'i' ( flat in int)
-0:194      add second child into first child ( temp uint)
-0:194        'iout' ( out uint)
-0:194        inclusive-or ( temp uint)
-0:194          Convert int to uint ( temp uint)
-0:194            'i' ( flat in int)
-0:194          'uu' ( uniform uint)
-0:198  Function Definition: subT1( ( temp float)
-0:198    Function Parameters: 
-0:198    Sequence
-0:198      Branch: Return with expression
-0:198        Constant:
-0:198          1.000000
-0:199  Function Definition: subT2( ( temp float)
-0:199    Function Parameters: 
-0:199    Sequence
-0:199      Branch: Return with expression
-0:199        Constant:
-0:199          1.000000
+0:84      textureProjGradOffset ( global float)
+0:84        'u2drs' ( uniform sampler2DRectShadow)
+0:84        'outp' ( out 4-component vector of float)
+0:84        Constant:
+0:84          0.000000
+0:84          0.000000
+0:84        Constant:
+0:84          0.000000
+0:84          0.000000
+0:84        Convert float to int ( temp 2-component vector of int)
+0:84          'c2D' ( smooth in 2-component vector of float)
+0:85      textureProjGradOffset ( global float)
+0:85        'u2drs' ( uniform sampler2DRectShadow)
+0:85        'outp' ( out 4-component vector of float)
+0:85        Constant:
+0:85          0.000000
+0:85          0.000000
+0:85        Constant:
+0:85          0.000000
+0:85          0.000000
+0:85        Constant:
+0:85          3 (const int)
+0:85          4 (const int)
+0:86      textureProjGradOffset ( global float)
+0:86        'u2drs' ( uniform sampler2DRectShadow)
+0:86        'outp' ( out 4-component vector of float)
+0:86        Constant:
+0:86          0.000000
+0:86          0.000000
+0:86        Constant:
+0:86          0.000000
+0:86          0.000000
+0:86        Constant:
+0:86          15 (const int)
+0:86          16 (const int)
+0:87      textureProjGradOffset ( global float)
+0:87        'u2drs' ( uniform sampler2DRectShadow)
+0:87        'outp' ( out 4-component vector of float)
+0:87        Constant:
+0:87          0.000000
+0:87          0.000000
+0:87        Constant:
+0:87          0.000000
+0:87          0.000000
+0:87        Constant:
+0:87          -10 (const int)
+0:87          20 (const int)
+0:93  Function Definition: foo24( ( global void)
+0:93    Function Parameters: 
+0:?     Sequence
+0:96      move second child to first child ( temp 3-component vector of double)
+0:96        'df' ( temp 3-component vector of double)
+0:96        modf ( global 3-component vector of double)
+0:96          Convert float to double ( temp 3-component vector of double)
+0:96            vector swizzle ( temp 3-component vector of float)
+0:96              'outp' ( out 4-component vector of float)
+0:96              Sequence
+0:96                Constant:
+0:96                  0 (const int)
+0:96                Constant:
+0:96                  1 (const int)
+0:96                Constant:
+0:96                  2 (const int)
+0:96          'di' ( temp 3-component vector of double)
+0:104  Function Definition: foodc1( ( global void)
+0:104    Function Parameters: 
+0:106    Sequence
+0:106      Sequence
+0:106        move second child to first child ( temp 2-component vector of float)
+0:106          'v2' ( temp 2-component vector of float)
+0:106          dPdxFine ( global 2-component vector of float)
+0:106            'in2' ( smooth in 2-component vector of float)
+0:107      Sequence
+0:107        move second child to first child ( temp 3-component vector of float)
+0:107          'v3' ( temp 3-component vector of float)
+0:107          dPdyCoarse ( global 3-component vector of float)
+0:107            'in3' ( smooth in 3-component vector of float)
+0:108      Sequence
+0:108        move second child to first child ( temp 4-component vector of float)
+0:108          'v4' ( temp 4-component vector of float)
+0:108          add ( temp 4-component vector of float)
+0:108            fwidthCoarse ( global 4-component vector of float)
+0:108              'in4' ( smooth in 4-component vector of float)
+0:108            fwidthFine ( global 4-component vector of float)
+0:108              'in4' ( smooth in 4-component vector of float)
+0:113  Function Definition: foodc2( ( global void)
+0:113    Function Parameters: 
+0:115    Sequence
+0:115      Sequence
+0:115        move second child to first child ( temp 2-component vector of float)
+0:115          'v2' ( temp 2-component vector of float)
+0:115          dPdxFine ( global 2-component vector of float)
+0:115            'in2' ( smooth in 2-component vector of float)
+0:116      Sequence
+0:116        move second child to first child ( temp 3-component vector of float)
+0:116          'v3' ( temp 3-component vector of float)
+0:116          dPdyCoarse ( global 3-component vector of float)
+0:116            'in3' ( smooth in 3-component vector of float)
+0:117      Sequence
+0:117        move second child to first child ( temp 4-component vector of float)
+0:117          'v4' ( temp 4-component vector of float)
+0:117          add ( temp 4-component vector of float)
+0:117            fwidthCoarse ( global 4-component vector of float)
+0:117              'in4' ( smooth in 4-component vector of float)
+0:117            fwidthFine ( global 4-component vector of float)
+0:117              'in4' ( smooth in 4-component vector of float)
+0:122      move second child to first child ( temp 2-component vector of float)
+0:122        'v2' ( temp 2-component vector of float)
+0:122        frexp ( global 2-component vector of float)
+0:122          'v2' ( temp 2-component vector of float)
+0:122          'i2' ( temp 2-component vector of int)
+0:123      move second child to first child ( temp 3-component vector of float)
+0:123        'v3' ( temp 3-component vector of float)
+0:123        ldexp ( global 3-component vector of float)
+0:123          'v3' ( temp 3-component vector of float)
+0:123          'i3' ( temp 3-component vector of int)
+0:125      move second child to first child ( temp uint)
+0:125        'u1' ( temp uint)
+0:125        PackUnorm4x8 ( global uint)
+0:125          'v4' ( temp 4-component vector of float)
+0:126      move second child to first child ( temp uint)
+0:126        'u1' ( temp uint)
+0:126        PackSnorm4x8 ( global uint)
+0:126          'v4' ( temp 4-component vector of float)
+0:127      move second child to first child ( temp 4-component vector of float)
+0:127        'v4' ( temp 4-component vector of float)
+0:127        UnpackUnorm4x8 ( global 4-component vector of float)
+0:127          'u1' ( temp uint)
+0:128      move second child to first child ( temp 4-component vector of float)
+0:128        'v4' ( temp 4-component vector of float)
+0:128        UnpackSnorm4x8 ( global 4-component vector of float)
+0:128          'u1' ( temp uint)
+0:132      move second child to first child ( temp double)
+0:132        'd' ( temp double)
+0:132        PackDouble2x32 ( global double)
+0:132          'u2' ( temp 2-component vector of uint)
+0:133      move second child to first child ( temp 2-component vector of uint)
+0:133        'u2' ( temp 2-component vector of uint)
+0:133        UnpackDouble2x32 ( global 2-component vector of uint)
+0:133          'd' ( temp double)
+0:150  Function Definition: interp( ( global void)
+0:150    Function Parameters: 
+0:152    Sequence
+0:152      interpolateAtCentroid ( global 2-component vector of float)
+0:152        'colorfc' ( centroid flat in 2-component vector of float)
+0:153      interpolateAtCentroid ( global 4-component vector of float)
+0:153        'colorSampIn' ( smooth sample in 4-component vector of float)
+0:154      interpolateAtCentroid ( global 4-component vector of float)
+0:154        'colorfsi' ( noperspective in 4-component vector of float)
+0:155      interpolateAtCentroid ( global float)
+0:155        'scalarIn' ( smooth in float)
+0:156      Constant:
+0:156        0.000000
+0:157      interpolateAtCentroid ( global 3-component vector of float)
+0:157        direct index ( smooth sample temp 3-component vector of float)
+0:157          'sampInArray' ( smooth sample in 4-element array of 3-component vector of float)
+0:157          Constant:
+0:157            2 (const int)
+0:158      interpolateAtCentroid ( global 2-component vector of float)
+0:158        vector swizzle ( temp 2-component vector of float)
+0:158          direct index ( smooth sample temp 3-component vector of float)
+0:158            'sampInArray' ( smooth sample in 4-element array of 3-component vector of float)
+0:158            Constant:
+0:158              2 (const int)
+0:158          Sequence
+0:158            Constant:
+0:158              0 (const int)
+0:158            Constant:
+0:158              1 (const int)
+0:160      Constant:
+0:160        0.000000
+0:161      interpolateAtSample ( global 3-component vector of float)
+0:161        indirect index ( smooth sample temp 3-component vector of float)
+0:161          'sampInArray' ( smooth sample in 4-element array of 3-component vector of float)
+0:161          'i' ( flat in int)
+0:161        Constant:
+0:161          0 (const int)
+0:162      interpolateAtSample ( global float)
+0:162        x: direct index for structure ( global float)
+0:162          's1' ( smooth in structure{ global float x})
+0:162          Constant:
+0:162            0 (const int)
+0:162        Constant:
+0:162          2 (const int)
+0:163      interpolateAtSample ( global float)
+0:163        'scalarIn' ( smooth in float)
+0:163        Constant:
+0:163          1 (const int)
+0:165      Constant:
+0:165        0.000000
+0:166      interpolateAtOffset ( global 3-component vector of float)
+0:166        direct index ( smooth sample temp 3-component vector of float)
+0:166          'sampInArray' ( smooth sample in 4-element array of 3-component vector of float)
+0:166          Constant:
+0:166            2 (const int)
+0:166        Constant:
+0:166          0.200000
+0:166          0.200000
+0:167      interpolateAtOffset ( global 2-component vector of float)
+0:167        vector swizzle ( temp 2-component vector of float)
+0:167          direct index ( smooth sample temp 3-component vector of float)
+0:167            'sampInArray' ( smooth sample in 4-element array of 3-component vector of float)
+0:167            Constant:
+0:167              2 (const int)
+0:167          Sequence
+0:167            Constant:
+0:167              0 (const int)
+0:167            Constant:
+0:167              1 (const int)
+0:167        Constant:
+0:167          0.200000
+0:167          0.200000
+0:168      interpolateAtOffset ( global float)
+0:168        add ( temp float)
+0:168          'scalarIn' ( smooth in float)
+0:168          'scalarIn' ( smooth in float)
+0:168        Constant:
+0:168          0.200000
+0:168          0.200000
+0:169      interpolateAtOffset ( global float)
+0:169        x: direct index for structure ( global float)
+0:169          's2' ( sample temp structure{ global float x})
+0:169          Constant:
+0:169            0 (const int)
+0:169        Constant:
+0:169          0.200000
+0:169          0.200000
+0:172      interpolateAtCentroid ( global float)
+0:172        'f' ( temp float)
+0:173      interpolateAtSample ( global 4-component vector of float)
+0:173        'outp' ( out 4-component vector of float)
+0:173        Constant:
+0:173          0 (const int)
+0:194  Function Definition: qlod( ( global void)
+0:194    Function Parameters: 
+0:?     Sequence
+0:201      move second child to first child ( temp 2-component vector of float)
+0:201        'lod' ( temp 2-component vector of float)
+0:201        textureQueryLod ( global 2-component vector of float)
+0:201          'samp1D' ( uniform sampler1D)
+0:201          'pf' ( temp float)
+0:202      move second child to first child ( temp 2-component vector of float)
+0:202        'lod' ( temp 2-component vector of float)
+0:202        textureQueryLod ( global 2-component vector of float)
+0:202          'isamp2D' ( uniform isampler2D)
+0:202          'pf2' ( temp 2-component vector of float)
+0:203      move second child to first child ( temp 2-component vector of float)
+0:203        'lod' ( temp 2-component vector of float)
+0:203        textureQueryLod ( global 2-component vector of float)
+0:203          'usamp3D' ( uniform usampler3D)
+0:203          'pf3' ( temp 3-component vector of float)
+0:204      move second child to first child ( temp 2-component vector of float)
+0:204        'lod' ( temp 2-component vector of float)
+0:204        textureQueryLod ( global 2-component vector of float)
+0:204          'sampCube' ( uniform samplerCube)
+0:204          'pf3' ( temp 3-component vector of float)
+0:205      move second child to first child ( temp 2-component vector of float)
+0:205        'lod' ( temp 2-component vector of float)
+0:205        textureQueryLod ( global 2-component vector of float)
+0:205          'isamp1DA' ( uniform isampler1DArray)
+0:205          'pf' ( temp float)
+0:206      move second child to first child ( temp 2-component vector of float)
+0:206        'lod' ( temp 2-component vector of float)
+0:206        textureQueryLod ( global 2-component vector of float)
+0:206          'usamp2DA' ( uniform usampler2DArray)
+0:206          'pf2' ( temp 2-component vector of float)
+0:207      move second child to first child ( temp 2-component vector of float)
+0:207        'lod' ( temp 2-component vector of float)
+0:207        textureQueryLod ( global 2-component vector of float)
+0:207          'isampCubeA' ( uniform isamplerCubeArray)
+0:207          'pf3' ( temp 3-component vector of float)
+0:209      move second child to first child ( temp 2-component vector of float)
+0:209        'lod' ( temp 2-component vector of float)
+0:209        textureQueryLod ( global 2-component vector of float)
+0:209          'samp1Ds' ( uniform sampler1DShadow)
+0:209          'pf' ( temp float)
+0:210      move second child to first child ( temp 2-component vector of float)
+0:210        'lod' ( temp 2-component vector of float)
+0:210        textureQueryLod ( global 2-component vector of float)
+0:210          'samp2Ds' ( uniform sampler2DShadow)
+0:210          'pf2' ( temp 2-component vector of float)
+0:211      move second child to first child ( temp 2-component vector of float)
+0:211        'lod' ( temp 2-component vector of float)
+0:211        textureQueryLod ( global 2-component vector of float)
+0:211          'sampCubes' ( uniform samplerCubeShadow)
+0:211          'pf3' ( temp 3-component vector of float)
+0:212      move second child to first child ( temp 2-component vector of float)
+0:212        'lod' ( temp 2-component vector of float)
+0:212        textureQueryLod ( global 2-component vector of float)
+0:212          'samp1DAs' ( uniform sampler1DArrayShadow)
+0:212          'pf' ( temp float)
+0:213      move second child to first child ( temp 2-component vector of float)
+0:213        'lod' ( temp 2-component vector of float)
+0:213        textureQueryLod ( global 2-component vector of float)
+0:213          'samp2DAs' ( uniform sampler2DArrayShadow)
+0:213          'pf2' ( temp 2-component vector of float)
+0:214      move second child to first child ( temp 2-component vector of float)
+0:214        'lod' ( temp 2-component vector of float)
+0:214        textureQueryLod ( global 2-component vector of float)
+0:214          'sampCubeAs' ( uniform samplerCubeArrayShadow)
+0:214          'pf3' ( temp 3-component vector of float)
+0:216      'lod' ( temp 2-component vector of float)
+0:217      'lod' ( temp 2-component vector of float)
+0:223  Function Definition: bitwiseConv( ( global void)
+0:223    Function Parameters: 
+0:225    Sequence
+0:225      move second child to first child ( temp uint)
+0:225        'iout' ( out uint)
+0:225        bitwise and ( temp uint)
+0:225          'uu' ( uniform uint)
+0:225          Convert int to uint ( temp uint)
+0:225            'i' ( flat in int)
+0:226      add second child into first child ( temp uint)
+0:226        'iout' ( out uint)
+0:226        exclusive-or ( temp uint)
+0:226          'uu' ( uniform uint)
+0:226          Convert int to uint ( temp uint)
+0:226            'i' ( flat in int)
+0:227      add second child into first child ( temp uint)
+0:227        'iout' ( out uint)
+0:227        inclusive-or ( temp uint)
+0:227          Convert int to uint ( temp uint)
+0:227            'i' ( flat in int)
+0:227          'uu' ( uniform uint)
+0:231  Function Definition: subT1( ( temp float)
+0:231    Function Parameters: 
+0:231    Sequence
+0:231      Branch: Return with expression
+0:231        Constant:
+0:231          1.000000
+0:232  Function Definition: subT2( ( temp float)
+0:232    Function Parameters: 
+0:232    Sequence
+0:232      Branch: Return with expression
+0:232        Constant:
+0:232          1.000000
 0:?   Linker Objects
 0:?     'c2D' ( smooth in 2-component vector of float)
 0:?     'i' ( flat in int)
@@ -512,6 +556,9 @@ ERROR: node is still EOpNull!
 0:?     'arrayedSampler' ( uniform 5-element array of sampler2D)
 0:?     'samp2dr' ( uniform usampler2DRect)
 0:?     'isamp2DA' ( uniform isampler2DArray)
+0:?     'anon@0' (layout( column_major shared) buffer block{layout( column_major shared) buffer int atomi, layout( column_major shared) buffer uint atomu})
+0:?     'ssboStd430Arr' (layout( column_major shared) buffer 2-element array of block{layout( column_major shared) buffer int member01, layout( column_major shared) buffer 2-element array of int memberArr01, layout( column_major shared) buffer unsized 1-element array of int memberUnsizedArr01})
+0:?     'ssboSharedArr' (layout( column_major shared) buffer 2-element array of block{layout( column_major shared) buffer int member02, layout( column_major shared) buffer 2-element array of int memberArr02, layout( column_major shared) buffer unsized 1-element array of int memberUnsizedArr02})
 0:?     'gl_ClipDistance' ( smooth in 4-element array of float ClipDistance)
 0:?     'vl' (layout( location=4) smooth in 4-component vector of float)
 0:?     'vl2' (layout( location=6) smooth in 4-component vector of float)
@@ -558,128 +605,129 @@ Linked fragment stage:
 Shader version: 400
 Requested GL_ARB_derivative_control
 Requested GL_ARB_separate_shader_objects
+Requested GL_ARB_shader_storage_buffer_object
 gl_FragCoord pixel center is integer
 gl_FragCoord origin is upper left
 ERROR: node is still EOpNull!
-0:10  Function Definition: main( ( global void)
-0:10    Function Parameters: 
+0:43  Function Definition: main( ( global void)
+0:43    Function Parameters: 
 0:?     Sequence
-0:13      move second child to first child ( temp 4-component vector of float)
-0:13        'v' ( temp 4-component vector of float)
-0:13        texture ( global 4-component vector of float)
-0:13          indirect index ( temp sampler2D)
-0:13            'arrayedSampler' ( uniform 5-element array of sampler2D)
-0:13            'i' ( flat in int)
-0:13          'c2D' ( smooth in 2-component vector of float)
-0:14      move second child to first child ( temp float)
-0:14        direct index ( temp float)
-0:14          'outp' ( out 4-component vector of float)
-0:14          Constant:
-0:14            0 (const int)
-0:14        direct index ( smooth temp float ClipDistance)
-0:14          'gl_ClipDistance' ( smooth in 4-element array of float ClipDistance)
-0:14          Constant:
-0:14            1 (const int)
-0:18      Sequence
-0:18        move second child to first child ( temp 4-component vector of uint)
-0:18          'uv4' ( temp 4-component vector of uint)
-0:18          textureGatherOffsets ( global 4-component vector of uint)
-0:18            'samp2dr' ( uniform usampler2DRect)
-0:18            'c2D' ( smooth in 2-component vector of float)
-0:18            'offsets' ( temp 4-element array of 2-component vector of int)
-0:18            Constant:
-0:18              2 (const int)
-0:19      move second child to first child ( temp 4-component vector of uint)
-0:19        'uv4' ( temp 4-component vector of uint)
-0:19        textureGatherOffsets ( global 4-component vector of uint)
-0:19          'samp2dr' ( uniform usampler2DRect)
-0:19          'c2D' ( smooth in 2-component vector of float)
-0:19          Constant:
-0:19            1 (const int)
-0:19            2 (const int)
-0:19            3 (const int)
-0:19            4 (const int)
-0:19            15 (const int)
-0:19            16 (const int)
-0:19            -2 (const int)
-0:19            0 (const int)
-0:19          Constant:
-0:19            2 (const int)
-0:20      Sequence
-0:20        move second child to first child ( temp 4-component vector of float)
-0:20          'v4' ( temp 4-component vector of float)
-0:20          textureGather ( global 4-component vector of float)
-0:20            direct index ( temp sampler2D)
-0:20              'arrayedSampler' ( uniform 5-element array of sampler2D)
-0:20              Constant:
-0:20                0 (const int)
-0:20            'c2D' ( smooth in 2-component vector of float)
-0:21      Sequence
-0:21        move second child to first child ( temp 4-component vector of int)
-0:21          'iv4' ( temp 4-component vector of int)
-0:21          textureGatherOffset ( global 4-component vector of int)
-0:21            'isamp2DA' ( uniform isampler2DArray)
-0:21            Constant:
-0:21              0.100000
-0:21              0.100000
-0:21              0.100000
-0:21            Constant:
-0:21              1 (const int)
-0:21              1 (const int)
-0:21            Constant:
-0:21              3 (const int)
-0:22      move second child to first child ( temp 4-component vector of int)
-0:22        'iv4' ( temp 4-component vector of int)
-0:22        textureGatherOffset ( global 4-component vector of int)
-0:22          'isamp2DA' ( uniform isampler2DArray)
-0:22          Constant:
-0:22            0.100000
-0:22            0.100000
-0:22            0.100000
-0:22          Constant:
-0:22            1 (const int)
-0:22            1 (const int)
-0:22          'i' ( flat in int)
-0:23      move second child to first child ( temp 4-component vector of int)
-0:23        'iv4' ( temp 4-component vector of int)
-0:23        textureGatherOffset ( global 4-component vector of int)
-0:23          'isamp2DA' ( uniform isampler2DArray)
-0:23          Constant:
-0:23            0.100000
-0:23            0.100000
-0:23            0.100000
-0:23          Constant:
-0:23            1 (const int)
-0:23            1 (const int)
-0:23          Constant:
-0:23            4 (const int)
-0:24      move second child to first child ( temp 4-component vector of int)
-0:24        'iv4' ( temp 4-component vector of int)
-0:24        textureGatherOffset ( global 4-component vector of int)
-0:24          'isamp2DA' ( uniform isampler2DArray)
-0:24          Constant:
-0:24            0.100000
-0:24            0.100000
-0:24            0.100000
-0:24          Constant:
-0:24            1 (const int)
-0:24            1 (const int)
-0:24          Constant:
-0:24            3 (const int)
-0:25      move second child to first child ( temp 4-component vector of int)
-0:25        'iv4' ( temp 4-component vector of int)
-0:25        textureGatherOffset ( global 4-component vector of int)
-0:25          'isamp2DA' ( uniform isampler2DArray)
-0:25          Constant:
-0:25            0.100000
-0:25            0.100000
-0:25            0.100000
-0:25          Construct ivec2 ( temp 2-component vector of int)
-0:25            'i' ( flat in int)
-0:27      Sequence
-0:27        move second child to first child ( temp 4-component vector of float)
-0:27          'c' ( temp 4-component vector of float)
-0:27          'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
+0:46      move second child to first child ( temp 4-component vector of float)
+0:46        'v' ( temp 4-component vector of float)
+0:46        texture ( global 4-component vector of float)
+0:46          indirect index ( temp sampler2D)
+0:46            'arrayedSampler' ( uniform 5-element array of sampler2D)
+0:46            'i' ( flat in int)
+0:46          'c2D' ( smooth in 2-component vector of float)
+0:47      move second child to first child ( temp float)
+0:47        direct index ( temp float)
+0:47          'outp' ( out 4-component vector of float)
+0:47          Constant:
+0:47            0 (const int)
+0:47        direct index ( smooth temp float ClipDistance)
+0:47          'gl_ClipDistance' ( smooth in 4-element array of float ClipDistance)
+0:47          Constant:
+0:47            1 (const int)
+0:51      Sequence
+0:51        move second child to first child ( temp 4-component vector of uint)
+0:51          'uv4' ( temp 4-component vector of uint)
+0:51          textureGatherOffsets ( global 4-component vector of uint)
+0:51            'samp2dr' ( uniform usampler2DRect)
+0:51            'c2D' ( smooth in 2-component vector of float)
+0:51            'offsets' ( temp 4-element array of 2-component vector of int)
+0:51            Constant:
+0:51              2 (const int)
+0:52      move second child to first child ( temp 4-component vector of uint)
+0:52        'uv4' ( temp 4-component vector of uint)
+0:52        textureGatherOffsets ( global 4-component vector of uint)
+0:52          'samp2dr' ( uniform usampler2DRect)
+0:52          'c2D' ( smooth in 2-component vector of float)
+0:52          Constant:
+0:52            1 (const int)
+0:52            2 (const int)
+0:52            3 (const int)
+0:52            4 (const int)
+0:52            15 (const int)
+0:52            16 (const int)
+0:52            -2 (const int)
+0:52            0 (const int)
+0:52          Constant:
+0:52            2 (const int)
+0:53      Sequence
+0:53        move second child to first child ( temp 4-component vector of float)
+0:53          'v4' ( temp 4-component vector of float)
+0:53          textureGather ( global 4-component vector of float)
+0:53            direct index ( temp sampler2D)
+0:53              'arrayedSampler' ( uniform 5-element array of sampler2D)
+0:53              Constant:
+0:53                0 (const int)
+0:53            'c2D' ( smooth in 2-component vector of float)
+0:54      Sequence
+0:54        move second child to first child ( temp 4-component vector of int)
+0:54          'iv4' ( temp 4-component vector of int)
+0:54          textureGatherOffset ( global 4-component vector of int)
+0:54            'isamp2DA' ( uniform isampler2DArray)
+0:54            Constant:
+0:54              0.100000
+0:54              0.100000
+0:54              0.100000
+0:54            Constant:
+0:54              1 (const int)
+0:54              1 (const int)
+0:54            Constant:
+0:54              3 (const int)
+0:55      move second child to first child ( temp 4-component vector of int)
+0:55        'iv4' ( temp 4-component vector of int)
+0:55        textureGatherOffset ( global 4-component vector of int)
+0:55          'isamp2DA' ( uniform isampler2DArray)
+0:55          Constant:
+0:55            0.100000
+0:55            0.100000
+0:55            0.100000
+0:55          Constant:
+0:55            1 (const int)
+0:55            1 (const int)
+0:55          'i' ( flat in int)
+0:56      move second child to first child ( temp 4-component vector of int)
+0:56        'iv4' ( temp 4-component vector of int)
+0:56        textureGatherOffset ( global 4-component vector of int)
+0:56          'isamp2DA' ( uniform isampler2DArray)
+0:56          Constant:
+0:56            0.100000
+0:56            0.100000
+0:56            0.100000
+0:56          Constant:
+0:56            1 (const int)
+0:56            1 (const int)
+0:56          Constant:
+0:56            4 (const int)
+0:57      move second child to first child ( temp 4-component vector of int)
+0:57        'iv4' ( temp 4-component vector of int)
+0:57        textureGatherOffset ( global 4-component vector of int)
+0:57          'isamp2DA' ( uniform isampler2DArray)
+0:57          Constant:
+0:57            0.100000
+0:57            0.100000
+0:57            0.100000
+0:57          Constant:
+0:57            1 (const int)
+0:57            1 (const int)
+0:57          Constant:
+0:57            3 (const int)
+0:58      move second child to first child ( temp 4-component vector of int)
+0:58        'iv4' ( temp 4-component vector of int)
+0:58        textureGatherOffset ( global 4-component vector of int)
+0:58          'isamp2DA' ( uniform isampler2DArray)
+0:58          Constant:
+0:58            0.100000
+0:58            0.100000
+0:58            0.100000
+0:58          Construct ivec2 ( temp 2-component vector of int)
+0:58            'i' ( flat in int)
+0:60      Sequence
+0:60        move second child to first child ( temp 4-component vector of float)
+0:60          'c' ( temp 4-component vector of float)
+0:60          'gl_FragCoord' ( gl_FragCoord 4-component vector of float FragCoord)
 0:?   Linker Objects
 0:?     'c2D' ( smooth in 2-component vector of float)
 0:?     'i' ( flat in int)
@@ -687,6 +735,9 @@ ERROR: node is still EOpNull!
 0:?     'arrayedSampler' ( uniform 5-element array of sampler2D)
 0:?     'samp2dr' ( uniform usampler2DRect)
 0:?     'isamp2DA' ( uniform isampler2DArray)
+0:?     'anon@0' (layout( column_major shared) buffer block{layout( column_major shared) buffer int atomi, layout( column_major shared) buffer uint atomu})
+0:?     'ssboStd430Arr' (layout( column_major shared) buffer 2-element array of block{layout( column_major shared) buffer int member01, layout( column_major shared) buffer 2-element array of int memberArr01, layout( column_major shared) buffer unsized 1-element array of int memberUnsizedArr01})
+0:?     'ssboSharedArr' (layout( column_major shared) buffer 2-element array of block{layout( column_major shared) buffer int member02, layout( column_major shared) buffer 2-element array of int memberArr02, layout( column_major shared) buffer unsized 1-element array of int memberUnsizedArr02})
 0:?     'gl_ClipDistance' ( smooth in 4-element array of float ClipDistance)
 0:?     'vl' (layout( location=4) smooth in 4-component vector of float)
 0:?     'vl2' (layout( location=6) smooth in 4-component vector of float)

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -144,10 +144,10 @@ EProfile EDesktopProfile = static_cast<EProfile>(ENoProfile | ECoreProfile | ECo
                                                   { EBadProfile } };
     const Versioning* Es300Desktop130 = &Es300Desktop130Version[0];
 
-    const Versioning Es310Desktop420Version[] = { { EEsProfile,      0, 310, 0, nullptr },
-                                                  { EDesktopProfile, 0, 420, 0, nullptr },
+    const Versioning Es310Desktop400Version[] = { { EEsProfile,      0, 310, 0, nullptr },
+                                                  { EDesktopProfile, 0, 400, 0, nullptr },
                                                   { EBadProfile } };
-    const Versioning* Es310Desktop420 = &Es310Desktop420Version[0];
+    const Versioning* Es310Desktop400 = &Es310Desktop400Version[0];
 
     const Versioning Es310Desktop450Version[] = { { EEsProfile,      0, 310, 0, nullptr },
                                                   { EDesktopProfile, 0, 450, 0, nullptr },
@@ -246,14 +246,14 @@ const BuiltInFunction BaseFunctions[] = {
     { EOpGreaterThanEqual, "greaterThanEqual", 2,   TypeU,     ClassBNS,     Es300Desktop130 },
     { EOpVectorEqual,      "equal",            2,   TypeU,     ClassBNS,     Es300Desktop130 },
     { EOpVectorNotEqual,   "notEqual",         2,   TypeU,     ClassBNS,     Es300Desktop130 },
-    { EOpAtomicAdd,        "atomicAdd",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop420 },
-    { EOpAtomicMin,        "atomicMin",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop420 },
-    { EOpAtomicMax,        "atomicMax",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop420 },
-    { EOpAtomicAnd,        "atomicAnd",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop420 },
-    { EOpAtomicOr,         "atomicOr",         2,   TypeIU,    ClassV1FIOCV, Es310Desktop420 },
-    { EOpAtomicXor,        "atomicXor",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop420 },
-    { EOpAtomicExchange,   "atomicExchange",   2,   TypeIU,    ClassV1FIOCV, Es310Desktop420 },
-    { EOpAtomicCompSwap,   "atomicCompSwap",   3,   TypeIU,    ClassV1FIOCV, Es310Desktop420 },
+    { EOpAtomicAdd,        "atomicAdd",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
+    { EOpAtomicMin,        "atomicMin",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
+    { EOpAtomicMax,        "atomicMax",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
+    { EOpAtomicAnd,        "atomicAnd",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
+    { EOpAtomicOr,         "atomicOr",         2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
+    { EOpAtomicXor,        "atomicXor",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
+    { EOpAtomicExchange,   "atomicExchange",   2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
+    { EOpAtomicCompSwap,   "atomicCompSwap",   3,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
     { EOpMix,              "mix",              3,   TypeB,     ClassRegular, Es310Desktop450 },
     { EOpMix,              "mix",              3,   TypeIU,    ClassLB,      Es310Desktop450 },
 


### PR DESCRIPTION
Ensure that GL_ARB_shader_storage_buffer_object is available from version GL 400 to GL 420.

Closes #3263.