### PR TITLE
add optimizerAllowExpandedIDBound to SpvOptions

### DIFF
--- a/SPIRV/GlslangToSpv.h
+++ b/SPIRV/GlslangToSpv.h
@@ -53,6 +53,7 @@ struct SpvOptions {
     bool emitNonSemanticShaderDebugInfo {false};
     bool emitNonSemanticShaderDebugSource{ false };
     bool compileOnly{false};
+    bool optimizerAllowExpandedIDBound{false};
 };
 
 void GetSpirvVersion(std::string&);

--- a/SPIRV/SpvTools.cpp
+++ b/SPIRV/SpvTools.cpp
@@ -218,9 +218,20 @@ void SpirvToolsTransform(const glslang::TIntermediate& intermediate, std::vector
     optimizer.RegisterPass(spvtools::CreateCFGCleanupPass());
 
     spvtools::OptimizerOptions spvOptOptions;
+    if (options->optimizerAllowExpandedIDBound)
+        spvOptOptions.set_max_id_bound(0x3FFFFFFF);
     optimizer.SetTargetEnv(MapToSpirvToolsEnv(intermediate.getSpv(), logger));
     spvOptOptions.set_run_validator(false); // The validator may run as a separate step later on
     optimizer.Run(spirv.data(), spirv.size(), &spirv, spvOptOptions);
+
+    if (options->optimizerAllowExpandedIDBound) {
+        if (spirv.size() > 3 && spirv[3] > kDefaultMaxIdBound) {
+            spvtools::Optimizer optimizer2(target_env);
+            optimizer2.SetMessageConsumer(OptimizerMesssageConsumer);
+            optimizer2.RegisterPass(spvtools::CreateCompactIdsPass());
+            optimizer2.Run(spirv.data(), spirv.size(), &spirv, spvOptOptions);
+        }
+    }
 }
 
 bool SpirvToolsAnalyzeDeadOutputStores(spv_target_env target_env, std::vector<unsigned int>& spirv,

--- a/glslang/Include/glslang_c_interface.h
+++ b/glslang/Include/glslang_c_interface.h
@@ -237,6 +237,7 @@ typedef struct glslang_spv_options_s {
     bool emit_nonsemantic_shader_debug_info;
     bool emit_nonsemantic_shader_debug_source;
     bool compile_only;
+    bool optimize_allow_expanded_id_bound;
 } glslang_spv_options_t;
 
 #ifdef __cplusplus


### PR DESCRIPTION
This option increases the max_id_bound in the optimizer to 0x3FFFFFFF, and then runs a compact-id pass if the final result has a max_id greater than the standard limit of 0x3FFFFF.