### PR TITLE
Add aliases for the public libraries

### DIFF
--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -78,6 +78,7 @@ set(PUBLIC_HEADERS
     SPVRemapper.h)
 
 add_library(SPIRV ${LIB_TYPE} ${SOURCES} ${HEADERS})
+add_library(glslang::SPIRV ALIAS SPIRV)
 set_target_properties(SPIRV PROPERTIES
     FOLDER glslang
     POSITION_INDEPENDENT_CODE ON
@@ -91,6 +92,7 @@ glslang_add_build_info_dependency(SPIRV)
 
 if (ENABLE_SPVREMAPPER)
     add_library(SPVRemapper ${LIB_TYPE} ${SPVREMAP_SOURCES} ${SPVREMAP_HEADERS})
+    add_library(glslang::SPVRemapper ALIAS SPVRemapper)
     set_target_properties(SPVRemapper PROPERTIES
         FOLDER glslang
         POSITION_INDEPENDENT_CODE ON

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -169,6 +169,7 @@ set(GLSLANG_HEADERS
     Include/Types.h)
 
 add_library(glslang ${LIB_TYPE} ${GLSLANG_SOURCES} ${GLSLANG_HEADERS})
+add_library(glslang::glslang ALIAS glslang)
 set_target_properties(glslang PROPERTIES
     FOLDER glslang
     POSITION_INDEPENDENT_CODE ON
@@ -201,6 +202,7 @@ set(RESOURCELIMITS_HEADERS
 )
 
 add_library(glslang-default-resource-limits ${RESOURCELIMITS_SOURCES} ${RESOURCELIMITS_HEADERS})
+add_library(glslang::glslang-default-resource-limits ALIAS glslang-default-resource-limits)
 set_target_properties(glslang-default-resource-limits PROPERTIES
     VERSION "${GLSLANG_VERSION}"
     SOVERSION "${GLSLANG_VERSION_MAJOR}"


### PR DESCRIPTION
This makes things consistent between when glslang is installed and imported versus when it's included as nested CMake project. You can now use `glslang::glslang` in both cases instead of needing the non-namespaced version sometimes and the namespaced one other times.

Resolves one of the problems discussed in https://github.com/KhronosGroup/glslang/issues/3509

Note: Some downstream projects may be using system-installed glslang as `glslang` instead of `glslang::glslang`, but this is fragile and isn't actually supposed to work - when passing an un-namespaced library name to `target_link_libraries`, if it's not an existing CMake target, CMake won't emit an error, and will fall back to just adding an extra linker flag like `-lglslang`. If you've already got the right library directory enabled (which is likely if you're using the system package), then it'll look like it's working, but you won't get any of the extras like CMake automatically setting up the right transitive include directories.