### PR TITLE
cmake: Remove SPIRV-Tools workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,6 @@ endif()
 # Furthermore testing is equally problematic.
 if (IOS OR ANDROID)
     set(ENABLE_GLSLANG_BINARIES OFF)
-    set(SPIRV_SKIP_EXECUTABLES ON)
 
     set(ENABLE_CTEST OFF)
     set(BUILD_TESTING OFF)

--- a/known_good.json
+++ b/known_good.json
@@ -5,7 +5,7 @@
       "site" : "github",
       "subrepo" : "KhronosGroup/SPIRV-Tools",
       "subdir" : "External/spirv-tools",
-      "commit" : "360d469b9eac54d6c6e20f609f9ec35e3a5380ad"
+      "commit": "afaf8fda2ad0364655909b56c8b634ce89095bb5"
     },
     {
       "name" : "spirv-tools/external/spirv-headers",


### PR DESCRIPTION
As of KhronosGroup/SPIRV-Tools/pull/5482

SPIRV-Tools builds cleanly for Android/iOS by default