### PR TITLE
-Wshadow fixes

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -3740,9 +3740,9 @@ bool TGlslangToSpvTraverser::visitAggregate(glslang::TVisit visit, glslang::TInt
 
         spv::Op spvOp = spv::OpRayQueryGetIntersectionTriangleVertexPositionsKHR;
 
-        spv::Id result = builder.createOp(spvOp, typeId, idImmOps);
+        spv::Id createResult = builder.createOp(spvOp, typeId, idImmOps);
         // store the result to the pointer (out param 'm')
-        builder.createStore(result, operands[2]);
+        builder.createStore(createResult, operands[2]);
         result = 0;
     } else if (node->getOp() == glslang::EOpCooperativeMatrixMulAdd) {
         uint32_t matrixOperands = 0;

--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -9479,24 +9479,24 @@ spv::Id TGlslangToSpvTraverser::createNoArgOperation(glslang::TOperator op, spv:
     {
         builder.addExtension(spv::E_SPV_EXT_shader_tile_image);
 
-        spv::Decoration precision;
+        spv::Decoration inner_precision;
         spv::Op spv_op;
         if (op == glslang::EOpStencilAttachmentReadEXT)
         {
-            precision = spv::DecorationRelaxedPrecision;
+            inner_precision = spv::DecorationRelaxedPrecision;
             spv_op = spv::OpStencilAttachmentReadEXT;
             builder.addCapability(spv::CapabilityTileImageStencilReadAccessEXT);
         }
         else
         {
-            precision = spv::NoPrecision;
+            inner_precision = spv::NoPrecision;
             spv_op = spv::OpDepthAttachmentReadEXT;
             builder.addCapability(spv::CapabilityTileImageDepthReadAccessEXT);
         }
 
         std::vector<spv::Id> args; // Dummy args
         spv::Id result = builder.createOp(spv_op, typeId, args);
-        return builder.setPrecision(result, precision);
+        return builder.setPrecision(result, inner_precision);
     }
     default:
         break;

--- a/SPIRV/SPVRemapper.cpp
+++ b/SPIRV/SPVRemapper.cpp
@@ -312,13 +312,13 @@ namespace spv {
         literal.reserve(16);
 
         do {
-            spirword_t word = *pos;
+            spirword_t value = *pos;
             for (int i = 0; i < 4; i++) {
-                char c = word & 0xff;
+                char c = value & 0xff;
                 if (c == '\0')
                     return literal;
                 literal += c;
-                word >>= 8;
+                value >>= 8;
             }
             pos++;
         } while (true);
@@ -1110,10 +1110,10 @@ namespace spv {
                     process(
                         [&](spv::Op opCode, unsigned start) {
                             if (opCode == spv::Op::OpFunctionCall) {
-                                const auto call_it = fnCalls.find(asId(start + 3));
-                                if (call_it != fnCalls.end()) {
-                                    if (--call_it->second <= 0)
-                                        fnCalls.erase(call_it);
+                                const auto itr = fnCalls.find(asId(start + 3));
+                                if (itr != fnCalls.end()) {
+                                    if (--itr->second <= 0)
+                                        fnCalls.erase(itr);
                                 }
                             }
 

--- a/SPIRV/SPVRemapper.h
+++ b/SPIRV/SPVRemapper.h
@@ -85,7 +85,7 @@ const Id NoResult = 0;
 class spirvbin_t : public spirvbin_base_t
 {
 public:
-   spirvbin_t(int verbose = 0) : entryPoint(spv::NoResult), largestNewId(0), verbose(verbose), errorLatch(false)
+   spirvbin_t(int in_verbose = 0) : entryPoint(spv::NoResult), largestNewId(0), verbose(in_verbose), errorLatch(false)
    { }
 
    virtual ~spirvbin_t() { }

--- a/SPIRV/SpvBuilder.cpp
+++ b/SPIRV/SpvBuilder.cpp
@@ -54,8 +54,8 @@
 
 namespace spv {
 
-Builder::Builder(unsigned int spvVersion, unsigned int magicNumber, SpvBuildLogger* buildLogger) :
-    spvVersion(spvVersion),
+Builder::Builder(unsigned int in_spvVersion, unsigned int magicNumber, SpvBuildLogger* buildLogger) :
+    spvVersion(in_spvVersion),
     sourceLang(SourceLanguageUnknown),
     sourceVersion(0),
     addressModel(AddressingModelLogical),
@@ -1918,7 +1918,7 @@ void Builder::addDecoration(Id id, Decoration decoration, const std::vector<unsi
     decorations.push_back(std::unique_ptr<Instruction>(dec));
 }
 
-void Builder::addDecoration(Id id, Decoration decoration, const std::vector<const char*>& strings)
+void Builder::addDecoration(Id id, Decoration decoration, const std::vector<const char*>& decorationStrings)
 {
     if (decoration == spv::DecorationMax)
         return;
@@ -1926,7 +1926,7 @@ void Builder::addDecoration(Id id, Decoration decoration, const std::vector<cons
     Instruction* dec = new Instruction(OpDecorateString);
     dec->addIdOperand(id);
     dec->addImmediateOperand(decoration);
-    for (auto string : strings)
+    for (auto string : decorationStrings)
         dec->addStringOperand(string);
 
     decorations.push_back(std::unique_ptr<Instruction>(dec));
@@ -2014,7 +2014,7 @@ void Builder::addMemberDecoration(Id id, unsigned int member, Decoration decorat
     decorations.push_back(std::unique_ptr<Instruction>(dec));
 }
 
-void Builder::addMemberDecoration(Id id, unsigned int member, Decoration decoration, const std::vector<const char*>& strings)
+void Builder::addMemberDecoration(Id id, unsigned int member, Decoration decoration, const std::vector<const char*>& decorationStrings)
 {
     if (decoration == spv::DecorationMax)
         return;
@@ -2023,7 +2023,7 @@ void Builder::addMemberDecoration(Id id, unsigned int member, Decoration decorat
     dec->addIdOperand(id);
     dec->addImmediateOperand(member);
     dec->addImmediateOperand(decoration);
-    for (auto string : strings)
+    for (auto string : decorationStrings)
         dec->addStringOperand(string);
 
     decorations.push_back(std::unique_ptr<Instruction>(dec));
@@ -2095,7 +2095,7 @@ Function* Builder::makeEntryPoint(const char* entryPoint)
 // Comments in header
 Function* Builder::makeFunctionEntry(Decoration precision, Id returnType, const char* name, LinkageType linkType,
                                      const std::vector<Id>& paramTypes,
-                                     const std::vector<std::vector<Decoration>>& decorations, Block** entry)
+                                     const std::vector<std::vector<Decoration>>& paramDecorations, Block** entry)
 {
     // Make the function and initial instructions in it
     Id typeId = makeFunctionType(returnType, paramTypes);
@@ -2106,10 +2106,10 @@ Function* Builder::makeFunctionEntry(Decoration precision, Id returnType, const 
     // Set up the precisions
     setPrecision(function->getId(), precision);
     function->setReturnPrecision(precision);
-    for (unsigned p = 0; p < (unsigned)decorations.size(); ++p) {
-        for (int d = 0; d < (int)decorations[p].size(); ++d) {
-            addDecoration(firstParamId + p, decorations[p][d]);
-            function->addParamPrecision(p, decorations[p][d]);
+    for (unsigned p = 0; p < (unsigned)paramDecorations.size(); ++p) {
+        for (int d = 0; d < (int)paramDecorations[p].size(); ++d) {
+            addDecoration(firstParamId + p, paramDecorations[p][d]);
+            function->addParamPrecision(p, paramDecorations[p][d]);
         }
     }
 

--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -649,8 +649,8 @@ public:
     void endSwitch(std::vector<Block*>& segmentBB);
 
     struct LoopBlocks {
-        LoopBlocks(Block& head, Block& body, Block& merge, Block& continue_target) :
-            head(head), body(body), merge(merge), continue_target(continue_target) { }
+        LoopBlocks(Block& in_head, Block& in_body, Block& in_merge, Block& in_continue_target) :
+            head(in_head), body(in_body), merge(in_merge), continue_target(in_continue_target) { }
         Block &head, &body, &merge, &continue_target;
     private:
         LoopBlocks();

--- a/SPIRV/SpvPostProcess.cpp
+++ b/SPIRV/SpvPostProcess.cpp
@@ -245,9 +245,9 @@ void Builder::postProcess(Instruction& inst)
             // (set via Builder::AccessChain::alignment) only accounts for the base of
             // the reference type and any scalar component selection in the accesschain,
             // and this function computes the rest from the SPIR-V Offset decorations.
-            Instruction *accessChain = module.getInstruction(inst.getIdOperand(0));
-            if (accessChain->getOpCode() == OpAccessChain) {
-                Instruction *base = module.getInstruction(accessChain->getIdOperand(0));
+            Instruction *moduleAccessChain = module.getInstruction(inst.getIdOperand(0));
+            if (moduleAccessChain->getOpCode() == OpAccessChain) {
+                Instruction *base = module.getInstruction(moduleAccessChain->getIdOperand(0));
                 // Get the type of the base of the access chain. It must be a pointer type.
                 Id typeId = base->getTypeId();
                 Instruction *type = module.getInstruction(typeId);
@@ -263,8 +263,8 @@ void Builder::postProcess(Instruction& inst)
                 // Offset/ArrayStride/MatrixStride decorations, and bitwise OR them all
                 // together.
                 int alignment = 0;
-                for (int i = 1; i < accessChain->getNumOperands(); ++i) {
-                    Instruction *idx = module.getInstruction(accessChain->getIdOperand(i));
+                for (int i = 1; i < moduleAccessChain->getNumOperands(); ++i) {
+                    Instruction *idx = module.getInstruction(moduleAccessChain->getIdOperand(i));
                     if (type->getOpCode() == OpTypeStruct) {
                         assert(idx->getOpCode() == OpConstant);
                         unsigned int c = idx->getImmediateOperand(0);

--- a/SPIRV/disassemble.cpp
+++ b/SPIRV/disassemble.cpp
@@ -86,7 +86,7 @@ enum ExtInstSet {
 // Container class for a single instance of a SPIR-V stream, with methods for disassembly.
 class SpirvStream {
 public:
-    SpirvStream(std::ostream& out, const std::vector<unsigned int>& stream) : out(out), stream(stream), word(0), nextNestedControl(0) { }
+    SpirvStream(std::ostream& in_out, const std::vector<unsigned int>& in_stream) : out(in_out), stream(in_stream), word(0), nextNestedControl(0) { }
     virtual ~SpirvStream() { }
 
     void validate();

--- a/SPIRV/spvIR.h
+++ b/SPIRV/spvIR.h
@@ -94,8 +94,8 @@ struct IdImmediate {
 
 class Instruction {
 public:
-    Instruction(Id resultId, Id typeId, Op opCode) : resultId(resultId), typeId(typeId), opCode(opCode), block(nullptr) { }
-    explicit Instruction(Op opCode) : resultId(NoResult), typeId(NoType), opCode(opCode), block(nullptr) { }
+    Instruction(Id in_resultId, Id in_typeId, Op in_opCode) : resultId(in_resultId), typeId(in_typeId), opCode(in_opCode), block(nullptr) { }
+    explicit Instruction(Op in_opCode) : resultId(NoResult), typeId(NoType), opCode(in_opCode), block(nullptr) { }
     virtual ~Instruction() {}
     void addIdOperand(Id id) {
         // ids can't be 0
@@ -514,8 +514,8 @@ protected:
 // Add both
 // - the OpFunction instruction
 // - all the OpFunctionParameter instructions
-__inline Function::Function(Id id, Id resultType, Id functionType, Id firstParamId, LinkageType linkage, const std::string& name, Module& parent)
-    : parent(parent), lineInstruction(nullptr),
+__inline Function::Function(Id id, Id resultType, Id functionType, Id firstParamId, LinkageType linkage, const std::string& name, Module& in_parent)
+    : parent(in_parent), lineInstruction(nullptr),
       functionInstruction(id, resultType, OpFunction), implicitThis(false),
       reducedPrecisionReturn(false),
       linkType(linkage)
@@ -548,7 +548,7 @@ __inline void Function::addLocalVariable(std::unique_ptr<Instruction> inst)
     parent.mapInstruction(raw_instruction);
 }
 
-__inline Block::Block(Id id, Function& parent) : parent(parent), unreachable(false)
+__inline Block::Block(Id id, Function& in_parent) : parent(in_parent), unreachable(false)
 {
     instructions.push_back(std::unique_ptr<Instruction>(new Instruction(id, NoType, OpLabel)));
     instructions.back()->setBlock(this);

--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -357,7 +357,7 @@ void ProcessBindingBase(int& argc, char**& argv, glslang::TResourceType res)
     if (argc < 2)
         usage();
 
-    EShLanguage lang = EShLangCount;
+    EShLanguage langSelected = EShLangCount;
     int singleBase = 0;
     TPerSetBaseBinding perSetBase;
     int arg = 1;
@@ -367,7 +367,7 @@ void ProcessBindingBase(int& argc, char**& argv, glslang::TResourceType res)
         if (argc < 3) // this form needs one more argument
             usage();
 
-        lang = FindLanguage(argv[arg++], false);
+        langSelected = FindLanguage(argv[arg++], false);
     }
 
     if ((argc - arg) >= 2 && isdigit(argv[arg+0][0]) && isdigit(argv[arg+1][0])) {
@@ -386,8 +386,8 @@ void ProcessBindingBase(int& argc, char**& argv, glslang::TResourceType res)
     argv += (arg-1);
 
     // Set one or all languages
-    const int langMin = (lang < EShLangCount) ? lang+0 : 0;
-    const int langMax = (lang < EShLangCount) ? lang+1 : EShLangCount;
+    const int langMin = (langSelected < EShLangCount) ? langSelected+0 : 0;
+    const int langMax = (langSelected < EShLangCount) ? langSelected+1 : EShLangCount;
 
     for (int lang = langMin; lang < langMax; ++lang) {
         if (!perSetBase.empty())
@@ -1227,7 +1227,7 @@ struct ShaderCompUnit {
     std::string fileName[maxCount];     // hold's the memory, but...
     const char* fileNameList[maxCount]; // downstream interface wants pointers
 
-    ShaderCompUnit(EShLanguage stage) : stage(stage), count(0) { }
+    ShaderCompUnit(EShLanguage in_stage) : stage(in_stage), count(0) { }
 
     ShaderCompUnit(const ShaderCompUnit& rhs)
     {

--- a/glslang/HLSL/hlslGrammar.h
+++ b/glslang/HLSL/hlslGrammar.h
@@ -51,8 +51,8 @@ namespace glslang {
 
     class HlslGrammar : public HlslTokenStream {
     public:
-        HlslGrammar(HlslScanContext& scanner, HlslParseContext& in_parseContext)
-            : HlslTokenStream(scanner), parseContext(in_parseContext), intermediate(parseContext.intermediate),
+        HlslGrammar(HlslScanContext& in_scanner, HlslParseContext& in_parseContext)
+            : HlslTokenStream(in_scanner), parseContext(in_parseContext), intermediate(parseContext.intermediate),
               typeIdentifiers(false), unitNode(nullptr) { }
         virtual ~HlslGrammar() { }
 

--- a/glslang/HLSL/hlslGrammar.h
+++ b/glslang/HLSL/hlslGrammar.h
@@ -51,8 +51,8 @@ namespace glslang {
 
     class HlslGrammar : public HlslTokenStream {
     public:
-        HlslGrammar(HlslScanContext& scanner, HlslParseContext& parseContext)
-            : HlslTokenStream(scanner), parseContext(parseContext), intermediate(parseContext.intermediate),
+        HlslGrammar(HlslScanContext& scanner, HlslParseContext& in_parseContext)
+            : HlslTokenStream(scanner), parseContext(in_parseContext), intermediate(parseContext.intermediate),
               typeIdentifiers(false), unitNode(nullptr) { }
         virtual ~HlslGrammar() { }
 

--- a/glslang/HLSL/hlslParseHelper.cpp
+++ b/glslang/HLSL/hlslParseHelper.cpp
@@ -53,13 +53,13 @@
 
 namespace glslang {
 
-HlslParseContext::HlslParseContext(TSymbolTable& symbolTable, TIntermediate& interm, bool parsingBuiltins,
-                                   int version, EProfile profile, const SpvVersion& spvVersion, EShLanguage language,
-                                   TInfoSink& infoSink,
-                                   const TString sourceEntryPointName,
-                                   bool forwardCompatible, EShMessages messages) :
-    TParseContextBase(symbolTable, interm, parsingBuiltins, version, profile, spvVersion, language, infoSink,
-                      forwardCompatible, messages, &sourceEntryPointName),
+HlslParseContext::HlslParseContext(TSymbolTable& in_symbolTable, TIntermediate& interm, bool in_parsingBuiltins,
+                                   int in_version, EProfile in_profile, const SpvVersion& in_spvVersion, EShLanguage in_language,
+                                   TInfoSink& in_infoSink,
+                                   const TString in_sourceEntryPointName,
+                                   bool in_forwardCompatible, EShMessages in_messages) :
+    TParseContextBase(in_symbolTable, interm, in_parsingBuiltins, in_version, in_profile, in_spvVersion, in_language, in_infoSink,
+                      in_forwardCompatible, in_messages, &in_sourceEntryPointName),
     annotationNestingLevel(0),
     inputPatch(nullptr),
     nextInLocation(0), nextOutLocation(0),
@@ -124,13 +124,13 @@ void HlslParseContext::setLimits(const TBuiltInResource& r)
 //
 // Returns true for successful acceptance of the shader, false if any errors.
 //
-bool HlslParseContext::parseShaderStrings(TPpContext& ppContext, TInputScanner& input, bool versionWillBeError)
+bool HlslParseContext::parseShaderStrings(TPpContext& context, TInputScanner& input, bool versionWillBeError)
 {
     currentScanner = &input;
-    ppContext.setInput(input, versionWillBeError);
+    context.setInput(input, versionWillBeError);
 
-    HlslScanContext scanContext(*this, ppContext);
-    HlslGrammar grammar(scanContext, *this);
+    HlslScanContext scan(*this, context);
+    HlslGrammar grammar(scan, *this);
     if (!grammar.parse()) {
         // Print a message formated such that if you click on the message it will take you right to
         // the line through most UIs.
@@ -301,9 +301,9 @@ TIntermTyped* HlslParseContext::handleLvalue(const TSourceLoc& loc, const char* 
     };
 
     // Helper to create an assign.
-    const auto makeBinary = [&](TOperator op, TIntermTyped* lhs, TIntermTyped* rhs) {
+    const auto makeBinary = [&](TOperator binaryOp, TIntermTyped* binaryLhs, TIntermTyped* binaryRhs) {
         sequence = intermediate.growAggregate(sequence,
-                                              intermediate.addBinaryNode(op, lhs, rhs, loc, lhs->getType()),
+                                              intermediate.addBinaryNode(binaryOp, binaryLhs, binaryRhs, loc, binaryLhs->getType()),
                                               loc);
     };
 
@@ -319,9 +319,9 @@ TIntermTyped* HlslParseContext::handleLvalue(const TSourceLoc& loc, const char* 
     };
 
     // Helper to add unary op
-    const auto makeUnary = [&](TOperator op, TIntermSymbol* rhsTmp) {
+    const auto makeUnary = [&](TOperator unaryOp, TIntermSymbol* rhsTmp) {
         sequence = intermediate.growAggregate(sequence,
-                                              intermediate.addUnaryNode(op, intermediate.addSymbol(*rhsTmp), loc,
+                                              intermediate.addUnaryNode(unaryOp, intermediate.addSymbol(*rhsTmp), loc,
                                                                         rhsTmp->getType()),
                                               loc);
     };
@@ -1546,8 +1546,8 @@ void HlslParseContext::fixBuiltInIoType(TType& type)
 // Assumes it is called in the order in which locations should be assigned.
 void HlslParseContext::assignToInterface(TVariable& variable)
 {
-    const auto assignLocation = [&](TVariable& variable) {
-        TType& type = variable.getWritableType();
+    const auto assignLocation = [&](TVariable& var) {
+        TType& type = var.getWritableType();
         if (!type.isStruct() || type.getStruct()->size() > 0) {
             TQualifier& qualifier = type.getQualifier();
             if (qualifier.storage == EvqVaryingIn || qualifier.storage == EvqVaryingOut) {
@@ -1561,14 +1561,14 @@ void HlslParseContext::assignToInterface(TVariable& variable)
                         size = intermediate.computeTypeLocationSize(type, language);
 
                     if (qualifier.storage == EvqVaryingIn) {
-                        variable.getWritableType().getQualifier().layoutLocation = nextInLocation;
+                        var.getWritableType().getQualifier().layoutLocation = nextInLocation;
                         nextInLocation += size;
                     } else {
-                        variable.getWritableType().getQualifier().layoutLocation = nextOutLocation;
+                        var.getWritableType().getQualifier().layoutLocation = nextOutLocation;
                         nextOutLocation += size;
                     }
                 }
-                trackLinkage(variable);
+                trackLinkage(var);
             }
         }
     };
@@ -1973,9 +1973,9 @@ void HlslParseContext::transferTypeAttributes(const TSourceLoc& loc, const TAttr
                 break;
             }
             if (it->getInt(value)) {
-                TSourceLoc loc;
-                loc.init();
-                setSpecConstantId(loc, type.getQualifier(), value);
+                TSourceLoc sloc;
+                sloc.init();
+                setSpecConstantId(sloc, type.getQualifier(), value);
             }
             break;
 
@@ -2316,13 +2316,13 @@ void HlslParseContext::remapEntryPointIO(TFunction& function, TVariable*& return
     // Hence, a missing ioTypeMap for 'input' might need to be synthesized.
     const auto synthesizeEditedInput = [this](TType& type) {
         // True if a type needs to be 'flat'
-        const auto needsFlat = [](const TType& type) {
-            return type.containsBasicType(EbtInt) ||
-                    type.containsBasicType(EbtUint) ||
-                    type.containsBasicType(EbtInt64) ||
-                    type.containsBasicType(EbtUint64) ||
-                    type.containsBasicType(EbtBool) ||
-                    type.containsBasicType(EbtDouble);
+        const auto needsFlat = [](const TType& t) {
+            return t.containsBasicType(EbtInt) ||
+                    t.containsBasicType(EbtUint) ||
+                    t.containsBasicType(EbtInt64) ||
+                    t.containsBasicType(EbtUint64) ||
+                    t.containsBasicType(EbtBool) ||
+                    t.containsBasicType(EbtDouble);
         };
 
         if (language == EShLangFragment && needsFlat(type)) {
@@ -3032,10 +3032,10 @@ TIntermTyped* HlslParseContext::handleAssign(const TSourceLoc& loc, TOperator op
             // arrayed io
             if (subTree->getType().isArray()) {
                 if (!arrayElement.empty()) {
-                    const TType derefType(subTree->getType(), arrayElement.front());
+                    const TType subTree_derefType(subTree->getType(), arrayElement.front());
                     subTree = intermediate.addIndex(EOpIndexDirect, subTree,
                                                     intermediate.addConstantUnion(arrayElement.front(), loc), loc);
-                    subTree->setType(derefType);
+                    subTree->setType(subTree_derefType);
                 } else {
                     // There's an index operation we should transfer to the output builtin.
                     assert(splitNode->getAsOperator() != nullptr &&
@@ -3072,21 +3072,20 @@ TIntermTyped* HlslParseContext::handleAssign(const TSourceLoc& loc, TOperator op
 
     // Cannot use auto here, because this is recursive, and auto can't work out the type without seeing the
     // whole thing.  So, we'll resort to an explicit type via std::function.
-    const std::function<void(TIntermTyped* left, TIntermTyped* right, TIntermTyped* splitLeft, TIntermTyped* splitRight,
-                             bool topLevel)>
-    traverse = [&](TIntermTyped* left, TIntermTyped* right, TIntermTyped* splitLeft, TIntermTyped* splitRight,
+    const std::function<void(TIntermTyped* outterLeft, TIntermTyped* outterRight, TIntermTyped* splitLeft, TIntermTyped* splitRight, bool topLevel)>
+    traverse = [&](TIntermTyped* outterLeft, TIntermTyped* outterRight, TIntermTyped* splitLeft, TIntermTyped* splitRight,
                    bool topLevel) -> void {
         // If we get here, we are assigning to or from a whole array or struct that must be
         // flattened, so have to do member-by-member assignment:
 
-        bool shouldFlattenSubsetLeft = isFlattenLeft && shouldFlatten(left->getType(), leftStorage, topLevel);
-        bool shouldFlattenSubsetRight = isFlattenRight && shouldFlatten(right->getType(), rightStorage, topLevel);
+        bool shouldFlattenSubsetLeft = isFlattenLeft && shouldFlatten(outterLeft->getType(), leftStorage, topLevel);
+        bool shouldFlattenSubsetRight = isFlattenRight && shouldFlatten(outterRight->getType(), rightStorage, topLevel);
 
-        if ((left->getType().isArray() || right->getType().isArray()) &&
+        if ((outterLeft->getType().isArray() || outterRight->getType().isArray()) &&
               (shouldFlattenSubsetLeft  || isSplitLeft ||
                shouldFlattenSubsetRight || isSplitRight)) {
-            const int elementsL = left->getType().isArray()  ? left->getType().getOuterArraySize()  : 1;
-            const int elementsR = right->getType().isArray() ? right->getType().getOuterArraySize() : 1;
+            const int elementsL = outterLeft->getType().isArray()  ? outterLeft->getType().getOuterArraySize()  : 1;
+            const int elementsR = outterRight->getType().isArray() ? outterRight->getType().getOuterArraySize() : 1;
 
             // The arrays might not be the same size,
             // e.g., if the size has been forced for EbvTessLevelInner/Outer.
@@ -3097,15 +3096,15 @@ TIntermTyped* HlslParseContext::handleAssign(const TSourceLoc& loc, TOperator op
                 arrayElement.push_back(element);
 
                 // Add a new AST symbol node if we have a temp variable holding a complex RHS.
-                TIntermTyped* subLeft  = getMember(true,  left->getType(),  element, left, element,
+                TIntermTyped* subLeft  = getMember(true,  outterLeft->getType(),  element, outterLeft, element,
                                                    shouldFlattenSubsetLeft);
-                TIntermTyped* subRight = getMember(false, right->getType(), element, right, element,
+                TIntermTyped* subRight = getMember(false, outterRight->getType(), element, outterRight, element,
                                                    shouldFlattenSubsetRight);
 
-                TIntermTyped* subSplitLeft =  isSplitLeft  ? getMember(true,  left->getType(),  element, splitLeft,
+                TIntermTyped* subSplitLeft =  isSplitLeft  ? getMember(true,  outterLeft->getType(),  element, splitLeft,
                                                                        element, shouldFlattenSubsetLeft)
                                                            : subLeft;
-                TIntermTyped* subSplitRight = isSplitRight ? getMember(false, right->getType(), element, splitRight,
+                TIntermTyped* subSplitRight = isSplitRight ? getMember(false, outterRight->getType(), element, splitRight,
                                                                        element, shouldFlattenSubsetRight)
                                                            : subRight;
 
@@ -3113,11 +3112,11 @@ TIntermTyped* HlslParseContext::handleAssign(const TSourceLoc& loc, TOperator op
 
                 arrayElement.pop_back();
             }
-        } else if (left->getType().isStruct() && (shouldFlattenSubsetLeft  || isSplitLeft ||
+        } else if (outterLeft->getType().isStruct() && (shouldFlattenSubsetLeft  || isSplitLeft ||
                                                   shouldFlattenSubsetRight || isSplitRight)) {
             // struct case
-            const auto& membersL = *left->getType().getStruct();
-            const auto& membersR = *right->getType().getStruct();
+            const auto& membersL = *outterLeft->getType().getStruct();
+            const auto& membersR = *outterRight->getType().getStruct();
 
             // These track the members in the split structures corresponding to the same in the unsplit structures,
             // which we traverse in parallel.
@@ -3126,34 +3125,34 @@ TIntermTyped* HlslParseContext::handleAssign(const TSourceLoc& loc, TOperator op
 
             // Handle empty structure assignment
             if (int(membersL.size()) == 0 && int(membersR.size()) == 0)
-                assignList = intermediate.growAggregate(assignList, intermediate.addAssign(op, left, right, loc), loc);
+                assignList = intermediate.growAggregate(assignList, intermediate.addAssign(op, outterLeft, outterRight, loc), loc);
 
             for (int member = 0; member < int(membersL.size()); ++member) {
                 const TType& typeL = *membersL[member].type;
                 const TType& typeR = *membersR[member].type;
 
-                TIntermTyped* subLeft  = getMember(true,  left->getType(), member, left, member,
+                TIntermTyped* subLeft  = getMember(true,  outterLeft->getType(), member, outterLeft, member,
                                                    shouldFlattenSubsetLeft);
-                TIntermTyped* subRight = getMember(false, right->getType(), member, right, member,
+                TIntermTyped* subRight = getMember(false, outterRight->getType(), member, outterRight, member,
                                                    shouldFlattenSubsetRight);
 
                 // If there is no splitting, use the same values to avoid inefficiency.
-                TIntermTyped* subSplitLeft =  isSplitLeft  ? getMember(true,  left->getType(),  member, splitLeft,
+                TIntermTyped* subSplitLeft =  isSplitLeft  ? getMember(true,  outterLeft->getType(),  member, splitLeft,
                                                                        memberL, shouldFlattenSubsetLeft)
                                                            : subLeft;
-                TIntermTyped* subSplitRight = isSplitRight ? getMember(false, right->getType(), member, splitRight,
+                TIntermTyped* subSplitRight = isSplitRight ? getMember(false, outterRight->getType(), member, splitRight,
                                                                        memberR, shouldFlattenSubsetRight)
                                                            : subRight;
 
                 if (isClipOrCullDistance(subSplitLeft->getType()) || isClipOrCullDistance(subSplitRight->getType())) {
-                    // Clip and cull distance built-in assignment is complex in its own right, and is handled in
+                    // Clip and cull distance built-in assignment is complex in its own outterRight, and is handled in
                     // a separate function dedicated to that task.  See comment above assignClipCullDistance;
 
                     const bool isOutput = isClipOrCullDistance(subSplitLeft->getType());
 
                     // Since all clip/cull semantics boil down to the same built-in type, we need to get the
                     // semantic ID from the dereferenced type's layout location, to avoid an N-1 mapping.
-                    const TType derefType((isOutput ? left : right)->getType(), member);
+                    const TType derefType((isOutput ? outterLeft : outterRight)->getType(), member);
                     const int semanticId = derefType.getQualifier().layoutLocation;
 
                     TIntermAggregate* clipCullAssign = assignClipCullDistance(loc, op, semanticId,
@@ -3190,7 +3189,7 @@ TIntermTyped* HlslParseContext::handleAssign(const TSourceLoc& loc, TOperator op
             }
         } else {
             // Member copy
-            assignList = intermediate.growAggregate(assignList, intermediate.addAssign(op, left, right, loc), loc);
+            assignList = intermediate.growAggregate(assignList, intermediate.addAssign(op, outterLeft, outterRight, loc), loc);
         }
 
     };
@@ -6345,13 +6344,13 @@ void HlslParseContext::handlePackOffset(const TSourceLoc& loc, TQualifier& quali
 //
 // Handle seeing something like "REGISTER LEFT_PAREN [shader_profile,] Type# RIGHT_PAREN"
 //
-// 'profile' points to the shader_profile part, or nullptr if not present.
+// 'shader_profile' points to the shader_profile part, or nullptr if not present.
 // 'desc' is the type# part.
 //
-void HlslParseContext::handleRegister(const TSourceLoc& loc, TQualifier& qualifier, const glslang::TString* profile,
+void HlslParseContext::handleRegister(const TSourceLoc& loc, TQualifier& qualifier, const glslang::TString* shader_profile,
                                       const glslang::TString& desc, int subComponent, const glslang::TString* spaceDesc)
 {
-    if (profile != nullptr)
+    if (shader_profile != nullptr)
         warn(loc, "ignoring shader_profile", "register", "");
 
     if (desc.size() < 1) {
@@ -7729,9 +7728,9 @@ const TFunction* HlslParseContext::findFunction(const TSourceLoc& loc, TFunction
     // printf has var args and is in the symbol table as "printf()",
     // mangled to "printf("
     if (call.getName() == "printf") {
-        TSymbol* symbol = symbolTable.find("printf(", &builtIn);
-        if (symbol)
-            return symbol->getAsFunction();
+        TSymbol* print_symbol = symbolTable.find("printf(", &builtIn);
+        if (print_symbol)
+            return print_symbol->getAsFunction();
     }
 
     bestMatch = selectFunction(candidateList, call, convertible, better, tie);

--- a/glslang/HLSL/hlslScanContext.cpp
+++ b/glslang/HLSL/hlslScanContext.cpp
@@ -559,17 +559,17 @@ glslang::TBuiltInVariable HlslScanContext::mapSemantic(const char* upperCase)
 // Returns the enum value of the token class of the next token found.
 // Return 0 (EndOfTokens) on end of input.
 //
-EHlslTokenClass HlslScanContext::tokenizeClass(HlslToken& token)
+EHlslTokenClass HlslScanContext::tokenizeClass(HlslToken& in_token)
 {
     do {
-        parserToken = &token;
-        TPpToken ppToken;
-        int token = ppContext.tokenize(ppToken);
+        parserToken = &in_token;
+        TPpToken local_ppToken;
+        int token = ppContext.tokenize(local_ppToken);
         if (token == EndOfInput)
             return EHTokNone;
 
-        tokenText = ppToken.name;
-        loc = ppToken.loc;
+        tokenText = local_ppToken.name;
+        loc = local_ppToken.loc;
         parserToken->loc = loc;
         switch (token) {
         case ';':                       return EHTokSemicolon;
@@ -629,15 +629,14 @@ EHlslTokenClass HlslScanContext::tokenizeClass(HlslToken& token)
 
         case PpAtomColonColon:         return EHTokColonColon;
 
-        case PpAtomConstInt:           parserToken->i = ppToken.ival;       return EHTokIntConstant;
-        case PpAtomConstUint:          parserToken->i = ppToken.ival;       return EHTokUintConstant;
-        case PpAtomConstFloat16:       parserToken->d = ppToken.dval;       return EHTokFloat16Constant;
-        case PpAtomConstFloat:         parserToken->d = ppToken.dval;       return EHTokFloatConstant;
-        case PpAtomConstDouble:        parserToken->d = ppToken.dval;       return EHTokDoubleConstant;
+        case PpAtomConstInt:           parserToken->i = local_ppToken.ival;       return EHTokIntConstant;
+        case PpAtomConstUint:          parserToken->i = local_ppToken.ival;       return EHTokUintConstant;
+        case PpAtomConstFloat16:       parserToken->d = local_ppToken.dval;       return EHTokFloat16Constant;
+        case PpAtomConstFloat:         parserToken->d = local_ppToken.dval;       return EHTokFloatConstant;
+        case PpAtomConstDouble:        parserToken->d = local_ppToken.dval;       return EHTokDoubleConstant;
         case PpAtomIdentifier:
         {
-            EHlslTokenClass token = tokenizeIdentifier();
-            return token;
+            return tokenizeIdentifier();
         }
 
         case PpAtomConstString: {

--- a/glslang/HLSL/hlslScanContext.h
+++ b/glslang/HLSL/hlslScanContext.h
@@ -73,8 +73,8 @@ struct HlslToken {
 //
 class HlslScanContext {
 public:
-    HlslScanContext(TParseContextBase& parseContext, TPpContext& ppContext)
-        : parseContext(parseContext), ppContext(ppContext) { }
+    HlslScanContext(TParseContextBase& in_parseContext, TPpContext& in_ppContext)
+        : parseContext(in_parseContext), ppContext(in_ppContext) { }
     virtual ~HlslScanContext() { }
 
     static void fillInKeywordMap();

--- a/glslang/HLSL/hlslTokenStream.h
+++ b/glslang/HLSL/hlslTokenStream.h
@@ -42,8 +42,8 @@ namespace glslang {
 
     class HlslTokenStream {
     public:
-        explicit HlslTokenStream(HlslScanContext& scanner)
-            : scanner(scanner), preTokenStackSize(0), tokenBufferPos(0) { }
+        explicit HlslTokenStream(HlslScanContext& in_scanner)
+            : scanner(in_scanner), preTokenStackSize(0), tokenBufferPos(0) { }
         virtual ~HlslTokenStream() { }
 
     public:

--- a/glslang/Include/PoolAlloc.h
+++ b/glslang/Include/PoolAlloc.h
@@ -74,8 +74,8 @@ namespace glslang {
 
 class TAllocation {
 public:
-    TAllocation(size_t size, unsigned char* mem, TAllocation* prev = nullptr) :
-        size(size), mem(mem), prevAlloc(prev) {
+    TAllocation(size_t in_size, unsigned char* in_mem, TAllocation* prev = nullptr) :
+        size(in_size), mem(in_mem), prevAlloc(prev) {
         // Allocations are bracketed:
         //    [allocationHeader][initialGuardBlock][userData][finalGuardBlock]
         // This would be cleaner with if (guardBlockSize)..., but that
@@ -192,11 +192,11 @@ protected:
     friend struct tHeader;
 
     struct tHeader {
-        tHeader(tHeader* nextPage, size_t pageCount) :
+        tHeader(tHeader* in_nextPage, size_t in_pageCount) :
 #ifdef GUARD_BLOCKS
         lastAllocation(nullptr),
 #endif
-        nextPage(nextPage), pageCount(pageCount) { }
+        nextPage(in_nextPage), pageCount(in_pageCount) { }
 
         ~tHeader() {
 #ifdef GUARD_BLOCKS

--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -1628,10 +1628,10 @@ public:
                                 }
                             }
     // for construction of sampler types
-    TType(const TSampler& sampler, TStorageQualifier q = EvqUniform, TArraySizes* as = nullptr) :
+    TType(const TSampler& in_sampler, TStorageQualifier q = EvqUniform, TArraySizes* as = nullptr) :
         basicType(EbtSampler), vectorSize(1u), matrixCols(0u), matrixRows(0u), vector1(false), coopmatNV(false), coopmatKHR(false), coopmatKHRuse(0), coopmatKHRUseValid(false),
         arraySizes(as), structure(nullptr), fieldName(nullptr), typeName(nullptr),
-        sampler(sampler), typeParameters(nullptr), spirvType(nullptr)
+        sampler(in_sampler), typeParameters(nullptr), spirvType(nullptr)
     {
         qualifier.clear();
         qualifier.storage = q;

--- a/glslang/Include/intermediate.h
+++ b/glslang/Include/intermediate.h
@@ -1738,8 +1738,8 @@ public:
         TIntermTyped(EbtVoid), condition(cond), trueBlock(trueB), falseBlock(falseB),
         shortCircuit(true),
         flatten(false), dontFlatten(false) {}
-    TIntermSelection(TIntermTyped* cond, TIntermNode* trueB, TIntermNode* falseB, const TType& type) :
-        TIntermTyped(type), condition(cond), trueBlock(trueB), falseBlock(falseB),
+    TIntermSelection(TIntermTyped* cond, TIntermNode* trueB, TIntermNode* falseB, const TType& in_type) :
+        TIntermTyped(in_type), condition(cond), trueBlock(trueB), falseBlock(falseB),
         shortCircuit(true),
         flatten(false), dontFlatten(false) {}
     virtual void traverse(TIntermTraverser*);
@@ -1828,11 +1828,11 @@ enum TVisit
 class TIntermTraverser {
 public:
     POOL_ALLOCATOR_NEW_DELETE(glslang::GetThreadPoolAllocator())
-    TIntermTraverser(bool preVisit = true, bool inVisit = false, bool postVisit = false, bool rightToLeft = false) :
-            preVisit(preVisit),
-            inVisit(inVisit),
-            postVisit(postVisit),
-            rightToLeft(rightToLeft),
+    TIntermTraverser(bool in_preVisit = true, bool in_inVisit = false, bool in_postVisit = false, bool in_rightToLeft = false) :
+            preVisit(in_preVisit),
+            inVisit(in_inVisit),
+            postVisit(in_postVisit),
+            rightToLeft(in_rightToLeft),
             depth(0),
             maxDepth(0) { }
     virtual ~TIntermTraverser() { }

--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -2831,7 +2831,7 @@ bool TIntermediate::postProcess(TIntermNode* root, EShLanguage /*language*/)
     return true;
 }
 
-void TIntermediate::addSymbolLinkageNodes(TIntermAggregate*& linkage, EShLanguage language, TSymbolTable& symbolTable)
+void TIntermediate::addSymbolLinkageNodes(TIntermAggregate*& linkage, EShLanguage in_language, TSymbolTable& symbolTable)
 {
     // Add top-level nodes for declarations that must be checked cross
     // compilation unit by a linker, yet might not have been referenced
@@ -2854,7 +2854,7 @@ void TIntermediate::addSymbolLinkageNodes(TIntermAggregate*& linkage, EShLanguag
     //    addSymbolLinkageNode(root, symbolTable, "gl_ModelViewProjectionMatrix");
     //}
 
-    if (language == EShLangVertex) {
+    if (in_language == EShLangVertex) {
         addSymbolLinkageNode(linkage, symbolTable, "gl_VertexID");
         if ((version < 140 && requestedExtensions.find(E_GL_EXT_draw_instanced) != requestedExtensions.end()) || version >= 140)
             addSymbolLinkageNode(linkage, symbolTable, "gl_InstanceID");
@@ -3802,7 +3802,7 @@ bool TIntermediate::promoteAggregate(TIntermAggregate& node)
 
         // If we successfully converted all the args, use the result.
         if (std::all_of(convertedArgs.begin(), convertedArgs.end(),
-                        [](const TIntermNode* node) { return node != nullptr; })) {
+                        [](const TIntermNode* in_node) { return in_node != nullptr; })) {
 
             std::swap(args, convertedArgs);
             return true;

--- a/glslang/MachineIndependent/LiveTraverser.h
+++ b/glslang/MachineIndependent/LiveTraverser.h
@@ -58,10 +58,10 @@ namespace glslang {
 
 class TLiveTraverser : public TIntermTraverser {
 public:
-    TLiveTraverser(const TIntermediate& i, bool traverseAll = false,
-                   bool preVisit = true, bool inVisit = false, bool postVisit = false) :
-        TIntermTraverser(preVisit, inVisit, postVisit),
-        intermediate(i), traverseAll(traverseAll)
+    TLiveTraverser(const TIntermediate& i, bool in_traverseAll = false,
+                   bool in_preVisit = true, bool in_inVisit = false, bool in_postVisit = false) :
+        TIntermTraverser(in_preVisit, in_inVisit, in_postVisit),
+        intermediate(i), traverseAll(in_traverseAll)
     { }
 
     //

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -50,12 +50,12 @@ extern int yyparse(glslang::TParseContext*);
 
 namespace glslang {
 
-TParseContext::TParseContext(TSymbolTable& in_symbolTable, TIntermediate& interm, bool parsingBuiltins,
-                             int version, EProfile profile, const SpvVersion& spvVersion, EShLanguage language,
-                             TInfoSink& infoSink, bool forwardCompatible, EShMessages messages,
+TParseContext::TParseContext(TSymbolTable& in_symbolTable, TIntermediate& interm, bool in_parsingBuiltins,
+                             int in_version, EProfile in_profile, const SpvVersion& in_spvVersion, EShLanguage in_language,
+                             TInfoSink& in_infoSink, bool in_forwardCompatible, EShMessages in_messages,
                              const TString* entryPoint) :
-            TParseContextBase(in_symbolTable, interm, parsingBuiltins, version, profile, spvVersion, language,
-                              infoSink, forwardCompatible, messages, entryPoint),
+            TParseContextBase(in_symbolTable, interm, in_parsingBuiltins, in_version, in_profile, in_spvVersion, in_language,
+                              in_infoSink, in_forwardCompatible, in_messages, entryPoint),
             inMain(false),
             blockName(nullptr),
             limits(resources.limits),

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -50,11 +50,11 @@ extern int yyparse(glslang::TParseContext*);
 
 namespace glslang {
 
-TParseContext::TParseContext(TSymbolTable& symbolTable, TIntermediate& interm, bool parsingBuiltins,
+TParseContext::TParseContext(TSymbolTable& in_symbolTable, TIntermediate& interm, bool parsingBuiltins,
                              int version, EProfile profile, const SpvVersion& spvVersion, EShLanguage language,
                              TInfoSink& infoSink, bool forwardCompatible, EShMessages messages,
                              const TString* entryPoint) :
-            TParseContextBase(symbolTable, interm, parsingBuiltins, version, profile, spvVersion, language,
+            TParseContextBase(in_symbolTable, interm, parsingBuiltins, version, profile, spvVersion, language,
                               infoSink, forwardCompatible, messages, entryPoint),
             inMain(false),
             blockName(nullptr),
@@ -190,10 +190,10 @@ void TParseContext::setLimits(const TBuiltInResource& r)
 //
 // Returns true for successful acceptance of the shader, false if any errors.
 //
-bool TParseContext::parseShaderStrings(TPpContext& ppContext, TInputScanner& input, bool versionWillBeError)
+bool TParseContext::parseShaderStrings(TPpContext& context, TInputScanner& input, bool versionWillBeError)
 {
     currentScanner = &input;
-    ppContext.setInput(input, versionWillBeError);
+    context.setInput(input, versionWillBeError);
     yyparse(this);
 
     finish();
@@ -4989,17 +4989,17 @@ TSymbol* TParseContext::redeclareBuiltinVariable(const TSourceLoc& loc, const TS
 // Either redeclare the requested block, or give an error message why it can't be done.
 //
 // TODO: functionality: explicitly sizing members of redeclared blocks is not giving them an explicit size
-void TParseContext::redeclareBuiltinBlock(const TSourceLoc& loc, TTypeList& newTypeList, const TString& blockName,
+void TParseContext::redeclareBuiltinBlock(const TSourceLoc& loc, TTypeList& newTypeList, const TString& blockNameToRedeclare,
     const TString* instanceName, TArraySizes* arraySizes)
 {
     const char* feature = "built-in block redeclaration";
     profileRequires(loc, EEsProfile, 320, Num_AEP_shader_io_blocks, AEP_shader_io_blocks, feature);
     profileRequires(loc, ~EEsProfile, 410, E_GL_ARB_separate_shader_objects, feature);
 
-    if (blockName != "gl_PerVertex" && blockName != "gl_PerFragment" &&
-        blockName != "gl_MeshPerVertexNV" && blockName != "gl_MeshPerPrimitiveNV" &&
-        blockName != "gl_MeshPerVertexEXT" && blockName != "gl_MeshPerPrimitiveEXT") {
-        error(loc, "cannot redeclare block: ", "block declaration", blockName.c_str());
+    if (blockNameToRedeclare != "gl_PerVertex" && blockNameToRedeclare != "gl_PerFragment" &&
+        blockNameToRedeclare != "gl_MeshPerVertexNV" && blockNameToRedeclare != "gl_MeshPerPrimitiveNV" &&
+        blockNameToRedeclare != "gl_MeshPerVertexEXT" && blockNameToRedeclare != "gl_MeshPerPrimitiveEXT") {
+        error(loc, "cannot redeclare block: ", "block declaration", blockNameToRedeclare.c_str());
         return;
     }
 
@@ -5029,7 +5029,7 @@ void TParseContext::redeclareBuiltinBlock(const TSourceLoc& loc, TTypeList& newT
     // Built-in blocks cannot be redeclared more than once, which if happened,
     // we'd be finding the already redeclared one here, rather than the built in.
     if (! builtIn) {
-        error(loc, "can only redeclare a built-in block once, and before any use", blockName.c_str(), "");
+        error(loc, "can only redeclare a built-in block once, and before any use", blockNameToRedeclare.c_str(), "");
         return;
     }
 
@@ -5172,10 +5172,10 @@ void TParseContext::redeclareBuiltinBlock(const TSourceLoc& loc, TTypeList& newT
     }
 
     if (numOriginalMembersFound < newTypeList.size())
-        error(loc, "block redeclaration has extra members", blockName.c_str(), "");
+        error(loc, "block redeclaration has extra members", blockNameToRedeclare.c_str(), "");
     if (type.isArray() != (arraySizes != nullptr) ||
         (type.isArray() && arraySizes != nullptr && type.getArraySizes()->getNumDims() != arraySizes->getNumDims()))
-        error(loc, "cannot change arrayness of redeclared block", blockName.c_str(), "");
+        error(loc, "cannot change arrayness of redeclared block", blockNameToRedeclare.c_str(), "");
     else if (type.isArray()) {
         // At this point, we know both are arrays and both have the same number of dimensions.
 
@@ -5190,7 +5190,7 @@ void TParseContext::redeclareBuiltinBlock(const TSourceLoc& loc, TTypeList& newT
 
         // Now, they must match in all dimensions.
         if (type.isSizedArray() && *type.getArraySizes() != *arraySizes)
-            error(loc, "cannot change array size of redeclared block", blockName.c_str(), "");
+            error(loc, "cannot change array size of redeclared block", blockNameToRedeclare.c_str(), "");
     }
 
     symbolTable.insert(*block);

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -5950,10 +5950,10 @@ void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publi
 // This is before we know any type information for error checking.
 void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publicType, TString& id, const TIntermTyped* node)
 {
-    const char* feature = "layout-id value";
+    const char* literalFeature = "layout-id value";
     const char* nonLiteralFeature = "non-literal layout-id value";
 
-    integerCheck(node, feature);
+    integerCheck(node, literalFeature);
     const TIntermConstantUnion* constUnion = node->getAsConstantUnion();
     int value;
     bool nonLiteral = false;
@@ -5970,7 +5970,7 @@ void TParseContext::setLayoutQualifier(const TSourceLoc& loc, TPublicType& publi
     }
 
     if (value < 0) {
-        error(loc, "cannot be negative", feature, "");
+        error(loc, "cannot be negative", literalFeature, "");
         return;
     }
 
@@ -8404,8 +8404,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
     case EOpConstructUVec2:
         if (node->getType().getBasicType() == EbtReference) {
             requireExtensions(loc, 1, &E_GL_EXT_buffer_reference_uvec2, "reference conversion to uvec2");
-            TIntermTyped* newNode = intermediate.addBuiltInFunctionCall(node->getLoc(), EOpConvPtrToUvec2, true, node,
-                type);
+            newNode = intermediate.addBuiltInFunctionCall(node->getLoc(), EOpConvPtrToUvec2, true, node, type);
             return newNode;
         } else if (node->getType().getBasicType() == EbtSampler) {
             requireExtensions(loc, 1, &E_GL_ARB_bindless_texture, "sampler conversion to uvec2");
@@ -8414,8 +8413,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
             TIntermTyped* newSrcNode = intermediate.createConversion(EbtUint, node);
             newSrcNode->getAsTyped()->getWritableType().setVectorSize(2);
 
-            TIntermTyped* newNode =
-                intermediate.addBuiltInFunctionCall(node->getLoc(), EOpConstructUVec2, false, newSrcNode, type);
+            newNode = intermediate.addBuiltInFunctionCall(node->getLoc(), EOpConstructUVec2, false, newSrcNode, type);
             return newNode;
         }
     case EOpConstructUVec3:
@@ -8435,8 +8433,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
             node->getType().getVectorSize() == 2) {
             requireExtensions(loc, 1, &E_GL_ARB_bindless_texture, "ivec2/uvec2 convert to texture handle");
             // No matter ivec2 or uvec2, Set EOpPackUint2x32 just to generate an opBitcast op code
-            TIntermTyped* newNode =
-                intermediate.addBuiltInFunctionCall(node->getLoc(), EOpPackUint2x32, true, node, type);
+            newNode = intermediate.addBuiltInFunctionCall(node->getLoc(), EOpPackUint2x32, true, node, type);
             return newNode;
         }
     case EOpConstructDVec2:
@@ -8588,7 +8585,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
 
     case EOpConstructUint64:
         if (type.isScalar() && node->getType().isReference()) {
-            TIntermTyped* newNode = intermediate.addBuiltInFunctionCall(node->getLoc(), EOpConvPtrToUint64, true, node, type);
+            newNode = intermediate.addBuiltInFunctionCall(node->getLoc(), EOpConvPtrToUint64, true, node, type);
             return newNode;
         }
         // fall through
@@ -8610,14 +8607,14 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
             return newNode;
         // construct reference from uint64
         } else if (node->getType().isScalar() && node->getType().getBasicType() == EbtUint64) {
-            TIntermTyped* newNode = intermediate.addBuiltInFunctionCall(node->getLoc(), EOpConvUint64ToPtr, true, node,
+            newNode = intermediate.addBuiltInFunctionCall(node->getLoc(), EOpConvUint64ToPtr, true, node,
                 type);
             return newNode;
         // construct reference from uvec2
         } else if (node->getType().isVector() && node->getType().getBasicType() == EbtUint &&
                    node->getVectorSize() == 2) {
             requireExtensions(loc, 1, &E_GL_EXT_buffer_reference_uvec2, "uvec2 conversion to reference");
-            TIntermTyped* newNode = intermediate.addBuiltInFunctionCall(node->getLoc(), EOpConvUvec2ToPtr, true, node,
+            newNode = intermediate.addBuiltInFunctionCall(node->getLoc(), EOpConvUvec2ToPtr, true, node,
                 type);
             return newNode;
         } else {
@@ -8637,113 +8634,113 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
             }
             node = intermediate.setAggregateOperator(node, op, type, node->getLoc());
         } else {
-            TOperator op = EOpNull;
+            TOperator convOp = EOpNull;
             switch (type.getBasicType()) {
             default:
                 assert(0);
                 break;
             case EbtInt:
                 switch (node->getType().getBasicType()) {
-                    case EbtFloat:   op = EOpConvFloatToInt;    break;
-                    case EbtFloat16: op = EOpConvFloat16ToInt;  break;
-                    case EbtUint8:   op = EOpConvUint8ToInt;    break;
-                    case EbtInt8:    op = EOpConvInt8ToInt;     break;
-                    case EbtUint16:  op = EOpConvUint16ToInt;   break;
-                    case EbtInt16:   op = EOpConvInt16ToInt;    break;
-                    case EbtUint:    op = EOpConvUintToInt;     break;
+                    case EbtFloat:   convOp = EOpConvFloatToInt;    break;
+                    case EbtFloat16: convOp = EOpConvFloat16ToInt;  break;
+                    case EbtUint8:   convOp = EOpConvUint8ToInt;    break;
+                    case EbtInt8:    convOp = EOpConvInt8ToInt;     break;
+                    case EbtUint16:  convOp = EOpConvUint16ToInt;   break;
+                    case EbtInt16:   convOp = EOpConvInt16ToInt;    break;
+                    case EbtUint:    convOp = EOpConvUintToInt;     break;
                     default: assert(0);
                 }
                 break;
             case EbtUint:
                 switch (node->getType().getBasicType()) {
-                    case EbtFloat:   op = EOpConvFloatToUint;    break;
-                    case EbtFloat16: op = EOpConvFloat16ToUint;  break;
-                    case EbtUint8:   op = EOpConvUint8ToUint;    break;
-                    case EbtInt8:    op = EOpConvInt8ToUint;     break;
-                    case EbtUint16:  op = EOpConvUint16ToUint;   break;
-                    case EbtInt16:   op = EOpConvInt16ToUint;    break;
-                    case EbtInt:     op = EOpConvIntToUint;      break;
+                    case EbtFloat:   convOp = EOpConvFloatToUint;    break;
+                    case EbtFloat16: convOp = EOpConvFloat16ToUint;  break;
+                    case EbtUint8:   convOp = EOpConvUint8ToUint;    break;
+                    case EbtInt8:    convOp = EOpConvInt8ToUint;     break;
+                    case EbtUint16:  convOp = EOpConvUint16ToUint;   break;
+                    case EbtInt16:   convOp = EOpConvInt16ToUint;    break;
+                    case EbtInt:     convOp = EOpConvIntToUint;      break;
                     default: assert(0);
                 }
                 break;
             case EbtInt16:
                 switch (node->getType().getBasicType()) {
-                    case EbtFloat:   op = EOpConvFloatToInt16;    break;
-                    case EbtFloat16: op = EOpConvFloat16ToInt16;  break;
-                    case EbtUint8:   op = EOpConvUint8ToInt16;    break;
-                    case EbtInt8:    op = EOpConvInt8ToInt16;     break;
-                    case EbtUint16:  op = EOpConvUint16ToInt16;   break;
-                    case EbtInt:     op = EOpConvIntToInt16;      break;
-                    case EbtUint:    op = EOpConvUintToInt16;     break;
+                    case EbtFloat:   convOp = EOpConvFloatToInt16;    break;
+                    case EbtFloat16: convOp = EOpConvFloat16ToInt16;  break;
+                    case EbtUint8:   convOp = EOpConvUint8ToInt16;    break;
+                    case EbtInt8:    convOp = EOpConvInt8ToInt16;     break;
+                    case EbtUint16:  convOp = EOpConvUint16ToInt16;   break;
+                    case EbtInt:     convOp = EOpConvIntToInt16;      break;
+                    case EbtUint:    convOp = EOpConvUintToInt16;     break;
                     default: assert(0);
                 }
                 break;
             case EbtUint16:
                 switch (node->getType().getBasicType()) {
-                    case EbtFloat:   op = EOpConvFloatToUint16;   break;
-                    case EbtFloat16: op = EOpConvFloat16ToUint16; break;
-                    case EbtUint8:   op = EOpConvUint8ToUint16;   break;
-                    case EbtInt8:    op = EOpConvInt8ToUint16;    break;
-                    case EbtInt16:   op = EOpConvInt16ToUint16;   break;
-                    case EbtInt:     op = EOpConvIntToUint16;     break;
-                    case EbtUint:    op = EOpConvUintToUint16;    break;
+                    case EbtFloat:   convOp = EOpConvFloatToUint16;   break;
+                    case EbtFloat16: convOp = EOpConvFloat16ToUint16; break;
+                    case EbtUint8:   convOp = EOpConvUint8ToUint16;   break;
+                    case EbtInt8:    convOp = EOpConvInt8ToUint16;    break;
+                    case EbtInt16:   convOp = EOpConvInt16ToUint16;   break;
+                    case EbtInt:     convOp = EOpConvIntToUint16;     break;
+                    case EbtUint:    convOp = EOpConvUintToUint16;    break;
                     default: assert(0);
                 }
                 break;
             case EbtInt8:
                 switch (node->getType().getBasicType()) {
-                    case EbtFloat:   op = EOpConvFloatToInt8;    break;
-                    case EbtFloat16: op = EOpConvFloat16ToInt8;  break;
-                    case EbtUint8:   op = EOpConvUint8ToInt8;    break;
-                    case EbtInt16:   op = EOpConvInt16ToInt8;    break;
-                    case EbtUint16:  op = EOpConvUint16ToInt8;   break;
-                    case EbtInt:     op = EOpConvIntToInt8;      break;
-                    case EbtUint:    op = EOpConvUintToInt8;     break;
+                    case EbtFloat:   convOp = EOpConvFloatToInt8;    break;
+                    case EbtFloat16: convOp = EOpConvFloat16ToInt8;  break;
+                    case EbtUint8:   convOp = EOpConvUint8ToInt8;    break;
+                    case EbtInt16:   convOp = EOpConvInt16ToInt8;    break;
+                    case EbtUint16:  convOp = EOpConvUint16ToInt8;   break;
+                    case EbtInt:     convOp = EOpConvIntToInt8;      break;
+                    case EbtUint:    convOp = EOpConvUintToInt8;     break;
                     default: assert(0);
                 }
                 break;
             case EbtUint8:
                 switch (node->getType().getBasicType()) {
-                    case EbtFloat:   op = EOpConvFloatToUint8;   break;
-                    case EbtFloat16: op = EOpConvFloat16ToUint8; break;
-                    case EbtInt8:    op = EOpConvInt8ToUint8;    break;
-                    case EbtInt16:   op = EOpConvInt16ToUint8;   break;
-                    case EbtUint16:  op = EOpConvUint16ToUint8;  break;
-                    case EbtInt:     op = EOpConvIntToUint8;     break;
-                    case EbtUint:    op = EOpConvUintToUint8;    break;
+                    case EbtFloat:   convOp = EOpConvFloatToUint8;   break;
+                    case EbtFloat16: convOp = EOpConvFloat16ToUint8; break;
+                    case EbtInt8:    convOp = EOpConvInt8ToUint8;    break;
+                    case EbtInt16:   convOp = EOpConvInt16ToUint8;   break;
+                    case EbtUint16:  convOp = EOpConvUint16ToUint8;  break;
+                    case EbtInt:     convOp = EOpConvIntToUint8;     break;
+                    case EbtUint:    convOp = EOpConvUintToUint8;    break;
                     default: assert(0);
                 }
                 break;
             case EbtFloat:
                 switch (node->getType().getBasicType()) {
-                    case EbtFloat16: op = EOpConvFloat16ToFloat;  break;
-                    case EbtInt8:    op = EOpConvInt8ToFloat;     break;
-                    case EbtUint8:   op = EOpConvUint8ToFloat;    break;
-                    case EbtInt16:   op = EOpConvInt16ToFloat;    break;
-                    case EbtUint16:  op = EOpConvUint16ToFloat;   break;
-                    case EbtInt:     op = EOpConvIntToFloat;      break;
-                    case EbtUint:    op = EOpConvUintToFloat;     break;
+                    case EbtFloat16: convOp = EOpConvFloat16ToFloat;  break;
+                    case EbtInt8:    convOp = EOpConvInt8ToFloat;     break;
+                    case EbtUint8:   convOp = EOpConvUint8ToFloat;    break;
+                    case EbtInt16:   convOp = EOpConvInt16ToFloat;    break;
+                    case EbtUint16:  convOp = EOpConvUint16ToFloat;   break;
+                    case EbtInt:     convOp = EOpConvIntToFloat;      break;
+                    case EbtUint:    convOp = EOpConvUintToFloat;     break;
                     default: assert(0);
                 }
                 break;
             case EbtFloat16:
                 switch (node->getType().getBasicType()) {
-                    case EbtFloat:  op = EOpConvFloatToFloat16;  break;
-                    case EbtInt8:   op = EOpConvInt8ToFloat16;   break;
-                    case EbtUint8:  op = EOpConvUint8ToFloat16;  break;
-                    case EbtInt16:  op = EOpConvInt16ToFloat16;   break;
-                    case EbtUint16: op = EOpConvUint16ToFloat16;  break;
-                    case EbtInt:    op = EOpConvIntToFloat16;    break;
-                    case EbtUint:   op = EOpConvUintToFloat16;   break;
+                    case EbtFloat:  convOp = EOpConvFloatToFloat16;  break;
+                    case EbtInt8:   convOp = EOpConvInt8ToFloat16;   break;
+                    case EbtUint8:  convOp = EOpConvUint8ToFloat16;  break;
+                    case EbtInt16:  convOp = EOpConvInt16ToFloat16;   break;
+                    case EbtUint16: convOp = EOpConvUint16ToFloat16;  break;
+                    case EbtInt:    convOp = EOpConvIntToFloat16;    break;
+                    case EbtUint:   convOp = EOpConvUintToFloat16;   break;
                     default: assert(0);
                 }
                 break;
             }
 
-            node = intermediate.addUnaryNode(op, node, node->getLoc(), type);
+            node = intermediate.addUnaryNode(convOp, node, node->getLoc(), type);
             // If it's a (non-specialization) constant, it must be folded.
             if (node->getAsUnaryNode()->getOperand()->getAsConstantUnion())
-                return node->getAsUnaryNode()->getOperand()->getAsConstantUnion()->fold(op, node->getType());
+                return node->getAsUnaryNode()->getOperand()->getAsConstantUnion()->fold(convOp, node->getType());
         }
 
         return node;

--- a/glslang/MachineIndependent/ParseHelper.h
+++ b/glslang/MachineIndependent/ParseHelper.h
@@ -76,19 +76,19 @@ typedef std::map<const TTypeList*, std::map<size_t, const TTypeList*>> TStructRe
 //
 class TParseContextBase : public TParseVersions {
 public:
-    TParseContextBase(TSymbolTable& symbolTable, TIntermediate& interm, bool parsingBuiltins, int version,
-                      EProfile profile, const SpvVersion& spvVersion, EShLanguage language,
-                      TInfoSink& infoSink, bool forwardCompatible, EShMessages messages,
+    TParseContextBase(TSymbolTable& in_symbolTable, TIntermediate& interm, bool in_parsingBuiltins, int in_version,
+                      EProfile in_profile, const SpvVersion& in_spvVersion, EShLanguage in_language,
+                      TInfoSink& in_infoSink, bool in_forwardCompatible, EShMessages in_messages,
                       const TString* entryPoint = nullptr)
-          : TParseVersions(interm, version, profile, spvVersion, language, infoSink, forwardCompatible, messages),
+          : TParseVersions(interm, in_version, in_profile, in_spvVersion, in_language, in_infoSink, in_forwardCompatible, in_messages),
             scopeMangler("::"),
-            symbolTable(symbolTable),
+            symbolTable(in_symbolTable),
             statementNestingLevel(0), loopNestingLevel(0), structNestingLevel(0), blockNestingLevel(0), controlFlowNestingLevel(0),
             currentFunctionType(nullptr),
             postEntryPointReturn(false),
             contextPragma(true, false),
             beginInvocationInterlockCount(0), endInvocationInterlockCount(0),
-            parsingBuiltins(parsingBuiltins), scanContext(nullptr), ppContext(nullptr),
+            parsingBuiltins(in_parsingBuiltins), scanContext(nullptr), ppContext(nullptr),
             limits(resources.limits),
             globalUniformBlock(nullptr),
             globalUniformBinding(TQualifier::layoutBindingEnd),
@@ -136,10 +136,10 @@ public:
 
     virtual bool parseShaderStrings(TPpContext&, TInputScanner& input, bool versionWillBeError = false) = 0;
 
-    virtual void notifyVersion(int line, int version, const char* type_string)
+    virtual void notifyVersion(int line, int in_version, const char* type_string)
     {
         if (versionCallback)
-            versionCallback(line, version, type_string);
+            versionCallback(line, in_version, type_string);
     }
     virtual void notifyErrorDirective(int line, const char* error_message)
     {

--- a/glslang/MachineIndependent/Scan.cpp
+++ b/glslang/MachineIndependent/Scan.cpp
@@ -821,17 +821,17 @@ void TScanContext::deleteKeywordMap()
 
 // Called by yylex to get the next token.
 // Returning 0 implies end of input.
-int TScanContext::tokenize(TPpContext* pp, TParserToken& token)
+int TScanContext::tokenize(TPpContext* pp, TParserToken& in_token)
 {
     do {
-        parserToken = &token;
-        TPpToken ppToken;
-        int token = pp->tokenize(ppToken);
+        parserToken = &in_token;
+        TPpToken local_ppToken;
+        int token = pp->tokenize(local_ppToken);
         if (token == EndOfInput)
             return 0;
 
-        tokenText = ppToken.name;
-        loc = ppToken.loc;
+        tokenText = local_ppToken.name;
+        loc = local_ppToken.loc;
         parserToken->sType.lex.loc = loc;
         switch (token) {
         case ';':  afterType = false; afterBuffer = false; return SEMICOLON;
@@ -894,20 +894,20 @@ int TScanContext::tokenize(TPpContext* pp, TParserToken& token)
             break;
 
         case PpAtomConstString:        parserToken->sType.lex.string = NewPoolTString(tokenText);     return STRING_LITERAL;
-        case PpAtomConstInt:           parserToken->sType.lex.i    = ppToken.ival;       return INTCONSTANT;
-        case PpAtomConstUint:          parserToken->sType.lex.i    = ppToken.ival;       return UINTCONSTANT;
-        case PpAtomConstFloat:         parserToken->sType.lex.d    = ppToken.dval;       return FLOATCONSTANT;
-        case PpAtomConstInt16:         parserToken->sType.lex.i    = ppToken.ival;       return INT16CONSTANT;
-        case PpAtomConstUint16:        parserToken->sType.lex.i    = ppToken.ival;       return UINT16CONSTANT;
-        case PpAtomConstInt64:         parserToken->sType.lex.i64  = ppToken.i64val;     return INT64CONSTANT;
-        case PpAtomConstUint64:        parserToken->sType.lex.i64  = ppToken.i64val;     return UINT64CONSTANT;
-        case PpAtomConstDouble:        parserToken->sType.lex.d    = ppToken.dval;       return DOUBLECONSTANT;
-        case PpAtomConstFloat16:       parserToken->sType.lex.d    = ppToken.dval;       return FLOAT16CONSTANT;
+        case PpAtomConstInt:           parserToken->sType.lex.i    = local_ppToken.ival;       return INTCONSTANT;
+        case PpAtomConstUint:          parserToken->sType.lex.i    = local_ppToken.ival;       return UINTCONSTANT;
+        case PpAtomConstFloat:         parserToken->sType.lex.d    = local_ppToken.dval;       return FLOATCONSTANT;
+        case PpAtomConstInt16:         parserToken->sType.lex.i    = local_ppToken.ival;       return INT16CONSTANT;
+        case PpAtomConstUint16:        parserToken->sType.lex.i    = local_ppToken.ival;       return UINT16CONSTANT;
+        case PpAtomConstInt64:         parserToken->sType.lex.i64  = local_ppToken.i64val;     return INT64CONSTANT;
+        case PpAtomConstUint64:        parserToken->sType.lex.i64  = local_ppToken.i64val;     return UINT64CONSTANT;
+        case PpAtomConstDouble:        parserToken->sType.lex.d    = local_ppToken.dval;       return DOUBLECONSTANT;
+        case PpAtomConstFloat16:       parserToken->sType.lex.d    = local_ppToken.dval;       return FLOAT16CONSTANT;
         case PpAtomIdentifier:
         {
-            int token = tokenizeIdentifier();
+            int tokenIdent = tokenizeIdentifier();
             field = false;
-            return token;
+            return tokenIdent;
         }
 
         case EndOfInput:               return 0;

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -996,8 +996,8 @@ bool ProcessDeferred(
 class SourceLineSynchronizer {
 public:
     SourceLineSynchronizer(const std::function<int()>& lastSourceIndex,
-                           std::string* output)
-      : getLastSourceIndex(lastSourceIndex), output(output), lastSource(-1), lastLine(0) {}
+                           std::string* in_output)
+      : getLastSourceIndex(lastSourceIndex), output(in_output), lastSource(-1), lastLine(0) {}
 //    SourceLineSynchronizer(const SourceLineSynchronizer&) = delete;
 //    SourceLineSynchronizer& operator=(const SourceLineSynchronizer&) = delete;
 

--- a/glslang/MachineIndependent/SymbolTable.h
+++ b/glslang/MachineIndependent/SymbolTable.h
@@ -153,8 +153,8 @@ protected:
 //
 class TVariable : public TSymbol {
 public:
-    TVariable(const TString *name, const TType& t, bool uT = false )
-        : TSymbol(name),
+    TVariable(const TString *in_name, const TType& t, bool uT = false )
+        : TSymbol(in_name),
           userType(uT),
           constSubtree(nullptr),
           memberExtensions(nullptr),
@@ -242,9 +242,9 @@ public:
         TSymbol(nullptr),
         op(o),
         defined(false), prototyped(false), implicitThis(false), illegalImplicitThis(false), defaultParamCount(0) { }
-    TFunction(const TString *name, const TType& retType, TOperator tOp = EOpNull) :
-        TSymbol(name),
-        mangledName(*name + '('),
+    TFunction(const TString *in_name, const TType& retType, TOperator tOp = EOpNull) :
+        TSymbol(in_name),
+        mangledName(*in_name + '('),
         op(tOp),
         defined(false), prototyped(false), implicitThis(false), illegalImplicitThis(false), defaultParamCount(0),
         linkType(ELinkNone)
@@ -273,9 +273,9 @@ public:
 
     // Install 'this' as the first parameter.
     // 'this' is reflected in the list of parameters, but not the mangled name.
-    virtual void addThisParameter(TType& type, const char* name)
+    virtual void addThisParameter(TType& type, const char* in_name)
     {
-        TParameter p = { NewPoolTString(name), new TType, nullptr };
+        TParameter p = { NewPoolTString(in_name), new TType, nullptr };
         p.type->shallowCopy(type);
         parameters.insert(parameters.begin(), p);
     }

--- a/glslang/MachineIndependent/Versions.cpp
+++ b/glslang/MachineIndependent/Versions.cpp
@@ -1391,9 +1391,9 @@ void TParseVersions::requireSpv(const TSourceLoc& loc, const char* op)
     if (spvVersion.spv == 0)
         error(loc, "only allowed when generating SPIR-V", op, "");
 }
-void TParseVersions::requireSpv(const TSourceLoc& loc, const char *op, unsigned int version)
+void TParseVersions::requireSpv(const TSourceLoc& loc, const char *op, unsigned int in_version)
 {
-    if (spvVersion.spv < version)
+    if (spvVersion.spv < in_version)
         error(loc, "not supported for current targeted SPIR-V version", op, "");
 }
 

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -62,11 +62,11 @@ namespace glslang {
 
 class TVarGatherTraverser : public TLiveTraverser {
 public:
-    TVarGatherTraverser(const TIntermediate& i, bool traverseDeadCode, TVarLiveMap& inList, TVarLiveMap& outList, TVarLiveMap& uniformList)
+    TVarGatherTraverser(const TIntermediate& i, bool traverseDeadCode, TVarLiveMap& inList, TVarLiveMap& outList, TVarLiveMap& in_uniformList)
       : TLiveTraverser(i, traverseDeadCode, true, true, false)
       , inputList(inList)
       , outputList(outList)
-      , uniformList(uniformList)
+      , uniformList(in_uniformList)
     {
     }
 
@@ -105,11 +105,11 @@ private:
 class TVarSetTraverser : public TLiveTraverser
 {
 public:
-    TVarSetTraverser(const TIntermediate& i, const TVarLiveMap& inList, const TVarLiveMap& outList, const TVarLiveMap& uniformList)
+    TVarSetTraverser(const TIntermediate& i, const TVarLiveMap& inList, const TVarLiveMap& outList, const TVarLiveMap& in_uniformList)
       : TLiveTraverser(i, true, true, true, false)
       , inputList(inList)
       , outputList(outList)
-      , uniformList(uniformList)
+      , uniformList(in_uniformList)
     {
     }
 
@@ -313,13 +313,13 @@ private:
 
 struct TSymbolValidater
 {
-    TSymbolValidater(TIoMapResolver& r, TInfoSink& i, TVarLiveMap* in[EShLangCount], TVarLiveMap* out[EShLangCount],
-                     TVarLiveMap* uniform[EShLangCount], bool& hadError, EProfile profile, int version)
-        : resolver(r)
-        , infoSink(i)
-        , hadError(hadError)
-        , profile(profile)
-        , version(version)
+    TSymbolValidater(TIoMapResolver& in_resolver, TInfoSink& in_infoSink, TVarLiveMap* in[EShLangCount], TVarLiveMap* out[EShLangCount],
+                     TVarLiveMap* uniform[EShLangCount], bool& in_hadError, EProfile in_profile, int in_version)
+        : resolver(in_resolver)
+        , infoSink(in_infoSink)
+        , hadError(in_hadError)
+        , profile(in_profile)
+        , version(in_version)
     {
         memcpy(inVarMaps, in, EShLangCount * (sizeof(TVarLiveMap*)));
         memcpy(outVarMaps, out, EShLangCount * (sizeof(TVarLiveMap*)));
@@ -511,17 +511,17 @@ struct TSymbolValidater
                         if (type1.getBasicType() == EbtBlock &&
                             type1.isStruct() && !type2.isStruct()) {
                             // Iterate through block members tracking layout
-                            glslang::TString name;
-                            type1.getStruct()->begin()->type->appendMangledName(name);
-                            if (name == mangleName2
+                            glslang::TString mangledName;
+                            type1.getStruct()->begin()->type->appendMangledName(mangledName);
+                            if (mangledName == mangleName2
                                 && type1.getQualifier().layoutLocation == type2.getQualifier().layoutLocation) return;
                         }
                         if (type2.getBasicType() == EbtBlock &&
                             type2.isStruct() && !type1.isStruct()) {
                             // Iterate through block members tracking layout
-                            glslang::TString name;
-                            type2.getStruct()->begin()->type->appendMangledName(name);
-                            if (name == mangleName1
+                            glslang::TString mangledName;
+                            type2.getStruct()->begin()->type->appendMangledName(mangledName);
+                            if (mangledName == mangleName1
                                 && type1.getQualifier().layoutLocation == type2.getQualifier().layoutLocation) return;
                         }
                         TString err = "Invalid In/Out variable type : " + entKey.first;

--- a/glslang/MachineIndependent/limits.cpp
+++ b/glslang/MachineIndependent/limits.cpp
@@ -129,9 +129,9 @@ bool TInductiveTraverser::visitAggregate(TVisit /* visit */, TIntermAggregate* n
 //
 // External function to call for loop check.
 //
-void TParseContext::inductiveLoopBodyCheck(TIntermNode* body, long long loopId, TSymbolTable& symbolTable)
+void TParseContext::inductiveLoopBodyCheck(TIntermNode* body, long long loopId, TSymbolTable& in_symbolTable)
 {
-    TInductiveTraverser it(loopId, symbolTable);
+    TInductiveTraverser it(loopId, in_symbolTable);
 
     if (body == nullptr)
         return;

--- a/glslang/MachineIndependent/linkValidate.cpp
+++ b/glslang/MachineIndependent/linkValidate.cpp
@@ -391,7 +391,7 @@ static const TString& getNameForIdMap(TIntermSymbol* symbol)
 // on having no bodies for the copy-constructor/operator=.)
 class TBuiltInIdTraverser : public TIntermTraverser {
 public:
-    TBuiltInIdTraverser(TIdMaps& idMaps) : idMaps(idMaps), idShift(0) { }
+    TBuiltInIdTraverser(TIdMaps& in_idMaps) : idMaps(in_idMaps), idShift(0) { }
     // If it's a built in, add it to the map.
     virtual void visitSymbol(TIntermSymbol* symbol)
     {
@@ -417,7 +417,7 @@ protected:
 // on having no bodies for the copy-constructor/operator=.)
 class TUserIdTraverser : public TIntermTraverser {
 public:
-    TUserIdTraverser(TIdMaps& idMaps) : idMaps(idMaps) { }
+    TUserIdTraverser(TIdMaps& in_idMaps) : idMaps(in_idMaps) { }
     // If its a non-built-in global, add it to the map.
     virtual void visitSymbol(TIntermSymbol* symbol)
     {
@@ -452,7 +452,7 @@ void TIntermediate::seedIdMap(TIdMaps& idMaps, long long& idShift)
 // on having no bodies for the copy-constructor/operator=.)
 class TRemapIdTraverser : public TIntermTraverser {
 public:
-    TRemapIdTraverser(const TIdMaps& idMaps, long long idShift) : idMaps(idMaps), idShift(idShift) { }
+    TRemapIdTraverser(const TIdMaps& in_idMaps, long long in_idShift) : idMaps(in_idMaps), idShift(in_idShift) { }
     // Do the mapping:
     //  - if the same symbol, adopt the 'this' ID
     //  - otherwise, ensure a unique ID by shifting to a new space
@@ -634,9 +634,9 @@ void TIntermediate::mergeBlockDefinitions(TInfoSink& infoSink, TIntermSymbol* bl
             : newSymbol(newSym), newType(nullptr), unit(nullptr), memberIndexUpdates(nullptr)
         {
         }
-        TMergeBlockTraverser(const TIntermSymbol* newSym, const glslang::TType* unitType, glslang::TIntermediate* unit,
+        TMergeBlockTraverser(const TIntermSymbol* newSym, const glslang::TType* unitType, glslang::TIntermediate* in_unit,
                              const std::map<unsigned int, unsigned int>* memberIdxUpdates)
-            : TIntermTraverser(false, true), newSymbol(newSym), newType(unitType), unit(unit), memberIndexUpdates(memberIdxUpdates)
+            : TIntermTraverser(false, true), newSymbol(newSym), newType(unitType), unit(in_unit), memberIndexUpdates(memberIdxUpdates)
         {
         }
         virtual ~TMergeBlockTraverser() {}

--- a/glslang/MachineIndependent/localintermediate.h
+++ b/glslang/MachineIndependent/localintermediate.h
@@ -110,7 +110,7 @@ struct TCall {
 
 // A generic 1-D range.
 struct TRange {
-    TRange(int start, int last) : start(start), last(last) { }
+    TRange(int in_start, int in_last) : start(in_start), last(in_last) { }
     bool overlap(const TRange& rhs) const
     {
         return last >= rhs.start && start <= rhs.last;
@@ -123,8 +123,8 @@ struct TRange {
 // within the same location range, component range, and index value.  Locations don't alias unless
 // all other dimensions of their range overlap.
 struct TIoRange {
-    TIoRange(TRange location, TRange component, TBasicType basicType, int index)
-        : location(location), component(component), basicType(basicType), index(index) { }
+    TIoRange(TRange in_location, TRange in_component, TBasicType in_basicType, int in_index)
+        : location(in_location), component(in_component), basicType(in_basicType), index(in_index) { }
     bool overlap(const TIoRange& rhs) const
     {
         return location.overlap(rhs.location) && component.overlap(rhs.component) && index == rhs.index;
@@ -138,8 +138,8 @@ struct TIoRange {
 // An offset range is a 2-D rectangle; the set of (binding, offset) pairs all lying
 // within the same binding and offset range.
 struct TOffsetRange {
-    TOffsetRange(TRange binding, TRange offset)
-        : binding(binding), offset(offset) { }
+    TOffsetRange(TRange in_binding, TRange in_offset)
+        : binding(in_binding), offset(in_offset) { }
     bool overlap(const TOffsetRange& rhs) const
     {
         return binding.overlap(rhs.binding) && offset.overlap(rhs.offset);

--- a/glslang/MachineIndependent/parseVersions.h
+++ b/glslang/MachineIndependent/parseVersions.h
@@ -54,16 +54,16 @@ namespace glslang {
 //
 class TParseVersions {
 public:
-    TParseVersions(TIntermediate& interm, int version, EProfile profile,
-                   const SpvVersion& spvVersion, EShLanguage language, TInfoSink& infoSink,
-                   bool forwardCompatible, EShMessages messages)
+    TParseVersions(TIntermediate& interm, int in_version, EProfile in_profile,
+                   const SpvVersion& in_spvVersion, EShLanguage in_language, TInfoSink& in_infoSink,
+                   bool in_forwardCompatible, EShMessages in_messages)
         :
-        forwardCompatible(forwardCompatible),
-        profile(profile),
-        infoSink(infoSink), version(version), 
-        language(language),
-        spvVersion(spvVersion), 
-        intermediate(interm), messages(messages), numErrors(0), currentScanner(nullptr) { }
+        forwardCompatible(in_forwardCompatible),
+        profile(in_profile),
+        infoSink(in_infoSink), version(in_version), 
+        language(in_language),
+        spvVersion(in_spvVersion), 
+        intermediate(interm), messages(in_messages), numErrors(0), currentScanner(nullptr) { }
     virtual ~TParseVersions() { }
     void requireStage(const TSourceLoc&, EShLanguageMask, const char* featureDesc);
     void requireStage(const TSourceLoc&, EShLanguage, const char* featureDesc);

--- a/glslang/MachineIndependent/preprocessor/PpContext.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpContext.cpp
@@ -84,9 +84,9 @@ NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace glslang {
 
-TPpContext::TPpContext(TParseContextBase& pc, const std::string& rootFileName, TShader::Includer& inclr) :
+TPpContext::TPpContext(TParseContextBase& pc, const std::string& in_rootFileName, TShader::Includer& inclr) :
     preamble(nullptr), strings(nullptr), previous_token('\n'), parseContext(pc), includer(inclr), inComment(false),
-    rootFileName(rootFileName),
+    rootFileName(in_rootFileName),
     currentSourceFile(rootFileName),
     disableEscapeSequences(false)
 {

--- a/glslang/MachineIndependent/preprocessor/PpContext.h
+++ b/glslang/MachineIndependent/preprocessor/PpContext.h
@@ -251,8 +251,8 @@ public:
         // of a TPpToken, plus its atom.
         class Token {
         public:
-            Token(int atom, const TPpToken& ppToken) : 
-                atom(atom),
+            Token(int in_atom, const TPpToken& ppToken) :
+                atom(in_atom),
                 space(ppToken.space),
                 i64val(ppToken.i64val),
                 name(ppToken.name) { }
@@ -416,7 +416,7 @@ protected:
 
     class tMacroInput : public tInput {
     public:
-        tMacroInput(TPpContext* pp) : tInput(pp), prepaste(false), postpaste(false) { }
+        tMacroInput(TPpContext* in_pp) : tInput(in_pp), prepaste(false), postpaste(false) { }
         virtual ~tMacroInput()
         {
             for (size_t i = 0; i < args.size(); ++i)
@@ -444,7 +444,7 @@ protected:
 
     class tMarkerInput : public tInput {
     public:
-        tMarkerInput(TPpContext* pp) : tInput(pp) { }
+        tMarkerInput(TPpContext* in_pp) : tInput(in_pp) { }
         virtual int scan(TPpToken*) override
         {
             if (done)
@@ -460,7 +460,7 @@ protected:
 
     class tZeroInput : public tInput {
     public:
-        tZeroInput(TPpContext* pp) : tInput(pp) { }
+        tZeroInput(TPpContext* in_pp) : tInput(in_pp) { }
         virtual int scan(TPpToken*) override;
         virtual int getch() override { assert(0); return EndOfInput; }
         virtual void ungetch() override { assert(0); }
@@ -504,8 +504,8 @@ protected:
 
     class tTokenInput : public tInput {
     public:
-        tTokenInput(TPpContext* pp, TokenStream* t, bool prepasting, bool expanded) :
-            tInput(pp),
+        tTokenInput(TPpContext* in_pp, TokenStream* t, bool prepasting, bool expanded) :
+            tInput(in_pp),
             tokens(t),
             lastTokenPastes(prepasting),
             preExpanded(expanded) { }
@@ -532,7 +532,7 @@ protected:
 
     class tUngotTokenInput : public tInput {
     public:
-        tUngotTokenInput(TPpContext* pp, int t, TPpToken* p) : tInput(pp), token(t), lval(*p) { }
+        tUngotTokenInput(TPpContext* in_pp, int t, TPpToken* p) : tInput(in_pp), token(t), lval(*p) { }
         virtual int scan(TPpToken *) override;
         virtual int getch() override { assert(0); return EndOfInput; }
         virtual void ungetch() override { assert(0); }

--- a/glslang/MachineIndependent/preprocessor/PpContext.h
+++ b/glslang/MachineIndependent/preprocessor/PpContext.h
@@ -546,7 +546,7 @@ protected:
     //
     class tStringInput : public tInput {
     public:
-        tStringInput(TPpContext* pp, TInputScanner& i) : tInput(pp), input(&i) { }
+        tStringInput(TPpContext* in_pp, TInputScanner& i) : tInput(in_pp), input(&i) { }
         virtual int scan(TPpToken*) override;
         bool isStringInput() override { return true; }
         // Scanner used to get source stream characters.
@@ -631,8 +631,8 @@ protected:
                           const std::string& prologue,
                           TShader::Includer::IncludeResult* includedFile,
                           const std::string& epilogue,
-                          TPpContext* pp)
-            : tInput(pp),
+                          TPpContext* in_pp)
+            : tInput(in_pp),
               prologue_(prologue),
               epilogue_(epilogue),
               includedFile_(includedFile),

--- a/glslang/MachineIndependent/preprocessor/PpScanner.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpScanner.cpp
@@ -112,9 +112,9 @@ namespace glslang {
 // See peekContinuedPasting().
 int TPpContext::lFloatConst(int len, int ch, TPpToken* ppToken)
 {
-    const auto saveName = [&](int ch) {
+    const auto saveName = [&](int c) {
         if (len <= MaxTokenLength)
-            ppToken->name[len++] = static_cast<char>(ch);
+            ppToken->name[len++] = static_cast<char>(c);
     };
 
     // find the range of non-zero digits before the decimal point
@@ -461,9 +461,9 @@ int TPpContext::tStringInput::scan(TPpToken* ppToken)
     int ch = 0;
     int ii = 0;
     unsigned long long ival = 0;
-    const auto floatingPointChar = [&](int ch) { return ch == '.' || ch == 'e' || ch == 'E' ||
-                                                                     ch == 'f' || ch == 'F' ||
-                                                                     ch == 'h' || ch == 'H'; };
+    const auto floatingPointChar = [&](int c) { return c == '.' || c == 'e' || c == 'E' ||
+                                                                     c == 'f' || c == 'F' ||
+                                                                     c == 'h' || c == 'H'; };
 
     static const char* const Int64_Extensions[] = {
         E_GL_ARB_gpu_shader_int64,

--- a/glslang/MachineIndependent/reflection.cpp
+++ b/glslang/MachineIndependent/reflection.cpp
@@ -1176,8 +1176,8 @@ bool TReflection::addStage(EShLanguage stage, const TIntermediate& intermediate)
             if (sequnence->getAsAggregate()->getOp() == glslang::EOpLinkerObjects) {
                 it.updateStageMasks = false;
                 TIntermAggregate* linkerObjects = sequnence->getAsAggregate();
-                for (auto& sequnence : linkerObjects->getSequence()) {
-                    auto pNode = sequnence->getAsSymbolNode();
+                for (auto& inner_sequnence : linkerObjects->getSequence()) {
+                    auto pNode = inner_sequnence->getAsSymbolNode();
                     if (pNode != nullptr) {
                         if ((pNode->getQualifier().storage == EvqUniform &&
                             (options & EShReflectionSharedStd140UBO)) ||

--- a/glslang/Public/ShaderLang.h
+++ b/glslang/Public/ShaderLang.h
@@ -591,8 +591,8 @@ public:
         // An IncludeResult contains the resolved name and content of a source
         // inclusion.
         struct IncludeResult {
-            IncludeResult(const std::string& headerName, const char* const headerData, const size_t headerLength, void* userData) :
-                headerName(headerName), headerData(headerData), headerLength(headerLength), userData(userData) { }
+            IncludeResult(const std::string& in_headerName, const char* const in_headerData, const size_t in_headerLength, void* in_userData) :
+                headerName(in_headerName), headerData(in_headerData), headerLength(in_headerLength), userData(in_userData) { }
             // For a successful inclusion, the fully resolved name of the requested
             // include.  For example, in a file system-based includer, full resolution
             // should convert a relative path name into an absolute path name.

--- a/gtests/GlslMapIO.FromFile.cpp
+++ b/gtests/GlslMapIO.FromFile.cpp
@@ -302,12 +302,12 @@ TEST_P(GlslMapIOTest, FromFile)
     result.validationResult = success;
 
     if (success && (controls & EShMsgSpvRules)) {
-        for (int stage = 0; stage < EShLangCount; ++stage) {
-            if (program.getIntermediate((EShLanguage)stage)) {
+        for (int inner_stage = 0; inner_stage < EShLangCount; ++inner_stage) {
+            if (program.getIntermediate((EShLanguage)inner_stage)) {
                 spv::SpvBuildLogger logger;
                 std::vector<uint32_t> spirv_binary;
                 options().disableOptimizer = false;
-                glslang::GlslangToSpv(*program.getIntermediate((EShLanguage)stage),
+                glslang::GlslangToSpv(*program.getIntermediate((EShLanguage)inner_stage),
                     spirv_binary, &logger, &options());
 
                 std::ostringstream disassembly_stream;

--- a/gtests/VkRelaxed.FromFile.cpp
+++ b/gtests/VkRelaxed.FromFile.cpp
@@ -255,12 +255,12 @@ TEST_P(VulkanRelaxedTest, FromFile)
     result.validationResult = success;
 
     if (success && (controls & EShMsgSpvRules)) {
-        for (int stage = 0; stage < EShLangCount; ++stage) {
+        for (int inner_stage = 0; inner_stage < EShLangCount; ++inner_stage) {
             if (program.getIntermediate((EShLanguage)stage)) {
                 spv::SpvBuildLogger logger;
                 std::vector<uint32_t> spirv_binary;
                 options().disableOptimizer = false;
-                glslang::GlslangToSpv(*program.getIntermediate((EShLanguage)stage),
+                glslang::GlslangToSpv(*program.getIntermediate((EShLanguage)inner_stage),
                     spirv_binary, &logger, &options());
 
                 std::ostringstream disassembly_stream;

--- a/gtests/VkRelaxed.FromFile.cpp
+++ b/gtests/VkRelaxed.FromFile.cpp
@@ -256,7 +256,7 @@ TEST_P(VulkanRelaxedTest, FromFile)
 
     if (success && (controls & EShMsgSpvRules)) {
         for (int inner_stage = 0; inner_stage < EShLangCount; ++inner_stage) {
-            if (program.getIntermediate((EShLanguage)stage)) {
+            if (program.getIntermediate((EShLanguage)inner_stage)) {
                 spv::SpvBuildLogger logger;
                 std::vector<uint32_t> spirv_binary;
                 options().disableOptimizer = false;


### PR DESCRIPTION
A revival of https://github.com/KhronosGroup/glslang/pull/3143, but not on Robert's VulkanSceneGraph-specific branch with extra CMake changes. I've applied the same approach of prefixing names as found in that PR for my extra commits, even though it's not my favourite approach stylistically for avoiding this problem. I don't know if it

Updated for the current state of the codebase so it'll apply cleanly.

I think I found a bug in `SPIRV/GlslangToSpv.cpp`, that would have been prevented had this warning been enabled, and it looks like Robert found an equivalent a year ago, too. It's in a separate commit, and someone should probably check it.

I've not actually enabled `-Wshadow` for the project, and that might be something that's wanted.