### PR TITLE
Additional C interface functions

### DIFF
--- a/glslang/CInterface/glslang_c_interface.cpp
+++ b/glslang/CInterface/glslang_c_interface.cpp
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "StandAlone/DirStackFileIncluder.h"
 #include "glslang/Public/ResourceLimits.h"
+#include "glslang/Public/ShaderLang.h"
 #include "glslang/Include/ShHandle.h"
 
 #include "glslang/Include/ResourceLimits.h"
@@ -54,6 +55,7 @@ static_assert(int(GLSLANG_REFLECTION_COUNT) == EShReflectionCount, "");
 static_assert(int(GLSLANG_PROFILE_COUNT) == EProfileCount, "");
 static_assert(sizeof(glslang_limits_t) == sizeof(TLimits), "");
 static_assert(sizeof(glslang_resource_t) == sizeof(TBuiltInResource), "");
+static_assert(sizeof(glslang_version_t) == sizeof(glslang::Version), "");
 
 typedef struct glslang_shader_s {
     glslang::TShader* shader;
@@ -140,6 +142,11 @@ private:
     /* User-defined context */
     void* context;
 };
+
+GLSLANG_EXPORT void glslang_get_version(glslang_version_t* version)
+{
+    *reinterpret_cast<glslang::Version*>(version) = glslang::GetVersion();
+}
 
 GLSLANG_EXPORT int glslang_initialize_process() { return static_cast<int>(glslang::InitializeProcess()); }
 

--- a/glslang/CInterface/glslang_c_interface.cpp
+++ b/glslang/CInterface/glslang_c_interface.cpp
@@ -391,6 +391,11 @@ GLSLANG_EXPORT const char* glslang_shader_get_preprocessed_code(glslang_shader_t
     return shader->preprocessedGLSL.c_str();
 }
 
+GLSLANG_EXPORT void glslang_shader_set_preprocessed_code(glslang_shader_t* shader, const char* code)
+{
+    shader->preprocessedGLSL.assign(code);
+}
+
 GLSLANG_EXPORT int glslang_shader_preprocess(glslang_shader_t* shader, const glslang_input_t* input)
 {
     DirStackFileIncluder dirStackFileIncluder;

--- a/glslang/CInterface/glslang_c_interface.cpp
+++ b/glslang/CInterface/glslang_c_interface.cpp
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "glslang/Include/ShHandle.h"
 
 #include "glslang/Include/ResourceLimits.h"
+#include "glslang/MachineIndependent/iomapper.h"
 #include "glslang/MachineIndependent/Versions.h"
 #include "glslang/MachineIndependent/localintermediate.h"
 
@@ -482,6 +483,11 @@ GLSLANG_EXPORT int glslang_program_map_io(glslang_program_t* program)
     return (int)program->program->mapIO();
 }
 
+GLSLANG_EXPORT int glslang_program_map_io_with_resolver_and_mapper(glslang_program_t* program, glslang_resolver_t* resolver, glslang_mapper_t* mapper)
+{
+    return (int)program->program->mapIO(reinterpret_cast<glslang::TDefaultGlslIoResolver*>(resolver), reinterpret_cast<glslang::TGlslIoMapper*>(mapper));
+}
+
 GLSLANG_EXPORT const char* glslang_program_get_info_log(glslang_program_t* program)
 {
     return program->program->getInfoLog();
@@ -490,4 +496,31 @@ GLSLANG_EXPORT const char* glslang_program_get_info_log(glslang_program_t* progr
 GLSLANG_EXPORT const char* glslang_program_get_info_debug_log(glslang_program_t* program)
 {
     return program->program->getInfoDebugLog();
+}
+
+GLSLANG_EXPORT glslang_mapper_t* glslang_glsl_mapper_create()
+{
+    return reinterpret_cast<glslang_mapper_t*>(new glslang::TGlslIoMapper());
+}
+
+GLSLANG_EXPORT void glslang_glsl_mapper_delete(glslang_mapper_t* mapper)
+{
+    if (!mapper)
+        return;
+
+    delete reinterpret_cast<glslang::TGlslIoMapper* >(mapper);
+}
+
+GLSLANG_EXPORT glslang_resolver_t* glslang_glsl_resolver_create(glslang_program_t* program, glslang_stage_t stage)
+{
+    glslang::TIntermediate* intermediate = program->program->getIntermediate(c_shader_stage(stage));
+    return reinterpret_cast<glslang_resolver_t*>(new glslang::TDefaultGlslIoResolver(reinterpret_cast<const glslang::TIntermediate&>(*intermediate)));
+}
+
+GLSLANG_EXPORT void glslang_glsl_resolver_delete(glslang_resolver_t* resolver)
+{
+    if (!resolver)
+        return;
+
+    delete reinterpret_cast<glslang::TDefaultGlslIoResolver* >(resolver);
 }

--- a/glslang/Include/glslang_c_interface.h
+++ b/glslang/Include/glslang_c_interface.h
@@ -274,6 +274,7 @@ GLSLANG_EXPORT void glslang_shader_set_default_uniform_block_name(glslang_shader
 GLSLANG_EXPORT int glslang_shader_preprocess(glslang_shader_t* shader, const glslang_input_t* input);
 GLSLANG_EXPORT int glslang_shader_parse(glslang_shader_t* shader, const glslang_input_t* input);
 GLSLANG_EXPORT const char* glslang_shader_get_preprocessed_code(glslang_shader_t* shader);
+GLSLANG_EXPORT void glslang_shader_set_preprocessed_code(glslang_shader_t* shader, const char* code);
 GLSLANG_EXPORT const char* glslang_shader_get_info_log(glslang_shader_t* shader);
 GLSLANG_EXPORT const char* glslang_shader_get_info_debug_log(glslang_shader_t* shader);
 

--- a/glslang/Include/glslang_c_interface.h
+++ b/glslang/Include/glslang_c_interface.h
@@ -41,6 +41,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 typedef struct glslang_shader_s glslang_shader_t;
 typedef struct glslang_program_s glslang_program_t;
 
+/* Version counterpart */
+typedef struct glslang_version_s {
+    int major;
+    int minor;
+    int patch;
+    const char* flavor;
+} glslang_version_t;
+
 /* TLimits counterpart */
 typedef struct glslang_limits_s {
     bool non_inductive_for_loops;
@@ -248,6 +256,8 @@ extern "C" {
 #ifndef GLSLANG_EXPORT
 #define GLSLANG_EXPORT
 #endif
+
+GLSLANG_EXPORT void glslang_get_version(glslang_version_t* version);
 
 GLSLANG_EXPORT int glslang_initialize_process(void);
 GLSLANG_EXPORT void glslang_finalize_process(void);

--- a/glslang/Include/glslang_c_interface.h
+++ b/glslang/Include/glslang_c_interface.h
@@ -40,6 +40,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 typedef struct glslang_shader_s glslang_shader_t;
 typedef struct glslang_program_s glslang_program_t;
+typedef struct glslang_mapper_s glslang_mapper_t;
+typedef struct glslang_resolver_s glslang_resolver_t;
 
 /* Version counterpart */
 typedef struct glslang_version_s {
@@ -285,6 +287,7 @@ GLSLANG_EXPORT int glslang_program_link(glslang_program_t* program, int messages
 GLSLANG_EXPORT void glslang_program_add_source_text(glslang_program_t* program, glslang_stage_t stage, const char* text, size_t len);
 GLSLANG_EXPORT void glslang_program_set_source_file(glslang_program_t* program, glslang_stage_t stage, const char* file);
 GLSLANG_EXPORT int glslang_program_map_io(glslang_program_t* program);
+GLSLANG_EXPORT int glslang_program_map_io_with_resolver_and_mapper(glslang_program_t* program, glslang_resolver_t* resolver, glslang_mapper_t* mapper);
 GLSLANG_EXPORT void glslang_program_SPIRV_generate(glslang_program_t* program, glslang_stage_t stage);
 GLSLANG_EXPORT void glslang_program_SPIRV_generate_with_options(glslang_program_t* program, glslang_stage_t stage, glslang_spv_options_t* spv_options);
 GLSLANG_EXPORT size_t glslang_program_SPIRV_get_size(glslang_program_t* program);
@@ -293,6 +296,12 @@ GLSLANG_EXPORT unsigned int* glslang_program_SPIRV_get_ptr(glslang_program_t* pr
 GLSLANG_EXPORT const char* glslang_program_SPIRV_get_messages(glslang_program_t* program);
 GLSLANG_EXPORT const char* glslang_program_get_info_log(glslang_program_t* program);
 GLSLANG_EXPORT const char* glslang_program_get_info_debug_log(glslang_program_t* program);
+
+GLSLANG_EXPORT glslang_mapper_t* glslang_glsl_mapper_create();
+GLSLANG_EXPORT void glslang_glsl_mapper_delete(glslang_mapper_t* mapper);
+
+GLSLANG_EXPORT glslang_resolver_t* glslang_glsl_resolver_create(glslang_program_t* program, glslang_stage_t stage);
+GLSLANG_EXPORT void glslang_glsl_resolver_delete(glslang_resolver_t* resolver);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR implements C versions of some functionality which is part of glslang's public C++ interface but currently missing from the C interface.

The first commit adds a C equivalent to glslang::GetVersion().

The second commit adds a function to directly supply preprocessed shader code, bypassing glslang's built-in preprocessor. This is useful for avoiding unnecessary double preprocessing overhead in scenarios where shader code has already been preprocessed once upstream (for example by a slower but more fully-featured preprocessor).

The third commit adds types and functions which provide additional control of glslang's IO mapping functionality. Together these functions allow for C interface users to make use of use of glslang's TGlslIoMapper and TDefaultGlslIoResolver mapper and resolver, which provide for proper cross-stage-aware automatic binding and location mapping functionality in a way that their non-GLSL counterparts exposed by the existing C interface IO mapping function do not.