### PR TITLE
-Wmissing-field-initializers fixes

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -7336,7 +7336,7 @@ TIntermTyped* TParseContext::vkRelaxedRemapFunctionCall(const TSourceLoc& loc, T
             realFunc.addParameter(TParameter().copyParam((*function)[i]));
         }
 
-        TParameter tmpP = { nullptr, &uintType };
+        TParameter tmpP = { nullptr, &uintType, {} };
         realFunc.addParameter(TParameter().copyParam(tmpP));
         arguments = intermediate.growAggregate(arguments, intermediate.addConstantUnion(1, loc, true));
 
@@ -7353,7 +7353,7 @@ TIntermTyped* TParseContext::vkRelaxedRemapFunctionCall(const TSourceLoc& loc, T
             realFunc.addParameter(TParameter().copyParam((*function)[i]));
         }
 
-        TParameter tmpP = { nullptr, &uintType };
+        TParameter tmpP = { nullptr, &uintType, {} };
         realFunc.addParameter(TParameter().copyParam(tmpP));
         arguments = intermediate.growAggregate(arguments, intermediate.addConstantUnion(-1, loc, true));
 
@@ -7676,7 +7676,7 @@ TIntermNode* TParseContext::vkRelaxedRemapFunctionArgument(const TSourceLoc& loc
     AccessChainTraverser accessChainTraverser{};
     intermTyped->traverse(&accessChainTraverser);
 
-    TParameter param = { NewPoolTString(accessChainTraverser.path.c_str()), new TType };
+    TParameter param = { NewPoolTString(accessChainTraverser.path.c_str()), new TType, {} };
     param.type->shallowCopy(intermTyped->getType());
 
     std::vector<int> newParams = {};

--- a/glslang/MachineIndependent/glslang.y
+++ b/glslang/MachineIndependent/glslang.y
@@ -494,7 +494,7 @@ function_call_header_with_parameters
         }
         else
         {
-            TParameter param = { 0, new TType };
+            TParameter param = { 0, new TType, {} };
             param.type->shallowCopy($2->getType());
 
             $1.function->addParameter(param);
@@ -513,7 +513,7 @@ function_call_header_with_parameters
         }
         else
         {
-            TParameter param = { 0, new TType };
+            TParameter param = { 0, new TType, {} };
             param.type->shallowCopy($3->getType());
 
             $1.function->addParameter(param);
@@ -1068,7 +1068,7 @@ parameter_declarator
         }
         parseContext.reservedErrorCheck($2.loc, *$2.string);
 
-        TParameter param = {$2.string, new TType($1)};
+        TParameter param = {$2.string, new TType($1), {}};
         $$.loc = $2.loc;
         $$.param = param;
     }
@@ -1086,7 +1086,7 @@ parameter_declarator
         parseContext.arraySizeRequiredCheck($3.loc, *$3.arraySizes);
         parseContext.reservedErrorCheck($2.loc, *$2.string);
 
-        TParameter param = { $2.string, type };
+        TParameter param = { $2.string, type, {} };
 
         $$.loc = $2.loc;
         $$.param = param;
@@ -1139,7 +1139,7 @@ parameter_declaration
 
 parameter_type_specifier
     : type_specifier {
-        TParameter param = { 0, new TType($1) };
+        TParameter param = { 0, new TType($1), {} };
         $$.param = param;
         if ($1.arraySizes)
             parseContext.arraySizeRequiredCheck($1.loc, *$1.arraySizes);

--- a/glslang/MachineIndependent/glslang_tab.cpp
+++ b/glslang/MachineIndependent/glslang_tab.cpp
@@ -5467,7 +5467,7 @@ yyreduce:
         }
         else
         {
-            TParameter param = { 0, new TType };
+            TParameter param = { 0, new TType, {} };
             param.type->shallowCopy((yyvsp[0].interm.intermTypedNode)->getType());
 
             (yyvsp[-1].interm).function->addParameter(param);
@@ -5491,7 +5491,7 @@ yyreduce:
         }
         else
         {
-            TParameter param = { 0, new TType };
+            TParameter param = { 0, new TType, {} };
             param.type->shallowCopy((yyvsp[0].interm.intermTypedNode)->getType());
 
             (yyvsp[-2].interm).function->addParameter(param);
@@ -6388,7 +6388,7 @@ yyreduce:
         }
         parseContext.reservedErrorCheck((yyvsp[0].lex).loc, *(yyvsp[0].lex).string);
 
-        TParameter param = {(yyvsp[0].lex).string, new TType((yyvsp[-1].interm.type))};
+        TParameter param = {(yyvsp[0].lex).string, new TType((yyvsp[-1].interm.type)), {}};
         (yyval.interm).loc = (yyvsp[0].lex).loc;
         (yyval.interm).param = param;
     }
@@ -6411,7 +6411,7 @@ yyreduce:
         parseContext.arraySizeRequiredCheck((yyvsp[0].interm).loc, *(yyvsp[0].interm).arraySizes);
         parseContext.reservedErrorCheck((yyvsp[-1].lex).loc, *(yyvsp[-1].lex).string);
 
-        TParameter param = { (yyvsp[-1].lex).string, type };
+        TParameter param = { (yyvsp[-1].lex).string, type, {} };
 
         (yyval.interm).loc = (yyvsp[-1].lex).loc;
         (yyval.interm).param = param;
@@ -6477,7 +6477,7 @@ yyreduce:
   case 124: /* parameter_type_specifier: type_specifier  */
 #line 1141 "MachineIndependent/glslang.y"
                      {
-        TParameter param = { 0, new TType((yyvsp[0].interm.type)) };
+        TParameter param = { 0, new TType((yyvsp[0].interm.type)), {} };
         (yyval.interm).param = param;
         if ((yyvsp[0].interm.type).arraySizes)
             parseContext.arraySizeRequiredCheck((yyvsp[0].interm.type).loc, *(yyvsp[0].interm.type).arraySizes);

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -85,7 +85,7 @@ public:
             addGlobalReference(base->getAccessName());
 
         if (target) {
-            TVarEntryInfo ent = {base->getId(), base, ! traverseAll};
+            TVarEntryInfo ent = {base->getId(), base, ! traverseAll, {}, {}, {}, {}, {}, {}, {}};
             ent.stage = intermediate.getStage();
             TVarLiveMap::iterator at = target->find(
                 ent.symbol->getAccessName()); // std::lower_bound(target->begin(), target->end(), ent, TVarEntryInfo::TOrderById());
@@ -124,7 +124,7 @@ public:
         else
             return;
 
-        TVarEntryInfo ent = { base->getId() };
+        TVarEntryInfo ent = { base->getId(), {}, {}, {}, {}, {}, {}, {}, {}, {} };
         // Fix a defect, when block has no instance name, we need to find its block name
         TVarLiveMap::const_iterator at = source->find(base->getAccessName());
         if (at == source->end())

--- a/gtests/Spv.FromFile.cpp
+++ b/gtests/Spv.FromFile.cpp
@@ -763,7 +763,7 @@ INSTANTIATE_TEST_SUITE_P(
         { "spv.register.autoassign.rangetest.frag", "main",
                 glslang::TQualifier::layoutBindingEnd-2,
                 glslang::TQualifier::layoutBindingEnd+5,
-                20, 30, true, false },
+                0, 20, 30, true, false },
     }),
     FileNameAsCustomTestSuffixIoMap
 );

--- a/gtests/VkRelaxed.FromFile.cpp
+++ b/gtests/VkRelaxed.FromFile.cpp
@@ -290,11 +290,11 @@ TEST_P(VulkanRelaxedTest, FromFile)
 INSTANTIATE_TEST_SUITE_P(
     Glsl, VulkanRelaxedTest,
     ::testing::ValuesIn(std::vector<vkRelaxedData>({
-        {{"vk.relaxed.frag"}},
-        {{"vk.relaxed.link1.frag", "vk.relaxed.link2.frag"}},
-        {{"vk.relaxed.stagelink.0.0.vert", "vk.relaxed.stagelink.0.1.vert", "vk.relaxed.stagelink.0.2.vert", "vk.relaxed.stagelink.0.0.frag", "vk.relaxed.stagelink.0.1.frag", "vk.relaxed.stagelink.0.2.frag"}},
-        {{"vk.relaxed.stagelink.vert", "vk.relaxed.stagelink.frag"}},
-        {{"vk.relaxed.errorcheck.vert", "vk.relaxed.errorcheck.frag"}},
+        {{"vk.relaxed.frag"}, {}},
+        {{"vk.relaxed.link1.frag", "vk.relaxed.link2.frag"}, {}},
+        {{"vk.relaxed.stagelink.0.0.vert", "vk.relaxed.stagelink.0.1.vert", "vk.relaxed.stagelink.0.2.vert", "vk.relaxed.stagelink.0.0.frag", "vk.relaxed.stagelink.0.1.frag", "vk.relaxed.stagelink.0.2.frag"}, {}},
+        {{"vk.relaxed.stagelink.vert", "vk.relaxed.stagelink.frag"}, {}},
+        {{"vk.relaxed.errorcheck.vert", "vk.relaxed.errorcheck.frag"}, {}},
         {{"vk.relaxed.changeSet.vert", "vk.relaxed.changeSet.frag" }, { {"0"}, {"1"} } },
     }))
 );


### PR DESCRIPTION
Like with the last few PRs from me, it fixes a warning that's commonly enabled in downstream projects that might want to consume glslang via FetchContent or equivalent.

It doesn't actually enable the warning, but that might be desirable.

I think I found a bug in the Spv.FromFile.cpp tests that would have been prevented had this warning been enabled all along. I had to guess the value for the missing field, so went for the most common one in the list. The only test case that used a different value before had an RWTexture1D, so if baseImageBinding is meaning the same kind of image as image load store in OpenGL, it would make sense that that would be the only one to need a non-zero value for the binding.

I'm a little concerned that the test wasn't previously failing with the incorrectly-assigned fields as it implies they don't make any difference, so the test might be too permissive.