### PR TITLE
Fix installation of glslangValidator link/copy

### DIFF
--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -104,7 +104,7 @@ if(GLSLANG_ENABLE_INSTALL)
     # Create the same symlink at install time
     install(CODE "execute_process( \
                       COMMAND ${CMAKE_COMMAND} -E ${link_method} $<TARGET_FILE_NAME:glslang-standalone> ${legacy_glslang_name} \
-                      WORKING_DIRECTORY \$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})")
+                      WORKING_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\")")
 
     if(ENABLE_SPVREMAPPER)
         install(TARGETS spirv-remap EXPORT glslang-targets)

--- a/StandAlone/CMakeLists.txt
+++ b/StandAlone/CMakeLists.txt
@@ -104,7 +104,7 @@ if(GLSLANG_ENABLE_INSTALL)
     # Create the same symlink at install time
     install(CODE "execute_process( \
                       COMMAND ${CMAKE_COMMAND} -E ${link_method} $<TARGET_FILE_NAME:glslang-standalone> ${legacy_glslang_name} \
-                      WORKING_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\")")
+                      WORKING_DIRECTORY \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\")")
 
     if(ENABLE_SPVREMAPPER)
         install(TARGETS spirv-remap EXPORT glslang-targets)


### PR DESCRIPTION
The generated `cmake_install.cmake` contains lines like
```cmake
file(INSTALL DESTINATION "${CMAKE_INSTALL_PREFIX}/bin" TYPE EXECUTABLE FILES "C:/vsg/glslang/build/StandAlone/Release/glslang.exe")
```

Note that it uses the install-time value of `CMAKE_INSTALL_PREFIX`, not the configure-time one.

The line which copies glslang/creates a symlink should use the same path - if it uses a different one, then glslang won't be there to copy, or will be the wrong instance.

https://github.com/KhronosGroup/glslang/pull/3283 attempted to fix the same problem, but only did so sometimes. My understanding is that on some people's setups, the combined install-time value of `DESTDIR` and the configure-time install prefix was equivalent to the install-time install prefix, but it's better to just use the install-time install prefix. https://cmake.org/cmake/help/latest/envvar/DESTDIR.html says you can't use `DESTDIR` on Windows in the first place.

Having the backslash before the dollar sign means `CMAKE_INSTALL_PREFIX` will not be evaluated at configure-time, so it's not exactly the same as undoing #3283.

Putting the whole expression in quotes solves a second problem where the install would fail if `CMAKE_INSTALL_PREFIX` contained spaces, as it does by default on Windows. Before the other changes in this MR, it was spaces in the configure-time variable that would cause problems, and after it was ones in the install-time variable.