### PR TITLE
Quote paths in runtest

### DIFF
--- a/Test/runtests
+++ b/Test/runtests
@@ -10,15 +10,15 @@ BASEDIR=baseResults
 EXE=${2:-../build/install/bin/glslang}
 REMAPEXE=${3:-../build/install/bin/spirv-remap}
 HASERROR=0
-mkdir -p $TARGETDIR
+mkdir -p "$TARGETDIR"
 
-LIBPATH="$(cd "$(dirname "$(dirname $EXE)")" && pwd)/lib"
+LIBPATH="$(cd "$(dirname "$(dirname "$EXE")")" && pwd)/lib"
 if [ -d "${LIBPATH}" ]; then
     export LD_LIBRARY_PATH="${LIBPATH}:${LD_LIBRARY_PATH}" 
 fi
 
 function run {
-    $EXE "$@"
+    "$EXE" "$@"
     result=$?
     case "$result" in
     [0-6]) # Valid success and error codes
@@ -35,8 +35,8 @@ if [ -a localtestlist ]
     while read t; do
         echo Running $t...
         b=`basename $t`
-        run -i -l $t > $TARGETDIR/$b.out
-        diff -b $BASEDIR/$b.out $TARGETDIR/$b.out || HASERROR=1
+        run -i -l $t > "$TARGETDIR/$b.out"
+        diff -b $BASEDIR/$b.out "$TARGETDIR/$b.out" || HASERROR=1
     done < localtestlist
 fi
 
@@ -46,64 +46,64 @@ rm -f comp.spv frag.spv geom.spv tesc.spv tese.spv vert.spv
 # special tests
 #
 
-run badMacroArgs.frag > $TARGETDIR/badMacroArgs.frag.out
-diff -b $BASEDIR/badMacroArgs.frag.out $TARGETDIR/badMacroArgs.frag.out || HASERROR=1
+run badMacroArgs.frag > "$TARGETDIR/badMacroArgs.frag.out"
+diff -b $BASEDIR/badMacroArgs.frag.out "$TARGETDIR/badMacroArgs.frag.out" || HASERROR=1
 
-run gl_samplemask_array_size.frag gl_MaxSamples_32.conf -i > $TARGETDIR/gl_samplemask_array_size_32.frag.out
-diff -b $BASEDIR/gl_samplemask_array_size_32.frag.out $TARGETDIR/gl_samplemask_array_size_32.frag.out || HASERROR=1
-run gl_samplemask_array_size.frag gl_MaxSamples_64.conf -i > $TARGETDIR/gl_samplemask_array_size_64.frag.out
-diff -b $BASEDIR/gl_samplemask_array_size_64.frag.out $TARGETDIR/gl_samplemask_array_size_64.frag.out || HASERROR=1
+run gl_samplemask_array_size.frag gl_MaxSamples_32.conf -i > "$TARGETDIR/gl_samplemask_array_size_32.frag.out"
+diff -b $BASEDIR/gl_samplemask_array_size_32.frag.out "$TARGETDIR/gl_samplemask_array_size_32.frag.out" || HASERROR=1
+run gl_samplemask_array_size.frag gl_MaxSamples_64.conf -i > "$TARGETDIR/gl_samplemask_array_size_64.frag.out"
+diff -b $BASEDIR/gl_samplemask_array_size_64.frag.out "$TARGETDIR/gl_samplemask_array_size_64.frag.out" || HASERROR=1
 #
 # reflection tests
 #
 echo Running reflection...
-run -l -q -C reflection.vert > $TARGETDIR/reflection.vert.out
-diff -b $BASEDIR/reflection.vert.out $TARGETDIR/reflection.vert.out || HASERROR=1
-run -l -q -C --reflect-strict-array-suffix --reflect-basic-array-suffix --reflect-intermediate-io --reflect-separate-buffers --reflect-all-block-variables --reflect-unwrap-io-blocks --reflect-all-io-variables --reflect-shared-std140-ubo --reflect-shared-std140-ssbo reflection.options.vert > $TARGETDIR/reflection.options.vert.out
-diff -b $BASEDIR/reflection.options.vert.out $TARGETDIR/reflection.options.vert.out || HASERROR=1
-run -l -q -C reflection.frag > $TARGETDIR/reflection.frag.out
-diff -b $BASEDIR/reflection.frag.out $TARGETDIR/reflection.frag.out || HASERROR=1
-run -l -q -C --reflect-strict-array-suffix --reflect-basic-array-suffix --reflect-intermediate-io --reflect-separate-buffers --reflect-all-block-variables --reflect-unwrap-io-blocks --reflect-all-io-variables --reflect-shared-std140-ubo --reflect-shared-std140-ssbo reflection.frag > $TARGETDIR/reflection.options.frag.out
-diff -b $BASEDIR/reflection.options.frag.out $TARGETDIR/reflection.options.frag.out || HASERROR=1
-run -l -q -C --reflect-strict-array-suffix --reflect-basic-array-suffix --reflect-intermediate-io --reflect-separate-buffers --reflect-all-block-variables --reflect-unwrap-io-blocks --reflect-all-io-variables --reflect-shared-std140-ubo --reflect-shared-std140-ssbo reflection.options.geom > $TARGETDIR/reflection.options.geom.out
-diff -b $BASEDIR/reflection.options.geom.out $TARGETDIR/reflection.options.geom.out || HASERROR=1
-run -l -q -C reflection.linked.vert reflection.linked.frag > $TARGETDIR/reflection.linked.out
-diff -b $BASEDIR/reflection.linked.out $TARGETDIR/reflection.linked.out || HASERROR=1
-run -l -q -C --reflect-strict-array-suffix --reflect-basic-array-suffix --reflect-intermediate-io --reflect-separate-buffers --reflect-all-block-variables --reflect-unwrap-io-blocks --reflect-all-io-variables --reflect-shared-std140-ubo --reflect-shared-std140-ssbo reflection.linked.vert reflection.linked.frag > $TARGETDIR/reflection.linked.options.out
-diff -b $BASEDIR/reflection.linked.options.out $TARGETDIR/reflection.linked.options.out || HASERROR=1
-run -D -Od -e flizv -l -q -C -V -Od hlsl.reflection.vert > $TARGETDIR/hlsl.reflection.vert.out
-diff -b $BASEDIR/hlsl.reflection.vert.out $TARGETDIR/hlsl.reflection.vert.out || HASERROR=1
-run -D -Od -e main -l -q -C -V -Od hlsl.reflection.binding.frag > $TARGETDIR/hlsl.reflection.binding.frag.out
-diff -b $BASEDIR/hlsl.reflection.binding.frag.out $TARGETDIR/hlsl.reflection.binding.frag.out || HASERROR=1
-run -D -Od -e main -l -q --hlsl-iomap --auto-map-bindings --stb 10 --sbb 20 --ssb 30 --suavb 40 --scb 50 -D -V -e main -Od hlsl.automap.frag > $TARGETDIR/hlsl.automap.frag.out
-diff -b $BASEDIR/hlsl.automap.frag.out $TARGETDIR/hlsl.automap.frag.out || HASERROR=1
+run -l -q -C reflection.vert > "$TARGETDIR/reflection.vert.out"
+diff -b $BASEDIR/reflection.vert.out "$TARGETDIR/reflection.vert.out" || HASERROR=1
+run -l -q -C --reflect-strict-array-suffix --reflect-basic-array-suffix --reflect-intermediate-io --reflect-separate-buffers --reflect-all-block-variables --reflect-unwrap-io-blocks --reflect-all-io-variables --reflect-shared-std140-ubo --reflect-shared-std140-ssbo reflection.options.vert > "$TARGETDIR/reflection.options.vert.out"
+diff -b $BASEDIR/reflection.options.vert.out "$TARGETDIR/reflection.options.vert.out" || HASERROR=1
+run -l -q -C reflection.frag > "$TARGETDIR/reflection.frag.out"
+diff -b $BASEDIR/reflection.frag.out "$TARGETDIR/reflection.frag.out" || HASERROR=1
+run -l -q -C --reflect-strict-array-suffix --reflect-basic-array-suffix --reflect-intermediate-io --reflect-separate-buffers --reflect-all-block-variables --reflect-unwrap-io-blocks --reflect-all-io-variables --reflect-shared-std140-ubo --reflect-shared-std140-ssbo reflection.frag > "$TARGETDIR/reflection.options.frag.out"
+diff -b $BASEDIR/reflection.options.frag.out "$TARGETDIR/reflection.options.frag.out" || HASERROR=1
+run -l -q -C --reflect-strict-array-suffix --reflect-basic-array-suffix --reflect-intermediate-io --reflect-separate-buffers --reflect-all-block-variables --reflect-unwrap-io-blocks --reflect-all-io-variables --reflect-shared-std140-ubo --reflect-shared-std140-ssbo reflection.options.geom > "$TARGETDIR/reflection.options.geom.out"
+diff -b $BASEDIR/reflection.options.geom.out "$TARGETDIR/reflection.options.geom.out" || HASERROR=1
+run -l -q -C reflection.linked.vert reflection.linked.frag > "$TARGETDIR/reflection.linked.out"
+diff -b $BASEDIR/reflection.linked.out "$TARGETDIR/reflection.linked.out" || HASERROR=1
+run -l -q -C --reflect-strict-array-suffix --reflect-basic-array-suffix --reflect-intermediate-io --reflect-separate-buffers --reflect-all-block-variables --reflect-unwrap-io-blocks --reflect-all-io-variables --reflect-shared-std140-ubo --reflect-shared-std140-ssbo reflection.linked.vert reflection.linked.frag > "$TARGETDIR/reflection.linked.options.out"
+diff -b $BASEDIR/reflection.linked.options.out "$TARGETDIR/reflection.linked.options.out" || HASERROR=1
+run -D -Od -e flizv -l -q -C -V -Od hlsl.reflection.vert > "$TARGETDIR/hlsl.reflection.vert.out"
+diff -b $BASEDIR/hlsl.reflection.vert.out "$TARGETDIR/hlsl.reflection.vert.out" || HASERROR=1
+run -D -Od -e main -l -q -C -V -Od hlsl.reflection.binding.frag > "$TARGETDIR/hlsl.reflection.binding.frag.out"
+diff -b $BASEDIR/hlsl.reflection.binding.frag.out "$TARGETDIR/hlsl.reflection.binding.frag.out" || HASERROR=1
+run -D -Od -e main -l -q --hlsl-iomap --auto-map-bindings --stb 10 --sbb 20 --ssb 30 --suavb 40 --scb 50 -D -V -e main -Od hlsl.automap.frag > "$TARGETDIR/hlsl.automap.frag.out"
+diff -b $BASEDIR/hlsl.automap.frag.out "$TARGETDIR/hlsl.automap.frag.out" || HASERROR=1
 
 #
 # multi-threaded test
 #
 echo Comparing single thread to multithread for all tests in current directory...
-run -i -C *.vert *.geom *.frag *.tesc *.tese *.comp > $TARGETDIR/singleThread.out
-run -i -C *.vert *.geom *.frag *.tesc *.tese *.comp -t > $TARGETDIR/multiThread.out
-diff $TARGETDIR/singleThread.out $TARGETDIR/multiThread.out || HASERROR=1
+run -i -C *.vert *.geom *.frag *.tesc *.tese *.comp > "$TARGETDIR/singleThread.out"
+run -i -C *.vert *.geom *.frag *.tesc *.tese *.comp -t > "$TARGETDIR/multiThread.out"
+diff "$TARGETDIR/singleThread.out" "$TARGETDIR/multiThread.out" || HASERROR=1
 if [ $HASERROR -eq 0 ]
 then
-    rm $TARGETDIR/singleThread.out
-    rm $TARGETDIR/multiThread.out
+    rm "$TARGETDIR/singleThread.out"
+    rm "$TARGETDIR/multiThread.out"
 fi
 
 #
 # entry point renaming tests
 #
 echo Running entry-point renaming tests
-run -i -H -V -D -Od --entry-point main_in_spv --ku --source-entrypoint main -Od hlsl.entry.rename.frag > $TARGETDIR/hlsl.entry.rename.frag.out
-diff -b $BASEDIR/hlsl.entry.rename.frag.out $TARGETDIR/hlsl.entry.rename.frag.out || HASERROR=1
+run -i -H -V -D -Od --entry-point main_in_spv --ku --source-entrypoint main -Od hlsl.entry.rename.frag > "$TARGETDIR/hlsl.entry.rename.frag.out"
+diff -b $BASEDIR/hlsl.entry.rename.frag.out "$TARGETDIR/hlsl.entry.rename.frag.out" || HASERROR=1
 
 #
 # Testing ill-defined uncalled function
 #
 echo Running ill-defined uncalled function
-run -D -Od -e main -H -Od hlsl.deadFunctionMissingBody.vert > $TARGETDIR/hlsl.deadFunctionMissingBody.vert.out
-diff -b $BASEDIR/hlsl.deadFunctionMissingBody.vert.out $TARGETDIR/hlsl.deadFunctionMissingBody.vert.out || HASERROR=1
+run -D -Od -e main -H -Od hlsl.deadFunctionMissingBody.vert > "$TARGETDIR/hlsl.deadFunctionMissingBody.vert.out"
+diff -b $BASEDIR/hlsl.deadFunctionMissingBody.vert.out "$TARGETDIR/hlsl.deadFunctionMissingBody.vert.out" || HASERROR=1
 
 if [ $HASERROR -eq 0 ]
 then
@@ -116,108 +116,108 @@ fi
 # Testing -S and compound suffixes
 #
 echo Running explicit stage test and compound suffix tests
-run -Od -i -S vert nosuffix > $TARGETDIR/nosuffix.out
-diff -b $BASEDIR/nosuffix.out $TARGETDIR/nosuffix.out || HASERROR=1
-run -Od -i compoundsuffix.vert.glsl > $TARGETDIR/compoundsuffix.vert.glsl
-diff -b $BASEDIR/compoundsuffix.vert.glsl $TARGETDIR/compoundsuffix.vert.glsl || HASERROR=1
-run -Od -e main -H compoundsuffix.frag.hlsl > $TARGETDIR/compoundsuffix.frag.hlsl
-diff -b $BASEDIR/compoundsuffix.frag.hlsl $TARGETDIR/compoundsuffix.frag.hlsl || HASERROR=1
+run -Od -i -S vert nosuffix > "$TARGETDIR/nosuffix.out"
+diff -b $BASEDIR/nosuffix.out "$TARGETDIR/nosuffix.out" || HASERROR=1
+run -Od -i compoundsuffix.vert.glsl > "$TARGETDIR/compoundsuffix.vert.glsl"
+diff -b $BASEDIR/compoundsuffix.vert.glsl "$TARGETDIR/compoundsuffix.vert.glsl" || HASERROR=1
+run -Od -e main -H compoundsuffix.frag.hlsl > "$TARGETDIR/compoundsuffix.frag.hlsl"
+diff -b $BASEDIR/compoundsuffix.frag.hlsl "$TARGETDIR/compoundsuffix.frag.hlsl" || HASERROR=1
 
 #
 # Testing --hlsl-offsets
 #
 echo Running hlsl offsets
-run -i --hlsl-offsets -H spv.hlslOffsets.vert > $TARGETDIR/spv.hlslOffsets.vert.out
-diff -b $BASEDIR/spv.hlslOffsets.vert.out $TARGETDIR/spv.hlslOffsets.vert.out || HASERROR=1
+run -i --hlsl-offsets -H spv.hlslOffsets.vert > "$TARGETDIR/spv.hlslOffsets.vert.out"
+diff -b $BASEDIR/spv.hlslOffsets.vert.out "$TARGETDIR/spv.hlslOffsets.vert.out" || HASERROR=1
 
 echo Running hlsl offsets
-run -i  --hlsl-offsets -D -Od -e main -H -Od hlsl.hlslOffset.vert > $TARGETDIR/hlsl.hlslOffset.vert.out
-diff -b $BASEDIR/hlsl.hlslOffset.vert.out $TARGETDIR/hlsl.hlslOffset.vert.out || HASERROR=1
+run -i  --hlsl-offsets -D -Od -e main -H -Od hlsl.hlslOffset.vert > "$TARGETDIR/hlsl.hlslOffset.vert.out"
+diff -b $BASEDIR/hlsl.hlslOffset.vert.out "$TARGETDIR/hlsl.hlslOffset.vert.out" || HASERROR=1
 
 #
 # Testing --resource-set-binding
 #
 echo Configuring HLSL descriptor set and binding number manually
-run -V -D -Od -e main -H -Od hlsl.multiDescriptorSet.frag --rsb frag t0 0 0 t1 1 0 s0 0 1 s1 1 1 b0 2 0 b1 2 1 b2 2 2 > $TARGETDIR/hlsl.multiDescriptorSet.frag.out
-diff -b $BASEDIR/hlsl.multiDescriptorSet.frag.out $TARGETDIR/hlsl.multiDescriptorSet.frag.out || HASERROR=1
+run -V -D -Od -e main -H -Od hlsl.multiDescriptorSet.frag --rsb frag t0 0 0 t1 1 0 s0 0 1 s1 1 1 b0 2 0 b1 2 1 b2 2 2 > "$TARGETDIR/hlsl.multiDescriptorSet.frag.out"
+diff -b $BASEDIR/hlsl.multiDescriptorSet.frag.out "$TARGETDIR/hlsl.multiDescriptorSet.frag.out" || HASERROR=1
 
-run -V -D -Od -e main -H -Od hlsl.explicitDescriptorSet.frag --hlsl-iomap --amb --ssb 10 --stb 20 --rsb 4 > $TARGETDIR/hlsl.explicitDescriptorSet.frag.out
-diff -b $BASEDIR/hlsl.explicitDescriptorSet.frag.out $TARGETDIR/hlsl.explicitDescriptorSet.frag.out || HASERROR=1
+run -V -D -Od -e main -H -Od hlsl.explicitDescriptorSet.frag --hlsl-iomap --amb --ssb 10 --stb 20 --rsb 4 > "$TARGETDIR/hlsl.explicitDescriptorSet.frag.out"
+diff -b $BASEDIR/hlsl.explicitDescriptorSet.frag.out "$TARGETDIR/hlsl.explicitDescriptorSet.frag.out" || HASERROR=1
 
-run -V -D -Od -e main -H -Od hlsl.explicitDescriptorSet.frag --hlsl-iomap --amb --ssb 10 --stb 20 --rsb frag 3 > $TARGETDIR/hlsl.explicitDescriptorSet-2.frag.out
-diff -b $BASEDIR/hlsl.explicitDescriptorSet-2.frag.out $TARGETDIR/hlsl.explicitDescriptorSet-2.frag.out || HASERROR=1
+run -V -D -Od -e main -H -Od hlsl.explicitDescriptorSet.frag --hlsl-iomap --amb --ssb 10 --stb 20 --rsb frag 3 > "$TARGETDIR/hlsl.explicitDescriptorSet-2.frag.out"
+diff -b $BASEDIR/hlsl.explicitDescriptorSet-2.frag.out "$TARGETDIR/hlsl.explicitDescriptorSet-2.frag.out" || HASERROR=1
 
 #
 # Testing per-descriptor-set IO map shift
 #
 echo 'Testing per-descriptor-set IO map shift'
-run -e main --hlsl-iomap --ssb 10 1 15 2 --stb 20 --stb 25 2 --stb 70 6 --suavb 30 --suavb 40 2 --sub 50 6 -i -q -D -Od -V hlsl.shift.per-set.frag > $TARGETDIR/hlsl.shift.per-set.frag.out || HASERROR=1
-diff -b $BASEDIR/hlsl.shift.per-set.frag.out $TARGETDIR/hlsl.shift.per-set.frag.out || HASERROR=1
+run -e main --hlsl-iomap --ssb 10 1 15 2 --stb 20 --stb 25 2 --stb 70 6 --suavb 30 --suavb 40 2 --sub 50 6 -i -q -D -Od -V hlsl.shift.per-set.frag > "$TARGETDIR/hlsl.shift.per-set.frag.out" || HASERROR=1
+diff -b $BASEDIR/hlsl.shift.per-set.frag.out "$TARGETDIR/hlsl.shift.per-set.frag.out" || HASERROR=1
 
 #
 # Testing location error
 #
 echo Testing SPV no location
-run -V -C spv.noLocation.vert > $TARGETDIR/spv.noLocation.vert.out
-diff -b $BASEDIR/spv.noLocation.vert.out $TARGETDIR/spv.noLocation.vert.out || HASERROR=1
-run -G -H --aml spv.noBuiltInLoc.vert > $TARGETDIR/spv.noBuiltInLoc.vert.out
-diff -b $BASEDIR/spv.noBuiltInLoc.vert.out $TARGETDIR/spv.noBuiltInLoc.vert.out || HASERROR=1
-run -G spv.looseUniformNoLoc.vert > $TARGETDIR/spv.looseUniformNoLoc.vert.out
-diff -b $BASEDIR/spv.looseUniformNoLoc.vert.out $TARGETDIR/spv.looseUniformNoLoc.vert.out || HASERROR=1
+run -V -C spv.noLocation.vert > "$TARGETDIR/spv.noLocation.vert.out"
+diff -b $BASEDIR/spv.noLocation.vert.out "$TARGETDIR/spv.noLocation.vert.out" || HASERROR=1
+run -G -H --aml spv.noBuiltInLoc.vert > "$TARGETDIR/spv.noBuiltInLoc.vert.out"
+diff -b $BASEDIR/spv.noBuiltInLoc.vert.out "$TARGETDIR/spv.noBuiltInLoc.vert.out" || HASERROR=1
+run -G spv.looseUniformNoLoc.vert > "$TARGETDIR/spv.looseUniformNoLoc.vert.out"
+diff -b $BASEDIR/spv.looseUniformNoLoc.vert.out "$TARGETDIR/spv.looseUniformNoLoc.vert.out" || HASERROR=1
 
 #
 # Testing debug information
 #
 echo Testing SPV Debug Information
 run -g --relaxed-errors --suppress-warnings --aml --amb --hlsl-offsets --nsf --spirv-val \
-     -G -H spv.debugInfo.frag --rsb frag 3 > $TARGETDIR/spv.debugInfo.frag.out
-diff -b $BASEDIR/spv.debugInfo.frag.out $TARGETDIR/spv.debugInfo.frag.out || HASERROR=1
+     -G -H spv.debugInfo.frag --rsb frag 3 > "$TARGETDIR/spv.debugInfo.frag.out"
+diff -b $BASEDIR/spv.debugInfo.frag.out "$TARGETDIR/spv.debugInfo.frag.out" || HASERROR=1
 run -g -Od --target-env vulkan1.1 --relaxed-errors --suppress-warnings --aml --amb --hlsl-offsets --nsf --spirv-val \
-     -V -H spv.debugInfo.frag --rsb frag 3 > $TARGETDIR/spv.debugInfo.1.1.frag.out
-diff -b $BASEDIR/spv.debugInfo.1.1.frag.out $TARGETDIR/spv.debugInfo.1.1.frag.out || HASERROR=1
+     -V -H spv.debugInfo.frag --rsb frag 3 > "$TARGETDIR/spv.debugInfo.1.1.frag.out"
+diff -b $BASEDIR/spv.debugInfo.1.1.frag.out "$TARGETDIR/spv.debugInfo.1.1.frag.out" || HASERROR=1
 run -g -D -Od -e newMain -g --amb --aml --fua --hlsl-iomap --nsf --spirv-val --sib 1 --ssb 2 --sbb 3 --stb 4 --suavb 5 --sub 6 \
-     --sep origMain -H -Od spv.hlslDebugInfo.vert --rsb vert t0 0 0 > $TARGETDIR/spv.hlslDebugInfo.frag.out
-diff -b $BASEDIR/spv.hlslDebugInfo.frag.out $TARGETDIR/spv.hlslDebugInfo.frag.out || HASERROR=1
+     --sep origMain -H -Od spv.hlslDebugInfo.vert --rsb vert t0 0 0 > "$TARGETDIR/spv.hlslDebugInfo.frag.out"
+diff -b $BASEDIR/spv.hlslDebugInfo.frag.out "$TARGETDIR/spv.hlslDebugInfo.frag.out" || HASERROR=1
 
 #
 # Testing Includer
 #
 echo Testing Includer
-run -D -Od -e main -H -Od ../Test/hlsl.include.vert > $TARGETDIR/hlsl.include.vert.out
-diff -b $BASEDIR/hlsl.include.vert.out $TARGETDIR/hlsl.include.vert.out || HASERROR=1
-run -D -Od -e main -H -Od hlsl.includeNegative.vert > $TARGETDIR/hlsl.includeNegative.vert.out
-diff -b $BASEDIR/hlsl.includeNegative.vert.out $TARGETDIR/hlsl.includeNegative.vert.out || HASERROR=1
-run -l -i include.vert > $TARGETDIR/include.vert.out
-diff -b $BASEDIR/include.vert.out $TARGETDIR/include.vert.out || HASERROR=1
-run -D -Od -e main -H -Od -Iinc1/path1 -Iinc1/path2 hlsl.dashI.vert > $TARGETDIR/hlsl.dashI.vert.out
-diff -b $BASEDIR/hlsl.dashI.vert.out $TARGETDIR/hlsl.dashI.vert.out || HASERROR=1
-run -D -Od -e MainPs -H -Od -g hlsl.pp.line3.frag > $TARGETDIR/hlsl.pp.line3.frag.out
-diff -b $BASEDIR/hlsl.pp.line3.frag.out $TARGETDIR/hlsl.pp.line3.frag.out || HASERROR=1
+run -D -Od -e main -H -Od ../Test/hlsl.include.vert > "$TARGETDIR/hlsl.include.vert.out"
+diff -b $BASEDIR/hlsl.include.vert.out "$TARGETDIR/hlsl.include.vert.out" || HASERROR=1
+run -D -Od -e main -H -Od hlsl.includeNegative.vert > "$TARGETDIR/hlsl.includeNegative.vert.out"
+diff -b $BASEDIR/hlsl.includeNegative.vert.out "$TARGETDIR/hlsl.includeNegative.vert.out" || HASERROR=1
+run -l -i include.vert > "$TARGETDIR/include.vert.out"
+diff -b $BASEDIR/include.vert.out "$TARGETDIR/include.vert.out" || HASERROR=1
+run -D -Od -e main -H -Od -Iinc1/path1 -Iinc1/path2 hlsl.dashI.vert > "$TARGETDIR/hlsl.dashI.vert.out"
+diff -b $BASEDIR/hlsl.dashI.vert.out "$TARGETDIR/hlsl.dashI.vert.out" || HASERROR=1
+run -D -Od -e MainPs -H -Od -g hlsl.pp.line3.frag > "$TARGETDIR/hlsl.pp.line3.frag.out"
+diff -b $BASEDIR/hlsl.pp.line3.frag.out "$TARGETDIR/hlsl.pp.line3.frag.out" || HASERROR=1
 
 #
 # Testing --depfile
 #
 
 echo "Testing --depfile"
-run -D -Od -e main -H --depfile $TARGETDIR/hlsl.include.vert.d.out -Od ../Test/hlsl.include.vert > $TARGETDIR/hlsl.include.vert.out
-diff -b $BASEDIR/hlsl.include.vert.d.out $TARGETDIR/hlsl.include.vert.d.out || HASERROR=1
-run -D -Od -e main -H --depfile $TARGETDIR/hlsl.dashI.vert.d.out -Od -Iinc1/path1 -Iinc1/path2 hlsl.dashI.vert > $TARGETDIR/hlsl.dashI.vert.out
-diff -b $BASEDIR/hlsl.dashI.vert.d.out $TARGETDIR/hlsl.dashI.vert.d.out || HASERROR=1
+run -D -Od -e main -H --depfile "$TARGETDIR/hlsl.include.vert.d.out" -Od ../Test/hlsl.include.vert > "$TARGETDIR/hlsl.include.vert.out"
+diff -b $BASEDIR/hlsl.include.vert.d.out "$TARGETDIR/hlsl.include.vert.d.out" || HASERROR=1
+run -D -Od -e main -H --depfile "$TARGETDIR/hlsl.dashI.vert.d.out" -Od -Iinc1/path1 -Iinc1/path2 hlsl.dashI.vert > "$TARGETDIR/hlsl.dashI.vert.out"
+diff -b $BASEDIR/hlsl.dashI.vert.d.out "$TARGETDIR/hlsl.dashI.vert.d.out" || HASERROR=1
 
 #
 # Testing -D, -U and -P
 #
 echo "Testing -D, -U and -P"
-run -DUNDEFED -UIN_SHADER -DFOO=200 -i -l --U UNDEFED --define-macro MUL=FOO*2 glsl.-D-U.frag > $TARGETDIR/glsl.-D-U.frag.out
-diff -b $BASEDIR/glsl.-D-U.frag.out $TARGETDIR/glsl.-D-U.frag.out || HASERROR=1
-run -D -Od -e main -V -i -DUNDEFED -UIN_SHADER --D FOO=200 --undef-macro UNDEFED -Od hlsl.-D-U.frag > $TARGETDIR/hlsl.-D-U.frag.out
-diff -b $BASEDIR/hlsl.-D-U.frag.out $TARGETDIR/hlsl.-D-U.frag.out || HASERROR=1
-run -P"#define TEST1" -i -l --preamble-text "#define TEST2" --p "#define TEST3" glsl.-P.frag > $TARGETDIR/glsl.-P.frag.out
-diff -b $BASEDIR/glsl.-P.frag.out $TARGETDIR/glsl.-P.frag.out || HASERROR=1
-run -i -l --preamble-text "vec4 getColor() { return vec4(1.0); }" glsl.-P.function.frag > $TARGETDIR/glsl.-P.function.frag.out
-diff -b $BASEDIR/glsl.-P.function.frag.out $TARGETDIR/glsl.-P.function.frag.out || HASERROR=1
-run -i -l --preamble-text "#extension GL_GOOGLE_include_directive : require" -I. glsl.-P.include.frag > $TARGETDIR/glsl.-P.include.frag.out
-diff -b $BASEDIR/glsl.-P.include.frag.out $TARGETDIR/glsl.-P.include.frag.out || HASERROR=1
+run -DUNDEFED -UIN_SHADER -DFOO=200 -i -l --U UNDEFED --define-macro MUL=FOO*2 glsl.-D-U.frag > "$TARGETDIR/glsl.-D-U.frag.out"
+diff -b $BASEDIR/glsl.-D-U.frag.out "$TARGETDIR/glsl.-D-U.frag.out" || HASERROR=1
+run -D -Od -e main -V -i -DUNDEFED -UIN_SHADER --D FOO=200 --undef-macro UNDEFED -Od hlsl.-D-U.frag > "$TARGETDIR/hlsl.-D-U.frag.out"
+diff -b $BASEDIR/hlsl.-D-U.frag.out "$TARGETDIR/hlsl.-D-U.frag.out" || HASERROR=1
+run -P"#define TEST1" -i -l --preamble-text "#define TEST2" --p "#define TEST3" glsl.-P.frag > "$TARGETDIR/glsl.-P.frag.out"
+diff -b $BASEDIR/glsl.-P.frag.out "$TARGETDIR/glsl.-P.frag.out" || HASERROR=1
+run -i -l --preamble-text "vec4 getColor() { return vec4(1.0); }" glsl.-P.function.frag > "$TARGETDIR/glsl.-P.function.frag.out"
+diff -b $BASEDIR/glsl.-P.function.frag.out "$TARGETDIR/glsl.-P.function.frag.out" || HASERROR=1
+run -i -l --preamble-text "#extension GL_GOOGLE_include_directive : require" -I. glsl.-P.include.frag > "$TARGETDIR/glsl.-P.include.frag.out"
+diff -b $BASEDIR/glsl.-P.include.frag.out "$TARGETDIR/glsl.-P.include.frag.out" || HASERROR=1
 
 #
 # Test --client and --target-env
@@ -237,116 +237,116 @@ run --target-env spirv1.2 -V spv.targetVulkan.vert || HASERROR=1
 # Testing GLSL entry point rename
 #
 echo "Testing GLSL entry point rename"
-run -H -e foo --source-entrypoint main glsl.entryPointRename.vert > $TARGETDIR/glsl.entryPointRename.vert.out
-diff -b $BASEDIR/glsl.entryPointRename.vert.out $TARGETDIR/glsl.entryPointRename.vert.out || HASERROR=1
-run -H -e foo --source-entrypoint bar glsl.entryPointRename.vert > $TARGETDIR/glsl.entryPointRename.vert.bad.out
-diff -b $BASEDIR/glsl.entryPointRename.vert.bad.out $TARGETDIR/glsl.entryPointRename.vert.bad.out || HASERROR=1
-run -H -e foo --source-entrypoint main glsl.entryPointRename2.vert > $TARGETDIR/glsl.entryPointRename2.vert.out
-diff -b $BASEDIR/glsl.entryPointRename2.vert.out $TARGETDIR/glsl.entryPointRename2.vert.out || HASERROR=1
+run -H -e foo --source-entrypoint main glsl.entryPointRename.vert > "$TARGETDIR/glsl.entryPointRename.vert.out"
+diff -b $BASEDIR/glsl.entryPointRename.vert.out "$TARGETDIR/glsl.entryPointRename.vert.out" || HASERROR=1
+run -H -e foo --source-entrypoint bar glsl.entryPointRename.vert > "$TARGETDIR/glsl.entryPointRename.vert.bad.out"
+diff -b $BASEDIR/glsl.entryPointRename.vert.bad.out "$TARGETDIR/glsl.entryPointRename.vert.bad.out" || HASERROR=1
+run -H -e foo --source-entrypoint main glsl.entryPointRename2.vert > "$TARGETDIR/glsl.entryPointRename2.vert.out"
+diff -b $BASEDIR/glsl.entryPointRename2.vert.out "$TARGETDIR/glsl.entryPointRename2.vert.out" || HASERROR=1
 
 #
 # Testing remapper error handling
 #
 echo "Testing remapper error handling"
-$REMAPEXE --do-everything -i remap.invalid-spirv-1.spv -o $TARGETDIR > $TARGETDIR/remap.invalid-spirv-1.out && HASERROR=1
-diff -b $BASEDIR/remap.invalid-spirv-1.out $TARGETDIR/remap.invalid-spirv-1.out || HASERROR=1
-$REMAPEXE --do-everything -i remap.invalid-spirv-2.spv -o $TARGETDIR > $TARGETDIR/remap.invalid-spirv-2.out && HASERROR=1
-diff -b $BASEDIR/remap.invalid-spirv-2.out $TARGETDIR/remap.invalid-spirv-2.out || HASERROR=1
+"$REMAPEXE" --do-everything -i remap.invalid-spirv-1.spv -o "$TARGETDIR" > "$TARGETDIR/remap.invalid-spirv-1.out" && HASERROR=1
+diff -b $BASEDIR/remap.invalid-spirv-1.out "$TARGETDIR/remap.invalid-spirv-1.out" || HASERROR=1
+"$REMAPEXE" --do-everything -i remap.invalid-spirv-2.spv -o "$TARGETDIR" > "$TARGETDIR/remap.invalid-spirv-2.out" && HASERROR=1
+diff -b $BASEDIR/remap.invalid-spirv-2.out "$TARGETDIR/remap.invalid-spirv-2.out" || HASERROR=1
 
 #
 # Testing position Y inversion
 #
 echo "Testing position Y inversion"
-run -H -e main -V -D -Od -H -i --iy hlsl.y-negate-1.vert > $TARGETDIR/hlsl.y-negate-1.vert.out
-diff -b $BASEDIR/hlsl.y-negate-1.vert.out $TARGETDIR/hlsl.y-negate-1.vert.out || HASERROR=1
-run -H -e main -V -D -Od -H -i --invert-y hlsl.y-negate-2.vert > $TARGETDIR/hlsl.y-negate-2.vert.out
-diff -b $BASEDIR/hlsl.y-negate-2.vert.out $TARGETDIR/hlsl.y-negate-2.vert.out || HASERROR=1
-run -H -e main -V -D -Od -H -i --invert-y hlsl.y-negate-3.vert > $TARGETDIR/hlsl.y-negate-3.vert.out
-diff -b $BASEDIR/hlsl.y-negate-3.vert.out $TARGETDIR/hlsl.y-negate-3.vert.out || HASERROR=1
+run -H -e main -V -D -Od -H -i --iy hlsl.y-negate-1.vert > "$TARGETDIR/hlsl.y-negate-1.vert.out"
+diff -b $BASEDIR/hlsl.y-negate-1.vert.out "$TARGETDIR/hlsl.y-negate-1.vert.out" || HASERROR=1
+run -H -e main -V -D -Od -H -i --invert-y hlsl.y-negate-2.vert > "$TARGETDIR/hlsl.y-negate-2.vert.out"
+diff -b $BASEDIR/hlsl.y-negate-2.vert.out "$TARGETDIR/hlsl.y-negate-2.vert.out" || HASERROR=1
+run -H -e main -V -D -Od -H -i --invert-y hlsl.y-negate-3.vert > "$TARGETDIR/hlsl.y-negate-3.vert.out"
+diff -b $BASEDIR/hlsl.y-negate-3.vert.out "$TARGETDIR/hlsl.y-negate-3.vert.out" || HASERROR=1
 
 #
 # Testing position W reciprocal
 #
 echo "Testing position W reciprocal"
-run -H -e main -V -D -Od -H -i --hlsl-dx-position-w hlsl.w-recip.frag > $TARGETDIR/hlsl.w-recip.frag.out
-diff -b $BASEDIR/hlsl.w-recip.frag.out $TARGETDIR/hlsl.w-recip.frag.out || HASERROR=1
-run -H -e main -V -D -Od -H -i --hlsl-dx-position-w hlsl.w-recip2.frag > $TARGETDIR/hlsl.w-recip2.frag.out
-diff -b $BASEDIR/hlsl.w-recip2.frag.out $TARGETDIR/hlsl.w-recip2.frag.out || HASERROR=1
+run -H -e main -V -D -Od -H -i --hlsl-dx-position-w hlsl.w-recip.frag > "$TARGETDIR/hlsl.w-recip.frag.out"
+diff -b $BASEDIR/hlsl.w-recip.frag.out "$TARGETDIR/hlsl.w-recip.frag.out" || HASERROR=1
+run -H -e main -V -D -Od -H -i --hlsl-dx-position-w hlsl.w-recip2.frag > "$TARGETDIR/hlsl.w-recip2.frag.out"
+diff -b $BASEDIR/hlsl.w-recip2.frag.out "$TARGETDIR/hlsl.w-recip2.frag.out" || HASERROR=1
 
 #
 # Testing hlsl_functionality1
 #
 echo "Testing hlsl_functionality1"
 run -H -e main -D -Od -fhlsl_functionality1 hlsl.structbuffer.incdec.frag > \
-    $TARGETDIR/hlsl.structbuffer.incdec.frag.hlslfun1.out
-diff -b $BASEDIR/hlsl.structbuffer.incdec.frag.hlslfun1.out $TARGETDIR/hlsl.structbuffer.incdec.frag.hlslfun1.out || HASERROR=1
+    "$TARGETDIR/hlsl.structbuffer.incdec.frag.hlslfun1.out"
+diff -b $BASEDIR/hlsl.structbuffer.incdec.frag.hlslfun1.out "$TARGETDIR/hlsl.structbuffer.incdec.frag.hlslfun1.out" || HASERROR=1
 run -H -e main -D -Od -fhlsl_functionality1 hlsl.noSemantic.functionality1.comp > \
-    $TARGETDIR/hlsl.noSemantic.functionality1.comp.out
-diff -b $BASEDIR/hlsl.noSemantic.functionality1.comp.out $TARGETDIR/hlsl.noSemantic.functionality1.comp.out || HASERROR=1
+    "$TARGETDIR/hlsl.noSemantic.functionality1.comp.out"
+diff -b $BASEDIR/hlsl.noSemantic.functionality1.comp.out "$TARGETDIR/hlsl.noSemantic.functionality1.comp.out" || HASERROR=1
 
 #
 # Testing HLSL-specific PP feature expansion
 #
 echo "Testing HLSL-specific PP feature expansion"
-run -D -E hlsl.pp.expand.frag > $TARGETDIR/hlsl.pp.expand.frag.out 2> $TARGETDIR/hlsl.pp.expand.frag.err
-diff -b $BASEDIR/hlsl.pp.expand.frag.out $TARGETDIR/hlsl.pp.expand.frag.out || HASERROR=1
-diff -b $BASEDIR/hlsl.pp.expand.frag.err $TARGETDIR/hlsl.pp.expand.frag.err || HASERROR=1
+run -D -E hlsl.pp.expand.frag > "$TARGETDIR/hlsl.pp.expand.frag.out" 2> "$TARGETDIR/hlsl.pp.expand.frag.err"
+diff -b $BASEDIR/hlsl.pp.expand.frag.out "$TARGETDIR/hlsl.pp.expand.frag.out" || HASERROR=1
+diff -b $BASEDIR/hlsl.pp.expand.frag.err "$TARGETDIR/hlsl.pp.expand.frag.err" || HASERROR=1
 
 #
 # Test --nan-clamp
 #
 echo "Testing nan-clamp"
-run --nan-clamp -H --aml --amb spv.400.frag > $TARGETDIR/spv.400.frag.nanclamp.out
-diff -b $BASEDIR/spv.400.frag.nanclamp.out $TARGETDIR/spv.400.frag.nanclamp.out || HASERROR=1
+run --nan-clamp -H --aml --amb spv.400.frag > "$TARGETDIR/spv.400.frag.nanclamp.out"
+diff -b $BASEDIR/spv.400.frag.nanclamp.out "$TARGETDIR/spv.400.frag.nanclamp.out" || HASERROR=1
 
 #
 # Test --auto-sampled-textures
 #
 echo "Testing auto-sampled-textures"
-run --auto-sampled-textures -H -Od -e MainPs -D -S frag hlsl.autosampledtextures.frag > $TARGETDIR/hlsl.autosampledtextures.frag.out
-diff -b $BASEDIR/hlsl.autosampledtextures.frag.out $TARGETDIR/hlsl.autosampledtextures.frag.out || HASERROR=1
-run --auto-sampled-textures -H -Od -S frag glsl.autosampledtextures.frag > $TARGETDIR/glsl.autosampledtextures.frag.out
-diff -b $BASEDIR/glsl.autosampledtextures.frag.out $TARGETDIR/glsl.autosampledtextures.frag.out || HASERROR=1
+run --auto-sampled-textures -H -Od -e MainPs -D -S frag hlsl.autosampledtextures.frag > "$TARGETDIR/hlsl.autosampledtextures.frag.out"
+diff -b $BASEDIR/hlsl.autosampledtextures.frag.out "$TARGETDIR/hlsl.autosampledtextures.frag.out" || HASERROR=1
+run --auto-sampled-textures -H -Od -S frag glsl.autosampledtextures.frag > "$TARGETDIR/glsl.autosampledtextures.frag.out"
+diff -b $BASEDIR/glsl.autosampledtextures.frag.out "$TARGETDIR/glsl.autosampledtextures.frag.out" || HASERROR=1
 
 # Test --glsl-version
 #
 echo "Testing --glsl-version"
-run --glsl-version 410 -V -S vert glsl.versionOverride.vert > $TARGETDIR/glsl.versionOverride.vert.out
-diff -b $BASEDIR/glsl.versionOverride.vert.out $TARGETDIR/glsl.versionOverride.vert.out || HASERROR=1
-run --glsl-version 420 -V -S frag glsl.versionOverride.frag > $TARGETDIR/glsl.versionOverride.frag.out
-diff -b $BASEDIR/glsl.versionOverride.frag.out $TARGETDIR/glsl.versionOverride.frag.out || HASERROR=1
-run --glsl-version 430 -V -S geom glsl.versionOverride.geom > $TARGETDIR/glsl.versionOverride.geom.out
-diff -b $BASEDIR/glsl.versionOverride.geom.out $TARGETDIR/glsl.versionOverride.geom.out || HASERROR=1
-run --glsl-version 440 -V -S tesc glsl.versionOverride.tesc > $TARGETDIR/glsl.versionOverride.tesc.out
-diff -b $BASEDIR/glsl.versionOverride.tesc.out $TARGETDIR/glsl.versionOverride.tesc.out || HASERROR=1
-run --glsl-version 450 -V -S tese glsl.versionOverride.tese > $TARGETDIR/glsl.versionOverride.tese.out
-diff -b $BASEDIR/glsl.versionOverride.tese.out $TARGETDIR/glsl.versionOverride.tese.out || HASERROR=1
-run --glsl-version 460 -V -S comp glsl.versionOverride.comp > $TARGETDIR/glsl.versionOverride.comp.out
-diff -b $BASEDIR/glsl.versionOverride.comp.out $TARGETDIR/glsl.versionOverride.comp.out || HASERROR=1
+run --glsl-version 410 -V -S vert glsl.versionOverride.vert > "$TARGETDIR/glsl.versionOverride.vert.out"
+diff -b $BASEDIR/glsl.versionOverride.vert.out "$TARGETDIR/glsl.versionOverride.vert.out" || HASERROR=1
+run --glsl-version 420 -V -S frag glsl.versionOverride.frag > "$TARGETDIR/glsl.versionOverride.frag.out"
+diff -b $BASEDIR/glsl.versionOverride.frag.out "$TARGETDIR/glsl.versionOverride.frag.out" || HASERROR=1
+run --glsl-version 430 -V -S geom glsl.versionOverride.geom > "$TARGETDIR/glsl.versionOverride.geom.out"
+diff -b $BASEDIR/glsl.versionOverride.geom.out "$TARGETDIR/glsl.versionOverride.geom.out" || HASERROR=1
+run --glsl-version 440 -V -S tesc glsl.versionOverride.tesc > "$TARGETDIR/glsl.versionOverride.tesc.out"
+diff -b $BASEDIR/glsl.versionOverride.tesc.out "$TARGETDIR/glsl.versionOverride.tesc.out" || HASERROR=1
+run --glsl-version 450 -V -S tese glsl.versionOverride.tese > "$TARGETDIR/glsl.versionOverride.tese.out"
+diff -b $BASEDIR/glsl.versionOverride.tese.out "$TARGETDIR/glsl.versionOverride.tese.out" || HASERROR=1
+run --glsl-version 460 -V -S comp glsl.versionOverride.comp > "$TARGETDIR/glsl.versionOverride.comp.out"
+diff -b $BASEDIR/glsl.versionOverride.comp.out "$TARGETDIR/glsl.versionOverride.comp.out" || HASERROR=1
 
 #
 # Test --enhanced-msgs
 #
 
 echo "Testing enhanced-msgs"
-run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.0.frag > $TARGETDIR/enhanced.0.frag.out
-diff -b $BASEDIR/enhanced.0.frag.out $TARGETDIR/enhanced.0.frag.out || HASERROR=1
-run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.1.frag > $TARGETDIR/enhanced.1.frag.out
-diff -b $BASEDIR/enhanced.1.frag.out $TARGETDIR/enhanced.1.frag.out || HASERROR=1
-run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.2.frag > $TARGETDIR/enhanced.2.frag.out
-diff -b $BASEDIR/enhanced.2.frag.out $TARGETDIR/enhanced.2.frag.out || HASERROR=1
-run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.3.vert enhanced.3.frag > $TARGETDIR/enhanced.3.link.out
-diff -b $BASEDIR/enhanced.3.link.out $TARGETDIR/enhanced.3.link.out || HASERROR=1
-run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.4.vert enhanced.4.frag > $TARGETDIR/enhanced.4.link.out
-diff -b $BASEDIR/enhanced.4.link.out $TARGETDIR/enhanced.4.link.out || HASERROR=1
-run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.5.vert enhanced.5.frag > $TARGETDIR/enhanced.5.link.out
-diff -b $BASEDIR/enhanced.5.link.out $TARGETDIR/enhanced.5.link.out || HASERROR=1
-run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.6.vert enhanced.6.frag > $TARGETDIR/enhanced.6.link.out
-diff -b $BASEDIR/enhanced.6.link.out $TARGETDIR/enhanced.6.link.out || HASERROR=1
-run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.7.vert enhanced.7.frag > $TARGETDIR/enhanced.7.link.out
-diff -b $BASEDIR/enhanced.7.link.out $TARGETDIR/enhanced.7.link.out || HASERROR=1
-run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml spv.textureError.frag > $TARGETDIR/spv.textureError.frag.out
-diff -b $BASEDIR/spv.textureError.frag.out $TARGETDIR/spv.textureError.frag.out || HASERROR=1
+run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.0.frag > "$TARGETDIR/enhanced.0.frag.out"
+diff -b $BASEDIR/enhanced.0.frag.out "$TARGETDIR/enhanced.0.frag.out" || HASERROR=1
+run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.1.frag > "$TARGETDIR/enhanced.1.frag.out"
+diff -b $BASEDIR/enhanced.1.frag.out "$TARGETDIR/enhanced.1.frag.out" || HASERROR=1
+run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.2.frag > "$TARGETDIR/enhanced.2.frag.out"
+diff -b $BASEDIR/enhanced.2.frag.out "$TARGETDIR/enhanced.2.frag.out" || HASERROR=1
+run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.3.vert enhanced.3.frag > "$TARGETDIR/enhanced.3.link.out"
+diff -b $BASEDIR/enhanced.3.link.out "$TARGETDIR/enhanced.3.link.out" || HASERROR=1
+run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.4.vert enhanced.4.frag > "$TARGETDIR/enhanced.4.link.out"
+diff -b $BASEDIR/enhanced.4.link.out "$TARGETDIR/enhanced.4.link.out" || HASERROR=1
+run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.5.vert enhanced.5.frag > "$TARGETDIR/enhanced.5.link.out"
+diff -b $BASEDIR/enhanced.5.link.out "$TARGETDIR/enhanced.5.link.out" || HASERROR=1
+run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.6.vert enhanced.6.frag > "$TARGETDIR/enhanced.6.link.out"
+diff -b $BASEDIR/enhanced.6.link.out "$TARGETDIR/enhanced.6.link.out" || HASERROR=1
+run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml enhanced.7.vert enhanced.7.frag > "$TARGETDIR/enhanced.7.link.out"
+diff -b $BASEDIR/enhanced.7.link.out "$TARGETDIR/enhanced.7.link.out" || HASERROR=1
+run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml spv.textureError.frag > "$TARGETDIR/spv.textureError.frag.out"
+diff -b $BASEDIR/spv.textureError.frag.out "$TARGETDIR/spv.textureError.frag.out" || HASERROR=1
 
 #
 # Final checking


### PR DESCRIPTION
This means it won't die if the build path contains spaces.

I've got the build directory in the VS Code CMake extension set to `${workspaceFolder}/build/${buildKit}` so I can have MSVC and MSYS2 (MinGW UCRT) build systems without having to clone the repo twice and sync my changes back and forth for testing. `${buildKit}` contains spaces, and there's apparently nothing I can do to stop that, so it's preferable that the tests can handle the build directory having spaces.