### PR TITLE
tweak error behavior for redeclared uniforms for vulkan-relaxed

### DIFF
--- a/Test/baseResults/vk.relaxed.errorcheck.vert.out
+++ b/Test/baseResults/vk.relaxed.errorcheck.vert.out
@@ -32,29 +32,39 @@ Shader version: 460
 0:?     'gl_InstanceIndex' ( in int InstanceIndex)
 
 vk.relaxed.errorcheck.frag
+ERROR: 0:11: 'test' :  Redeclaration: already declared as " uniform highp float"
+ERROR: 1 compilation errors.  No code generated.
+
+
 Shader version: 460
 gl_FragCoord origin is upper left
-0:? Sequence
-0:10  Function Definition: foo( ( global highp 4-component vector of float)
-0:10    Function Parameters: 
-0:11    Sequence
-0:11      Branch: Return with expression
-0:11        a: direct index for structure ( uniform highp 4-component vector of float)
-0:11          'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a})
-0:11          Constant:
-0:11            0 (const uint)
-0:14  Function Definition: main( ( global void)
-0:14    Function Parameters: 
-0:15    Sequence
-0:15      move second child to first child ( temp highp 4-component vector of float)
-0:15        'o' ( out highp 4-component vector of float)
-0:15        add ( temp highp 4-component vector of float)
-0:15          'io' (layout( location=0) smooth in highp 4-component vector of float)
-0:15          Function Call: foo( ( global highp 4-component vector of float)
+ERROR: node is still EOpNull!
+0:13  Function Definition: foo( ( global highp 4-component vector of float)
+0:13    Function Parameters: 
+0:14    Sequence
+0:14      Branch: Return with expression
+0:14        add ( temp highp 4-component vector of float)
+0:14          a: direct index for structure ( uniform highp 4-component vector of float)
+0:14            'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp float test})
+0:14            Constant:
+0:14              0 (const uint)
+0:14          Construct vec4 ( temp highp 4-component vector of float)
+0:14            test: direct index for structure ( uniform highp float)
+0:14              'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp float test})
+0:14              Constant:
+0:14                1 (const uint)
+0:17  Function Definition: main( ( global void)
+0:17    Function Parameters: 
+0:18    Sequence
+0:18      move second child to first child ( temp highp 4-component vector of float)
+0:18        'o' ( out highp 4-component vector of float)
+0:18        add ( temp highp 4-component vector of float)
+0:18          'io' (layout( location=0) smooth in highp 4-component vector of float)
+0:18          Function Call: foo( ( global highp 4-component vector of float)
 0:?   Linker Objects
 0:?     'io' (layout( location=0) smooth in highp 4-component vector of float)
 0:?     'o' ( out highp 4-component vector of float)
-0:?     'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a})
+0:?     'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp float test})
 
 
 Linked vertex stage:
@@ -98,27 +108,33 @@ Shader version: 460
 0:?     'gl_InstanceIndex' ( in int InstanceIndex)
 Shader version: 460
 gl_FragCoord origin is upper left
-0:? Sequence
-0:10  Function Definition: foo( ( global highp 4-component vector of float)
-0:10    Function Parameters: 
-0:11    Sequence
-0:11      Branch: Return with expression
-0:11        a: direct index for structure ( uniform highp 4-component vector of float)
-0:11          'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a})
-0:11          Constant:
-0:11            0 (const uint)
-0:14  Function Definition: main( ( global void)
-0:14    Function Parameters: 
-0:15    Sequence
-0:15      move second child to first child ( temp highp 4-component vector of float)
-0:15        'o' ( out highp 4-component vector of float)
-0:15        add ( temp highp 4-component vector of float)
-0:15          'io' (layout( location=0) smooth in highp 4-component vector of float)
-0:15          Function Call: foo( ( global highp 4-component vector of float)
+ERROR: node is still EOpNull!
+0:13  Function Definition: foo( ( global highp 4-component vector of float)
+0:13    Function Parameters: 
+0:14    Sequence
+0:14      Branch: Return with expression
+0:14        add ( temp highp 4-component vector of float)
+0:14          a: direct index for structure ( uniform highp 4-component vector of float)
+0:14            'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp float test})
+0:14            Constant:
+0:14              0 (const uint)
+0:14          Construct vec4 ( temp highp 4-component vector of float)
+0:14            test: direct index for structure ( uniform highp float)
+0:14              'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp float test})
+0:14              Constant:
+0:14                1 (const uint)
+0:17  Function Definition: main( ( global void)
+0:17    Function Parameters: 
+0:18    Sequence
+0:18      move second child to first child ( temp highp 4-component vector of float)
+0:18        'o' ( out highp 4-component vector of float)
+0:18        add ( temp highp 4-component vector of float)
+0:18          'io' (layout( location=0) smooth in highp 4-component vector of float)
+0:18          Function Call: foo( ( global highp 4-component vector of float)
 0:?   Linker Objects
 0:?     'io' (layout( location=0) smooth in highp 4-component vector of float)
 0:?     'o' ( out highp 4-component vector of float)
-0:?     'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a})
+0:?     'anon@0' (layout( column_major std140) uniform block{ uniform highp 4-component vector of float a,  uniform highp float test})
 
 Validation failed
 SPIR-V is not generated for failed compile or link

--- a/Test/vk.relaxed.errorcheck.frag
+++ b/Test/vk.relaxed.errorcheck.frag
@@ -7,8 +7,11 @@ out vec4 o;
 // default uniforms will be gathered into a uniform block
 uniform vec4 a;     // declared in both stages with different types
 
+uniform float test; // declared twice in this compilation unit
+uniform vec2 test;
+
 vec4 foo() {
-    return a;
+    return a + vec4(test);
 }
 
 void main() {

--- a/glslang/MachineIndependent/ParseContextBase.cpp
+++ b/glslang/MachineIndependent/ParseContextBase.cpp
@@ -626,10 +626,8 @@ void TParseContextBase::growGlobalUniformBlock(const TSourceLoc& loc, TType& mem
     if (symbol) {
         if (memberType != symbol->getType()) {
             TString err;
-            err += "\"" + memberType.getCompleteString() + "\"";
-            err += " versus ";
-            err += "\"" + symbol->getType().getCompleteString() + "\"";
-            error(loc, "Types must match:", memberType.getFieldName().c_str(), err.c_str());
+            err += "Redeclaration: already declared as \"" + symbol->getType().getCompleteString() + "\"";
+            error(loc, "", memberName.c_str(), err.c_str());
         }
         return;
     }


### PR DESCRIPTION
avoids nullptr crash from reading memberType's name, and more user friendly error message.