### PR TITLE
Fix for #3607

### DIFF
--- a/glslang/MachineIndependent/ParseHelper.cpp
+++ b/glslang/MachineIndependent/ParseHelper.cpp
@@ -8570,12 +8570,21 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
             TType tempType(EbtInt, EvqTemporary, type.getVectorSize());
             newNode = node;
             if (tempType != newNode->getType()) {
-                TOperator aggregateOp;
-                if (op == EOpConstructInt8)
-                    aggregateOp = EOpConstructInt;
-                else
-                    aggregateOp = (TOperator)(EOpConstructIVec2 + op - EOpConstructI8Vec2);
-                newNode = intermediate.setAggregateOperator(newNode, aggregateOp, tempType, node->getLoc());
+                // if the source and target size matches then we need to emit OpSConvert instruction
+                // which would convert 8-bit or 16-bit integer types to 32-bit sized integer type (including vector composites)
+                if (type.getVectorSize() == node->getType().getVectorSize()) {
+                    newNode = intermediate.addConversion(EbtInt, newNode);
+                }
+                // otherwise create aggregate operator
+                // which internally emits OpCompositeExtract followed by OpCompositeConstruct instruction.
+                else {
+                    TOperator aggregateOp;
+                    if (op == EOpConstructInt8)
+                        aggregateOp = EOpConstructInt;
+                    else
+                        aggregateOp = (TOperator)(EOpConstructIVec2 + op - EOpConstructI8Vec2);
+                    newNode = intermediate.setAggregateOperator(newNode, aggregateOp, tempType, node->getLoc());
+                }
             }
             newNode = intermediate.addConversion(EbtInt8, newNode);
             return newNode;
@@ -8594,12 +8603,21 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
             TType tempType(EbtUint, EvqTemporary, type.getVectorSize());
             newNode = node;
             if (tempType != newNode->getType()) {
-                TOperator aggregateOp;
-                if (op == EOpConstructUint8)
-                    aggregateOp = EOpConstructUint;
-                else
-                    aggregateOp = (TOperator)(EOpConstructUVec2 + op - EOpConstructU8Vec2);
-                newNode = intermediate.setAggregateOperator(newNode, aggregateOp, tempType, node->getLoc());
+                // if the source and target size matches then we need to emit OpUConvert instruction
+                // which would convert 8-bit or 16-bit integer types to 32-bit sized integer type (including vector composites)
+                if (type.getVectorSize() == node->getType().getVectorSize()) {
+                    newNode = intermediate.addConversion(EbtUint, newNode);
+                }
+                // otherwise create aggregate operator
+                // which internally emits OpCompositeExtract followed by OpCompositeConstruct instruction.
+                else {
+                    TOperator aggregateOp;
+                    if (op == EOpConstructUint8)
+                        aggregateOp = EOpConstructUint;
+                    else
+                        aggregateOp = (TOperator)(EOpConstructUVec2 + op - EOpConstructU8Vec2);
+                    newNode = intermediate.setAggregateOperator(newNode, aggregateOp, tempType, node->getLoc());
+                }
             }
             newNode = intermediate.addConversion(EbtUint8, newNode);
             return newNode;
@@ -8618,12 +8636,21 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
             TType tempType(EbtInt, EvqTemporary, type.getVectorSize());
             newNode = node;
             if (tempType != newNode->getType()) {
-                TOperator aggregateOp;
-                if (op == EOpConstructInt16)
-                    aggregateOp = EOpConstructInt;
-                else
-                    aggregateOp = (TOperator)(EOpConstructIVec2 + op - EOpConstructI16Vec2);
-                newNode = intermediate.setAggregateOperator(newNode, aggregateOp, tempType, node->getLoc());
+                // if the source and target size matches then we need to emit OpSConvert instruction
+                // which would convert 8-bit or 16-bit integer types to 32-bit sized integer type (including vector composites)
+                if (type.getVectorSize() == node->getType().getVectorSize()) {
+                    newNode = intermediate.addConversion(EbtInt, newNode);
+                }
+                // otherwise create aggregate operator
+                // which internally emits OpCompositeExtract followed by OpCompositeConstruct instruction.
+                else {
+                    TOperator aggregateOp;
+                    if (op == EOpConstructInt16)
+                        aggregateOp = EOpConstructInt;
+                    else
+                        aggregateOp = (TOperator)(EOpConstructIVec2 + op - EOpConstructI16Vec2);
+                    newNode = intermediate.setAggregateOperator(newNode, aggregateOp, tempType, node->getLoc());
+                }
             }
             newNode = intermediate.addConversion(EbtInt16, newNode);
             return newNode;
@@ -8642,12 +8669,21 @@ TIntermTyped* TParseContext::constructBuiltIn(const TType& type, TOperator op, T
             TType tempType(EbtUint, EvqTemporary, type.getVectorSize());
             newNode = node;
             if (tempType != newNode->getType()) {
-                TOperator aggregateOp;
-                if (op == EOpConstructUint16)
-                    aggregateOp = EOpConstructUint;
-                else
-                    aggregateOp = (TOperator)(EOpConstructUVec2 + op - EOpConstructU16Vec2);
-                newNode = intermediate.setAggregateOperator(newNode, aggregateOp, tempType, node->getLoc());
+                // if the source and target size matches then we need to emit OpUConvert instruction
+                // which would convert 8-bit or 16-bit integer types to 32-bit sized integer type (including vector composites)
+                if (type.getVectorSize() == node->getType().getVectorSize()) {
+                    newNode = intermediate.addConversion(EbtUint, newNode);
+                }
+                // otherwise create aggregate operator
+                // which internally emits OpCompositeExtract followed by OpCompositeConstruct instruction.
+                else {
+                    TOperator aggregateOp;
+                    if (op == EOpConstructUint16)
+                        aggregateOp = EOpConstructUint;
+                    else
+                        aggregateOp = (TOperator)(EOpConstructUVec2 + op - EOpConstructU16Vec2);
+                    newNode = intermediate.setAggregateOperator(newNode, aggregateOp, tempType, node->getLoc());
+                }
             }
             newNode = intermediate.addConversion(EbtUint16, newNode);
             return newNode;


### PR DESCRIPTION
Convert 8/16-bit int (and their composite vector) types to their corresponding 32-bit types first and then convert the resulting 32-bit type to the target 8/16-bit type.

This change emits appropriate Op{S|U}Convert instructions instead of OpCompositeExtract followed by OpCompositeConstruct for 8/16-bit integer types.

 - this fixes #3607
 - and this also fixes assertion failure in the PR #3628

### What types of shaders are affected?
The following GLSL shader:
```GLSL
#version 460


#extension GL_EXT_shader_8bit_storage : require
#extension GL_EXT_shader_16bit_storage : require
#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require


layout(binding = 1 ) uniform _16bit_storage
{
        i16vec4 i16v4;
};

// This is read back and checked on the CPU side to verify the converions
layout(binding = 2 ) writeonly buffer ConversionOutBuffer
{
        i8vec4 i16v4_to_i8v4;
} cob;

out vec4 fcolor;

void main()
{
        // Conversions
        {
                cob.i16v4_to_i8v4   = i8vec4(i16v4);
        }

        bool RED = true;
        bool GREEN = false;

        fcolor = vec4( (RED) ? 1.0f : 0.0f,
                                   (GREEN) ? 1.0f : 0.0f,
                                   0.0f, 1.0f);
}
```

Now compiles to the SPIR-V (i.e. with this patch applied):

```
...
    %19 = OpAccessChain %_ptr_Uniform_v4short %_ %int_0
    %20 = OpLoad %v4short %19
    %22 = OpSConvert %v4int %20
    %23 = OpSConvert %v4char %22
    %25 = OpAccessChain %_ptr_Uniform_v4char %cob %int_0
    OpStore %25 %23
...
```

Earlier it used to be compiled to the following SPIR-V instructions (i.e. without patch applied):
```
...
    %19 = OpAccessChain %_ptr_Uniform_v4short %_ %int_0
    %20 = OpLoad %v4short %19
    %22 = OpCompositeExtract %int %20 0 <-- incorrect instruction
    %23 = OpCompositeExtract %int %20 1 <-- incorrect instruction
    %24 = OpCompositeExtract %int %20 2 <-- incorrect instruction
    %25 = OpCompositeExtract %int %20 3 <-- incorrect instruction
    %26 = OpCompositeConstruct %v4int %22 %23 %24 %25
    %27 = OpSConvert %v4char %26
    %29 = OpAccessChain %_ptr_Uniform_v4char %cob %int_0
    OpStore %29 %27
...
```