### PR TITLE
Iomapper api cleanup

### DIFF
--- a/glslang/CInterface/glslang_c_interface.cpp
+++ b/glslang/CInterface/glslang_c_interface.cpp
@@ -37,7 +37,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "glslang/Public/ShaderLang.h"
 #include "glslang/Include/ShHandle.h"
 
+#include "glslang/Include/BaseTypes.h"
 #include "glslang/Include/ResourceLimits.h"
+#include "glslang/Include/Types.h"
 #include "glslang/MachineIndependent/iomapper.h"
 #include "glslang/MachineIndependent/Versions.h"
 #include "glslang/MachineIndependent/localintermediate.h"

--- a/glslang/CMakeLists.txt
+++ b/glslang/CMakeLists.txt
@@ -243,6 +243,7 @@ if(GLSLANG_ENABLE_INSTALL)
         Include/glslang_c_interface.h
         Include/glslang_c_shader_types.h
         Include/ResourceLimits.h
+        MachineIndependent/iomapper.h
         MachineIndependent/Versions.h)
 
     foreach(file ${PUBLIC_HEADERS})

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -39,6 +39,7 @@
 
 #include "gl_types.h"
 #include "iomapper.h"
+#include "LiveTraverser.h"
 #include "SymbolTable.h"
 
 //
@@ -59,6 +60,108 @@
 //
 
 namespace glslang {
+
+struct TVarEntryInfo {
+    long long id;
+    TIntermSymbol* symbol;
+    bool live;
+    bool upgradedToPushConstant;
+    int newBinding;
+    int newSet;
+    int newLocation;
+    int newComponent;
+    int newIndex;
+    EShLanguage stage;
+
+    void clearNewAssignments() {
+        upgradedToPushConstant = false;
+        newBinding = -1;
+        newSet = -1;
+        newLocation = -1;
+        newComponent = -1;
+        newIndex = -1;
+    }
+
+    struct TOrderById {
+        inline bool operator()(const TVarEntryInfo& l, const TVarEntryInfo& r) { return l.id < r.id; }
+    };
+
+    struct TOrderByPriority {
+        // ordering:
+        // 1) has both binding and set
+        // 2) has binding but no set
+        // 3) has no binding but set
+        // 4) has no binding and no set
+        inline bool operator()(const TVarEntryInfo& l, const TVarEntryInfo& r) {
+            const TQualifier& lq = l.symbol->getQualifier();
+            const TQualifier& rq = r.symbol->getQualifier();
+
+            // simple rules:
+            // has binding gives 2 points
+            // has set gives 1 point
+            // who has the most points is more important.
+            int lPoints = (lq.hasBinding() ? 2 : 0) + (lq.hasSet() ? 1 : 0);
+            int rPoints = (rq.hasBinding() ? 2 : 0) + (rq.hasSet() ? 1 : 0);
+
+            if (lPoints == rPoints)
+                return l.id < r.id;
+            return lPoints > rPoints;
+        }
+    };
+
+    struct TOrderByPriorityAndLive {
+        // ordering:
+        // 1) do live variables first
+        // 2) has both binding and set
+        // 3) has binding but no set
+        // 4) has no binding but set
+        // 5) has no binding and no set
+        inline bool operator()(const TVarEntryInfo& l, const TVarEntryInfo& r) {
+
+            const TQualifier& lq = l.symbol->getQualifier();
+            const TQualifier& rq = r.symbol->getQualifier();
+
+            // simple rules:
+            // has binding gives 2 points
+            // has set gives 1 point
+            // who has the most points is more important.
+            int lPoints = (lq.hasBinding() ? 2 : 0) + (lq.hasSet() ? 1 : 0);
+            int rPoints = (rq.hasBinding() ? 2 : 0) + (rq.hasSet() ? 1 : 0);
+
+            if (l.live != r.live)
+                return l.live > r.live;
+
+            if (lPoints != rPoints)
+                return lPoints > rPoints;
+
+            return l.id < r.id;
+        }
+    };
+};
+
+// override function "operator=", if a vector<const _Kty, _Ty> being sort,
+// when use vc++, the sort function will call :
+// pair& operator=(const pair<_Other1, _Other2>& _Right)
+// {
+//     first = _Right.first;
+//     second = _Right.second;
+//     return (*this);
+// }
+// that will make a const type handing on left.
+// override this function can avoid a compiler error.
+// In the future, if the vc++ compiler can handle such a situation,
+// this part of the code will be removed.
+struct TVarLivePair : std::pair<const TString, TVarEntryInfo> {
+    TVarLivePair(const std::pair<const TString, TVarEntryInfo>& _Right) : pair(_Right.first, _Right.second) {}
+    TVarLivePair& operator=(const TVarLivePair& _Right) {
+        const_cast<TString&>(first) = _Right.first;
+        second = _Right.second;
+        return (*this);
+    }
+    TVarLivePair(const TVarLivePair& src) : pair(src) { }
+};
+typedef std::vector<TVarLivePair> TVarLiveVector;
+
 
 class TVarGatherTraverser : public TLiveTraverser {
 public:
@@ -176,7 +279,7 @@ struct TNotifyInOutAdaptor
 {
     EShLanguage stage;
     TIoMapResolver& resolver;
-    inline TNotifyInOutAdaptor(EShLanguage s, TIoMapResolver& r) 
+    inline TNotifyInOutAdaptor(EShLanguage s, TIoMapResolver& r)
       : stage(s)
       , resolver(r)
     {
@@ -1495,6 +1598,36 @@ bool TIoMapper::addStage(EShLanguage stage, TIntermediate& intermediate, TInfoSi
         root->traverse(&iter_iomap);
     }
     return !hadError;
+}
+
+TGlslIoMapper::TGlslIoMapper() {
+    memset(inVarMaps,     0, sizeof(TVarLiveMap*)   * (EShLangCount + 1));
+    memset(outVarMaps,    0, sizeof(TVarLiveMap*)   * (EShLangCount + 1));
+    memset(uniformVarMap, 0, sizeof(TVarLiveMap*)   * (EShLangCount + 1));
+    memset(intermediates, 0, sizeof(TIntermediate*) * (EShLangCount + 1));
+    profile = ENoProfile;
+    version = 0;
+    autoPushConstantMaxSize = 128;
+    autoPushConstantBlockPacking = ElpStd430;
+}
+
+TGlslIoMapper::~TGlslIoMapper() {
+    for (size_t stage = 0; stage < EShLangCount; stage++) {
+        if (inVarMaps[stage] != nullptr) {
+            delete inVarMaps[stage];
+            inVarMaps[stage] = nullptr;
+        }
+        if (outVarMaps[stage] != nullptr) {
+            delete outVarMaps[stage];
+            outVarMaps[stage] = nullptr;
+        }
+        if (uniformVarMap[stage] != nullptr) {
+            delete uniformVarMap[stage];
+            uniformVarMap[stage] = nullptr;
+        }
+        if (intermediates[stage] != nullptr)
+            intermediates[stage] = nullptr;
+    }
 }
 
 // Map I/O variables to provided offsets, and make bindings for

--- a/glslang/MachineIndependent/iomapper.cpp
+++ b/glslang/MachineIndependent/iomapper.cpp
@@ -1601,10 +1601,10 @@ bool TIoMapper::addStage(EShLanguage stage, TIntermediate& intermediate, TInfoSi
 }
 
 TGlslIoMapper::TGlslIoMapper() {
-    memset(inVarMaps,     0, sizeof(TVarLiveMap*)   * (EShLangCount + 1));
-    memset(outVarMaps,    0, sizeof(TVarLiveMap*)   * (EShLangCount + 1));
-    memset(uniformVarMap, 0, sizeof(TVarLiveMap*)   * (EShLangCount + 1));
-    memset(intermediates, 0, sizeof(TIntermediate*) * (EShLangCount + 1));
+    memset(inVarMaps,     0, sizeof(TVarLiveMap*)   * EShLangCount);
+    memset(outVarMaps,    0, sizeof(TVarLiveMap*)   * EShLangCount);
+    memset(uniformVarMap, 0, sizeof(TVarLiveMap*)   * EShLangCount);
+    memset(intermediates, 0, sizeof(TIntermediate*) * EShLangCount);
     profile = ENoProfile;
     version = 0;
     autoPushConstantMaxSize = 128;

--- a/glslang/MachineIndependent/iomapper.h
+++ b/glslang/MachineIndependent/iomapper.h
@@ -37,7 +37,6 @@
 #define _IOMAPPER_INCLUDED
 
 #include <cstdint>
-#include "LiveTraverser.h"
 #include <unordered_map>
 #include <unordered_set>
 //
@@ -49,84 +48,7 @@ class TInfoSink;
 namespace glslang {
 
 class TIntermediate;
-struct TVarEntryInfo {
-    long long id;
-    TIntermSymbol* symbol;
-    bool live;
-    bool upgradedToPushConstant;
-    int newBinding;
-    int newSet;
-    int newLocation;
-    int newComponent;
-    int newIndex;
-    EShLanguage stage;
-
-    void clearNewAssignments() {
-        upgradedToPushConstant = false;
-        newBinding = -1;
-        newSet = -1;
-        newLocation = -1;
-        newComponent = -1;
-        newIndex = -1;
-    }
-
-    struct TOrderById {
-        inline bool operator()(const TVarEntryInfo& l, const TVarEntryInfo& r) { return l.id < r.id; }
-    };
-
-    struct TOrderByPriority {
-        // ordering:
-        // 1) has both binding and set
-        // 2) has binding but no set
-        // 3) has no binding but set
-        // 4) has no binding and no set
-        inline bool operator()(const TVarEntryInfo& l, const TVarEntryInfo& r) {
-            const TQualifier& lq = l.symbol->getQualifier();
-            const TQualifier& rq = r.symbol->getQualifier();
-
-            // simple rules:
-            // has binding gives 2 points
-            // has set gives 1 point
-            // who has the most points is more important.
-            int lPoints = (lq.hasBinding() ? 2 : 0) + (lq.hasSet() ? 1 : 0);
-            int rPoints = (rq.hasBinding() ? 2 : 0) + (rq.hasSet() ? 1 : 0);
-
-            if (lPoints == rPoints)
-                return l.id < r.id;
-            return lPoints > rPoints;
-        }
-    };
-
-    struct TOrderByPriorityAndLive {
-        // ordering:
-        // 1) do live variables first
-        // 2) has both binding and set
-        // 3) has binding but no set
-        // 4) has no binding but set
-        // 5) has no binding and no set
-        inline bool operator()(const TVarEntryInfo& l, const TVarEntryInfo& r) {
-
-            const TQualifier& lq = l.symbol->getQualifier();
-            const TQualifier& rq = r.symbol->getQualifier();
-
-            // simple rules:
-            // has binding gives 2 points
-            // has set gives 1 point
-            // who has the most points is more important.
-            int lPoints = (lq.hasBinding() ? 2 : 0) + (lq.hasSet() ? 1 : 0);
-            int rPoints = (rq.hasBinding() ? 2 : 0) + (rq.hasSet() ? 1 : 0);
-
-            if (l.live != r.live)
-                return l.live > r.live;
-
-            if (lPoints != rPoints)
-                return lPoints > rPoints;
-
-            return l.id < r.id;
-        }
-    };
-};
-
+struct TVarEntryInfo;
 // Base class for shared TIoMapResolver services, used by several derivations.
 struct TDefaultIoResolverBase : public glslang::TIoMapResolver {
 public:
@@ -267,29 +189,6 @@ protected:
 
 typedef std::map<TString, TVarEntryInfo> TVarLiveMap;
 
-// override function "operator=", if a vector<const _Kty, _Ty> being sort,
-// when use vc++, the sort function will call :
-// pair& operator=(const pair<_Other1, _Other2>& _Right)
-// {
-//     first = _Right.first;
-//     second = _Right.second;
-//     return (*this);
-// }
-// that will make a const type handing on left.
-// override this function can avoid a compiler error.
-// In the future, if the vc++ compiler can handle such a situation,
-// this part of the code will be removed.
-struct TVarLivePair : std::pair<const TString, TVarEntryInfo> {
-    TVarLivePair(const std::pair<const TString, TVarEntryInfo>& _Right) : pair(_Right.first, _Right.second) {}
-    TVarLivePair& operator=(const TVarLivePair& _Right) {
-        const_cast<TString&>(first) = _Right.first;
-        second = _Right.second;
-        return (*this);
-    }
-    TVarLivePair(const TVarLivePair& src) : pair(src) { }
-};
-typedef std::vector<TVarLivePair> TVarLiveVector;
-
 // I/O mapper
 class TIoMapper {
 public:
@@ -303,34 +202,8 @@ public:
 // I/O mapper for GLSL
 class TGlslIoMapper : public TIoMapper {
 public:
-    TGlslIoMapper() {
-        memset(inVarMaps,     0, sizeof(TVarLiveMap*)   * (EShLangCount + 1));
-        memset(outVarMaps,    0, sizeof(TVarLiveMap*)   * (EShLangCount + 1));
-        memset(uniformVarMap, 0, sizeof(TVarLiveMap*)   * (EShLangCount + 1));
-        memset(intermediates, 0, sizeof(TIntermediate*) * (EShLangCount + 1));
-        profile = ENoProfile;
-        version = 0;
-        autoPushConstantMaxSize = 128;
-        autoPushConstantBlockPacking = ElpStd430;
-    }
-    virtual ~TGlslIoMapper() {
-        for (size_t stage = 0; stage < EShLangCount; stage++) {
-            if (inVarMaps[stage] != nullptr) {
-                delete inVarMaps[stage];
-                inVarMaps[stage] = nullptr;
-            }
-            if (outVarMaps[stage] != nullptr) {
-                delete outVarMaps[stage];
-                outVarMaps[stage] = nullptr;
-            }
-            if (uniformVarMap[stage] != nullptr) {
-                delete uniformVarMap[stage];
-                uniformVarMap[stage] = nullptr;
-            }
-            if (intermediates[stage] != nullptr)
-                intermediates[stage] = nullptr;
-        }
-    }
+    TGlslIoMapper();
+    virtual ~TGlslIoMapper();
     // If set, the uniform block with the given name will be changed to be backed by
     // push_constant if it's size is <= maxSize
     void setAutoPushConstantBlock(const char* name, unsigned int maxSize, TLayoutPacking packing) {

--- a/glslang/MachineIndependent/iomapper.h
+++ b/glslang/MachineIndependent/iomapper.h
@@ -214,8 +214,6 @@ public:
     // grow the reflection stage by stage
     bool addStage(EShLanguage, TIntermediate&, TInfoSink&, TIoMapResolver*) override;
     bool doMap(TIoMapResolver*, TInfoSink&) override;
-    TVarLiveMap *inVarMaps[EShLangCount], *outVarMaps[EShLangCount],
-                *uniformVarMap[EShLangCount];
     TIntermediate* intermediates[EShLangCount];
     bool hadError = false;
     EProfile profile;
@@ -225,6 +223,8 @@ private:
     TString autoPushConstantBlockName;
     unsigned int autoPushConstantMaxSize;
     TLayoutPacking autoPushConstantBlockPacking;
+    TVarLiveMap *inVarMaps[EShLangCount], *outVarMaps[EShLangCount],
+                *uniformVarMap[EShLangCount];
 };
 
 } // end namespace glslang

--- a/gtests/GlslMapIO.FromFile.cpp
+++ b/gtests/GlslMapIO.FromFile.cpp
@@ -39,6 +39,7 @@
 
 #include "TestFixture.h"
 
+#include "glslang/MachineIndependent/localintermediate.h"
 #include "glslang/MachineIndependent/iomapper.h"
 #include "glslang/MachineIndependent/reflection.h"
 


### PR DESCRIPTION
Clean up iomapper.h to make it suitable as a public API

Remove the dependency on LiveTraverser.h, which transitively includes localintermediate.h. As a result, some things have been moved from iomapper.h to iomapper.cpp, specifically the TVarEntry type and the constructor and destructor of TGlslIoMapper.

Add MachineIndependent/iomapper.h to the list of installed headers.

Fixes #3681 