### PR TITLE
Add symbol visibility annotations to symbols in SPIRV/

### DIFF
--- a/SPIRV/GlslangToSpv.h
+++ b/SPIRV/GlslangToSpv.h
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include "Logger.h"
+#include "glslang/Include/visibility.h"
 
 namespace glslang {
 class TIntermediate;
@@ -56,13 +57,13 @@ struct SpvOptions {
     bool optimizerAllowExpandedIDBound{false};
 };
 
-void GetSpirvVersion(std::string&);
-int GetSpirvGeneratorVersion();
-void GlslangToSpv(const glslang::TIntermediate& intermediate, std::vector<unsigned int>& spirv,
-                  SpvOptions* options = nullptr);
-void GlslangToSpv(const glslang::TIntermediate& intermediate, std::vector<unsigned int>& spirv,
-                  spv::SpvBuildLogger* logger, SpvOptions* options = nullptr);
-bool OutputSpvBin(const std::vector<unsigned int>& spirv, const char* baseName);
-bool OutputSpvHex(const std::vector<unsigned int>& spirv, const char* baseName, const char* varName);
+GLSLANG_EXPORT void GetSpirvVersion(std::string&);
+GLSLANG_EXPORT int GetSpirvGeneratorVersion();
+GLSLANG_EXPORT void GlslangToSpv(const glslang::TIntermediate& intermediate, std::vector<unsigned int>& spirv,
+                                 SpvOptions* options = nullptr);
+GLSLANG_EXPORT void GlslangToSpv(const glslang::TIntermediate& intermediate, std::vector<unsigned int>& spirv,
+                                 spv::SpvBuildLogger* logger, SpvOptions* options = nullptr);
+GLSLANG_EXPORT bool OutputSpvBin(const std::vector<unsigned int>& spirv, const char* baseName);
+GLSLANG_EXPORT bool OutputSpvHex(const std::vector<unsigned int>& spirv, const char* baseName, const char* varName);
 
 }

--- a/SPIRV/Logger.h
+++ b/SPIRV/Logger.h
@@ -37,6 +37,7 @@
 
 #include <string>
 #include <vector>
+#include "glslang/Include/visibility.h"
 
 namespace spv {
 
@@ -58,7 +59,7 @@ public:
 
     // Returns all messages accumulated in the order of:
     // TBD functionalities, missing functionalities, warnings, errors.
-    std::string getAllMessages() const;
+    GLSLANG_EXPORT std::string getAllMessages() const;
 
 private:
     SpvBuildLogger(const SpvBuildLogger&);

--- a/SPIRV/SpvTools.h
+++ b/SPIRV/SpvTools.h
@@ -49,6 +49,7 @@
 #endif
 
 #include "glslang/MachineIndependent/Versions.h"
+#include "glslang/Include/visibility.h"
 #include "GlslangToSpv.h"
 #include "Logger.h"
 
@@ -59,44 +60,46 @@ namespace glslang {
 class TIntermediate;
 
 // Translate glslang's view of target versioning to what SPIRV-Tools uses.
-spv_target_env MapToSpirvToolsEnv(const SpvVersion& spvVersion, spv::SpvBuildLogger* logger);
+GLSLANG_EXPORT spv_target_env MapToSpirvToolsEnv(const SpvVersion& spvVersion, spv::SpvBuildLogger* logger);
 
 // Use the SPIRV-Tools disassembler to print SPIR-V using a SPV_ENV_UNIVERSAL_1_3 environment.
-void SpirvToolsDisassemble(std::ostream& out, const std::vector<unsigned int>& spirv);
+GLSLANG_EXPORT void SpirvToolsDisassemble(std::ostream& out, const std::vector<unsigned int>& spirv);
 
 // Use the SPIRV-Tools disassembler to print SPIR-V with a provided SPIR-V environment.
-void SpirvToolsDisassemble(std::ostream& out, const std::vector<unsigned int>& spirv,
-                           spv_target_env requested_context);
+GLSLANG_EXPORT void SpirvToolsDisassemble(std::ostream& out, const std::vector<unsigned int>& spirv,
+                                          spv_target_env requested_context);
 
 // Apply the SPIRV-Tools validator to generated SPIR-V.
-void SpirvToolsValidate(const glslang::TIntermediate& intermediate, std::vector<unsigned int>& spirv,
-                        spv::SpvBuildLogger*, bool prelegalization);
+GLSLANG_EXPORT void SpirvToolsValidate(const glslang::TIntermediate& intermediate, std::vector<unsigned int>& spirv,
+                                       spv::SpvBuildLogger*, bool prelegalization);
 
 // Apply the SPIRV-Tools optimizer to generated SPIR-V.  HLSL SPIR-V is legalized in the process.
-void SpirvToolsTransform(const glslang::TIntermediate& intermediate, std::vector<unsigned int>& spirv,
-                         spv::SpvBuildLogger*, const SpvOptions*);
+GLSLANG_EXPORT void SpirvToolsTransform(const glslang::TIntermediate& intermediate, std::vector<unsigned int>& spirv,
+                                        spv::SpvBuildLogger*, const SpvOptions*);
 
 // Apply the SPIRV-Tools EliminateDeadInputComponents pass to generated SPIR-V. Put result in |spirv|.
-void SpirvToolsEliminateDeadInputComponents(spv_target_env target_env, std::vector<unsigned int>& spirv,
-                                            spv::SpvBuildLogger*);
+GLSLANG_EXPORT void SpirvToolsEliminateDeadInputComponents(spv_target_env target_env, std::vector<unsigned int>& spirv,
+                                                           spv::SpvBuildLogger*);
 
 // Apply the SPIRV-Tools AnalyzeDeadOutputStores pass to generated SPIR-V. Put result in |live_locs|.
 // Return true if the result is valid.
-bool SpirvToolsAnalyzeDeadOutputStores(spv_target_env target_env, std::vector<unsigned int>& spirv,
-                                       std::unordered_set<uint32_t>* live_locs,
-                                       std::unordered_set<uint32_t>* live_builtins, spv::SpvBuildLogger*);
+GLSLANG_EXPORT bool SpirvToolsAnalyzeDeadOutputStores(spv_target_env target_env, std::vector<unsigned int>& spirv,
+                                                      std::unordered_set<uint32_t>* live_locs,
+                                                      std::unordered_set<uint32_t>* live_builtins,
+                                                      spv::SpvBuildLogger*);
 
 // Apply the SPIRV-Tools EliminateDeadOutputStores and AggressiveDeadCodeElimination passes to generated SPIR-V using
 // |live_locs|. Put result in |spirv|.
-void SpirvToolsEliminateDeadOutputStores(spv_target_env target_env, std::vector<unsigned int>& spirv,
-                                         std::unordered_set<uint32_t>* live_locs,
-                                         std::unordered_set<uint32_t>* live_builtins, spv::SpvBuildLogger*);
+GLSLANG_EXPORT void SpirvToolsEliminateDeadOutputStores(spv_target_env target_env, std::vector<unsigned int>& spirv,
+                                                        std::unordered_set<uint32_t>* live_locs,
+                                                        std::unordered_set<uint32_t>* live_builtins,
+                                                        spv::SpvBuildLogger*);
 
 // Apply the SPIRV-Tools optimizer to strip debug info from SPIR-V.  This is implicitly done by
 // SpirvToolsTransform if spvOptions->stripDebugInfo is set, but can be called separately if
 // optimization is disabled.
-void SpirvToolsStripDebugInfo(const glslang::TIntermediate& intermediate,
-        std::vector<unsigned int>& spirv, spv::SpvBuildLogger*);
+GLSLANG_EXPORT void SpirvToolsStripDebugInfo(const glslang::TIntermediate& intermediate,
+                                             std::vector<unsigned int>& spirv, spv::SpvBuildLogger*);
 
 #endif
 

--- a/SPIRV/disassemble.h
+++ b/SPIRV/disassemble.h
@@ -43,10 +43,12 @@
 #include <iostream>
 #include <vector>
 
+#include "glslang/Include/visibility.h"
+
 namespace spv {
 
     // disassemble with glslang custom disassembler
-    void Disassemble(std::ostream& out, const std::vector<unsigned int>&);
+    GLSLANG_EXPORT void Disassemble(std::ostream& out, const std::vector<unsigned int>&);
 
 }  // end namespace spv
 


### PR DESCRIPTION
Symbols in the SPIRV/ directory that are meant to be part of the public API of glslangnow have GLSLANG_EXPORT annotations that make sure they will be accessible when building glslang as a shared library if -fvisibility=hidden is enabled.

Fixes #2308 