### PR TITLE
Advertise GL_ARB_bindless_texture as unavailable for SPIR-V outputs

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -1663,7 +1663,9 @@ TIntermNode* TParseContext::handleReturnValue(const TSourceLoc& loc, TIntermType
         }
     } else {
         if (value->getType().isTexture() || value->getType().isImage()) {
-            if (!extensionTurnedOn(E_GL_ARB_bindless_texture))
+            if (spvVersion.spv != 0)
+                error(loc, "sampler or image cannot be used as return type when generating SPIR-V", "return", "");
+            else if (!extensionTurnedOn(E_GL_ARB_bindless_texture))
                 error(loc, "sampler or image can be used as return type only when the extension GL_ARB_bindless_texture enabled", "return", "");
         }
         branch = intermediate.addBranch(EOpReturn, value, loc);

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -487,7 +487,7 @@ void TParseVersions::getPreamble(std::string& preamble)
             "#define GL_ARB_vertex_attrib_64bit 1\n"
             "#define GL_ARB_draw_instanced 1\n"
             "#define GL_ARB_fragment_coord_conventions 1\n"
-            "#define GL_ARB_bindless_texture 1\n"
+
             "#define GL_EXT_shader_non_constant_global_initializers 1\n"
             "#define GL_EXT_shader_image_load_formatted 1\n"
             "#define GL_EXT_post_depth_coverage 1\n"
@@ -581,6 +581,10 @@ void TParseVersions::getPreamble(std::string& preamble)
 
             "#define GL_EXT_fragment_shader_barycentric 1\n"
             ;
+
+        if (spvVersion.spv == 0) {
+            preamble += "#define GL_ARB_bindless_texture 1\n";
+        }
 
         if (version >= 150) {
             // define GL_core_profile and GL_compatibility_profile


### PR DESCRIPTION
As mentioned in issue https://github.com/KhronosGroup/glslang/issues/3223, the support for `GL_ARB_bindless_texture` results in confusing error messages, where a user is asked to enable an extension that is actually unavailable to them.

This PR amends one such error message to be clearer. It also moves the unconditionnal definition of the `GL_ARB_bindless_texture` macro so it isn't defined when targeting SPIR-V, since defining it anyway could break shader code that relied on it to test for the extension's availability.