### PR TITLE
Fixes undefined behavior due to unspecified bitflag enum backing

### DIFF
--- a/SPIRV/spirv.hpp
+++ b/SPIRV/spirv.hpp
@@ -385,7 +385,7 @@ enum ImageOperandsShift {
     ImageOperandsMax = 0x7fffffff,
 };
 
-enum ImageOperandsMask {
+enum ImageOperandsMask : unsigned {
     ImageOperandsMaskNone = 0,
     ImageOperandsBiasMask = 0x00000001,
     ImageOperandsLodMask = 0x00000002,
@@ -420,7 +420,7 @@ enum FPFastMathModeShift {
     FPFastMathModeMax = 0x7fffffff,
 };
 
-enum FPFastMathModeMask {
+enum FPFastMathModeMask : unsigned {
     FPFastMathModeMaskNone = 0,
     FPFastMathModeNotNaNMask = 0x00000001,
     FPFastMathModeNotInfMask = 0x00000002,
@@ -745,7 +745,7 @@ enum SelectionControlShift {
     SelectionControlMax = 0x7fffffff,
 };
 
-enum SelectionControlMask {
+enum SelectionControlMask : unsigned {
     SelectionControlMaskNone = 0,
     SelectionControlFlattenMask = 0x00000001,
     SelectionControlDontFlattenMask = 0x00000002,
@@ -774,7 +774,7 @@ enum LoopControlShift {
     LoopControlMax = 0x7fffffff,
 };
 
-enum LoopControlMask {
+enum LoopControlMask : unsigned {
     LoopControlMaskNone = 0,
     LoopControlUnrollMask = 0x00000001,
     LoopControlDontUnrollMask = 0x00000002,
@@ -806,7 +806,7 @@ enum FunctionControlShift {
     FunctionControlMax = 0x7fffffff,
 };
 
-enum FunctionControlMask {
+enum FunctionControlMask : unsigned {
     FunctionControlMaskNone = 0,
     FunctionControlInlineMask = 0x00000001,
     FunctionControlDontInlineMask = 0x00000002,
@@ -836,7 +836,7 @@ enum MemorySemanticsShift {
     MemorySemanticsMax = 0x7fffffff,
 };
 
-enum MemorySemanticsMask {
+enum MemorySemanticsMask : unsigned {
     MemorySemanticsMaskNone = 0,
     MemorySemanticsAcquireMask = 0x00000002,
     MemorySemanticsReleaseMask = 0x00000004,
@@ -872,7 +872,7 @@ enum MemoryAccessShift {
     MemoryAccessMax = 0x7fffffff,
 };
 
-enum MemoryAccessMask {
+enum MemoryAccessMask : unsigned {
     MemoryAccessMaskNone = 0,
     MemoryAccessVolatileMask = 0x00000001,
     MemoryAccessAlignedMask = 0x00000002,
@@ -922,7 +922,7 @@ enum KernelProfilingInfoShift {
     KernelProfilingInfoMax = 0x7fffffff,
 };
 
-enum KernelProfilingInfoMask {
+enum KernelProfilingInfoMask : unsigned {
     KernelProfilingInfoMaskNone = 0,
     KernelProfilingInfoCmdExecTimeMask = 0x00000001,
 };
@@ -1194,7 +1194,7 @@ enum RayFlagsShift {
     RayFlagsMax = 0x7fffffff,
 };
 
-enum RayFlagsMask {
+enum RayFlagsMask : unsigned {
     RayFlagsMaskNone = 0,
     RayFlagsOpaqueKHRMask = 0x00000001,
     RayFlagsNoOpaqueKHRMask = 0x00000002,
@@ -1236,7 +1236,7 @@ enum FragmentShadingRateShift {
     FragmentShadingRateMax = 0x7fffffff,
 };
 
-enum FragmentShadingRateMask {
+enum FragmentShadingRateMask : unsigned {
     FragmentShadingRateMaskNone = 0,
     FragmentShadingRateVertical2PixelsMask = 0x00000001,
     FragmentShadingRateVertical4PixelsMask = 0x00000002,
@@ -1291,7 +1291,7 @@ enum CooperativeMatrixOperandsShift {
     CooperativeMatrixOperandsMax = 0x7fffffff,
 };
 
-enum CooperativeMatrixOperandsMask {
+enum CooperativeMatrixOperandsMask : unsigned {
     CooperativeMatrixOperandsMaskNone = 0,
     CooperativeMatrixOperandsMatrixASignedComponentsKHRMask = 0x00000001,
     CooperativeMatrixOperandsMatrixBSignedComponentsKHRMask = 0x00000002,


### PR DESCRIPTION
I build my engine with Zig, which enables LLVM's [Undefined Behavior Sanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) by default in debug builds. UBSAN caught undefined behavior during shader compilation at the following location:

```
0.  0x000000000426e391 in spv::operator& (a=spv::MemoryAccessMaskNone,
    b=(spv::MemoryAccessVolatileMask | spv::MemoryAccessAlignedMask | spv::MemoryAccessNontemporalMask | spv::MemoryAccessMakePointerVisibleMask | spv::MemoryAccessNonPrivatePointerMask | spv::MemoryAccessAliasScopeINTELMaskMask | spv::MemoryAccessNoAliasINTELMaskMask | unknown: 0xfffcffc0)) at SPIRV/spirv.hpp:2804
1.  0x00000000041e81e0 in (anonymous namespace)::TGlslangToSpvTraverser::accessChainLoad (this=0x7fffffffcbb8, type=...) at SPIRV/GlslangToSpv.cpp:5127
2.  0x00000000041bc059 in (anonymous namespace)::TGlslangToSpvTraverser::visitBinary (this=0x7fffffffcbb8, node=0x5f6a6c8) at SPIRV/GlslangToSpv.cpp:2192
3.  0x0000000003db8660 in glslang::TIntermBinary::traverse (this=0x5f6a6c8, it=0x7fffffffcbb8) at glslang/glslang/MachineIndependent/IntermTraverse.cpp:92
4.  0x0000000003db952e in glslang::TIntermAggregate::traverse (this=0x5f6a7d8, it=0x7fffffffcbb8) at glslang/glslang/MachineIndependent/IntermTraverse.cpp:175
5.  0x00000000042082db in (anonymous namespace)::TGlslangToSpvTraverser::makeGlobalInitializers (this=0x7fffffffcbb8, initializers=...) at SPIRV/GlslangToSpv.cpp:5618
6.  0x00000000041c511f in (anonymous namespace)::TGlslangToSpvTraverser::visitAggregate (this=0x7fffffffcbb8, visit=glslang::EvPreVisit, node=0x5f6a9b8) at SPIRV/GlslangToSpv.cpp:2907
7.  0x0000000003db8fb9 in glslang::TIntermAggregate::traverse (this=0x5f6a9b8, it=0x7fffffffcbb8) at glslang/glslang/MachineIndependent/IntermTraverse.cpp:159
8.  0x00000000041acc04 in glslang::GlslangToSpv (intermediate=..., spirv=..., logger=0x7fffffffdc38, options=0x7fffffffdc2f) at SPIRV/GlslangToSpv.cpp:10398
9.  0x0000000003bfd6f1 in CompileAndLinkShaderUnits (compUnits=...) at StandAlone/StandAlone.cpp:1547
10. 0x0000000003bfe2f8 in CompileAndLinkShaderFiles (Worklist=...) at StandAlone/StandAlone.cpp:1640
11. 0x0000000003bfec2c in singleMain () at StandAlone/StandAlone.cpp:1713
12. 0x0000000003bff4dd in main (argc=5, argv=0x7fffffffe3d8) at StandAlone/StandAlone.cpp:1767
```

The explanation is that enums *when used as bitflags* in C++ must declare a backing type. If they don't, you can end up with "out of range" values (for example when bitwise negated as is the case in this trace) leading to undefined behavior when converting to/from integral values.

It's a bit hard to follow, but see the [discussion here](https://stackoverflow.com/questions/54379993/which-enum-values-are-undefined-behavior-in-c14-and-why) on C++ enums and undefined behavior.

Thankfully, the fix is easy. This PR simply sets the relevant enum backing types to `unsigned int`. I chose `unsigned int` since these enums are already assumed to be unsigned ints in other parts of the code anyway.