### PR TITLE
Improve non-semantic debug info for variables

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -4311,7 +4311,8 @@ spv::Id TGlslangToSpvTraverser::createSpvVariable(const glslang::TIntermSymbol* 
         initializer = builder.makeNullConstant(spvType);
     }
 
-    return builder.createVariable(spv::NoPrecision, storageClass, spvType, name, initializer, false);
+    return builder.createVariable(spv::NoPrecision, storageClass, spvType, name, initializer, false,
+                                  node->getDefinitionLoc().getFilename(), node->getDefinitionLoc().line);
 }
 
 // Return type Id of the sampled type.

--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -63,6 +63,7 @@ namespace spv {
 #include <stack>
 #include <unordered_map>
 #include <map>
+#include <optional>
 
 namespace spv {
 
@@ -214,6 +215,12 @@ public:
         int line {0};
         int column {0};
     };
+    struct DebugParamInfo {
+        // 0-based index of parameter
+        size_t argNumber = 0;
+        // Indicate the OpFunctionParameter is actually wrapped with a pointer type.
+        bool passByRef = false;
+    };
     std::unordered_map<Id, DebugTypeLoc> debugTypeLocs;
     Id makeDebugInfoNone();
     Id makeBoolDebugType(int const size);
@@ -228,8 +235,10 @@ public:
         NonSemanticShaderDebugInfo100DebugCompositeType const tag, bool const isOpaqueType = false);
     Id makeDebugSource(const Id fileName);
     Id makeDebugCompilationUnit();
-    Id createDebugGlobalVariable(Id const type, char const*const name, Id const variable);
-    Id createDebugLocalVariable(Id type, char const*const name, size_t const argNumber = 0);
+    Id createDebugGlobalVariable(Id const type, char const* const name, Id const variable,
+                                 Id const sourceFileName, int const line);
+    Id createDebugLocalVariable(Id type, char const* const name,
+                                std::optional<DebugParamInfo> paramInfo = std::nullopt);
     Id makeDebugExpression();
     Id makeDebugDeclare(Id const debugLocalVariable, Id const pointer);
     Id makeDebugValue(Id const debugLocalVariable, Id const value);
@@ -450,8 +459,9 @@ public:
     void makeStatementTerminator(spv::Op opcode, const std::vector<Id>& operands, const char* name);
 
     // Create a global or function local or IO variable.
+    // Note sourceFileName and line are not applicable for function locals.
     Id createVariable(Decoration precision, StorageClass storageClass, Id type, const char* name = nullptr,
-        Id initializer = NoResult, bool const compilerGenerated = true);
+        Id initializer = NoResult, bool const compilerGenerated = true, const char* sourceFileName = nullptr, int line = 0);
 
     // Create an intermediate with an undefined value.
     Id createUndefined(Id type);

--- a/glslang/Include/intermediate.h
+++ b/glslang/Include/intermediate.h
@@ -1368,12 +1368,18 @@ public:
     // later on, it becomes necessary to switch to a different symbol.
     virtual void switchId(long long newId) { id = newId; }
 
+    void setDefinitionLoc(const TSourceLoc& loc) { definitionLoc = loc; }
+    const TSourceLoc& getDefinitionLoc() const { return definitionLoc; }
+
 protected:
     long long id;                // the unique id of the symbol this node represents
     int flattenSubset;           // how deeply the flattened object rooted at id has been dereferenced
     TString name;                // the name of the symbol this node represents
     TConstUnionArray constArray; // if the symbol is a front-end compile-time constant, this is its value
     TIntermTyped* constSubtree;
+
+    // A hint to the source location where the symbol is defined.
+    TSourceLoc definitionLoc;
 };
 
 class TIntermConstantUnion : public TIntermTyped {

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -10195,7 +10195,7 @@ void TBuiltIns::identifyBuiltIns(int version, EProfile profile, const SpvVersion
             TArraySizes* arraySizes = new TArraySizes;
             arraySizes->addInnerSize(resources.maxDrawBuffers);
             fragData.transferArraySizes(arraySizes);
-            symbolTable.insert(*new TVariable(NewPoolTString("gl_FragData"), fragData));
+            symbolTable.insert(*new TVariable(NewPoolTString("gl_FragData"), fragData, {}));
             SpecialQualifier("gl_FragData", EvqFragColor, EbvFragData, symbolTable);
         }
 

--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -66,12 +66,13 @@ namespace glslang {
 //
 
 TIntermSymbol* TIntermediate::addSymbol(long long id, const TString& name, const TType& type, const TConstUnionArray& constArray,
-                                        TIntermTyped* constSubtree, const TSourceLoc& loc)
+                                        TIntermTyped* constSubtree, const TSourceLoc& loc, const TSourceLoc& definitionLoc)
 {
     TIntermSymbol* node = new TIntermSymbol(id, name, type);
     node->setLoc(loc);
     node->setConstArray(constArray);
     node->setConstSubtree(constSubtree);
+    node->setDefinitionLoc(definitionLoc);
 
     return node;
 }
@@ -83,7 +84,8 @@ TIntermSymbol* TIntermediate::addSymbol(const TIntermSymbol& intermSymbol)
                      intermSymbol.getType(),
                      intermSymbol.getConstArray(),
                      intermSymbol.getConstSubtree(),
-                     intermSymbol.getLoc());
+                     intermSymbol.getLoc(),
+                     intermSymbol.getDefinitionLoc());
 }
 
 TIntermSymbol* TIntermediate::addSymbol(const TVariable& variable)
@@ -96,14 +98,16 @@ TIntermSymbol* TIntermediate::addSymbol(const TVariable& variable)
 
 TIntermSymbol* TIntermediate::addSymbol(const TVariable& variable, const TSourceLoc& loc)
 {
-    return addSymbol(variable.getUniqueId(), variable.getName(), variable.getType(), variable.getConstArray(), variable.getConstSubtree(), loc);
+    return addSymbol(variable.getUniqueId(), variable.getName(), variable.getType(), variable.getConstArray(),
+                     variable.getConstSubtree(), loc, variable.getLoc());
 }
 
 TIntermSymbol* TIntermediate::addSymbol(const TType& type, const TSourceLoc& loc)
 {
     TConstUnionArray unionArray;  // just a null constant
 
-    return addSymbol(0, "", type, unionArray, nullptr, loc);
+    // TODO: could we track the location of the (struct) type definition?
+    return addSymbol(0, "", type, unionArray, nullptr, loc, {});
 }
 
 //

--- a/glslang/MachineIndependent/ParseContextBase.cpp
+++ b/glslang/MachineIndependent/ParseContextBase.cpp
@@ -613,7 +613,7 @@ void TParseContextBase::growGlobalUniformBlock(const TSourceLoc& loc, TType& mem
         blockQualifier.storage = EvqUniform;
         TType blockType(new TTypeList, *NewPoolTString(getGlobalUniformBlockName()), blockQualifier);
         setUniformBlockDefaults(blockType);
-        globalUniformBlock = new TVariable(NewPoolTString(""), blockType, true);
+        globalUniformBlock = new TVariable(NewPoolTString(""), blockType, {}, true);
         firstNewMember = 0;
     }
 
@@ -682,7 +682,7 @@ void TParseContextBase::growAtomicCounterBlock(int binding, const TSourceLoc& lo
         TType blockType(new TTypeList, *NewPoolTString(charBuffer), blockQualifier);
         setUniformBlockDefaults(blockType);
         blockType.getQualifier().layoutPacking = ElpStd430;
-        atomicCounterBuffer = new TVariable(NewPoolTString(""), blockType, true);
+        atomicCounterBuffer = new TVariable(NewPoolTString(""), blockType, loc, true);
         // If we arn't auto mapping bindings then set the block to use the same
         // binding as what the atomic was set to use
         if (!intermediate.getAutoMapBindings()) {

--- a/glslang/MachineIndependent/SymbolTable.h
+++ b/glslang/MachineIndependent/SymbolTable.h
@@ -123,9 +123,18 @@ public:
     virtual bool isReadOnly() const { return ! writable; }
     virtual void makeReadOnly() { writable = false; }
 
+    void setLoc(const TSourceLoc& newLoc) { loc = newLoc; }
+    const TSourceLoc& getLoc() const { return loc; }
+
 protected:
     explicit TSymbol(const TSymbol&);
     TSymbol& operator=(const TSymbol&);
+
+    // A hint to the source location where the symbol is defined.
+    // This is a best-of-effort hint and may not point to the exact location of definition.
+    // We may not have AST node for some constructs to obtain the accurate location.
+    // For internal symbols, this should be empty.
+    TSourceLoc loc;
 
     const TString *name;
     unsigned long long uniqueId;      // For cross-scope comparing during code generation
@@ -153,13 +162,16 @@ protected:
 //
 class TVariable : public TSymbol {
 public:
-    TVariable(const TString *name, const TType& t, bool uT = false )
+    TVariable(const TString *name, const TType& t, const TSourceLoc& loc, bool uT = false)
         : TSymbol(name),
           userType(uT),
           constSubtree(nullptr),
           memberExtensions(nullptr),
           anonId(-1)
-        { type.shallowCopy(t); }
+    {
+        setLoc(loc);
+        type.shallowCopy(t); 
+    }
     virtual TVariable* clone() const;
     virtual ~TVariable() { }
 

--- a/glslang/MachineIndependent/glslang_tab.cpp
+++ b/glslang/MachineIndependent/glslang_tab.cpp
@@ -10929,7 +10929,7 @@ yyreduce:
                                                                                                                    {
         TType* structure = new TType((yyvsp[-1].interm.typeList), *(yyvsp[-4].lex).string);
         parseContext.structArrayCheck((yyvsp[-4].lex).loc, *structure);
-        TVariable* userTypeDef = new TVariable((yyvsp[-4].lex).string, *structure, true);
+        TVariable* userTypeDef = new TVariable((yyvsp[-4].lex).string, *structure, (yyvsp[-4].lex).loc, true);
         if (! parseContext.symbolTable.insert(*userTypeDef))
             parseContext.error((yyvsp[-4].lex).loc, "redefinition", (yyvsp[-4].lex).string->c_str(), "struct");
         (yyval.interm.type).init((yyvsp[-5].lex).loc);

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -1094,7 +1094,8 @@ public:
         { on ? numericFeatures.insert(f) : numericFeatures.erase(f); }
 
 protected:
-    TIntermSymbol* addSymbol(long long Id, const TString&, const TType&, const TConstUnionArray&, TIntermTyped* subtree, const TSourceLoc&);
+    TIntermSymbol* addSymbol(long long Id, const TString&, const TType&, const TConstUnionArray&, TIntermTyped* subtree,
+                             const TSourceLoc& loc, const TSourceLoc& definitionLoc);
     void error(TInfoSink& infoSink, const char*, EShLanguage unitStage = EShLangCount);
     void warn(TInfoSink& infoSink, const char*, EShLanguage unitStage = EShLangCount);
     void mergeCallGraphs(TInfoSink&, TIntermediate&);


### PR DESCRIPTION
This patch fixes two things:
1. Correctly set the source location of global variable correctly. Currently, glslang will set the location of the debug variable to the site of its first use, which is definitely undesirable. This patch forwards the site of definition from `TSymbol` to `TIntermSymbol` and finally to `createDebugGlobalVariable`. This is technically inefficient usage of space, but we don't have AST node for decls in glslang. 
```
int x; // <-- now we point here

int foo() {
    return x; // <-- we used to point here in DebugGlobalVariable
}
```
2. Set FlagTypePassByReference/FlagTypePassByValue properly to parameter so the consumer could identify a wrapping pointer and a real pointer in parameter type.