### PR TITLE
cmake: remove generation of deprecated *Targets.cmake files

### DIFF
--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -125,30 +125,5 @@ if(PROJECT_IS_TOP_LEVEL)
 
     install(TARGETS SPIRV EXPORT glslang-targets)
 
-    # Backward compatibility
-    if (ENABLE_SPVREMAPPER)
-        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/SPVRemapperTargets.cmake" "
-            message(WARNING \"Using `SPVRemapperTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
-
-            if (NOT TARGET glslang::SPVRemapper)
-                include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
-            endif()
-
-            add_library(SPVRemapper ALIAS glslang::SPVRemapper)
-        ")
-        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/SPVRemapperTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
-    endif()
-
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/SPIRVTargets.cmake" "
-        message(WARNING \"Using `SPIRVTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
-
-        if (NOT TARGET glslang::SPIRV)
-            include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
-        endif()
-
-        add_library(SPIRV ALIAS glslang::SPIRV)
-    ")
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/SPIRVTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
-
     install(FILES ${PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/glslang/SPIRV/)
 endif()

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -90,18 +90,6 @@ endif()
 if(PROJECT_IS_TOP_LEVEL)
     install(TARGETS glslang-standalone EXPORT glslang-targets)
 
-    # Backward compatibility
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/glslang-standaloneTargets.cmake" "
-        message(WARNING \"Using `glslang-standaloneTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
-
-        if (NOT TARGET glslang::glslang-standalone)
-            include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
-        endif()
-
-        add_library(glslang-standalone ALIAS glslang::glslang-standalone)
-    ")
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/glslang-standaloneTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
-
     # Create a symbolic link to glslang named glslangValidator for backwards compatibility
     set(legacy_glslang_name "glslangValidator${CMAKE_EXECUTABLE_SUFFIX}")
     set(link_method create_symlink)
@@ -120,18 +108,6 @@ if(PROJECT_IS_TOP_LEVEL)
 
     if(ENABLE_SPVREMAPPER)
         install(TARGETS spirv-remap EXPORT glslang-targets)
-
-        # Backward compatibility
-        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/spirv-remapTargets.cmake" "
-            message(WARNING \"Using `spirv-remapTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
-
-            if (NOT TARGET glslang::spirv-remap)
-                include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
-            endif()
-
-            add_library(spirv-remap ALIAS glslang::spirv-remap)
-        ")
-        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/spirv-remapTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
     endif()
 
 endif()

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -232,24 +232,6 @@ if(PROJECT_IS_TOP_LEVEL)
     if(NOT BUILD_SHARED_LIBS)
         install(TARGETS MachineIndependent EXPORT glslang-targets)
         install(TARGETS GenericCodeGen EXPORT glslang-targets)
-
-        # Backward compatibility
-        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/glslangTargets.cmake" "
-            message(WARNING \"Using `glslangTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
-
-            if (NOT TARGET glslang::glslang)
-                include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
-            endif()
-
-            if(${BUILD_SHARED_LIBS})
-                add_library(glslang ALIAS glslang::glslang)
-            else()
-                add_library(glslang ALIAS glslang::glslang)
-                add_library(MachineIndependent ALIAS glslang::MachineIndependent)
-                add_library(GenericCodeGen ALIAS glslang::GenericCodeGen)
-            endif()
-        ")
-        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/glslangTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
     endif()
 
     set(PUBLIC_HEADERS
@@ -269,17 +251,4 @@ if(PROJECT_IS_TOP_LEVEL)
     install(FILES ${GLSLANG_BUILD_INFO_H} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/glslang)
 
     install(TARGETS glslang-default-resource-limits EXPORT glslang-targets)
-
-    # Backward compatibility
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/glslang-default-resource-limitsTargets.cmake" "
-        message(WARNING \"Using `glslang-default-resource-limitsTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
-
-        if (NOT TARGET glslang::glslang-default-resource-limits)
-            include(\"\${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
-        endif()
-
-        add_library(glslang-default-resource-limits ALIAS glslang::glslang-default-resource-limits)
-    ")
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/glslang-default-resource-limitsTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
-
 endif()

--- a/glslang/OSDependent/Unix/CMakeLists.txt
+++ b/glslang/OSDependent/Unix/CMakeLists.txt
@@ -42,16 +42,4 @@ target_link_libraries(OSDependent Threads::Threads)
 
 if(PROJECT_IS_TOP_LEVEL AND NOT BUILD_SHARED_LIBS)
     install(TARGETS OSDependent EXPORT glslang-targets)
-
-    # Backward compatibility
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/OSDependentTargets.cmake" "
-        message(WARNING \"Using `OSDependentTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
-
-        if (NOT TARGET glslang::OSDependent)
-            include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
-        endif()
-
-        add_library(OSDependent ALIAS glslang::OSDependent)
-    ")
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/OSDependentTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 endif()

--- a/glslang/OSDependent/Windows/CMakeLists.txt
+++ b/glslang/OSDependent/Windows/CMakeLists.txt
@@ -53,16 +53,4 @@ endif()
 
 if(PROJECT_IS_TOP_LEVEL)
     install(TARGETS OSDependent EXPORT glslang-targets)
-
-    # Backward compatibility
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/OSDependentTargets.cmake" "
-        message(WARNING \"Using `OSDependentTargets.cmake` is deprecated: use `find_package(glslang)` to find glslang CMake targets.\")
-
-        if (NOT TARGET glslang::OSDependent)
-            include(\"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake\")
-        endif()
-
-        add_library(OSDependent ALIAS glslang::OSDependent)
-    ")
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/OSDependentTargets.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 endif()


### PR DESCRIPTION
These files have had a deprecation notice for a few years now and the cmake find_package mechanism should be used instead.