### PR TITLE
Improve overflow_underflow_toinf_0 test somewhat

### DIFF
--- a/Test/baseResults/overflow_underflow_toinf_0.frag.out
+++ b/Test/baseResults/overflow_underflow_toinf_0.frag.out
@@ -14,15 +14,23 @@ Shader version: 320
 0:10          'correct1' ( temp highp float)
 0:10          Constant:
 0:10            1.000000
-0:11      move second child to first child ( temp highp 4-component vector of float)
-0:11        'my_FragColor' ( out highp 4-component vector of float)
-0:11        Construct vec4 ( temp highp 4-component vector of float)
+0:11      Sequence
+0:11        move second child to first child ( temp highp 4-component vector of float)
+0:11          'foo' ( temp highp 4-component vector of float)
 0:11          Constant:
 0:11            0.000000
-0:11          'correct' ( temp highp float)
-0:11          'correct1' ( temp highp float)
-0:11          Constant:
-0:11            1.000000
+0:11            -0.000000
+0:11            +1.#INF
+0:11            -1.#INF
+0:12      move second child to first child ( temp highp 4-component vector of float)
+0:12        'my_FragColor' ( out highp 4-component vector of float)
+0:12        Construct vec4 ( temp highp 4-component vector of float)
+0:12          Constant:
+0:12            0.000000
+0:12          'correct' ( temp highp float)
+0:12          'correct1' ( temp highp float)
+0:12          Constant:
+0:12            1.000000
 0:?   Linker Objects
 0:?     'my_FragColor' ( out highp 4-component vector of float)
 
@@ -45,15 +53,23 @@ Shader version: 320
 0:10          'correct1' ( temp highp float)
 0:10          Constant:
 0:10            1.000000
-0:11      move second child to first child ( temp highp 4-component vector of float)
-0:11        'my_FragColor' ( out highp 4-component vector of float)
-0:11        Construct vec4 ( temp highp 4-component vector of float)
+0:11      Sequence
+0:11        move second child to first child ( temp highp 4-component vector of float)
+0:11          'foo' ( temp highp 4-component vector of float)
 0:11          Constant:
 0:11            0.000000
-0:11          'correct' ( temp highp float)
-0:11          'correct1' ( temp highp float)
-0:11          Constant:
-0:11            1.000000
+0:11            -0.000000
+0:11            +1.#INF
+0:11            -1.#INF
+0:12      move second child to first child ( temp highp 4-component vector of float)
+0:12        'my_FragColor' ( out highp 4-component vector of float)
+0:12        Construct vec4 ( temp highp 4-component vector of float)
+0:12          Constant:
+0:12            0.000000
+0:12          'correct' ( temp highp float)
+0:12          'correct1' ( temp highp float)
+0:12          Constant:
+0:12            1.000000
 0:?   Linker Objects
 0:?     'my_FragColor' ( out highp 4-component vector of float)
 

--- a/Test/baseResults/overflow_underflow_toinf_0.frag.out
+++ b/Test/baseResults/overflow_underflow_toinf_0.frag.out
@@ -26,3 +26,34 @@ Shader version: 320
 0:?   Linker Objects
 0:?     'my_FragColor' ( out highp 4-component vector of float)
 
+
+Linked fragment stage:
+
+
+Shader version: 320
+0:? Sequence
+0:4  Function Definition: main( ( global void)
+0:4    Function Parameters: 
+0:9    Sequence
+0:9      Sequence
+0:9        move second child to first child ( temp highp float)
+0:9          'correct' ( temp highp float)
+0:9          Constant:
+0:9            1.000000
+0:10      Sequence
+0:10        move second child to first child ( temp highp float)
+0:10          'correct1' ( temp highp float)
+0:10          Constant:
+0:10            1.000000
+0:11      move second child to first child ( temp highp 4-component vector of float)
+0:11        'my_FragColor' ( out highp 4-component vector of float)
+0:11        Construct vec4 ( temp highp 4-component vector of float)
+0:11          Constant:
+0:11            0.000000
+0:11          'correct' ( temp highp float)
+0:11          'correct1' ( temp highp float)
+0:11          Constant:
+0:11            1.000000
+0:?   Linker Objects
+0:?     'my_FragColor' ( out highp 4-component vector of float)
+

--- a/Test/overflow_underflow_toinf_0.frag
+++ b/Test/overflow_underflow_toinf_0.frag
@@ -1,12 +1,13 @@
-    #version 320 es
-	precision highp float;
-    out vec4 my_FragColor;
-    void main()
-    {
+#version 320 es
+precision highp float;
+out vec4 my_FragColor;
+void main()
+{
     // GLSL ES 3.00.6 section 4.1.4 Floats:
     // "A value with a magnitude too small to be represented as a mantissa and exponent is converted to zero."
     // 1.0e-50 is small enough that it can't even be stored as subnormal.
     float correct = (1.0e-50 == 0.0) ? 1.0 : 0.0;
-	float correct1 = isinf(1.0e40) ? 1.0 : 0.0;
+    float correct1 = isinf(1.0e40) ? 1.0 : 0.0;
+    vec4 foo = vec4(1.0e-50, -1.0e-50, 1.0e50, -1.0e50);
     my_FragColor = vec4(0.0, correct, correct1, 1.0);
-    }
+}

--- a/Test/runtests
+++ b/Test/runtests
@@ -343,8 +343,6 @@ run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.7.vert enhanc
 diff -b $BASEDIR/enhanced.7.link.out $TARGETDIR/enhanced.7.link.out || HASERROR=1
 run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml spv.textureError.frag > $TARGETDIR/spv.textureError.frag.out
 diff -b $BASEDIR/spv.textureError.frag.out $TARGETDIR/spv.textureError.frag.out || HASERROR=1
-run -i overflow_underflow_toinf_0.frag > $TARGETDIR/overflow_underflow_toinf_0.out
-diff -b $BASEDIR/overflow_underflow_toinf_0.out $TARGETDIR/overflow_underflow_toinf_0.out || HASERROR=1
 
 #
 # Final checking

--- a/gtests/AST.FromFile.cpp
+++ b/gtests/AST.FromFile.cpp
@@ -301,6 +301,7 @@ INSTANTIATE_TEST_SUITE_P(
         "coord_conventions.frag",
         "gl_FragCoord.frag",
         "glsl.interpOp.error.frag",
+        "overflow_underflow_toinf_0.frag",
     })),
     FileNameAsCustomTestSuffix
 );


### PR DESCRIPTION
Add test cases that will make explicit ±0.0 and ±INF appear in the AST output to make sure those cases are handled correctly.
Also, move overflow_underflow_toinf_0 from runtests to gtest. gtest is the preferred framework for simple tests that don't require    passing special command-line options to glslang.
