### PR TITLE
Linker option cleanup

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -35,6 +35,7 @@ jobs:
           CMAKE_GENERATOR: Ninja
           CMAKE_C_COMPILER_LAUNCHER: ccache
           CMAKE_CXX_COMPILER_LAUNCHER: ccache
+          LDFLAGS: -Wl,--no-undefined
       - name: Build
         run: cmake --build build
       - name: Install

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -154,12 +154,11 @@ jobs:
         with:
           python-version: '3.7'
       - run: python update_glslang_sources.py
-      - name: Build
-        run: |
-          cmake -S. -Bbuild -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="$PWD/build/install"
-          cmake --build build --config ${{matrix.cmake_build_type}} --target install
-      - name: Test
-        run: ctest -C ${{matrix.cmake_build_type}} --output-on-failure --test-dir build
+      - run: cmake -S . -B build -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="$PWD/build/install"
+        env:
+          LDFLAGS: /WX
+      - run: cmake --build build --config ${{matrix.cmake_build_type}} --target install
+      - run: ctest -C ${{matrix.cmake_build_type}} --output-on-failure --test-dir build
       - name: Test (standalone)
         run: bash -c 'cd ./Test && ./runtests'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,13 +141,6 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
     if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0.0")
         add_compile_options(-Werror=deprecated-copy)
     endif()
-
-    if(NOT (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD"))
-        if (NOT APPLE)
-            # Error if there's symbols that are not found at link time.
-            add_link_options("-Wl,--no-undefined")
-        endif()
-    endif()
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" AND NOT MSVC)
     add_compile_options(-Wall -Wuninitialized -Wunused -Wunused-local-typedefs
                         -Wunused-parameter -Wunused-value  -Wunused-variable)
@@ -156,13 +149,6 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" AND NOT MSVC)
     endif()
     if(NOT ENABLE_EXCEPTIONS)
         add_compile_options(-fno-exceptions)
-    endif()
-
-    if(NOT (CMAKE_SYSTEM_NAME MATCHES "OpenBSD|Emscripten"))
-        # Error if there's symbols that are not found at link time. Some linkers do not support this flag.
-        if(NOT APPLE)
-            add_link_options("-Wl,--no-undefined")
-        endif()
     endif()
 elseif(MSVC)
     if(NOT ENABLE_RTTI)


### PR DESCRIPTION
1. Move -Wl,--no-undefined into CI script

Removes complexity around setting this linker option from the
CMakeLists.txt while still providing error checking.

Furthermore given there are now 4 linkers it's simpler to just have this linker option in CI than worry about individual users setups:
- gnu
- gold
- llvm
- mold

Not to mention how this apparently doesn't work for OpenBSD and
Emscripten it's much simpler to set this via LDFLAGS instead.

2. Set linker warnings as errors for Windows builds
