### PR TITLE
Update macOS requirement from 11 to 12 in github CD workflow

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -101,7 +101,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [{genus: macos-11, family: osx}]
+                os: [{genus: macos-12, family: osx}]
                 compiler: [{cc: clang, cxx: clang++}]
                 cmake_build_type: [Debug, Release]
         steps:


### PR DESCRIPTION
Our github continuous delivery workflow appears to be failing for macOS, possibly because the requested version of the OS is too old.