### PR TITLE
Out-of-range floats should overflow to infinity

### DIFF
--- a/Test/baseResults/positive_infinity.frag.out
+++ b/Test/baseResults/positive_infinity.frag.out
@@ -1,0 +1,51 @@
+positive_infinity.frag
+Shader version: 300
+0:? Sequence
+0:4  Function Definition: main( ( global void)
+0:4    Function Parameters: 
+0:9    Sequence
+0:9      Sequence
+0:9        move second child to first child ( temp highp float)
+0:9          'correct' ( temp highp float)
+0:9          Constant:
+0:9            1.000000
+0:10      move second child to first child ( temp highp 4-component vector of float)
+0:10        'my_FragColor' ( out highp 4-component vector of float)
+0:10        Construct vec4 ( temp highp 4-component vector of float)
+0:10          Constant:
+0:10            0.000000
+0:10          'correct' ( temp highp float)
+0:10          Constant:
+0:10            0.000000
+0:10          Constant:
+0:10            1.000000
+0:?   Linker Objects
+0:?     'my_FragColor' ( out highp 4-component vector of float)
+
+
+Linked fragment stage:
+
+
+Shader version: 300
+0:? Sequence
+0:4  Function Definition: main( ( global void)
+0:4    Function Parameters: 
+0:9    Sequence
+0:9      Sequence
+0:9        move second child to first child ( temp highp float)
+0:9          'correct' ( temp highp float)
+0:9          Constant:
+0:9            1.000000
+0:10      move second child to first child ( temp highp 4-component vector of float)
+0:10        'my_FragColor' ( out highp 4-component vector of float)
+0:10        Construct vec4 ( temp highp 4-component vector of float)
+0:10          Constant:
+0:10            0.000000
+0:10          'correct' ( temp highp float)
+0:10          Constant:
+0:10            0.000000
+0:10          Constant:
+0:10            1.000000
+0:?   Linker Objects
+0:?     'my_FragColor' ( out highp 4-component vector of float)
+

--- a/Test/positive_infinity.frag
+++ b/Test/positive_infinity.frag
@@ -1,0 +1,11 @@
+#version 300 es
+precision highp float;
+out vec4 my_FragColor;
+void main()
+{
+    // Out-of-range floats should overflow to infinity
+    // GLSL ES 3.00.6 section 4.1.4 Floats:
+    // "If the value of the floating point number is too large (small) to be stored as a single precision value, it is converted to positive (negative) infinity"
+    float correct = isinf(1.0e2147483649) ? 1.0 : 0.0;
+    my_FragColor = vec4(0.0, correct, 0.0, 1.0);
+}

--- a/glslang/MachineIndependent/preprocessor/PpScanner.cpp
+++ b/glslang/MachineIndependent/preprocessor/PpScanner.cpp
@@ -207,7 +207,7 @@ int TPpContext::lFloatConst(int len, int ch, TPpToken* ppToken)
     // Exponent:
     bool negativeExponent = false;
     double exponentValue = 0.0;
-    int exponent = 0;
+    long long int exponent = 0;
     {
         if (ch == 'e' || ch == 'E') {
             hasDecimalOrExponent = true;

--- a/gtests/AST.FromFile.cpp
+++ b/gtests/AST.FromFile.cpp
@@ -309,6 +309,7 @@ INSTANTIATE_TEST_SUITE_P(
         "GL_EXT_draw_instanced.vert",
         "overflow_underflow_toinf_0.frag",
         "GL_EXT_texture_array.frag",
+        "positive_infinity.frag",
     })),
     FileNameAsCustomTestSuffix
 );


### PR DESCRIPTION
"2147483649" of 1.0e2147483649 is out of range that positive 32bits int can store.

    precision highp float;
    out vec4 my_FragColor;
    void main()
    {
        // Out-of-range floats should overflow to infinity
        // GLSL ES 3.00.6 section 4.1.4 Floats:
        // "If the value of the floating point number is too large (small) to be stored as a single precision value, it is converted to positive (negative) infinity"
        float correct = isinf(1.0e2147483649) ? 1.0 : 0.0;
        my_FragColor = vec4(0.0, correct, 0.0, 1.0);
    }