### PR TITLE
 index outside gl_SampleMask range, compiler need report error.

### DIFF
--- a/Test/baseResults/index_outside_sample_mask_range.frag.out
+++ b/Test/baseResults/index_outside_sample_mask_range.frag.out
@@ -1,0 +1,55 @@
+index_outside_sample_mask_range.frag
+ERROR: 0:6: '[' : gl_SampleMask array index out of range '1'
+ERROR: 1 compilation errors.  No code generated.
+
+
+Shader version: 320
+ERROR: node is still EOpNull!
+0:3  Function Definition: main( ( global void)
+0:3    Function Parameters: 
+0:?     Sequence
+0:6      Sequence
+0:6        move second child to first child ( temp highp int)
+0:6          'invalidValue' ( temp highp int)
+0:6          direct index ( temp highp int SampleMaskIn)
+0:6            'gl_SampleMask' ( out unsized 2-element array of highp int SampleMaskIn)
+0:6            Constant:
+0:6              1 (const int)
+0:7      move second child to first child ( temp mediump 4-component vector of float)
+0:7        'fs_color' (layout( location=0) out mediump 4-component vector of float)
+0:7        Constant:
+0:7          1.000000
+0:7          0.000000
+0:7          0.000000
+0:7          1.000000
+0:?   Linker Objects
+0:?     'fs_color' (layout( location=0) out mediump 4-component vector of float)
+0:?     'gl_SampleMask' ( out unsized 2-element array of highp int SampleMaskIn)
+
+
+Linked fragment stage:
+
+
+Shader version: 320
+ERROR: node is still EOpNull!
+0:3  Function Definition: main( ( global void)
+0:3    Function Parameters: 
+0:?     Sequence
+0:6      Sequence
+0:6        move second child to first child ( temp highp int)
+0:6          'invalidValue' ( temp highp int)
+0:6          direct index ( temp highp int SampleMaskIn)
+0:6            'gl_SampleMask' ( out 2-element array of highp int SampleMaskIn)
+0:6            Constant:
+0:6              1 (const int)
+0:7      move second child to first child ( temp mediump 4-component vector of float)
+0:7        'fs_color' (layout( location=0) out mediump 4-component vector of float)
+0:7        Constant:
+0:7          1.000000
+0:7          0.000000
+0:7          0.000000
+0:7          1.000000
+0:?   Linker Objects
+0:?     'fs_color' (layout( location=0) out mediump 4-component vector of float)
+0:?     'gl_SampleMask' ( out 2-element array of highp int SampleMaskIn)
+

--- a/Test/index_outside_sample_mask_range.frag
+++ b/Test/index_outside_sample_mask_range.frag
@@ -1,0 +1,8 @@
+#version 320 es 
+layout (location = 0) out mediump vec4 fs_color; 
+void main() 
+{ 
+	const highp int invalidIndex = (gl_MaxSamples + 31) / 32; 
+	highp int invalidValue = gl_SampleMask[invalidIndex]; 
+	fs_color = vec4(1.0f, 0.0f, 0.0f, 1.0f); 
+} 

--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -598,6 +598,10 @@ TIntermTyped* TParseContext::handleBracketDereference(const TSourceLoc& loc, TIn
                 indexValue >= resources.maxCullDistances) {
                 error(loc, "gl_CullDistance", "[", "array index out of range '%d'", indexValue);
             }
+            else if (base->getQualifier().builtIn == EbvSampleMask &&
+                indexValue >= (resources.maxSamples + 31) / 32) {
+                error(loc, "gl_SampleMask", "[", "array index out of range '%d'", indexValue);
+            }
             // For 2D per-view builtin arrays, update the inner dimension size in parent type
             if (base->getQualifier().isPerView() && base->getQualifier().builtIn != EbvNone) {
                 TIntermBinary* binaryNode = base->getAsBinaryNode();

--- a/gtests/AST.FromFile.cpp
+++ b/gtests/AST.FromFile.cpp
@@ -309,6 +309,7 @@ INSTANTIATE_TEST_SUITE_P(
         "GL_EXT_draw_instanced.vert",
         "overflow_underflow_toinf_0.frag",
         "GL_EXT_texture_array.frag",
+        "index_outside_sample_mask_range.frag",
     })),
     FileNameAsCustomTestSuffix
 );


### PR DESCRIPTION
 index outside gl_SampleMask range, compiler need report error.
#version 320 es 
layout (location = 0) out mediump vec4 fs_color; 
void main() 
{ 
	const highp int invalidIndex = (gl_MaxSamples + 31) / 32; 
	highp int invalidValue = gl_SampleMask[invalidIndex]; 
	fs_color = vec4(1.0f, 0.0f, 0.0f, 1.0f); 
} 
