### PR TITLE
Add SPIRV/SpvTools.h back to the public headers

### DIFF
--- a/SPIRV/CInterface/spirv_c_interface.cpp
+++ b/SPIRV/CInterface/spirv_c_interface.cpp
@@ -32,6 +32,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "glslang/Include/glslang_c_interface.h"
 
+#include <cstring>
+#include "glslang/Public/ShaderLang.h"
 #include "SPIRV/GlslangToSpv.h"
 #include "SPIRV/Logger.h"
 #include "SPIRV/SpvTools.h"

--- a/SPIRV/CMakeLists.txt
+++ b/SPIRV/CMakeLists.txt
@@ -76,7 +76,8 @@ set(PUBLIC_HEADERS
     disassemble.h
     Logger.h
     spirv.hpp
-    SPVRemapper.h)
+    SPVRemapper.h
+    SpvTools.h)
 
 add_library(SPIRV ${LIB_TYPE} ${SOURCES} ${HEADERS})
 add_library(glslang::SPIRV ALIAS SPIRV)

--- a/SPIRV/SpvTools.cpp
+++ b/SPIRV/SpvTools.cpp
@@ -44,6 +44,7 @@
 
 #include "SpvTools.h"
 #include "spirv-tools/optimizer.hpp"
+#include "glslang/MachineIndependent/localintermediate.h"
 
 namespace glslang {
 

--- a/SPIRV/SpvTools.h
+++ b/SPIRV/SpvTools.h
@@ -44,16 +44,19 @@
 #if ENABLE_OPT
 #include <vector>
 #include <ostream>
+#include <unordered_set>
 #include "spirv-tools/libspirv.h"
 #endif
 
-#include "glslang/MachineIndependent/localintermediate.h"
+#include "glslang/MachineIndependent/Versions.h"
 #include "GlslangToSpv.h"
 #include "Logger.h"
 
 namespace glslang {
 
 #if ENABLE_OPT
+
+class TIntermediate;
 
 // Translate glslang's view of target versioning to what SPIRV-Tools uses.
 spv_target_env MapToSpirvToolsEnv(const SpvVersion& spvVersion, spv::SpvBuildLogger* logger);


### PR DESCRIPTION
Clean up the includes in SpvTools.h so that it doesn't require any transitive dependencies and add it back to the headers that get installed.