### PR TITLE
Support files with UTF8BOM character

### DIFF
--- a/StandAlone/StandAlone.cpp
+++ b/StandAlone/StandAlone.cpp
@@ -2167,6 +2167,20 @@ char* ReadFileData(const char* fileName)
 
     fseek(in, 0, SEEK_SET);
 
+    if (count > 3) {
+        unsigned char head[3];
+        if (fread(head, 1, 3, in) == 3) {
+            if (head[0] == 0xef && head[1] == 0xbb && head[2] == 0xbf) {
+                // skip BOM
+                count -= 3;
+            } else {
+                fseek(in, 0, SEEK_SET);
+            }
+        } else {
+            Error("can't read input file");
+        }
+    }
+
     char* return_data = (char*)malloc(count + 1);  // freed in FreeFileData()
     if ((int)fread(return_data, 1, count, in) != count) {
         free(return_data);

--- a/Test/UTF8BOM.vert
+++ b/Test/UTF8BOM.vert
@@ -1,0 +1,11 @@
+﻿/*
+
+glslangValidator.exe --glsl-version 410 -V -S vert -o UTF8BOM.vert.out UTF8BOM.vert
+
+*/
+
+#version 110
+
+void main()
+{
+}

--- a/Test/baseResults/UTF8BOM.vert.out
+++ b/Test/baseResults/UTF8BOM.vert.out
@@ -1,0 +1,1 @@
+UTF8BOM.vert

--- a/Test/runtests
+++ b/Test/runtests
@@ -349,6 +349,13 @@ run --enhanced-msgs -V --target-env vulkan1.2 --amb --aml spv.textureError.frag 
 diff -b $BASEDIR/spv.textureError.frag.out "$TARGETDIR/spv.textureError.frag.out" || HASERROR=1
 
 #
+# Test UTF8BOM
+#
+echo "Testing UTF8BOM"
+run --glsl-version 410 -V -S vert UTF8BOM.vert > $TARGETDIR/UTF8BOM.vert.out
+diff -b $BASEDIR/UTF8BOM.vert.out $TARGETDIR/UTF8BOM.vert.out || HASERROR=1
+
+#
 # Final checking
 #
 if [ $HASERROR -eq 0 ]


### PR DESCRIPTION
This PR allows glslangvalidator to consume the byte-order mark (BOM) when it appears at the start of a text stream.  The Unicode spec, Version 9.0, Section 23.8, reads: "Systems that use the byte order mark must recognize when an initial U+FEFF signals the byte order. In those cases, it is not part of the textual content and should be removed before processing,"