### PR TITLE
kokoro: use Python 3.12 for Linux builds

### DIFF
--- a/kokoro/linux-clang-cmake/build-docker.sh
+++ b/kokoro/linux-clang-cmake/build-docker.sh
@@ -42,6 +42,7 @@ set -x # Display commands being run.
 using cmake-3.17.2
 using clang-10.0.0
 using ninja-1.10.0
+using python-3.12
 
 echo "Building..."
 mkdir /build && cd /build

--- a/kokoro/linux-gcc-cmake/build-docker.sh
+++ b/kokoro/linux-gcc-cmake/build-docker.sh
@@ -42,6 +42,7 @@ set -x # Display commands being run.
 using cmake-3.17.2
 using gcc-9
 using ninja-1.10.0
+using python-3.12
 
 echo "Building..."
 mkdir /build && cd /build


### PR DESCRIPTION
Bug: crbug.com/350048185