### PR TITLE
Apply GLSL memory decorations to top-level OpVariable

### DIFF
--- a/SPIRV/GlslangToSpv.cpp
+++ b/SPIRV/GlslangToSpv.cpp
@@ -4372,7 +4372,14 @@ spv::Id TGlslangToSpvTraverser::createSpvVariable(const glslang::TIntermSymbol* 
         initializer = builder.makeNullConstant(spvType);
     }
 
-    return builder.createVariable(spv::NoPrecision, storageClass, spvType, name, initializer, false);
+    spv::Id var = builder.createVariable(spv::NoPrecision, storageClass, spvType, name, initializer, false);
+    std::vector<spv::Decoration> topLevelDecorations;
+    glslang::TQualifier typeQualifier = node->getType().getQualifier();
+    TranslateMemoryDecoration(typeQualifier, topLevelDecorations, glslangIntermediate->usingVulkanMemoryModel());
+    for (auto deco : topLevelDecorations) {
+        builder.addDecoration(var, deco);
+    }
+    return var;
 }
 
 // Return type Id of the sampled type.

--- a/Test/baseResults/hlsl.attributeC11.frag.out
+++ b/Test/baseResults/hlsl.attributeC11.frag.out
@@ -132,8 +132,10 @@ Validation failed
                               Decorate 43(buffer1) BufferBlock
                               MemberDecorate 43(buffer1) 0 NonWritable
                               MemberDecorate 43(buffer1) 0 Offset 0
+                              Decorate 45(buffer1) NonWritable
                               Decorate 45(buffer1) Binding 1
                               Decorate 45(buffer1) DescriptorSet 0
+                              Decorate 46(buffer3) NonWritable
                               Decorate 46(buffer3) Binding 3
                               Decorate 46(buffer3) DescriptorSet 2
                               Decorate 47(ci) SpecId 13

--- a/Test/baseResults/hlsl.buffer.frag.out
+++ b/Test/baseResults/hlsl.buffer.frag.out
@@ -205,6 +205,7 @@ Validation failed
                               Decorate 37(buf2) BufferBlock
                               MemberDecorate 37(buf2) 0 NonWritable
                               MemberDecorate 37(buf2) 0 Offset 0
+                              Decorate 39 NonWritable
                               Decorate 39 Binding 1
                               Decorate 39 DescriptorSet 0
                               Decorate 43(cbufName) Block
@@ -245,6 +246,7 @@ Validation failed
                               MemberDecorate 50(tbufName) 11 MatrixStride 16
                               MemberDecorate 50(tbufName) 11 NonWritable
                               MemberDecorate 50(tbufName) 11 Offset 304
+                              Decorate 52 NonWritable
                               Decorate 52 Binding 8
                               Decorate 52 DescriptorSet 0
                               Decorate 65(input) BuiltIn FragCoord

--- a/Test/baseResults/hlsl.buffer_ref_parameter.comp.out
+++ b/Test/baseResults/hlsl.buffer_ref_parameter.comp.out
@@ -279,6 +279,7 @@ local_size = (64, 1, 1)
                               MemberDecorate 8 0 NonWritable
                               MemberDecorate 8 0 Offset 0
                               Decorate 14(buffer_position) NonWritable
+                              Decorate 53(buffer_position_ms) NonWritable
                               Decorate 53(buffer_position_ms) Binding 0
                               Decorate 53(buffer_position_ms) DescriptorSet 0
                               Decorate 59 ArrayStride 4

--- a/Test/baseResults/hlsl.layout.frag.out
+++ b/Test/baseResults/hlsl.layout.frag.out
@@ -114,14 +114,17 @@ Validation failed
                               Decorate 17(tbufName) BufferBlock
                               MemberDecorate 17(tbufName) 0 NonWritable
                               MemberDecorate 17(tbufName) 0 Offset 16
+                              Decorate 19 NonWritable
                               Decorate 19 Binding 5
                               Decorate 19 DescriptorSet 3
                               Decorate 26(tbufName2) BufferBlock
                               MemberDecorate 26(tbufName2) 0 NonWritable
                               MemberDecorate 26(tbufName2) 0 Offset 0
+                              Decorate 28 NonWritable
                               Decorate 33(tbufName2) BufferBlock
                               MemberDecorate 33(tbufName2) 0 NonWritable
                               MemberDecorate 33(tbufName2) 0 Offset 16
+                              Decorate 35 NonWritable
                               Decorate 35 Binding 7
                               Decorate 35 DescriptorSet 4
                               Decorate 43(specConst) SpecId 17

--- a/Test/baseResults/hlsl.structbuffer.byte.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.byte.frag.out
@@ -351,6 +351,7 @@ gl_FragCoord origin is upper left
                               Decorate 16(sbuf) BufferBlock
                               MemberDecorate 16(sbuf) 0 NonWritable
                               MemberDecorate 16(sbuf) 0 Offset 0
+                              Decorate 18(sbuf) NonWritable
                               Decorate 18(sbuf) Binding 0
                               Decorate 18(sbuf) DescriptorSet 0
                               Decorate 107(pos) Flat

--- a/Test/baseResults/hlsl.structbuffer.coherent.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.coherent.frag.out
@@ -207,6 +207,7 @@ gl_FragCoord origin is upper left
                               Decorate 15(sbuf2) BufferBlock
                               MemberDecorate 15(sbuf2) 0 Coherent
                               MemberDecorate 15(sbuf2) 0 Offset 0
+                              Decorate 17(sbuf2) Coherent
                               Decorate 17(sbuf2) Binding 1
                               Decorate 17(sbuf2) DescriptorSet 0
                               MemberDecorate 28(sb_t) 0 Offset 0
@@ -215,6 +216,7 @@ gl_FragCoord origin is upper left
                               Decorate 30(sbuf) BufferBlock
                               MemberDecorate 30(sbuf) 0 Coherent
                               MemberDecorate 30(sbuf) 0 Offset 0
+                              Decorate 32(sbuf) Coherent
                               Decorate 32(sbuf) Binding 0
                               Decorate 32(sbuf) DescriptorSet 0
                               Decorate 71(pos) Flat

--- a/Test/baseResults/hlsl.structbuffer.fn.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.fn.frag.out
@@ -194,6 +194,7 @@ Validation failed
                               Decorate 47(sbuf2) DescriptorSet 0
                               Decorate 48(sbuf2@count) Binding 0
                               Decorate 48(sbuf2@count) DescriptorSet 0
+                              Decorate 50(sbuf) NonWritable
                               Decorate 50(sbuf) Binding 10
                               Decorate 50(sbuf) DescriptorSet 0
                               Decorate 63(pos) Flat
@@ -207,6 +208,7 @@ Validation failed
                               Decorate 75(sbuf3) BufferBlock
                               MemberDecorate 75(sbuf3) 0 NonWritable
                               MemberDecorate 75(sbuf3) 0 Offset 0
+                              Decorate 77(sbuf3) NonWritable
                               Decorate 77(sbuf3) Binding 12
                               Decorate 77(sbuf3) DescriptorSet 0
                2:             TypeVoid

--- a/Test/baseResults/hlsl.structbuffer.fn2.comp.out
+++ b/Test/baseResults/hlsl.structbuffer.fn2.comp.out
@@ -169,6 +169,7 @@ local_size = (256, 1, 1)
                               MemberDecorate 9 0 NonWritable
                               MemberDecorate 9 0 Offset 0
                               Decorate 14(buffer) NonWritable
+                              Decorate 44(g_input) NonWritable
                               Decorate 44(g_input) Binding 0
                               Decorate 44(g_input) DescriptorSet 0
                               Decorate 50(g_output) Binding 1

--- a/Test/baseResults/hlsl.structbuffer.frag.out
+++ b/Test/baseResults/hlsl.structbuffer.frag.out
@@ -228,12 +228,14 @@ gl_FragCoord origin is upper left
                               Decorate 21(sbuf) BufferBlock
                               MemberDecorate 21(sbuf) 0 NonWritable
                               MemberDecorate 21(sbuf) 0 Offset 0
+                              Decorate 23(sbuf) NonWritable
                               Decorate 23(sbuf) Binding 10
                               Decorate 23(sbuf) DescriptorSet 0
                               Decorate 58 ArrayStride 4
                               Decorate 59(sbuf2) BufferBlock
                               MemberDecorate 59(sbuf2) 0 NonWritable
                               MemberDecorate 59(sbuf2) 0 Offset 0
+                              Decorate 61(sbuf2) NonWritable
                               Decorate 61(sbuf2) Binding 0
                               Decorate 61(sbuf2) DescriptorSet 0
                               Decorate 89(pos) Flat

--- a/Test/baseResults/hlsl.structcopy.comp.out
+++ b/Test/baseResults/hlsl.structcopy.comp.out
@@ -288,12 +288,14 @@ local_size = (128, 1, 1)
                               Decorate 30(sb) BufferBlock
                               MemberDecorate 30(sb) 0 NonWritable
                               MemberDecorate 30(sb) 0 Offset 0
+                              Decorate 32(sb) NonWritable
                               Decorate 32(sb) Binding 0
                               Decorate 32(sb) DescriptorSet 0
                               Decorate 64 ArrayStride 12
                               Decorate 65(o) BufferBlock
                               MemberDecorate 65(o) 0 NonWritable
                               MemberDecorate 65(o) 0 Offset 0
+                              Decorate 67(o) NonWritable
                               Decorate 67(o) Binding 1
                               Decorate 67(o) DescriptorSet 0
                               Decorate 83(id) BuiltIn LocalInvocationIndex

--- a/Test/baseResults/hlsl.structcopylogical.comp.out
+++ b/Test/baseResults/hlsl.structcopylogical.comp.out
@@ -288,12 +288,14 @@ local_size = (128, 1, 1)
                               Decorate 30(sb) Block
                               MemberDecorate 30(sb) 0 NonWritable
                               MemberDecorate 30(sb) 0 Offset 0
+                              Decorate 32(sb) NonWritable
                               Decorate 32(sb) Binding 0
                               Decorate 32(sb) DescriptorSet 0
                               Decorate 54 ArrayStride 12
                               Decorate 55(o) Block
                               MemberDecorate 55(o) 0 NonWritable
                               MemberDecorate 55(o) 0 Offset 0
+                              Decorate 57(o) NonWritable
                               Decorate 57(o) Binding 1
                               Decorate 57(o) DescriptorSet 0
                               Decorate 74(id) BuiltIn LocalInvocationIndex

--- a/Test/baseResults/hlsl.texturebuffer.frag.out
+++ b/Test/baseResults/hlsl.texturebuffer.frag.out
@@ -99,6 +99,7 @@ gl_FragCoord origin is upper left
                               MemberDecorate 15(TextureBuffer_var) 0 Offset 0
                               MemberDecorate 15(TextureBuffer_var) 1 NonWritable
                               MemberDecorate 15(TextureBuffer_var) 1 Offset 16
+                              Decorate 17(TextureBuffer_var) NonWritable
                               Decorate 17(TextureBuffer_var) Binding 0
                               Decorate 17(TextureBuffer_var) DescriptorSet 0
                               Decorate 22(tbuf2) BufferBlock
@@ -106,6 +107,7 @@ gl_FragCoord origin is upper left
                               MemberDecorate 22(tbuf2) 0 Offset 0
                               MemberDecorate 22(tbuf2) 1 NonWritable
                               MemberDecorate 22(tbuf2) 1 Offset 16
+                              Decorate 24 NonWritable
                               Decorate 24 Binding 1
                               Decorate 24 DescriptorSet 0
                               Decorate 32(pos) BuiltIn FragCoord

--- a/Test/baseResults/iomap.crossStage.vk.vert.out
+++ b/Test/baseResults/iomap.crossStage.vk.vert.out
@@ -421,6 +421,7 @@ gl_FragCoord origin is upper left
                               Decorate 29(vertOnlyBlock) BufferBlock
                               MemberDecorate 29(vertOnlyBlock) 0 NonWritable
                               MemberDecorate 29(vertOnlyBlock) 0 Offset 0
+                              Decorate 31 NonWritable
                               Decorate 31 Binding 0
                               Decorate 31 DescriptorSet 0
                               Decorate 32(crossStageBlock2) Block
@@ -616,6 +617,7 @@ gl_FragCoord origin is upper left
                               Decorate 15(fragOnlyBlock) BufferBlock
                               MemberDecorate 15(fragOnlyBlock) 0 NonWritable
                               MemberDecorate 15(fragOnlyBlock) 0 Offset 0
+                              Decorate 17 NonWritable
                               Decorate 17 Binding 2
                               Decorate 17 DescriptorSet 0
                               Decorate 23(crossStageBlock2) Block

--- a/Test/baseResults/spv.1.3.8bitstorage-ssbo.vert.out
+++ b/Test/baseResults/spv.1.3.8bitstorage-ssbo.vert.out
@@ -22,6 +22,7 @@ spv.1.3.8bitstorage-ssbo.vert
                               Decorate 12(Vertices) Block
                               MemberDecorate 12(Vertices) 0 NonWritable
                               MemberDecorate 12(Vertices) 0 Offset 0
+                              Decorate 14 NonWritable
                               Decorate 14 Binding 0
                               Decorate 14 DescriptorSet 0
                               Decorate 18(gl_VertexIndex) BuiltIn VertexIndex

--- a/Test/baseResults/spv.1.3.8bitstorage-ubo.vert.out
+++ b/Test/baseResults/spv.1.3.8bitstorage-ubo.vert.out
@@ -21,6 +21,7 @@ spv.1.3.8bitstorage-ubo.vert
                               Decorate 13 ArrayStride 16
                               Decorate 14(Vertices) Block
                               MemberDecorate 14(Vertices) 0 Offset 0
+                              Decorate 16 NonWritable
                               Decorate 16 Binding 0
                               Decorate 16 DescriptorSet 0
                               Decorate 20(gl_VertexIndex) BuiltIn VertexIndex

--- a/Test/baseResults/spv.8bitstorage-ssbo.vert.out
+++ b/Test/baseResults/spv.8bitstorage-ssbo.vert.out
@@ -22,6 +22,7 @@ spv.8bitstorage-ssbo.vert
                               Decorate 12(Vertices) BufferBlock
                               MemberDecorate 12(Vertices) 0 NonWritable
                               MemberDecorate 12(Vertices) 0 Offset 0
+                              Decorate 14 NonWritable
                               Decorate 14 Binding 0
                               Decorate 14 DescriptorSet 0
                               Decorate 18(gl_VertexIndex) BuiltIn VertexIndex

--- a/Test/baseResults/spv.8bitstorage-ubo.vert.out
+++ b/Test/baseResults/spv.8bitstorage-ubo.vert.out
@@ -21,6 +21,7 @@ spv.8bitstorage-ubo.vert
                               Decorate 13 ArrayStride 16
                               Decorate 14(Vertices) Block
                               MemberDecorate 14(Vertices) 0 Offset 0
+                              Decorate 16 NonWritable
                               Decorate 16 Binding 0
                               Decorate 16 DescriptorSet 0
                               Decorate 20(gl_VertexIndex) BuiltIn VertexIndex

--- a/Test/baseResults/spv.atomiAddEXT.task.out
+++ b/Test/baseResults/spv.atomiAddEXT.task.out
@@ -26,6 +26,7 @@ spv.atomiAddEXT.task
                               Decorate 7(Buffer) Block
                               MemberDecorate 7(Buffer) 0 Coherent
                               MemberDecorate 7(Buffer) 0 Offset 0
+                              Decorate 9 Coherent
                               Decorate 9 Binding 1
                               Decorate 9 DescriptorSet 0
                               Decorate 19 ArrayStride 4

--- a/Test/baseResults/spv.atomic.comp.out
+++ b/Test/baseResults/spv.atomic.comp.out
@@ -40,6 +40,7 @@ spv.atomic.comp
                               MemberDecorate 62(dataSSB) 0 Offset 0
                               MemberDecorate 62(dataSSB) 1 Restrict
                               MemberDecorate 62(dataSSB) 1 Offset 16
+                              Decorate 64(result) Restrict
                               Decorate 64(result) Binding 0
                               Decorate 64(result) DescriptorSet 0
                2:             TypeVoid

--- a/Test/baseResults/spv.bufferhandle13.frag.out
+++ b/Test/baseResults/spv.bufferhandle13.frag.out
@@ -45,10 +45,12 @@ spv.bufferhandle13.frag
                               MemberDecorate 35(t5) 0 Offset 0
                               Decorate 37(s5) Binding 0
                               Decorate 37(s5) DescriptorSet 0
+                              Decorate 42(b) Restrict
                               Decorate 42(b) DecorationRestrictPointerEXT
                               Decorate 47(param) DecorationAliasedPointerEXT
                               Decorate 52(param) DecorationAliasedPointerEXT
                               Decorate 56(g1) DecorationAliasedPointerEXT
+                              Decorate 57(g2) Restrict
                               Decorate 57(g2) DecorationRestrictPointerEXT
                2:             TypeVoid
                3:             TypeFunction 2

--- a/Test/baseResults/spv.debuginfo.bufferref.glsl.frag.out
+++ b/Test/baseResults/spv.debuginfo.bufferref.glsl.frag.out
@@ -89,6 +89,7 @@ void main() {
                               Decorate 64(PerPass_meshes) Block
                               MemberDecorate 64(PerPass_meshes) 0 NonWritable
                               MemberDecorate 64(PerPass_meshes) 0 Offset 0
+                              Decorate 73(perPass_meshes) NonWritable
                               Decorate 73(perPass_meshes) Binding 0
                               Decorate 73(perPass_meshes) DescriptorSet 0
                               Decorate 82(tri_idx0) Flat

--- a/Test/baseResults/spv.debuginfo.hlsl.comp.out
+++ b/Test/baseResults/spv.debuginfo.hlsl.comp.out
@@ -157,6 +157,7 @@ spv.debuginfo.hlsl.comp
                               Decorate 199(particleIn) BufferBlock
                               MemberDecorate 199(particleIn) 0 NonWritable
                               MemberDecorate 199(particleIn) 0 Offset 0
+                              Decorate 208(particleIn) NonWritable
                               Decorate 208(particleIn) Binding 0
                               Decorate 208(particleIn) DescriptorSet 0
                               Decorate 220 ArrayStride 80

--- a/Test/baseResults/spv.expect_assume.assumeEXT.comp.out
+++ b/Test/baseResults/spv.expect_assume.assumeEXT.comp.out
@@ -19,6 +19,7 @@ spv.expect_assume.assumeEXT.comp
                               Decorate 7(roblock) BufferBlock
                               MemberDecorate 7(roblock) 0 NonWritable
                               MemberDecorate 7(roblock) 0 Offset 0
+                              Decorate 9(ro) NonWritable
                               Decorate 9(ro) Binding 0
                               Decorate 9(ro) DescriptorSet 0
                               Decorate 21 BuiltIn WorkgroupSize

--- a/Test/baseResults/spv.expect_assume.expectEXT.comp.out
+++ b/Test/baseResults/spv.expect_assume.expectEXT.comp.out
@@ -53,6 +53,7 @@ spv.expect_assume.expectEXT.comp
                               MemberDecorate 18(roblock) 10 Offset 112
                               MemberDecorate 18(roblock) 11 NonWritable
                               MemberDecorate 18(roblock) 11 Offset 128
+                              Decorate 20(ro) NonWritable
                               Decorate 20(ro) Binding 0
                               Decorate 20(ro) DescriptorSet 0
                               Decorate 177 BuiltIn WorkgroupSize

--- a/Test/baseResults/spv.expect_assume.expectEXT.exttypes.comp.out
+++ b/Test/baseResults/spv.expect_assume.expectEXT.exttypes.comp.out
@@ -121,6 +121,7 @@ spv.expect_assume.expectEXT.exttypes.comp
                               MemberDecorate 42(roblock) 30 Offset 320
                               MemberDecorate 42(roblock) 31 NonWritable
                               MemberDecorate 42(roblock) 31 Offset 352
+                              Decorate 44(ro) NonWritable
                               Decorate 44(ro) Binding 0
                               Decorate 44(ro) DescriptorSet 0
                               Decorate 457 BuiltIn WorkgroupSize

--- a/Test/baseResults/spv.fsi.frag.out
+++ b/Test/baseResults/spv.fsi.frag.out
@@ -21,6 +21,7 @@ spv.fsi.frag
                               Decorate 7(B1) BufferBlock
                               MemberDecorate 7(B1) 0 Coherent
                               MemberDecorate 7(B1) 0 Offset 0
+                              Decorate 9(b1) Coherent
                               Decorate 9(b1) Binding 0
                               Decorate 9(b1) DescriptorSet 0
                               Decorate 17(im) Coherent

--- a/Test/baseResults/spv.memoryQualifier.frag.out
+++ b/Test/baseResults/spv.memoryQualifier.frag.out
@@ -65,6 +65,7 @@ Validation failed
                               MemberDecorate 50(Buffer) 4 Offset 48
                               MemberDecorate 50(Buffer) 5 Coherent
                               MemberDecorate 50(Buffer) 5 Offset 56
+                              Decorate 52 Coherent
                               Decorate 52 Binding 4
                               Decorate 52 DescriptorSet 0
                2:             TypeVoid

--- a/Test/baseResults/spv.specConstant.float16.comp.out
+++ b/Test/baseResults/spv.specConstant.float16.comp.out
@@ -25,6 +25,7 @@ spv.specConstant.float16.comp
                               MemberDecorate 7(Output) 0 Offset 0
                               MemberDecorate 7(Output) 1 NonReadable
                               MemberDecorate 7(Output) 1 Offset 2
+                              Decorate 9(sb_out) NonReadable
                               Decorate 9(sb_out) Binding 0
                               Decorate 9(sb_out) DescriptorSet 0
                               Decorate 12(sc0) SpecId 1

--- a/Test/baseResults/spv.specConstant.int16.comp.out
+++ b/Test/baseResults/spv.specConstant.int16.comp.out
@@ -25,6 +25,7 @@ spv.specConstant.int16.comp
                               MemberDecorate 7(Output) 0 Offset 0
                               MemberDecorate 7(Output) 1 NonReadable
                               MemberDecorate 7(Output) 1 Offset 2
+                              Decorate 9(sb_out) NonReadable
                               Decorate 9(sb_out) Binding 0
                               Decorate 9(sb_out) DescriptorSet 0
                               Decorate 12(sc0) SpecId 1

--- a/Test/baseResults/spv.specConstant.int8.comp.out
+++ b/Test/baseResults/spv.specConstant.int8.comp.out
@@ -25,6 +25,7 @@ spv.specConstant.int8.comp
                               MemberDecorate 7(Output) 0 Offset 0
                               MemberDecorate 7(Output) 1 NonReadable
                               MemberDecorate 7(Output) 1 Offset 1
+                              Decorate 9(sb_out) NonReadable
                               Decorate 9(sb_out) Binding 0
                               Decorate 9(sb_out) DescriptorSet 0
                               Decorate 12(sc0) SpecId 1

--- a/Test/baseResults/spv.specConstantOp.float16.comp.out
+++ b/Test/baseResults/spv.specConstantOp.float16.comp.out
@@ -23,6 +23,8 @@ spv.specConstantOp.float16.comp
                               MemberDecorate 8(S) 0 Restrict
                               MemberDecorate 8(S) 0 NonReadable
                               MemberDecorate 8(S) 0 Offset 0
+                              Decorate 10 Restrict
+                              Decorate 10 NonReadable
                               Decorate 10 Binding 0
                               Decorate 10 DescriptorSet 0
                               Decorate 14(c) SpecId 0

--- a/Test/baseResults/spv.specConstantOp.int16.comp.out
+++ b/Test/baseResults/spv.specConstantOp.int16.comp.out
@@ -23,6 +23,8 @@ spv.specConstantOp.int16.comp
                               MemberDecorate 8(S) 0 Restrict
                               MemberDecorate 8(S) 0 NonReadable
                               MemberDecorate 8(S) 0 Offset 0
+                              Decorate 10 Restrict
+                              Decorate 10 NonReadable
                               Decorate 10 Binding 0
                               Decorate 10 DescriptorSet 0
                               Decorate 13(c) SpecId 0

--- a/Test/baseResults/spv.specConstantOp.int8.comp.out
+++ b/Test/baseResults/spv.specConstantOp.int8.comp.out
@@ -23,6 +23,8 @@ spv.specConstantOp.int8.comp
                               MemberDecorate 8(S) 0 Restrict
                               MemberDecorate 8(S) 0 NonReadable
                               MemberDecorate 8(S) 0 Offset 0
+                              Decorate 10 Restrict
+                              Decorate 10 NonReadable
                               Decorate 10 Binding 0
                               Decorate 10 DescriptorSet 0
                               Decorate 13(c) SpecId 0

--- a/Test/baseResults/spv.ssbo.autoassign.frag.out
+++ b/Test/baseResults/spv.ssbo.autoassign.frag.out
@@ -36,6 +36,7 @@ spv.ssbo.autoassign.frag
                               Decorate 16(SB0) BufferBlock
                               MemberDecorate 16(SB0) 0 NonWritable
                               MemberDecorate 16(SB0) 0 Offset 0
+                              Decorate 18(SB0) NonWritable
                               Decorate 18(SB0) Binding 30
                               Decorate 18(SB0) DescriptorSet 0
                               Decorate 26(TestCB) Block

--- a/Test/baseResults/spv.subgroupExtendedTypesRotate.comp.out
+++ b/Test/baseResults/spv.subgroupExtendedTypesRotate.comp.out
@@ -44,6 +44,7 @@ spv.subgroupExtendedTypesRotate.comp
                               Decorate 9(roblock) Block
                               MemberDecorate 9(roblock) 0 NonWritable
                               MemberDecorate 9(roblock) 0 Offset 0
+                              Decorate 11(ro) NonWritable
                               Decorate 11(ro) Binding 1
                               Decorate 11(ro) DescriptorSet 0
                               Decorate 31(Buffers) Block

--- a/Test/baseResults/spv.subgroupRotate.comp.out
+++ b/Test/baseResults/spv.subgroupRotate.comp.out
@@ -27,6 +27,7 @@ spv.subgroupRotate.comp
                               Decorate 9(roblock) Block
                               MemberDecorate 9(roblock) 0 NonWritable
                               MemberDecorate 9(roblock) 0 Offset 0
+                              Decorate 11(ro) NonWritable
                               Decorate 11(ro) Binding 1
                               Decorate 11(ro) DescriptorSet 0
                               Decorate 23(Buffers) Block

--- a/Test/baseResults/spv.volatileAtomic.comp.out
+++ b/Test/baseResults/spv.volatileAtomic.comp.out
@@ -18,6 +18,8 @@ spv.volatileAtomic.comp
                               MemberDecorate 8(D) 0 Volatile
                               MemberDecorate 8(D) 0 Coherent
                               MemberDecorate 8(D) 0 Offset 0
+                              Decorate 10(d) Volatile
+                              Decorate 10(d) Coherent
                               Decorate 10(d) Binding 3
                               Decorate 10(d) DescriptorSet 0
                2:             TypeVoid

--- a/Test/baseResults/vk.relaxed.stagelink.0.0.vert.out
+++ b/Test/baseResults/vk.relaxed.stagelink.0.0.vert.out
@@ -7465,6 +7465,8 @@ gl_FragCoord origin is upper left
                               MemberDecorate 919(TDEnvLightBuffer) 0 Restrict
                               MemberDecorate 919(TDEnvLightBuffer) 0 NonWritable
                               MemberDecorate 919(TDEnvLightBuffer) 0 Offset 0
+                              Decorate 922(uTDEnvLightBuffers) Restrict
+                              Decorate 922(uTDEnvLightBuffers) NonWritable
                               Decorate 922(uTDEnvLightBuffers) Binding 0
                               Decorate 922(uTDEnvLightBuffers) DescriptorSet 0
                               Decorate 926(mTD2DImageOutputs) Binding 0
@@ -9146,6 +9148,8 @@ gl_FragCoord origin is upper left
                               MemberDecorate 1293(TDEnvLightBuffer) 0 Restrict
                               MemberDecorate 1293(TDEnvLightBuffer) 0 NonWritable
                               MemberDecorate 1293(TDEnvLightBuffer) 0 Offset 0
+                              Decorate 1296(uTDEnvLightBuffers) Restrict
+                              Decorate 1296(uTDEnvLightBuffers) NonWritable
                               Decorate 1296(uTDEnvLightBuffers) Binding 0
                               Decorate 1296(uTDEnvLightBuffers) DescriptorSet 0
                2:             TypeVoid


### PR DESCRIPTION
Apply memory decorations from GLSL source to the top-level OpVariable. Previously, these decorations would only be applied to individual members. While this is correct behavior, it is more convenient for some front ends to see the decorations (specifically ReadOnly and WriteOnly) applied to the whole variable rather than individual members.

This change relates to https://github.com/KhronosGroup/glslang/issues/792.