### PR TITLE
SPIRV-Tools EXCLUDE_FROM_ALL

### DIFF
--- a/External/CMakeLists.txt
+++ b/External/CMakeLists.txt
@@ -71,7 +71,8 @@ endif()
 if(ENABLE_OPT AND NOT TARGET SPIRV-Tools-opt)
     if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/spirv-tools)
         set(SPIRV_SKIP_TESTS ON CACHE BOOL "Skip building SPIRV-Tools tests")
-        add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/spirv-tools spirv-tools)
+        # EXCLUDE_FROM_ALL will prevent unneccessary build/installation from spirv-tools
+        add_subdirectory(spirv-tools EXCLUDE_FROM_ALL)
     endif()
 endif()
 


### PR DESCRIPTION
Currently glslang will build everything from spirv-tools regardless of if it needs to.

EXCLUDE_FROM_ALL dramatically improves the build performance.

Compiling 446 files to 292

Furthermore only the targets we need to install are installed.