### PR TITLE
Fix CMake spirv-tools dependency

### DIFF
--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -106,11 +106,7 @@ if(WIN32 AND BUILD_SHARED_LIBS)
 endif()
 
 if(ENABLE_OPT)
-    target_include_directories(SPIRV
-        PRIVATE ${spirv-tools_SOURCE_DIR}/include
-        PRIVATE ${spirv-tools_SOURCE_DIR}/source
-    )
-    target_link_libraries(SPIRV PRIVATE MachineIndependent SPIRV-Tools-opt)
+    target_link_libraries(SPIRV PRIVATE MachineIndependent PUBLIC SPIRV-Tools-opt)
     target_include_directories(SPIRV PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../External>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/External>)

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -76,12 +76,6 @@ target_include_directories(glslang-standalone PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../External>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/External>)
 
-if(ENABLE_OPT)
-    target_include_directories(glslang-standalone
-        PRIVATE ${spirv-tools_SOURCE_DIR}/include
-    )
-endif()
-
 if(ENABLE_SPVREMAPPER)
     set(REMAPPER_SOURCES spirv-remap.cpp)
     add_executable(spirv-remap ${REMAPPER_SOURCES})

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -97,8 +97,8 @@ if(BUILD_TESTING)
                                    ${gtest_SOURCE_DIR}/include)
 
         if(ENABLE_OPT)
-            target_include_directories(glslangtests
-                PRIVATE ${spirv-tools_SOURCE_DIR}/include
+            target_link_libraries(glslangtests
+                PRIVATE SPIRV-Tools-opt
             )
         endif()
 


### PR DESCRIPTION
The build is currently broken when using external SPIRV-Tools. This happens when `find_package(SPIRV-Tools-opt)` is used here: https://github.com/KhronosGroup/glslang/blob/589431af5c86b0be3cc23175258451be1f5d25b3/CMakeLists.txt#L271

The problem is using `${spirv-tools_SOURCE_DIR}`. This variable is defined by CMake on [a project() command](https://cmake.org/cmake/help/latest/variable/PROJECT-NAME_SOURCE_DIR.html). But a spirv-tools project() command is only present when using spirv-tools via `add_subdirectory`. Therefore, when using external spirv-tools via find_package, the variable is just empty and no include dirs are set.

This PR is trying to fix this by linking the spirv-tools-opt target instead, which should set the include directories automatically and will work with using spirv-tools via add_subdirectory and find_package. I have no full overview of the glslang cmake sources, so I'm not aware of side effects, but here is what I intended to do:
- Do not include ${spirv-tools_SOURCE_DIR}/source. I hope there is no dependency on internal sources of the spirv-tools repo, but in that case external spiv tools would probably not work at all.
- It seems headers of the SPIRV target include spirv-tools headers, so SPPIRV-Tools-opt seems to be a public dependency of the SPIRV target
- remove spirv-tools include from StandAlone. From a quick search through the sources it seems no spirv-tool headers are used. If this was present because of transitive dependency of the SPIRV target this should now be solved by the SPIRV target having a public dependency on SPIRV-Tools-opt