### PR TITLE
Update comment to more succint for 8/16-bit types

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -8539,7 +8539,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
     case EOpConstructF16Mat4x4:
     case EOpConstructFloat16:
         basicOp = EOpConstructFloat16;
-        // 8/16-bit storage extensions don't support constructing composites of 8/16-bit types,
+        // 8/16-bit storage extensions don't support direct constructing composites of 8/16-bit types,
         // so construct a 32-bit type and convert
         // and do not generate any conversion if it is an identity conversion, i.e. float16_t(<float16_t> var)
         if (!intermediate.getArithemeticFloat16Enabled() && (node->getBasicType() != EbtFloat16)) {
@@ -8563,7 +8563,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
     case EOpConstructI8Vec4:
     case EOpConstructInt8:
         basicOp = EOpConstructInt8;
-        // 8/16-bit storage extensions don't support constructing composites of 8/16-bit types,
+        // 8/16-bit storage extensions don't support direct constructing composites of 8/16-bit types,
         // so construct a 32-bit type and convert
         // and do not generate any conversion if it is an identity conversion, i.e. int8_t(<int8_t> var)
         if (!intermediate.getArithemeticInt8Enabled() && (node->getBasicType() != EbtInt8)) {
@@ -8587,7 +8587,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
     case EOpConstructU8Vec4:
     case EOpConstructUint8:
         basicOp = EOpConstructUint8;
-        // 8/16-bit storage extensions don't support constructing composites of 8/16-bit types,
+        // 8/16-bit storage extensions don't support direct constructing composites of 8/16-bit types,
         // so construct a 32-bit type and convert
         // and do not generate any conversion if it is an identity conversion, i.e. uint8_t(<uint8_t> var)
         if (!intermediate.getArithemeticInt8Enabled() && (node->getBasicType() != EbtUint8)) {
@@ -8611,7 +8611,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
     case EOpConstructI16Vec4:
     case EOpConstructInt16:
         basicOp = EOpConstructInt16;
-        // 8/16-bit storage extensions don't support constructing composites of 8/16-bit types,
+        // 8/16-bit storage extensions don't support direct constructing composites of 8/16-bit types,
         // so construct a 32-bit type and convert
         // and do not generate any conversion if it is an identity conversion, i.e. int16_t(<int16_t> var)
         if (!intermediate.getArithemeticInt16Enabled() && (node->getBasicType() != EbtInt16)) {
@@ -8635,7 +8635,7 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
     case EOpConstructU16Vec4:
     case EOpConstructUint16:
         basicOp = EOpConstructUint16;
-        // 8/16-bit storage extensions don't support constructing composites of 8/16-bit types,
+        // 8/16-bit storage extensions don't support direct constructing composites of 8/16-bit types,
         // so construct a 32-bit type and convert
         // and do not generate any conversion if it is an identity conversion, i.e. uint16_t(<uint16_t> var)
         if (!intermediate.getArithemeticInt16Enabled() && (node->getBasicType() != EbtUint16)) {


### PR DESCRIPTION
... that 8/16-bit composites can't be directly constructed.

Earlier the comment looked misleading that composites of 8/16-bit types can't be constructed at all. As per the GL_EXT_shader_16bit_storage extension, they can't be constructed directly, however, can be constructed indirectly.