### PR TITLE
Update version of macOS deployment GHA runner

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -101,7 +101,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [{genus: macos-11, family: osx}]
+                os: [{genus: macos-12, family: osx}]
                 compiler: [{cc: clang, cxx: clang++}]
                 cmake_build_type: [Debug, Release]
         steps:


### PR DESCRIPTION
@juan-lunarg Should we be setting `MACOSX_DEPLOYMENT_TARGET` in our builds as well?