### PR TITLE
Fix compilation for WASI target

### DIFF
--- a/glslang/Include/Common.h
+++ b/glslang/Include/Common.h
@@ -94,6 +94,11 @@ std::string to_string(const T& val) {
     #pragma warning(disable : 4201) // nameless union
 #endif
 
+// Allow compilation to WASI which does not support threads yet.
+#ifdef __wasi__ 
+#define DISABLE_THREAD_SUPPORT
+#endif
+
 #include "PoolAlloc.h"
 
 //

--- a/glslang/MachineIndependent/PoolAlloc.cpp
+++ b/glslang/MachineIndependent/PoolAlloc.cpp
@@ -35,14 +35,21 @@
 #include "../Include/Common.h"
 #include "../Include/PoolAlloc.h"
 
+// Mostly here for target that do not support threads such as WASI.
+#ifdef DISABLE_THREAD_SUPPORT
+#define THREAD_LOCAL 
+#else
+#define THREAD_LOCAL thread_local
+#endif
+
 namespace glslang {
 
 namespace {
-thread_local TPoolAllocator* threadPoolAllocator = nullptr;
+THREAD_LOCAL TPoolAllocator* threadPoolAllocator = nullptr;
 
 TPoolAllocator* GetDefaultThreadPoolAllocator()
 {
-    thread_local TPoolAllocator defaultAllocator;
+    THREAD_LOCAL TPoolAllocator defaultAllocator;
     return &defaultAllocator;
 }
 } // anonymous namespace

--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -82,7 +82,10 @@ namespace { // anonymous namespace for file-local functions and symbols
 int NumberOfClients = 0;
 
 // global initialization lock
+#ifndef DISABLE_THREAD_SUPPORT
 std::mutex init_lock;
+#endif
+
 
 using namespace glslang;
 
@@ -420,7 +423,9 @@ void SetupBuiltinSymbolTable(int version, EProfile profile, const SpvVersion& sp
     TInfoSink infoSink;
 
     // Make sure only one thread tries to do this at a time
+#ifndef DISABLE_THREAD_SUPPORT
     const std::lock_guard<std::mutex> lock(init_lock);
+#endif
 
     // See if it's already been done for this version/profile combination
     int versionIndex = MapVersionToIndex(version);
@@ -1311,7 +1316,9 @@ bool CompileDeferred(
 //
 int ShInitialize()
 {
+#ifndef DISABLE_THREAD_SUPPORT
     const std::lock_guard<std::mutex> lock(init_lock);
+#endif
     ++NumberOfClients;
 
     if (PerProcessGPA == nullptr)
@@ -1371,7 +1378,9 @@ void ShDestruct(ShHandle handle)
 //
 int ShFinalize()
 {
+#ifndef DISABLE_THREAD_SUPPORT
     const std::lock_guard<std::mutex> lock(init_lock);
+#endif
     --NumberOfClients;
     assert(NumberOfClients >= 0);
     if (NumberOfClients > 0)


### PR DESCRIPTION
I was looking into compiling glslang for [WASM WASI](https://wasi.dev/) target, and I successfully did so by removing some reference to threads as WASI does not support threads yet. 
So here is a small PR that disable thread safety in order to allow compilation for WASI, the preprocessor guarding is safe so this should not impact anything other than WASI target.