### PR TITLE
cmake: only install public headers

### DIFF
--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -70,6 +70,13 @@ set(SPVREMAP_HEADERS
     SPVRemapper.h
     doc.h)
 
+set(PUBLIC_HEADERS
+    GlslangToSpv.h
+    disassemble.h
+    Logger.h
+    spirv.hpp
+    SPVRemapper.h)
+
 add_library(SPIRV ${LIB_TYPE} ${SOURCES} ${HEADERS})
 set_target_properties(SPIRV PROPERTIES
     FOLDER glslang
@@ -148,5 +155,5 @@ if(ENABLE_GLSLANG_INSTALL)
     ")
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/SPIRVTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 
-    install(FILES ${HEADERS} ${SPVREMAP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/glslang/SPIRV/)
+    install(FILES ${PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/glslang/SPIRV/)
 endif()

--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -43,6 +43,7 @@
 #include "spirv.hpp"
 #include "GlslangToSpv.h"
 #include "SpvBuilder.h"
+#include "SpvTools.h"
 namespace spv {
     #include "GLSL.std.450.h"
     #include "GLSL.ext.KHR.h"

--- a/SPIRV/GlslangToSpv.h
+++ b/SPIRV/GlslangToSpv.h
@@ -35,12 +35,7 @@
 
 #pragma once
 
-#if defined(_MSC_VER) && _MSC_VER >= 1900
-    #pragma warning(disable : 4464) // relative include path contains '..'
-#endif
-
 #include "SpvTools.h"
-#include "glslang/Include/intermediate.h"
 
 #include <string>
 #include <vector>
@@ -48,6 +43,7 @@
 #include "Logger.h"
 
 namespace glslang {
+class TIntermediate;
 
 void GetSpirvVersion(std::string&);
 int GetSpirvGeneratorVersion();

--- a/SPIRV/GlslangToSpv.h
+++ b/SPIRV/GlslangToSpv.h
@@ -35,8 +35,6 @@
 
 #pragma once
 
-#include "SpvTools.h"
-
 #include <string>
 #include <vector>
 
@@ -44,6 +42,18 @@
 
 namespace glslang {
 class TIntermediate;
+
+struct SpvOptions {
+    bool generateDebugInfo {false};
+    bool stripDebugInfo {false};
+    bool disableOptimizer {true};
+    bool optimizeSize {false};
+    bool disassemble {false};
+    bool validate {false};
+    bool emitNonSemanticShaderDebugInfo {false};
+    bool emitNonSemanticShaderDebugSource{ false };
+    bool compileOnly{false};
+};
 
 void GetSpirvVersion(std::string&);
 int GetSpirvGeneratorVersion();

--- a/SPIRV/SPVRemapper.h
+++ b/SPIRV/SPVRemapper.h
@@ -77,9 +77,9 @@ public:
 #include <cassert>
 
 #include "spirv.hpp"
-#include "spvIR.h"
 
 namespace spv {
+const Id NoResult = 0;
 
 // class to hold SPIR-V binary data for remapping, DCE, and debug stripping
 class spirvbin_t : public spirvbin_base_t

--- a/SPIRV/SpvTools.h
+++ b/SPIRV/SpvTools.h
@@ -48,21 +48,10 @@
 #endif
 
 #include "glslang/MachineIndependent/localintermediate.h"
+#include "GlslangToSpv.h"
 #include "Logger.h"
 
 namespace glslang {
-
-struct SpvOptions {
-    bool generateDebugInfo {false};
-    bool stripDebugInfo {false};
-    bool disableOptimizer {true};
-    bool optimizeSize {false};
-    bool disassemble {false};
-    bool validate {false};
-    bool emitNonSemanticShaderDebugInfo {false};
-    bool emitNonSemanticShaderDebugSource{ false };
-    bool compileOnly{false};
-};
 
 #if ENABLE_OPT
 

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -46,6 +46,7 @@
 #include "DirStackFileIncluder.h"
 #include "./../glslang/Include/ShHandle.h"
 #include "./../glslang/Public/ShaderLang.h"
+#include "../glslang/MachineIndependent/localintermediate.h"
 #include "../SPIRV/GlslangToSpv.h"
 #include "../SPIRV/GLSL.std.450.h"
 #include "../SPIRV/doc.h"

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -163,7 +163,7 @@ set(GLSLANG_HEADERS
     Include/SpirvIntrinsics.h
     Include/Types.h)
 
-add_library(glslang ${LIB_TYPE} ${BISON_GLSLParser_OUTPUT_SOURCE} ${GLSLANG_SOURCES} ${GLSLANG_HEADERS})
+add_library(glslang ${LIB_TYPE} ${GLSLANG_SOURCES} ${GLSLANG_HEADERS})
 set_target_properties(glslang PROPERTIES
     FOLDER glslang
     POSITION_INDEPENDENT_CODE ON
@@ -247,12 +247,16 @@ if(ENABLE_GLSLANG_INSTALL)
         install(FILES "${CMAKE_CURRENT_BINARY_DIR}/glslangTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
     endif()
 
-    set(ALL_HEADERS
-        ${GLSLANG_HEADERS}
-        ${MACHINEINDEPENDENT_HEADERS}
-        ${RESOURCELIMITS_HEADERS})
+    set(PUBLIC_HEADERS
+        Public/ResourceLimits.h
+        Public/ShaderLang.h
+        Public/resource_limits_c.h
+        Include/glslang_c_interface.h
+        Include/glslang_c_shader_types.h
+        Include/ResourceLimits.h
+        MachineIndependent/Versions.h)
 
-    foreach(file ${ALL_HEADERS})
+    foreach(file ${PUBLIC_HEADERS})
         get_filename_component(dir ${file} DIRECTORY)
         install(FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/glslang/${dir})
     endforeach()

--- a/gtests/TestFixture.h
+++ b/gtests/TestFixture.h
@@ -48,6 +48,7 @@
 #include "SPIRV/disassemble.h"
 #include "SPIRV/doc.h"
 #include "SPIRV/SPVRemapper.h"
+#include "glslang/Include/Types.h"
 #include "glslang/Public/ResourceLimits.h"
 #include "glslang/Public/ShaderLang.h"
 


### PR DESCRIPTION
Only the headers that are part of glslang's public interface are installed. Previously, all of its headers were installed, which exposed a lot of internal implementation details and made it difficult to maintain backward compatiblity. This reduces the API surface somewhat and will make it easier to maintain API and ABI compatibility.

This PR also makes some changes to header files to remove dependencies on things outside the "public API" set listed in #3320. The only exception not on that list but still used is `SPIRV/spirv.hpp`.