### PR TITLE
Use C++ containers for builtin versioning

### DIFF
--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -52,6 +52,7 @@
 //
 
 #include "Initialize.h"
+#include "span.h"
 
 namespace glslang {
 
@@ -139,20 +140,17 @@ struct Versioning {
 EProfile EDesktopProfile = static_cast<EProfile>(ENoProfile | ECoreProfile | ECompatibilityProfile);
 
 // Declare pointers to put into the table for versioning.
-    const Versioning Es300Desktop130Version[] = { { EEsProfile,      0, 300, 0, nullptr },
-                                                  { EDesktopProfile, 0, 130, 0, nullptr },
-                                                  { EBadProfile } };
-    const Versioning* Es300Desktop130 = &Es300Desktop130Version[0];
+    const std::array Es300Desktop130Version = { Versioning{ EEsProfile,      0, 300, 0, nullptr },
+                                                Versioning{ EDesktopProfile, 0, 130, 0, nullptr },
+                                              };
 
-    const Versioning Es310Desktop400Version[] = { { EEsProfile,      0, 310, 0, nullptr },
-                                                  { EDesktopProfile, 0, 400, 0, nullptr },
-                                                  { EBadProfile } };
-    const Versioning* Es310Desktop400 = &Es310Desktop400Version[0];
+    const std::array Es310Desktop400Version = { Versioning{ EEsProfile,      0, 310, 0, nullptr },
+                                                Versioning{ EDesktopProfile, 0, 400, 0, nullptr },
+                                              };
 
-    const Versioning Es310Desktop450Version[] = { { EEsProfile,      0, 310, 0, nullptr },
-                                                  { EDesktopProfile, 0, 450, 0, nullptr },
-                                                  { EBadProfile } };
-    const Versioning* Es310Desktop450 = &Es310Desktop450Version[0];
+    const std::array Es310Desktop450Version = { Versioning{ EEsProfile,      0, 310, 0, nullptr },
+                                                Versioning{ EDesktopProfile, 0, 450, 0, nullptr },
+                                              };
 
 // The main descriptor of what a set of function prototypes can look like, and
 // a pointer to extra versioning information, when needed.
@@ -162,7 +160,7 @@ struct BuiltInFunction {
     int numArguments;             // number of arguments (overloads with varying arguments need different entries)
     ArgType types;                // ArgType mask
     ArgClass classes;             // the ways this particular function entry manifests
-    const Versioning* versioning; // nullptr means always a valid version
+    const span<const Versioning> versioning; // An empty span means always a valid version
 };
 
 // The tables can have the same built-in function name more than one time,
@@ -174,151 +172,146 @@ struct BuiltInFunction {
 //
 // Table is terminated by an OpNull TOperator.
 
-const BuiltInFunction BaseFunctions[] = {
+const std::array BaseFunctions = {
 //    TOperator,           name,       arg-count,   ArgType,   ArgClass,     versioning
 //    ---------            ----        ---------    -------    --------      ----------
-    { EOpRadians,          "radians",          1,   TypeF,     ClassRegular, nullptr },
-    { EOpDegrees,          "degrees",          1,   TypeF,     ClassRegular, nullptr },
-    { EOpSin,              "sin",              1,   TypeF,     ClassRegular, nullptr },
-    { EOpCos,              "cos",              1,   TypeF,     ClassRegular, nullptr },
-    { EOpTan,              "tan",              1,   TypeF,     ClassRegular, nullptr },
-    { EOpAsin,             "asin",             1,   TypeF,     ClassRegular, nullptr },
-    { EOpAcos,             "acos",             1,   TypeF,     ClassRegular, nullptr },
-    { EOpAtan,             "atan",             2,   TypeF,     ClassRegular, nullptr },
-    { EOpAtan,             "atan",             1,   TypeF,     ClassRegular, nullptr },
-    { EOpPow,              "pow",              2,   TypeF,     ClassRegular, nullptr },
-    { EOpExp,              "exp",              1,   TypeF,     ClassRegular, nullptr },
-    { EOpLog,              "log",              1,   TypeF,     ClassRegular, nullptr },
-    { EOpExp2,             "exp2",             1,   TypeF,     ClassRegular, nullptr },
-    { EOpLog2,             "log2",             1,   TypeF,     ClassRegular, nullptr },
-    { EOpSqrt,             "sqrt",             1,   TypeF,     ClassRegular, nullptr },
-    { EOpInverseSqrt,      "inversesqrt",      1,   TypeF,     ClassRegular, nullptr },
-    { EOpAbs,              "abs",              1,   TypeF,     ClassRegular, nullptr },
-    { EOpSign,             "sign",             1,   TypeF,     ClassRegular, nullptr },
-    { EOpFloor,            "floor",            1,   TypeF,     ClassRegular, nullptr },
-    { EOpCeil,             "ceil",             1,   TypeF,     ClassRegular, nullptr },
-    { EOpFract,            "fract",            1,   TypeF,     ClassRegular, nullptr },
-    { EOpMod,              "mod",              2,   TypeF,     ClassLS,      nullptr },
-    { EOpMin,              "min",              2,   TypeF,     ClassLS,      nullptr },
-    { EOpMax,              "max",              2,   TypeF,     ClassLS,      nullptr },
-    { EOpClamp,            "clamp",            3,   TypeF,     ClassLS2,     nullptr },
-    { EOpMix,              "mix",              3,   TypeF,     ClassLS,      nullptr },
-    { EOpStep,             "step",             2,   TypeF,     ClassFS,      nullptr },
-    { EOpSmoothStep,       "smoothstep",       3,   TypeF,     ClassFS2,     nullptr },
-    { EOpNormalize,        "normalize",        1,   TypeF,     ClassRegular, nullptr },
-    { EOpFaceForward,      "faceforward",      3,   TypeF,     ClassRegular, nullptr },
-    { EOpReflect,          "reflect",          2,   TypeF,     ClassRegular, nullptr },
-    { EOpRefract,          "refract",          3,   TypeF,     ClassXLS,     nullptr },
-    { EOpLength,           "length",           1,   TypeF,     ClassRS,      nullptr },
-    { EOpDistance,         "distance",         2,   TypeF,     ClassRS,      nullptr },
-    { EOpDot,              "dot",              2,   TypeF,     ClassRS,      nullptr },
-    { EOpCross,            "cross",            2,   TypeF,     ClassV3,      nullptr },
-    { EOpLessThan,         "lessThan",         2,   TypeFI,    ClassBNS,     nullptr },
-    { EOpLessThanEqual,    "lessThanEqual",    2,   TypeFI,    ClassBNS,     nullptr },
-    { EOpGreaterThan,      "greaterThan",      2,   TypeFI,    ClassBNS,     nullptr },
-    { EOpGreaterThanEqual, "greaterThanEqual", 2,   TypeFI,    ClassBNS,     nullptr },
-    { EOpVectorEqual,      "equal",            2,   TypeFIB,   ClassBNS,     nullptr },
-    { EOpVectorNotEqual,   "notEqual",         2,   TypeFIB,   ClassBNS,     nullptr },
-    { EOpAny,              "any",              1,   TypeB,     ClassRSNS,    nullptr },
-    { EOpAll,              "all",              1,   TypeB,     ClassRSNS,    nullptr },
-    { EOpVectorLogicalNot, "not",              1,   TypeB,     ClassNS,      nullptr },
-    { EOpSinh,             "sinh",             1,   TypeF,     ClassRegular, Es300Desktop130 },
-    { EOpCosh,             "cosh",             1,   TypeF,     ClassRegular, Es300Desktop130 },
-    { EOpTanh,             "tanh",             1,   TypeF,     ClassRegular, Es300Desktop130 },
-    { EOpAsinh,            "asinh",            1,   TypeF,     ClassRegular, Es300Desktop130 },
-    { EOpAcosh,            "acosh",            1,   TypeF,     ClassRegular, Es300Desktop130 },
-    { EOpAtanh,            "atanh",            1,   TypeF,     ClassRegular, Es300Desktop130 },
-    { EOpAbs,              "abs",              1,   TypeI,     ClassRegular, Es300Desktop130 },
-    { EOpSign,             "sign",             1,   TypeI,     ClassRegular, Es300Desktop130 },
-    { EOpTrunc,            "trunc",            1,   TypeF,     ClassRegular, Es300Desktop130 },
-    { EOpRound,            "round",            1,   TypeF,     ClassRegular, Es300Desktop130 },
-    { EOpRoundEven,        "roundEven",        1,   TypeF,     ClassRegular, Es300Desktop130 },
-    { EOpModf,             "modf",             2,   TypeF,     ClassLO,      Es300Desktop130 },
-    { EOpMin,              "min",              2,   TypeIU,    ClassLS,      Es300Desktop130 },
-    { EOpMax,              "max",              2,   TypeIU,    ClassLS,      Es300Desktop130 },
-    { EOpClamp,            "clamp",            3,   TypeIU,    ClassLS2,     Es300Desktop130 },
-    { EOpMix,              "mix",              3,   TypeF,     ClassLB,      Es300Desktop130 },
-    { EOpIsInf,            "isinf",            1,   TypeF,     ClassB,       Es300Desktop130 },
-    { EOpIsNan,            "isnan",            1,   TypeF,     ClassB,       Es300Desktop130 },
-    { EOpLessThan,         "lessThan",         2,   TypeU,     ClassBNS,     Es300Desktop130 },
-    { EOpLessThanEqual,    "lessThanEqual",    2,   TypeU,     ClassBNS,     Es300Desktop130 },
-    { EOpGreaterThan,      "greaterThan",      2,   TypeU,     ClassBNS,     Es300Desktop130 },
-    { EOpGreaterThanEqual, "greaterThanEqual", 2,   TypeU,     ClassBNS,     Es300Desktop130 },
-    { EOpVectorEqual,      "equal",            2,   TypeU,     ClassBNS,     Es300Desktop130 },
-    { EOpVectorNotEqual,   "notEqual",         2,   TypeU,     ClassBNS,     Es300Desktop130 },
-    { EOpAtomicAdd,        "atomicAdd",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
-    { EOpAtomicMin,        "atomicMin",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
-    { EOpAtomicMax,        "atomicMax",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
-    { EOpAtomicAnd,        "atomicAnd",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
-    { EOpAtomicOr,         "atomicOr",         2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
-    { EOpAtomicXor,        "atomicXor",        2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
-    { EOpAtomicExchange,   "atomicExchange",   2,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
-    { EOpAtomicCompSwap,   "atomicCompSwap",   3,   TypeIU,    ClassV1FIOCV, Es310Desktop400 },
-    { EOpMix,              "mix",              3,   TypeB,     ClassRegular, Es310Desktop450 },
-    { EOpMix,              "mix",              3,   TypeIU,    ClassLB,      Es310Desktop450 },
-
-    { EOpNull }
+    BuiltInFunction{ EOpRadians,          "radians",          1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpDegrees,          "degrees",          1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpSin,              "sin",              1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpCos,              "cos",              1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpTan,              "tan",              1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpAsin,             "asin",             1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpAcos,             "acos",             1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpAtan,             "atan",             2,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpAtan,             "atan",             1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpPow,              "pow",              2,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpExp,              "exp",              1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpLog,              "log",              1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpExp2,             "exp2",             1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpLog2,             "log2",             1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpSqrt,             "sqrt",             1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpInverseSqrt,      "inversesqrt",      1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpAbs,              "abs",              1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpSign,             "sign",             1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpFloor,            "floor",            1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpCeil,             "ceil",             1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpFract,            "fract",            1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpMod,              "mod",              2,   TypeF,     ClassLS,      {} },
+    BuiltInFunction{ EOpMin,              "min",              2,   TypeF,     ClassLS,      {} },
+    BuiltInFunction{ EOpMax,              "max",              2,   TypeF,     ClassLS,      {} },
+    BuiltInFunction{ EOpClamp,            "clamp",            3,   TypeF,     ClassLS2,     {} },
+    BuiltInFunction{ EOpMix,              "mix",              3,   TypeF,     ClassLS,      {} },
+    BuiltInFunction{ EOpStep,             "step",             2,   TypeF,     ClassFS,      {} },
+    BuiltInFunction{ EOpSmoothStep,       "smoothstep",       3,   TypeF,     ClassFS2,     {} },
+    BuiltInFunction{ EOpNormalize,        "normalize",        1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpFaceForward,      "faceforward",      3,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpReflect,          "reflect",          2,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpRefract,          "refract",          3,   TypeF,     ClassXLS,     {} },
+    BuiltInFunction{ EOpLength,           "length",           1,   TypeF,     ClassRS,      {} },
+    BuiltInFunction{ EOpDistance,         "distance",         2,   TypeF,     ClassRS,      {} },
+    BuiltInFunction{ EOpDot,              "dot",              2,   TypeF,     ClassRS,      {} },
+    BuiltInFunction{ EOpCross,            "cross",            2,   TypeF,     ClassV3,      {} },
+    BuiltInFunction{ EOpLessThan,         "lessThan",         2,   TypeFI,    ClassBNS,     {} },
+    BuiltInFunction{ EOpLessThanEqual,    "lessThanEqual",    2,   TypeFI,    ClassBNS,     {} },
+    BuiltInFunction{ EOpGreaterThan,      "greaterThan",      2,   TypeFI,    ClassBNS,     {} },
+    BuiltInFunction{ EOpGreaterThanEqual, "greaterThanEqual", 2,   TypeFI,    ClassBNS,     {} },
+    BuiltInFunction{ EOpVectorEqual,      "equal",            2,   TypeFIB,   ClassBNS,     {} },
+    BuiltInFunction{ EOpVectorNotEqual,   "notEqual",         2,   TypeFIB,   ClassBNS,     {} },
+    BuiltInFunction{ EOpAny,              "any",              1,   TypeB,     ClassRSNS,    {} },
+    BuiltInFunction{ EOpAll,              "all",              1,   TypeB,     ClassRSNS,    {} },
+    BuiltInFunction{ EOpVectorLogicalNot, "not",              1,   TypeB,     ClassNS,      {} },
+    BuiltInFunction{ EOpSinh,             "sinh",             1,   TypeF,     ClassRegular, {Es300Desktop130Version} },
+    BuiltInFunction{ EOpCosh,             "cosh",             1,   TypeF,     ClassRegular, {Es300Desktop130Version} },
+    BuiltInFunction{ EOpTanh,             "tanh",             1,   TypeF,     ClassRegular, {Es300Desktop130Version} },
+    BuiltInFunction{ EOpAsinh,            "asinh",            1,   TypeF,     ClassRegular, {Es300Desktop130Version} },
+    BuiltInFunction{ EOpAcosh,            "acosh",            1,   TypeF,     ClassRegular, {Es300Desktop130Version} },
+    BuiltInFunction{ EOpAtanh,            "atanh",            1,   TypeF,     ClassRegular, {Es300Desktop130Version} },
+    BuiltInFunction{ EOpAbs,              "abs",              1,   TypeI,     ClassRegular, {Es300Desktop130Version} },
+    BuiltInFunction{ EOpSign,             "sign",             1,   TypeI,     ClassRegular, {Es300Desktop130Version} },
+    BuiltInFunction{ EOpTrunc,            "trunc",            1,   TypeF,     ClassRegular, {Es300Desktop130Version} },
+    BuiltInFunction{ EOpRound,            "round",            1,   TypeF,     ClassRegular, {Es300Desktop130Version} },
+    BuiltInFunction{ EOpRoundEven,        "roundEven",        1,   TypeF,     ClassRegular, {Es300Desktop130Version} },
+    BuiltInFunction{ EOpModf,             "modf",             2,   TypeF,     ClassLO,      {Es300Desktop130Version} },
+    BuiltInFunction{ EOpMin,              "min",              2,   TypeIU,    ClassLS,      {Es300Desktop130Version} },
+    BuiltInFunction{ EOpMax,              "max",              2,   TypeIU,    ClassLS,      {Es300Desktop130Version} },
+    BuiltInFunction{ EOpClamp,            "clamp",            3,   TypeIU,    ClassLS2,     {Es300Desktop130Version} },
+    BuiltInFunction{ EOpMix,              "mix",              3,   TypeF,     ClassLB,      {Es300Desktop130Version} },
+    BuiltInFunction{ EOpIsInf,            "isinf",            1,   TypeF,     ClassB,       {Es300Desktop130Version} },
+    BuiltInFunction{ EOpIsNan,            "isnan",            1,   TypeF,     ClassB,       {Es300Desktop130Version} },
+    BuiltInFunction{ EOpLessThan,         "lessThan",         2,   TypeU,     ClassBNS,     {Es300Desktop130Version} },
+    BuiltInFunction{ EOpLessThanEqual,    "lessThanEqual",    2,   TypeU,     ClassBNS,     {Es300Desktop130Version} },
+    BuiltInFunction{ EOpGreaterThan,      "greaterThan",      2,   TypeU,     ClassBNS,     {Es300Desktop130Version} },
+    BuiltInFunction{ EOpGreaterThanEqual, "greaterThanEqual", 2,   TypeU,     ClassBNS,     {Es300Desktop130Version} },
+    BuiltInFunction{ EOpVectorEqual,      "equal",            2,   TypeU,     ClassBNS,     {Es300Desktop130Version} },
+    BuiltInFunction{ EOpVectorNotEqual,   "notEqual",         2,   TypeU,     ClassBNS,     {Es300Desktop130Version} },
+    BuiltInFunction{ EOpAtomicAdd,        "atomicAdd",        2,   TypeIU,    ClassV1FIOCV, {Es310Desktop400Version} },
+    BuiltInFunction{ EOpAtomicMin,        "atomicMin",        2,   TypeIU,    ClassV1FIOCV, {Es310Desktop400Version} },
+    BuiltInFunction{ EOpAtomicMax,        "atomicMax",        2,   TypeIU,    ClassV1FIOCV, {Es310Desktop400Version} },
+    BuiltInFunction{ EOpAtomicAnd,        "atomicAnd",        2,   TypeIU,    ClassV1FIOCV, {Es310Desktop400Version} },
+    BuiltInFunction{ EOpAtomicOr,         "atomicOr",         2,   TypeIU,    ClassV1FIOCV, {Es310Desktop400Version} },
+    BuiltInFunction{ EOpAtomicXor,        "atomicXor",        2,   TypeIU,    ClassV1FIOCV, {Es310Desktop400Version} },
+    BuiltInFunction{ EOpAtomicExchange,   "atomicExchange",   2,   TypeIU,    ClassV1FIOCV, {Es310Desktop400Version} },
+    BuiltInFunction{ EOpAtomicCompSwap,   "atomicCompSwap",   3,   TypeIU,    ClassV1FIOCV, {Es310Desktop400Version} },
+    BuiltInFunction{ EOpMix,              "mix",              3,   TypeB,     ClassRegular, {Es310Desktop450Version} },
+    BuiltInFunction{ EOpMix,              "mix",              3,   TypeIU,    ClassLB,      {Es310Desktop450Version} },
 };
 
-const BuiltInFunction DerivativeFunctions[] = {
-    { EOpDPdx,             "dFdx",             1,   TypeF,     ClassRegular, nullptr },
-    { EOpDPdy,             "dFdy",             1,   TypeF,     ClassRegular, nullptr },
-    { EOpFwidth,           "fwidth",           1,   TypeF,     ClassRegular, nullptr },
-    { EOpNull }
+const std::array DerivativeFunctions = {
+    BuiltInFunction{ EOpDPdx,             "dFdx",             1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpDPdy,             "dFdy",             1,   TypeF,     ClassRegular, {} },
+    BuiltInFunction{ EOpFwidth,           "fwidth",           1,   TypeF,     ClassRegular, {} },
 };
 
 // For functions declared some other way, but still use the table to relate to operator.
 struct CustomFunction {
     TOperator op;                 // operator to map the name to
     const char* name;             // function name
-    const Versioning* versioning; // nullptr means always a valid version
+    const span<const Versioning> versioning; // An empty span means always a valid version
 };
 
 const CustomFunction CustomFunctions[] = {
-    { EOpBarrier,             "barrier",             nullptr },
-    { EOpMemoryBarrierShared, "memoryBarrierShared", nullptr },
-    { EOpGroupMemoryBarrier,  "groupMemoryBarrier",  nullptr },
-    { EOpMemoryBarrier,       "memoryBarrier",       nullptr },
-    { EOpMemoryBarrierBuffer, "memoryBarrierBuffer", nullptr },
+    { EOpBarrier,             "barrier",             {} },
+    { EOpMemoryBarrierShared, "memoryBarrierShared", {} },
+    { EOpGroupMemoryBarrier,  "groupMemoryBarrier",  {} },
+    { EOpMemoryBarrier,       "memoryBarrier",       {} },
+    { EOpMemoryBarrierBuffer, "memoryBarrierBuffer", {} },
 
-    { EOpPackSnorm2x16,       "packSnorm2x16",       nullptr },
-    { EOpUnpackSnorm2x16,     "unpackSnorm2x16",     nullptr },
-    { EOpPackUnorm2x16,       "packUnorm2x16",       nullptr },
-    { EOpUnpackUnorm2x16,     "unpackUnorm2x16",     nullptr },
-    { EOpPackHalf2x16,        "packHalf2x16",        nullptr },
-    { EOpUnpackHalf2x16,      "unpackHalf2x16",      nullptr },
+    { EOpPackSnorm2x16,       "packSnorm2x16",       {} },
+    { EOpUnpackSnorm2x16,     "unpackSnorm2x16",     {} },
+    { EOpPackUnorm2x16,       "packUnorm2x16",       {} },
+    { EOpUnpackUnorm2x16,     "unpackUnorm2x16",     {} },
+    { EOpPackHalf2x16,        "packHalf2x16",        {} },
+    { EOpUnpackHalf2x16,      "unpackHalf2x16",      {} },
 
-    { EOpMul,                 "matrixCompMult",      nullptr },
-    { EOpOuterProduct,        "outerProduct",        nullptr },
-    { EOpTranspose,           "transpose",           nullptr },
-    { EOpDeterminant,         "determinant",         nullptr },
-    { EOpMatrixInverse,       "inverse",             nullptr },
-    { EOpFloatBitsToInt,      "floatBitsToInt",      nullptr },
-    { EOpFloatBitsToUint,     "floatBitsToUint",     nullptr },
-    { EOpIntBitsToFloat,      "intBitsToFloat",      nullptr },
-    { EOpUintBitsToFloat,     "uintBitsToFloat",     nullptr },
+    { EOpMul,                 "matrixCompMult",      {} },
+    { EOpOuterProduct,        "outerProduct",        {} },
+    { EOpTranspose,           "transpose",           {} },
+    { EOpDeterminant,         "determinant",         {} },
+    { EOpMatrixInverse,       "inverse",             {} },
+    { EOpFloatBitsToInt,      "floatBitsToInt",      {} },
+    { EOpFloatBitsToUint,     "floatBitsToUint",     {} },
+    { EOpIntBitsToFloat,      "intBitsToFloat",      {} },
+    { EOpUintBitsToFloat,     "uintBitsToFloat",     {} },
 
-    { EOpTextureQuerySize,      "textureSize",           nullptr },
-    { EOpTextureQueryLod,       "textureQueryLod",       nullptr },
-    { EOpTextureQueryLod,       "textureQueryLOD",       nullptr }, // extension GL_ARB_texture_query_lod
-    { EOpTextureQueryLevels,    "textureQueryLevels",    nullptr },
-    { EOpTextureQuerySamples,   "textureSamples",        nullptr },
-    { EOpTexture,               "texture",               nullptr },
-    { EOpTextureProj,           "textureProj",           nullptr },
-    { EOpTextureLod,            "textureLod",            nullptr },
-    { EOpTextureOffset,         "textureOffset",         nullptr },
-    { EOpTextureFetch,          "texelFetch",            nullptr },
-    { EOpTextureFetchOffset,    "texelFetchOffset",      nullptr },
-    { EOpTextureProjOffset,     "textureProjOffset",     nullptr },
-    { EOpTextureLodOffset,      "textureLodOffset",      nullptr },
-    { EOpTextureProjLod,        "textureProjLod",        nullptr },
-    { EOpTextureProjLodOffset,  "textureProjLodOffset",  nullptr },
-    { EOpTextureGrad,           "textureGrad",           nullptr },
-    { EOpTextureGradOffset,     "textureGradOffset",     nullptr },
-    { EOpTextureProjGrad,       "textureProjGrad",       nullptr },
-    { EOpTextureProjGradOffset, "textureProjGradOffset", nullptr },
-
-    { EOpNull }
+    { EOpTextureQuerySize,      "textureSize",           {} },
+    { EOpTextureQueryLod,       "textureQueryLod",       {} },
+    { EOpTextureQueryLod,       "textureQueryLOD",       {} }, // extension GL_ARB_texture_query_lod
+    { EOpTextureQueryLevels,    "textureQueryLevels",    {} },
+    { EOpTextureQuerySamples,   "textureSamples",        {} },
+    { EOpTexture,               "texture",               {} },
+    { EOpTextureProj,           "textureProj",           {} },
+    { EOpTextureLod,            "textureLod",            {} },
+    { EOpTextureOffset,         "textureOffset",         {} },
+    { EOpTextureFetch,          "texelFetch",            {} },
+    { EOpTextureFetchOffset,    "texelFetchOffset",      {} },
+    { EOpTextureProjOffset,     "textureProjOffset",     {} },
+    { EOpTextureLodOffset,      "textureLodOffset",      {} },
+    { EOpTextureProjLod,        "textureProjLod",        {} },
+    { EOpTextureProjLodOffset,  "textureProjLodOffset",  {} },
+    { EOpTextureGrad,           "textureGrad",           {} },
+    { EOpTextureGradOffset,     "textureGradOffset",     {} },
+    { EOpTextureProjGrad,       "textureProjGrad",       {} },
+    { EOpTextureProjGradOffset, "textureProjGradOffset", {} },
 };
 
 // For the given table of functions, add all the indicated prototypes for each
@@ -403,13 +396,13 @@ void AddTabledBuiltin(TString& decls, const BuiltInFunction& function)
 bool ValidVersion(const BuiltInFunction& function, int version, EProfile profile, const SpvVersion& /* spVersion */)
 {
     // nullptr means always valid
-    if (function.versioning == nullptr)
+    if (function.versioning.empty())
         return true;
 
     // check for what is said about our current profile
-    for (const Versioning* v = function.versioning; v->profiles != EBadProfile; ++v) {
-        if ((v->profiles & profile) != 0) {
-            if (v->minCoreVersion <= version || (v->numExtensions > 0 && v->minExtendedVersion <= version))
+    for (const auto& v : function.versioning) {
+        if ((v.profiles & profile) != 0) {
+            if (v.minCoreVersion <= version || (v.numExtensions > 0 && v.minExtendedVersion <= version))
                 return true;
         }
     }
@@ -422,12 +415,11 @@ bool ValidVersion(const BuiltInFunction& function, int version, EProfile profile
 // called once per stage). This is a performance issue only, not a correctness
 // concern.  It is done for quality arising from simplicity, as there are subtleties
 // to get correct if instead trying to do it surgically.
-template<class FunctionT>
-void RelateTabledBuiltins(const FunctionT* functions, TSymbolTable& symbolTable)
+template<class FunctionContainer>
+void RelateTabledBuiltins(const FunctionContainer& functions, TSymbolTable& symbolTable)
 {
-    while (functions->op != EOpNull) {
-        symbolTable.relateToOperator(functions->name, functions->op);
-        ++functions;
+    for (const auto& fn : functions) {
+        symbolTable.relateToOperator(fn.name, fn.op);
     }
 }
 
@@ -436,11 +428,10 @@ void RelateTabledBuiltins(const FunctionT* functions, TSymbolTable& symbolTable)
 // Add declarations for all tables of built-in functions.
 void TBuiltIns::addTabledBuiltins(int version, EProfile profile, const SpvVersion& spvVersion)
 {
-    const auto forEachFunction = [&](TString& decls, const BuiltInFunction* function) {
-        while (function->op != EOpNull) {
-            if (ValidVersion(*function, version, profile, spvVersion))
-                AddTabledBuiltin(decls, *function);
-            ++function;
+    const auto forEachFunction = [&](TString& decls, const span<const BuiltInFunction>& functions) {
+        for (const auto& fn : functions) {
+            if (ValidVersion(fn, version, profile, spvVersion))
+                AddTabledBuiltin(decls, fn);
         }
     };
 

--- a/glslang/MachineIndependent/span.h
+++ b/glslang/MachineIndependent/span.h
@@ -1,0 +1,92 @@
+#pragma once
+
+//
+// Copyright (C) 2023 LunarG, Inc.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//    Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//    Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+//    Neither the name of 3Dlabs Inc. Ltd. nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+// Partial implementation of std::span for C++11
+// Replace with std::span if repo standard is bumped to C++20
+//
+// This code was copied from https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/main/layers/containers/custom_containers.h
+template <typename T>
+class span {
+  public:
+    using pointer = T *;
+    using const_pointer = T const *;
+    using iterator = pointer;
+    using const_iterator = const_pointer;
+
+    span() = default;
+    span(pointer start, size_t n) : data_(start), count_(n) {}
+    template <typename Iterator>
+    span(Iterator start, Iterator end) : data_(&(*start)), count_(end - start) {}
+    template <typename Container>
+    span(Container &c) : data_(c.data()), count_(c.size()) {}
+
+    iterator begin() { return data_; }
+    const_iterator begin() const { return data_; }
+
+    iterator end() { return data_ + count_; }
+    const_iterator end() const { return data_ + count_; }
+
+    T &operator[](int i) { return data_[i]; }
+    const T &operator[](int i) const { return data_[i]; }
+
+    T &front() { return *data_; }
+    const T &front() const { return *data_; }
+
+    T &back() { return *(data_ + (count_ - 1)); }
+    const T &back() const { return *(data_ + (count_ - 1)); }
+
+    size_t size() const { return count_; }
+    bool empty() const { return count_ == 0; }
+
+    pointer data() { return data_; }
+    const_pointer data() const { return data_; }
+
+  private:
+    pointer data_ = {};
+    size_t count_ = 0;
+};
+
+//
+// Allow type inference that using the constructor doesn't allow in C++11
+template <typename T>
+span<T> make_span(T *begin, size_t count) {
+    return span<T>(begin, count);
+}
+template <typename T>
+span<T> make_span(T *begin, T *end) {
+    return make_span<T>(begin, end);
+}


### PR DESCRIPTION
Removes some of the pointers/"end markes" used in the BuiltInFuntion versioning, replacing them with std::arrays and spans.

NOTE: The span class used is a copy of the span class that has been in use in the Vulkan-ValidationLayers as a temporary solution until C++20 is available.

NOTE: The std::arrays could be constexprs, but this requires some extra work pre-C++20, and is therefore not included in this change, but could be done in a follow up PR.