### PR TITLE
Remove custom implementations of isinf and isnan

### DIFF
--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -292,34 +292,6 @@ template <class T> int IntLog2(T n)
     return result;
 }
 
-inline bool IsInfinity(double x) {
-#ifdef _MSC_VER
-    switch (_fpclass(x)) {
-    case _FPCLASS_NINF:
-    case _FPCLASS_PINF:
-        return true;
-    default:
-        return false;
-    }
-#else
-    return std::isinf(x);
-#endif
-}
-
-inline bool IsNan(double x) {
-#ifdef _MSC_VER
-    switch (_fpclass(x)) {
-    case _FPCLASS_SNAN:
-    case _FPCLASS_QNAN:
-        return true;
-    default:
-        return false;
-    }
-#else
-  return std::isnan(x);
-#endif
-}
-
 } // end namespace glslang
 
 #endif // _COMMON_INCLUDED_

--- a/glslang/MachineIndependent/Constant.cpp
+++ b/glslang/MachineIndependent/Constant.cpp
@@ -628,12 +628,12 @@ TIntermTyped* TIntermConstantUnion::fold(TOperator op, const TType& returnType) 
 
         case EOpIsNan:
         {
-            newConstArray[i].setBConst(IsNan(unionArray[i].getDConst()));
+            newConstArray[i].setBConst(std::isnan(unionArray[i].getDConst()));
             break;
         }
         case EOpIsInf:
         {
-            newConstArray[i].setBConst(IsInfinity(unionArray[i].getDConst()));
+            newConstArray[i].setBConst(std::isinf(unionArray[i].getDConst()));
             break;
         }
 

--- a/glslang/MachineIndependent/intermOut.cpp
+++ b/glslang/MachineIndependent/intermOut.cpp
@@ -1208,12 +1208,12 @@ bool TOutputTraverser::visitSelection(TVisit /* visit */, TIntermSelection* node
 //   - shows all digits, no premature rounding
 static void OutputDouble(TInfoSink& out, double value, TOutputTraverser::EExtraOutput extra)
 {
-    if (IsInfinity(value)) {
+    if (std::isinf(value)) {
         if (value < 0)
             out.debug << "-1.#INF";
         else
             out.debug << "+1.#INF";
-    } else if (IsNan(value))
+    } else if (std::isnan(value))
         out.debug << "1.#IND";
     else {
         const int maxSize = 340;


### PR DESCRIPTION
Use the ones from the <cmath> header instead, now that that is available on all the currently supported versions of MSVC.