### PR TITLE
Fix crash in glslang_program_SPIRV_generate_with_options on arm64-v8a

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -9249,6 +9249,7 @@ spv::Id TGlslangToSpvTraverser::createMiscOperation(glslang::TOperator op, spv::
         // Use an extended instruction from the standard library.
         // Construct the call arguments, without modifying the original operands vector.
         // We might need the remaining arguments, e.g. in the EOpFrexp case.
+        // https://github.com/KhronosGroup/glslang/pull/3514
         std::vector<spv::Id> callArguments(consumedOperands);
         for (size_t i = 0; i < consumedOperands; ++i) {
           callArguments[i] = operands[i];

--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -9249,7 +9249,10 @@ spv::Id TGlslangToSpvTraverser::createMiscOperation(glslang::TOperator op, spv::
         // Use an extended instruction from the standard library.
         // Construct the call arguments, without modifying the original operands vector.
         // We might need the remaining arguments, e.g. in the EOpFrexp case.
-        std::vector<spv::Id> callArguments(operands.begin(), operands.begin() + consumedOperands);
+        std::vector<spv::Id> callArguments(consumedOperands);
+        for (size_t i = 0; i < consumedOperands; ++i) {
+          callArguments[i] = operands[i];
+        }
         id = builder.createBuiltinCall(typeId, extBuiltins >= 0 ? extBuiltins : stdBuiltins, libCall, callArguments);
     } else if (opCode == spv::OpDot && !isFloat) {
         // int dot(int, int)


### PR DESCRIPTION
# Problem
Compiling the following shader to SPIR-V on Android device (arm64-v8a) leads to crash in compiler.
```glsl
#version 460
#extension GL_EXT_buffer_reference_uvec2 : require
#extension GL_EXT_debug_printf : enable
#extension GL_EXT_nonuniform_qualifier : require
#extension GL_EXT_samplerless_texture_functions : require
#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require

layout (set = 0, binding = 0) uniform texture2D kTextures2D[];
layout (set = 0, binding = 1) uniform sampler kSamplers[];

layout (location = 0) in vec4 in_color;
layout (location = 1) in vec2 in_uv;
layout (location = 2) in flat uint in_textureId;

layout (location = 0) out vec4 out_color;

layout (constant_id = 0) const bool kNonLinearColorSpace = false;

void main() {
  vec4 c = in_color * texture(sampler2D(kTextures2D[in_textureId], kSamplers[0]), in_uv);
  // Render UI in linear color space to sRGB framebuffer.
  out_color = kNonLinearColorSpace ? vec4(pow(c.rgb, vec3(2.2)), c.a) : c;
}
```

## Crash stack:
```
#00 pc 0000000000a97648  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (void std::__ndk1::allocator<unsigned int>::construct[abi:v170000]<unsigned int, unsigned int&>(unsigned int*, unsigned int&)+28) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#01 pc 0000000000a97594  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (void std::__ndk1::allocator_traits<std::__ndk1::allocator<unsigned int> >::construct[abi:v170000]<unsigned int, unsigned int&, void>(std::__ndk1::allocator<unsigned int>&, unsigned int*, unsigned int&)+36) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#02 pc 0000000000eb4080  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#03 pc 0000000000eb3f00  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (void std::__ndk1::vector<unsigned int, std::__ndk1::allocator<unsigned int> >::__construct_at_end<std::__ndk1::__wrap_iter<unsigned int*>, 0>(std::__ndk1::__wrap_iter<unsigned int*>, std::__ndk1::__wrap_iter<unsigned int*>, unsigned long)+104) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#04 pc 0000000000eb1f64  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (std::__ndk1::vector<unsigned int, std::__ndk1::allocator<unsigned int> >::vector<std::__ndk1::__wrap_iter<unsigned int*>, 0>(std::__ndk1::__wrap_iter<unsigned int*>, std::__ndk1::__wrap_iter<unsigned int*>)+204) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#05 pc 0000000000ea562c  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#06 pc 0000000000e56d20  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)
 
#07 pc 0000000000f479bc  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (glslang::TIntermAggregate::traverse(glslang::TIntermTraverser*)+84) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#08 pc 0000000000e573f8  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#09 pc 0000000000f4834c  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (glslang::TIntermBranch::traverse(glslang::TIntermTraverser*)+72) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#10 pc 0000000000f47b34  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (glslang::TIntermAggregate::traverse(glslang::TIntermTraverser*)+460) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#11 pc 0000000000e9eebc  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#12 pc 0000000000e53eac  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#13 pc 0000000000f47f64  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (glslang::TIntermSelection::traverse(glslang::TIntermTraverser*)+72) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#14 pc 0000000000f47b34  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (glslang::TIntermAggregate::traverse(glslang::TIntermTraverser*)+460) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#15 pc 0000000000f47b34  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (glslang::TIntermAggregate::traverse(glslang::TIntermTraverser*)+460) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#16 pc 0000000000ea1c28  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#17 pc 0000000000e541b4  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#18 pc 0000000000f479bc  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (glslang::TIntermAggregate::traverse(glslang::TIntermTraverser*)+84) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#19 pc 0000000000e4c128  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (glslang::GlslangToSpv(glslang::TIntermediate const&, std::__ndk1::vector<unsigned int, std::__ndk1::allocator<unsigned int> >&, spv::SpvBuildLogger*, glslang::SpvOptions*)+164) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)

#20 pc 0000000000e4b30c  /data/app/~~5nZrItIXbZvTM17cKJbe1A==/org.lvk.samples.Tiny_MeshLarge-WXp1AFnIhUV-fYwJE7yJ8A==/base.apk!liblvk_android_native_Tiny_MeshLarge.so (offset 0x2da7000) (glslang_program_SPIRV_generate_with_options+108) (BuildId: df4f13a95be87c9c4384ab1cf9619d80de606f71)
```

Tested on 2 Android devices both with Android 14, crash is stable. After debugging, line of code that leads to it was found.
```cpp
// https://github.com/KhronosGroup/glslang/blob/9fd0fcd737f1369e89fb3aa8b2e62bad57ac46c6/SPIRV/GlslangToSpv.cpp#L9252

std::vector<spv::Id> callArguments(operands.begin(), operands.begin() + consumedOperands);
```

Workaround was also found, equivalent code works. The original problem is not reproducable on other platforms. Address sanitizer didn't show any issue.