### PR TITLE
Fix missing calls to SetThreadPoolAllocator() in TProgram public interface functions

### DIFF
--- a/glslang/MachineIndependent/ShaderLang.cpp
+++ b/glslang/MachineIndependent/ShaderLang.cpp
@@ -2121,6 +2121,8 @@ bool TProgram::buildReflection(int opts)
     if (! linked || reflection != nullptr)
         return false;
 
+    SetThreadPoolAllocator(pool);
+
     int firstStage = EShLangVertex, lastStage = EShLangFragment;
 
     if (opts & EShReflectionIntermediateIO) {
@@ -2176,6 +2178,9 @@ bool TProgram::mapIO(TIoMapResolver* pResolver, TIoMapper* pIoMapper)
 {
     if (! linked)
         return false;
+
+    SetThreadPoolAllocator(pool);
+
     TIoMapper* ioMapper = nullptr;
     TIoMapper defaultIOMapper;
     if (pIoMapper == nullptr)


### PR DESCRIPTION
This PR adds missing calls to SetThreadPoolAllocator() in TProgram functions which allocate and/or free memory and are part of glslang's public interface. Without these calls crashes can occur upon calling these functions in debug builds of glslang on Windows.