### PR TITLE
Remove implicit fallthrough

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -8320,7 +8320,7 @@ spv::Id TGlslangToSpvTraverser::createSubgroupOperation(glslang::TOperator op, s
     case glslang::EOpSubgroupQuadAny:
         builder.addExtension(spv::E_SPV_KHR_quad_control);
         builder.addCapability(spv::CapabilityQuadControlKHR);
-        // pass through
+        [[fallthrough]];
     case glslang::EOpSubgroupAll:
     case glslang::EOpSubgroupAny:
     case glslang::EOpSubgroupAllEqual:

--- a/SPIRV/SpvPostProcess.cpp
+++ b/SPIRV/SpvPostProcess.cpp
@@ -181,6 +181,7 @@ void Builder::postProcessType(const Instruction& inst, Id typeId)
             else if (width == 8)
                 addCapability(CapabilityInt8);
         }
+        break;
     default:
         if (basicTypeOp == OpTypeInt) {
             if (width == 16)

--- a/glslang/MachineIndependent/Intermediate.cpp
+++ b/glslang/MachineIndependent/Intermediate.cpp
@@ -1277,6 +1277,7 @@ void TIntermediate::addBiShapeConversion(TOperator op, TIntermTyped*& lhsNode, T
         // matrix multiply does not change shapes
         if (lhsNode->isMatrix() && rhsNode->isMatrix())
             return;
+        [[fallthrough]];
     case EOpAdd:
     case EOpSub:
     case EOpDiv:

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -8418,6 +8418,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
                 intermediate.addBuiltInFunctionCall(node->getLoc(), EOpConstructUVec2, false, newSrcNode, type);
             return newNode;
         }
+        [[fallthrough]];
     case EOpConstructUVec3:
     case EOpConstructUVec4:
     case EOpConstructUint:
@@ -8439,6 +8440,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
                 intermediate.addBuiltInFunctionCall(node->getLoc(), EOpPackUint2x32, true, node, type);
             return newNode;
         }
+        [[fallthrough]];
     case EOpConstructDVec2:
     case EOpConstructDVec3:
     case EOpConstructDVec4:

--- a/glslang/MachineIndependent/reflection.cpp
+++ b/glslang/MachineIndependent/reflection.cpp
@@ -707,6 +707,7 @@ public:
                     switch ((int)sampler.shadow) {
                     case false: return sampler.arrayed ? GL_SAMPLER_1D_ARRAY : GL_SAMPLER_1D;
                     case true:  return sampler.arrayed ? GL_SAMPLER_1D_ARRAY_SHADOW : GL_SAMPLER_1D_SHADOW;
+                    default: assert(0);
                     }
                 case Esd2D:
                     switch ((int)sampler.ms) {
@@ -714,8 +715,10 @@ public:
                         switch ((int)sampler.shadow) {
                         case false: return sampler.arrayed ? GL_SAMPLER_2D_ARRAY : GL_SAMPLER_2D;
                         case true:  return sampler.arrayed ? GL_SAMPLER_2D_ARRAY_SHADOW : GL_SAMPLER_2D_SHADOW;
+                        default: assert(0);
                         }
                     case true:      return sampler.arrayed ? GL_SAMPLER_2D_MULTISAMPLE_ARRAY : GL_SAMPLER_2D_MULTISAMPLE;
+                    default: assert(0);
                     }
                 case Esd3D:
                     return GL_SAMPLER_3D;
@@ -723,11 +726,13 @@ public:
                     switch ((int)sampler.shadow) {
                     case false: return sampler.arrayed ? GL_SAMPLER_CUBE_MAP_ARRAY : GL_SAMPLER_CUBE;
                     case true:  return sampler.arrayed ? GL_SAMPLER_CUBE_MAP_ARRAY_SHADOW : GL_SAMPLER_CUBE_SHADOW;
+                    default: assert(0);
                     }
                 case EsdRect:
                     return sampler.shadow ? GL_SAMPLER_2D_RECT_SHADOW : GL_SAMPLER_2D_RECT;
                 case EsdBuffer:
                     return GL_SAMPLER_BUFFER;
+                default: assert(0);
                 }
             case EbtFloat16:
                 switch ((int)sampler.dim) {
@@ -735,6 +740,7 @@ public:
                     switch ((int)sampler.shadow) {
                     case false: return sampler.arrayed ? GL_FLOAT16_SAMPLER_1D_ARRAY_AMD : GL_FLOAT16_SAMPLER_1D_AMD;
                     case true:  return sampler.arrayed ? GL_FLOAT16_SAMPLER_1D_ARRAY_SHADOW_AMD : GL_FLOAT16_SAMPLER_1D_SHADOW_AMD;
+                    default: assert(0);
                     }
                 case Esd2D:
                     switch ((int)sampler.ms) {
@@ -742,8 +748,10 @@ public:
                         switch ((int)sampler.shadow) {
                         case false: return sampler.arrayed ? GL_FLOAT16_SAMPLER_2D_ARRAY_AMD : GL_FLOAT16_SAMPLER_2D_AMD;
                         case true:  return sampler.arrayed ? GL_FLOAT16_SAMPLER_2D_ARRAY_SHADOW_AMD : GL_FLOAT16_SAMPLER_2D_SHADOW_AMD;
+                        default: assert(0);
                         }
                     case true:      return sampler.arrayed ? GL_FLOAT16_SAMPLER_2D_MULTISAMPLE_ARRAY_AMD : GL_FLOAT16_SAMPLER_2D_MULTISAMPLE_AMD;
+                    default: assert(0);
                     }
                 case Esd3D:
                     return GL_FLOAT16_SAMPLER_3D_AMD;
@@ -751,11 +759,13 @@ public:
                     switch ((int)sampler.shadow) {
                     case false: return sampler.arrayed ? GL_FLOAT16_SAMPLER_CUBE_MAP_ARRAY_AMD : GL_FLOAT16_SAMPLER_CUBE_AMD;
                     case true:  return sampler.arrayed ? GL_FLOAT16_SAMPLER_CUBE_MAP_ARRAY_SHADOW_AMD : GL_FLOAT16_SAMPLER_CUBE_SHADOW_AMD;
+                    default: assert(0);
                     }
                 case EsdRect:
                     return sampler.shadow ? GL_FLOAT16_SAMPLER_2D_RECT_SHADOW_AMD : GL_FLOAT16_SAMPLER_2D_RECT_AMD;
                 case EsdBuffer:
                     return GL_FLOAT16_SAMPLER_BUFFER_AMD;
+                default: assert(0);
                 }
             case EbtInt:
                 switch ((int)sampler.dim) {
@@ -766,6 +776,7 @@ public:
                     case false:  return sampler.arrayed ? GL_INT_SAMPLER_2D_ARRAY : GL_INT_SAMPLER_2D;
                     case true:   return sampler.arrayed ? GL_INT_SAMPLER_2D_MULTISAMPLE_ARRAY
                                                         : GL_INT_SAMPLER_2D_MULTISAMPLE;
+                    default: assert(0);
                     }
                 case Esd3D:
                     return GL_INT_SAMPLER_3D;
@@ -775,6 +786,7 @@ public:
                     return GL_INT_SAMPLER_2D_RECT;
                 case EsdBuffer:
                     return GL_INT_SAMPLER_BUFFER;
+                default: assert(0);
                 }
             case EbtUint:
                 switch ((int)sampler.dim) {
@@ -785,6 +797,7 @@ public:
                     case false:  return sampler.arrayed ? GL_UNSIGNED_INT_SAMPLER_2D_ARRAY : GL_UNSIGNED_INT_SAMPLER_2D;
                     case true:   return sampler.arrayed ? GL_UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE_ARRAY
                                                         : GL_UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE;
+                    default: assert(0);
                     }
                 case Esd3D:
                     return GL_UNSIGNED_INT_SAMPLER_3D;
@@ -794,6 +807,7 @@ public:
                     return GL_UNSIGNED_INT_SAMPLER_2D_RECT;
                 case EsdBuffer:
                     return GL_UNSIGNED_INT_SAMPLER_BUFFER;
+                default: assert(0);
                 }
             default:
                 return 0;
@@ -809,6 +823,7 @@ public:
                     switch ((int)sampler.ms) {
                     case false:     return sampler.arrayed ? GL_IMAGE_2D_ARRAY : GL_IMAGE_2D;
                     case true:      return sampler.arrayed ? GL_IMAGE_2D_MULTISAMPLE_ARRAY : GL_IMAGE_2D_MULTISAMPLE;
+                    default: assert(0);
                     }
                 case Esd3D:
                     return GL_IMAGE_3D;
@@ -818,6 +833,7 @@ public:
                     return GL_IMAGE_2D_RECT;
                 case EsdBuffer:
                     return GL_IMAGE_BUFFER;
+                default: assert(0);
                 }
             case EbtFloat16:
                 switch ((int)sampler.dim) {
@@ -827,6 +843,7 @@ public:
                     switch ((int)sampler.ms) {
                     case false:     return sampler.arrayed ? GL_FLOAT16_IMAGE_2D_ARRAY_AMD : GL_FLOAT16_IMAGE_2D_AMD;
                     case true:      return sampler.arrayed ? GL_FLOAT16_IMAGE_2D_MULTISAMPLE_ARRAY_AMD : GL_FLOAT16_IMAGE_2D_MULTISAMPLE_AMD;
+                    default: assert(0);
                     }
                 case Esd3D:
                     return GL_FLOAT16_IMAGE_3D_AMD;
@@ -836,6 +853,7 @@ public:
                     return GL_FLOAT16_IMAGE_2D_RECT_AMD;
                 case EsdBuffer:
                     return GL_FLOAT16_IMAGE_BUFFER_AMD;
+                default: assert(0);
                 }
             case EbtInt:
                 switch ((int)sampler.dim) {
@@ -845,6 +863,7 @@ public:
                     switch ((int)sampler.ms) {
                     case false:  return sampler.arrayed ? GL_INT_IMAGE_2D_ARRAY : GL_INT_IMAGE_2D;
                     case true:   return sampler.arrayed ? GL_INT_IMAGE_2D_MULTISAMPLE_ARRAY : GL_INT_IMAGE_2D_MULTISAMPLE;
+                    default: assert(0);
                     }
                 case Esd3D:
                     return GL_INT_IMAGE_3D;
@@ -854,6 +873,7 @@ public:
                     return GL_INT_IMAGE_2D_RECT;
                 case EsdBuffer:
                     return GL_INT_IMAGE_BUFFER;
+                default: assert(0);
                 }
             case EbtUint:
                 switch ((int)sampler.dim) {
@@ -864,6 +884,7 @@ public:
                     case false:  return sampler.arrayed ? GL_UNSIGNED_INT_IMAGE_2D_ARRAY : GL_UNSIGNED_INT_IMAGE_2D;
                     case true:   return sampler.arrayed ? GL_UNSIGNED_INT_IMAGE_2D_MULTISAMPLE_ARRAY
                                                         : GL_UNSIGNED_INT_IMAGE_2D_MULTISAMPLE;
+                    default: assert(0);
                     }
                 case Esd3D:
                     return GL_UNSIGNED_INT_IMAGE_3D;
@@ -873,6 +894,7 @@ public:
                     return GL_UNSIGNED_INT_IMAGE_2D_RECT;
                 case EsdBuffer:
                     return GL_UNSIGNED_INT_IMAGE_BUFFER;
+                default: assert(0);
                 }
             default:
                 return 0;
@@ -937,6 +959,7 @@ public:
                     case 4:    return GL_FLOAT_MAT4;
                     default:   return 0;
                     }
+                default: assert(0);
                 }
             case EbtDouble:
                 switch (type.getMatrixCols()) {
@@ -961,6 +984,7 @@ public:
                     case 4:    return GL_DOUBLE_MAT4;
                     default:   return 0;
                     }
+                default: assert(0);
                 }
             case EbtFloat16:
                 switch (type.getMatrixCols()) {
@@ -985,6 +1009,7 @@ public:
                     case 4:    return GL_FLOAT16_MAT4_AMD;
                     default:   return 0;
                     }
+                default: assert(0);
                 }
             default:
                 return 0;


### PR DESCRIPTION
This is intended so that downstream projects consuming glslang with FetchContent or similar means can use `-Wimplicit-fallthrough` without getting warning spam.

I've used my best judgement to determine whether the implicit fallthrough was desired, or was simply unreachable code. `std::unreachable` is unavailable until C++23, but I saw places where `default: assert(0);` was used, so copied that. There were a few places where some code might actually have been reachable and intended to return a value that represented an error, so someone should double check that kind of thing.

I've run the tests, and get a single failure that also fails on main, so it doesn't look like I broke anything, but I don't know how exhaustive the tests are.

This doesn't enable `-Wimplicit-fallthrough`, but that might be desirable, and can be done in another commit.