### PR TITLE
Allow external control of whether Glslang will be tested or installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,9 @@ if (CMAKE_VERSION VERSION_LESS "3.21")
     string(COMPARE EQUAL ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} PROJECT_IS_TOP_LEVEL)
 endif()
 
+set(GLSLANG_TESTS_DEFAULT ON) # Can be turned off, below, based on environment.
+set(GLSLANG_ENABLE_INSTALL_DEFAULT ON) # Can be turned off, below, based on environment.
+
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Adhere to GNU filesystem layout conventions
@@ -75,8 +78,24 @@ endif()
 # Furthermore testing is equally problematic.
 if (IOS OR ANDROID)
     set(ENABLE_GLSLANG_BINARIES OFF)
-    set(GLSLANG_TESTS OFF)
+    set(GLSLANG_TESTS_DEFAULT OFF)
 endif()
+
+# Simplify the default case of including this project.
+# Otherwise add_subdirectory users have a harder time consuming the library.
+# Since glslang will pollute the installation and add undesirable testing.
+if(NOT PROJECT_IS_TOP_LEVEL)
+    set(GLSLANG_TESTS_DEFAULT OFF)
+    set(GLSLANG_ENABLE_INSTALL_DEFAULT OFF)
+endif()
+
+# Control whether Glslang self-tests are built and tested.
+# Always expose this as an option, so the defaults can be overridden.
+option(GLSLANG_TESTS "Enable glslang testing" ${GLSLANG_TESTS_DEFAULT})
+
+# Control whether to install Glslang.
+# Always expose this as an option, so the defaults can be overridden.
+option(GLSLANG_ENABLE_INSTALL "Enable glslang installation" ${GLSLANG_ENABLE_INSTALL_DEFAULT})
 
 option(ENABLE_SPVREMAPPER "Enables building of SPVRemapper" ON)
 
@@ -300,38 +319,33 @@ if(ENABLE_GLSLANG_BINARIES)
 endif()
 add_subdirectory(SPIRV)
 
-# Testing / installation only makes sense when the project is top level.
-#
-# Otherwise add_subdirectory users have a harder time consuming the library.
-# Since glslang will pollute the installation and add undesirable testing.
-if(PROJECT_IS_TOP_LEVEL)
-    option(GLSLANG_TESTS "Enable glslang testing")
-    if(GLSLANG_TESTS)
-        enable_testing()
-        add_subdirectory(gtests)
+if(GLSLANG_TESTS)
+    enable_testing()
+    add_subdirectory(gtests)
 
-        # glslang-testsuite runs a bash script on Windows.
-        # Make sure to use '-o igncr' flag to ignore carriage returns (\r).
-        set(IGNORE_CR_FLAG "")
-        if(WIN32)
-            set(IGNORE_CR_FLAG -o igncr)
-        endif()
-
-        if (CMAKE_CONFIGURATION_TYPES)
-            set(RESULTS_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/localResults)
-            set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/$<CONFIG>/glslang)
-            set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/$<CONFIG>/spirv-remap)
-        else()
-            set(RESULTS_PATH ${CMAKE_CURRENT_BINARY_DIR}/localResults)
-            set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/glslang)
-            set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/spirv-remap)
-        endif()
-
-        add_test(NAME glslang-testsuite
-            COMMAND bash ${IGNORE_CR_FLAG} runtests ${RESULTS_PATH} ${VALIDATOR_PATH} ${REMAP_PATH}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Test/)
+    # glslang-testsuite runs a bash script on Windows.
+    # Make sure to use '-o igncr' flag to ignore carriage returns (\r).
+    set(IGNORE_CR_FLAG "")
+    if(WIN32)
+	set(IGNORE_CR_FLAG -o igncr)
     endif()
 
+    if (CMAKE_CONFIGURATION_TYPES)
+	set(RESULTS_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/localResults)
+	set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/$<CONFIG>/glslang)
+	set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/$<CONFIG>/spirv-remap)
+    else()
+	set(RESULTS_PATH ${CMAKE_CURRENT_BINARY_DIR}/localResults)
+	set(VALIDATOR_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/glslang)
+	set(REMAP_PATH ${CMAKE_CURRENT_BINARY_DIR}/StandAlone/spirv-remap)
+    endif()
+
+    add_test(NAME glslang-testsuite
+	COMMAND bash ${IGNORE_CR_FLAG} runtests ${RESULTS_PATH} ${VALIDATOR_PATH} ${REMAP_PATH}
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Test/)
+endif(GLSLANG_TESTS)
+
+if (GLSLANG_ENABLE_INSTALL)
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake.in" [=[
         @PACKAGE_INIT@
         include(CMakeFindDependencyMacro)
@@ -375,4 +389,4 @@ if(PROJECT_IS_TOP_LEVEL)
         DESTINATION
             "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
     )
-endif()
+endif(GLSLANG_ENABLE_INSTALL)

--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -118,7 +118,7 @@ if(WIN32)
     source_group("Source" FILES ${SPVREMAP_SOURCES} ${SPVREMAP_HEADERS})
 endif()
 
-if(PROJECT_IS_TOP_LEVEL)
+if(GLSLANG_ENABLE_INSTALL)
     if (ENABLE_SPVREMAPPER)
         install(TARGETS SPVRemapper EXPORT glslang-targets)
     endif()

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -87,19 +87,19 @@ if(WIN32)
     source_group("Source" FILES ${SOURCES})
 endif()
 
-if(PROJECT_IS_TOP_LEVEL)
-    install(TARGETS glslang-standalone EXPORT glslang-targets)
+# Create a symbolic link to glslang named glslangValidator for backwards compatibility
+set(legacy_glslang_name "glslangValidator${CMAKE_EXECUTABLE_SUFFIX}")
+set(link_method create_symlink)
+if (WIN32 OR MINGW)
+set(link_method copy_if_different)
+endif()
+add_custom_command(TARGET glslang-standalone
+	       POST_BUILD
+	       COMMAND ${CMAKE_COMMAND} -E ${link_method} $<TARGET_FILE_NAME:glslang-standalone> ${legacy_glslang_name}
+	       WORKING_DIRECTORY $<TARGET_FILE_DIR:glslang-standalone>)
 
-    # Create a symbolic link to glslang named glslangValidator for backwards compatibility
-    set(legacy_glslang_name "glslangValidator${CMAKE_EXECUTABLE_SUFFIX}")
-    set(link_method create_symlink)
-    if (WIN32 OR MINGW)
-        set(link_method copy_if_different)
-    endif()
-    add_custom_command(TARGET glslang-standalone
-                       POST_BUILD
-                       COMMAND ${CMAKE_COMMAND} -E ${link_method} $<TARGET_FILE_NAME:glslang-standalone> ${legacy_glslang_name}
-                       WORKING_DIRECTORY $<TARGET_FILE_DIR:glslang-standalone>)
+if(GLSLANG_ENABLE_INSTALL)
+    install(TARGETS glslang-standalone EXPORT glslang-targets)
 
     # Create the same symlink at install time
     install(CODE "execute_process( \
@@ -109,5 +109,4 @@ if(PROJECT_IS_TOP_LEVEL)
     if(ENABLE_SPVREMAPPER)
         install(TARGETS spirv-remap EXPORT glslang-targets)
     endif()
-
-endif()
+endif(GLSLANG_ENABLE_INSTALL)

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -227,7 +227,7 @@ endif()
 ################################################################################
 # install
 ################################################################################
-if(PROJECT_IS_TOP_LEVEL)
+if(GLSLANG_ENABLE_INSTALL)
     install(TARGETS glslang EXPORT glslang-targets)
     if(NOT BUILD_SHARED_LIBS)
         install(TARGETS MachineIndependent EXPORT glslang-targets)

--- a/glslang/OSDependent/Unix/CMakeLists.txt
+++ b/glslang/OSDependent/Unix/CMakeLists.txt
@@ -40,6 +40,6 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(OSDependent Threads::Threads)
 
-if(PROJECT_IS_TOP_LEVEL AND NOT BUILD_SHARED_LIBS)
+if(GLSLANG_ENABLE_INSTALL AND NOT BUILD_SHARED_LIBS)
     install(TARGETS OSDependent EXPORT glslang-targets)
 endif()

--- a/glslang/OSDependent/Windows/CMakeLists.txt
+++ b/glslang/OSDependent/Windows/CMakeLists.txt
@@ -51,6 +51,6 @@ if(WIN32)
     source_group("Source" FILES ${SOURCES})
 endif()
 
-if(PROJECT_IS_TOP_LEVEL)
+if(GLSLANG_ENABLE_INSTALL)
     install(TARGETS OSDependent EXPORT glslang-targets)
 endif()


### PR DESCRIPTION
Expose GLSLANG_TESTS and GLSLANG_ENABLE_INSTALL as options that can be controlled from an enclosing project, or from the command line.

They retain the prior default behaviour. In particular, if Glslang is not the top level project, then they default to OFF.

Fixes: #3507