### PR TITLE
Adjust hlsl infinity-constant test

### DIFF
--- a/Test/baseResults/hlsl.inf.vert.out
+++ b/Test/baseResults/hlsl.inf.vert.out
@@ -29,21 +29,21 @@ Shader version: 500
 0:6                +1.#INF
 0:6            Constant:
 0:6              +1.#INF
-0:10      Branch: Return with expression
-0:10        Construct vec4 ( temp 4-component vector of float)
-0:10          add ( temp float)
-0:10            add ( temp float)
-0:10              add ( temp float)
-0:10                add ( temp float)
-0:10                  add ( temp float)
-0:10                    'f1' ( temp float)
-0:10                    'f2' ( temp float)
-0:10                  'f3' ( temp float)
-0:10                'f4' ( temp float)
-0:10              Constant:
-0:10                -1.#INF
-0:10            Constant:
-0:10              1.#IND
+0:15      Branch: Return with expression
+0:15        Construct vec4 ( temp 4-component vector of float)
+0:15          add ( temp float)
+0:15            add ( temp float)
+0:15              add ( temp float)
+0:15                add ( temp float)
+0:15                  add ( temp float)
+0:15                    'f1' ( temp float)
+0:15                    'f2' ( temp float)
+0:15                  'f3' ( temp float)
+0:15                'f4' ( temp float)
+0:15              Constant:
+0:15                -1.#INF
+0:15            Constant:
+0:15              1.#IND
 0:2  Function Definition: main( ( temp void)
 0:2    Function Parameters: 
 0:?     Sequence
@@ -87,21 +87,21 @@ Shader version: 500
 0:6                +1.#INF
 0:6            Constant:
 0:6              +1.#INF
-0:10      Branch: Return with expression
-0:10        Construct vec4 ( temp 4-component vector of float)
-0:10          add ( temp float)
-0:10            add ( temp float)
-0:10              add ( temp float)
-0:10                add ( temp float)
-0:10                  add ( temp float)
-0:10                    'f1' ( temp float)
-0:10                    'f2' ( temp float)
-0:10                  'f3' ( temp float)
-0:10                'f4' ( temp float)
-0:10              Constant:
-0:10                -1.#INF
-0:10            Constant:
-0:10              1.#IND
+0:15      Branch: Return with expression
+0:15        Construct vec4 ( temp 4-component vector of float)
+0:15          add ( temp float)
+0:15            add ( temp float)
+0:15              add ( temp float)
+0:15                add ( temp float)
+0:15                  add ( temp float)
+0:15                    'f1' ( temp float)
+0:15                    'f2' ( temp float)
+0:15                  'f3' ( temp float)
+0:15                'f4' ( temp float)
+0:15              Constant:
+0:15                -1.#INF
+0:15            Constant:
+0:15              1.#IND
 0:2  Function Definition: main( ( temp void)
 0:2    Function Parameters: 
 0:?     Sequence
@@ -136,7 +136,7 @@ Shader version: 500
               11:             TypePointer Function 6(float)
               13:    6(float) Constant 4286578688
               15:    6(float) Constant 2139095040
-              29:    6(float) Constant 4290772992
+              29:    6(float) Constant 2143289344
               34:             TypePointer Output 7(fvec4)
 35(@entryPointOutput):     34(ptr) Variable Output
          4(main):           2 Function None 3

--- a/Test/hlsl.inf.vert
+++ b/Test/hlsl.inf.vert
@@ -5,7 +5,12 @@ float4 main() : SV_Position
     float f3 = +1.#INF;
     float f4 = f2 * 1.#INF + 1.#INF;
     const float f5 = -1.#INF;
-    const float f6 = f5 * 0.0f;
+    // An infinity times zero is a NaN.
+    // In IEEE 754, the sign of a NaN is significant only for
+    // abs, copy, negate, or copySign.  Use abs(.) here to
+    // set the sign bit to zero. Otherwise, some platforms will
+    // have a 1 sign bit and others will have a 0 sign bit.
+    const float f6 = abs(f5 * 0.0f);
 
     return (float4)(f1 + f2 + f3 + f4 + f5 + f6);
 }


### PR DESCRIPTION
Test/hlsl.inf.vert tests parsing and some constant math on infinities, including (-1.#INF * 0.0).
By IEEE 754 rules, that result is a NaN, but its sign is not significant. The test output assumes a negative-NaN is in the generated SPIR-V.

However, the math library on some platforms (like macOS 14, a.k.a. Sonoma) will produce a positive NaN instead.

This PR adjusts the test so it takes the absolute value of the NaN, to ensure we the emitted SPIR-V has the NaN with a 0 for it sign bit.