### PR TITLE
cmake: add missing SPIRV-Tools-opt dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,10 @@ if(PROJECT_IS_TOP_LEVEL)
 
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake.in" [=[
         @PACKAGE_INIT@
+        include(CMakeFindDependencyMacro)
+        if(@ENABLE_OPT@)
+            find_dependency(SPIRV-Tools-opt)
+        endif()
         @INSTALL_CONFIG_UNIX@
         include("@PACKAGE_PATH_EXPORT_TARGETS@")
     ]=])
@@ -341,9 +345,8 @@ if(PROJECT_IS_TOP_LEVEL)
     set(PATH_EXPORT_TARGETS "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/glslang-targets.cmake")
     if(UNIX OR "${CMAKE_SYSTEM_NAME}" STREQUAL "Fuchsia")
         set(INSTALL_CONFIG_UNIX [=[
-            include(CMakeFindDependencyMacro)
             set(THREADS_PREFER_PTHREAD_FLAG ON)
-            find_dependency(Threads REQUIRED)
+            find_dependency(Threads)
         ]=])
     endif()
     configure_package_config_file(


### PR DESCRIPTION
The generated `glslang-targets.cmake` file (for static glslang targets) contains this:
```cmake
set_target_properties(glslang::SPIRV PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "\$<LINK_ONLY:glslang::MachineIndependent>;\$<LINK_ONLY:SPIRV-Tools-opt>"
)
```
The `SPIRV-Tools-opt` here is as CMake target, but also the name of a real library file (`libSPIRV-Tools-opt.so` or `libSPIRV-Tools-opt.a`) which will be linked with (missing its dependency `SPIRV-Tools`) if the target is nonexistent. The `find_dependency` will import the target automatically.

`REQUIRED` is not needed in `find_dependency`, otherwise `find_package(glslang)` without `REQUIRED` will produce a fatal error if `Threads` is not found.