### PR TITLE
Fixed check uint64 before set bool

### DIFF
--- a/glslang/MachineIndependent/Constant.cpp
+++ b/glslang/MachineIndependent/Constant.cpp
@@ -689,7 +689,7 @@ TIntermTyped* TIntermConstantUnion::fold(TOperator op, const TType& returnType) 
         case EOpConvInt64ToBool:
             newConstArray[i].setBConst(unionArray[i].getI64Const() != 0); break;
         case EOpConvUint64ToBool:
-            newConstArray[i].setBConst(unionArray[i].getI64Const() != 0); break;
+            newConstArray[i].setBConst(unionArray[i].getU64Const() != 0); break;
         case EOpConvFloat16ToBool:
             newConstArray[i].setBConst(unionArray[i].getDConst() != 0); break;
 


### PR DESCRIPTION
@arcady-lunarg U64 value type was incorrectly checked, commit fixed this.