### PR TITLE
support GL_ARB_texture_multisample extension.

### DIFF
--- a/Test/GL_ARB_texture_multisample.vert
+++ b/Test/GL_ARB_texture_multisample.vert
@@ -1,0 +1,14 @@
+#version 140
+#extension GL_ARB_texture_multisample : enable
+
+out float result;
+
+uniform sampler2DMS data;
+uniform sampler2DMSArray data1;
+void main()
+{
+result = texelFetch(data, ivec2(0), 3).r;
+ivec2 temp = textureSize(data);
+result = texelFetch(data1, ivec3(0), 3).r;
+ivec3 temp1 = textureSize(data1);
+}

--- a/Test/GL_ARB_texture_multisample.vert
+++ b/Test/GL_ARB_texture_multisample.vert
@@ -2,13 +2,27 @@
 #extension GL_ARB_texture_multisample : enable
 
 out float result;
+out int result1;
+out uint result2;
 
 uniform sampler2DMS data;
 uniform sampler2DMSArray data1;
+uniform isampler2DMS data2;
+uniform usampler2DMSArray data3;
+uniform usampler2DMS data4;
+uniform isampler2DMSArray data5;
 void main()
 {
     result = texelFetch(data, ivec2(0), 3).r;
     ivec2 temp = textureSize(data);
     result = texelFetch(data1, ivec3(0), 3).r;
     ivec3 temp1 = textureSize(data1);
+	result1 = texelFetch(data2, ivec2(0), 3).r;
+    temp = textureSize(data2);
+	result2 = texelFetch(data3, ivec3(0), 3).r;
+    temp1 = textureSize(data3);
+	result2 = texelFetch(data4, ivec2(0), 3).r;
+    temp = textureSize(data4);
+	result1 = texelFetch(data5, ivec3(0), 3).r;
+    temp1 = textureSize(data5);
 }

--- a/Test/GL_ARB_texture_multisample.vert
+++ b/Test/GL_ARB_texture_multisample.vert
@@ -7,8 +7,8 @@ uniform sampler2DMS data;
 uniform sampler2DMSArray data1;
 void main()
 {
-result = texelFetch(data, ivec2(0), 3).r;
-ivec2 temp = textureSize(data);
-result = texelFetch(data1, ivec3(0), 3).r;
-ivec3 temp1 = textureSize(data1);
+    result = texelFetch(data, ivec2(0), 3).r;
+    ivec2 temp = textureSize(data);
+    result = texelFetch(data1, ivec3(0), 3).r;
+    ivec3 temp1 = textureSize(data1);
 }

--- a/Test/baseResults/GL_ARB_texture_multisample.vert.out
+++ b/Test/baseResults/GL_ARB_texture_multisample.vert.out
@@ -1,0 +1,101 @@
+GL_ARB_texture_multisample.vert
+Shader version: 140
+Requested GL_ARB_texture_multisample
+0:? Sequence
+0:8  Function Definition: main( ( global void)
+0:8    Function Parameters: 
+0:10    Sequence
+0:10      move second child to first child ( temp float)
+0:10        'result' ( smooth out float)
+0:10        direct index ( temp float)
+0:10          textureFetch ( global 4-component vector of float)
+0:10            'data' ( uniform sampler2DMS)
+0:10            Constant:
+0:10              0 (const int)
+0:10              0 (const int)
+0:10            Constant:
+0:10              3 (const int)
+0:10          Constant:
+0:10            0 (const int)
+0:11      Sequence
+0:11        move second child to first child ( temp 2-component vector of int)
+0:11          'temp' ( temp 2-component vector of int)
+0:11          textureSize ( global 2-component vector of int)
+0:11            'data' ( uniform sampler2DMS)
+0:12      move second child to first child ( temp float)
+0:12        'result' ( smooth out float)
+0:12        direct index ( temp float)
+0:12          textureFetch ( global 4-component vector of float)
+0:12            'data1' ( uniform sampler2DMSArray)
+0:12            Constant:
+0:12              0 (const int)
+0:12              0 (const int)
+0:12              0 (const int)
+0:12            Constant:
+0:12              3 (const int)
+0:12          Constant:
+0:12            0 (const int)
+0:13      Sequence
+0:13        move second child to first child ( temp 3-component vector of int)
+0:13          'temp1' ( temp 3-component vector of int)
+0:13          textureSize ( global 3-component vector of int)
+0:13            'data1' ( uniform sampler2DMSArray)
+0:?   Linker Objects
+0:?     'result' ( smooth out float)
+0:?     'data' ( uniform sampler2DMS)
+0:?     'data1' ( uniform sampler2DMSArray)
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+
+Linked vertex stage:
+
+
+Shader version: 140
+Requested GL_ARB_texture_multisample
+0:? Sequence
+0:8  Function Definition: main( ( global void)
+0:8    Function Parameters: 
+0:10    Sequence
+0:10      move second child to first child ( temp float)
+0:10        'result' ( smooth out float)
+0:10        direct index ( temp float)
+0:10          textureFetch ( global 4-component vector of float)
+0:10            'data' ( uniform sampler2DMS)
+0:10            Constant:
+0:10              0 (const int)
+0:10              0 (const int)
+0:10            Constant:
+0:10              3 (const int)
+0:10          Constant:
+0:10            0 (const int)
+0:11      Sequence
+0:11        move second child to first child ( temp 2-component vector of int)
+0:11          'temp' ( temp 2-component vector of int)
+0:11          textureSize ( global 2-component vector of int)
+0:11            'data' ( uniform sampler2DMS)
+0:12      move second child to first child ( temp float)
+0:12        'result' ( smooth out float)
+0:12        direct index ( temp float)
+0:12          textureFetch ( global 4-component vector of float)
+0:12            'data1' ( uniform sampler2DMSArray)
+0:12            Constant:
+0:12              0 (const int)
+0:12              0 (const int)
+0:12              0 (const int)
+0:12            Constant:
+0:12              3 (const int)
+0:12          Constant:
+0:12            0 (const int)
+0:13      Sequence
+0:13        move second child to first child ( temp 3-component vector of int)
+0:13          'temp1' ( temp 3-component vector of int)
+0:13          textureSize ( global 3-component vector of int)
+0:13            'data1' ( uniform sampler2DMSArray)
+0:?   Linker Objects
+0:?     'result' ( smooth out float)
+0:?     'data' ( uniform sampler2DMS)
+0:?     'data1' ( uniform sampler2DMSArray)
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+

--- a/Test/baseResults/GL_ARB_texture_multisample.vert.out
+++ b/Test/baseResults/GL_ARB_texture_multisample.vert.out
@@ -2,48 +2,120 @@ GL_ARB_texture_multisample.vert
 Shader version: 140
 Requested GL_ARB_texture_multisample
 0:? Sequence
-0:8  Function Definition: main( ( global void)
-0:8    Function Parameters: 
-0:10    Sequence
-0:10      move second child to first child ( temp float)
-0:10        'result' ( smooth out float)
-0:10        direct index ( temp float)
-0:10          textureFetch ( global 4-component vector of float)
-0:10            'data' ( uniform sampler2DMS)
-0:10            Constant:
-0:10              0 (const int)
-0:10              0 (const int)
-0:10            Constant:
-0:10              3 (const int)
-0:10          Constant:
-0:10            0 (const int)
-0:11      Sequence
-0:11        move second child to first child ( temp 2-component vector of int)
-0:11          'temp' ( temp 2-component vector of int)
-0:11          textureSize ( global 2-component vector of int)
-0:11            'data' ( uniform sampler2DMS)
-0:12      move second child to first child ( temp float)
-0:12        'result' ( smooth out float)
-0:12        direct index ( temp float)
-0:12          textureFetch ( global 4-component vector of float)
-0:12            'data1' ( uniform sampler2DMSArray)
-0:12            Constant:
-0:12              0 (const int)
-0:12              0 (const int)
-0:12              0 (const int)
-0:12            Constant:
-0:12              3 (const int)
-0:12          Constant:
-0:12            0 (const int)
-0:13      Sequence
-0:13        move second child to first child ( temp 3-component vector of int)
-0:13          'temp1' ( temp 3-component vector of int)
-0:13          textureSize ( global 3-component vector of int)
-0:13            'data1' ( uniform sampler2DMSArray)
+0:14  Function Definition: main( ( global void)
+0:14    Function Parameters: 
+0:16    Sequence
+0:16      move second child to first child ( temp float)
+0:16        'result' ( smooth out float)
+0:16        direct index ( temp float)
+0:16          textureFetch ( global 4-component vector of float)
+0:16            'data' ( uniform sampler2DMS)
+0:16            Constant:
+0:16              0 (const int)
+0:16              0 (const int)
+0:16            Constant:
+0:16              3 (const int)
+0:16          Constant:
+0:16            0 (const int)
+0:17      Sequence
+0:17        move second child to first child ( temp 2-component vector of int)
+0:17          'temp' ( temp 2-component vector of int)
+0:17          textureSize ( global 2-component vector of int)
+0:17            'data' ( uniform sampler2DMS)
+0:18      move second child to first child ( temp float)
+0:18        'result' ( smooth out float)
+0:18        direct index ( temp float)
+0:18          textureFetch ( global 4-component vector of float)
+0:18            'data1' ( uniform sampler2DMSArray)
+0:18            Constant:
+0:18              0 (const int)
+0:18              0 (const int)
+0:18              0 (const int)
+0:18            Constant:
+0:18              3 (const int)
+0:18          Constant:
+0:18            0 (const int)
+0:19      Sequence
+0:19        move second child to first child ( temp 3-component vector of int)
+0:19          'temp1' ( temp 3-component vector of int)
+0:19          textureSize ( global 3-component vector of int)
+0:19            'data1' ( uniform sampler2DMSArray)
+0:20      move second child to first child ( temp int)
+0:20        'result1' ( smooth out int)
+0:20        direct index ( temp int)
+0:20          textureFetch ( global 4-component vector of int)
+0:20            'data2' ( uniform isampler2DMS)
+0:20            Constant:
+0:20              0 (const int)
+0:20              0 (const int)
+0:20            Constant:
+0:20              3 (const int)
+0:20          Constant:
+0:20            0 (const int)
+0:21      move second child to first child ( temp 2-component vector of int)
+0:21        'temp' ( temp 2-component vector of int)
+0:21        textureSize ( global 2-component vector of int)
+0:21          'data2' ( uniform isampler2DMS)
+0:22      move second child to first child ( temp uint)
+0:22        'result2' ( smooth out uint)
+0:22        direct index ( temp uint)
+0:22          textureFetch ( global 4-component vector of uint)
+0:22            'data3' ( uniform usampler2DMSArray)
+0:22            Constant:
+0:22              0 (const int)
+0:22              0 (const int)
+0:22              0 (const int)
+0:22            Constant:
+0:22              3 (const int)
+0:22          Constant:
+0:22            0 (const int)
+0:23      move second child to first child ( temp 3-component vector of int)
+0:23        'temp1' ( temp 3-component vector of int)
+0:23        textureSize ( global 3-component vector of int)
+0:23          'data3' ( uniform usampler2DMSArray)
+0:24      move second child to first child ( temp uint)
+0:24        'result2' ( smooth out uint)
+0:24        direct index ( temp uint)
+0:24          textureFetch ( global 4-component vector of uint)
+0:24            'data4' ( uniform usampler2DMS)
+0:24            Constant:
+0:24              0 (const int)
+0:24              0 (const int)
+0:24            Constant:
+0:24              3 (const int)
+0:24          Constant:
+0:24            0 (const int)
+0:25      move second child to first child ( temp 2-component vector of int)
+0:25        'temp' ( temp 2-component vector of int)
+0:25        textureSize ( global 2-component vector of int)
+0:25          'data4' ( uniform usampler2DMS)
+0:26      move second child to first child ( temp int)
+0:26        'result1' ( smooth out int)
+0:26        direct index ( temp int)
+0:26          textureFetch ( global 4-component vector of int)
+0:26            'data5' ( uniform isampler2DMSArray)
+0:26            Constant:
+0:26              0 (const int)
+0:26              0 (const int)
+0:26              0 (const int)
+0:26            Constant:
+0:26              3 (const int)
+0:26          Constant:
+0:26            0 (const int)
+0:27      move second child to first child ( temp 3-component vector of int)
+0:27        'temp1' ( temp 3-component vector of int)
+0:27        textureSize ( global 3-component vector of int)
+0:27          'data5' ( uniform isampler2DMSArray)
 0:?   Linker Objects
 0:?     'result' ( smooth out float)
+0:?     'result1' ( smooth out int)
+0:?     'result2' ( smooth out uint)
 0:?     'data' ( uniform sampler2DMS)
 0:?     'data1' ( uniform sampler2DMSArray)
+0:?     'data2' ( uniform isampler2DMS)
+0:?     'data3' ( uniform usampler2DMSArray)
+0:?     'data4' ( uniform usampler2DMS)
+0:?     'data5' ( uniform isampler2DMSArray)
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 
@@ -54,48 +126,120 @@ Linked vertex stage:
 Shader version: 140
 Requested GL_ARB_texture_multisample
 0:? Sequence
-0:8  Function Definition: main( ( global void)
-0:8    Function Parameters: 
-0:10    Sequence
-0:10      move second child to first child ( temp float)
-0:10        'result' ( smooth out float)
-0:10        direct index ( temp float)
-0:10          textureFetch ( global 4-component vector of float)
-0:10            'data' ( uniform sampler2DMS)
-0:10            Constant:
-0:10              0 (const int)
-0:10              0 (const int)
-0:10            Constant:
-0:10              3 (const int)
-0:10          Constant:
-0:10            0 (const int)
-0:11      Sequence
-0:11        move second child to first child ( temp 2-component vector of int)
-0:11          'temp' ( temp 2-component vector of int)
-0:11          textureSize ( global 2-component vector of int)
-0:11            'data' ( uniform sampler2DMS)
-0:12      move second child to first child ( temp float)
-0:12        'result' ( smooth out float)
-0:12        direct index ( temp float)
-0:12          textureFetch ( global 4-component vector of float)
-0:12            'data1' ( uniform sampler2DMSArray)
-0:12            Constant:
-0:12              0 (const int)
-0:12              0 (const int)
-0:12              0 (const int)
-0:12            Constant:
-0:12              3 (const int)
-0:12          Constant:
-0:12            0 (const int)
-0:13      Sequence
-0:13        move second child to first child ( temp 3-component vector of int)
-0:13          'temp1' ( temp 3-component vector of int)
-0:13          textureSize ( global 3-component vector of int)
-0:13            'data1' ( uniform sampler2DMSArray)
+0:14  Function Definition: main( ( global void)
+0:14    Function Parameters: 
+0:16    Sequence
+0:16      move second child to first child ( temp float)
+0:16        'result' ( smooth out float)
+0:16        direct index ( temp float)
+0:16          textureFetch ( global 4-component vector of float)
+0:16            'data' ( uniform sampler2DMS)
+0:16            Constant:
+0:16              0 (const int)
+0:16              0 (const int)
+0:16            Constant:
+0:16              3 (const int)
+0:16          Constant:
+0:16            0 (const int)
+0:17      Sequence
+0:17        move second child to first child ( temp 2-component vector of int)
+0:17          'temp' ( temp 2-component vector of int)
+0:17          textureSize ( global 2-component vector of int)
+0:17            'data' ( uniform sampler2DMS)
+0:18      move second child to first child ( temp float)
+0:18        'result' ( smooth out float)
+0:18        direct index ( temp float)
+0:18          textureFetch ( global 4-component vector of float)
+0:18            'data1' ( uniform sampler2DMSArray)
+0:18            Constant:
+0:18              0 (const int)
+0:18              0 (const int)
+0:18              0 (const int)
+0:18            Constant:
+0:18              3 (const int)
+0:18          Constant:
+0:18            0 (const int)
+0:19      Sequence
+0:19        move second child to first child ( temp 3-component vector of int)
+0:19          'temp1' ( temp 3-component vector of int)
+0:19          textureSize ( global 3-component vector of int)
+0:19            'data1' ( uniform sampler2DMSArray)
+0:20      move second child to first child ( temp int)
+0:20        'result1' ( smooth out int)
+0:20        direct index ( temp int)
+0:20          textureFetch ( global 4-component vector of int)
+0:20            'data2' ( uniform isampler2DMS)
+0:20            Constant:
+0:20              0 (const int)
+0:20              0 (const int)
+0:20            Constant:
+0:20              3 (const int)
+0:20          Constant:
+0:20            0 (const int)
+0:21      move second child to first child ( temp 2-component vector of int)
+0:21        'temp' ( temp 2-component vector of int)
+0:21        textureSize ( global 2-component vector of int)
+0:21          'data2' ( uniform isampler2DMS)
+0:22      move second child to first child ( temp uint)
+0:22        'result2' ( smooth out uint)
+0:22        direct index ( temp uint)
+0:22          textureFetch ( global 4-component vector of uint)
+0:22            'data3' ( uniform usampler2DMSArray)
+0:22            Constant:
+0:22              0 (const int)
+0:22              0 (const int)
+0:22              0 (const int)
+0:22            Constant:
+0:22              3 (const int)
+0:22          Constant:
+0:22            0 (const int)
+0:23      move second child to first child ( temp 3-component vector of int)
+0:23        'temp1' ( temp 3-component vector of int)
+0:23        textureSize ( global 3-component vector of int)
+0:23          'data3' ( uniform usampler2DMSArray)
+0:24      move second child to first child ( temp uint)
+0:24        'result2' ( smooth out uint)
+0:24        direct index ( temp uint)
+0:24          textureFetch ( global 4-component vector of uint)
+0:24            'data4' ( uniform usampler2DMS)
+0:24            Constant:
+0:24              0 (const int)
+0:24              0 (const int)
+0:24            Constant:
+0:24              3 (const int)
+0:24          Constant:
+0:24            0 (const int)
+0:25      move second child to first child ( temp 2-component vector of int)
+0:25        'temp' ( temp 2-component vector of int)
+0:25        textureSize ( global 2-component vector of int)
+0:25          'data4' ( uniform usampler2DMS)
+0:26      move second child to first child ( temp int)
+0:26        'result1' ( smooth out int)
+0:26        direct index ( temp int)
+0:26          textureFetch ( global 4-component vector of int)
+0:26            'data5' ( uniform isampler2DMSArray)
+0:26            Constant:
+0:26              0 (const int)
+0:26              0 (const int)
+0:26              0 (const int)
+0:26            Constant:
+0:26              3 (const int)
+0:26          Constant:
+0:26            0 (const int)
+0:27      move second child to first child ( temp 3-component vector of int)
+0:27        'temp1' ( temp 3-component vector of int)
+0:27        textureSize ( global 3-component vector of int)
+0:27          'data5' ( uniform isampler2DMSArray)
 0:?   Linker Objects
 0:?     'result' ( smooth out float)
+0:?     'result1' ( smooth out int)
+0:?     'result2' ( smooth out uint)
 0:?     'data' ( uniform sampler2DMS)
 0:?     'data1' ( uniform sampler2DMSArray)
+0:?     'data2' ( uniform isampler2DMS)
+0:?     'data3' ( uniform usampler2DMSArray)
+0:?     'data4' ( uniform usampler2DMS)
+0:?     'data5' ( uniform isampler2DMSArray)
 0:?     'gl_VertexID' ( gl_VertexId int VertexId)
 0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
 

--- a/glslang/MachineIndependent/Initialize.cpp
+++ b/glslang/MachineIndependent/Initialize.cpp
@@ -6278,7 +6278,7 @@ void TBuiltIns::add2ndGenerationSamplingImaging(int version, EProfile profile, c
             {
                 if ((ms || image) && shadow)
                     continue;
-                if (ms && profile != EEsProfile && version < 150)
+                if (ms && profile != EEsProfile && version < 140)
                     continue;
                 if (ms && image && profile == EEsProfile)
                     continue;

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -1353,8 +1353,7 @@ TIntermTyped* TParseContext::handleFunctionCall(const TSourceLoc& loc, TFunction
             if (builtIn && fnCandidate->getType().contains8BitInt())
                 requireInt8Arithmetic(loc, "built-in function", "(u)int8 types can only be in uniform block or buffer storage");
             if (builtIn && (fnCandidate->getBuiltInOp() == EOpTextureFetch || fnCandidate->getBuiltInOp() == EOpTextureQuerySize)) {
-                TString typeName = (*fnCandidate)[0].type->getSampler().getString();
-                if ((typeName == "sampler2DMS" || typeName == "sampler2DMSArray") && version <= 140)
+                if ((*fnCandidate)[0].type->getSampler().isMultiSample() && version <= 140)
                     requireExtensions(loc, 1, &E_GL_ARB_texture_multisample, fnCandidate->getName().c_str());
             }
             if (arguments != nullptr) {

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -1352,7 +1352,11 @@ TIntermTyped* TParseContext::handleFunctionCall(const TSourceLoc& loc, TFunction
                 requireInt16Arithmetic(loc, "built-in function", "(u)int16 types can only be in uniform block or buffer storage");
             if (builtIn && fnCandidate->getType().contains8BitInt())
                 requireInt8Arithmetic(loc, "built-in function", "(u)int8 types can only be in uniform block or buffer storage");
-
+            if (builtIn && (fnCandidate->getBuiltInOp() == EOpTextureFetch || fnCandidate->getBuiltInOp() == EOpTextureQuerySize)) {
+                TString typeName = (*fnCandidate)[0].type->getSampler().getString();
+                if ((typeName == "sampler2DMS" || typeName == "sampler2DMSArray") && version <= 140)
+                    requireExtensions(loc, 1, &E_GL_ARB_texture_multisample, fnCandidate->getName().c_str());
+            }
             if (arguments != nullptr) {
                 // Make sure qualifications work for these arguments.
                 TIntermAggregate* aggregate = arguments->getAsAggregate();

--- a/gtests/AST.FromFile.cpp
+++ b/gtests/AST.FromFile.cpp
@@ -295,6 +295,7 @@ INSTANTIATE_TEST_SUITE_P(
         "GL_ARB_draw_instanced.vert",
         "GL_ARB_fragment_coord_conventions.vert",
         "GL_ARB_bindless_texture.frag",
+        "GL_ARB_texture_multisample.vert",
         "BestMatchFunction.vert",
         "EndStreamPrimitive.geom",
         "floatBitsToInt.vert",


### PR DESCRIPTION
This extension allows the use of "texelFetch" and "textureSize" with 2DMS sampler.
#version 140
out float result;

uniform sampler2DMS data;
uniform sampler2DMSArray data1;
void main()
{
result = texelFetch(data, ivec2(0), 3).r;
ivec2 temp = textureSize(data);
result = texelFetch(data1, ivec3(0), 3).r;
ivec3 temp1 = textureSize(data1);
}