### PR TITLE
Only install/test if PROJECT_IS_TOP_LEVEL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,11 @@
 cmake_minimum_required(VERSION 3.17.2)
 project(glslang)
 
+if (CMAKE_VERSION VERSION_LESS "3.21")
+    # https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html
+    string(COMPARE EQUAL ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} PROJECT_IS_TOP_LEVEL)
+endif()
+
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Adhere to GNU filesystem layout conventions
@@ -73,13 +78,6 @@ if (IOS OR ANDROID)
     set(GLSLANG_TESTS OFF)
 endif()
 
-option(GLSLANG_TESTS "Enable glslang testing")
-
-option(SKIP_GLSLANG_INSTALL "Skip installation")
-
-if(NOT ${SKIP_GLSLANG_INSTALL})
-  set(ENABLE_GLSLANG_INSTALL ON)
-endif()
 option(ENABLE_SPVREMAPPER "Enables building of SPVRemapper" ON)
 
 option(ENABLE_GLSLANG_BINARIES "Builds glslang and spirv-remap" ON)
@@ -302,33 +300,38 @@ if(ENABLE_GLSLANG_BINARIES)
 endif()
 add_subdirectory(SPIRV)
 
-if(GLSLANG_TESTS)
-    enable_testing()
-    add_subdirectory(gtests)
+# Testing / installation only makes sense when the project is top level.
+#
+# Otherwise add_subdirectory users have a harder time consuming the library.
+# Since glslang will pollute the installation and add undesirable testing.
+if(PROJECT_IS_TOP_LEVEL)
+    option(GLSLANG_TESTS "Enable glslang testing")
+    if(GLSLANG_TESTS)
+        enable_testing()
+        add_subdirectory(gtests)
 
-    # glslang-testsuite runs a bash script on Windows.
-    # Make sure to use '-o igncr' flag to ignore carriage returns (\r).
-    set(IGNORE_CR_FLAG "")
-    if(WIN32)
-        set(IGNORE_CR_FLAG -o igncr)
+        # glslang-testsuite runs a bash script on Windows.
+        # Make sure to use '-o igncr' flag to ignore carriage returns (\r).
+        set(IGNORE_CR_FLAG "")
+        if(WIN32)
+            set(IGNORE_CR_FLAG -o igncr)
+        endif()
+
+        if (CMAKE_CONFIGURATION_TYPES)
+            set(RESULTS_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/localResults)
+            set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/$<CONFIG>/glslang)
+            set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/$<CONFIG>/spirv-remap)
+        else()
+            set(RESULTS_PATH ${CMAKE_CURRENT_BINARY_DIR}/localResults)
+            set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/glslang)
+            set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/spirv-remap)
+        endif()
+
+        add_test(NAME glslang-testsuite
+            COMMAND bash ${IGNORE_CR_FLAG} runtests ${RESULTS_PATH} ${VALIDATOR_PATH} ${REMAP_PATH}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Test/)
     endif()
 
-    if (CMAKE_CONFIGURATION_TYPES)
-        set(RESULTS_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/localResults)
-        set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/$<CONFIG>/glslang)
-        set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/$<CONFIG>/spirv-remap)
-    else()
-        set(RESULTS_PATH ${CMAKE_CURRENT_BINARY_DIR}/localResults)
-        set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/glslang)
-        set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/spirv-remap)
-    endif()
-
-    add_test(NAME glslang-testsuite
-        COMMAND bash ${IGNORE_CR_FLAG} runtests ${RESULTS_PATH} ${VALIDATOR_PATH} ${REMAP_PATH}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Test/)
-endif()
-
-if(ENABLE_GLSLANG_INSTALL)
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake.in" [=[
         @PACKAGE_INIT@
         @INSTALL_CONFIG_UNIX@

--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -118,7 +118,7 @@ if(WIN32)
     source_group("Source" FILES ${SPVREMAP_SOURCES} ${SPVREMAP_HEADERS})
 endif()
 
-if(ENABLE_GLSLANG_INSTALL)
+if(PROJECT_IS_TOP_LEVEL)
     if (ENABLE_SPVREMAPPER)
         install(TARGETS SPVRemapper EXPORT glslang-targets)
     endif()

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -87,7 +87,7 @@ if(WIN32)
     source_group("Source" FILES ${SOURCES})
 endif()
 
-if(ENABLE_GLSLANG_INSTALL)
+if(PROJECT_IS_TOP_LEVEL)
     install(TARGETS glslang-standalone EXPORT glslang-targets)
 
     # Backward compatibility

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -227,7 +227,7 @@ endif()
 ################################################################################
 # install
 ################################################################################
-if(ENABLE_GLSLANG_INSTALL)
+if(PROJECT_IS_TOP_LEVEL)
     install(TARGETS glslang EXPORT glslang-targets)
     if(NOT BUILD_SHARED_LIBS)
         install(TARGETS MachineIndependent EXPORT glslang-targets)

--- a/glslang/OSDependent/Unix/CMakeLists.txt
+++ b/glslang/OSDependent/Unix/CMakeLists.txt
@@ -40,7 +40,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(OSDependent Threads::Threads)
 
-if(ENABLE_GLSLANG_INSTALL AND NOT BUILD_SHARED_LIBS)
+if(PROJECT_IS_TOP_LEVEL AND NOT BUILD_SHARED_LIBS)
     install(TARGETS OSDependent EXPORT glslang-targets)
 
     # Backward compatibility

--- a/glslang/OSDependent/Windows/CMakeLists.txt
+++ b/glslang/OSDependent/Windows/CMakeLists.txt
@@ -51,7 +51,7 @@ if(WIN32)
     source_group("Source" FILES ${SOURCES})
 endif()
 
-if(ENABLE_GLSLANG_INSTALL)
+if(PROJECT_IS_TOP_LEVEL)
     install(TARGETS OSDependent EXPORT glslang-targets)
 
     # Backward compatibility

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -68,21 +68,6 @@ if(GLSLANG_TESTS)
         glslang_pch(glslangtests ${CMAKE_CURRENT_SOURCE_DIR}/pch.h)
         set_property(TARGET glslangtests PROPERTY FOLDER tests)
         glslang_set_link_args(glslangtests)
-        if(ENABLE_GLSLANG_INSTALL)
-            install(TARGETS glslangtests EXPORT glslang-targets)
-
-            # Backward compatibility
-            file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/glslangtestsTargets.cmake" "
-                message(WARNING \"Using `glslangtestsTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
-
-                if (NOT TARGET glslang::glslangtests)
-                    include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
-                endif()
-
-                add_library(glslangtests ALIAS glslang::glslangtests)
-            ")
-            install(FILES "${CMAKE_CURRENT_BINARY_DIR}/glslangtestsTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
-        endif()
 
         set(GLSLANG_TEST_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../Test")
         # Supply a default test root directory, so that manual testing


### PR DESCRIPTION
Further remove installing glslangtests. There isn't a need to do that. glslangtests isn't a deliverable.