### PR TITLE
Increase TStorageQualifier bitfield width

### DIFF
--- a/glslang/Include/Types.h
+++ b/glslang/Include/Types.h
@@ -573,7 +573,8 @@ public:
     }
 
     const char*         semanticName;
-    TStorageQualifier   storage   : 6;
+    TStorageQualifier   storage   : 7;
+    static_assert(EvqLast < 64, "need to increase size of TStorageQualifier bitfields!");
     TBuiltInVariable    builtIn   : 9;
     TBuiltInVariable    declaredBuiltIn : 9;
     static_assert(EbvLast < 256, "need to increase size of TBuiltInVariable bitfields!");


### PR DESCRIPTION
Fix #3538.

Visual Studio 2022 added a new warning to detect when enumerators can not be represented within the given bit field width. This warning is disabled by default but can be enabled using the flag /w15249. This PR increases the width by one to accommodate the signed maximum value of EvqLast, which is currently 32.

Perhaps a future improvement would be to use scoped enums; however, that is more work as the typing is more strict and would require more changes.