### PR TITLE
SPIRV/SpvBuilder.h: add missing <cstdint> include

### DIFF
--- a/SPIRV/SpvBuilder.h
+++ b/SPIRV/SpvBuilder.h
@@ -56,6 +56,7 @@ namespace spv {
 }
 
 #include <algorithm>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <set>


### PR DESCRIPTION
Without the change `glslang` build fails on upcoming `gcc-15` as:

    In file included from /build/source/SPIRV/GlslangToSpv.cpp:45:
    SPIRV/SpvBuilder.h:248:30: error: 'uint32_t' has not been declared
      248 |     Id makeDebugLexicalBlock(uint32_t line);
          |                              ^~~~~~~~