### PR TITLE
Fix Xcode 15 linker warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,9 +126,11 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
         add_compile_options(-Werror=deprecated-copy)
     endif()
 
-    if(NOT CMAKE_SYSTEM_NAME STREQUAL "OpenBSD" AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-        # Error if there's symbols that are not found at link time.
-        add_link_options("-Wl,--no-undefined")
+    if(NOT (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD"))
+        if (NOT APPLE)
+            # Error if there's symbols that are not found at link time.
+            add_link_options("-Wl,--no-undefined")
+        endif()
     endif()
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" AND NOT MSVC)
     add_compile_options(-Wall -Wuninitialized -Wunused -Wunused-local-typedefs
@@ -140,11 +142,9 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" AND NOT MSVC)
         add_compile_options(-fno-exceptions)
     endif()
 
-    if(NOT (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD" OR CMAKE_SYSTEM_NAME STREQUAL "Emscripten"))
+    if(NOT (CMAKE_SYSTEM_NAME MATCHES "OpenBSD|Emscripten"))
         # Error if there's symbols that are not found at link time. Some linkers do not support this flag.
-        if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-            add_link_options("-Wl,-undefined,error")
-        elseif(NOT APPLE)
+        if(NOT APPLE)
             add_link_options("-Wl,--no-undefined")
         endif()
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ option(ENABLE_RTTI "Enables RTTI" OFF)
 option(ENABLE_EXCEPTIONS "Enables Exceptions" OFF)
 option(ENABLE_OPT "Enables spirv-opt capability if present" ON)
 
-if(MINGW OR (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU"))
+if(MINGW OR (APPLE AND ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU"))
     # Workaround for CMake behavior on Mac OS with gcc, cmake generates -Xarch_* arguments
     # which gcc rejects
     option(ENABLE_PCH "Enables Precompiled header" OFF)


### PR DESCRIPTION
XCode 15 includes a completely new linker implementation. Hence some flags are deprecated.

The default is now error so we can simply remove the linker option.