### PR TITLE
Support constant expression calculated by matrixCompMult.

### DIFF
--- a/Test/baseResults/matrixCompMult.vert.out
+++ b/Test/baseResults/matrixCompMult.vert.out
@@ -1,0 +1,33 @@
+matrixCompMult.vert
+Shader version: 460
+0:? Sequence
+0:5  Function Definition: main( ( global void)
+0:5    Function Parameters: 
+0:?     Sequence
+0:26      move second child to first child ( temp float)
+0:26        'o1' ( smooth out float)
+0:26        Constant:
+0:26          18.000000
+0:?   Linker Objects
+0:?     'o1' ( smooth out float)
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+
+
+Linked vertex stage:
+
+
+Shader version: 460
+0:? Sequence
+0:5  Function Definition: main( ( global void)
+0:5    Function Parameters: 
+0:?     Sequence
+0:26      move second child to first child ( temp float)
+0:26        'o1' ( smooth out float)
+0:26        Constant:
+0:26          18.000000
+0:?   Linker Objects
+0:?     'o1' ( smooth out float)
+0:?     'gl_VertexID' ( gl_VertexId int VertexId)
+0:?     'gl_InstanceID' ( gl_InstanceId int InstanceId)
+

--- a/Test/matrixCompMult.vert
+++ b/Test/matrixCompMult.vert
@@ -1,0 +1,32 @@
+#version 460
+precision highp float;
+precision highp int;
+out float o1;
+void main()
+{
+	const mat2 cval = matrixCompMult(mat2(1.0), mat2(1.0));
+	const mat3 cval1 = matrixCompMult(mat3(1.0), mat3(1.0));
+	const mat4 cval2 = matrixCompMult(mat4(1.0), mat4(1.0));
+	const mat2x3 cval3 = matrixCompMult(mat2x3(1.0), mat2x3(1.0));
+	const mat2x4 cval4 = matrixCompMult(mat2x4(1.0), mat2x4(1.0));
+	const mat3x2 cval5 = matrixCompMult(mat3x2(1.0), mat3x2(1.0));
+	const mat3x4 cval6 = matrixCompMult(mat3x4(1.0), mat3x4(1.0));
+	const mat4x2 cval7 = matrixCompMult(mat4x2(1.0), mat4x2(1.0));
+    const mat4x3 cval8 = matrixCompMult(mat4x3(1.0), mat4x3(1.0));
+	const dmat2 cval9 = matrixCompMult(dmat2(1.0), dmat2(1.0));
+	const dmat3 cval10 = matrixCompMult(dmat3(1.0), dmat3(1.0));
+	const dmat4 cval11 = matrixCompMult(dmat4(1.0), dmat4(1.0));
+	const dmat2x3 cval12 = matrixCompMult(dmat2x3(1.0), dmat2x3(1.0));
+	const dmat2x4 cval13 = matrixCompMult(dmat2x4(1.0), dmat2x4(1.0));
+	const dmat3x2 cval14 = matrixCompMult(dmat3x2(1.0), dmat3x2(1.0));
+	const dmat3x4 cval15 = matrixCompMult(dmat3x4(1.0), dmat3x4(1.0));
+	const dmat4x2 cval16 = matrixCompMult(dmat4x2(1.0), dmat4x2(1.0));
+    const dmat4x3 cval17 = matrixCompMult(dmat4x3(1.0), dmat4x3(1.0));
+	
+	o1 = float(cval[0][0] + cval1[0][0] + cval2[0][0] + cval3[0][0] + 
+	     cval4[0][0] + cval5[0][0] + cval6[0][0] + cval7[0][0] + 
+		 cval8[0][0] + cval9[0][0] + cval10[0][0] + cval11[0][0] + 
+		 cval12[0][0] + cval13[0][0] + cval14[0][0] + cval15[0][0] + 
+		 cval16[0][0] + cval17[0][0]);
+}
+

--- a/glslang/MachineIndependent/Constant.cpp
+++ b/glslang/MachineIndependent/Constant.cpp
@@ -1009,6 +1009,12 @@ TIntermTyped* TIntermediate::fold(TIntermAggregate* aggrNode)
         objectSize = std::max(children[0]->getAsTyped()->getType().getVectorSize(),
                               children[2]->getAsTyped()->getType().getVectorSize());
         break;
+    case EOpMul:
+        {
+        TIntermConstantUnion* left = children[0]->getAsConstantUnion();
+        TIntermConstantUnion* right = children[1]->getAsConstantUnion();
+        return left->fold(EOpMul, right);
+        }
     default:
         return aggrNode;
     }

--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -482,6 +482,13 @@ TIntermTyped* TIntermediate::addBuiltInFunctionCall(const TSourceLoc& loc, TOper
 
         return addUnaryNode(op, child, child->getLoc(), returnType);
     } else {
+        if (op == EOpMul) {
+            TIntermConstantUnion* left = childNode->getAsAggregate()->getSequence()[0]->getAsConstantUnion();
+            TIntermConstantUnion* right = childNode->getAsAggregate()->getSequence()[1]->getAsConstantUnion();
+            if (left && right) {
+                return left->fold(EOpMul, right);
+            }
+        }
         // setAggregateOperater() calls fold() for constant folding
         TIntermTyped* node = setAggregateOperator(childNode, op, returnType, loc);
 

--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -482,13 +482,6 @@ TIntermTyped* TIntermediate::addBuiltInFunctionCall(const TSourceLoc& loc, TOper
 
         return addUnaryNode(op, child, child->getLoc(), returnType);
     } else {
-        if (op == EOpMul) {
-            TIntermConstantUnion* left = childNode->getAsAggregate()->getSequence()[0]->getAsConstantUnion();
-            TIntermConstantUnion* right = childNode->getAsAggregate()->getSequence()[1]->getAsConstantUnion();
-            if (left && right) {
-                return left->fold(EOpMul, right);
-            }
-        }
         // setAggregateOperater() calls fold() for constant folding
         TIntermTyped* node = setAggregateOperator(childNode, op, returnType, loc);
 

--- a/gtests/AST.FromFile.cpp
+++ b/gtests/AST.FromFile.cpp
@@ -313,6 +313,7 @@ INSTANTIATE_TEST_SUITE_P(
         "GL_EXT_texture_array.frag",
         "index_outside_sample_mask_range.frag",
         "positive_infinity.frag",
+        "matrixCompMult.vert",
     })),
     FileNameAsCustomTestSuffix
 );


### PR DESCRIPTION
glslang report error for  "const mat2 cval = matrixCompMult(mat2(1.0), mat2(1.0));".
Spec says:
The value returned by certain built-in function calls whose arguments are all constant expressions is also constant expressions.